### PR TITLE
chore: add convenience alias to root BUILD file for aspect binary

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,3 +13,8 @@ gazelle(
     ],
     command = "update-repos",
 )
+
+alias(
+    name = "aspect",
+    actual = "//cmd/aspect",
+)


### PR DESCRIPTION
Convenience alias so `bazel run aspect` works