### PR TITLE
feat: generate markdown docs, for some future GitHub pages site

### DIFF
--- a/cmd/aspect/BUILD.bazel
+++ b/cmd/aspect/BUILD.bazel
@@ -2,21 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "aspect_lib",
-    srcs = [
-        "main.go",
-        "root.go",
-    ],
+    srcs = ["main.go"],
     importpath = "aspect.build/cli/cmd/aspect",
-    visibility = ["//visibility:private"],
+    visibility = ["//cmd:__subpackages__"],
     deps = [
-        "//cmd/aspect/version",
-        "//docs/help/topics",
-        "//pkg/ioutils",
-        "@com_github_fatih_color//:color",
-        "@com_github_mattn_go_isatty//:go-isatty",
-        "@com_github_mitchellh_go_homedir//:go-homedir",
+        "//cmd/aspect/root",
         "@com_github_spf13_cobra//:cobra",
-        "@com_github_spf13_viper//:viper",
     ],
 )
 

--- a/cmd/aspect/main.go
+++ b/cmd/aspect/main.go
@@ -6,6 +6,7 @@ Not licensed for re-use.
 
 package main
 
+import "aspect.build/cli/cmd/aspect/root"
 import "github.com/spf13/cobra"
 
 func main() {
@@ -20,6 +21,6 @@ func main() {
 	//     ask the user if they want to install for all users of the workspace, if so
 	//         - tools/bazel file and put our bootstrap code in there
 	//
-	cmd := NewDefaultRootCmd()
+	cmd := root.NewDefaultRootCmd()
 	cobra.CheckErr(cmd.Execute())
 }

--- a/cmd/aspect/root/BUILD.bazel
+++ b/cmd/aspect/root/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "root",
+    srcs = ["root.go"],
+    importpath = "aspect.build/cli/cmd/aspect/root",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/aspect/version",
+        "//docs/help/topics",
+        "//pkg/ioutils",
+        "@com_github_fatih_color//:color",
+        "@com_github_mattn_go_isatty//:go-isatty",
+        "@com_github_mitchellh_go_homedir//:go-homedir",
+        "@com_github_spf13_cobra//:cobra",
+        "@com_github_spf13_viper//:viper",
+    ],
+)

--- a/cmd/aspect/root/root.go
+++ b/cmd/aspect/root/root.go
@@ -4,7 +4,7 @@ Copyright © 2021 Aspect Build Systems Inc
 Not licensed for re-use.
 */
 
-package main
+package root
 
 import (
 	"os"

--- a/cmd/aspect/version/version.go
+++ b/cmd/aspect/version/version.go
@@ -31,7 +31,7 @@ func NewVersionCmd(streams ioutils.Streams) *cobra.Command {
 		RunE:  v.Run,
 	}
 
-	cmd.PersistentFlags().BoolVarP(&v.GNUFormat, "gnu_format", "", false, "format help following GNU convention")
+	cmd.PersistentFlags().BoolVarP(&v.GNUFormat, "gnu_format", "", false, "format space-separated following GNU convention")
 
 	return cmd
 }

--- a/cmd/docgen/BUILD.bazel
+++ b/cmd/docgen/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "docgen_lib",
+    srcs = ["main.go"],
+    importpath = "aspect.build/cli/cmd/docgen",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//cmd/aspect/root",
+        "@com_github_spf13_cobra//doc",
+    ],
+)
+
+go_binary(
+    name = "docgen",
+    embed = [":docgen_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/docgen/README.md
+++ b/cmd/docgen/README.md
@@ -1,0 +1,8 @@
+# Generating docs
+
+Run `bazel run //cmd/docgen /tmp | less`
+
+Note that piping the command to less is required, so that it's not interactive.
+Otherwise we'll turn on coloring and put ANSI escape codes in our markdown.
+
+The github.com/aspect-dev/docs repo will do the work of publishing the outputs of this docgen step.

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"aspect.build/cli/cmd/aspect/root"
+	"github.com/spf13/cobra/doc"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatal("Usage: cmd/docgen /path/to/outdir")
+		os.Exit(1)
+	}
+
+	err := doc.GenMarkdownTree(root.NewDefaultRootCmd(), os.Args[1])
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Note for reviewer: I was forced to move code out of the "main" package in cmd/aspect since you can't import from that into another file declaring a "main" symbol.