### PR TITLE
feat(query): add query verb with initial preset features

### DIFF
--- a/cmd/aspect/query/BUILD.bazel
+++ b/cmd/aspect/query/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "query",
+    srcs = ["query.go"],
+    importpath = "aspect.build/cli/cmd/aspect/query",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/aspect/query",
+        "//pkg/bazel",
+        "//pkg/ioutils",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/cmd/aspect/query/query.go
+++ b/cmd/aspect/query/query.go
@@ -32,6 +32,7 @@ func NewQueryCommand(streams ioutils.Streams, bzl bazel.Spawner) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:   "query",
 		Short: "Executes a dependency graph query.",
+		Long: "Executes a query language expression over a specified subgraph of the build dependency graph.",
 		RunE:  q.Run,
 	}
 

--- a/cmd/aspect/query/query.go
+++ b/cmd/aspect/query/query.go
@@ -37,7 +37,5 @@ func NewQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 		RunE:  q.Run,
 	}
 
-	cmd.PersistentFlags().BoolVarP(&q.ShowGraph, "show_graph", "", false, `Shows a graph for of the result`)
-
 	return cmd
 }

--- a/cmd/aspect/query/query.go
+++ b/cmd/aspect/query/query.go
@@ -20,7 +20,8 @@ func NewDefaultQueryCmd() *cobra.Command {
 func NewQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 	q := query.New(streams, bzl, true)
 
-	// Load these from somewhere
+	// TODO: Queries should be loadable from the plugin config
+	// https://github.com/aspect-build/aspect-cli/issues/98
 	q.Presets = []*query.PresetQuery{
 		{
 			Name:        "why",
@@ -32,7 +33,7 @@ func NewQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "query",
 		Short: "Executes a dependency graph query.",
-		Long: "Executes a query language expression over a specified subgraph of the build dependency graph.",
+		Long:  "Executes a query language expression over a specified subgraph of the build dependency graph.",
 		RunE:  q.Run,
 	}
 

--- a/cmd/aspect/query/query.go
+++ b/cmd/aspect/query/query.go
@@ -20,16 +20,6 @@ func NewDefaultQueryCmd() *cobra.Command {
 func NewQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 	q := query.New(streams, bzl, true)
 
-	// TODO: Queries should be loadable from the plugin config
-	// https://github.com/aspect-build/aspect-cli/issues/98
-	q.Presets = []*query.PresetQuery{
-		{
-			Name:        "why",
-			Description: "Determine why targetA depends on targetB",
-			Query:       "somepath(?targetA, ?targetB)",
-		},
-	}
-
 	cmd := &cobra.Command{
 		Use:   "query",
 		Short: "Executes a dependency graph query.",

--- a/cmd/aspect/query/query.go
+++ b/cmd/aspect/query/query.go
@@ -24,8 +24,8 @@ func NewQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 	q.Presets = []*query.PresetQuery{
 		{
 			Name:        "why",
-			Description: "Determine why a target depends on another",
-			Query:       "somepath(?target, ?dependency)",
+			Description: "Determine why targetA depends on targetB",
+			Query:       "somepath(?targetA, ?targetB)",
 		},
 	}
 

--- a/cmd/aspect/query/query.go
+++ b/cmd/aspect/query/query.go
@@ -1,0 +1,41 @@
+/*
+Copyright © 2021 Aspect Build Systems
+
+Not licensed for re-use
+*/
+
+package query
+
+import (
+	"aspect.build/cli/pkg/aspect/query"
+	"aspect.build/cli/pkg/bazel"
+	"aspect.build/cli/pkg/ioutils"
+	"github.com/spf13/cobra"
+)
+
+func NewDefaultQueryCmd() *cobra.Command {
+	return NewQueryCommand(ioutils.DefaultStreams, bazel.New())
+}
+
+func NewQueryCommand(streams ioutils.Streams, bzl bazel.Spawner) *cobra.Command {
+	q := query.New(streams, bzl, true)
+
+	// Load these from somewhere
+	q.Presets = []*query.PresetQuery{
+		{
+			Name:        "why",
+			Description: "Determine why a target depends on another",
+			Query:       "somepath(?target, ?dependency)",
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "query",
+		Short: "Executes a dependency graph query.",
+		RunE:  q.Run,
+	}
+
+	cmd.PersistentFlags().BoolVarP(&q.ShowGraph, "show_graph", "", false, `Shows a graph for of the result`)
+
+	return cmd
+}

--- a/cmd/aspect/query/query.go
+++ b/cmd/aspect/query/query.go
@@ -17,7 +17,7 @@ func NewDefaultQueryCmd() *cobra.Command {
 	return NewQueryCommand(ioutils.DefaultStreams, bazel.New())
 }
 
-func NewQueryCommand(streams ioutils.Streams, bzl bazel.Spawner) *cobra.Command {
+func NewQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 	q := query.New(streams, bzl, true)
 
 	// Load these from somewhere

--- a/cmd/aspect/root/BUILD.bazel
+++ b/cmd/aspect/root/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//cmd/aspect/clean",
         "//cmd/aspect/docs",
         "//cmd/aspect/info",
+        "//cmd/aspect/query",
         "//cmd/aspect/run",
         "//cmd/aspect/test",
         "//cmd/aspect/version",

--- a/cmd/aspect/root/root.go
+++ b/cmd/aspect/root/root.go
@@ -20,7 +20,6 @@ import (
 	"aspect.build/cli/cmd/aspect/docs"
 	"aspect.build/cli/cmd/aspect/info"
 	"aspect.build/cli/cmd/aspect/query"
-	"aspect.build/cli/cmd/aspect/root/flags"
 	"aspect.build/cli/cmd/aspect/run"
 	"aspect.build/cli/cmd/aspect/test"
 	"aspect.build/cli/cmd/aspect/version"

--- a/cmd/aspect/root/root.go
+++ b/cmd/aspect/root/root.go
@@ -7,6 +7,7 @@ Not licensed for re-use.
 package root
 
 import (
+	"aspect.build/cli/cmd/aspect/query"
 	"os"
 
 	"github.com/fatih/color"
@@ -83,6 +84,7 @@ func NewRootCmd(
 	cmd.AddCommand(clean.NewDefaultCleanCmd())
 	cmd.AddCommand(docs.NewDefaultDocsCmd())
 	cmd.AddCommand(info.NewDefaultInfoCmd())
+	cmd.AddCommand(query.NewDefaultQueryCmd())
 	cmd.AddCommand(run.NewDefaultRunCmd(pluginSystem))
 	cmd.AddCommand(test.NewDefaultTestCmd(pluginSystem))
 	cmd.AddCommand(version.NewDefaultVersionCmd())

--- a/cmd/aspect/root/root.go
+++ b/cmd/aspect/root/root.go
@@ -7,7 +7,6 @@ Not licensed for re-use.
 package root
 
 import (
-	"aspect.build/cli/cmd/aspect/query"
 	"os"
 
 	"github.com/fatih/color"
@@ -20,6 +19,8 @@ import (
 	"aspect.build/cli/cmd/aspect/clean"
 	"aspect.build/cli/cmd/aspect/docs"
 	"aspect.build/cli/cmd/aspect/info"
+	"aspect.build/cli/cmd/aspect/query"
+	"aspect.build/cli/cmd/aspect/root/flags"
 	"aspect.build/cli/cmd/aspect/run"
 	"aspect.build/cli/cmd/aspect/test"
 	"aspect.build/cli/cmd/aspect/version"

--- a/docs/aspect.md
+++ b/docs/aspect.md
@@ -20,6 +20,7 @@ Aspect CLI is a better frontend for running bazel
 * [aspect clean](aspect_clean.md)	 - Removes the output tree.
 * [aspect docs](aspect_docs.md)	 - Open documentation in the browser.
 * [aspect info](aspect_info.md)	 - Displays runtime info about the bazel server.
+* [aspect query](aspect_query.md)	 - Executes a dependency graph query.
 * [aspect run](aspect_run.md)	 - Builds the specified target and runs it with the given arguments.
 * [aspect test](aspect_test.md)	 - Builds the specified targets and runs all test targets among them.
 * [aspect version](aspect_version.md)	 - Print the version of aspect CLI as well as tools it invokes.

--- a/docs/aspect_query.md
+++ b/docs/aspect_query.md
@@ -1,0 +1,29 @@
+## aspect query
+
+Executes a dependency graph query.
+
+### Synopsis
+
+Executes a query language expression over a specified subgraph of the build dependency graph.
+
+```
+aspect query [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for query
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default is $HOME/.aspect.yaml)
+      --interactive     Interactive mode (e.g. prompts for user input)
+```
+
+### SEE ALSO
+
+* [aspect](aspect.md)	 - Aspect.build bazel wrapper
+

--- a/docs/command_list.bzl
+++ b/docs/command_list.bzl
@@ -6,6 +6,7 @@ COMMAND_LIST = [
     "clean",
     "docs",
     "info",
+    "query",
     "run",
     "test",
     "version",

--- a/docs/help/topics/BUILD.bazel
+++ b/docs/help/topics/BUILD.bazel
@@ -11,6 +11,7 @@ bindata(
     package = "topics",
 )
 
+# keep
 go_library(
     name = "topics",
     srcs = [":bindata"],  # keep

--- a/docs/help/topics/BUILD.bazel
+++ b/docs/help/topics/BUILD.bazel
@@ -11,7 +11,6 @@ bindata(
     package = "topics",
 )
 
-# keep
 go_library(
     name = "topics",
     srcs = [":bindata"],  # keep

--- a/pkg/aspect/query/BUILD.bazel
+++ b/pkg/aspect/query/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "query",
@@ -12,5 +12,17 @@ go_library(
         "@com_github_manifoldco_promptui//:promptui",
         "@com_github_pkg_browser//:browser",
         "@com_github_spf13_cobra//:cobra",
+    ],
+)
+
+go_test(
+    name = "query_test",
+    srcs = ["query_test.go"],
+    deps = [
+        ":query",
+        "//pkg/bazel/mock",
+        "//pkg/ioutils",
+        "@com_github_golang_mock//gomock",
+        "@com_github_onsi_gomega//:gomega",
     ],
 )

--- a/pkg/aspect/query/BUILD.bazel
+++ b/pkg/aspect/query/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     srcs = ["query_test.go"],
     deps = [
         ":query",
+        "//pkg/aspect/query/mock",
         "//pkg/bazel/mock",
         "//pkg/ioutils",
         "@com_github_golang_mock//gomock",

--- a/pkg/aspect/query/BUILD.bazel
+++ b/pkg/aspect/query/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//pkg/bazel",
         "//pkg/ioutils",
         "@com_github_manifoldco_promptui//:promptui",
-        "@com_github_pkg_browser//:browser",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/pkg/aspect/query/BUILD.bazel
+++ b/pkg/aspect/query/BUILD.bazel
@@ -24,5 +24,6 @@ go_test(
         "//pkg/ioutils",
         "@com_github_golang_mock//gomock",
         "@com_github_onsi_gomega//:gomega",
+        "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/pkg/aspect/query/BUILD.bazel
+++ b/pkg/aspect/query/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "query",
+    srcs = ["query.go"],
+    importpath = "aspect.build/cli/pkg/aspect/query",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/aspecterrors",
+        "//pkg/bazel",
+        "//pkg/ioutils",
+        "@com_github_manifoldco_promptui//:promptui",
+        "@com_github_pkg_browser//:browser",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/pkg/aspect/query/mock/BUILD.bazel
+++ b/pkg/aspect/query/mock/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@bazel_gomock//:gomock.bzl", "gomock")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# gazelle:exclude mock_query_test.go
+
+gomock(
+    name = "mock_query_source",
+    out = "mock_query_test.go",
+    interfaces = [
+        "PromptRunner",
+        "SelectRunner",
+    ],
+    library = "//pkg/aspect/query",
+    package = "mock",
+    visibility = ["//visibility:private"],
+)
+
+go_library(
+    name = "mock",
+    srcs = [
+        "doc.go",
+        ":mock_query_source",  # keep
+    ],
+    importpath = "aspect.build/cli/pkg/aspect/query/mock",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@com_github_golang_mock//gomock",  # keep
+    ],
+)

--- a/pkg/aspect/query/mock/doc.go
+++ b/pkg/aspect/query/mock/doc.go
@@ -1,0 +1,2 @@
+// Package mock contains generated files.
+package mock

--- a/pkg/aspect/query/query.go
+++ b/pkg/aspect/query/query.go
@@ -131,7 +131,7 @@ func (q *Query) RunQuery(query string) error {
 			Err:      err,
 			ExitCode: exitCode,
 		}
-		return err
+		return fmt.Errorf("failed to run query %q: %w", query, err)
 	}
 
 	return nil

--- a/pkg/aspect/query/query.go
+++ b/pkg/aspect/query/query.go
@@ -69,12 +69,12 @@ func (q *Query) Run(_ *cobra.Command, args []string) error {
 		preset = q.Presets[i]
 	} else {
 		maybeQueryOrPreset := args[0]
-		if strings.HasPrefix(maybeQueryOrPreset, "\"") || strings.HasPrefix(maybeQueryOrPreset, "'") {
-			// Treat this as a raw query expression?
-			return q.RunQuery(maybeQueryOrPreset, []string{})
-		} else if value, ok := presets[maybeQueryOrPreset]; ok {
+		if value, ok := presets[maybeQueryOrPreset]; ok {
 			// Treat this as the name of the preset query, so don't prompt for it.
 			preset = value
+		} else {
+			// Treat this as a raw query expression
+			return q.RunQuery(maybeQueryOrPreset, []string{})
 		}
 	}
 

--- a/pkg/aspect/query/query.go
+++ b/pkg/aspect/query/query.go
@@ -38,10 +38,21 @@ type Query struct {
 }
 
 func New(streams ioutils.Streams, bzl bazel.Bazel, isInteractive bool) *Query {
+	// TODO: Queries should be loadable from the plugin config
+	// https://github.com/aspect-build/aspect-cli/issues/98
+	presets := []*PresetQuery{
+		{
+			Name:        "why",
+			Description: "Determine why targetA depends on targetB",
+			Query:       "somepath(?targetA, ?targetB)",
+		},
+	}
+
 	return &Query{
 		Streams:       streams,
 		Bzl:           bzl,
 		IsInteractive: isInteractive,
+		Presets:       presets,
 		GetAPrompt:    GetAPrompt,
 		GetASelect:    GetASelect,
 	}

--- a/pkg/aspect/query/query.go
+++ b/pkg/aspect/query/query.go
@@ -31,14 +31,14 @@ type PresetQuery struct {
 type Query struct {
 	ioutils.Streams
 
-	bzl           bazel.Spawner
+	bzl           bazel.Bazel
 	isInteractive bool
 
 	Presets   []*PresetQuery
 	ShowGraph bool
 }
 
-func New(streams ioutils.Streams, bzl bazel.Spawner, isInteractive bool) *Query {
+func New(streams ioutils.Streams, bzl bazel.Bazel, isInteractive bool) *Query {
 	return &Query{
 		Streams:       streams,
 		bzl:           bzl,

--- a/pkg/aspect/query/query.go
+++ b/pkg/aspect/query/query.go
@@ -1,0 +1,161 @@
+/*
+Copyright © 2021 Aspect Build Systems Inc
+
+Not licensed for re-use.
+*/
+
+package query
+
+import (
+	"aspect.build/cli/pkg/aspecterrors"
+	"aspect.build/cli/pkg/bazel"
+	"fmt"
+	"github.com/manifoldco/promptui"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"aspect.build/cli/pkg/ioutils"
+)
+
+type PresetQuery struct {
+	Name        string
+	Description string
+	Query       string
+}
+
+type Query struct {
+	ioutils.Streams
+
+	bzl           bazel.Spawner
+	isInteractive bool
+
+	Presets   []*PresetQuery
+	ShowGraph bool
+}
+
+func New(streams ioutils.Streams, bzl bazel.Spawner, isInteractive bool) *Query {
+	return &Query{
+		Streams:       streams,
+		bzl:           bzl,
+		isInteractive: isInteractive,
+	}
+}
+
+func (v *Query) Run(_ *cobra.Command, args []string) error {
+	presets := make(map[string]*PresetQuery)
+	var names []string
+	for _, p := range v.Presets {
+		presets[p.Name] = p
+		names = append(names, fmt.Sprintf("%s: %s", p.Name, p.Description))
+	}
+
+	var preset *PresetQuery
+	if len(args) == 0 {
+		selectQueryPrompt := &promptui.Select{
+			Label: "Select a preset query",
+			Items: names,
+		}
+
+		i, _, err := selectQueryPrompt.Run()
+		if err != nil {
+			return fmt.Errorf("prompt failed: %w", err)
+		}
+
+		preset = v.Presets[i]
+	} else {
+		maybeQueryOrPreset := args[0]
+		if strings.HasPrefix(maybeQueryOrPreset, "\"") || strings.HasPrefix(maybeQueryOrPreset, "'") {
+			// Treat this as a raw query expression?
+			return v.RunQuery(maybeQueryOrPreset, []string{})
+		} else if value, ok := presets[maybeQueryOrPreset]; ok {
+			// Treat this as the name of the preset query, so don't prompt for it.
+			preset = value
+		}
+	}
+
+	if preset == nil {
+		return fmt.Errorf("unable to determine preset query")
+	}
+
+	query := preset.Query
+	placeholders := regexp.MustCompile(`(\?[a-zA-Z]*)`).FindAllString(query, -1)
+
+	if len(placeholders) > 0 {
+		for _, placeholder := range placeholders {
+			prompt := &promptui.Prompt{
+				Label: fmt.Sprintf("Value for '%s'", strings.TrimPrefix(placeholder, "?")),
+			}
+			val, err := prompt.Run()
+			if err != nil {
+				return fmt.Errorf("prompt failed: %w", err)
+			}
+
+			query = strings.ReplaceAll(query, placeholder, val)
+		}
+	}
+
+	return v.RunQuery(query, []string{})
+}
+
+func (v *Query) RunQuery(query string, flags []string) error {
+	if v.ShowGraph {
+		return v.RunQueryAndOpenResult(query, flags)
+	}
+
+	bazelCmd := []string{
+		"query",
+		query,
+	}
+
+	bazelCmd = append(bazelCmd, flags...)
+
+	if exitCode, err := v.bzl.Spawn(bazelCmd); exitCode != 0 {
+		err = &aspecterrors.ExitError{
+			Err:      err,
+			ExitCode: exitCode,
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (v *Query) RunQueryAndOpenResult(query string, flags []string) error {
+	bazelCmd := []string{
+		"query",
+		query,
+		"--output=graph",
+	}
+
+	bazelCmd = append(bazelCmd, flags...)
+
+	r, w := io.Pipe()
+	bazelErrs := make(chan error, 1)
+	defer close(bazelErrs)
+	go func() {
+		defer w.Close()
+		_, err := v.bzl.RunCommand(bazelCmd, w)
+		bazelErrs <- err
+	}()
+
+	bazelQueryOutput, err := ioutil.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("failed to get bazel query response: %w", err)
+	}
+
+	if err := <-bazelErrs; err != nil {
+		return fmt.Errorf("failed to get bazel query response: %w", err)
+	}
+
+	graphVizUrl := fmt.Sprintf("https://edotor.net/?engine=dot#%s", url.PathEscape(string(bazelQueryOutput)))
+	if err := browser.OpenURL(graphVizUrl); err != nil {
+		return fmt.Errorf("failed to open link in the browser: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/aspect/query/query.go
+++ b/pkg/aspect/query/query.go
@@ -71,6 +71,8 @@ func (q *Query) Run(_ *cobra.Command, args []string) error {
 		maybeQueryOrPreset := args[0]
 		if value, ok := presets[maybeQueryOrPreset]; ok {
 			// Treat this as the name of the preset query, so don't prompt for it.
+			fmt.Printf("Preset query \"%s\" selected\n", value.Name)
+			fmt.Printf("%s: %s\n", value.Name, value.Description)
 			preset = value
 		} else {
 			// Treat this as a raw query expression

--- a/pkg/aspect/query/query_test.go
+++ b/pkg/aspect/query/query_test.go
@@ -29,7 +29,7 @@ func TestQuery(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		spawner := mock.NewMockSpawner(ctrl)
+		spawner := mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
 			Spawn([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}).

--- a/pkg/aspect/query/query_test.go
+++ b/pkg/aspect/query/query_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 
 	"aspect.build/cli/pkg/aspect/query"
 	query_mock "aspect.build/cli/pkg/aspect/query/mock"
@@ -78,7 +79,7 @@ func TestQuery(t *testing.T) {
 			Streams:       streams,
 			Bzl:           spawner,
 			IsInteractive: true,
-			GetAPrompt: func(label string) query.PromptRunner {
+			Prompt: func(label string) query.PromptRunner {
 				return promptRunner
 			},
 		}
@@ -105,6 +106,8 @@ func TestQuery(t *testing.T) {
 
 		spawner := bazel_mock.NewMockBazel(ctrl)
 
+		cmd := &cobra.Command{Use: "fake"}
+
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)
 		gomock.InOrder(
 			promptRunner.
@@ -123,7 +126,7 @@ func TestQuery(t *testing.T) {
 			Streams:       streams,
 			Bzl:           spawner,
 			IsInteractive: true,
-			GetAPrompt: func(label string) query.PromptRunner {
+			Prompt: func(label string) query.PromptRunner {
 				return promptRunner
 			},
 		}
@@ -134,7 +137,7 @@ func TestQuery(t *testing.T) {
 				Query:       "somepath(?target, ?dependency)",
 			},
 		}
-		err := q.Run(nil, []string{"why"})
+		err := q.Run(cmd, []string{"why"})
 		g.Expect(err).To(MatchError(expectedError))
 	})
 
@@ -177,11 +180,11 @@ func TestQuery(t *testing.T) {
 			Streams:       streams,
 			Bzl:           spawner,
 			IsInteractive: true,
-			GetAPrompt: func(label string) query.PromptRunner {
+			Prompt: func(label string) query.PromptRunner {
 				g.Expect(strings.Contains(label, "targettwo") || strings.Contains(label, "dependencytwo")).To(Equal(true))
 				return promptRunner
 			},
-			GetASelect: func(presetNames []string) query.SelectRunner {
+			Select: func(presetNames []string) query.SelectRunner {
 				return selectRunner
 			},
 		}

--- a/pkg/aspect/query/query_test.go
+++ b/pkg/aspect/query/query_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2021 Aspect Build Systems Inc
+
+Not licensed for re-use.
+*/
+
+package query_test
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+
+	"aspect.build/cli/pkg/aspect/query"
+	"aspect.build/cli/pkg/bazel/mock"
+	"aspect.build/cli/pkg/ioutils"
+)
+
+type confirm struct{}
+
+func (p confirm) Run() (string, error) {
+	return "", nil
+}
+
+func TestQuery(t *testing.T) {
+	t.Run("long version query calls directly down to bazel query", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		spawner := mock.NewMockSpawner(ctrl)
+		spawner.
+			EXPECT().
+			Spawn([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}).
+			Return(0, nil)
+
+		b := query.New(ioutils.Streams{}, spawner, true)
+		b.Presets = []*query.PresetQuery{
+			{
+				Name:        "why",
+				Description: "Determine why a target depends on another",
+				Query:       "somepath(?target, ?dependency)",
+			},
+		}
+		g.Expect(b.Run(nil, []string{"why", "//cmd/aspect/query:query", "@com_github_bazelbuild_bazelisk//core:go_default_library"})).Should(Succeed())
+	})
+}

--- a/pkg/aspect/query/query_test.go
+++ b/pkg/aspect/query/query_test.go
@@ -7,42 +7,202 @@ Not licensed for re-use.
 package query_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 
 	"aspect.build/cli/pkg/aspect/query"
-	"aspect.build/cli/pkg/bazel/mock"
+	query_mock "aspect.build/cli/pkg/aspect/query/mock"
+	bazel_mock "aspect.build/cli/pkg/bazel/mock"
 	"aspect.build/cli/pkg/ioutils"
 )
 
-type confirm struct{}
-
-func (p confirm) Run() (string, error) {
-	return "", nil
-}
-
 func TestQuery(t *testing.T) {
-	t.Run("long version query calls directly down to bazel query", func(t *testing.T) {
+	t.Run("long version of preset query calls directly down to bazel query", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		spawner := mock.NewMockBazel(ctrl)
+		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
 			Spawn([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}).
 			Return(0, nil)
 
-		b := query.New(ioutils.Streams{}, spawner, true)
-		b.Presets = []*query.PresetQuery{
+		var stdout strings.Builder
+		streams := ioutils.Streams{Stdout: &stdout}
+		q := query.New(streams, spawner, true)
+		q.Presets = []*query.PresetQuery{
 			{
 				Name:        "why",
 				Description: "Determine why a target depends on another",
 				Query:       "somepath(?target, ?dependency)",
 			},
 		}
-		g.Expect(b.Run(nil, []string{"why", "//cmd/aspect/query:query", "@com_github_bazelbuild_bazelisk//core:go_default_library"})).Should(Succeed())
+
+		g.Expect(q.Run(nil, []string{"why", "//cmd/aspect/query:query", "@com_github_bazelbuild_bazelisk//core:go_default_library"})).Should(Succeed())
+	})
+
+	t.Run("query can be selected by default and will prompt for inputs", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		var stdout strings.Builder
+		streams := ioutils.Streams{Stdout: &stdout}
+
+		spawner := bazel_mock.NewMockBazel(ctrl)
+		spawner.
+			EXPECT().
+			Spawn([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}).
+			Return(0, nil)
+
+		promptRunner := query_mock.NewMockPromptRunner(ctrl)
+		gomock.InOrder(
+			promptRunner.
+				EXPECT().
+				Run().
+				Return("//cmd/aspect/query:query", nil).
+				Times(1),
+			promptRunner.
+				EXPECT().
+				Run().
+				Return("@com_github_bazelbuild_bazelisk//core:go_default_library", nil).
+				Times(1),
+		)
+
+		q := &query.Query{
+			Streams:       streams,
+			Bzl:           spawner,
+			IsInteractive: true,
+			GetAPrompt: func(label string) query.PromptRunner {
+				return promptRunner
+			},
+		}
+		q.Presets = []*query.PresetQuery{
+			{
+				Name:        "why",
+				Description: "Determine why a target depends on another",
+				Query:       "somepath(?target, ?dependency)",
+			},
+		}
+		err := q.Run(nil, []string{"why"})
+		g.Expect(err).To(BeNil())
+	})
+
+	t.Run("a thrown error while prompting for input is handled", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		expectedError := fmt.Errorf("The prompt failed!")
+
+		var stdout strings.Builder
+		streams := ioutils.Streams{Stdout: &stdout}
+
+		spawner := bazel_mock.NewMockBazel(ctrl)
+
+		promptRunner := query_mock.NewMockPromptRunner(ctrl)
+		gomock.InOrder(
+			promptRunner.
+				EXPECT().
+				Run().
+				Return("//foo", nil).
+				Times(1),
+			promptRunner.
+				EXPECT().
+				Run().
+				Return("", expectedError).
+				Times(1),
+		)
+
+		q := &query.Query{
+			Streams:       streams,
+			Bzl:           spawner,
+			IsInteractive: true,
+			GetAPrompt: func(label string) query.PromptRunner {
+				return promptRunner
+			},
+		}
+		q.Presets = []*query.PresetQuery{
+			{
+				Name:        "why",
+				Description: "Determine why a target depends on another",
+				Query:       "somepath(?target, ?dependency)",
+			},
+		}
+		err := q.Run(nil, []string{"why"})
+		g.Expect(err).To(MatchError(expectedError))
+	})
+
+	t.Run("will prompt user to select a preset query", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		var stdout strings.Builder
+		streams := ioutils.Streams{Stdout: &stdout}
+
+		spawner := bazel_mock.NewMockBazel(ctrl)
+		spawner.
+			EXPECT().
+			Spawn([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}).
+			Return(0, nil)
+
+		promptRunner := query_mock.NewMockPromptRunner(ctrl)
+		gomock.InOrder(
+			promptRunner.
+				EXPECT().
+				Run().
+				Return("//cmd/aspect/query:query", nil).
+				Times(1),
+			promptRunner.
+				EXPECT().
+				Run().
+				Return("@com_github_bazelbuild_bazelisk//core:go_default_library", nil).
+				Times(1),
+		)
+
+		selectRunner := query_mock.NewMockSelectRunner(ctrl)
+		selectRunner.
+			EXPECT().
+			Run().
+			Return(1, "", nil).
+			Times(1)
+
+		q := &query.Query{
+			Streams:       streams,
+			Bzl:           spawner,
+			IsInteractive: true,
+			GetAPrompt: func(label string) query.PromptRunner {
+				g.Expect(strings.Contains(label, "targettwo") || strings.Contains(label, "dependencytwo")).To(Equal(true))
+				return promptRunner
+			},
+			GetASelect: func(presetNames []string) query.SelectRunner {
+				return selectRunner
+			},
+		}
+		q.Presets = []*query.PresetQuery{
+			{
+				Name:        "why1",
+				Description: "Determine why a target depends on another",
+				Query:       "somepath(?targetone, ?dependencyone)",
+			},
+			{
+				Name:        "why2",
+				Description: "Determine why a target depends on another",
+				Query:       "somepath(?targettwo, ?dependencytwo)",
+			},
+			{
+				Name:        "why3",
+				Description: "Determine why a target depends on another",
+				Query:       "somepath(?targetthree, ?dependencythree)",
+			},
+		}
+		err := q.Run(nil, []string{})
+		g.Expect(err).To(BeNil())
 	})
 }


### PR DESCRIPTION
Add query functionality. Users can provide regular bazel queries that will be passed directly to bazel. Users can also take advantage of predefined queries that will simply prompt the user for bazel label(s) as needed