### PR TITLE
refactor: use buildeventstream alias for clarity

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 # TODO: follow https://sagikazarmark.hu/blog/vanity-import-paths-in-go/
 # so we have savvy go imports for users
 # gazelle:prefix aspect.build/cli
+# gazelle:resolve go aspect.build/cli/bazel/buildeventstream/proto //bazel/buildeventstream/proto
 gazelle(name = "gazelle")
 
 gazelle(

--- a/bazel/buildeventstream/proto/BUILD.bazel
+++ b/bazel/buildeventstream/proto/BUILD.bazel
@@ -1,1 +1,7 @@
 # gazelle:exclude dummy.go
+
+alias(
+    name = "proto",
+    actual = "//third-party/github.com/bazelbuild/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/aspect/build/bep/BUILD.bazel
+++ b/pkg/aspect/build/bep/BUILD.bazel
@@ -6,9 +6,9 @@ go_library(
     importpath = "aspect.build/cli/pkg/aspect/build/bep",
     visibility = ["//visibility:public"],
     deps = [
+        "//bazel/buildeventstream/proto",
         "//pkg/aspecterrors",
         "//pkg/aspectgrpc",
-        "//third-party/github.com/bazelbuild/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto",
         "@go_googleapis//google/devtools/build/v1:build_go_proto",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@org_golang_google_grpc//:go_default_library",
@@ -20,10 +20,10 @@ go_test(
     srcs = ["bes_backend_test.go"],
     embed = [":bep"],
     deps = [
+        "//bazel/buildeventstream/proto",
         "//pkg/aspecterrors",
         "//pkg/aspectgrpc/mock",
         "//pkg/stdlib/mock",
-        "//third-party/github.com/bazelbuild/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto",
         "@com_github_golang_mock//gomock",
         "@com_github_onsi_gomega//:gomega",
         "@go_googleapis//google/devtools/build/v1:build_go_proto",

--- a/pkg/plugin/sdk/v1alpha1/plugin/BUILD.bazel
+++ b/pkg/plugin/sdk/v1alpha1/plugin/BUILD.bazel
@@ -9,9 +9,9 @@ go_library(
     importpath = "aspect.build/cli/pkg/plugin/sdk/v1alpha1/plugin",
     visibility = ["//visibility:public"],
     deps = [
+        "//bazel/buildeventstream/proto",
         "//pkg/ioutils",
         "//pkg/plugin/sdk/v1alpha1/proto",
-        "//third-party/github.com/bazelbuild/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto",
         "@com_github_hashicorp_go_plugin//:go-plugin",
         "@com_github_manifoldco_promptui//:promptui",
         "@org_golang_google_grpc//:go_default_library",

--- a/plugins/fix-visibility/BUILD.bazel
+++ b/plugins/fix-visibility/BUILD.bazel
@@ -6,9 +6,9 @@ go_library(
     importpath = "aspect.build/cli/plugins/fix-visibility",
     visibility = ["//release:__pkg__"],
     deps = [
+        "//bazel/buildeventstream/proto",
         "//pkg/ioutils",
         "//pkg/plugin/sdk/v1alpha1/config",
-        "//third-party/github.com/bazelbuild/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto",
         "@bazel_gazelle//label:go_default_library",
         "@com_github_bazelbuild_buildtools//edit:go_default_library",
         "@com_github_hashicorp_go_plugin//:go-plugin",


### PR DESCRIPTION
Since the buildeventstream proto is vendored and lives under third-party, we do some workarounds to make it appear to come from //bazel/buildeventstream/proto.

We enforce it with Gazelle now. Makes it simpler to reason about when importing `aspect.build/cli/bazel/buildeventstream/proto`.