### PR TITLE
Implement WorkspaceFinder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bazel-*
 /.idea
 /.cache
+/.ijwb

--- a/cmd/aspect/build/BUILD.bazel
+++ b/cmd/aspect/build/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/bazel",
         "//pkg/hooks",
         "//pkg/ioutils",
+        "//pkg/pathutils",
         "//pkg/plugin/system",
         "@com_github_spf13_cobra//:cobra",
     ],

--- a/cmd/aspect/build/build.go
+++ b/cmd/aspect/build/build.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	rootFlags "aspect.build/cli/cmd/aspect/root/flags"
+	"aspect.build/cli/pkg/pathutils"
 	"aspect.build/cli/pkg/aspect/build"
 	"aspect.build/cli/pkg/aspect/build/bep"
 	"aspect.build/cli/pkg/bazel"
@@ -42,24 +43,26 @@ func NewBuildCmd(
 		Long: "Invokes bazel build on the specified targets. " +
 			"See 'bazel help target-syntax' for details and examples on how to specify targets to build.",
 		RunE: func(cmd *cobra.Command, args []string) (exitErr error) {
-			pluginSystem := system.NewPluginSystem()
-			if err := pluginSystem.Configure(streams); err != nil {
-				return err
-			}
-			defer pluginSystem.TearDown()
+			return pathutils.InvokeCmdInsideWorkspace(func(cmd *cobra.Command, args []string) error {
+				pluginSystem := system.NewPluginSystem()
+				if err := pluginSystem.Configure(streams); err != nil {
+					return err
+				}
+				defer pluginSystem.TearDown()
 
-			for node := pluginSystem.PluginList().Head; node != nil; node = node.Next {
-				besBackend.RegisterSubscriber(node.Plugin.BEPEventCallback)
-				hooks.RegisterPostBuild(node.Plugin.PostBuildHook)
-			}
+				for node := pluginSystem.PluginList().Head; node != nil; node = node.Next {
+					besBackend.RegisterSubscriber(node.Plugin.BEPEventCallback)
+					hooks.RegisterPostBuild(node.Plugin.PostBuildHook)
+				}
 
-			isInteractiveMode, err := cmd.Root().PersistentFlags().GetBool(rootFlags.InteractiveFlagName)
-			if err != nil {
-				return err
-			}
+				isInteractiveMode, err := cmd.Root().PersistentFlags().GetBool(rootFlags.InteractiveFlagName)
+				if err != nil {
+					return err
+				}
 
-			b := build.New(streams, bzl, besBackend, hooks)
-			return b.Run(cmd.Context(), cmd, args, isInteractiveMode)
+				buildCmd := build.New(streams, bzl, besBackend, hooks)
+				return buildCmd.Run(cmd.Context(), args, isInteractiveMode)
+			})(cmd, args)
 		},
 	}
 

--- a/cmd/aspect/clean/BUILD.bazel
+++ b/cmd/aspect/clean/BUILD.bazel
@@ -6,8 +6,9 @@ go_library(
     importpath = "aspect.build/cli/cmd/aspect/clean",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/aspect/root/flags",
         "//pkg/aspect/clean",
-        "@com_github_mattn_go_isatty//:go-isatty",
+        "//pkg/pathutils",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/cmd/aspect/docs/docs.go
+++ b/cmd/aspect/docs/docs.go
@@ -18,7 +18,7 @@ func NewDefaultDocsCmd() *cobra.Command {
 }
 
 func NewDocsCmd(streams ioutils.Streams) *cobra.Command {
-	v := docs.New(streams)
+	docsCmd := docs.New(streams)
 
 	cmd := &cobra.Command{
 		Use:   "docs",
@@ -26,7 +26,7 @@ func NewDocsCmd(streams ioutils.Streams) *cobra.Command {
 		Long: `Given a selected topic, open the relevant API docs in a browser window.
 The mechanism of choosing the browser to open is documented at https://github.com/pkg/browser
 By default, opens docs.bazel.build`,
-		RunE: v.Run,
+		RunE: docsCmd.Run,
 	}
 
 	return cmd

--- a/cmd/aspect/info/BUILD.bazel
+++ b/cmd/aspect/info/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/aspect/info",
         "//pkg/ioutils",
+        "//pkg/pathutils",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/cmd/aspect/info/info.go
+++ b/cmd/aspect/info/info.go
@@ -11,6 +11,7 @@ import (
 
 	"aspect.build/cli/pkg/aspect/info"
 	"aspect.build/cli/pkg/ioutils"
+	"aspect.build/cli/pkg/pathutils"
 )
 
 func NewDefaultInfoCmd() *cobra.Command {
@@ -18,7 +19,7 @@ func NewDefaultInfoCmd() *cobra.Command {
 }
 
 func NewInfoCmd(streams ioutils.Streams) *cobra.Command {
-	v := info.New(streams)
+	infoCmd := info.New(streams)
 
 	cmd := &cobra.Command{
 		Use:   "info",
@@ -42,10 +43,14 @@ the bazel User Manual, and can be programmatically obtained with
 See also 'bazel version' for more detailed bazel version
 information.`,
 		Args: cobra.MaximumNArgs(1),
-		RunE: v.Run,
+		RunE: func(cmd *cobra.Command, args []string) (exitErr error) {
+			return pathutils.InvokeCmdInsideWorkspace(func(cmd *cobra.Command, args []string) error {
+				return infoCmd.Run(cmd, args)
+			})(cmd, args)
+		},
 	}
 
-	cmd.PersistentFlags().BoolVarP(&v.ShowMakeEnv, "show_make_env", "", false, `include the set of key/value pairs in the "Make" environment,
+	cmd.PersistentFlags().BoolVarP(&infoCmd.ShowMakeEnv, "show_make_env", "", false, `include the set of key/value pairs in the "Make" environment,
 accessible within BUILD files`)
 	return cmd
 }

--- a/cmd/aspect/main.go
+++ b/cmd/aspect/main.go
@@ -34,8 +34,8 @@ func main() {
 	if wd, exists := os.LookupEnv("BUILD_WORKING_DIRECTORY"); exists {
 		_ = os.Chdir(wd)
 	}
-	cmd := root.NewDefaultRootCmd()
-	if err := cmd.ExecuteContext(context.Background()); err != nil {
+	rootCmd := root.NewDefaultRootCmd()
+	if err := rootCmd.ExecuteContext(context.Background()); err != nil {
 		var exitErr *aspecterrors.ExitError
 		if errors.As(err, &exitErr) {
 			if exitErr.Err != nil {

--- a/cmd/aspect/root/root.go
+++ b/cmd/aspect/root/root.go
@@ -37,7 +37,7 @@ func NewDefaultRootCmd() *cobra.Command {
 }
 
 func NewRootCmd(streams ioutils.Streams, defaultInteractive bool) *cobra.Command {
-	cmd := &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:           "aspect",
 		Short:         "Aspect.build bazel wrapper",
 		SilenceUsage:  true,
@@ -50,8 +50,8 @@ func NewRootCmd(streams ioutils.Streams, defaultInteractive bool) *cobra.Command
 	// ### Flags
 	var cfgFile string
 	var interactive bool
-	cmd.PersistentFlags().StringVar(&cfgFile, flags.ConfigFlagName, "", "config file (default is $HOME/.aspect.yaml)")
-	cmd.PersistentFlags().BoolVar(&interactive, flags.InteractiveFlagName, defaultInteractive, "Interactive mode (e.g. prompts for user input)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, flags.ConfigFlagName, "", "config file (default is $HOME/.aspect.yaml)")
+	rootCmd.PersistentFlags().BoolVar(&interactive, flags.InteractiveFlagName, defaultInteractive, "Interactive mode (e.g. prompts for user input)")
 
 	// ### Viper
 	if cfgFile != "" {
@@ -73,30 +73,30 @@ func NewRootCmd(streams ioutils.Streams, defaultInteractive bool) *cobra.Command
 
 	// ### Child commands
 	// IMPORTANT: when adding a new command, also update the _DOCS list in /docs/BUILD.bazel
-	cmd.AddCommand(build.NewDefaultBuildCmd())
-	cmd.AddCommand(clean.NewDefaultCleanCmd())
-	cmd.AddCommand(version.NewDefaultVersionCmd())
-	cmd.AddCommand(docs.NewDefaultDocsCmd())
-	cmd.AddCommand(info.NewDefaultInfoCmd())
-	cmd.AddCommand(test.NewDefaultTestCmd())
+	rootCmd.AddCommand(build.NewDefaultBuildCmd())
+	rootCmd.AddCommand(clean.NewDefaultCleanCmd())
+	rootCmd.AddCommand(version.NewDefaultVersionCmd())
+	rootCmd.AddCommand(docs.NewDefaultDocsCmd())
+	rootCmd.AddCommand(info.NewDefaultInfoCmd())
+	rootCmd.AddCommand(test.NewDefaultTestCmd())
 
 	// ### "Additional help topic commands" which are not runnable
 	// https://pkg.go.dev/github.com/spf13/cobra#Command.IsAdditionalHelpTopicCommand
-	cmd.AddCommand(&cobra.Command{
+	rootCmd.AddCommand(&cobra.Command{
 		Use:   "target-syntax",
 		Short: "Explains the syntax for specifying targets.",
 		Long:  topics.MustAssetString("target-syntax.md"),
 	})
-	cmd.AddCommand(&cobra.Command{
+	rootCmd.AddCommand(&cobra.Command{
 		Use:   "info-keys",
 		Short: "Displays a list of keys used by the info command.",
 		Long:  topics.MustAssetString("info-keys.md"),
 	})
-	cmd.AddCommand(&cobra.Command{
+	rootCmd.AddCommand(&cobra.Command{
 		Use:   "tags",
 		Short: "Conventions for tags which are special",
 		Long:  topics.MustAssetString("tags.md"),
 	})
 
-	return cmd
+	return rootCmd
 }

--- a/cmd/aspect/test/BUILD.bazel
+++ b/cmd/aspect/test/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/aspect/test",
         "//pkg/bazel",
         "//pkg/ioutils",
+        "//pkg/pathutils",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/cmd/aspect/test/test.go
+++ b/cmd/aspect/test/test.go
@@ -7,6 +7,7 @@ Not licensed for re-use
 package test
 
 import (
+	"aspect.build/cli/pkg/pathutils"
 	"github.com/spf13/cobra"
 
 	"aspect.build/cli/pkg/aspect/test"
@@ -19,7 +20,7 @@ func NewDefaultTestCmd() *cobra.Command {
 }
 
 func NewTestCmd(streams ioutils.Streams, bzl bazel.Spawner) *cobra.Command {
-	v := test.New(streams, bzl)
+	testCmd := test.New(streams, bzl)
 
 	cmd := &cobra.Command{
 		Use:   "test",
@@ -35,7 +36,11 @@ don't forget to pass all your 'build' options to 'test' too.
 See 'bazel help target-syntax' for details and examples on how to
 specify targets.
 `,
-		RunE: v.Run,
+		RunE: func(cmd *cobra.Command, args []string) (exitErr error) {
+			return pathutils.InvokeCmdInsideWorkspace(func(cmd *cobra.Command, args []string) error {
+				return testCmd.Run(cmd, args)
+			})(cmd, args)
+		},
 	}
 
 	return cmd

--- a/cmd/aspect/version/version.go
+++ b/cmd/aspect/version/version.go
@@ -19,19 +19,19 @@ func NewDefaultVersionCmd() *cobra.Command {
 }
 
 func NewVersionCmd(streams ioutils.Streams) *cobra.Command {
-	v := version.New(streams)
+	versionCmd := version.New(streams)
 
-	v.BuildinfoRelease = buildinfo.Release
-	v.BuildinfoGitStatus = buildinfo.GitStatus
+	versionCmd.BuildinfoRelease = buildinfo.Release
+	versionCmd.BuildinfoGitStatus = buildinfo.GitStatus
 
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version of aspect CLI as well as tools it invokes.",
 		Long:  `Prints version info on colon-separated lines, just like bazel does`,
-		RunE:  v.Run,
+		RunE:  versionCmd.Run,
 	}
 
-	cmd.PersistentFlags().BoolVarP(&v.GNUFormat, "gnu_format", "", false, "format space-separated following GNU convention")
+	cmd.PersistentFlags().BoolVarP(&versionCmd.GNUFormat, "gnu_format", "", false, "format space-separated following GNU convention")
 
 	return cmd
 }

--- a/pkg/aspect/build/BUILD.bazel
+++ b/pkg/aspect/build/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//pkg/bazel",
         "//pkg/hooks",
         "//pkg/ioutils",
-        "@com_github_spf13_cobra//:cobra",
     ],
 )
 

--- a/pkg/aspect/build/build_test.go
+++ b/pkg/aspect/build/build_test.go
@@ -60,9 +60,9 @@ func TestBuild(t *testing.T) {
 			Times(0)
 
 		hooks := hooks.New()
-		b := build.New(streams, spawner, besBackend, hooks)
+		buildCmd := build.New(streams, spawner, besBackend, hooks)
 		ctx := context.Background()
-		err := b.Run(ctx, nil, []string{"//..."}, false)
+		err := buildCmd.Run(ctx, []string{"//..."}, false)
 
 		g.Expect(err).To(MatchError(fmt.Errorf("failed to run build command: %w", setupErr)))
 	})
@@ -104,9 +104,9 @@ func TestBuild(t *testing.T) {
 			Times(0)
 
 		hooks := hooks.New()
-		b := build.New(streams, spawner, besBackend, hooks)
+		buildCmd := build.New(streams, spawner, besBackend, hooks)
 		ctx := context.Background()
-		err := b.Run(ctx, nil, []string{"//..."}, false)
+		err := buildCmd.Run(ctx, []string{"//..."}, false)
 
 		g.Expect(err).To(MatchError(fmt.Errorf("failed to run build command: %w", serveWaitErr)))
 	})
@@ -152,9 +152,9 @@ func TestBuild(t *testing.T) {
 			Times(1)
 
 		hooks := hooks.New()
-		b := build.New(streams, spawner, besBackend, hooks)
+		buildCmd := build.New(streams, spawner, besBackend, hooks)
 		ctx := context.Background()
-		err := b.Run(ctx, nil, []string{"//..."}, false)
+		err := buildCmd.Run(ctx, []string{"//..."}, false)
 
 		g.Expect(err).To(MatchError(expectErr))
 	})
@@ -201,9 +201,9 @@ func TestBuild(t *testing.T) {
 			Times(1)
 
 		hooks := hooks.New()
-		b := build.New(streams, spawner, besBackend, hooks)
+		buildCmd := build.New(streams, spawner, besBackend, hooks)
 		ctx := context.Background()
-		err := b.Run(ctx, nil, []string{"//..."}, false)
+		err := buildCmd.Run(ctx, []string{"//..."}, false)
 
 		g.Expect(err).To(MatchError(&aspecterrors.ExitError{ExitCode: 1}))
 		g.Expect(stderr.String()).To(Equal("Error: failed to run build command: error 1\nError: failed to run build command: error 2\n"))
@@ -247,9 +247,9 @@ func TestBuild(t *testing.T) {
 			Times(1)
 
 		hooks := hooks.New()
-		b := build.New(streams, spawner, besBackend, hooks)
+		buildCmd := build.New(streams, spawner, besBackend, hooks)
 		ctx := context.Background()
-		err := b.Run(ctx, nil, []string{"//..."}, false)
+		err := buildCmd.Run(ctx, []string{"//..."}, false)
 
 		g.Expect(err).To(BeNil())
 	})

--- a/pkg/aspect/clean/BUILD.bazel
+++ b/pkg/aspect/clean/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//pkg/bazel",
         "//pkg/ioutils",
         "@com_github_manifoldco_promptui//:promptui",
-        "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_viper//:viper",
     ],
 )

--- a/pkg/aspect/clean/clean.go
+++ b/pkg/aspect/clean/clean.go
@@ -55,7 +55,6 @@ type PromptRunner interface {
 type Clean struct {
 	ioutils.Streams
 	bzl               bazel.Spawner
-	isInteractiveMode bool
 
 	Behavior   SelectRunner
 	Workaround PromptRunner
@@ -105,7 +104,7 @@ func NewDefault() *Clean {
 // Run runs the aspect clean command.
 func (cleanCmd *Clean) Run(isInteractiveMode bool) error {
 	skip := cleanCmd.Prefs.GetBool(skipPromptKey)
-	if cleanCmd.isInteractiveMode && !skip {
+	if isInteractiveMode && !skip {
 
 		_, chosen, err := cleanCmd.Behavior.Run()
 

--- a/pkg/aspect/clean/clean_test.go
+++ b/pkg/aspect/clean/clean_test.go
@@ -161,9 +161,9 @@ func TestClean(t *testing.T) {
 		g.Expect(string(content)).To(Equal("[clean]\nskip_prompt=true\n\n"))
 
 		// If we run it again, there should be no prompt
-		cleanCmd := clean.New(streams, spawner)
-		cleanCmd.Prefs = viper
-		g.Expect(cleanCmd.Run(true)).Should(Succeed())
+		cleanCmd2 := clean.New(streams, spawner)
+		cleanCmd2.Prefs = viper
+		g.Expect(cleanCmd2.Run(true)).Should(Succeed())
 	})
 
 	t.Run("interactive clean prompts for usage, option 2", func(t *testing.T) {

--- a/pkg/aspect/clean/clean_test.go
+++ b/pkg/aspect/clean/clean_test.go
@@ -71,8 +71,8 @@ func TestClean(t *testing.T) {
 			Spawn([]string{"clean"}).
 			Return(0, nil)
 
-		b := clean.New(ioutils.Streams{}, spawner, false)
-		g.Expect(b.Run(nil, []string{})).Should(Succeed())
+		cleanCmd := clean.New(ioutils.Streams{}, spawner)
+		g.Expect(cleanCmd.Run(false)).Should(Succeed())
 	})
 
 	t.Run("clean expunge calls bazel clean expunge", func(t *testing.T) {
@@ -86,9 +86,9 @@ func TestClean(t *testing.T) {
 			Spawn([]string{"clean", "--expunge"}).
 			Return(0, nil)
 
-		b := clean.New(ioutils.Streams{}, spawner, false)
-		b.Expunge = true
-		g.Expect(b.Run(nil, []string{})).Should(Succeed())
+		cleanCmd := clean.New(ioutils.Streams{}, spawner)
+		cleanCmd.Expunge = true
+		g.Expect(cleanCmd.Run(false)).Should(Succeed())
 	})
 
 	t.Run("clean expunge_async calls bazel clean expunge_async", func(t *testing.T) {
@@ -102,9 +102,9 @@ func TestClean(t *testing.T) {
 			Spawn([]string{"clean", "--expunge_async"}).
 			Return(0, nil)
 
-		b := clean.New(ioutils.Streams{}, spawner, false)
-		b.ExpungeAsync = true
-		g.Expect(b.Run(nil, []string{})).Should(Succeed())
+		cleanCmd := clean.New(ioutils.Streams{}, spawner)
+		cleanCmd.ExpungeAsync = true
+		g.Expect(cleanCmd.Run(false)).Should(Succeed())
 	})
 
 	t.Run("interactive clean prompts for usage, option 1", func(t *testing.T) {
@@ -120,12 +120,12 @@ func TestClean(t *testing.T) {
 
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
-		b := clean.New(streams, spawner, true)
+		cleanCmd := clean.New(streams, spawner)
 
-		b.Behavior = chooseReclaim{}
-		b.Remember = deny{}
+		cleanCmd.Behavior = chooseReclaim{}
+		cleanCmd.Remember = deny{}
 
-		g.Expect(b.Run(nil, []string{})).Should(Succeed())
+		g.Expect(cleanCmd.Run(true)).Should(Succeed())
 		g.Expect(stdout.String()).To(ContainSubstring("skip this prompt"))
 	})
 
@@ -142,17 +142,17 @@ func TestClean(t *testing.T) {
 
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
-		b := clean.New(streams, spawner, true)
+		cleanCmd1 := clean.New(streams, spawner)
 
 		viper := *viper.New()
 		cfg, err := os.CreateTemp(os.Getenv("TEST_TMPDIR"), "cfg***.ini")
 		g.Expect(err).To(BeNil())
 
 		viper.SetConfigFile(cfg.Name())
-		b.Behavior = chooseReclaim{}
-		b.Remember = confirm{}
-		b.Prefs = viper
-		g.Expect(b.Run(nil, []string{})).Should(Succeed())
+		cleanCmd1.Behavior = chooseReclaim{}
+		cleanCmd1.Remember = confirm{}
+		cleanCmd1.Prefs = viper
+		g.Expect(cleanCmd1.Run(true)).Should(Succeed())
 		g.Expect(stdout.String()).To(ContainSubstring("skip this prompt"))
 
 		// Recorded your preference for next time
@@ -161,9 +161,9 @@ func TestClean(t *testing.T) {
 		g.Expect(string(content)).To(Equal("[clean]\nskip_prompt=true\n\n"))
 
 		// If we run it again, there should be no prompt
-		c := clean.New(streams, spawner, true)
-		c.Prefs = viper
-		g.Expect(c.Run(nil, []string{})).Should(Succeed())
+		cleanCmd := clean.New(streams, spawner)
+		cleanCmd.Prefs = viper
+		g.Expect(cleanCmd.Run(true)).Should(Succeed())
 	})
 
 	t.Run("interactive clean prompts for usage, option 2", func(t *testing.T) {
@@ -171,9 +171,9 @@ func TestClean(t *testing.T) {
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
 
-		c := clean.New(streams, nil, true)
-		c.Behavior = chooseNonIncremental{}
-		g.Expect(c.Run(nil, []string{})).Should(Succeed())
+		cleanCmd := clean.New(streams, nil)
+		cleanCmd.Behavior = chooseNonIncremental{}
+		g.Expect(cleanCmd.Run(true)).Should(Succeed())
 		g.Expect(stdout.String()).To(ContainSubstring("use the --output_base flag"))
 	})
 
@@ -182,9 +182,9 @@ func TestClean(t *testing.T) {
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
 
-		c := clean.New(streams, nil, true)
-		c.Behavior = chooseInvalidateRepos{}
-		g.Expect(c.Run(nil, []string{})).Should(Succeed())
+		cleanCmd := clean.New(streams, nil)
+		cleanCmd.Behavior = chooseInvalidateRepos{}
+		g.Expect(cleanCmd.Run(true)).Should(Succeed())
 		g.Expect(stdout.String()).To(ContainSubstring("aspect sync --configure"))
 	})
 
@@ -202,10 +202,10 @@ func TestClean(t *testing.T) {
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
 
-		c := clean.New(streams, spawner, true)
-		c.Behavior = chooseWorkaround{}
-		c.Workaround = confirm{}
-		g.Expect(c.Run(nil, []string{})).Should(Succeed())
+		cleanCmd := clean.New(streams, spawner)
+		cleanCmd.Behavior = chooseWorkaround{}
+		cleanCmd.Workaround = confirm{}
+		g.Expect(cleanCmd.Run(true)).Should(Succeed())
 		g.Expect(stdout.String()).To(ContainSubstring("recommend you file a bug"))
 	})
 }

--- a/pkg/aspect/info/info.go
+++ b/pkg/aspect/info/info.go
@@ -7,11 +7,11 @@ Not licensed for re-use.
 package info
 
 import (
-	"aspect.build/cli/pkg/bazel"
-	"aspect.build/cli/pkg/ioutils"
 	"github.com/spf13/cobra"
 
 	"aspect.build/cli/pkg/aspecterrors"
+	"aspect.build/cli/pkg/bazel"
+	"aspect.build/cli/pkg/ioutils"
 )
 
 type Info struct {
@@ -26,9 +26,9 @@ func New(streams ioutils.Streams) *Info {
 	}
 }
 
-func (v *Info) Run(_ *cobra.Command, args []string) error {
+func (infoCmd *Info) Run(_ *cobra.Command, args []string) error {
 	bazelCmd := []string{"info"}
-	if v.ShowMakeEnv {
+	if infoCmd.ShowMakeEnv {
 		// Propagate the flag
 		bazelCmd = append(bazelCmd, "--show_make_env")
 	}

--- a/pkg/aspect/test/test.go
+++ b/pkg/aspect/test/test.go
@@ -14,19 +14,19 @@ import (
 	"aspect.build/cli/pkg/aspecterrors"
 )
 
-type Test struct {
+type TestCmd struct {
 	ioutils.Streams
 	bzl bazel.Spawner
 }
 
-func New(streams ioutils.Streams, bzl bazel.Spawner) *Test {
-	return &Test{
+func New(streams ioutils.Streams, bzl bazel.Spawner) *TestCmd {
+	return &TestCmd{
 		Streams: streams,
 		bzl:     bzl,
 	}
 }
 
-func (v *Test) Run(_ *cobra.Command, args []string) error {
+func (v *TestCmd) Run(_ *cobra.Command, args []string) error {
 	bazelCmd := []string{"test"}
 	bazelCmd = append(bazelCmd, args...)
 

--- a/pkg/aspect/test/test_test.go
+++ b/pkg/aspect/test/test_test.go
@@ -3,11 +3,12 @@ package test_test
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+
 	"aspect.build/cli/pkg/aspect/test"
 	"aspect.build/cli/pkg/bazel/mock"
 	"aspect.build/cli/pkg/ioutils"
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/gomega"
 )
 
 // Embrace the stutter :)
@@ -24,7 +25,7 @@ func TestTest(t *testing.T) {
 			Spawn([]string{"test"}).
 			Return(0, nil)
 
-		b := test.New(ioutils.Streams{}, spawner)
-		g.Expect(b.Run(nil, []string{})).Should(Succeed())
+		testCmd := test.New(ioutils.Streams{}, spawner)
+		g.Expect(testCmd.Run(nil, []string{})).Should(Succeed())
 	})
 }

--- a/pkg/aspect/version/version.go
+++ b/pkg/aspect/version/version.go
@@ -30,11 +30,11 @@ func New(streams ioutils.Streams) *Version {
 	}
 }
 
-func (v *Version) Run(_ *cobra.Command, _ []string) error {
+func (versionCmd *Version) Run(_ *cobra.Command, _ []string) error {
 	var versionBuilder strings.Builder
-	if v.BuildinfoRelease != "" {
-		versionBuilder.WriteString(v.BuildinfoRelease)
-		if v.BuildinfoGitStatus != "clean" {
+	if versionCmd.BuildinfoRelease != "" {
+		versionBuilder.WriteString(versionCmd.BuildinfoRelease)
+		if versionCmd.BuildinfoGitStatus != "clean" {
 			versionBuilder.WriteString(" (with local changes)")
 		}
 	} else {
@@ -44,12 +44,12 @@ func (v *Version) Run(_ *cobra.Command, _ []string) error {
 	// Check if the --gnu_format flag is set, if that is the case,
 	// the version is printed differently
 	bazelCmd := []string{"version"}
-	if v.GNUFormat {
-		fmt.Fprintf(v.Stdout, "Aspect %s\n", version)
+	if versionCmd.GNUFormat {
+		fmt.Fprintf(versionCmd.Stdout, "Aspect %s\n", version)
 		// Propagate the flag
 		bazelCmd = append(bazelCmd, "--gnu_format")
 	} else {
-		fmt.Fprintf(v.Stdout, "Aspect version: %s\n", version)
+		fmt.Fprintf(versionCmd.Stdout, "Aspect version: %s\n", version)
 	}
 	bzl := bazel.New()
 	bzl.Spawn(bazelCmd)

--- a/pkg/aspect/version/version_test.go
+++ b/pkg/aspect/version/version_test.go
@@ -21,8 +21,8 @@ func TestVersion(t *testing.T) {
 		g := NewGomegaWithT(t)
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
-		v := version.New(streams)
-		err := v.Run(nil, nil)
+		versionCmd := version.New(streams)
+		err := versionCmd.Run(nil, nil)
 		g.Expect(err).To(BeNil())
 		g.Expect(stdout.String()).To(Equal("Aspect version: unknown [not built with --stamp]\n"))
 	})
@@ -32,10 +32,10 @@ func TestVersion(t *testing.T) {
 			g := NewGomegaWithT(t)
 			var stdout strings.Builder
 			streams := ioutils.Streams{Stdout: &stdout}
-			v := version.New(streams)
-			v.BuildinfoRelease = "1.2.3"
-			v.BuildinfoGitStatus = "clean"
-			err := v.Run(nil, nil)
+			versionCmd := version.New(streams)
+			versionCmd.BuildinfoRelease = "1.2.3"
+			versionCmd.BuildinfoGitStatus = "clean"
+			err := versionCmd.Run(nil, nil)
 			g.Expect(err).To(BeNil())
 			g.Expect(stdout.String()).To(Equal("Aspect version: 1.2.3\n"))
 		})
@@ -44,10 +44,10 @@ func TestVersion(t *testing.T) {
 			g := NewGomegaWithT(t)
 			var stdout strings.Builder
 			streams := ioutils.Streams{Stdout: &stdout}
-			v := version.New(streams)
-			v.BuildinfoRelease = "1.2.3"
-			v.BuildinfoGitStatus = ""
-			err := v.Run(nil, nil)
+			versionCmd := version.New(streams)
+			versionCmd.BuildinfoRelease = "1.2.3"
+			versionCmd.BuildinfoGitStatus = ""
+			err := versionCmd.Run(nil, nil)
 			g.Expect(err).To(BeNil())
 			g.Expect(stdout.String()).To(Equal("Aspect version: 1.2.3 (with local changes)\n"))
 		})
@@ -57,11 +57,11 @@ func TestVersion(t *testing.T) {
 		g := NewGomegaWithT(t)
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
-		v := version.New(streams)
-		v.GNUFormat = true
-		v.BuildinfoRelease = "1.2.3"
-		v.BuildinfoGitStatus = "clean"
-		err := v.Run(nil, nil)
+		versionCmd := version.New(streams)
+		versionCmd.GNUFormat = true
+		versionCmd.BuildinfoRelease = "1.2.3"
+		versionCmd.BuildinfoGitStatus = "clean"
+		err := versionCmd.Run(nil, nil)
 		g.Expect(err).To(BeNil())
 		g.Expect(stdout.String()).To(Equal("Aspect 1.2.3\n"))
 	})

--- a/pkg/bazel/BUILD.bazel
+++ b/pkg/bazel/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "aspect.build/cli/pkg/bazel",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//pkg/pathutils",
         "@com_github_bazelbuild_bazelisk//core:go_default_library",
         "@com_github_bazelbuild_bazelisk//httputil:go_default_library",
         "@com_github_bazelbuild_bazelisk//platforms:go_default_library",

--- a/pkg/pathutils/BUILD.bazel
+++ b/pkg/pathutils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "pathutils",
@@ -6,4 +6,18 @@ go_library(
     importpath = "aspect.build/cli/pkg/pathutils",
     visibility = ["//visibility:public"],
     deps = ["@com_github_spf13_cobra//:cobra"],
+)
+
+go_test(
+    name = "pathutils_test",
+    srcs = ["pathutils_test.go"],
+    data = glob(["testfixtures/**/*"]),
+    deps = [
+        ":pathutils",
+        "//cmd/aspect/info",
+        "//pkg/aspect/info",
+        "//pkg/ioutils",
+        "@com_github_onsi_gomega//:gomega",
+        "@com_github_spf13_cobra//:cobra",
+    ],
 )

--- a/pkg/pathutils/BUILD.bazel
+++ b/pkg/pathutils/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "pathutils",
+    srcs = ["pathutils.go"],
+    importpath = "aspect.build/cli/pkg/pathutils",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_spf13_cobra//:cobra"],
+)

--- a/pkg/pathutils/pathutils.go
+++ b/pkg/pathutils/pathutils.go
@@ -17,8 +17,6 @@ import (
 
 // https://github.com/bazelbuild/bazel/blob/8346ea4c/src/main/cpp/workspace_layout.cc#L37
 var workspaceFilenames = []string{"WORKSPACE", "WORKSPACE.bazel"}
-// TODO: create package finder
-var packageFilenames = []string{"BUILD", "BUILD.bazel"}
 
 type RunFn func(cmd *cobra.Command, args []string) (exitErr error)
 
@@ -60,7 +58,6 @@ func NewDefaultWorkspaceFinder() *WorkspaceFinder {
 // Find finds the WORKSPACE file under a Bazel workspace. If the returned
 // path is empty and no error was produced, the user's current working directory
 // is not a Bazel workspace.
-// TODO create unit tests
 func (f *WorkspaceFinder) Find(cwd string) (string, error) {
 	for {
 		if cwd == "." {

--- a/pkg/pathutils/pathutils.go
+++ b/pkg/pathutils/pathutils.go
@@ -1,0 +1,82 @@
+/*
+Copyright © 2021 Aspect Build Systems Inc
+Not licensed for re-use.
+*/
+
+package pathutils
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// https://github.com/bazelbuild/bazel/blob/8346ea4c/src/main/cpp/workspace_layout.cc#L37
+var workspaceFilenames = []string{"WORKSPACE", "WORKSPACE.bazel"}
+// TODO: create package finder
+var packageFilenames = []string{"BUILD", "BUILD.bazel"}
+
+type RunFn func(cmd *cobra.Command, args []string) (exitErr error)
+
+func InvokeCmdInsideWorkspace(toRun RunFn) (wrapped RunFn) {
+	return func(cmd *cobra.Command, args []string) (exitErr error) {
+		finder := NewDefaultWorkspaceFinder()
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to run command %q inside workspace: %w", cmd.Use, err)
+		}
+		workspacePath, err := finder.Find(cwd)
+		if err != nil {
+			return fmt.Errorf("failed to run command %q inside workspace: %w", cmd.Use, err)
+		}
+		if workspacePath == "" {
+			err = fmt.Errorf("the current working directory %q is not a bazel workspace", cwd)
+			return fmt.Errorf("failed to run command %q inside workspace: %w", cmd.Use, err)
+		}
+		return toRun(cmd, args)
+	}
+}
+
+// WorkspaceFinder is the interface that wraps the simple Find method that performs the
+// finding of the WORKSPACE file in the user's Bazel project.
+type WorkspaceFinder struct {
+	osGetwd func() (string, error)
+	osStat  func(string) (fs.FileInfo, error)
+}
+
+// NewDefaultWorkspaceFinder instantiates a default internal implementation of the WorkspaceFinder
+// interface.
+func NewDefaultWorkspaceFinder() *WorkspaceFinder {
+	return &WorkspaceFinder{
+		osGetwd: os.Getwd,
+		osStat:  os.Stat,
+	}
+}
+
+// Find finds the WORKSPACE file under a Bazel workspace. If the returned
+// path is empty and no error was produced, the user's current working directory
+// is not a Bazel workspace.
+// TODO create unit tests
+func (f *WorkspaceFinder) Find(cwd string) (string, error) {
+	for {
+		if cwd == "." {
+			return "", nil
+		}
+		for _, workspaceFilename := range workspaceFilenames {
+			workspacePath := path.Join(cwd, workspaceFilename)
+			_, err := f.osStat(workspacePath)
+
+			if err == nil {
+				return workspacePath, nil
+			}
+			if !os.IsNotExist(err) {
+				return "", fmt.Errorf("failed to find bazel workspace: %w", err)
+			}
+			cwd = filepath.Dir(cwd)
+		}
+	}
+}

--- a/pkg/pathutils/pathutils_test.go
+++ b/pkg/pathutils/pathutils_test.go
@@ -1,0 +1,57 @@
+package pathutils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	. "github.com/onsi/gomega"
+
+	"aspect.build/cli/pkg/ioutils"
+	"aspect.build/cli/pkg/pathutils"
+	infocmd "aspect.build/cli/cmd/aspect/info"
+	infopkg "aspect.build/cli/pkg/aspect/info"
+)
+
+func TestInvokeCmdInsideWorkspace(t *testing.T) {
+
+	t.Run("invoke info inside a workspace", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		workingDirectory, err := os.Getwd()
+		g.Expect(err).To(BeNil())
+		// Set $HOME, which is needed to create a cache directory for Bazel
+		err = os.Setenv("HOME", workingDirectory)
+		g.Expect(err).To(BeNil())
+		// cd into workspace within test fixtures
+		err = os.Chdir(filepath.Join(workingDirectory, "testfixtures/workspace_1"))
+		g.Expect(err).To(BeNil())
+
+		infoCmd := infopkg.New(ioutils.Streams{})
+		err = infoCmd.Run(nil, nil)
+
+		err = pathutils.InvokeCmdInsideWorkspace(func(cmd *cobra.Command, args []string) error {
+			infoCmd := infopkg.New(ioutils.Streams{})
+			return infoCmd.Run(nil, nil)
+		})(infocmd.NewDefaultInfoCmd(), []string{})
+
+		g.Expect(err).To(BeNil())
+
+		// cd back to original working directory
+		err = os.Chdir(workingDirectory)
+		g.Expect(err).To(BeNil())
+	})
+
+	t.Run("invoke info outside workspace", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		err := pathutils.InvokeCmdInsideWorkspace(func(cmd *cobra.Command, args []string) error {
+			infoCmd := infopkg.New(ioutils.Streams{})
+			return infoCmd.Run(nil, nil)
+		})(infocmd.NewDefaultInfoCmd(), []string{})
+
+		g.Expect(err).To(Equal(fmt.Errorf("the 'info' command is only supported from within a workspace " +
+			"(below a directory having a WORKSPACE file)")))
+	})
+}


### PR DESCRIPTION
- Introduce `pkg/pathutils/pathutils.go` with `WorskpaceFinder`
- Refactor `build`, `test`, `clean`, `info` commands to use `InvokeCmdInsideWorkspace` 
- Cleanup refactor of single letter command variables