### PR TITLE
feat: run command

### DIFF
--- a/cmd/aspect/root/BUILD.bazel
+++ b/cmd/aspect/root/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//cmd/aspect/docs",
         "//cmd/aspect/info",
         "//cmd/aspect/root/flags",
+        "//cmd/aspect/run",
         "//cmd/aspect/test",
         "//cmd/aspect/version",
         "//docs/help/topics",

--- a/cmd/aspect/root/root.go
+++ b/cmd/aspect/root/root.go
@@ -20,6 +20,7 @@ import (
 	"aspect.build/cli/cmd/aspect/docs"
 	"aspect.build/cli/cmd/aspect/info"
 	"aspect.build/cli/cmd/aspect/root/flags"
+	"aspect.build/cli/cmd/aspect/run"
 	"aspect.build/cli/cmd/aspect/test"
 	"aspect.build/cli/cmd/aspect/version"
 	"aspect.build/cli/docs/help/topics"
@@ -80,10 +81,11 @@ func NewRootCmd(
 	// IMPORTANT: when adding a new command, also update the _DOCS list in /docs/BUILD.bazel
 	cmd.AddCommand(build.NewDefaultBuildCmd(pluginSystem))
 	cmd.AddCommand(clean.NewDefaultCleanCmd())
-	cmd.AddCommand(version.NewDefaultVersionCmd())
 	cmd.AddCommand(docs.NewDefaultDocsCmd())
 	cmd.AddCommand(info.NewDefaultInfoCmd())
+	cmd.AddCommand(run.NewDefaultRunCmd(pluginSystem))
 	cmd.AddCommand(test.NewDefaultTestCmd(pluginSystem))
+	cmd.AddCommand(version.NewDefaultVersionCmd())
 
 	// ### "Additional help topic commands" which are not runnable
 	// https://pkg.go.dev/github.com/spf13/cobra#Command.IsAdditionalHelpTopicCommand

--- a/cmd/aspect/run/BUILD.bazel
+++ b/cmd/aspect/run/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "run",
+    srcs = ["run.go"],
+    importpath = "aspect.build/cli/cmd/aspect/run",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/aspect/run",
+        "//pkg/bazel",
+        "//pkg/interceptors",
+        "//pkg/ioutils",
+        "//pkg/plugin/system",
+        "//pkg/plugin/system/bep",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/cmd/aspect/run/run.go
+++ b/cmd/aspect/run/run.go
@@ -1,0 +1,64 @@
+/*
+Copyright © 2021 Aspect Build Systems
+
+Not licensed for re-use
+*/
+
+package run
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"aspect.build/cli/pkg/aspect/run"
+	"aspect.build/cli/pkg/bazel"
+	"aspect.build/cli/pkg/interceptors"
+	"aspect.build/cli/pkg/ioutils"
+	"aspect.build/cli/pkg/plugin/system"
+	"aspect.build/cli/pkg/plugin/system/bep"
+)
+
+// NewDefaultRunCmd creates a new run cobra command with the default
+// dependencies.
+func NewDefaultRunCmd(pluginSystem system.PluginSystem) *cobra.Command {
+	return NewRunCmd(
+		ioutils.DefaultStreams,
+		pluginSystem,
+		bazel.New(),
+	)
+}
+
+func NewRunCmd(
+	streams ioutils.Streams,
+	pluginSystem system.PluginSystem,
+	bzl bazel.Bazel,
+) *cobra.Command {
+	return &cobra.Command{
+		Use:   "run",
+		Short: "Builds the specified target and runs it with the given arguments.",
+		Long: `'run' accepts any 'build' options, and will inherit any defaults
+provided by .bazelrc.
+
+TODO(f0rmiga): the following comment from 'bazel --help run' may not be what we
+want to provide to our users.
+If your script needs stdin or execution not constrained by the bazel lock,
+use 'bazel run --script_path' to write a script and then execute it.
+`,
+		RunE: interceptors.Run(
+			[]interceptors.Interceptor{
+				interceptors.WorkspaceRootInterceptor(),
+				pluginSystem.BESBackendInterceptor(),
+			},
+			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
+				// TODO(f0rmiga): post-run hook.
+
+				workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
+				bzl.SetWorkspaceRoot(workspaceRoot)
+				r := run.New(streams, bzl)
+				besBackend := ctx.Value(system.BESBackendInterceptorKey).(bep.BESBackend)
+				return r.Run(args, besBackend)
+			},
+		),
+	}
+}

--- a/cmd/aspect/run/run.go
+++ b/cmd/aspect/run/run.go
@@ -37,11 +37,11 @@ func NewRunCmd(
 	return &cobra.Command{
 		Use:   "run",
 		Short: "Builds the specified target and runs it with the given arguments.",
+		// TODO(f0rmiga): the following comment from 'bazel --help run' may not
+		// be what we want to provide to our users.
 		Long: `'run' accepts any 'build' options, and will inherit any defaults
 provided by .bazelrc.
 
-TODO(f0rmiga): the following comment from 'bazel --help run' may not be what we
-want to provide to our users.
 If your script needs stdin or execution not constrained by the bazel lock,
 use 'bazel run --script_path' to write a script and then execute it.
 `,

--- a/docs/aspect.md
+++ b/docs/aspect.md
@@ -20,6 +20,7 @@ Aspect CLI is a better frontend for running bazel
 * [aspect clean](aspect_clean.md)	 - Removes the output tree.
 * [aspect docs](aspect_docs.md)	 - Open documentation in the browser.
 * [aspect info](aspect_info.md)	 - Displays runtime info about the bazel server.
+* [aspect run](aspect_run.md)	 - Builds the specified target and runs it with the given arguments.
 * [aspect test](aspect_test.md)	 - Builds the specified targets and runs all test targets among them.
 * [aspect version](aspect_version.md)	 - Print the version of aspect CLI as well as tools it invokes.
 

--- a/pkg/aspect/run/BUILD.bazel
+++ b/pkg/aspect/run/BUILD.bazel
@@ -1,10 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "test",
-    srcs = ["test.go"],
-    importpath = "aspect.build/cli/pkg/aspect/test",
-    visibility = ["//visibility:public"],
+    name = "run",
+    srcs = ["run.go"],
+    importpath = "aspect.build/cli/pkg/aspect/run",
+    visibility = ["//cmd/aspect/run:__pkg__"],
     deps = [
         "//pkg/aspecterrors",
         "//pkg/bazel",
@@ -14,10 +14,11 @@ go_library(
 )
 
 go_test(
-    name = "test_test",
-    srcs = ["test_test.go"],
+    name = "run_test",
+    srcs = ["run_test.go"],
     deps = [
-        ":test",
+        ":run",
+        "//pkg/aspecterrors",
         "//pkg/bazel/mock",
         "//pkg/ioutils",
         "//pkg/plugin/system/bep/mock",

--- a/pkg/aspect/run/run.go
+++ b/pkg/aspect/run/run.go
@@ -1,0 +1,59 @@
+/*
+Copyright © 2021 Aspect Build Systems Inc
+
+Not licensed for re-use.
+*/
+
+package run
+
+import (
+	"fmt"
+
+	"aspect.build/cli/pkg/aspecterrors"
+	"aspect.build/cli/pkg/bazel"
+	"aspect.build/cli/pkg/ioutils"
+	"aspect.build/cli/pkg/plugin/system/bep"
+)
+
+// Run represents the aspect run command.
+type Run struct {
+	ioutils.Streams
+	bzl bazel.Bazel
+}
+
+// New creates a Run command.
+func New(
+	streams ioutils.Streams,
+	bzl bazel.Bazel,
+) *Run {
+	return &Run{
+		Streams: streams,
+		bzl:     bzl,
+	}
+}
+
+// Run runs the aspect run command, calling `bazel run` with a local Build
+// Event Protocol backend used by Aspect plugins to subscribe to build events.
+func (cmd *Run) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
+	besBackendFlag := fmt.Sprintf("--bes_backend=grpc://%s", besBackend.Addr())
+	exitCode, bazelErr := cmd.bzl.Spawn(append([]string{"run", besBackendFlag}, args...))
+
+	// Process the subscribers errors before the Bazel one.
+	subscriberErrors := besBackend.Errors()
+	if len(subscriberErrors) > 0 {
+		for _, err := range subscriberErrors {
+			fmt.Fprintf(cmd.Streams.Stderr, "Error: failed to run 'aspect run' command: %v\n", err)
+		}
+		exitCode = 1
+	}
+
+	if exitCode != 0 {
+		err := &aspecterrors.ExitError{ExitCode: exitCode}
+		if bazelErr != nil {
+			err.Err = bazelErr
+		}
+		return err
+	}
+
+	return nil
+}

--- a/pkg/aspect/run/run_test.go
+++ b/pkg/aspect/run/run_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright © 2021 Aspect Build Systems Inc
+
+Not licensed for re-use.
+*/
+
+package run_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+
+	"aspect.build/cli/pkg/aspect/run"
+	"aspect.build/cli/pkg/aspecterrors"
+	bazel_mock "aspect.build/cli/pkg/bazel/mock"
+	"aspect.build/cli/pkg/ioutils"
+	bep_mock "aspect.build/cli/pkg/plugin/system/bep/mock"
+)
+
+func TestRun(t *testing.T) {
+	t.Run("when the bazel runner fails, the aspect run fails", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		streams := ioutils.Streams{}
+		bzl := bazel_mock.NewMockBazel(ctrl)
+		expectErr := &aspecterrors.ExitError{
+			Err:      fmt.Errorf("failed to run bazel run"),
+			ExitCode: 5,
+		}
+		bzl.
+			EXPECT().
+			Spawn([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}).
+			Return(expectErr.ExitCode, expectErr.Err)
+		besBackend := bep_mock.NewMockBESBackend(ctrl)
+		besBackend.
+			EXPECT().
+			Addr().
+			Return("127.0.0.1:12345").
+			Times(1)
+		besBackend.
+			EXPECT().
+			Errors().
+			Times(1)
+
+		b := run.New(streams, bzl)
+		err := b.Run([]string{"//..."}, besBackend)
+
+		g.Expect(err).To(MatchError(expectErr))
+	})
+
+	t.Run("when the BES backend contains errors, the aspect run fails", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		var stderr strings.Builder
+		streams := ioutils.Streams{Stderr: &stderr}
+		bzl := bazel_mock.NewMockBazel(ctrl)
+		bzl.
+			EXPECT().
+			Spawn([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}).
+			Return(0, nil)
+		besBackend := bep_mock.NewMockBESBackend(ctrl)
+		besBackend.
+			EXPECT().
+			Addr().
+			Return("127.0.0.1:12345").
+			Times(1)
+		besBackend.
+			EXPECT().
+			Errors().
+			Return([]error{
+				fmt.Errorf("error 1"),
+				fmt.Errorf("error 2"),
+			}).
+			Times(1)
+
+		b := run.New(streams, bzl)
+		err := b.Run([]string{"//..."}, besBackend)
+
+		g.Expect(err).To(MatchError(&aspecterrors.ExitError{ExitCode: 1}))
+		g.Expect(stderr.String()).To(Equal("Error: failed to run 'aspect run' command: error 1\nError: failed to run 'aspect run' command: error 2\n"))
+	})
+
+	t.Run("when the bazel runner succeeds, the aspect run succeeds", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		streams := ioutils.Streams{}
+		bzl := bazel_mock.NewMockBazel(ctrl)
+		bzl.
+			EXPECT().
+			Spawn([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}).
+			Return(0, nil)
+		besBackend := bep_mock.NewMockBESBackend(ctrl)
+		besBackend.
+			EXPECT().
+			Addr().
+			Return("127.0.0.1:12345").
+			Times(1)
+		besBackend.
+			EXPECT().
+			Errors().
+			Times(1)
+
+		b := run.New(streams, bzl)
+		err := b.Run([]string{"//..."}, besBackend)
+
+		g.Expect(err).To(BeNil())
+	})
+}


### PR DESCRIPTION
Introduces the `aspect run` command. This PR only adds the command based on the pattern we did for `aspect build` and `aspect test`. The hooks and further functionality are going to be added in separate PRs.