### PR TITLE
fix: short-circuit allowed files check on CI

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Validate changed files
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'allow sdk change')
+        run: ./.github/workflows/validate_changed_files.sh ${{ github.head_ref }} ${{ github.base_ref }}
       - uses: bazelbuild/setup-bazelisk@v1
       - name: Bazel caches
         uses: actions/cache@v2
@@ -22,9 +25,6 @@ jobs:
             ~/.cache/bazel
             ~/.cache/bazel-repo
           key: bazel-cache
-      - name: Validate changed files
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'allow sdk change')
-        run: ./.github/workflows/validate_changed_files.sh ${{ github.head_ref }} ${{ github.base_ref }}
       - name: Tidy up repository
         run: ./.github/workflows/tidy_up_repository.sh
       - name: bazel test //...


### PR DESCRIPTION
We can run the check before other jobs, especially the more expensive and time-consuming cache restore job.