### PR TITLE
feat: CI cache keys with hashes

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -24,7 +24,8 @@ jobs:
           path: |
             ~/.cache/bazel
             ~/.cache/bazel-repo
-          key: bazel-cache
+          key: bazel-cache-${{ hashFiles('**/*.go', '**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+          restore-keys: bazel-cache-
       - name: Go cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
The hash controls when to save the changes to the cached files. Without it, GitHub Actions believes it to always be a cache hit and we keep using the first saved cache.

The globs I added should be sufficient to capture almost all times we want to save the cache. If it misses some changes, it's still fine since the files I included in the globs are frequently changed in this repository, meaning that we will frequently save the cache.