### PR TITLE
fix: No names found, cannot describe anything

### DIFF
--- a/buildinfo/bazel_stamp_info.sh
+++ b/buildinfo/bazel_stamp_info.sh
@@ -21,4 +21,7 @@ echo "BUILD_TIME $(date "+%Y-%m-%d %H:%M:%S %Z")"
 # Note, BUILD_USER is automatically available in the stable-status.txt, it matches $USER
 echo "STABLE_BUILD_SCM_SHA $(git rev-parse HEAD)"
 echo "STABLE_BUILD_SCM_LOCAL_CHANGES $(has_local_changes)"
-echo "STABLE_BUILD_SCM_TAG $(git describe --tags)"
+
+if [ "$(git tag | wc -l)" -gt 0 ]; then
+    echo "STABLE_BUILD_SCM_TAG $(git describe --tags)"
+fi


### PR DESCRIPTION
On CI, when we are running the workspace status script, it not always contains tags.