### PR TITLE
fix: ensure the workspaceRoot is set before running Bazel

### DIFF
--- a/cmd/aspect/version/BUILD.bazel
+++ b/cmd/aspect/version/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
     deps = [
         "//buildinfo",
         "//pkg/aspect/version",
+        "//pkg/bazel",
+        "//pkg/interceptors",
         "//pkg/ioutils",
         "@com_github_spf13_cobra//:cobra",
     ],

--- a/integration_tests/version_test.sh
+++ b/integration_tests/version_test.sh
@@ -4,6 +4,7 @@ set -o pipefail -o errexit -o nounset
 HOME="$TEST_TMPDIR"
 ASPECT="$TEST_SRCDIR/build_aspect_cli/cmd/aspect/aspect_/aspect"
 export HOME
+touch WORKSPACE
 
 # Only capture stdout, just like `bazel version` prints to stdout
 ver=$($ASPECT version 2>/dev/null) || "$ASPECT" version

--- a/pkg/aspect/version/BUILD.bazel
+++ b/pkg/aspect/version/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/bazel",
         "//pkg/ioutils",
-        "@com_github_spf13_cobra//:cobra",
     ],
 )
 
@@ -17,6 +16,7 @@ go_test(
     srcs = ["version_test.go"],
     deps = [
         ":version",
+        "//pkg/bazel",
         "//pkg/ioutils",
         "@com_github_onsi_gomega//:gomega",
     ],

--- a/pkg/aspect/version/version.go
+++ b/pkg/aspect/version/version.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"aspect.build/cli/pkg/bazel"
 	"aspect.build/cli/pkg/ioutils"
 )
@@ -30,7 +28,7 @@ func New(streams ioutils.Streams) *Version {
 	}
 }
 
-func (v *Version) Run(_ *cobra.Command, _ []string) error {
+func (v *Version) Run(bzl bazel.Bazel) error {
 	var versionBuilder strings.Builder
 	if v.BuildinfoRelease != "" {
 		versionBuilder.WriteString(v.BuildinfoRelease)
@@ -51,7 +49,6 @@ func (v *Version) Run(_ *cobra.Command, _ []string) error {
 	} else {
 		fmt.Fprintf(v.Stdout, "Aspect version: %s\n", version)
 	}
-	bzl := bazel.New()
 	bzl.Spawn(bazelCmd)
 
 	return nil

--- a/pkg/aspect/version/version_test.go
+++ b/pkg/aspect/version/version_test.go
@@ -13,16 +13,19 @@ import (
 	. "github.com/onsi/gomega"
 
 	"aspect.build/cli/pkg/aspect/version"
+	"aspect.build/cli/pkg/bazel"
 	"aspect.build/cli/pkg/ioutils"
 )
 
 func TestVersion(t *testing.T) {
+	bzl := bazel.New()
+	bzl.SetWorkspaceRoot(".")
 	t.Run("without release build info", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
 		v := version.New(streams)
-		err := v.Run(nil, nil)
+		err := v.Run(bzl)
 		g.Expect(err).To(BeNil())
 		g.Expect(stdout.String()).To(Equal("Aspect version: unknown [not built with --stamp]\n"))
 	})
@@ -35,7 +38,7 @@ func TestVersion(t *testing.T) {
 			v := version.New(streams)
 			v.BuildinfoRelease = "1.2.3"
 			v.BuildinfoGitStatus = "clean"
-			err := v.Run(nil, nil)
+			err := v.Run(bzl)
 			g.Expect(err).To(BeNil())
 			g.Expect(stdout.String()).To(Equal("Aspect version: 1.2.3\n"))
 		})
@@ -47,7 +50,7 @@ func TestVersion(t *testing.T) {
 			v := version.New(streams)
 			v.BuildinfoRelease = "1.2.3"
 			v.BuildinfoGitStatus = ""
-			err := v.Run(nil, nil)
+			err := v.Run(bzl)
 			g.Expect(err).To(BeNil())
 			g.Expect(stdout.String()).To(Equal("Aspect version: 1.2.3 (with local changes)\n"))
 		})
@@ -61,7 +64,7 @@ func TestVersion(t *testing.T) {
 		v.GNUFormat = true
 		v.BuildinfoRelease = "1.2.3"
 		v.BuildinfoGitStatus = "clean"
-		err := v.Run(nil, nil)
+		err := v.Run(bzl)
 		g.Expect(err).To(BeNil())
 		g.Expect(stdout.String()).To(Equal("Aspect 1.2.3\n"))
 	})

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -51,6 +51,10 @@ func (b *bazel) Spawn(command []string) (int, error) {
 
 func (b *bazel) RunCommand(command []string, out io.Writer) (int, error) {
 	repos := b.createRepositories()
+	if len(b.workspaceRoot) < 1 {
+		panic("Illegal state: running bazel without the workspaceRoot set")
+	}
+
 	bazelisk := NewBazelisk(b.workspaceRoot)
 	exitCode, err := bazelisk.Run(command, repos, out)
 	return exitCode, err


### PR DESCRIPTION
Otherwise some of our commands don't tell bazelisk how to find the .bazelversion file, and we run the wrong Bazel.
This results in churning the Bazel server when running these aspect commands, and is clearly wrong for users as well.