### PR TITLE
chore: enable strict_action_env

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 build --workspace_status_command=buildinfo/bazel_stamp_info.sh
 build:release -c opt --stamp
+build --incompatible_strict_action_env
 
 test --keep_going
 test --test_output=errors


### PR DESCRIPTION
This is needed to prevent changes in variables like PATH from invalidating the action cache.
As an example, when I record a demo in asciinema the environment is slightly different, so I watch protoc recompile from sources :(