### PR TITLE
refactor: move plugin client+loading into own packages

### DIFF
--- a/pkg/plugin/client/BUILD.bazel
+++ b/pkg/plugin/client/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "client",
+    srcs = ["client.go"],
+    importpath = "aspect.build/cli/pkg/plugin/client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/ioutils",
+        "//pkg/plugin/loader",
+        "//pkg/plugin/sdk/v1alpha2/config",
+        "//pkg/plugin/sdk/v1alpha2/plugin",
+        "@com_github_hashicorp_go_hclog//:go-hclog",
+        "@com_github_hashicorp_go_plugin//:go-plugin",
+    ],
+)

--- a/pkg/plugin/client/client.go
+++ b/pkg/plugin/client/client.go
@@ -1,0 +1,86 @@
+/*
+Copyright © 2021 Aspect Build Systems Inc
+
+Not licensed for re-use.
+*/
+
+package client
+
+import (
+	"fmt"
+	"os/exec"
+
+	hclog "github.com/hashicorp/go-hclog"
+	goplugin "github.com/hashicorp/go-plugin"
+
+	"aspect.build/cli/pkg/ioutils"
+	"aspect.build/cli/pkg/plugin/loader"
+	"aspect.build/cli/pkg/plugin/sdk/v1alpha2/config"
+	"aspect.build/cli/pkg/plugin/sdk/v1alpha2/plugin"
+)
+
+// A Factory class for constructing plugin instances.
+type Factory interface {
+	New(config loader.AspectPlugin, streams ioutils.Streams) (*PluginInstance, error)
+}
+
+func NewFactory() Factory {
+	return &clientFactory{}
+}
+
+type clientFactory struct{}
+
+// New calls the goplugin.NewClient with the given config.
+func (*clientFactory) New(aspectplugin loader.AspectPlugin, streams ioutils.Streams) (*PluginInstance, error) {
+	logLevel := hclog.LevelFromString(aspectplugin.LogLevel)
+	if logLevel == hclog.NoLevel {
+		logLevel = hclog.Error
+	}
+	pluginLogger := hclog.New(&hclog.LoggerOptions{
+		Name:  aspectplugin.Name,
+		Level: logLevel,
+	})
+
+	clientConfig := &goplugin.ClientConfig{
+		HandshakeConfig:  config.Handshake,
+		Plugins:          config.PluginMap,
+		Cmd:              exec.Command(aspectplugin.From),
+		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
+		SyncStdout:       streams.Stdout,
+		SyncStderr:       streams.Stderr,
+		Logger:           pluginLogger,
+	}
+
+	goclient := goplugin.NewClient(clientConfig)
+
+	rpcClient, err := goclient.Client()
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure plugin client: %w", err)
+	}
+
+	rawplugin, err := rpcClient.Dispense(config.DefaultPluginName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure plugin client: %w", err)
+	}
+
+	res := &PluginInstance{
+		Plugin:   rawplugin.(plugin.Plugin),
+		Provider: goclient,
+	}
+
+	return res, nil
+}
+
+// Provider is an interface for goplugin.Client returned by
+// goplugin.NewClient.
+type Provider interface {
+	Client() (goplugin.ClientProtocol, error)
+	Kill()
+}
+
+// A PluginInstance consists of the underling Plugin as well
+// as any associated objects or metadata.
+type PluginInstance struct {
+	plugin.Plugin
+	Provider
+}

--- a/pkg/plugin/client/mock/BUILD.bazel
+++ b/pkg/plugin/client/mock/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@bazel_gomock//:gomock.bzl", "gomock")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# gazelle:exclude mock_client_test.go
+
+gomock(
+    name = "mock_client_source",
+    out = "mock_client_test.go",
+    interfaces = ["Provider"],
+    library = "//pkg/plugin/client",
+    package = "mock",
+    visibility = ["//visibility:private"],
+)
+
+go_library(
+    name = "mock",
+    srcs = [
+        "doc.go",
+        ":mock_client_source",  # keep
+    ],
+    importpath = "aspect.build/cli/pkg/plugin/client/mock",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//pkg/aspecterrors",  # keep
+        "//pkg/interceptors",  # keep
+        "//pkg/ioutils",  # keep
+        "//pkg/plugin/client",  # keep
+        "@com_github_golang_mock//gomock",  # keep
+        "@com_github_hashicorp_go_plugin//:go-plugin",  #keep
+    ],
+)

--- a/pkg/plugin/client/mock/doc.go
+++ b/pkg/plugin/client/mock/doc.go
@@ -1,0 +1,2 @@
+// Package mock contains generated files.
+package mock

--- a/pkg/plugin/loader/BUILD.bazel
+++ b/pkg/plugin/loader/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "loader",
+    srcs = ["loader.go"],
+    importpath = "aspect.build/cli/pkg/plugin/loader",
+    visibility = ["//visibility:public"],
+    deps = ["@in_gopkg_yaml_v2//:yaml_v2"],
+)

--- a/pkg/plugin/loader/loader.go
+++ b/pkg/plugin/loader/loader.go
@@ -4,7 +4,7 @@ Copyright © 2021 Aspect Build Systems Inc
 Not licensed for re-use.
 */
 
-package system
+package loader
 
 import (
 	"fmt"

--- a/pkg/plugin/system/BUILD.bazel
+++ b/pkg/plugin/system/BUILD.bazel
@@ -2,10 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "system",
-    srcs = [
-        "aspectplugins.go",
-        "system.go",
-    ],
+    srcs = ["system.go"],
     importpath = "aspect.build/cli/pkg/plugin/system",
     visibility = ["//visibility:public"],
     deps = [
@@ -13,11 +10,9 @@ go_library(
         "//pkg/aspecterrors",
         "//pkg/interceptors",
         "//pkg/ioutils",
-        "//pkg/plugin/sdk/v1alpha2/config",
-        "//pkg/plugin/sdk/v1alpha2/plugin",
+        "//pkg/plugin/client",
+        "//pkg/plugin/loader",
         "//pkg/plugin/system/bep",
-        "@com_github_hashicorp_go_hclog//:go-hclog",
-        "@com_github_hashicorp_go_plugin//:go-plugin",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
@@ -31,6 +26,8 @@ go_test(
         "//pkg/aspect/root/flags",
         "//pkg/aspecterrors",
         "//pkg/ioutils",
+        "//pkg/plugin/client",
+        "//pkg/plugin/client/mock",
         "//pkg/plugin/sdk/v1alpha2/plugin/mock",
         "@com_github_golang_mock//gomock",
         "@com_github_onsi_gomega//:gomega",

--- a/pkg/plugin/system/system.go
+++ b/pkg/plugin/system/system.go
@@ -166,7 +166,7 @@ func (ps *pluginSystem) commandHooksInterceptor(methodName string, streams iouti
 					reflect.ValueOf(isInteractiveMode),
 					reflect.ValueOf(ps.promptRunner),
 				}
-				if err := reflect.ValueOf(node.payload.Plugin).MethodByName(methodName).Call(params)[0].Interface(); err != nil {
+				if err := reflect.ValueOf(node.payload).MethodByName(methodName).Call(params)[0].Interface(); err != nil {
 					fmt.Fprintf(streams.Stderr, "Error: failed to run 'aspect %s' command: %v\n", cmd.Use, err)
 					hasPluginErrors = true
 				}

--- a/pkg/plugin/system/system_test.go
+++ b/pkg/plugin/system/system_test.go
@@ -19,6 +19,8 @@ import (
 	rootFlags "aspect.build/cli/pkg/aspect/root/flags"
 	"aspect.build/cli/pkg/aspecterrors"
 	"aspect.build/cli/pkg/ioutils"
+	"aspect.build/cli/pkg/plugin/client"
+	client_mock "aspect.build/cli/pkg/plugin/client/mock"
 	plugin_mock "aspect.build/cli/pkg/plugin/sdk/v1alpha2/plugin/mock"
 )
 
@@ -47,7 +49,10 @@ func TestPluginSystemInterceptors(t *testing.T) {
 
 		ps := NewPluginSystem().(*pluginSystem)
 		plugin := plugin_mock.NewMockPlugin(ctrl)
-		ps.addPlugin(plugin)
+		ps.addPlugin(&client.PluginInstance{
+			Plugin:   plugin,
+			Provider: client_mock.NewMockProvider(ctrl),
+		})
 
 		// Expect the callbacks in reverse-order of execution
 		gomock.InOrder(
@@ -87,8 +92,14 @@ func TestPluginSystemInterceptors(t *testing.T) {
 		ps := NewPluginSystem().(*pluginSystem)
 		plugin1 := plugin_mock.NewMockPlugin(ctrl)
 		plugin2 := plugin_mock.NewMockPlugin(ctrl)
-		ps.addPlugin(plugin1)
-		ps.addPlugin(plugin2)
+		ps.addPlugin(&client.PluginInstance{
+			Plugin:   plugin1,
+			Provider: client_mock.NewMockProvider(ctrl),
+		})
+		ps.addPlugin(&client.PluginInstance{
+			Plugin:   plugin2,
+			Provider: client_mock.NewMockProvider(ctrl),
+		})
 
 		// Expect the callbacks in reverse-order of execution, plugins in order added
 		gomock.InOrder(
@@ -125,7 +136,10 @@ func TestPluginSystemInterceptors(t *testing.T) {
 		// Plugin to be invoked
 		ps := NewPluginSystem().(*pluginSystem)
 		plugin := plugin_mock.NewMockPlugin(ctrl)
-		ps.addPlugin(plugin)
+		ps.addPlugin(&client.PluginInstance{
+			Plugin:   plugin,
+			Provider: client_mock.NewMockProvider(ctrl),
+		})
 
 		// Expect the callbacks in reverse-order of execution
 		gomock.InOrder(
@@ -165,7 +179,10 @@ func TestPluginSystemInterceptors(t *testing.T) {
 		// Plugin to be invoked
 		ps := NewPluginSystem().(*pluginSystem)
 		plugin := plugin_mock.NewMockPlugin(ctrl)
-		ps.addPlugin(plugin)
+		ps.addPlugin(&client.PluginInstance{
+			Plugin:   plugin,
+			Provider: client_mock.NewMockProvider(ctrl),
+		})
 
 		// Expect the callbacks in reverse-order of execution
 		gomock.InOrder(
@@ -242,7 +259,10 @@ func TestPluginSystemInterceptors(t *testing.T) {
 			) error {
 				return fmt.Errorf("plugin error")
 			})
-		ps.addPlugin(plugin)
+		ps.addPlugin(&client.PluginInstance{
+			Plugin:   plugin,
+			Provider: client_mock.NewMockProvider(ctrl),
+		})
 
 		// Hook interceptors
 		runInterceptor := ps.RunHooksInterceptor(streams)


### PR DESCRIPTION
So I had to do a few things at once which I was hoping to do independently:
* split system => client/loader/system
* I used "loader" instead of "config" because there is already a config within the plugin sdk
* loader finds and reads the config file, returning a set of `AspectPlugin`s
* client creates and (mostly) hides the goplugin
* client returns a `PluginInstance` (originally `InternalPlugin` in the other PR) which contains the plugin instance and any "associated objects or metadata" such as the underlying `goplugin.Client` and I think some stuff @JesseTatasciore is adding in his PR could go in there

~~#148 needs to merge first.~~

Names are all up for debate still...