### PR TITLE
fix: embed data properly when built externally

### DIFF
--- a/docs/help/topics/BUILD.bazel
+++ b/docs/help/topics/BUILD.bazel
@@ -9,6 +9,7 @@ bindata(
         "target-syntax.md",
     ],
     package = "topics",
+    strip_external = True,
 )
 
 go_library(


### PR DESCRIPTION
A plugin repo might have a starlark dependency on the build_aspect_cli repository (this repo).
When building the binary, it currently has an error because the bindata isn't resolved.
rules_go/extras/bindata.bzl already has logic to account for this:
https://github.com/bazelbuild/rules_go/blob/e9a7054ff11a520e3b8aceb76a3ba44bb8da4c94/extras/bindata.bzl#L45-L46
but it requires an opt-in attribute on the bindata target.