### PR TITLE
Make bazel package visible outside of the repo

### DIFF
--- a/pkg/bazel/BUILD.bazel
+++ b/pkg/bazel/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
     ],
     embed = [":bazel_go_proto"],
     importpath = "aspect.build/cli/pkg/bazel",
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "@com_github_bazelbuild_bazelisk//core:go_default_library",
         "@com_github_bazelbuild_bazelisk//httputil:go_default_library",


### PR DESCRIPTION
With the recent addition of plugins being able to implement custom commands, they need to be able to call bazel using the the CLI's bazel package. This will happen outside of the repo and the current visibility causes problems