### PR TITLE
fix: bump BES server recv max message size

### DIFF
--- a/pkg/plugin/system/BUILD.bazel
+++ b/pkg/plugin/system/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/plugin/system/bep",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/plugin/system/bep/bes_backend.go
+++ b/pkg/plugin/system/bep/bes_backend.go
@@ -61,6 +61,7 @@ func NewBESBackend() BESBackend {
 
 // Setup sets up the gRPC server.
 func (bb *besBackend) Setup(opts ...grpc.ServerOption) error {
+	// Never expose this to the network.
 	lis, err := bb.netListen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("failed to setup BES backend: %w", err)


### PR DESCRIPTION
Bazel doesn't seem to set an outbound limit for gRPC message sizes. Here, since the [BES server is not exposed to the network](https://github.com/aspect-build/aspect-cli/blob/fac6baa3307651b488b9c46f371b4f0efbd46fde/pkg/plugin/system/bep/bes_backend.go#L64), it's okay to set the max value.