### PR TITLE
fix: allow Bazel to be used outside of an interceptor chain

### DIFF
--- a/pkg/bazel/BUILD.bazel
+++ b/pkg/bazel/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "aspect.build/cli/pkg/bazel",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pathutils",
         "@com_github_bazelbuild_bazelisk//core:go_default_library",
         "@com_github_bazelbuild_bazelisk//httputil:go_default_library",
         "@com_github_bazelbuild_bazelisk//platforms:go_default_library",


### PR DESCRIPTION
Prefactoring for passing through all flags, which wants to call bazel help --flags-as-proto before interceptors are setup.
I need it for registering plugins from targets as well.