### PR TITLE
cleanup: remove calls to SetWorkspaceRoot

### DIFF
--- a/cmd/aspect/aquery/aquery.go
+++ b/cmd/aspect/aquery/aquery.go
@@ -29,12 +29,8 @@ func NewAQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 		Short: "Executes an aquery.",
 		Long:  "Executes a query language expression over a specified subgraph of the build dependency graph using aquery.",
 		RunE: interceptors.Run(
-			[]interceptors.Interceptor{
-				interceptors.WorkspaceRootInterceptor(),
-			},
+			[]interceptors.Interceptor{},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
-				workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
-				bzl.SetWorkspaceRoot(workspaceRoot)
 				q := aquery.New(streams, bzl, true)
 				return q.Run(cmd, args)
 			},

--- a/cmd/aspect/build/build.go
+++ b/cmd/aspect/build/build.go
@@ -44,13 +44,10 @@ func NewBuildCmd(
 			"See 'bazel help target-syntax' for details and examples on how to specify targets to build.",
 		RunE: interceptors.Run(
 			[]interceptors.Interceptor{
-				interceptors.WorkspaceRootInterceptor(),
 				pluginSystem.BESBackendInterceptor(),
 				pluginSystem.BuildHooksInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
-				workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
-				bzl.SetWorkspaceRoot(workspaceRoot)
 				b := build.New(streams, bzl)
 				besBackend := ctx.Value(system.BESBackendInterceptorKey).(bep.BESBackend)
 				return b.Run(args, besBackend)

--- a/cmd/aspect/clean/clean.go
+++ b/cmd/aspect/clean/clean.go
@@ -65,12 +65,8 @@ Workaround inconistent state:
 	If you ever find an incorrect incremental build, please file a bug report,
 	and only use clean as a temporary workaround.`,
 		RunE: interceptors.Run(
-			[]interceptors.Interceptor{
-				interceptors.WorkspaceRootInterceptor(),
-			},
+			[]interceptors.Interceptor{},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
-				workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
-				bzl.SetWorkspaceRoot(workspaceRoot)
 				isInteractive := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 				c := clean.NewDefault(bzl, isInteractive)
 				c.Expunge = expunge

--- a/cmd/aspect/cquery/cquery.go
+++ b/cmd/aspect/cquery/cquery.go
@@ -29,12 +29,8 @@ func NewCQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 		Short: "Executes a cquery.",
 		Long:  "Executes a query language expression over a specified subgraph of the build dependency graph using cquery.",
 		RunE: interceptors.Run(
-			[]interceptors.Interceptor{
-				interceptors.WorkspaceRootInterceptor(),
-			},
+			[]interceptors.Interceptor{},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
-				workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
-				bzl.SetWorkspaceRoot(workspaceRoot)
 				q := cquery.New(streams, bzl, true)
 				return q.Run(cmd, args)
 			},

--- a/cmd/aspect/query/query.go
+++ b/cmd/aspect/query/query.go
@@ -29,12 +29,8 @@ func NewQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 		Short: "Executes a dependency graph query.",
 		Long:  "Executes a query language expression over a specified subgraph of the build dependency graph.",
 		RunE: interceptors.Run(
-			[]interceptors.Interceptor{
-				interceptors.WorkspaceRootInterceptor(),
-			},
+			[]interceptors.Interceptor{},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
-				workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
-				bzl.SetWorkspaceRoot(workspaceRoot)
 				q := query.New(streams, bzl, true)
 				return q.Run(cmd, args)
 			},

--- a/cmd/aspect/run/run.go
+++ b/cmd/aspect/run/run.go
@@ -49,13 +49,10 @@ use 'bazel run --script_path' to write a script and then execute it.
 `,
 		RunE: interceptors.Run(
 			[]interceptors.Interceptor{
-				interceptors.WorkspaceRootInterceptor(),
 				pluginSystem.BESBackendInterceptor(),
 				pluginSystem.RunHooksInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
-				workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
-				bzl.SetWorkspaceRoot(workspaceRoot)
 				r := run.New(streams, bzl)
 				besBackend := ctx.Value(system.BESBackendInterceptorKey).(bep.BESBackend)
 				return r.Run(args, besBackend)

--- a/cmd/aspect/test/test.go
+++ b/cmd/aspect/test/test.go
@@ -52,13 +52,10 @@ specify targets.
 `,
 		RunE: interceptors.Run(
 			[]interceptors.Interceptor{
-				interceptors.WorkspaceRootInterceptor(),
 				pluginSystem.BESBackendInterceptor(),
 				pluginSystem.TestHooksInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
-				workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
-				bzl.SetWorkspaceRoot(workspaceRoot)
 				t := test.New(streams, bzl)
 				besBackend := ctx.Value(system.BESBackendInterceptorKey).(bep.BESBackend)
 				return t.Run(args, besBackend)

--- a/cmd/aspect/version/version.go
+++ b/cmd/aspect/version/version.go
@@ -35,12 +35,8 @@ func NewVersionCmd(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 		Short: "Print the version of aspect CLI as well as tools it invokes.",
 		Long:  `Prints version info on colon-separated lines, just like bazel does`,
 		RunE: interceptors.Run(
-			[]interceptors.Interceptor{
-				interceptors.WorkspaceRootInterceptor(),
-			},
+			[]interceptors.Interceptor{},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
-				workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
-				bzl.SetWorkspaceRoot(workspaceRoot)
 				return v.Run(bzl)
 			},
 		),

--- a/pkg/aspect/info/BUILD.bazel
+++ b/pkg/aspect/info/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/aspecterrors",
         "//pkg/bazel",
-        "//pkg/interceptors",
         "//pkg/ioutils",
         "@com_github_spf13_cobra//:cobra",
     ],

--- a/pkg/aspect/info/info.go
+++ b/pkg/aspect/info/info.go
@@ -12,7 +12,6 @@ import (
 	"context"
 
 	"aspect.build/cli/pkg/bazel"
-	"aspect.build/cli/pkg/interceptors"
 	"aspect.build/cli/pkg/ioutils"
 	"github.com/spf13/cobra"
 
@@ -39,8 +38,6 @@ func (v *Info) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	}
 	bazelCmd = append(bazelCmd, args...)
 	bzl := bazel.New()
-	workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
-	bzl.SetWorkspaceRoot(workspaceRoot)
 
 	if exitCode, err := bzl.Spawn(bazelCmd); exitCode != 0 {
 		err = &aspecterrors.ExitError{

--- a/pkg/aspect/version/version_test.go
+++ b/pkg/aspect/version/version_test.go
@@ -21,7 +21,6 @@ import (
 
 func TestVersion(t *testing.T) {
 	bzl := bazel.New()
-	bzl.SetWorkspaceRoot(".")
 	t.Run("without release build info", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		var stdout strings.Builder

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -32,7 +32,6 @@ var workspaceRoot string
 
 type Bazel interface {
 	AQuery(expr string) (*ActionGraphContainer, error)
-	SetWorkspaceRoot(workspaceRoot string)
 	Spawn(command []string) (int, error)
 	RunCommand(command []string, out io.Writer) (int, error)
 }
@@ -47,11 +46,6 @@ func New() Bazel {
 		osGetwd:         os.Getwd,
 		workspaceFinder: pathutils.DefaultWorkspaceFinder,
 	}
-}
-
-// Deprecated. WorkspaceRoot is set lazily by this class
-func (b *bazel) SetWorkspaceRoot(w string) {
-	workspaceRoot = w
 }
 
 // maybeSetWorkspaceRoot lazily sets the workspaceRoot if it isn't set already.

--- a/pkg/plugin/sdk/v1alpha2/plugin/interface.go
+++ b/pkg/plugin/sdk/v1alpha2/plugin/interface.go
@@ -14,7 +14,6 @@ import (
 
 	buildeventstream "aspect.build/cli/bazel/buildeventstream/proto"
 	"aspect.build/cli/pkg/bazel"
-	"aspect.build/cli/pkg/interceptors"
 	"aspect.build/cli/pkg/ioutils"
 	"aspect.build/cli/pkg/plugin/sdk/v1alpha2/proto"
 )
@@ -130,9 +129,7 @@ func (cm *PluginCommandManager) Save(commands []*Command) error {
 
 // Execute satisfies CommandManager.
 func (cm *PluginCommandManager) Execute(command string, ctx context.Context, args []string) error {
-	workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
 	bzl := bazel.New()
-	bzl.SetWorkspaceRoot(workspaceRoot)
 
 	return cm.commands[command](ctx, args, bzl)
 }

--- a/pkg/plugin/sdk/v1alpha3/plugin/interface.go
+++ b/pkg/plugin/sdk/v1alpha3/plugin/interface.go
@@ -14,7 +14,6 @@ import (
 
 	buildeventstream "aspect.build/cli/bazel/buildeventstream/proto"
 	"aspect.build/cli/pkg/bazel"
-	"aspect.build/cli/pkg/interceptors"
 	"aspect.build/cli/pkg/ioutils"
 	"aspect.build/cli/pkg/plugin/sdk/v1alpha3/proto"
 )
@@ -161,9 +160,7 @@ func (cm *PluginCommandManager) Save(commands []*Command) error {
 
 // Execute satisfies CommandManager.
 func (cm *PluginCommandManager) Execute(command string, ctx context.Context, args []string) error {
-	workspaceRoot := ctx.Value(interceptors.WorkspaceRootKey).(string)
 	bzl := bazel.New()
-	bzl.SetWorkspaceRoot(workspaceRoot)
 
 	return cm.commands[command](ctx, args, bzl)
 }


### PR DESCRIPTION
It is deprecated since we lazily set it in #168