### PR TITLE
refactor: move plugin setup out of versioned sdk

### DIFF
--- a/pkg/plugin/loader/BUILD.bazel
+++ b/pkg/plugin/loader/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "loader",
-    srcs = ["loader.go"],
+    srcs = [
+        "config.go",
+        "loader.go",
+    ],
     importpath = "aspect.build/cli/pkg/plugin/loader",
     visibility = ["//visibility:public"],
     deps = ["@in_gopkg_yaml_v2//:yaml_v2"],

--- a/pkg/plugin/loader/config.go
+++ b/pkg/plugin/loader/config.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Aspect Build Systems, Inc.
+ *
+ * Licensed under the aspect.build Commercial License (the "License");
+ * you may not use this file except in compliance with the License.
+ * Full License text is in the LICENSE file included in the root of this repository.
+ */
+
+package loader
+
+// SetupConfig represents a plugin configuration parsed from the aspectplugins
+// file.
+type SetupConfig struct {
+	File       *AspectPluginFile
+	Properties []byte
+}
+
+// NewSetupConfig creates a new SetupConfig.
+func NewSetupConfig(
+	file *AspectPluginFile,
+	properties []byte,
+) *SetupConfig {
+	return &SetupConfig{
+		File:       file,
+		Properties: properties,
+	}
+}
+
+// AspectPluginFile contains metadata for the aspectplugins file relevant for
+// a plugin.
+type AspectPluginFile struct {
+	Path string
+}
+
+// NewAspectPluginFile creates a new AspectPluginFile.
+func NewAspectPluginFile(path string) *AspectPluginFile {
+	return &AspectPluginFile{
+		Path: path,
+	}
+}

--- a/pkg/plugin/sdk/v1alpha3/plugin/BUILD.bazel
+++ b/pkg/plugin/sdk/v1alpha3/plugin/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//bazel/buildeventstream/proto",
         "//pkg/bazel",
         "//pkg/ioutils",
+        "//pkg/plugin/loader",
         "//pkg/plugin/sdk/v1alpha3/proto",
         "@com_github_hashicorp_go_plugin//:go-plugin",
         "@com_github_manifoldco_promptui//:promptui",

--- a/pkg/plugin/sdk/v1alpha3/plugin/grpc.go
+++ b/pkg/plugin/sdk/v1alpha3/plugin/grpc.go
@@ -21,6 +21,7 @@ import (
 
 	buildeventstream "aspect.build/cli/bazel/buildeventstream/proto"
 	"aspect.build/cli/pkg/ioutils"
+	"aspect.build/cli/pkg/plugin/loader"
 	"aspect.build/cli/pkg/plugin/sdk/v1alpha3/proto"
 )
 
@@ -69,8 +70,8 @@ func (m *GRPCServer) Setup(
 	ctx context.Context,
 	req *proto.SetupReq,
 ) (*proto.SetupRes, error) {
-	file := NewAspectPluginFile(req.File.Path)
-	config := NewSetupConfig(file, req.Properties)
+	file := loader.NewAspectPluginFile(req.File.Path)
+	config := loader.NewSetupConfig(file, req.Properties)
 	return &proto.SetupRes{}, m.Impl.Setup(config)
 }
 
@@ -186,7 +187,7 @@ func (m *GRPCClient) BEPEventCallback(event *buildeventstream.BuildEvent) error 
 }
 
 // Setup is called from the Core to execute the Plugin Setup.
-func (m *GRPCClient) Setup(config *SetupConfig) error {
+func (m *GRPCClient) Setup(config *loader.SetupConfig) error {
 	req := &proto.SetupReq{
 		Properties: config.Properties,
 		File: &proto.File{

--- a/pkg/plugin/sdk/v1alpha3/plugin/interface.go
+++ b/pkg/plugin/sdk/v1alpha3/plugin/interface.go
@@ -15,6 +15,7 @@ import (
 	buildeventstream "aspect.build/cli/bazel/buildeventstream/proto"
 	"aspect.build/cli/pkg/bazel"
 	"aspect.build/cli/pkg/ioutils"
+	"aspect.build/cli/pkg/plugin/loader"
 	"aspect.build/cli/pkg/plugin/sdk/v1alpha3/proto"
 )
 
@@ -34,38 +35,7 @@ type Plugin interface {
 		isInteractiveMode bool,
 		promptRunner ioutils.PromptRunner,
 	) error
-	Setup(config *SetupConfig) error
-}
-
-// SetupConfig represents a plugin configuration parsed from the aspectplugins
-// file.
-type SetupConfig struct {
-	File       *AspectPluginFile
-	Properties []byte
-}
-
-// NewSetupConfig creates a new SetupConfig.
-func NewSetupConfig(
-	file *AspectPluginFile,
-	properties []byte,
-) *SetupConfig {
-	return &SetupConfig{
-		File:       file,
-		Properties: properties,
-	}
-}
-
-// AspectPluginFile contains metadata for the aspectplugins file relevant for
-// a plugin.
-type AspectPluginFile struct {
-	Path string
-}
-
-// NewAspectPluginFile creates a new AspectPluginFile.
-func NewAspectPluginFile(path string) *AspectPluginFile {
-	return &AspectPluginFile{
-		Path: path,
-	}
+	Setup(config *loader.SetupConfig) error
 }
 
 // Base satisfies the Plugin interface. For plugins that only implement a subset
@@ -76,7 +46,7 @@ type Base struct{}
 var _ Plugin = (*Base)(nil)
 
 // Setup satisfies Plugin.Setup.
-func (*Base) Setup(*SetupConfig) error {
+func (*Base) Setup(*loader.SetupConfig) error {
 	return nil
 }
 

--- a/pkg/plugin/sdk/v1alpha3/plugin/mock/BUILD.bazel
+++ b/pkg/plugin/sdk/v1alpha3/plugin/mock/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     deps = [
         "//bazel/buildeventstream/proto",  # keep
         "//pkg/ioutils",  # keep
+        "//pkg/plugin/loader",  # keep
         "//pkg/plugin/sdk/v1alpha3/plugin",  # keep
         "@com_github_golang_mock//gomock",  # keep
     ],

--- a/pkg/plugin/system/BUILD.bazel
+++ b/pkg/plugin/system/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/ioutils",
         "//pkg/plugin/client",
         "//pkg/plugin/loader",
-        "//pkg/plugin/sdk/v1alpha3/plugin",
         "//pkg/plugin/system/bep",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/pkg/plugin/system/system.go
+++ b/pkg/plugin/system/system.go
@@ -27,7 +27,6 @@ import (
 	"aspect.build/cli/pkg/ioutils"
 	"aspect.build/cli/pkg/plugin/client"
 	"aspect.build/cli/pkg/plugin/loader"
-	"aspect.build/cli/pkg/plugin/sdk/v1alpha3/plugin"
 	"aspect.build/cli/pkg/plugin/system/bep"
 )
 
@@ -90,8 +89,8 @@ func (ps *pluginSystem) Configure(streams ioutils.Streams) error {
 				return fmt.Errorf("failed to configure plugin system: %w", err)
 			}
 
-			aspectPluginFile := plugin.NewAspectPluginFile(aspectpluginsPath)
-			setupConfig := plugin.NewSetupConfig(aspectPluginFile, properties)
+			aspectPluginFile := loader.NewAspectPluginFile(aspectpluginsPath)
+			setupConfig := loader.NewSetupConfig(aspectPluginFile, properties)
 			if err := aspectplugin.Setup(setupConfig); err != nil {
 				return fmt.Errorf("failed to configure plugin system: %w", err)
 			}

--- a/pkg/plugin/system/system_test.go
+++ b/pkg/plugin/system/system_test.go
@@ -27,7 +27,6 @@ import (
 	client_mock "aspect.build/cli/pkg/plugin/client/mock"
 	"aspect.build/cli/pkg/plugin/loader"
 	loader_mock "aspect.build/cli/pkg/plugin/loader/mock"
-	"aspect.build/cli/pkg/plugin/sdk/v1alpha3/plugin"
 	plugin_mock "aspect.build/cli/pkg/plugin/sdk/v1alpha3/plugin/mock"
 )
 
@@ -546,8 +545,8 @@ func TestConfigure(t *testing.T) {
 
 		propertiesMap := make(map[string]interface{})
 		propertiesBytes, _ := yaml.Marshal(propertiesMap)
-		file := plugin.NewAspectPluginFile("/foo/bar")
-		setupConfig := plugin.NewSetupConfig(file, propertiesBytes)
+		file := loader.NewAspectPluginFile("/foo/bar")
+		setupConfig := loader.NewSetupConfig(file, propertiesBytes)
 
 		testPlugin := loader.AspectPlugin{
 			Name:       "test plugin",


### PR DESCRIPTION
This is one step of moving the sdk out of the cli repo.
The core uses these interfaces to create instances of plugins, regardless what language the plugins are written in.