### PR TITLE
refactor: bes_backend scheme as part of Addr()

### DIFF
--- a/pkg/aspect/build/build.go
+++ b/pkg/aspect/build/build.go
@@ -37,7 +37,7 @@ func New(
 // Run runs the aspect build command, calling `bazel build` with a local Build
 // Event Protocol backend used by Aspect plugins to subscribe to build events.
 func (b *Build) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
-	besBackendFlag := fmt.Sprintf("--bes_backend=grpc://%s", besBackend.Addr())
+	besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
 	exitCode, bazelErr := b.bzl.Spawn(append([]string{"build", besBackendFlag}, args...))
 
 	// Process the subscribers errors before the Bazel one.

--- a/pkg/aspect/build/build_test.go
+++ b/pkg/aspect/build/build_test.go
@@ -43,7 +43,7 @@ func TestBuild(t *testing.T) {
 		besBackend.
 			EXPECT().
 			Addr().
-			Return("127.0.0.1:12345").
+			Return("grpc://127.0.0.1:12345").
 			Times(1)
 		besBackend.
 			EXPECT().
@@ -72,7 +72,7 @@ func TestBuild(t *testing.T) {
 		besBackend.
 			EXPECT().
 			Addr().
-			Return("127.0.0.1:12345").
+			Return("grpc://127.0.0.1:12345").
 			Times(1)
 		besBackend.
 			EXPECT().
@@ -105,7 +105,7 @@ func TestBuild(t *testing.T) {
 		besBackend.
 			EXPECT().
 			Addr().
-			Return("127.0.0.1:12345").
+			Return("grpc://127.0.0.1:12345").
 			Times(1)
 		besBackend.
 			EXPECT().

--- a/pkg/aspect/run/run.go
+++ b/pkg/aspect/run/run.go
@@ -37,7 +37,7 @@ func New(
 // Run runs the aspect run command, calling `bazel run` with a local Build
 // Event Protocol backend used by Aspect plugins to subscribe to build events.
 func (cmd *Run) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
-	besBackendFlag := fmt.Sprintf("--bes_backend=grpc://%s", besBackend.Addr())
+	besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
 	exitCode, bazelErr := cmd.bzl.Spawn(append([]string{"run", besBackendFlag}, args...))
 
 	// Process the subscribers errors before the Bazel one.

--- a/pkg/aspect/run/run_test.go
+++ b/pkg/aspect/run/run_test.go
@@ -43,7 +43,7 @@ func TestRun(t *testing.T) {
 		besBackend.
 			EXPECT().
 			Addr().
-			Return("127.0.0.1:12345").
+			Return("grpc://127.0.0.1:12345").
 			Times(1)
 		besBackend.
 			EXPECT().
@@ -72,7 +72,7 @@ func TestRun(t *testing.T) {
 		besBackend.
 			EXPECT().
 			Addr().
-			Return("127.0.0.1:12345").
+			Return("grpc://127.0.0.1:12345").
 			Times(1)
 		besBackend.
 			EXPECT().
@@ -105,7 +105,7 @@ func TestRun(t *testing.T) {
 		besBackend.
 			EXPECT().
 			Addr().
-			Return("127.0.0.1:12345").
+			Return("grpc://127.0.0.1:12345").
 			Times(1)
 		besBackend.
 			EXPECT().

--- a/pkg/aspect/test/test.go
+++ b/pkg/aspect/test/test.go
@@ -30,7 +30,7 @@ func New(streams ioutils.Streams, bzl bazel.Bazel) *Test {
 }
 
 func (t *Test) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
-	besBackendFlag := fmt.Sprintf("--bes_backend=grpc://%s", besBackend.Addr())
+	besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
 	bazelCmd := []string{"test", besBackendFlag}
 	bazelCmd = append(bazelCmd, args...)
 

--- a/pkg/aspect/test/test_test.go
+++ b/pkg/aspect/test/test_test.go
@@ -37,7 +37,7 @@ func TestTest(t *testing.T) {
 		besBackend.
 			EXPECT().
 			Addr().
-			Return("127.0.0.1:12345").
+			Return("grpc://127.0.0.1:12345").
 			Times(1)
 		besBackend.
 			EXPECT().

--- a/pkg/plugin/system/bep/bes_backend.go
+++ b/pkg/plugin/system/bep/bes_backend.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	buildv1 "google.golang.org/genproto/googleapis/devtools/build/v1"
@@ -110,9 +111,14 @@ func (bb *besBackend) GracefulStop() {
 // Addr returns the address for the gRPC server. Since the address is determined
 // by the OS based on an available port at the time the gRPC server starts, this
 // method returns the address to be used to construct the `bes_backend` flag
-// passed to the `bazel build` command.
+// passed to the `bazel (build|test|run)` commands. The address includes the
+// scheme (protocol).
 func (bb *besBackend) Addr() string {
-	return bb.listener.Addr().String()
+	url := url.URL{
+		Scheme: "grpc",
+		Host:   bb.listener.Addr().String(),
+	}
+	return url.String()
 }
 
 // Errors return the errors produced by the subscriber callback functions.

--- a/pkg/plugin/system/bep/bes_backend_test.go
+++ b/pkg/plugin/system/bep/bes_backend_test.go
@@ -83,7 +83,7 @@ func TestServeWait(t *testing.T) {
 		grpcDialer := grpc_mock.NewMockDialer(ctrl)
 		grpcDialer.
 			EXPECT().
-			DialContext(gomock.Any(), "127.0.0.1:12345", gomock.Any(), gomock.Any()).
+			DialContext(gomock.Any(), "grpc://127.0.0.1:12345", gomock.Any(), gomock.Any()).
 			Return(nil, fmt.Errorf("dial error")).
 			AnyTimes()
 
@@ -123,7 +123,7 @@ func TestServeWait(t *testing.T) {
 		grpcDialer := grpc_mock.NewMockDialer(ctrl)
 		grpcDialer.
 			EXPECT().
-			DialContext(gomock.Any(), "127.0.0.1:12345", gomock.Any(), gomock.Any()).
+			DialContext(gomock.Any(), "grpc://127.0.0.1:12345", gomock.Any(), gomock.Any()).
 			Return(nil, context.DeadlineExceeded).
 			Times(1)
 
@@ -169,7 +169,7 @@ func TestServeWait(t *testing.T) {
 		grpcDialer := grpc_mock.NewMockDialer(ctrl)
 		grpcDialer.
 			EXPECT().
-			DialContext(gomock.Any(), "127.0.0.1:12345", gomock.Any(), gomock.Any()).
+			DialContext(gomock.Any(), "grpc://127.0.0.1:12345", gomock.Any(), gomock.Any()).
 			Return(clientConn, nil).
 			Times(1)
 


### PR DESCRIPTION
It's the responsibility of the same object that performs the listening to tell which scheme (protocol) to be used.