### PR TITLE
fix: pass grpc server address without protocol

### DIFF
--- a/pkg/plugin/system/bep/bes_backend.go
+++ b/pkg/plugin/system/bep/bes_backend.go
@@ -101,7 +101,7 @@ func (bb *besBackend) ServeWait(ctx context.Context) error {
 			errs <- err
 		}
 	}()
-	serverAddr := bb.Addr()
+	serverAddr := bb.listener.Addr().String()
 	for {
 		select {
 		case err := <-errs:

--- a/pkg/plugin/system/bep/bes_backend_test.go
+++ b/pkg/plugin/system/bep/bes_backend_test.go
@@ -83,7 +83,7 @@ func TestServeWait(t *testing.T) {
 		grpcDialer := grpc_mock.NewMockDialer(ctrl)
 		grpcDialer.
 			EXPECT().
-			DialContext(gomock.Any(), "grpc://127.0.0.1:12345", gomock.Any(), gomock.Any()).
+			DialContext(gomock.Any(), "127.0.0.1:12345", gomock.Any(), gomock.Any()).
 			Return(nil, fmt.Errorf("dial error")).
 			AnyTimes()
 
@@ -123,7 +123,7 @@ func TestServeWait(t *testing.T) {
 		grpcDialer := grpc_mock.NewMockDialer(ctrl)
 		grpcDialer.
 			EXPECT().
-			DialContext(gomock.Any(), "grpc://127.0.0.1:12345", gomock.Any(), gomock.Any()).
+			DialContext(gomock.Any(), "127.0.0.1:12345", gomock.Any(), gomock.Any()).
 			Return(nil, context.DeadlineExceeded).
 			Times(1)
 
@@ -169,7 +169,7 @@ func TestServeWait(t *testing.T) {
 		grpcDialer := grpc_mock.NewMockDialer(ctrl)
 		grpcDialer.
 			EXPECT().
-			DialContext(gomock.Any(), "grpc://127.0.0.1:12345", gomock.Any(), gomock.Any()).
+			DialContext(gomock.Any(), "127.0.0.1:12345", gomock.Any(), gomock.Any()).
 			Return(clientConn, nil).
 			Times(1)
 


### PR DESCRIPTION
5a5d8344c308384a69a56bdad764d8ce98d58436 changed the way the grpc address was passed around, but it seems that starting the server doesn't want the protocol appended, so it fails to start and results in the follow error for all `aspect build / test / run` commands:

```
$ bazel-bin/cmd/aspect/aspect_/aspect build aspect
Error: failed to run BES backend: failed to serve and wait BES backend: context deadline exceeded
```

Changes back to just the address sans protocol.