### PR TITLE
fix: don't output build info when building plugins

### DIFF
--- a/pkg/bazel/BUILD.bazel
+++ b/pkg/bazel/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//bazel/analysis",
         "//bazel/flags",
+        "//pkg/ioutils",
         "//pkg/pathutils",
         "@com_github_bazelbuild_bazelisk//core:go_default_library",
         "@com_github_bazelbuild_bazelisk//httputil:go_default_library",

--- a/pkg/bazel/mock/BUILD.bazel
+++ b/pkg/bazel/mock/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//bazel/analysis",  # keep
         "//bazel/flags",  # keep
         "//pkg/bazel",  # keep
+        "//pkg/ioutils",  # keep
         "@com_github_golang_mock//gomock",  # keep
     ],
 )

--- a/pkg/plugin/client/client.go
+++ b/pkg/plugin/client/client.go
@@ -11,6 +11,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -67,12 +68,18 @@ func (c *clientFactory) buildPlugin(target string) (string, error) {
 		return "", fmt.Errorf("failed to build plugin %q with Bazel: no output file from a GoLink action was found", target)
 	}
 
+	streams := ioutils.Streams{
+		Stdin:  os.Stdin,
+		Stdout: nil,
+		Stderr: nil,
+	}
+
 	// WARNING: be careful to use flags for this build matching the .bazelrc
 	// to avoid busting the analysis cache. We want to pretend to be a typical
 	// build the developer or CI would be performing.
 	// This is important only in the setup we don't recommend, where normal users
 	// are building the plugin from source instead of a pre-built binary.
-	if _, err := c.bzl.Spawn([]string{"build", target}); err != nil {
+	if _, err := c.bzl.RunCommand([]string{"build", target}, streams); err != nil {
 		return "", fmt.Errorf("failed to build plugin %q with Bazel: %w", target, err)
 	}
 


### PR DESCRIPTION
When building plugins from source there is an overwhelming amount of output. This adds the ability to pass each stream individually to the bazel interface, allowing control over `stdout` and `stderr`.

Also removes the `fmt` statement from `Aquery` that was printing the mnemonics? 

Before:
```
$ aspect build //plugins/summary/tests:flaky_sh_test
INFO: Invocation ID: f448fe27-96d4-4ffb-999d-034a7cf3ea29
Loading:
Loading: 0 packages loaded
Analyzing: target //:cli-plugins-pro (0 packages loaded, 0 targets configured)
INFO: Analyzed target //:cli-plugins-pro (0 packages loaded, 0 targets configured).
INFO: Found 1 target...

INFO: Elapsed time: 0.128s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
INFO: Build completed successfully, 0 total actions
GoCompilePkg
GoCompilePkg
GoLink
SourceSymlinkManifest
SymlinkTree
Middleman
INFO: Invocation ID: e7a921be-a526-4029-bf4f-7ddb6234db2b
INFO: Analyzed target //:cli-plugins-pro (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:cli-plugins-pro up-to-date:
  bazel-bin/cli-plugins-pro_/cli-plugins-pro
INFO: Elapsed time: 0.110s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
2022-03-27T20:09:29.167-0400 [DEBUG] pro: starting plugin: path=bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro args=["bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro"]
2022-03-27T20:09:29.169-0400 [DEBUG] pro: plugin started: path=bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro pid=72074
2022-03-27T20:09:29.170-0400 [DEBUG] pro: waiting for RPC address: path=bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro
2022-03-27T20:09:29.178-0400 [DEBUG] pro: using plugin: version=3
2022-03-27T20:09:29.178-0400 [DEBUG] pro.cli-plugins-pro: plugin address: address=/var/folders/z5/n7s9370n5f73js5xm9gl8qm40000gn/T/plugin1145700077 network=unix timestamp=2022-03-27T20:09:29.178-0400
INFO: Invocation ID: 5605adb5-509c-48e6-8f2f-c39978fb38e8
INFO: Analyzed target //plugins/summary/tests:flaky_sh_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //plugins/summary/tests:flaky_sh_test up-to-date:
  bazel-bin/plugins/summary/tests/flaky_sh_test
INFO: Elapsed time: 0.111s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
----------------------------
<details>
<summary>0 test target passed with no errors or flakes (expand to see) :raised_hands:</summary>
<pre>
</pre>
</details>

----------------------------
2022-03-27T20:09:29.396-0400 [DEBUG] pro.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2022-03-27T20:09:29.396-0400 [DEBUG] pro: plugin process exited: path=bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro pid=72074
2022-03-27T20:09:29.396-0400 [DEBUG] pro: plugin exited
```

After:
```
$ aspect build //plugins/summary/tests:flaky_sh_test
2022-03-27T20:26:09.758-0400 [DEBUG] pro: starting plugin: path=bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro args=["bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro"]
2022-03-27T20:26:09.760-0400 [DEBUG] pro: plugin started: path=bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro pid=79848
2022-03-27T20:26:09.760-0400 [DEBUG] pro: waiting for RPC address: path=bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro
2022-03-27T20:26:09.801-0400 [DEBUG] pro.cli-plugins-pro: plugin address: address=/var/folders/z5/n7s9370n5f73js5xm9gl8qm40000gn/T/plugin2369098353 network=unix timestamp=2022-03-27T20:26:09.800-0400
2022-03-27T20:26:09.801-0400 [DEBUG] pro: using plugin: version=3
INFO: Invocation ID: fe899248-29d1-4bd3-9fb0-96965a0f6e0d
INFO: Analyzed target //plugins/summary/tests:flaky_sh_test (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //plugins/summary/tests:flaky_sh_test up-to-date:
  bazel-bin/plugins/summary/tests/flaky_sh_test
INFO: Elapsed time: 0.115s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
----------------------------
<details>
<summary>0 test target passed with no errors or flakes (expand to see) :raised_hands:</summary>
<pre>
</pre>
</details>

----------------------------
2022-03-27T20:26:10.117-0400 [DEBUG] pro.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2022-03-27T20:26:10.118-0400 [DEBUG] pro: plugin process exited: path=bazel-out/darwin_arm64-fastbuild/bin/cli-plugins-pro_/cli-plugins-pro pid=79848
2022-03-27T20:26:10.118-0400 [DEBUG] pro: plugin exited
```

Fixes: #181