### PR TITLE
fix: execute custom command rebind lazy access

### DIFF
--- a/pkg/plugin/system/system.go
+++ b/pkg/plugin/system/system.go
@@ -141,7 +141,7 @@ func (ps *pluginSystem) RegisterCustomCommands(cmd *cobra.Command) error {
 				RunE: interceptors.Run(
 					[]interceptors.Interceptor{},
 					func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
-						return callback.ExecuteCustomCommand(command.Use, ctx, args)
+						return callback.ExecuteCustomCommand(cmd.Use, ctx, args)
 					},
 				),
 			})


### PR DESCRIPTION
Since `command` gets accessed lazily inside the function below when we execute the command, `command.Use` always points to the latest registered command.

cc @dymart who discovered the bug initially.