### PR TITLE
feat: enable almost all go/analysis checkers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,7 +26,6 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/ctrlflow",
         "@org_golang_x_tools//go/analysis/passes/deepequalerrors",
         "@org_golang_x_tools//go/analysis/passes/errorsas",
-        "@org_golang_x_tools//go/analysis/passes/fieldalignment",
         "@org_golang_x_tools//go/analysis/passes/findcall",
         "@org_golang_x_tools//go/analysis/passes/framepointer",
         "@org_golang_x_tools//go/analysis/passes/httpresponse",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "TOOLS_NOGO", "nogo")
+load("@io_bazel_rules_go//go:def.bzl", "nogo")
 
 # When generating the documents for this repo bazel needs to be started so that we can generate
 # the correct flags. To do this we need version from .bazelversion
@@ -12,7 +12,49 @@ nogo(
     name = "nogo",
     config = "nogo_config.json",
     visibility = ["//visibility:public"],
-    deps = TOOLS_NOGO,
+    deps = [
+        "@org_golang_x_tools//go/analysis/passes/asmdecl",
+        "@org_golang_x_tools//go/analysis/passes/assign",
+        "@org_golang_x_tools//go/analysis/passes/atomic",
+        "@org_golang_x_tools//go/analysis/passes/atomicalign",
+        "@org_golang_x_tools//go/analysis/passes/bools",
+        "@org_golang_x_tools//go/analysis/passes/buildssa",
+        "@org_golang_x_tools//go/analysis/passes/buildtag",
+        "@org_golang_x_tools//go/analysis/passes/cgocall",
+        "@org_golang_x_tools//go/analysis/passes/composite",
+        "@org_golang_x_tools//go/analysis/passes/copylock",
+        "@org_golang_x_tools//go/analysis/passes/ctrlflow",
+        "@org_golang_x_tools//go/analysis/passes/deepequalerrors",
+        "@org_golang_x_tools//go/analysis/passes/errorsas",
+        "@org_golang_x_tools//go/analysis/passes/fieldalignment",
+        "@org_golang_x_tools//go/analysis/passes/findcall",
+        "@org_golang_x_tools//go/analysis/passes/framepointer",
+        "@org_golang_x_tools//go/analysis/passes/httpresponse",
+        "@org_golang_x_tools//go/analysis/passes/ifaceassert",
+        "@org_golang_x_tools//go/analysis/passes/inspect",
+        "@org_golang_x_tools//go/analysis/passes/loopclosure",
+        "@org_golang_x_tools//go/analysis/passes/lostcancel",
+        "@org_golang_x_tools//go/analysis/passes/nilfunc",
+        "@org_golang_x_tools//go/analysis/passes/nilness",
+        "@org_golang_x_tools//go/analysis/passes/pkgfact",
+        "@org_golang_x_tools//go/analysis/passes/printf",
+        "@org_golang_x_tools//go/analysis/passes/reflectvaluecompare",
+        "@org_golang_x_tools//go/analysis/passes/shadow",
+        "@org_golang_x_tools//go/analysis/passes/shift",
+        "@org_golang_x_tools//go/analysis/passes/sigchanyzer",
+        "@org_golang_x_tools//go/analysis/passes/sortslice",
+        "@org_golang_x_tools//go/analysis/passes/stdmethods",
+        "@org_golang_x_tools//go/analysis/passes/stringintconv",
+        "@org_golang_x_tools//go/analysis/passes/structtag",
+        "@org_golang_x_tools//go/analysis/passes/testinggoroutine",
+        "@org_golang_x_tools//go/analysis/passes/tests",
+        "@org_golang_x_tools//go/analysis/passes/unmarshal",
+        "@org_golang_x_tools//go/analysis/passes/unreachable",
+        "@org_golang_x_tools//go/analysis/passes/unsafeptr",
+        "@org_golang_x_tools//go/analysis/passes/unusedresult",
+        "@org_golang_x_tools//go/analysis/passes/unusedwrite",
+        "@org_golang_x_tools//go/analysis/passes/usesgenerics",
+    ],
 )
 
 # gazelle:prefix aspect.build/cli

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -9,14 +9,6 @@
       "(third_party|vendor|external)/.*": "only run for first-party code"
     }
   },
-  "fieldalignment": {
-    "exclude_files": {
-      ".*/bindata.go": "only run for first-party code",
-      ".*/mock_.*\\.go": "only run for first-party code",
-      ".*/.*\\.pb\\.go": "only run for first-party code",
-      "(third_party|vendor|external)/.*": "only run for first-party code"
-    }
-  },
   "nilness": {
     "exclude_files": {
       "(third_party|vendor|external)/.*": "only run for first-party code"

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -9,7 +9,20 @@
       "(third_party|vendor|external)/.*": "only run for first-party code"
     }
   },
+  "fieldalignment": {
+    "exclude_files": {
+      ".*/bindata.go": "only run for first-party code",
+      ".*/mock_.*\\.go": "only run for first-party code",
+      ".*/.*\\.pb\\.go": "only run for first-party code",
+      "(third_party|vendor|external)/.*": "only run for first-party code"
+    }
+  },
   "nilness": {
+    "exclude_files": {
+      "(third_party|vendor|external)/.*": "only run for first-party code"
+    }
+  },
+  "reflectvaluecompare": {
     "exclude_files": {
       "(third_party|vendor|external)/.*": "only run for first-party code"
     }
@@ -18,6 +31,11 @@
     "exclude_files": {
       "(third_party|vendor|external)/.*": "only run for first-party code",
       "pkg/bazel/bazelisk.go": "copied third-party code"
+    }
+  },
+  "sigchanyzer": {
+    "exclude_files": {
+      "(third_party|vendor|external)/.*": "only run for first-party code"
     }
   },
   "stdmethods": {
@@ -31,6 +49,11 @@
     }
   },
   "unsafeptr": {
+    "exclude_files": {
+      "(third_party|vendor|external)/.*": "only run for first-party code"
+    }
+  },
+  "unusedwrite": {
     "exclude_files": {
       "(third_party|vendor|external)/.*": "only run for first-party code"
     }

--- a/pkg/bazel/bazelisk.go
+++ b/pkg/bazel/bazelisk.go
@@ -9,14 +9,8 @@
 package bazel
 
 import (
-	"aspect.build/cli/pkg/ioutils"
 	"bufio"
 	"fmt"
-	"github.com/bazelbuild/bazelisk/core"
-	"github.com/bazelbuild/bazelisk/httputil"
-	"github.com/bazelbuild/bazelisk/platforms"
-	"github.com/bazelbuild/bazelisk/versions"
-	"github.com/mitchellh/go-homedir"
 	"io"
 	"io/ioutil"
 	"log"
@@ -30,6 +24,14 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+
+	"github.com/bazelbuild/bazelisk/core"
+	"github.com/bazelbuild/bazelisk/httputil"
+	"github.com/bazelbuild/bazelisk/platforms"
+	"github.com/bazelbuild/bazelisk/versions"
+	"github.com/mitchellh/go-homedir"
+
+	"aspect.build/cli/pkg/ioutils"
 )
 
 const (
@@ -395,7 +397,7 @@ func (bazelisk *Bazelisk) runBazel(bazel string, args []string, streams ioutils.
 		return 1, fmt.Errorf("could not start Bazel: %v", err)
 	}
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		s := <-c


### PR DESCRIPTION
The only one I disabled was the `fieldalignment` one since it would require sorting fields on structs for no perceived gain.