### PR TITLE
fix: Remove restriction on number of arguments passed to aspect info

### DIFF
--- a/cmd/aspect/info/info.go
+++ b/cmd/aspect/info/info.go
@@ -45,7 +45,6 @@ the bazel User Manual, and can be programmatically obtained with
 
 See also 'bazel version' for more detailed bazel version
 information.`,
-		Args: cobra.MaximumNArgs(1),
 		RunE: interceptors.Run(
 			[]interceptors.Interceptor{
 				flags.FlagsInterceptor(streams),

--- a/integration_tests/info/BUILD.bazel
+++ b/integration_tests/info/BUILD.bazel
@@ -1,0 +1,5 @@
+sh_test(
+    name = "can_pass_arguments",
+    srcs = ["can_pass_arguments.sh"],
+    data = ["//cmd/aspect"],
+)

--- a/integration_tests/info/can_pass_arguments.sh
+++ b/integration_tests/info/can_pass_arguments.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o pipefail -o errexit -o nounset
+HOME="$TEST_TMPDIR"
+touch "$HOME"/.aspect.yaml
+ASPECT="$TEST_SRCDIR/build_aspect_cli/cmd/aspect/aspect_/aspect"
+export HOME
+touch WORKSPACE
+
+# Only capture stdout
+info=$($ASPECT info bazel-bin --color=no 2>/dev/null) || "$ASPECT" info bazel-bin --color=no
+
+# Should include a path section that contains bazel-out
+[[ "$info" =~ "/bazel-out/" ]] || {
+    echo >&2 "Expected 'aspect info bazel-bin --color=no' stdout to contain 'bazel-out', but was"
+    echo "$info"
+    exit 1
+}


### PR DESCRIPTION
When running a command such as `aspect info bazel-bin --color=no` both `bazel-bin` and `--color=no` are picked up as arguments by cobra. Given this we do not want to restrict it to 1 argument