### PR TITLE
Pass a context struct to RunCommand

### DIFF
--- a/pkg/aspect/build/build.go
+++ b/pkg/aspect/build/build.go
@@ -38,7 +38,7 @@ func New(
 // Event Protocol backend used by Aspect plugins to subscribe to build events.
 func (b *Build) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
 	besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
-	exitCode, bazelErr := b.bzl.Spawn(append([]string{"build", besBackendFlag}, args...))
+	exitCode, bazelErr := b.bzl.Spawn(append([]string{"build", besBackendFlag}, args...)...)
 
 	// Process the subscribers errors before the Bazel one.
 	subscriberErrors := besBackend.Errors()

--- a/pkg/aspect/clean/clean.go
+++ b/pkg/aspect/clean/clean.go
@@ -180,7 +180,7 @@ func (c *Clean) Run(_ *cobra.Command, _ []string) error {
 	if c.ExpungeAsync {
 		cmd = append(cmd, "--expunge_async")
 	}
-	if exitCode, err := c.bzl.Spawn(cmd); exitCode != 0 {
+	if exitCode, err := c.bzl.Spawn(cmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,
@@ -332,16 +332,20 @@ func (c *Clean) findDiskCaches(
 	// Running an invalid query should ensure that repository rules are not executed.
 	// However, bazel will still emit its BEP containing the flag that we are interested in.
 	// This will ensure it returns quickly and allows us to easily access said flag.
-	c.bzl.RunCommand([]string{
+	c.bzl.RunCommand(
+		bazel.BazelContext{
+			WorkspaceRoot: "",
+			EnvVars:       nil,
+			Streams:       streams,
+		},
 		"query",
 		"//",
-		"--build_event_json_file=" + bepLocation,
+		"--build_event_json_file="+bepLocation,
 
 		// We dont want bazel to print anything to the command line.
 		// We are only interested in the BEP output
 		"--ui_event_filters=-fatal,-error,-warning,-info,-progress,-debug,-start,-finish,-subcommand,-stdout,-stderr,-pass,-fail,-timeout,-cancelled,-depchecker",
-		"--noshow_progress",
-	}, streams)
+		"--noshow_progress")
 
 	file, err := os.Open(bepLocation)
 	if err != nil {

--- a/pkg/aspect/info/info.go
+++ b/pkg/aspect/info/info.go
@@ -39,7 +39,7 @@ func (v *Info) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd = append(bazelCmd, args...)
 	bzl := bazel.New()
 
-	if exitCode, err := bzl.Spawn(bazelCmd); exitCode != 0 {
+	if exitCode, err := bzl.Spawn(bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/query/shared/query.go
+++ b/pkg/aspect/query/shared/query.go
@@ -157,12 +157,7 @@ func ProcessQueries(presets []*PresetQuery) (map[string]*PresetQuery, []string, 
 }
 
 func RunQuery(bzl bazel.Bazel, verb string, query string) error {
-	bazelCmd := []string{
-		verb,
-		query,
-	}
-
-	if exitCode, err := bzl.Spawn(bazelCmd); exitCode != 0 {
+	if exitCode, err := bzl.Spawn(verb, query); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/run/run.go
+++ b/pkg/aspect/run/run.go
@@ -38,7 +38,7 @@ func New(
 // Event Protocol backend used by Aspect plugins to subscribe to build events.
 func (cmd *Run) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
 	besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
-	exitCode, bazelErr := cmd.bzl.Spawn(append([]string{"run", besBackendFlag}, args...))
+	exitCode, bazelErr := cmd.bzl.Spawn(append([]string{"run", besBackendFlag}, args...)...)
 
 	// Process the subscribers errors before the Bazel one.
 	subscriberErrors := besBackend.Errors()

--- a/pkg/aspect/test/test.go
+++ b/pkg/aspect/test/test.go
@@ -34,7 +34,7 @@ func (t *Test) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
 	bazelCmd := []string{"test", besBackendFlag}
 	bazelCmd = append(bazelCmd, args...)
 
-	exitCode, bazelErr := t.bzl.Spawn(bazelCmd)
+	exitCode, bazelErr := t.bzl.Spawn(bazelCmd...)
 
 	// Process the subscribers errors before the Bazel one.
 	subscriberErrors := besBackend.Errors()

--- a/pkg/aspect/version/version.go
+++ b/pkg/aspect/version/version.go
@@ -51,7 +51,7 @@ func (v *Version) Run(bzl bazel.Bazel) error {
 	} else {
 		fmt.Fprintf(v.Stdout, "Aspect version: %s\n", version)
 	}
-	bzl.Spawn(bazelCmd)
+	bzl.Spawn(bazelCmd...)
 
 	return nil
 }

--- a/pkg/bazel/bazel_test.go
+++ b/pkg/bazel/bazel_test.go
@@ -31,7 +31,7 @@ func TestBazel(t *testing.T) {
 			workspaceFinder: nil,
 		}
 
-		_, err := bzl.Spawn([]string{"help"})
+		_, err := bzl.Spawn("help")
 		g.Expect(err).To(MatchError(expectedErr))
 	})
 
@@ -57,7 +57,7 @@ func TestBazel(t *testing.T) {
 			workspaceFinder: workspaceFinder,
 		}
 
-		_, err := bzl.Spawn([]string{"help"})
+		_, err := bzl.Spawn("help")
 		g.Expect(err).To(MatchError(expectedErr))
 	})
 
@@ -83,7 +83,7 @@ func TestBazel(t *testing.T) {
 			workspaceFinder: workspaceFinder,
 		}
 
-		_, err := bzl.Spawn([]string{"help"})
+		_, err := bzl.Spawn("help")
 		g.Expect(err).To(MatchError(expectedErrStr))
 	})
 }

--- a/pkg/plugin/client/client.go
+++ b/pkg/plugin/client/client.go
@@ -79,7 +79,13 @@ func (c *clientFactory) buildPlugin(target string) (string, error) {
 	// build the developer or CI would be performing.
 	// This is important only in the setup we don't recommend, where normal users
 	// are building the plugin from source instead of a pre-built binary.
-	if _, err := c.bzl.RunCommand([]string{"build", target}, streams); err != nil {
+	if _, err := c.bzl.RunCommand(
+		bazel.BazelContext{
+			WorkspaceRoot: "",
+			EnvVars:       nil,
+			Streams:       streams,
+		},
+		"build", target); err != nil {
 		return "", fmt.Errorf("failed to build plugin %q with Bazel: %w", target, err)
 	}
 


### PR DESCRIPTION
This makes it possible to set the location of the workspace
directory, and pass in environment variables if needed.

The Target Determinator in `bazel-contrib` needs us to be
able to set the workspace root, and repinning deps when
using `rules_jvm_external` requires us to set an environment
variable.

By passing a context object in, we can add additional
parameters should we find these necessary.