### PR TITLE
feat: avoid re-entrance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,9 +78,17 @@ Companies with more than 250 employees can contact us at sales@aspect.dev for a 
 
 # Installation
 
-## Using a package manager
+## In `.bazelversion` (recommended)
 
-> Coming soon
+Add a new line at the top of your `.bazelversion` file containing `aspect-build/[version]`,
+keeping your original content on following lines.
+
+For example, to use Aspect CLI 1.2.3 with Bazel 5.2.0, your `.bazelversion` would contain
+
+```
+aspect-build/1.2.3
+5.2.0
+```
 
 ## Manual installation
 

--- a/pkg/bazel/bazelisk.go
+++ b/pkg/bazel/bazelisk.go
@@ -257,8 +257,17 @@ func (bazelisk *Bazelisk) getBazelVersion() (string, error) {
 			defer f.Close()
 
 			scanner := bufio.NewScanner(f)
+			scanner.Split(bufio.ScanLines)
 			scanner.Scan()
 			bazelVersion := scanner.Text()
+			// If the first line of .bazelversion is Aspect CLI, then when we call
+			// bazelisk it will read the file again and we'll call ourselves in a loop.
+			// We don't want to be re-entrant, so detect when our fork is selected.
+			// In this case, the user should put their bazel version on the following line.
+			if strings.HasPrefix(bazelVersion, "aspect-build/") {
+				scanner.Scan()
+				bazelVersion = scanner.Text()
+			}
 			if err := scanner.Err(); err != nil {
 				return "", fmt.Errorf("could not read version from file %s: %v", bazelVersion, err)
 			}


### PR DESCRIPTION
If the aspect-build/bazel fork is chosen by the first line in .bazelversion, then aspect-cli will try to call itself.
Instead it can provide the second line of the file in this case when calling our nested bazelisk