### PR TITLE
Update `bootstrap` test to use shell assertion functions from `bazel-lib`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,11 +16,16 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-http_archive(
+# http_archive(
+#     name = "aspect_bazel_lib",
+#     sha256 = "4d709266337d8e147fb647d6dfa3bbcfb6983ab79bece9cf661e3dc13ae3c3bc",
+#     strip_prefix = "bazel-lib-0.6.1",
+#     url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v0.6.1.tar.gz",
+# )
+
+local_repository(
     name = "aspect_bazel_lib",
-    sha256 = "4d709266337d8e147fb647d6dfa3bbcfb6983ab79bece9cf661e3dc13ae3c3bc",
-    strip_prefix = "bazel-lib-0.6.1",
-    url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v0.6.1.tar.gz",
+    path = "/Users/chuck/code/aspect-build/bazel-lib/port_shlib_assertions",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,16 +16,11 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-# http_archive(
-#     name = "aspect_bazel_lib",
-#     sha256 = "4d709266337d8e147fb647d6dfa3bbcfb6983ab79bece9cf661e3dc13ae3c3bc",
-#     strip_prefix = "bazel-lib-0.6.1",
-#     url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v0.6.1.tar.gz",
-# )
-
-local_repository(
+http_archive(
     name = "aspect_bazel_lib",
-    path = "/Users/chuck/code/aspect-build/bazel-lib/port_shlib_assertions",
+    sha256 = "3a4745bb5a649612148ab9fdb4bdfcf0fa4120b469fabdb007acb50f85670139",
+    strip_prefix = "bazel-lib-1.11.7",
+    url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.11.7.tar.gz",
 )
 
 http_archive(

--- a/integration_tests/bootstrap/BUILD.bazel
+++ b/integration_tests/bootstrap/BUILD.bazel
@@ -2,4 +2,8 @@ sh_test(
     name = "no_cmd_test",
     srcs = ["no_cmd_test.sh"],
     data = ["//cmd/bootstrap"],
+    deps = [
+        "@aspect_bazel_lib//shlib/lib:assertions",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )

--- a/integration_tests/bootstrap/no_cmd_test.sh
+++ b/integration_tests/bootstrap/no_cmd_test.sh
@@ -1,34 +1,27 @@
 #!/usr/bin/env bash
 
-set -o pipefail -o errexit -o nounset
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
 
-# Functions
-
-fail() {
-  local err_msg="${1:-}"
-  [[ -n "${err_msg}" ]] || err_msg="Unspecified error occurred."
-  echo >&2 "${err_msg}"
-  exit 1
-}
-
-make_err_msg() {
-  local err_msg="${1}"
-  local prefix="${2:-}"
-  [[ -z "${prefix}" ]] || \
-    local err_msg="${prefix} ${err_msg}"
-  echo "${err_msg}"
-}
-
-assert_match() {
-  local pattern=${1}
-  local actual="${2}"
-  local err_msg="$(make_err_msg "Expected to match. pattern: ${pattern}, actual: ${actual}" "${3:-}")"
-  [[ "${actual}" =~ ${pattern} ]] || fail "${err_msg}"
-}
+assertions_sh_location=aspect_bazel_lib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
 
 # Variables
 
-bootstrap="$TEST_SRCDIR/build_aspect_cli/cmd/bootstrap/bootstrap_/bootstrap"
+bootstrap_location=build_aspect_cli/cmd/bootstrap
+bootstrap="$(rlocation "${bootstrap_location}")/bootstrap_/bootstrap" || \
+  (echo >&2 "Failed to locate ${bootstrap_location}" && exit 1)
 
 # Tests
 

--- a/integration_tests/bootstrap/no_cmd_test.sh
+++ b/integration_tests/bootstrap/no_cmd_test.sh
@@ -15,6 +15,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 assertions_sh_location=aspect_bazel_lib/shlib/lib/assertions.sh
 assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+# shellcheck disable=SC1090
 source "${assertions_sh}"
 
 # Variables


### PR DESCRIPTION
Closes #243.

- Upgrade `bazel-lib` to 1.11.7.
- Update `bootstrap` integration tests to use assertion functions.