### PR TITLE
refactor: downloaded plugins are always versioned

### DIFF
--- a/.aspectplugins
+++ b/.aspectplugins
@@ -2,3 +2,8 @@
 #- name: hello-world
 #  version: v0.2.0
 #  from: github.com/aspect-build/aspect-cli-plugin-template
+
+# Example: Aspect's pro plugin
+# - name: plugin-aspect-pro
+#   from: https://static.aspect.build/cli
+#   version: v0.8.0

--- a/pkg/plugin/client/client.go
+++ b/pkg/plugin/client/client.go
@@ -112,16 +112,23 @@ func (c *clientFactory) New(aspectplugin loader.AspectPlugin, streams ioutils.St
 			aspectplugin.From = built
 		}
 	} else if strings.Contains(aspectplugin.From, "/") {
-		if strings.HasPrefix(aspectplugin.From, "github.com/") {
-			if len(aspectplugin.Version) < 1 {
-				return nil, fmt.Errorf("when using a plugin released on GitHub, the version field is required")
-			}
-			// Example release URL:
-			// https://github.com/aspect-build/aspect-cli-plugin-template/releases/download/v0.1.0/plugin-plugin-linux_amd64
-			aspectplugin.From = fmt.Sprintf("https://%s/releases/download/%s/%s", aspectplugin.From, aspectplugin.Version, aspectplugin.Name)
+		if len(aspectplugin.Version) < 1 {
+			return nil, fmt.Errorf("failed to download plugin '%s': the version field is required", aspectplugin.Name)
 		}
+		// Syntax sugar:
+		//   from: github.com/org/repo
+		// is the same as
+		//   from: https://github.com/org/repo/releases/download
+		// Example release URL:
+		//   https://github.com/aspect-build/aspect-cli-plugin-template/releases/download/v0.1.0/plugin-plugin-linux_amd64
+		if strings.HasPrefix(aspectplugin.From, "github.com/") {
+			aspectplugin.From = fmt.Sprintf("https://%s/releases/download", aspectplugin.From)
+		}
+		// Example release URL:
+		// http://static.aspect.build/v0.1.0/plugin-aspect-pro-darwin_amd64
 		if strings.HasPrefix(aspectplugin.From, "http://") || strings.HasPrefix(aspectplugin.From, "https://") {
-			downloaded, err := DownloadPlugin(aspectplugin.From, aspectplugin.Name)
+			versionedUrl := fmt.Sprintf("%s/%s/%s", aspectplugin.From, aspectplugin.Version, aspectplugin.Name)
+			downloaded, err := DownloadPlugin(versionedUrl, aspectplugin.Name)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Note, we'll probably want to support `version: latest` as well. This will need
- a way for us to keep an index.json up-to-date in the S3 bucket
- logic here to look for the index file to know what versions exist
- probably also matching logic to find latest github release
- write back to the plugins config file to pin to what we discovered