### PR TITLE
feat: add sync pass-through command

### DIFF
--- a/cmd/aspect/root/BUILD.bazel
+++ b/cmd/aspect/root/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//cmd/aspect/info",
         "//cmd/aspect/query",
         "//cmd/aspect/run",
+        "//cmd/aspect/sync",
         "//cmd/aspect/test",
         "//cmd/aspect/version",
         "//docs/help/topics",

--- a/cmd/aspect/root/root.go
+++ b/cmd/aspect/root/root.go
@@ -31,6 +31,7 @@ import (
 	"aspect.build/cli/cmd/aspect/info"
 	"aspect.build/cli/cmd/aspect/query"
 	"aspect.build/cli/cmd/aspect/run"
+	"aspect.build/cli/cmd/aspect/sync"
 	"aspect.build/cli/cmd/aspect/test"
 	"aspect.build/cli/cmd/aspect/version"
 	"aspect.build/cli/docs/help/topics"
@@ -78,6 +79,7 @@ func NewRootCmd(
 	cmd.AddCommand(run.NewDefaultRunCmd(pluginSystem))
 	cmd.AddCommand(test.NewDefaultTestCmd(pluginSystem))
 	cmd.AddCommand(version.NewDefaultVersionCmd())
+	cmd.AddCommand(sync.NewDefaultSyncCmd())
 
 	// ### "Additional help topic commands" which are not runnable
 	// https://pkg.go.dev/github.com/spf13/cobra#Command.IsAdditionalHelpTopicCommand

--- a/cmd/aspect/sync/BUILD.bazel
+++ b/cmd/aspect/sync/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sync",
+    srcs = ["sync.go"],
+    importpath = "aspect.build/cli/cmd/aspect/sync",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/aspect/root/flags",
+        "//pkg/aspect/sync",
+        "//pkg/interceptors",
+        "//pkg/ioutils",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/cmd/aspect/sync/sync.go
+++ b/cmd/aspect/sync/sync.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sync
+
+import (
+	"github.com/spf13/cobra"
+
+	"aspect.build/cli/pkg/aspect/root/flags"
+	"aspect.build/cli/pkg/aspect/sync"
+	"aspect.build/cli/pkg/interceptors"
+	"aspect.build/cli/pkg/ioutils"
+)
+
+func NewDefaultSyncCmd() *cobra.Command {
+	return NewSyncCmd(ioutils.DefaultStreams)
+}
+
+func NewSyncCmd(streams ioutils.Streams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Syncs all repositories specified in the workspace file.",
+		Long: `Ensures that all Starlark repository rules of the top-level WORKSPACE
+file are called.
+
+NOTE: This command is still very experimental and the precise semantics
+will change in the near future.`,
+		RunE: interceptors.Run(
+			[]interceptors.Interceptor{
+				flags.FlagsInterceptor(streams),
+			},
+			sync.New(streams).Run,
+		),
+	}
+
+	return cmd
+}

--- a/docs/aspect.md
+++ b/docs/aspect.md
@@ -24,6 +24,7 @@ Aspect CLI is a better frontend for running bazel
 * [aspect info](aspect_info.md)	 - Displays runtime info about the bazel server.
 * [aspect query](aspect_query.md)	 - Executes a dependency graph query.
 * [aspect run](aspect_run.md)	 - Builds the specified target and runs it with the given arguments.
+* [aspect sync](aspect_sync.md)	 - Syncs all repositories specified in the workspace file.
 * [aspect test](aspect_test.md)	 - Builds the specified targets and runs all test targets among them.
 * [aspect version](aspect_version.md)	 - Print the version of aspect CLI as well as tools it invokes.
 

--- a/docs/aspect_sync.md
+++ b/docs/aspect_sync.md
@@ -1,0 +1,33 @@
+## aspect sync
+
+Syncs all repositories specified in the workspace file.
+
+### Synopsis
+
+Ensures that all Starlark repository rules of the top-level WORKSPACE
+file are called.
+
+NOTE: This command is still very experimental and the precise semantics
+will change in the near future.
+
+```
+aspect sync [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for sync
+```
+
+### Options inherited from parent commands
+
+```
+      --aspect:config string   config file (default is $HOME/.aspect.yaml)
+      --aspect:interactive     Interactive mode (e.g. prompts for user input)
+```
+
+### SEE ALSO
+
+* [aspect](aspect.md)	 - Aspect.build bazel wrapper
+

--- a/docs/command_list.bzl
+++ b/docs/command_list.bzl
@@ -10,6 +10,7 @@ COMMAND_LIST = [
     "info",
     "query",
     "run",
+    "sync",
     "test",
     "version",
 ]

--- a/pkg/aspect/sync/BUILD.bazel
+++ b/pkg/aspect/sync/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sync",
+    srcs = ["sync.go"],
+    importpath = "aspect.build/cli/pkg/aspect/sync",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/aspecterrors",
+        "//pkg/bazel",
+        "//pkg/ioutils",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/pkg/aspect/sync/sync.go
+++ b/pkg/aspect/sync/sync.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sync
+
+import (
+	"context"
+
+	"aspect.build/cli/pkg/bazel"
+	"aspect.build/cli/pkg/ioutils"
+	"github.com/spf13/cobra"
+
+	"aspect.build/cli/pkg/aspecterrors"
+)
+
+type Sync struct {
+	ioutils.Streams
+}
+
+func New(streams ioutils.Streams) *Sync {
+	return &Sync{
+		Streams: streams,
+	}
+}
+
+func (v *Sync) Run(ctx context.Context, _ *cobra.Command, args []string) error {
+	bazelCmd := []string{"sync"}
+	bazelCmd = append(bazelCmd, args...)
+	bzl := bazel.New()
+
+	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+		err = &aspecterrors.ExitError{
+			Err:      err,
+			ExitCode: exitCode,
+		}
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
First PR of many so that aspect cli can be correctly advertised as a drop-in replacement for the bazel cli.

Goal is to have all missing bazel commands added as pass-through,

```
Available commands:
  analyze-profile     Analyzes build profile data.
  aquery              Analyzes the given targets and queries the action graph.
  build               Builds the specified targets.
  canonicalize-flags  Canonicalizes a list of bazel options.
  clean               Removes output files and optionally stops the server.
  coverage            Generates code coverage report for specified test targets.
  cquery              Loads, analyzes, and queries the specified targets w/ configurations.
  dump                Dumps the internal state of the bazel server process.
  fetch               Fetches external repositories that are prerequisites to the targets.
  help                Prints help for commands, or the index.
  info                Displays runtime info about the bazel server.
  license             Prints the license of this software.
  mobile-install      Installs targets to mobile devices.
  modquery            Queries the Bzlmod external dependency graph
  print_action        Prints the command line args for compiling a file.
  query               Executes a dependency graph query.
  run                 Runs the specified target.
  shutdown            Stops the bazel server.
  sync                Syncs all repositories specified in the workspace file
  test                Builds and runs the specified test targets.
  version             Prints version information for bazel.
```

Intentionally light on testing here so we can burn through this list quickly. Not more to unit test on pass-through commands. Future integration testing will need to be added.