### PR TITLE
feat: add license pass-through command

### DIFF
--- a/cmd/aspect/license/BUILD.bazel
+++ b/cmd/aspect/license/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "license",
+    srcs = ["license.go"],
+    importpath = "aspect.build/cli/cmd/aspect/license",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/aspect/license",
+        "//pkg/aspect/root/flags",
+        "//pkg/interceptors",
+        "//pkg/ioutils",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/cmd/aspect/license/license.go
+++ b/cmd/aspect/license/license.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package license
+
+import (
+	"github.com/spf13/cobra"
+
+	"aspect.build/cli/pkg/aspect/license"
+	"aspect.build/cli/pkg/aspect/root/flags"
+	"aspect.build/cli/pkg/interceptors"
+	"aspect.build/cli/pkg/ioutils"
+)
+
+func NewDefaultLicenseCmd() *cobra.Command {
+	return NewLicenseCmd(ioutils.DefaultStreams)
+}
+
+func NewLicenseCmd(streams ioutils.Streams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "license",
+		Short: "Prints the license of this software.",
+		Long:  "Prints the license of this software.",
+		RunE: interceptors.Run(
+			[]interceptors.Interceptor{
+				flags.FlagsInterceptor(streams),
+			},
+			license.New(streams).Run,
+		),
+	}
+
+	return cmd
+}

--- a/cmd/aspect/root/BUILD.bazel
+++ b/cmd/aspect/root/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//cmd/aspect/dump",
         "//cmd/aspect/fetch",
         "//cmd/aspect/info",
+        "//cmd/aspect/license",
         "//cmd/aspect/mobileinstall",
         "//cmd/aspect/modquery",
         "//cmd/aspect/printaction",

--- a/cmd/aspect/root/root.go
+++ b/cmd/aspect/root/root.go
@@ -33,6 +33,7 @@ import (
 	"aspect.build/cli/cmd/aspect/dump"
 	"aspect.build/cli/cmd/aspect/fetch"
 	"aspect.build/cli/cmd/aspect/info"
+	"aspect.build/cli/cmd/aspect/license"
 	"aspect.build/cli/cmd/aspect/mobileinstall"
 	"aspect.build/cli/cmd/aspect/modquery"
 	"aspect.build/cli/cmd/aspect/printaction"
@@ -87,7 +88,8 @@ func NewRootCmd(
 	cmd.AddCommand(fetch.NewDefaultFetchCmd())
 	cmd.AddCommand(docs.NewDefaultDocsCmd())
 	cmd.AddCommand(info.NewDefaultInfoCmd())
-	// license
+	cmd.AddCommand(license.NewDefaultLicenseCmd())
+	cmd.AddCommand(mobileinstall.NewDefaultMobileInstallCmd())
 	cmd.AddCommand(mobileinstall.NewDefaultMobileInstallCmd())
 	cmd.AddCommand(modquery.NewDefaultModQueryCmd())
 	cmd.AddCommand(printaction.NewDefaultPrintActionCmd())

--- a/docs/aspect.md
+++ b/docs/aspect.md
@@ -26,6 +26,8 @@ Aspect CLI is a better frontend for running bazel
 * [aspect dump](aspect_dump.md)	 - Dumps the internal state of the bazel server process.
 * [aspect fetch](aspect_fetch.md)	 - Fetches external repositories that are prerequisites to the targets.
 * [aspect info](aspect_info.md)	 - Displays runtime info about the bazel server.
+* [aspect license](aspect_license.md)	 - Prints the license of this software.
+* [aspect mobile-install](aspect_mobile-install.md)	 - Installs targets to mobile devices.
 * [aspect mobile-install](aspect_mobile-install.md)	 - Installs targets to mobile devices.
 * [aspect modquery](aspect_modquery.md)	 - Queries the Bzlmod external dependency graph.
 * [aspect print_action](aspect_print_action.md)	 - Prints the command line args for compiling a file.

--- a/docs/aspect_license.md
+++ b/docs/aspect_license.md
@@ -1,0 +1,29 @@
+## aspect license
+
+Prints the license of this software.
+
+### Synopsis
+
+Prints the license of this software.
+
+```
+aspect license [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for license
+```
+
+### Options inherited from parent commands
+
+```
+      --aspect:config string   config file (default is $HOME/.aspect.yaml)
+      --aspect:interactive     Interactive mode (e.g. prompts for user input)
+```
+
+### SEE ALSO
+
+* [aspect](aspect.md)	 - Aspect.build bazel wrapper
+

--- a/docs/command_list.bzl
+++ b/docs/command_list.bzl
@@ -12,6 +12,7 @@ COMMAND_LIST = [
     "dump",
     "fetch",
     "info",
+    "license",
     "mobile-install",
     "modquery",
     "print_action",

--- a/pkg/aspect/license/BUILD.bazel
+++ b/pkg/aspect/license/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "license",
+    srcs = ["license.go"],
+    importpath = "aspect.build/cli/pkg/aspect/license",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/aspecterrors",
+        "//pkg/bazel",
+        "//pkg/ioutils",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/pkg/aspect/license/license.go
+++ b/pkg/aspect/license/license.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package license
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"aspect.build/cli/pkg/aspecterrors"
+	"aspect.build/cli/pkg/bazel"
+	"aspect.build/cli/pkg/ioutils"
+)
+
+type License struct {
+	ioutils.Streams
+}
+
+func New(streams ioutils.Streams) *License {
+	return &License{
+		Streams: streams,
+	}
+}
+
+func (v *License) Run(ctx context.Context, _ *cobra.Command, args []string) error {
+	bazelCmd := []string{"license"}
+	bazelCmd = append(bazelCmd, args...)
+	bzl := bazel.New()
+
+	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+		err = &aspecterrors.ExitError{
+			Err:      err,
+			ExitCode: exitCode,
+		}
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This one needs thought and design since we probably want to include our license in the list as well and maybe not the bazel license at all since bazel is a tool that the aspect CLI uses under the hood. Will leave in DRAFT for now.