### PR TITLE
chore: update .bazelversion to use aspect CLI 0.8.0 and bazel 5.3.1

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,2 +1,2 @@
-aspect-build/0.6.0
-5.0.0
+aspect-build/0.8.0
+5.3.1


### PR DESCRIPTION
Using the bazel fork release trick to pull binaries from https://github.com/aspect-build/bazel/releases/tag/0.8.0