### PR TITLE
refactor: bazel

### DIFF
--- a/cmd/aspect/aquery/aquery.go
+++ b/cmd/aspect/aquery/aquery.go
@@ -29,10 +29,10 @@ import (
 )
 
 func NewDefaultAQueryCmd() *cobra.Command {
-	return NewAQueryCommand(ioutils.DefaultStreams, bazel.New())
+	return NewAQueryCommand(ioutils.DefaultStreams, bazel.FindFromWd)
 }
 
-func NewAQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
+func NewAQueryCommand(streams ioutils.Streams, bzlProvider bazel.BazelProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aquery",
 		Short: "Executes an aquery.",
@@ -42,6 +42,10 @@ func NewAQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 				flags.FlagsInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
+				bzl, err := bzlProvider()
+				if err != nil {
+					return err
+				}
 				q := aquery.New(streams, bzl, true)
 				return q.Run(cmd, args)
 			},

--- a/cmd/aspect/build/build.go
+++ b/cmd/aspect/build/build.go
@@ -36,7 +36,7 @@ func NewDefaultBuildCmd(pluginSystem system.PluginSystem) *cobra.Command {
 	return NewBuildCmd(
 		ioutils.DefaultStreams,
 		pluginSystem,
-		bazel.New(),
+		bazel.FindFromWd,
 	)
 }
 
@@ -44,7 +44,7 @@ func NewDefaultBuildCmd(pluginSystem system.PluginSystem) *cobra.Command {
 func NewBuildCmd(
 	streams ioutils.Streams,
 	pluginSystem system.PluginSystem,
-	bzl bazel.Bazel,
+	bzlProvider bazel.BazelProvider,
 ) *cobra.Command {
 	return &cobra.Command{
 		Use:   "build",
@@ -58,6 +58,10 @@ func NewBuildCmd(
 				pluginSystem.BuildHooksInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
+				bzl, err := bzlProvider()
+				if err != nil {
+					return err
+				}
 				b := build.New(streams, bzl)
 				besBackend := bep.BESBackendFromContext(ctx)
 				return b.Run(args, besBackend)

--- a/cmd/aspect/clean/clean.go
+++ b/cmd/aspect/clean/clean.go
@@ -32,11 +32,11 @@ import (
 
 // NewDefaultCleanCmd creates a new default clean cobra command.
 func NewDefaultCleanCmd() *cobra.Command {
-	return NewCleanCmd(ioutils.DefaultStreams, bazel.New())
+	return NewCleanCmd(ioutils.DefaultStreams, bazel.FindFromWd)
 }
 
 // NewCleanCmd creates a new clean cobra command.
-func NewCleanCmd(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
+func NewCleanCmd(streams ioutils.Streams, bzlProvider bazel.BazelProvider) *cobra.Command {
 	var expunge bool
 	var expungeAsync bool
 
@@ -79,6 +79,10 @@ Workaround inconistent state:
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
 				isInteractive := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+				bzl, err := bzlProvider()
+				if err != nil {
+					return err
+				}
 				c := clean.NewDefault(streams, bzl, isInteractive)
 				c.Expunge = expunge
 				c.ExpungeAsync = expungeAsync

--- a/cmd/aspect/cquery/cquery.go
+++ b/cmd/aspect/cquery/cquery.go
@@ -29,10 +29,10 @@ import (
 )
 
 func NewDefaultCQueryCmd() *cobra.Command {
-	return NewCQueryCommand(ioutils.DefaultStreams, bazel.New())
+	return NewCQueryCommand(ioutils.DefaultStreams, bazel.FindFromWd)
 }
 
-func NewCQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
+func NewCQueryCommand(streams ioutils.Streams, bzlProvider bazel.BazelProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cquery",
 		Short: "Executes a cquery.",
@@ -42,6 +42,10 @@ func NewCQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 				flags.FlagsInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
+				bzl, err := bzlProvider()
+				if err != nil {
+					return err
+				}
 				q := cquery.New(streams, bzl, true)
 				return q.Run(cmd, args)
 			},

--- a/cmd/aspect/query/query.go
+++ b/cmd/aspect/query/query.go
@@ -29,10 +29,10 @@ import (
 )
 
 func NewDefaultQueryCmd() *cobra.Command {
-	return NewQueryCommand(ioutils.DefaultStreams, bazel.New())
+	return NewQueryCommand(ioutils.DefaultStreams, bazel.FindFromWd)
 }
 
-func NewQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
+func NewQueryCommand(streams ioutils.Streams, bzlProvider bazel.BazelProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "query",
 		Short: "Executes a dependency graph query.",
@@ -42,6 +42,10 @@ func NewQueryCommand(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 				flags.FlagsInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
+				bzl, err := bzlProvider()
+				if err != nil {
+					return err
+				}
 				q := query.New(streams, bzl, true)
 				return q.Run(cmd, args)
 			},

--- a/cmd/aspect/run/run.go
+++ b/cmd/aspect/run/run.go
@@ -36,14 +36,14 @@ func NewDefaultRunCmd(pluginSystem system.PluginSystem) *cobra.Command {
 	return NewRunCmd(
 		ioutils.DefaultStreams,
 		pluginSystem,
-		bazel.New(),
+		bazel.FindFromWd,
 	)
 }
 
 func NewRunCmd(
 	streams ioutils.Streams,
 	pluginSystem system.PluginSystem,
-	bzl bazel.Bazel,
+	bzlProvider bazel.BazelProvider,
 ) *cobra.Command {
 	return &cobra.Command{
 		Use:   "run",
@@ -63,6 +63,10 @@ use 'bazel run --script_path' to write a script and then execute it.
 				pluginSystem.RunHooksInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
+				bzl, err := bzlProvider()
+				if err != nil {
+					return err
+				}
 				r := run.New(streams, bzl)
 				besBackend := bep.BESBackendFromContext(ctx)
 				return r.Run(args, besBackend)

--- a/cmd/aspect/test/test.go
+++ b/cmd/aspect/test/test.go
@@ -36,14 +36,14 @@ func NewDefaultTestCmd(pluginSystem system.PluginSystem) *cobra.Command {
 	return NewTestCmd(
 		ioutils.DefaultStreams,
 		pluginSystem,
-		bazel.New(),
+		bazel.FindFromWd,
 	)
 }
 
 func NewTestCmd(
 	streams ioutils.Streams,
 	pluginSystem system.PluginSystem,
-	bzl bazel.Bazel,
+	bzlProvider bazel.BazelProvider,
 ) *cobra.Command {
 	return &cobra.Command{
 		Use:   "test",
@@ -66,6 +66,10 @@ specify targets.
 				pluginSystem.TestHooksInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
+				bzl, err := bzlProvider()
+				if err != nil {
+					return err
+				}
 				t := test.New(streams, bzl)
 				besBackend := bep.BESBackendFromContext(ctx)
 				return t.Run(args, besBackend)

--- a/cmd/aspect/version/BUILD.bazel
+++ b/cmd/aspect/version/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/aspect/root/flags",
         "//pkg/aspect/version",
         "//pkg/bazel",
+        "//pkg/bazel/workspace",
         "//pkg/interceptors",
         "//pkg/ioutils",
         "@com_github_spf13_cobra//:cobra",

--- a/cmd/aspect/version/version.go
+++ b/cmd/aspect/version/version.go
@@ -25,6 +25,7 @@ import (
 	"aspect.build/cli/pkg/aspect/root/flags"
 	"aspect.build/cli/pkg/aspect/version"
 	"aspect.build/cli/pkg/bazel"
+	"aspect.build/cli/pkg/bazel/workspace"
 	"aspect.build/cli/pkg/interceptors"
 	"aspect.build/cli/pkg/ioutils"
 )
@@ -47,7 +48,7 @@ func NewVersionCmd(streams ioutils.Streams, bzlProvider bazel.BazelProvider) *co
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
 				bzl, err := bzlProvider()
-				if err != nil {
+				if err != nil && !workspace.IsNotFoundError(err) {
 					return err
 				}
 				return v.Run(bzl)

--- a/cmd/aspect/version/version.go
+++ b/cmd/aspect/version/version.go
@@ -30,10 +30,10 @@ import (
 )
 
 func NewDefaultVersionCmd() *cobra.Command {
-	return NewVersionCmd(ioutils.DefaultStreams, bazel.New())
+	return NewVersionCmd(ioutils.DefaultStreams, bazel.FindFromWd)
 }
 
-func NewVersionCmd(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
+func NewVersionCmd(streams ioutils.Streams, bzlProvider bazel.BazelProvider) *cobra.Command {
 	v := version.New(streams)
 	v.BuildInfo = *buildinfo.Current()
 
@@ -46,6 +46,10 @@ func NewVersionCmd(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
 				flags.FlagsInterceptor(streams),
 			},
 			func(ctx context.Context, cmd *cobra.Command, args []string) (exitErr error) {
+				bzl, err := bzlProvider()
+				if err != nil {
+					return err
+				}
 				return v.Run(bzl)
 			},
 		),

--- a/pkg/aspect/analyzeprofile/analyzeprofile.go
+++ b/pkg/aspect/analyzeprofile/analyzeprofile.go
@@ -39,9 +39,12 @@ func New(streams ioutils.Streams) *AnalyzeProfile {
 func (v *AnalyzeProfile) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd := []string{"analyze-profile"}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/aquery/aquery_test.go
+++ b/pkg/aspect/aquery/aquery_test.go
@@ -43,7 +43,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			Spawn([]string{"aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand([]string{"aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
 			Return(0, nil)
 
 		q := aquery.New(streams, spawner, true)
@@ -71,7 +71,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			Spawn([]string{"aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand([]string{"aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)
@@ -167,7 +167,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			Spawn([]string{"aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand([]string{"aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)

--- a/pkg/aspect/build/build.go
+++ b/pkg/aspect/build/build.go
@@ -46,7 +46,7 @@ func New(
 // Event Protocol backend used by Aspect plugins to subscribe to build events.
 func (b *Build) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
 	besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
-	exitCode, bazelErr := b.bzl.Spawn(append([]string{"build", besBackendFlag}, args...), b.Streams)
+	exitCode, bazelErr := b.bzl.RunCommand(append([]string{"build", besBackendFlag}, args...), b.Streams)
 
 	// Process the subscribers errors before the Bazel one.
 	subscriberErrors := besBackend.Errors()

--- a/pkg/aspect/build/build_test.go
+++ b/pkg/aspect/build/build_test.go
@@ -45,7 +45,7 @@ func TestBuild(t *testing.T) {
 		}
 		bzl.
 			EXPECT().
-			Spawn([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
 			Return(expectErr.ExitCode, expectErr.Err)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.
@@ -74,7 +74,7 @@ func TestBuild(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
 			Return(0, nil)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.
@@ -107,7 +107,7 @@ func TestBuild(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
 			Return(0, nil)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.

--- a/pkg/aspect/canonicalizeflags/canonicalizeflags.go
+++ b/pkg/aspect/canonicalizeflags/canonicalizeflags.go
@@ -39,9 +39,12 @@ func New(streams ioutils.Streams) *CanonicalizeFlags {
 func (v *CanonicalizeFlags) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd := []string{"canonicalize-flags"}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/clean/clean.go
+++ b/pkg/aspect/clean/clean.go
@@ -193,7 +193,7 @@ func (c *Clean) Run(_ *cobra.Command, _ []string) error {
 	if c.ExpungeAsync {
 		cmd = append(cmd, "--expunge_async")
 	}
-	if exitCode, err := c.bzl.Spawn(cmd, c.Streams); exitCode != 0 {
+	if exitCode, err := c.bzl.RunCommand(cmd, c.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/clean/clean_test.go
+++ b/pkg/aspect/clean/clean_test.go
@@ -79,7 +79,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"clean"}, streams).
+			RunCommand([]string{"clean"}, streams).
 			Return(0, nil)
 
 		b := clean.New(streams, bzl, false)
@@ -95,7 +95,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"clean", "--expunge"}, streams).
+			RunCommand([]string{"clean", "--expunge"}, streams).
 			Return(0, nil)
 
 		b := clean.New(streams, bzl, false)
@@ -112,7 +112,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"clean", "--expunge_async"}, streams).
+			RunCommand([]string{"clean", "--expunge_async"}, streams).
 			Return(0, nil)
 
 		b := clean.New(streams, bzl, false)
@@ -130,7 +130,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"clean"}, streams).
+			RunCommand([]string{"clean"}, streams).
 			Return(0, nil)
 
 		b := clean.New(streams, bzl, true)
@@ -152,7 +152,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"clean"}, streams).
+			RunCommand([]string{"clean"}, streams).
 			Return(0, nil).AnyTimes()
 
 		b := clean.New(streams, bzl, true)
@@ -211,7 +211,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"clean"}, streams).
+			RunCommand([]string{"clean"}, streams).
 			Return(0, nil)
 
 		c := clean.New(streams, bzl, true)

--- a/pkg/aspect/cquery/cquery_test.go
+++ b/pkg/aspect/cquery/cquery_test.go
@@ -43,7 +43,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			Spawn([]string{"cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand([]string{"cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
 			Return(0, nil)
 
 		q := cquery.New(streams, spawner, true)
@@ -71,7 +71,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			Spawn([]string{"cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand([]string{"cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)
@@ -167,7 +167,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			Spawn([]string{"cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand([]string{"cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)

--- a/pkg/aspect/dump/dump.go
+++ b/pkg/aspect/dump/dump.go
@@ -39,9 +39,12 @@ func New(streams ioutils.Streams) *Dump {
 func (v *Dump) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd := []string{"dump"}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/fetch/fetch.go
+++ b/pkg/aspect/fetch/fetch.go
@@ -38,9 +38,12 @@ func New(streams ioutils.Streams) *Fetch {
 func (v *Fetch) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd := []string{"fetch"}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/info/info.go
+++ b/pkg/aspect/info/info.go
@@ -45,9 +45,12 @@ func (v *Info) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 		bazelCmd = append(bazelCmd, "--show_make_env")
 	}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/mobileinstall/mobileinstall.go
+++ b/pkg/aspect/mobileinstall/mobileinstall.go
@@ -39,9 +39,12 @@ func New(streams ioutils.Streams) *MobileInstall {
 func (v *MobileInstall) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd := []string{"mobile-install"}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/modquery/modquery.go
+++ b/pkg/aspect/modquery/modquery.go
@@ -39,9 +39,12 @@ func New(streams ioutils.Streams) *ModQuery {
 func (v *ModQuery) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd := []string{"modquery"}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/printaction/printaction.go
+++ b/pkg/aspect/printaction/printaction.go
@@ -39,9 +39,12 @@ func New(streams ioutils.Streams) *PrintAction {
 func (v *PrintAction) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd := []string{"print_action"}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/query/query_test.go
+++ b/pkg/aspect/query/query_test.go
@@ -45,7 +45,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			Spawn([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
 			Return(0, nil)
 
 		q := query.New(streams, spawner, true)
@@ -80,7 +80,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			Spawn([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)
@@ -225,7 +225,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			Spawn([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)

--- a/pkg/aspect/query/shared/query.go
+++ b/pkg/aspect/query/shared/query.go
@@ -170,7 +170,7 @@ func RunQuery(bzl bazel.Bazel, verb string, query string, streams ioutils.Stream
 		query,
 	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/root/flags/bazel_flags.go
+++ b/pkg/aspect/root/flags/bazel_flags.go
@@ -72,7 +72,10 @@ func AddBazelFlags(cmd *cobra.Command) error {
 		subCommands[command.Use] = command
 	}
 
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 	bzlFlags, err := bzl.Flags()
 	if err != nil {
 		return fmt.Errorf("unable to determine available bazel flags: %w", err)

--- a/pkg/aspect/root/flags/interceptor.go
+++ b/pkg/aspect/root/flags/interceptor.go
@@ -55,7 +55,10 @@ func FlagsInterceptor(streams ioutils.Streams) interceptors.Interceptor {
 			}
 		}
 
-		bzl := bazel.New()
+		bzl, err := bazel.FindFromWd()
+		if err != nil {
+			return err
+		}
 		availableStartupFlags := bzl.AvailableStartupFlags()
 		startupFlags := []string{}
 		argsWithoutStartupFlags := []string{}

--- a/pkg/aspect/run/run.go
+++ b/pkg/aspect/run/run.go
@@ -46,7 +46,7 @@ func New(
 // Event Protocol backend used by Aspect plugins to subscribe to build events.
 func (cmd *Run) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
 	besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
-	exitCode, bazelErr := cmd.bzl.Spawn(append([]string{"run", besBackendFlag}, args...), cmd.Streams)
+	exitCode, bazelErr := cmd.bzl.RunCommand(append([]string{"run", besBackendFlag}, args...), cmd.Streams)
 
 	// Process the subscribers errors before the Bazel one.
 	subscriberErrors := besBackend.Errors()

--- a/pkg/aspect/run/run_test.go
+++ b/pkg/aspect/run/run_test.go
@@ -45,7 +45,7 @@ func TestRun(t *testing.T) {
 		}
 		bzl.
 			EXPECT().
-			Spawn([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
 			Return(expectErr.ExitCode, expectErr.Err)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.
@@ -74,7 +74,7 @@ func TestRun(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
 			Return(0, nil)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.
@@ -107,7 +107,7 @@ func TestRun(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
 			Return(0, nil)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.

--- a/pkg/aspect/shutdown/shutdown.go
+++ b/pkg/aspect/shutdown/shutdown.go
@@ -39,9 +39,12 @@ func New(streams ioutils.Streams) *Shutdown {
 func (v *Shutdown) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd := []string{"shutdown"}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/sync/sync.go
+++ b/pkg/aspect/sync/sync.go
@@ -39,9 +39,12 @@ func New(streams ioutils.Streams) *Sync {
 func (v *Sync) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 	bazelCmd := []string{"sync"}
 	bazelCmd = append(bazelCmd, args...)
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 
-	if exitCode, err := bzl.Spawn(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/test/test.go
+++ b/pkg/aspect/test/test.go
@@ -42,7 +42,7 @@ func (t *Test) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
 	bazelCmd := []string{"test", besBackendFlag}
 	bazelCmd = append(bazelCmd, args...)
 
-	exitCode, bazelErr := t.bzl.Spawn(bazelCmd, t.Streams)
+	exitCode, bazelErr := t.bzl.RunCommand(bazelCmd, t.Streams)
 
 	// Process the subscribers errors before the Bazel one.
 	subscriberErrors := besBackend.Errors()

--- a/pkg/aspect/test/test_test.go
+++ b/pkg/aspect/test/test_test.go
@@ -39,7 +39,7 @@ func TestTest(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			Spawn([]string{"test", "--bes_backend=grpc://127.0.0.1:12345"}, streams).
+			RunCommand([]string{"test", "--bes_backend=grpc://127.0.0.1:12345"}, streams).
 			Return(0, nil)
 
 		besBackend := bep_mock.NewMockBESBackend(ctrl)

--- a/pkg/aspect/version/BUILD.bazel
+++ b/pkg/aspect/version/BUILD.bazel
@@ -18,8 +18,9 @@ go_test(
     deps = [
         ":version",
         "//buildinfo",
-        "//pkg/bazel",
+        "//pkg/bazel/mock",
         "//pkg/ioutils",
+        "@com_github_golang_mock//gomock",
         "@com_github_onsi_gomega//:gomega",
     ],
 )

--- a/pkg/aspect/version/version.go
+++ b/pkg/aspect/version/version.go
@@ -55,7 +55,7 @@ func (v *Version) Run(bzl bazel.Bazel) error {
 		// Propagate the flag
 		bazelCmd = append(bazelCmd, "--gnu_format")
 	}
-	bzl.Spawn(bazelCmd, v.Streams)
+	bzl.RunCommand(bazelCmd, v.Streams)
 
 	return nil
 }

--- a/pkg/aspect/version/version.go
+++ b/pkg/aspect/version/version.go
@@ -48,6 +48,12 @@ func (v *Version) Run(bzl bazel.Bazel) error {
 		return err
 	}
 
+	// If we do not have a Bazel workspace, do not bother trying to get additional version
+	// information.
+	if bzl == nil {
+		return nil
+	}
+
 	// Check if the --gnu_format flag is set, if that is the case,
 	// the version is printed differently
 	bazelCmd := []string{"version"}

--- a/pkg/aspect/version/version_test.go
+++ b/pkg/aspect/version/version_test.go
@@ -17,17 +17,15 @@
 package version_test
 
 import (
-	"io"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
 
 	"aspect.build/cli/buildinfo"
 	"aspect.build/cli/pkg/aspect/version"
-	"aspect.build/cli/pkg/bazel"
+	bazel_mock "aspect.build/cli/pkg/bazel/mock"
 	"aspect.build/cli/pkg/ioutils"
 )
 
@@ -39,39 +37,71 @@ const (
 	release        = "1.2.3"
 )
 
-func createWorkspace() (string, error) {
-	wr, err := os.MkdirTemp("", "wksp_root")
-	if err != nil {
-		return "", err
-	}
-	wksp, err := os.Create(filepath.Join(wr, "WORKSPACE"))
-	if err != nil {
-		return "", err
-	}
-	defer wksp.Close()
-	if _, err := io.WriteString(wksp, `workspace(name = "test_workspace")`); err != nil {
-		return "", err
-	}
-	return wr, nil
-}
+// func createWorkspace() (string, error) {
+// 	wr, err := os.MkdirTemp("", "wksp_root")
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	wksp, err := os.Create(filepath.Join(wr, "WORKSPACE"))
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	defer wksp.Close()
+// 	if _, err := io.WriteString(wksp, `workspace(name = "test_workspace")`); err != nil {
+// 		return "", err
+// 	}
+// 	return wr, nil
+// }
 
 func TestVersion(t *testing.T) {
-	g := NewGomegaWithT(t)
-	wr, err := createWorkspace()
-	g.Expect(err).ToNot(HaveOccurred())
-	bzl := bazel.New(wr)
+	t.Run("with a Bazel instance", func(t *testing.T) {
+		g := NewWithT(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	t.Run("without release build info", func(t *testing.T) {
+		var stdout strings.Builder
+		streams := ioutils.Streams{Stdout: &stdout}
+		bzl := bazel_mock.NewMockBazel(ctrl)
+		bzl.
+			EXPECT().
+			RunCommand([]string{"version"}, streams).
+			Return(0, nil)
+
+		v := version.New(streams)
+		err := v.Run(bzl)
+		g.Expect(err).To(BeNil())
+	})
+
+	t.Run("with a Bazel instance, with --gnu_format", func(t *testing.T) {
+		g := NewWithT(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		var stdout strings.Builder
+		streams := ioutils.Streams{Stdout: &stdout}
+		bzl := bazel_mock.NewMockBazel(ctrl)
+		bzl.
+			EXPECT().
+			RunCommand([]string{"version", "--gnu_format"}, streams).
+			Return(0, nil)
+
+		v := version.New(streams)
+		v.GNUFormat = true
+		err := v.Run(bzl)
+		g.Expect(err).To(BeNil())
+	})
+
+	t.Run("no Bazel instance, without release build info", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
 		v := version.New(streams)
-		err := v.Run(bzl)
+		err := v.Run(nil)
 		g.Expect(err).To(BeNil())
 		g.Expect(stdout.String()).To(Equal("Aspect version: unknown [not built with --stamp]\n"))
 	})
 
-	t.Run("with release build info", func(t *testing.T) {
+	t.Run("no Bazel instance, with release build info", func(t *testing.T) {
 		t.Run("git is clean", func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			var stdout strings.Builder
@@ -84,7 +114,7 @@ func TestVersion(t *testing.T) {
 				buildinfo.CleanGitStatus,
 				release,
 			)
-			err := v.Run(bzl)
+			err := v.Run(nil)
 			g.Expect(err).To(BeNil())
 			g.Expect(stdout.String()).To(Equal("Aspect version: 1.2.3\n"))
 		})
@@ -101,13 +131,13 @@ func TestVersion(t *testing.T) {
 				dirtyGitStatus,
 				release,
 			)
-			err := v.Run(bzl)
+			err := v.Run(nil)
 			g.Expect(err).To(BeNil())
 			g.Expect(stdout.String()).To(Equal("Aspect version: 1.2.3 (with local changes)\n"))
 		})
 	})
 
-	t.Run("with --gnu_format", func(t *testing.T) {
+	t.Run("no Bazel instance, with --gnu_format", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
@@ -120,7 +150,7 @@ func TestVersion(t *testing.T) {
 			buildinfo.CleanGitStatus,
 			release,
 		)
-		err := v.Run(bzl)
+		err := v.Run(nil)
 		g.Expect(err).To(BeNil())
 		g.Expect(stdout.String()).To(Equal("Aspect 1.2.3\n"))
 	})

--- a/pkg/aspect/version/version_test.go
+++ b/pkg/aspect/version/version_test.go
@@ -37,22 +37,6 @@ const (
 	release        = "1.2.3"
 )
 
-// func createWorkspace() (string, error) {
-// 	wr, err := os.MkdirTemp("", "wksp_root")
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	wksp, err := os.Create(filepath.Join(wr, "WORKSPACE"))
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	defer wksp.Close()
-// 	if _, err := io.WriteString(wksp, `workspace(name = "test_workspace")`); err != nil {
-// 		return "", err
-// 	}
-// 	return wr, nil
-// }
-
 func TestVersion(t *testing.T) {
 	t.Run("with a Bazel instance", func(t *testing.T) {
 		g := NewWithT(t)

--- a/pkg/aspect/version/version_test.go
+++ b/pkg/aspect/version/version_test.go
@@ -17,6 +17,9 @@
 package version_test
 
 import (
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -36,8 +39,28 @@ const (
 	release        = "1.2.3"
 )
 
+func createWorkspace() (string, error) {
+	wr, err := os.MkdirTemp("", "wksp_root")
+	if err != nil {
+		return "", err
+	}
+	wksp, err := os.Create(filepath.Join(wr, "WORKSPACE"))
+	if err != nil {
+		return "", err
+	}
+	defer wksp.Close()
+	if _, err := io.WriteString(wksp, `workspace(name = "test_workspace")`); err != nil {
+		return "", err
+	}
+	return wr, nil
+}
+
 func TestVersion(t *testing.T) {
-	bzl := bazel.New()
+	g := NewGomegaWithT(t)
+	wr, err := createWorkspace()
+	g.Expect(err).ToNot(HaveOccurred())
+	bzl := bazel.New(wr)
+
 	t.Run("without release build info", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		var stdout strings.Builder

--- a/pkg/bazel/BUILD.bazel
+++ b/pkg/bazel/BUILD.bazel
@@ -28,9 +28,7 @@ go_test(
     srcs = ["bazel_test.go"],
     embed = [":bazel"],
     deps = [
-        "//pkg/bazel/workspace/mock",
         "//pkg/ioutils",
-        "@com_github_golang_mock//gomock",
         "@com_github_onsi_gomega//:gomega",
     ],
 )

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -90,23 +90,6 @@ func (b *bazel) WithEnv(env []string) Bazel {
 	return b
 }
 
-// // WithOverrideWorkspaceRoot returns a new instance of Bazel, overriding the
-// // value for the workspace root.
-// func (b *bazel) WithOverrideWorkspaceRoot(workspaceRoot string) Bazel {
-// 	newBazel := *b
-// 	newBazel.workspaceFinder = nil
-// 	newBazel.overrideWorkspaceRoot = workspaceRoot
-// 	return &newBazel
-// }
-
-// // WithEnv returns a new instance of Bazel, setting the provided environment
-// // variables.
-// func (b *bazel) WithEnv(env []string) Bazel {
-// 	newBazel := *b
-// 	newBazel.env = env
-// 	return &newBazel
-// }
-
 // AvailableStartupFlags will return the full list of startup flags available for
 // the current version of bazel. This is NOT the list of startup flags that have been
 // set for the current run via SetStartupFlags.

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -46,8 +46,6 @@ var availableStartupFlags []string
 // cli execution.
 var startupFlags []string
 
-// TODO(chuck): REMOVE ME
-
 type BazelProvider func() (Bazel, error)
 
 type Bazel interface {

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -46,6 +46,8 @@ var availableStartupFlags []string
 // cli execution.
 var startupFlags []string
 
+// TODO(chuck): REMOVE ME
+
 type BazelProvider func() (Bazel, error)
 
 type Bazel interface {

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -28,6 +28,7 @@ import (
 	"aspect.build/cli/bazel/flags"
 	"aspect.build/cli/pkg/bazel/workspace"
 	"aspect.build/cli/pkg/ioutils"
+
 	"github.com/bazelbuild/bazelisk/core"
 	"github.com/bazelbuild/bazelisk/repositories"
 	"google.golang.org/protobuf/proto"

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -28,7 +28,6 @@ import (
 	"aspect.build/cli/bazel/flags"
 	"aspect.build/cli/pkg/bazel/workspace"
 	"aspect.build/cli/pkg/ioutils"
-
 	"github.com/bazelbuild/bazelisk/core"
 	"github.com/bazelbuild/bazelisk/repositories"
 	"google.golang.org/protobuf/proto"
@@ -47,9 +46,11 @@ var availableStartupFlags []string
 // cli execution.
 var startupFlags []string
 
+type BazelProvider func() (Bazel, error)
+
 type Bazel interface {
+	WithEnv(env []string) Bazel
 	AQuery(expr string) (*analysis.ActionGraphContainer, error)
-	Spawn(command []string, streams ioutils.Streams) (int, error)
 	RunCommand(command []string, streams ioutils.Streams) (int, error)
 	Flags() (map[string]*flags.FlagInfo, error)
 	AvailableStartupFlags() []string
@@ -57,34 +58,54 @@ type Bazel interface {
 }
 
 type bazel struct {
-	workspaceFinder workspace.Finder
-
-	overrideWorkspaceRoot string
-	env                   []string
+	workspaceRoot string
+	env           []string
 }
 
-func New() Bazel {
+func New(workspaceRoot string) Bazel {
 	return &bazel{
-		workspaceFinder: workspace.DefaultFinder,
+		workspaceRoot: workspaceRoot,
 	}
 }
 
-// WithOverrideWorkspaceRoot returns a new instance of Bazel, overriding the
-// value for the workspace root.
-func (b *bazel) WithOverrideWorkspaceRoot(workspaceRoot string) Bazel {
-	newBazel := *b
-	newBazel.workspaceFinder = nil
-	newBazel.overrideWorkspaceRoot = workspaceRoot
-	return &newBazel
+func Find(startDir string) (Bazel, error) {
+	finder := workspace.DefaultFinder
+	wr, err := finder.Find(startDir)
+	if err != nil {
+		return nil, err
+	}
+	return New(wr), nil
 }
 
-// WithEnv returns a new instance of Bazel, setting the provided environment
-// variables.
-func (b *bazel) WithEnv(env []string) Bazel {
-	newBazel := *b
-	newBazel.env = env
-	return &newBazel
+func FindFromWd() (Bazel, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return Find(wd)
 }
+
+func (b *bazel) WithEnv(env []string) Bazel {
+	b.env = env
+	return b
+}
+
+// // WithOverrideWorkspaceRoot returns a new instance of Bazel, overriding the
+// // value for the workspace root.
+// func (b *bazel) WithOverrideWorkspaceRoot(workspaceRoot string) Bazel {
+// 	newBazel := *b
+// 	newBazel.workspaceFinder = nil
+// 	newBazel.overrideWorkspaceRoot = workspaceRoot
+// 	return &newBazel
+// }
+
+// // WithEnv returns a new instance of Bazel, setting the provided environment
+// // variables.
+// func (b *bazel) WithEnv(env []string) Bazel {
+// 	newBazel := *b
+// 	newBazel.env = env
+// 	return &newBazel
+// }
 
 // AvailableStartupFlags will return the full list of startup flags available for
 // the current version of bazel. This is NOT the list of startup flags that have been
@@ -110,29 +131,13 @@ func (*bazel) createRepositories() *core.Repositories {
 	return core.CreateRepositories(gcs, gcs, gitHub, gcs, gcs, true)
 }
 
-// Spawn is similar to the main() function of bazelisk
-// see https://github.com/bazelbuild/bazelisk/blob/7c3d9d5/bazelisk.go
-func (b *bazel) Spawn(command []string, streams ioutils.Streams) (int, error) {
-	return b.RunCommand(command, streams)
-}
-
 func (b *bazel) RunCommand(command []string, streams ioutils.Streams) (int, error) {
 	// Prepend startup flags
 	command = append(startupFlags, command...)
 
 	repos := b.createRepositories()
 
-	var bazelisk *Bazelisk
-	if b.overrideWorkspaceRoot != "" {
-		bazelisk = NewBazelisk(b.overrideWorkspaceRoot)
-	} else {
-		workspaceRoot, err := b.workspaceFinder.Find()
-		if err != nil {
-			return 1, err
-		}
-		bazelisk = NewBazelisk(workspaceRoot)
-	}
-
+	bazelisk := NewBazelisk(b.workspaceRoot)
 	exitCode, err := bazelisk.Run(command, repos, streams, b.env)
 	return exitCode, err
 }

--- a/pkg/bazel/bazel_test.go
+++ b/pkg/bazel/bazel_test.go
@@ -57,47 +57,11 @@ func init() {
 	if err := os.WriteFile(wrapperOverridePath, wrapperContents, 0777); err != nil {
 		panic(err)
 	}
-	// if err := os.Chdir(workspaceDir); err != nil {
-	// 	panic(err)
-	// }
 }
-
-// func createWorkspace() (string, error) {
-// 	wr, err := os.MkdirTemp("", "wksp_root")
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	wksp, err := os.Create(filepath.Join(wr, "WORKSPACE"))
-// 	if err != nil {
-// 		return "", err
-// 	}
-// 	defer wksp.Close()
-// 	if _, err := io.WriteString(wksp, `workspace(name = "test_workspace")`); err != nil {
-// 		return "", err
-// 	}
-// 	return wr, nil
-// }
 
 func TestBazel(t *testing.T) {
 	t.Run("when a custom environment is passed, it should be used by bazelisk", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		// ctrl := gomock.NewController(t)
-		// defer ctrl.Finish()
-
-		// workspaceFinder := workspace_mock.NewMockFinder(ctrl)
-		// workspaceFinder.EXPECT().
-		// 	Find().
-		// 	Return("", nil).
-		// 	Times(1)
-
-		// bzl := &bazel{
-		// 	workspaceFinder: workspaceFinder,
-		// }
-
-		// wr, err := createWorkspace()
-		// g.Expect(err).ToNot(HaveOccurred())
-		// defer os.RemoveAll(wr)
-		// bzl := bazel.New(wr)
 
 		bzl := New(workspaceDir)
 
@@ -111,22 +75,6 @@ func TestBazel(t *testing.T) {
 
 	t.Run("when the workspace override directory is set, it should be used by bazelisk", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		// ctrl := gomock.NewController(t)
-		// defer ctrl.Finish()
-
-		// workspaceFinder := workspace_mock.NewMockFinder(ctrl)
-		// workspaceFinder.EXPECT().
-		// 	Find().
-		// 	Times(0)
-
-		// bzl := &bazel{
-		// 	workspaceFinder: workspaceFinder,
-		// }
-
-		// wr, err := createWorkspace()
-		// g.Expect(err).ToNot(HaveOccurred())
-		// defer os.RemoveAll(wr)
-		// bzl := bazel.New(wr)
 
 		bzl := New(workspaceOverrideDir)
 

--- a/pkg/bazel/workspace/BUILD.bazel
+++ b/pkg/bazel/workspace/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "workspace",
-    srcs = ["finder.go"],
+    srcs = [
+        "finder.go",
+        "not_found_error.go",
+    ],
     importpath = "aspect.build/cli/pkg/bazel/workspace",
     visibility = ["//visibility:public"],
 )

--- a/pkg/bazel/workspace/BUILD.bazel
+++ b/pkg/bazel/workspace/BUILD.bazel
@@ -12,7 +12,10 @@ go_library(
 
 go_test(
     name = "workspace_test",
-    srcs = ["finder_test.go"],
+    srcs = [
+        "finder_test.go",
+        "not_found_error_test.go",
+    ],
     embed = [":workspace"],
     deps = [
         "//pkg/stdlib/mock",

--- a/pkg/bazel/workspace/finder.go
+++ b/pkg/bazel/workspace/finder.go
@@ -27,6 +27,14 @@ import (
 // https://github.com/bazelbuild/bazel/blob/8346ea4c/src/main/cpp/workspace_layout.cc#L37
 var workspaceFilenames = []string{"WORKSPACE", "WORKSPACE.bazel"}
 
+type NotFoundError struct {
+	startDir string
+}
+
+func (nfe *NotFoundError) Error() string {
+	return fmt.Sprintf("failed to find a Bazel workspace starting at %s", nfe.startDir)
+}
+
 // Finder wraps the Find method that performs the finding of the WORKSPACE file
 // in the user's Bazel project.
 type Finder interface {
@@ -52,7 +60,8 @@ func (f *finder) Find(startDir string) (string, error) {
 				if os.IsNotExist(err) {
 					continue
 				}
-				return "", fmt.Errorf("failed to find bazel workspace: %w", err)
+				// return "", fmt.Errorf("failed to find bazel workspace: %w", err)
+				return "", &NotFoundError{startDir: startDir}
 			}
 			if fileInfo.IsDir() {
 				continue

--- a/pkg/bazel/workspace/finder.go
+++ b/pkg/bazel/workspace/finder.go
@@ -52,7 +52,7 @@ func (f *finder) Find(startDir string) (string, error) {
 				if os.IsNotExist(err) {
 					continue
 				}
-				return "", &NotFoundError{startDir: startDir}
+				return "", &NotFoundError{StartDir: startDir}
 			}
 			if fileInfo.IsDir() {
 				continue

--- a/pkg/bazel/workspace/finder.go
+++ b/pkg/bazel/workspace/finder.go
@@ -27,14 +27,6 @@ import (
 // https://github.com/bazelbuild/bazel/blob/8346ea4c/src/main/cpp/workspace_layout.cc#L37
 var workspaceFilenames = []string{"WORKSPACE", "WORKSPACE.bazel"}
 
-type NotFoundError struct {
-	startDir string
-}
-
-func (nfe *NotFoundError) Error() string {
-	return fmt.Sprintf("failed to find a Bazel workspace starting at %s", nfe.startDir)
-}
-
 // Finder wraps the Find method that performs the finding of the WORKSPACE file
 // in the user's Bazel project.
 type Finder interface {
@@ -60,7 +52,6 @@ func (f *finder) Find(startDir string) (string, error) {
 				if os.IsNotExist(err) {
 					continue
 				}
-				// return "", fmt.Errorf("failed to find bazel workspace: %w", err)
 				return "", &NotFoundError{startDir: startDir}
 			}
 			if fileInfo.IsDir() {

--- a/pkg/bazel/workspace/finder.go
+++ b/pkg/bazel/workspace/finder.go
@@ -30,34 +30,21 @@ var workspaceFilenames = []string{"WORKSPACE", "WORKSPACE.bazel"}
 // Finder wraps the Find method that performs the finding of the WORKSPACE file
 // in the user's Bazel project.
 type Finder interface {
-	Find() (string, error)
+	Find(string) (string, error)
 }
 
 type finder struct {
-	osGetwd func() (dir string, err error)
-	osStat  func(string) (fs.FileInfo, error)
-
-	workspaceRoot string
+	osStat func(string) (fs.FileInfo, error)
 }
 
 // DefaultFinder is the Finder with default dependencies.
 var DefaultFinder = &finder{
-	osGetwd: os.Getwd,
-	osStat:  os.Stat,
+	osStat: os.Stat,
 }
 
 // Find tries to find the root of a Bazel workspace.
-func (f *finder) Find() (string, error) {
-	if f.workspaceRoot != "" {
-		return f.workspaceRoot, nil
-	}
-
-	wd, err := f.osGetwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to find bazel workspace: %w", err)
-	}
-
-	for current := wd; current != "." && current != filepath.Dir(current); current = filepath.Dir(current) {
+func (f *finder) Find(startDir string) (string, error) {
+	for current := startDir; current != "." && current != filepath.Dir(current); current = filepath.Dir(current) {
 		for _, workspaceFilename := range workspaceFilenames {
 			workspacePath := path.Join(current, workspaceFilename)
 			fileInfo, err := f.osStat(workspacePath)
@@ -70,10 +57,10 @@ func (f *finder) Find() (string, error) {
 			if fileInfo.IsDir() {
 				continue
 			}
-			f.workspaceRoot = path.Dir(workspacePath)
-			return f.workspaceRoot, nil
+			workspaceRoot := path.Dir(workspacePath)
+			return workspaceRoot, nil
 		}
 	}
 
-	return "", fmt.Errorf("failed to find bazel workspace: the current working directory %q is not a Bazel workspace", wd)
+	return "", fmt.Errorf("failed to find bazel workspace: the current working directory %q is not a Bazel workspace", startDir)
 }

--- a/pkg/bazel/workspace/finder_test.go
+++ b/pkg/bazel/workspace/finder_test.go
@@ -28,23 +28,23 @@ import (
 	stdlib_mock "aspect.build/cli/pkg/stdlib/mock"
 )
 
+const (
+	startDir = "fake_working_directory/foo/bar"
+)
+
 func TestWorkspaceFinder(t *testing.T) {
-	t.Run("when os.Getwd fails, Find fails", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+	// t.Run("when os.Getwd fails, Find fails", func(t *testing.T) {
+	// 	g := NewGomegaWithT(t)
+	// 	ctrl := gomock.NewController(t)
+	// 	defer ctrl.Finish()
 
-		expectedErr := fmt.Errorf("os.Getwd failed")
+	// 	expectedErr := fmt.Errorf("os.Getwd failed")
 
-		finder := &finder{
-			osGetwd: func() (string, error) {
-				return "", expectedErr
-			},
-		}
-		workspacePath, err := finder.Find()
-		g.Expect(workspacePath).To(BeEmpty())
-		g.Expect(err).To(MatchError(expectedErr))
-	})
+	// 	finder := &finder{}
+	// 	workspacePath, err := finder.Find()
+	// 	g.Expect(workspacePath).To(BeEmpty())
+	// 	g.Expect(err).To(MatchError(expectedErr))
+	// })
 
 	t.Run("when os.Stat fails, Find fails", func(t *testing.T) {
 		g := NewGomegaWithT(t)
@@ -54,14 +54,11 @@ func TestWorkspaceFinder(t *testing.T) {
 		expectedErr := fmt.Errorf("os.Stat failed")
 
 		finder := &finder{
-			osGetwd: func() (string, error) {
-				return "fake_working_directory/foo/bar", nil
-			},
 			osStat: func(s string) (fs.FileInfo, error) {
 				return nil, expectedErr
 			},
 		}
-		workspacePath, err := finder.Find()
+		workspacePath, err := finder.Find(startDir)
 		g.Expect(workspacePath).To(BeEmpty())
 		g.Expect(err).To(MatchError(expectedErr))
 	})
@@ -86,14 +83,11 @@ func TestWorkspaceFinder(t *testing.T) {
 		for _, wd := range wds {
 			expectedErr := fmt.Errorf("failed to find bazel workspace: the current working directory \"%s\" is not a Bazel workspace", wd)
 			finder := &finder{
-				osGetwd: func() (string, error) {
-					return wd, nil
-				},
 				osStat: func(s string) (fs.FileInfo, error) {
 					return nil, os.ErrNotExist
 				},
 			}
-			workspacePath, err := finder.Find()
+			workspacePath, err := finder.Find(wd)
 			g.Expect(workspacePath).To(BeEmpty())
 			g.Expect(err).To(MatchError(expectedErr))
 		}
@@ -112,15 +106,12 @@ func TestWorkspaceFinder(t *testing.T) {
 				Times(1)
 
 			finder := &finder{
-				osGetwd: func() (string, error) {
-					return "fake_working_directory/foo/bar", nil
-				},
 				osStat: func(s string) (fs.FileInfo, error) {
 					return fsFileInfo, nil
 				},
 			}
-			workspacePath, err := finder.Find()
-			g.Expect(workspacePath).To(Equal("fake_working_directory/foo/bar"))
+			workspacePath, err := finder.Find(startDir)
+			g.Expect(workspacePath).To(Equal(startDir))
 			g.Expect(err).To(BeNil())
 		})
 		t.Run("case 2", func(t *testing.T) {
@@ -141,15 +132,12 @@ func TestWorkspaceFinder(t *testing.T) {
 			)
 
 			finder := &finder{
-				osGetwd: func() (string, error) {
-					return "fake_working_directory/foo/bar", nil
-				},
 				osStat: func(s string) (fs.FileInfo, error) {
 					return fsFileInfo, nil
 				},
 			}
-			workspacePath, err := finder.Find()
-			g.Expect(workspacePath).To(Equal("fake_working_directory/foo/bar"))
+			workspacePath, err := finder.Find(startDir)
+			g.Expect(workspacePath).To(Equal(startDir))
 			g.Expect(err).To(BeNil())
 		})
 		t.Run("case 3", func(t *testing.T) {
@@ -174,14 +162,11 @@ func TestWorkspaceFinder(t *testing.T) {
 			)
 
 			finder := &finder{
-				osGetwd: func() (string, error) {
-					return "fake_working_directory/foo/bar", nil
-				},
 				osStat: func(s string) (fs.FileInfo, error) {
 					return fsFileInfo, nil
 				},
 			}
-			workspacePath, err := finder.Find()
+			workspacePath, err := finder.Find(startDir)
 			g.Expect(workspacePath).To(Equal("fake_working_directory/foo"))
 			g.Expect(err).To(BeNil())
 		})
@@ -211,14 +196,11 @@ func TestWorkspaceFinder(t *testing.T) {
 			)
 
 			finder := &finder{
-				osGetwd: func() (string, error) {
-					return "fake_working_directory/foo/bar", nil
-				},
 				osStat: func(s string) (fs.FileInfo, error) {
 					return fsFileInfo, nil
 				},
 			}
-			workspacePath, err := finder.Find()
+			workspacePath, err := finder.Find(startDir)
 			g.Expect(workspacePath).To(Equal("fake_working_directory/foo"))
 			g.Expect(err).To(BeNil())
 		})

--- a/pkg/bazel/workspace/finder_test.go
+++ b/pkg/bazel/workspace/finder_test.go
@@ -33,19 +33,6 @@ const (
 )
 
 func TestWorkspaceFinder(t *testing.T) {
-	// t.Run("when os.Getwd fails, Find fails", func(t *testing.T) {
-	// 	g := NewGomegaWithT(t)
-	// 	ctrl := gomock.NewController(t)
-	// 	defer ctrl.Finish()
-
-	// 	expectedErr := fmt.Errorf("os.Getwd failed")
-
-	// 	finder := &finder{}
-	// 	workspacePath, err := finder.Find()
-	// 	g.Expect(workspacePath).To(BeEmpty())
-	// 	g.Expect(err).To(MatchError(expectedErr))
-	// })
-
 	t.Run("when os.Stat fails, Find fails", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		ctrl := gomock.NewController(t)

--- a/pkg/bazel/workspace/finder_test.go
+++ b/pkg/bazel/workspace/finder_test.go
@@ -38,7 +38,7 @@ func TestWorkspaceFinder(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		expectedErr := fmt.Errorf("os.Stat failed")
+		expectedErr := &NotFoundError{startDir: startDir}
 
 		finder := &finder{
 			osStat: func(s string) (fs.FileInfo, error) {

--- a/pkg/bazel/workspace/finder_test.go
+++ b/pkg/bazel/workspace/finder_test.go
@@ -38,7 +38,7 @@ func TestWorkspaceFinder(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		expectedErr := &NotFoundError{startDir: startDir}
+		expectedErr := &NotFoundError{StartDir: startDir}
 
 		finder := &finder{
 			osStat: func(s string) (fs.FileInfo, error) {

--- a/pkg/bazel/workspace/not_found_error.go
+++ b/pkg/bazel/workspace/not_found_error.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package workspace
+
+import (
+	"fmt"
+)
+
+type NotFoundError struct {
+	startDir string
+}
+
+func (nfe *NotFoundError) Error() string {
+	return fmt.Sprintf("failed to find a Bazel workspace starting at %s", nfe.startDir)
+}
+
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*NotFoundError)
+	return ok
+}

--- a/pkg/bazel/workspace/not_found_error.go
+++ b/pkg/bazel/workspace/not_found_error.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 )
 
+// Represents a failure to find a Bazel workspace.
 type NotFoundError struct {
 	StartDir string
 }
@@ -28,6 +29,7 @@ func (nfe *NotFoundError) Error() string {
 	return fmt.Sprintf("failed to find a Bazel workspace starting at %s", nfe.StartDir)
 }
 
+// Determines whether the provided error is a NotFoundError.
 func IsNotFoundError(err error) bool {
 	if err == nil {
 		return false

--- a/pkg/bazel/workspace/not_found_error_test.go
+++ b/pkg/bazel/workspace/not_found_error_test.go
@@ -14,24 +14,25 @@
  * limitations under the License.
  */
 
-package workspace
+package workspace_test
 
 import (
-	"fmt"
+	"errors"
+	"testing"
+
+	"aspect.build/cli/pkg/bazel/workspace"
+	. "github.com/onsi/gomega"
 )
 
-type NotFoundError struct {
-	StartDir string
-}
-
-func (nfe *NotFoundError) Error() string {
-	return fmt.Sprintf("failed to find a Bazel workspace starting at %s", nfe.StartDir)
-}
-
-func IsNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, ok := err.(*NotFoundError)
-	return ok
+func TestIsNotFoundError(t *testing.T) {
+	t.Run("when it is a NotFoundError", func(t *testing.T) {
+		g := NewWithT(t)
+		err := &workspace.NotFoundError{StartDir: "path"}
+		g.Expect(workspace.IsNotFoundError(err)).To(BeTrue())
+	})
+	t.Run("when it is not a NotFoundError", func(t *testing.T) {
+		g := NewWithT(t)
+		err := errors.New("not a NotFoundError")
+		g.Expect(workspace.IsNotFoundError(err)).To(BeFalse())
+	})
 }

--- a/pkg/plugin/sdk/v1alpha2/plugin/interface.go
+++ b/pkg/plugin/sdk/v1alpha2/plugin/interface.go
@@ -137,8 +137,10 @@ func (cm *PluginCommandManager) Save(commands []*Command) error {
 
 // Execute satisfies CommandManager.
 func (cm *PluginCommandManager) Execute(command string, ctx context.Context, args []string) error {
-	bzl := bazel.New()
-
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 	return cm.commands[command](ctx, args, bzl)
 }
 

--- a/pkg/plugin/sdk/v1alpha3/plugin/interface.go
+++ b/pkg/plugin/sdk/v1alpha3/plugin/interface.go
@@ -168,7 +168,10 @@ func (cm *PluginCommandManager) Save(commands []*Command) error {
 
 // Execute satisfies CommandManager.
 func (cm *PluginCommandManager) Execute(command string, ctx context.Context, args []string) error {
-	bzl := bazel.New()
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		return err
+	}
 	return cm.commands[command](ctx, args, bzl)
 }
 


### PR DESCRIPTION
- Refactor `bazel.bazel`
  - Remove `workspace.Finder`.
  - Add `workspaceRoot` to store the path to the root of the Bazel workspace.
- Update `bazel.New()` to take a `workspaceRoot` parameter.
- Add `bazel.Find()` and `bazel.FindFromWd()` to find a workspace root and return an initialized `Bazel` instance.
- Refactor `Bazel` interface
  - Remove `WithOverrideWorkspaceRoot()`. Instances can now be created using a path.
  - Remove `Spawn()`. Appears to be an alias for `RunCommand()`.
  - Update `WithEnv()` to not create a new instance when applying the environment variables.