### PR TITLE
refactor: convert RunCommand to accept variadic command argument

### DIFF
--- a/pkg/aspect/analyzeprofile/analyzeprofile.go
+++ b/pkg/aspect/analyzeprofile/analyzeprofile.go
@@ -44,7 +44,7 @@ func (v *AnalyzeProfile) Run(ctx context.Context, _ *cobra.Command, args []strin
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/aquery/aquery_test.go
+++ b/pkg/aspect/aquery/aquery_test.go
@@ -43,7 +43,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			RunCommand([]string{"aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand(streams, "aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)").
 			Return(0, nil)
 
 		q := aquery.New(streams, spawner, true)
@@ -71,7 +71,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			RunCommand([]string{"aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand(streams, "aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)").
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)
@@ -167,7 +167,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			RunCommand([]string{"aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand(streams, "aquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)").
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)

--- a/pkg/aspect/build/build.go
+++ b/pkg/aspect/build/build.go
@@ -46,7 +46,7 @@ func New(
 // Event Protocol backend used by Aspect plugins to subscribe to build events.
 func (b *Build) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
 	besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
-	exitCode, bazelErr := b.bzl.RunCommand(append([]string{"build", besBackendFlag}, args...), b.Streams)
+	exitCode, bazelErr := b.bzl.RunCommand(b.Streams, append([]string{"build", besBackendFlag}, args...)...)
 
 	// Process the subscribers errors before the Bazel one.
 	subscriberErrors := besBackend.Errors()

--- a/pkg/aspect/build/build_test.go
+++ b/pkg/aspect/build/build_test.go
@@ -45,7 +45,7 @@ func TestBuild(t *testing.T) {
 		}
 		bzl.
 			EXPECT().
-			RunCommand([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand(streams, "build", "--bes_backend=grpc://127.0.0.1:12345", "//...").
 			Return(expectErr.ExitCode, expectErr.Err)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.
@@ -74,7 +74,7 @@ func TestBuild(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand(streams, "build", "--bes_backend=grpc://127.0.0.1:12345", "//...").
 			Return(0, nil)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.
@@ -107,7 +107,7 @@ func TestBuild(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand(streams, "build", "--bes_backend=grpc://127.0.0.1:12345", "//...").
 			Return(0, nil)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.

--- a/pkg/aspect/canonicalizeflags/canonicalizeflags.go
+++ b/pkg/aspect/canonicalizeflags/canonicalizeflags.go
@@ -44,7 +44,7 @@ func (v *CanonicalizeFlags) Run(ctx context.Context, _ *cobra.Command, args []st
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/clean/clean.go
+++ b/pkg/aspect/clean/clean.go
@@ -192,7 +192,7 @@ func (c *Clean) Run(_ *cobra.Command, _ []string) error {
 	if c.ExpungeAsync {
 		cmd = append(cmd, "--expunge_async")
 	}
-	if exitCode, err := c.bzl.RunCommand(cmd, c.Streams); exitCode != 0 {
+	if exitCode, err := c.bzl.RunCommand(c.Streams, cmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,
@@ -344,16 +344,17 @@ func (c *Clean) findDiskCaches(
 	// Running an invalid query should ensure that repository rules are not executed.
 	// However, bazel will still emit its BEP containing the flag that we are interested in.
 	// This will ensure it returns quickly and allows us to easily access said flag.
-	c.bzl.RunCommand([]string{
+	c.bzl.RunCommand(
+		streams,
 		"query",
 		"//",
-		"--build_event_json_file=" + bepLocation,
+		"--build_event_json_file="+bepLocation,
 
 		// We dont want bazel to print anything to the command line.
 		// We are only interested in the BEP output
 		"--ui_event_filters=-fatal,-error,-warning,-info,-progress,-debug,-start,-finish,-subcommand,-stdout,-stderr,-pass,-fail,-timeout,-cancelled,-depchecker",
 		"--noshow_progress",
-	}, streams)
+	)
 
 	file, err := os.Open(bepLocation)
 	if err != nil {

--- a/pkg/aspect/clean/clean_test.go
+++ b/pkg/aspect/clean/clean_test.go
@@ -78,7 +78,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"clean"}, streams).
+			RunCommand(streams, "clean").
 			Return(0, nil)
 
 		b := clean.New(streams, bzl, false)
@@ -94,7 +94,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"clean", "--expunge"}, streams).
+			RunCommand(streams, "clean", "--expunge").
 			Return(0, nil)
 
 		b := clean.New(streams, bzl, false)
@@ -111,7 +111,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"clean", "--expunge_async"}, streams).
+			RunCommand(streams, "clean", "--expunge_async").
 			Return(0, nil)
 
 		b := clean.New(streams, bzl, false)
@@ -129,7 +129,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"clean"}, streams).
+			RunCommand(streams, "clean").
 			Return(0, nil)
 
 		b := clean.New(streams, bzl, true)
@@ -151,7 +151,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"clean"}, streams).
+			RunCommand(streams, "clean").
 			Return(0, nil).AnyTimes()
 
 		b := clean.New(streams, bzl, true)
@@ -210,7 +210,7 @@ func TestClean(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"clean"}, streams).
+			RunCommand(streams, "clean").
 			Return(0, nil)
 
 		c := clean.New(streams, bzl, true)

--- a/pkg/aspect/cquery/cquery_test.go
+++ b/pkg/aspect/cquery/cquery_test.go
@@ -43,7 +43,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			RunCommand([]string{"cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand(streams, "cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)").
 			Return(0, nil)
 
 		q := cquery.New(streams, spawner, true)
@@ -71,7 +71,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			RunCommand([]string{"cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand(streams, "cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)").
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)
@@ -167,7 +167,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			RunCommand([]string{"cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand(streams, "cquery", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)").
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)

--- a/pkg/aspect/dump/dump.go
+++ b/pkg/aspect/dump/dump.go
@@ -44,7 +44,7 @@ func (v *Dump) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/fetch/fetch.go
+++ b/pkg/aspect/fetch/fetch.go
@@ -43,7 +43,7 @@ func (v *Fetch) Run(ctx context.Context, _ *cobra.Command, args []string) error 
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/info/info.go
+++ b/pkg/aspect/info/info.go
@@ -50,7 +50,7 @@ func (v *Info) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/mobileinstall/mobileinstall.go
+++ b/pkg/aspect/mobileinstall/mobileinstall.go
@@ -44,7 +44,7 @@ func (v *MobileInstall) Run(ctx context.Context, _ *cobra.Command, args []string
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/modquery/modquery.go
+++ b/pkg/aspect/modquery/modquery.go
@@ -44,7 +44,7 @@ func (v *ModQuery) Run(ctx context.Context, _ *cobra.Command, args []string) err
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/printaction/printaction.go
+++ b/pkg/aspect/printaction/printaction.go
@@ -44,7 +44,7 @@ func (v *PrintAction) Run(ctx context.Context, _ *cobra.Command, args []string) 
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/query/query_test.go
+++ b/pkg/aspect/query/query_test.go
@@ -45,7 +45,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			RunCommand([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand(streams, "query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)").
 			Return(0, nil)
 
 		q := query.New(streams, spawner, true)
@@ -80,7 +80,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			RunCommand([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand(streams, "query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)").
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)
@@ -225,7 +225,7 @@ func TestQuery(t *testing.T) {
 		spawner := bazel_mock.NewMockBazel(ctrl)
 		spawner.
 			EXPECT().
-			RunCommand([]string{"query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)"}, streams).
+			RunCommand(streams, "query", "somepath(//cmd/aspect/query:query, @com_github_bazelbuild_bazelisk//core:go_default_library)").
 			Return(0, nil)
 
 		promptRunner := query_mock.NewMockPromptRunner(ctrl)

--- a/pkg/aspect/query/shared/query.go
+++ b/pkg/aspect/query/shared/query.go
@@ -170,7 +170,7 @@ func RunQuery(bzl bazel.Bazel, verb string, query string, streams ioutils.Stream
 		query,
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/run/run.go
+++ b/pkg/aspect/run/run.go
@@ -46,7 +46,7 @@ func New(
 // Event Protocol backend used by Aspect plugins to subscribe to build events.
 func (cmd *Run) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
 	besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
-	exitCode, bazelErr := cmd.bzl.RunCommand(append([]string{"run", besBackendFlag}, args...), cmd.Streams)
+	exitCode, bazelErr := cmd.bzl.RunCommand(cmd.Streams, append([]string{"run", besBackendFlag}, args...)...)
 
 	// Process the subscribers errors before the Bazel one.
 	subscriberErrors := besBackend.Errors()

--- a/pkg/aspect/run/run_test.go
+++ b/pkg/aspect/run/run_test.go
@@ -45,7 +45,7 @@ func TestRun(t *testing.T) {
 		}
 		bzl.
 			EXPECT().
-			RunCommand([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand(streams, "run", "--bes_backend=grpc://127.0.0.1:12345", "//...").
 			Return(expectErr.ExitCode, expectErr.Err)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.
@@ -74,7 +74,7 @@ func TestRun(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand(streams, "run", "--bes_backend=grpc://127.0.0.1:12345", "//...").
 			Return(0, nil)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.
@@ -107,7 +107,7 @@ func TestRun(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"run", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
+			RunCommand(streams, "run", "--bes_backend=grpc://127.0.0.1:12345", "//...").
 			Return(0, nil)
 		besBackend := bep_mock.NewMockBESBackend(ctrl)
 		besBackend.

--- a/pkg/aspect/shutdown/shutdown.go
+++ b/pkg/aspect/shutdown/shutdown.go
@@ -44,7 +44,7 @@ func (v *Shutdown) Run(ctx context.Context, _ *cobra.Command, args []string) err
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/sync/sync.go
+++ b/pkg/aspect/sync/sync.go
@@ -44,7 +44,7 @@ func (v *Sync) Run(ctx context.Context, _ *cobra.Command, args []string) error {
 		return err
 	}
 
-	if exitCode, err := bzl.RunCommand(bazelCmd, v.Streams); exitCode != 0 {
+	if exitCode, err := bzl.RunCommand(v.Streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{
 			Err:      err,
 			ExitCode: exitCode,

--- a/pkg/aspect/test/test.go
+++ b/pkg/aspect/test/test.go
@@ -42,7 +42,7 @@ func (t *Test) Run(args []string, besBackend bep.BESBackend) (exitErr error) {
 	bazelCmd := []string{"test", besBackendFlag}
 	bazelCmd = append(bazelCmd, args...)
 
-	exitCode, bazelErr := t.bzl.RunCommand(bazelCmd, t.Streams)
+	exitCode, bazelErr := t.bzl.RunCommand(t.Streams, bazelCmd...)
 
 	// Process the subscribers errors before the Bazel one.
 	subscriberErrors := besBackend.Errors()

--- a/pkg/aspect/test/test_test.go
+++ b/pkg/aspect/test/test_test.go
@@ -39,7 +39,7 @@ func TestTest(t *testing.T) {
 		bzl := mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"test", "--bes_backend=grpc://127.0.0.1:12345"}, streams).
+			RunCommand(streams, "test", "--bes_backend=grpc://127.0.0.1:12345").
 			Return(0, nil)
 
 		besBackend := bep_mock.NewMockBESBackend(ctrl)

--- a/pkg/aspect/version/version.go
+++ b/pkg/aspect/version/version.go
@@ -61,7 +61,7 @@ func (v *Version) Run(bzl bazel.Bazel) error {
 		// Propagate the flag
 		bazelCmd = append(bazelCmd, "--gnu_format")
 	}
-	bzl.RunCommand(bazelCmd, v.Streams)
+	bzl.RunCommand(v.Streams, bazelCmd...)
 
 	return nil
 }

--- a/pkg/aspect/version/version_test.go
+++ b/pkg/aspect/version/version_test.go
@@ -48,7 +48,7 @@ func TestVersion(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"version"}, streams).
+			RunCommand(streams, "version").
 			Return(0, nil)
 
 		v := version.New(streams)
@@ -66,7 +66,7 @@ func TestVersion(t *testing.T) {
 		bzl := bazel_mock.NewMockBazel(ctrl)
 		bzl.
 			EXPECT().
-			RunCommand([]string{"version", "--gnu_format"}, streams).
+			RunCommand(streams, "version", "--gnu_format").
 			Return(0, nil)
 
 		v := version.New(streams)

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -51,7 +51,7 @@ type BazelProvider func() (Bazel, error)
 type Bazel interface {
 	WithEnv(env []string) Bazel
 	AQuery(expr string) (*analysis.ActionGraphContainer, error)
-	RunCommand(command []string, streams ioutils.Streams) (int, error)
+	RunCommand(streams ioutils.Streams, command ...string) (int, error)
 	Flags() (map[string]*flags.FlagInfo, error)
 	AvailableStartupFlags() []string
 	SetStartupFlags(flags []string)
@@ -114,7 +114,7 @@ func (*bazel) createRepositories() *core.Repositories {
 	return core.CreateRepositories(gcs, gcs, gitHub, gcs, gcs, true)
 }
 
-func (b *bazel) RunCommand(command []string, streams ioutils.Streams) (int, error) {
+func (b *bazel) RunCommand(streams ioutils.Streams, command ...string) (int, error) {
 	// Prepend startup flags
 	command = append(startupFlags, command...)
 
@@ -138,7 +138,7 @@ func (b *bazel) Flags() (map[string]*flags.FlagInfo, error) {
 	defer close(bazelErrs)
 	go func() {
 		defer w.Close()
-		_, err := b.RunCommand([]string{"help", "flags-as-proto"}, streams)
+		_, err := b.RunCommand(streams, "help", "flags-as-proto")
 		bazelErrs <- err
 	}()
 
@@ -186,7 +186,7 @@ func (b *bazel) AQuery(query string) (*analysis.ActionGraphContainer, error) {
 	defer close(bazelErrs)
 	go func() {
 		defer w.Close()
-		_, err := b.RunCommand([]string{"aquery", "--output=proto", query}, streams)
+		_, err := b.RunCommand(streams, "aquery", "--output=proto", query)
 		bazelErrs <- err
 	}()
 

--- a/pkg/bazel/bazel_test.go
+++ b/pkg/bazel/bazel_test.go
@@ -68,7 +68,7 @@ func TestBazel(t *testing.T) {
 		env := []string{fmt.Sprintf("FOO=%s", "BAR")}
 		var stdout strings.Builder
 		streams := ioutils.Streams{Stdout: &stdout}
-		_, err := bzl.WithEnv(env).RunCommand([]string{"--print_env"}, streams)
+		_, err := bzl.WithEnv(env).RunCommand(streams, "--print_env")
 		g.Expect(err).To(Not(HaveOccurred()))
 		g.Expect(stdout.String()).To(ContainSubstring("FOO=BAR"))
 	})
@@ -82,7 +82,7 @@ func TestBazel(t *testing.T) {
 		streams := ioutils.Streams{Stdout: &out, Stderr: &out}
 		// workspaceOverrideDir is an unconventional location that has a tools/bazel to be used.
 		// It must run the tools/bazel we placed under that location.
-		_, err := bzl.RunCommand([]string{"build"}, streams)
+		_, err := bzl.RunCommand(streams, "build")
 		g.Expect(err).To(Not(HaveOccurred()))
 		g.Expect(out.String()).To(Equal("wrapper called"))
 	})

--- a/pkg/plugin/client/client.go
+++ b/pkg/plugin/client/client.go
@@ -100,7 +100,7 @@ func (c *clientFactory) buildPlugin(target string) (string, error) {
 	// build the developer or CI would be performing.
 	// This is important only in the setup we don't recommend, where normal users
 	// are building the plugin from source instead of a pre-built binary.
-	if _, err := bzl.RunCommand([]string{"build", target}, streams); err != nil {
+	if _, err := bzl.RunCommand(streams, "build", target); err != nil {
 		return "", fmt.Errorf("failed to build plugin %q with Bazel: %w", target, err)
 	}
 


### PR DESCRIPTION
Update `Bazel` interface's `RunCommand()` so that the command argument follows the streams argument allowing for less verbose function calls.

Before:
```go
RunCommand([]string{"build", "--bes_backend=grpc://127.0.0.1:12345", "//..."}, streams).
```

After:
```go
RunCommand(streams, "build", "--bes_backend=grpc://127.0.0.1:12345", "//...").
``