### PR TITLE
fix: gather and set start-up flags in before configuring the plugin system

### DIFF
--- a/cmd/aspect/BUILD.bazel
+++ b/cmd/aspect/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//cmd/aspect/root",
         "//pkg/aspect/root/flags",
         "//pkg/aspecterrors",
+        "//pkg/bazel",
         "//pkg/ioutils",
         "//pkg/plugin/system",
     ],

--- a/cmd/aspect/main.go
+++ b/cmd/aspect/main.go
@@ -23,6 +23,7 @@ import (
 	"aspect.build/cli/cmd/aspect/root"
 	"aspect.build/cli/pkg/aspect/root/flags"
 	"aspect.build/cli/pkg/aspecterrors"
+	"aspect.build/cli/pkg/bazel"
 	"aspect.build/cli/pkg/ioutils"
 	"aspect.build/cli/pkg/plugin/system"
 )
@@ -45,6 +46,17 @@ func main() {
 	if wd, exists := os.LookupEnv("BUILD_WORKING_DIRECTORY"); exists {
 		_ = os.Chdir(wd)
 	}
+
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		aspecterrors.HandleError(err)
+	}
+
+	argsWithoutStartupFlags, err := bzl.InitializeStartupFlags(os.Args)
+	if err != nil {
+		aspecterrors.HandleError(err)
+	}
+	os.Args = argsWithoutStartupFlags
 
 	pluginSystem := system.NewPluginSystem()
 	if err := pluginSystem.Configure(ioutils.DefaultStreams); err != nil {

--- a/cmd/docgen/BUILD.bazel
+++ b/cmd/docgen/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cmd/aspect/root",
         "//pkg/aspect/root/flags",
+        "//pkg/bazel",
         "//pkg/ioutils",
         "//pkg/plugin/system",
         "@com_github_spf13_cobra//:cobra",

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -19,18 +19,31 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
 	"aspect.build/cli/cmd/aspect/root"
 	"aspect.build/cli/pkg/aspect/root/flags"
+	"aspect.build/cli/pkg/bazel"
 	"aspect.build/cli/pkg/ioutils"
 	"aspect.build/cli/pkg/plugin/system"
 )
 
 func main() {
 	cmd := &cobra.Command{Use: "docgen"}
+
+	bzl, err := bazel.FindFromWd()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	argsWithoutStartupFlags, err := bzl.InitializeStartupFlags(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Args = argsWithoutStartupFlags
 
 	pluginSystem := system.NewPluginSystem()
 	if err := pluginSystem.Configure(ioutils.DefaultStreams); err != nil {

--- a/pkg/aspect/root/flags/interceptor.go
+++ b/pkg/aspect/root/flags/interceptor.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"aspect.build/cli/pkg/bazel"
 	"aspect.build/cli/pkg/interceptors"
 	"aspect.build/cli/pkg/ioutils"
 )
@@ -49,33 +48,6 @@ func FlagsInterceptor(streams ioutils.Streams) interceptors.Interceptor {
 				return err
 			}
 		}
-
-		bzl, err := bazel.FindFromWd()
-		if err != nil {
-			return err
-		}
-		availableStartupFlags := bzl.AvailableStartupFlags()
-		startupFlags := []string{}
-		argsWithoutStartupFlags := []string{}
-
-		for _, arg := range args {
-			isStartup := false
-			for _, availableStartupFlag := range availableStartupFlags {
-				if arg == "--"+availableStartupFlag || strings.Contains(arg, "--"+availableStartupFlag+"=") {
-					isStartup = true
-					break
-				}
-			}
-
-			if isStartup {
-				startupFlags = append(startupFlags, arg)
-			} else {
-				argsWithoutStartupFlags = append(argsWithoutStartupFlags, arg)
-			}
-		}
-
-		bzl.SetStartupFlags(startupFlags)
-		args = argsWithoutStartupFlags
 
 		// If user specifies the config file to use then we want to only use that config.
 		// If user does not specify a config file to use then we want to load ".aspect" from the


### PR DESCRIPTION
Also store all flags as a global so we only ever call `bazel help flags-as-proto` once per aspect cli invocation