### PR TITLE
fix: forward query args if not using canned queries

### DIFF
--- a/pkg/aspect/aquery/aquery.go
+++ b/pkg/aspect/aquery/aquery.go
@@ -74,7 +74,9 @@ func (q *AQuery) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return shared.GetPrettyError(cmd, err)
 		}
-	}
 
-	return shared.RunQuery(q.Bzl, presetVerb, query, q.Streams)
+		return shared.RunQuery(q.Bzl, presetVerb, query, q.Streams)
+	} else {
+		return shared.RunQuery(q.Bzl, presetVerb, query, q.Streams, args[1:]...)
+	}
 }

--- a/pkg/aspect/cquery/cquery.go
+++ b/pkg/aspect/cquery/cquery.go
@@ -74,7 +74,9 @@ func (q *CQuery) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return shared.GetPrettyError(cmd, err)
 		}
-	}
 
-	return shared.RunQuery(q.Bzl, presetVerb, query, q.Streams)
+		return shared.RunQuery(q.Bzl, presetVerb, query, q.Streams)
+	} else {
+		return shared.RunQuery(q.Bzl, presetVerb, query, q.Streams, args[1:]...)
+	}
 }

--- a/pkg/aspect/query/query.go
+++ b/pkg/aspect/query/query.go
@@ -115,9 +115,11 @@ func (q *Query) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return shared.GetPrettyError(cmd, err)
 		}
-	}
 
-	return shared.RunQuery(q.Bzl, presetVerb, query, q.Streams)
+		return shared.RunQuery(q.Bzl, presetVerb, query, q.Streams)
+	} else {
+		return shared.RunQuery(q.Bzl, presetVerb, query, q.Streams, args[1:]...)
+	}
 }
 
 func (q *Query) checkConfig(baseUseKey string, baseInquiredKey string, question string) error {

--- a/pkg/aspect/query/shared/query.go
+++ b/pkg/aspect/query/shared/query.go
@@ -164,11 +164,12 @@ func ProcessQueries(presets []*PresetQuery) (map[string]*PresetQuery, []string, 
 	return processedPresets, presetNames, nil
 }
 
-func RunQuery(bzl bazel.Bazel, verb string, query string, streams ioutils.Streams) error {
+func RunQuery(bzl bazel.Bazel, verb string, query string, streams ioutils.Streams, args ...string) error {
 	bazelCmd := []string{
 		verb,
 		query,
 	}
+	bazelCmd = append(bazelCmd, args...)
 
 	if exitCode, err := bzl.RunCommand(streams, bazelCmd...); exitCode != 0 {
 		err = &aspecterrors.ExitError{


### PR DESCRIPTION
Fixes https://github.com/aspect-build/aspect-cli/issues/284

Some DX improvements are likely needed to the query command since there is still no way to pass additional flags when using the canned query with replacements but will leave that for a follow-up