### PR TITLE
fix: remove non-existant bootstrap release target

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -6,17 +6,10 @@ multi_platform_binaries(
     tags = ["manual"],
 )
 
-multi_platform_binaries(
-    name = "bootstrap",
-    embed = ["//cmd/bootstrap:bootstrap_lib"],
-    tags = ["manual"],
-)
-
 release(
     name = "release",
     tags = ["manual"],
     targets = [
         ":aspect",
-        ":bootstrap",
     ],
 )


### PR DESCRIPTION
This was left-over from when the bootstrap binary was in here