### PR TITLE
feat: add `//install` target for installing the Aspect CLI on the system

### DIFF
--- a/install/BUILD.bazel
+++ b/install/BUILD.bazel
@@ -1,0 +1,8 @@
+sh_binary(
+    name = "install",
+    srcs = ["install.sh"],
+    data = [
+        "//cmd/aspect",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/install/BUILD.bazel
+++ b/install/BUILD.bazel
@@ -6,3 +6,15 @@ sh_binary(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+sh_test(
+    name = "install_test",
+    srcs = ["install_test.sh"],
+    data = [
+        ":install",
+    ],
+    deps = [
+        "@aspect_bazel_lib//shlib/lib:assertions",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/install/install.sh
+++ b/install/install.sh
@@ -94,7 +94,7 @@ dest_path="${bin_dir}/aspect"
 
 # Remove an existing file
 if [[ -e "${dest_path}" ]]; then
-  warn "Removing existing file ${dest_path}."
+  echo "Removing existing file ${dest_path}."
   rm "${dest_path}"
 fi
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+# --- end runfiles.bash initialization v2 ---
+
+
+aspect_location=build_aspect_cli/cmd/aspect/aspect_/aspect
+aspect="$(rlocation "${aspect_location}")" || \
+  (echo >&2 "Failed to locate ${aspect_location}" && exit 1)
+
+# DEBUG BEGIN
+echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") aspect: ${aspect}" 
+ls -l >&2 "${aspect}"
+# DEBUG END

--- a/install/install.sh
+++ b/install/install.sh
@@ -68,6 +68,7 @@ EOF
 # Process Arguments
 
 bin_dir=/usr/local/bin
+create_if_missing=true
 args=()
 while (("$#")); do
   case "${1}" in
@@ -79,6 +80,14 @@ while (("$#")); do
       bin_dir="${2}"
       shift 2
       ;;
+    "--create_if_missing")
+      create_if_missing=true
+      shift 1
+      ;;
+    "--nocreate_if_missing")
+      create_if_missing=false
+      shift 1
+      ;;
     *)
       args+=("${1}")
       shift 1
@@ -87,7 +96,12 @@ while (("$#")); do
 done
 
 if [[ ! -d "${bin_dir}" ]]; then
-  usage_error "The installation directory was not found. ${bin_dir}"
+  if [[ "${create_if_missing}" == "true" ]]; then
+    echo "The installation directory was not found. Creating ${bin_dir}."
+    mkdir -p "${bin_dir}"
+  else
+    usage_error "The installation directory was not found. ${bin_dir}"
+  fi
 fi
 
 dest_path="${bin_dir}/aspect"

--- a/install/install.sh
+++ b/install/install.sh
@@ -11,12 +11,94 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
 # --- end runfiles.bash initialization v2 ---
 
+# Locate Resources
 
 aspect_location=build_aspect_cli/cmd/aspect/aspect_/aspect
 aspect="$(rlocation "${aspect_location}")" || \
   (echo >&2 "Failed to locate ${aspect_location}" && exit 1)
 
-# DEBUG BEGIN
-echo >&2 "*** CHUCK $(basename "${BASH_SOURCE[0]}") aspect: ${aspect}" 
-ls -l >&2 "${aspect}"
-# DEBUG END
+# Functions
+
+warn() {
+  local msg="${1:-}"
+  shift 1
+  while (("$#")); do
+    msg="${msg:-}"$'\n'"${1}"
+    shift 1
+  done
+  echo >&2 "${msg}"
+}
+
+# Echos the provided message to stderr and exits with an error (1).
+fail() {
+  warn "${1:-}"
+  exit 1
+}
+
+# Print an error message and dump the usage/help for the utility.
+# This function expects a get_usage function to be defined.
+usage_error() {
+  local msg="${1:-}"
+  cmd=(fail)
+  [[ -z "${msg:-}" ]] || cmd+=("${msg}" "")
+  cmd+=("$(get_usage)")
+  "${cmd[@]}"
+}
+
+show_usage() {
+  get_usage
+  exit 0
+}
+
+get_usage() {
+  local utility
+  utility="$(basename "${BASH_SOURCE[0]}")"
+  cat <<-EOF
+Install the Aspect CLI on the system.
+
+Usage:
+${utility} [OPTION]
+
+Options:
+  --help                 Show usage.
+  --bin <bin_dir>        The directory where the binary should be installed.
+EOF
+}
+
+# Process Arguments
+
+bin_dir=/usr/local/bin
+args=()
+while (("$#")); do
+  case "${1}" in
+    "--help")
+      show_usage
+      exit 0
+      ;;
+    "--bin")
+      bin_dir="${2}"
+      shift 2
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
+  esac
+done
+
+if [[ ! -d "${bin_dir}" ]]; then
+  usage_error "The installation directory was not found. ${bin_dir}"
+fi
+
+dest_path="${bin_dir}/aspect"
+
+# Remove an existing file
+if [[ -e "${dest_path}" ]]; then
+  warn "Removing existing file ${dest_path}."
+  rm "${dest_path}"
+fi
+
+# Copy the binary
+cp "${aspect}" "${dest_path}"
+
+echo "Aspect CLI installed: ${dest_path}"

--- a/install/install_test.sh
+++ b/install/install_test.sh
@@ -41,7 +41,7 @@ assert_same_contents() {
   diff "${first}" "${second}" || fail "Contents for ${first} and ${second} differ."
 }
 
-# Test
+# Setup
 
 bin_dir="${PWD}/bin"
 expected_dest_path="${bin_dir}/aspect"
@@ -51,9 +51,21 @@ setup_test() {
   mkdir -p "${bin_dir}"
 }
 
-# Install the binary
+# Test clean install
+
 setup_test
 output="$("${install}" --bin "${bin_dir}")"
 assert_file_exists "${expected_dest_path}"
 assert_same_contents "${aspect}" "${expected_dest_path}"
 assert_match "Aspect CLI installed: ${expected_dest_path}" "${output}"
+
+# Test existing file
+
+setup_test
+echo "Not a binary" > "${expected_dest_path}"
+output="$("${install}" --bin "${bin_dir}")"
+assert_file_exists "${expected_dest_path}"
+assert_same_contents "${aspect}" "${expected_dest_path}"
+assert_match "Removing existing file ${expected_dest_path}" "${output}"
+assert_match "Aspect CLI installed: ${expected_dest_path}" "${output}"
+

--- a/install/install_test.sh
+++ b/install/install_test.sh
@@ -51,6 +51,13 @@ setup_test() {
   mkdir -p "${bin_dir}"
 }
 
+# Test help flag
+
+setup_test
+output="$("${install}" --help)"
+assert_match "Install the Aspect CLI on the system." "${output}"
+assert_match "Usage:" "${output}"
+
 # Test clean install
 
 setup_test

--- a/install/install_test.sh
+++ b/install/install_test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -o nounset -o pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -o errexit
+# --- end runfiles.bash initialization v2 ---
+
+# Locate Deps
+
+assertions_sh_location=aspect_bazel_lib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+install_location=build_aspect_cli/install/install
+install="$(rlocation "${install_location}")" || \
+  (echo >&2 "Failed to locate ${install_location}" && exit 1)
+
+aspect_location=build_aspect_cli/cmd/aspect/aspect_/aspect
+aspect="$(rlocation "${aspect_location}")" || \
+  (echo >&2 "Failed to locate ${aspect_location}" && exit 1)
+
+
+# Functions
+
+assert_file_exists() {
+  local target="${1}"
+  [[ -e "${target}" ]] || fail "File does not exist: ${target}"
+}
+
+assert_same_contents() {
+  local first="${1}"
+  local second="${2}"
+  diff "${first}" "${second}" || fail "Contents for ${first} and ${second} differ."
+}
+
+# Test
+
+bin_dir="${PWD}/bin"
+expected_dest_path="${bin_dir}/aspect"
+
+setup_test() {
+  rm -rf "${bin_dir}"
+  mkdir -p "${bin_dir}"
+}
+
+# Install the binary
+setup_test
+output="$("${install}" --bin "${bin_dir}")"
+assert_file_exists "${expected_dest_path}"
+assert_same_contents "${aspect}" "${expected_dest_path}"
+assert_match "Aspect CLI installed: ${expected_dest_path}" "${output}"

--- a/install/install_test.sh
+++ b/install/install_test.sh
@@ -76,3 +76,10 @@ assert_same_contents "${aspect}" "${expected_dest_path}"
 assert_match "Removing existing file ${expected_dest_path}" "${output}"
 assert_match "Aspect CLI installed: ${expected_dest_path}" "${output}"
 
+# Test create destination directory
+
+setup_test
+rm -rf "${bin_dir}"
+output="$("${install}" --bin "${bin_dir}")"
+assert_match "The installation directory was not found. Creating ${bin_dir}" "${output}"
+assert_match "Aspect CLI installed: ${expected_dest_path}" "${output}"


### PR DESCRIPTION
Related to aspect-build/silo#329

This target will be used to build and install the Aspect CLI for the Homebrew formula.