### PR TITLE
refactor: make a test less brittle

### DIFF
--- a/pkg/aspect/clean/clean_test.go
+++ b/pkg/aspect/clean/clean_test.go
@@ -170,7 +170,7 @@ func TestClean(t *testing.T) {
 		// Recorded your preference for next time
 		content, err := os.ReadFile(cfg.Name())
 		g.Expect(err).To(BeNil())
-		g.Expect(string(content)).To(Equal("[clean]\nskip_prompt=true\n"))
+		g.Expect(string(content)).To(ContainSubstring("[clean]\nskip_prompt=true"))
 
 		// If we run it again, there should be no prompt
 		c := clean.New(streams, bzl, true)


### PR DESCRIPTION
I've seen this test fail when the config file contains one more newline than it expects.