### PR TITLE
chore: add bazelisk setup snippet

### DIFF
--- a/.github/workflows/install_snippet.sh
+++ b/.github/workflows/install_snippet.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+
+# Set by GH actions, see
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+TAG=${GITHUB_REF_NAME}
+
+
+cat << EOF
+## Install [Aspect CLI](https://www.aspect.build/cli)
+
+See full install instructions in [README.md](https://github.com/aspect-build/aspect-cli/blob/${TAG}/README.md).
+
+### Homebrew (MacOS)
+
+Link the [Aspect CLI](https://www.aspect.build/cli) as \`bazel\` just like the [bazelisk](https://github.com/bazelbuild/bazelisk) installer does:
+
+\`\`\`
+% brew install aspect-build/aspect/aspect
+\`\`\`
+
+### Bazelisk (MacOS / Linux / Windows)
+
+Configure [bazelisk](https://github.com/bazelbuild/bazelisk) to use the [Aspect CLI](https://www.aspect.build/cli) for all developers. Add this to \`.bazeliskrc\` in your project folder:
+
+\`\`\`
+BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
+USE_BAZEL_VERSION=aspect/${TAG}
+\`\`\`
+
+The underlying version of Bazel can be configured in your \`.bazelversion\` file or the \`BAZEL_VERSION\` environment variable.
+
+EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,12 @@ jobs:
             >&2 echo "ERROR: the release contained changes in the git state and the release will not be produced"
             exit 1
           fi
+      - name: Prepare workspace snippet
+        run: .github/workflows/install_snippet.sh > release_notes.txt
       - name: Create GitHub draft release and upload artifacts
         uses: softprops/action-gh-release@v1
         with:
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
+          body_path: release_notes.txt
           files: /tmp/aspect/release/*


### PR DESCRIPTION
Running it with `GITHUB_REF_NAME=1234` outputs:

-----
## Intsall

See install instructions in [README.md](https://github.com/aspect-build/aspect-cli/blob/1234/README.md).

If you already have [bazelisk](https://github.com/bazelbuild/bazelisk) installed, you can have [bazelisk](https://github.com/bazelbuild/bazelisk) install the Aspect CLI just like it can install the standard Bazel CLI.

Add this to your `.bazeliskrc` in your project folder to install Aspect for all developers:

```
BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
USE_BAZEL_VERSION=aspect/1234
```