### PR TITLE
chore: update to aspect-cli/latest version

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,2 +1,1 @@
-BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
-USE_BAZEL_VERSION=aspect/5.1.2
+USE_BAZEL_VERSION=aspect-cli/latest


### PR DESCRIPTION
Requires an auth fix in bazelisk to fetch versions from a fork without BAZELISK_GITHUB_TOKEN set: https://github.com/bazelbuild/bazelisk/pull/412