### PR TITLE
chore: update docs for plugins to reference config.yaml

### DIFF
--- a/docs/plugins/plugins.d.ts
+++ b/docs/plugins/plugins.d.ts
@@ -17,7 +17,7 @@ export interface AspectCLIPluginsCatalog {
      */
     homepage?: string;
     /**
-     * The value users of the plugin put in the 'name' field of their .aspect/cli/plugins.yaml when using this plugin
+     * The value users of the plugin put in the 'name' field in .aspect/cli/config.yaml when using this plugin
      */
     name: string;
     /**

--- a/docs/plugins/plugins.schema.json
+++ b/docs/plugins/plugins.schema.json
@@ -18,7 +18,7 @@
             "type": "string"
           },
           "name": {
-            "description": "The value users of the plugin put in the 'name' field of their .aspect/cli/plugins.yaml when using this plugin",
+            "description": "The value users of the plugin put in the 'name' field in .aspect/cli/config.yaml when using this plugin",
             "type": "string"
           },
           "maintainers": {


### PR DESCRIPTION
Looks like these docs have their SoT here still. Future change will be to move the SoT to silo.