### PR TITLE
chore(ci): enable aspect workflows

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,0 +1,4 @@
+# See https://docs.aspect.build/v/workflows/config
+---
+tasks:
+  test:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,4 +1,4 @@
-name: Default
+name: CI/CD
 
 on:
   push:
@@ -10,6 +10,10 @@ on:
   workflow_dispatch:
 
 jobs:
+  aspect-workflows:
+    name: Aspect Workflows
+    uses: aspect-build/workflows-action/.github/workflows/aspect-workflows.yaml@5.3.4
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Gives us a "staging" environment for workflows releases that has actual public traffic, and we don't use it as a "dev" environment.
