### PR TITLE
chore: update to aspect-build/workflows CCI orb v5.4.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ orbs:
   # CCI doesn't allow us to use a relative path in the monorepo, so we have to refer to an
   # already-published orb in their registry.
   # Run `bazel run --stamp //rosetta/cci-orb:publish` to produce a new version.
-  bazel: aspect-build/workflows@dev:5.4.5
+  bazel: aspect-build/workflows@dev:5.4.6
 
 workflows:
   bazel-setup:


### PR DESCRIPTION
Workflows v5.4.6 is now live for CI on this repo.

```
#!/bin/bash -eo pipefail
configure_workflows_env

Workflows Information
	Version: v5.4.6
```