### PR TITLE
chore: update workflows config so same config is use by circleci and github actions

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,5 +1,6 @@
 # See https://docs.aspect.build/v/workflows/config
 ---
+queue: aspect-cli
 tasks:
   branch_freshness:
     update_strategy: rebase

--- a/.aspect/workflows/config_cci.yaml
+++ b/.aspect/workflows/config_cci.yaml
@@ -1,8 +1,0 @@
-# See https://docs.aspect.build/v/workflows/config
----
-queue: aspect-cli
-tasks:
-  branch_freshness:
-    update_strategy: rebase
-  buildifier:
-  test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ workflows:
   bazel-setup:
     jobs:
       - bazel/setup:
-          aspect-config: .aspect/workflows/config_cci.yaml
+          aspect-config: .aspect/workflows/config.yaml
           resource_class: aspect-build/aspect-cli
           context:
             - slack

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   aspect-workflows:
     name: Aspect Workflows
-    uses: aspect-build/workflows-action/.github/workflows/aspect-workflows.yaml@5.3.4
+    with:
+      queue: aspect-cli
+    uses: aspect-build/workflows-action/.github/workflows/aspect-workflows.yaml@5.4.12-dev.23.g1efd33a
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unlike silo, the aim in this repo is to have a single Aspect Workflows config with matching queue/runner pool names on all CI providers covered.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
