### PR TITLE
chore: update Workflows orb to 5.6.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ orbs:
   # CCI doesn't allow us to use a relative path in the monorepo, so we have to refer to an
   # already-published orb in their registry.
   # Run `bazel run --stamp //rosetta/cci-orb:publish` to produce a new version.
-  bazel: aspect-build/workflows@dev:5.6.0-rc8
+  bazel: aspect-build/workflows@5.6.0
 
 workflows:
   bazel-setup:


### PR DESCRIPTION
Bump Aspect CLI to Workflows 5.6.0 orb.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases

CI
