### PR TITLE
ci: don't depend on system patch for go_googleapis dep

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,7 +78,10 @@ http_archive(
 http_archive(
     name = "io_bazel_rules_go",
     patch_args = ["-p1"],
-    patches = ["//patches:rules_go.patch"],
+    patches = [
+        "//patches:rules_go.patch",
+        "//patches:rules_go.pr3617.patch",
+    ],
     sha256 = "19ef30b21eae581177e0028f6f4b1f54c66467017be33d211ab6fc81da01ea4d",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.38.0/rules_go-v0.38.0.zip"],
 )

--- a/patches/rules_go.pr3617.patch
+++ b/patches/rules_go.pr3617.patch
@@ -1,0 +1,21 @@
+commit 11d5bb9072ed7f73dd4b35017f11472e51cff8d1
+Author: Alex Eagle <alex@aspect.dev>
+Date:   Wed Jul 5 12:31:08 2023 -0700
+
+    Revert "Make googleapis work on FreeBSD."
+    
+    This reverts commit 62b1d302e2fb4af5646ead1eb135aaf5b3c1a0e4.
+
+diff --git a/go/private/repositories.bzl b/go/private/repositories.bzl
+index 44c2da30..467c9054 100644
+--- a/go/private/repositories.bzl
++++ b/go/private/repositories.bzl
+@@ -262,7 +262,7 @@ def go_rules_dependencies(force = False):
+             # releaser:patch-cmd gazelle -repo_root .
+             Label("//third_party:go_googleapis-gazelle.patch"),
+         ],
+-        patch_args = ["-E", "-p1"],
++        patch_args = ["-p1"],
+     )
+ 
+     # releaser:upgrade-dep golang mock


### PR DESCRIPTION
Same as https://github.com/bazelbuild/rules_go/pull/3617.

 ---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Will remove `patch` from the PATH on Amazon Linux 2 CI workers and observe that warming is still green: https://buildkite.com/aspect/aspect-cli-warming/builds/217#018984b7-ed55-4234-9804-e29985609a76