### PR TITLE
chore: tweak CCI config yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ parameters:
 setup: true
 
 orbs:
-  continuation: circleci/continuation@0.3.1
   slack: circleci/slack@4.12.1
   aspect-workflows: aspect-build/workflows@5.8.0
 


### PR DESCRIPTION
The continuation orb is a dep of the aspect-workflows orb and doesn't need to be explicitly specified