### PR TITLE
chore: update buildifier targets used by Aspect Workflows

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -125,15 +125,15 @@ alias(
 )
 
 buildifier(
+    name = "buildifier",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier(
     name = "buildifier.check",
-    # By default the diffs appear on stdout,
-    # but the rest of Buildifier appears on
-    # stderr making it harder to capture in Workflows,
-    # so we do a cheeky redirect here in the diff_command.
-    diff_command = "diff -U 5 >&2",
-    exclude_patterns = [
-        "./.git/*",
-    ],
+    exclude_patterns = ["./.git/*"],
     lint_mode = "warn",
     mode = "diff",
 )


### PR DESCRIPTION
Aspect Workflows currently expects a `//:buildifier.check` target for checking and a `//:buildifier` target that is the suggested target to run when the buildifier check is red