### PR TITLE
chore: fixup CCI yaml for Aspect Workflows warming job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
     docker:
       - image: cimg/base:2023.03
     steps:
+      - run: echo "No-op step since CCI requires one step for the job to be valid"
       - when:
           condition:
             and:
@@ -33,7 +34,7 @@ jobs:
                   equal: [scheduled_pipeline, << pipeline.trigger_source >>]
           steps:
             - checkout
-            - run: echo "this is an example of legacy non-workflows job"
+            - run: echo "This is an example of legacy non-workflows job"
 
 workflows:
   default-workflow:


### PR DESCRIPTION
Warming currently failing with
```
ERROR IN CONFIG FILE:
[#/jobs/legacy] only 1 subschema matches out of 2
1. [#/jobs/legacy/steps] expected minimum item count: 1, found: 0
|   SCHEMA:
|     minItems: 1
```
because the condition on the legacy job removes ALL of the steps.

Ideally we'd have a different workflow defined for the legacy job _but_ CCI has a limitation to 1 workflows when you are using a continuation orb. I have some ideas to improve this in the future but that is a task for another day.