### PR TITLE
chore: switch to smaller 'small' instances without nvme drives

### DIFF
--- a/.aspect/workflows/terraform/workflows.tf
+++ b/.aspect/workflows/terraform/workflows.tf
@@ -81,25 +81,23 @@ module "aspect_workflows" {
     default = {}
   }
 
-  # Resource types for use by runner groups
+  # Resource types for use by runner groups. Aspect recommends instance types that have nvme drives
+  # for large Bazel workflows. See https://aws.amazon.com/ec2/instance-types/ for list of instance
+  # types available on AWS.
   resource_types = {
     "default" = {
-      # Aspect Workflows requires instance types that have nvme drives. See
-      # https://aws.amazon.com/ec2/instance-types/ for full list of instance types available on AWS.
       instance_types = ["c5ad.xlarge"]
       image_id       = data.aws_ami.runner_amd64_ami.id
     }
     "small-amd64" = {
-      # Aspect Workflows requires instance types that have nvme drives. See
-      # https://aws.amazon.com/ec2/instance-types/ for full list of instance types available on AWS.
-      instance_types = ["c5ad.large"]
-      image_id       = data.aws_ami.runner_amd64_ami.id
+      instance_types      = ["t3a.micro"]
+      image_id            = data.aws_ami.runner_amd64_ami.id
+      root_volume_size_gb = 32
     }
     "small-arm64" = {
-      # Aspect Workflows requires instance types that have nvme drives. See
-      # https://aws.amazon.com/ec2/instance-types/ for full list of instance types available on AWS.
-      instance_types = ["m6gd.medium"]
-      image_id       = data.aws_ami.runner_arm64_ami.id
+      instance_types      = ["t4g.micro"]
+      image_id            = data.aws_ami.runner_arm64_ami.id
+      root_volume_size_gb = 32
     }
   }
 
@@ -108,7 +106,6 @@ module "aspect_workflows" {
     # The default runner group is use for the main build & test workflows.
     default = {
       agent_idle_timeout_min    = 1
-      job_max_run_time_min      = 5 * 60
       max_runners               = 10
       min_runners               = 0
       resource_type             = "default"
@@ -116,8 +113,7 @@ module "aspect_workflows" {
       warming                   = true
     }
     small-amd64 = {
-      agent_idle_timeout_min    = 1
-      job_max_run_time_min      = 5 * 60
+      agent_idle_timeout_min    = 30
       max_runners               = 10
       min_runners               = 0
       resource_type             = "small-amd64"
@@ -125,8 +121,7 @@ module "aspect_workflows" {
       warming                   = false # don't warm for faster bootstrap; these runners won't be running large builds
     }
     small-arm64 = {
-      agent_idle_timeout_min    = 1
-      job_max_run_time_min      = 5 * 60
+      agent_idle_timeout_min    = 30
       max_runners               = 10
       min_runners               = 0
       resource_type             = "small-arm64"
@@ -137,7 +132,6 @@ module "aspect_workflows" {
     # warming archives for use by other runner groups.
     warming = {
       agent_idle_timeout_min = 1
-      job_max_run_time_min   = 5 * 60
       max_runners            = 1
       min_runners            = 0
       policies               = { warming_manage : module.aspect_workflows.warming_management_policies["default"].arn }


### PR DESCRIPTION
Instances without nvme drives are supported in Aspect Workflows 5.9.
