### PR TITLE
chore: fix remote_download_minimal flag for delivery

### DIFF
--- a/.aspect/workflows/bazelrc
+++ b/.aspect/workflows/bazelrc
@@ -1,3 +1,3 @@
 # build without the bytes
-test --remote_download_minimal
-test --nobuild_runfile_links
+common --remote_download_outputs=minimal
+common --nobuild_runfile_links

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -10,3 +10,5 @@ tasks:
   - test:
   - delivery:
       always_deliver: true
+      branches:
+        - main


### PR DESCRIPTION
Turns out there is a Bazel bug with `common --remote_download_minimal` as the expansion to `--nobuild_runfile_links` is not filtered out from `bazel query` and bazel ERRORs out. See https://github.com/bazelbuild/bazel/pull/18130#issuecomment-1874687869 for more info.

So instead we set

```
common --remote_download_outputs=minimal
common --nobuild_runfile_links
```


---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
