### PR TITLE
chore: update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,18 +18,18 @@ repos:
         language: script
         files: \.go$
   - repo: https://github.com/syntaqx/git-hooks
-    rev: v0.0.17
+    rev: v0.0.18
     hooks:
       # Requires that shellcheck is already installed
       - id: shellcheck
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.37.0
+    rev: v3.13.0
     hooks:
       # Requires that commitizen is already installed
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 4.0.1.1
+    rev: 6.4.0
     hooks:
       # Requires that buildifier is already installed
       - id: buildifier
@@ -38,11 +38,11 @@ repos:
       - id: buildifier-lint
         args: *args
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.4.0'
+    rev: v3.1.0
     hooks:
       - id: prettier
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.12
+    rev: v1.5.0
     hooks:
       - id: insert-license
         files: \.go$


### PR DESCRIPTION
The older version of `https://github.com/Lucas-C/pre-commit-hooks` had issues being installed with a global python 3.11.6 on a new M3 machine. Updating to the latest resolved it. Also updated the other pre-commit hook versions while I was at it.
