### PR TITLE
chore: fix build without the bytes with Bazel 7

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,12 @@ common --workspace_status_command "${PWD}/workspace_status.sh"
 
 common:release -c opt --stamp
 
+# --noexperimental_check_output_files setting from .aspect/bazelrc/performance.bazelrc breaks "build without the bytes" with Bazel 7
+# NB: these can't be common since since performance.bazel uses {build,fetch,query} and these will stop over any common settings
+build --experimental_check_output_files
+fetch --experimental_check_output_files
+query --experimental_check_output_files
+
 # bzlmod causes issues with LLVM toolchain
 common --noenable_bzlmod
 


### PR DESCRIPTION
Tracked down the issue that caused delivery with build without the bytes to fail with Bazel 7. This will green up main.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)


### Test plan

- Covered by existing test cases

CI