### PR TITLE
chore: upgrade to Aspect bazel-lib 2.2.0

### DIFF
--- a/.aspect/bazelrc/javascript.bazelrc
+++ b/.aspect/bazelrc/javascript.bazelrc
@@ -8,21 +8,3 @@
 # details.
 # Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 run:debug -- --node_options=--inspect-brk
-
-# Enable runfiles on all platforms. Runfiles are on by default on Linux and MacOS but off on
-# Windows.
-#
-# In general, rules_js and derivate rule sets assume that runfiles are enabled and do not support no
-# runfiles case because it does not scale to teach all Node.js tools to use the runfiles manifest.
-#
-# If you are developing on Windows, you must either run bazel with administrator privileges or
-# enable developer mode. If you do not you may hit this error on Windows:
-#
-#   Bazel needs to create symlinks to build the runfiles tree.
-#   Creating symlinks on Windows requires one of the following:
-#       1. Bazel is run with administrator privileges.
-#       2. The system version is Windows 10 Creators Update (1703) or later
-#          and developer mode is enabled.
-#
-# Docs: https://bazel.build/reference/command-line-reference#flag--enable_runfiles
-build --enable_runfiles

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,16 +4,16 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "a9ea6902c860918bd6928114efbc6ea2093df006af66459c9ac1637f9dd08f6a",
-    strip_prefix = "bazel-lib-2.1.2",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.1.2/bazel-lib-v2.1.2.tar.gz",
+    sha256 = "8d71a578e4e1b6a54aea7598ebfbd8fc9e3be5da881ff9d2b80249577b933a40",
+    strip_prefix = "bazel-lib-2.2.0",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.2.0/bazel-lib-v2.2.0.tar.gz",
 )
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "76a04ef2120ee00231d85d1ff012ede23963733339ad8db81f590791a031f643",
-    strip_prefix = "rules_js-1.34.1",
-    url = "https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz",
+    sha256 = "a2f941e27f02e84521c2d47fd530c66d57dd6d6e44b4a4f1496fe304851d8e48",
+    strip_prefix = "rules_js-1.35.0",
+    url = "https://github.com/aspect-build/rules_js/releases/download/v1.35.0/rules_js-v1.35.0.tar.gz",
 )
 
 http_archive(

--- a/docs/bazelrc/javascript.bazelrc
+++ b/docs/bazelrc/javascript.bazelrc
@@ -8,21 +8,3 @@
 # details.
 # Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 run:debug -- --node_options=--inspect-brk
-
-# Enable runfiles on all platforms. Runfiles are on by default on Linux and MacOS but off on
-# Windows.
-#
-# In general, rules_js and derivate rule sets assume that runfiles are enabled and do not support no
-# runfiles case because it does not scale to teach all Node.js tools to use the runfiles manifest.
-#
-# If you are developing on Windows, you must either run bazel with administrator privileges or
-# enable developer mode. If you do not you may hit this error on Windows:
-#
-#   Bazel needs to create symlinks to build the runfiles tree.
-#   Creating symlinks on Windows requires one of the following:
-#       1. Bazel is run with administrator privileges.
-#       2. The system version is Windows 10 Creators Update (1703) or later
-#          and developer mode is enabled.
-#
-# Docs: https://bazel.build/reference/command-line-reference#flag--enable_runfiles
-build --enable_runfiles


### PR DESCRIPTION
bazelrc preset updates in this version. Also bump rules_js as that bump is related to the preset changes.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
