### PR TITLE
chore: bump to golang v1.21.6 and rules_go v0.41.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,11 +85,11 @@ http_archive(
     name = "io_bazel_rules_go",
     patch_args = ["-p1"],
     patches = [
-        "//patches:rules_go.patch",
-        "//patches:rules_go.pr3617.patch",
+        # "//patches:rules_go.patch",
+        # "//patches:rules_go.pr3617.patch",
     ],
-    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip"],
+    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
 )
 
 http_archive(
@@ -128,7 +128,7 @@ go_rules_dependencies()
 
 go_embed_data_dependencies()
 
-go_register_toolchains(version = "1.20.4")
+go_register_toolchains(version = "1.21.6")
 
 http_archive(
     name = "bazel_gazelle",

--- a/pkg/plugin/system/bep/BUILD.bazel
+++ b/pkg/plugin/system/bep/BUILD.bazel
@@ -2,7 +2,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 # Ensure that Aspect silo gets the same result as aspect-cli repo so this is gazelle-stable in both.
 # Silo has a /third_party directory with the same thing vendored in.
-# gazelle:resolve go google.golang.org/genproto/googleapis/devtools/build/v1 @go_googleapis//google/devtools/build/v1:build_go_proto
 
 go_library(
     name = "bep",
@@ -15,7 +14,7 @@ go_library(
         "//pkg/aspectgrpc",
         "//pkg/plugin/system/besproxy",
         "@com_github_golang_protobuf//ptypes/empty",
-        "@go_googleapis//google/devtools/build/v1:build_go_proto",
+        "@org_golang_google_genproto//googleapis/devtools/build/v1:build",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_protobuf//types/known/emptypb",
@@ -36,7 +35,7 @@ go_test(
         "//pkg/stdlib/mock",
         "@com_github_golang_mock//gomock",
         "@com_github_onsi_gomega//:gomega",
-        "@go_googleapis//google/devtools/build/v1:build_go_proto",
+        "@org_golang_google_genproto//googleapis/devtools/build/v1:build",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_x_sync//errgroup",

--- a/pkg/plugin/system/besproxy/BUILD.bazel
+++ b/pkg/plugin/system/besproxy/BUILD.bazel
@@ -2,7 +2,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 # Ensure that Aspect silo gets the same result as aspect-cli repo so this is gazelle-stable in both.
 # Silo has a /third_party directory with the same thing vendored in.
-# gazelle:resolve go google.golang.org/genproto/googleapis/devtools/build/v1 @go_googleapis//google/devtools/build/v1:build_go_proto
 
 go_library(
     name = "besproxy",
@@ -14,7 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//bazel/buildeventstream",
-        "@go_googleapis//google/devtools/build/v1:build_go_proto",
+        "@org_golang_google_genproto//googleapis/devtools/build/v1:build",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials",
         "@org_golang_google_grpc//credentials/insecure",


### PR DESCRIPTION
Minimum rules_go version for golang v1.21 is [v0.41.0](https://github.com/bazelbuild/rules_go/releases/tag/v0.41.0) due to a change in the VERSION format that go reports.

golang v1.21 includes the [slices package](https://www.gopherguides.com/articles/golang-slices-package#:~:text=In%20release%201.21%2C%20the%20slices,included%20in%20the%20Slices%20package.) as well as the [cmp package](https://medium.com/@goel.yash143/exploring-the-new-cmp-package-in-go-v1-21-simplifying-ordered-value-comparisons-eb1ead9a28e0#:~:text=With%20the%20release%20of%20Go,a%20consistent%20and%20efficient%20manner.).

With `slices` and `cmp` includes this will resolve warnings with the `configure` command for go that these imports are not found. For example,

```
2023/12/22 01:53:17 finding module path for import slices: finding module path for import slices: template: main:1:9: executing "main" at [.Module.Path](https://app.slack.com/client/.Module.Path): nil pointer evaluating *modinfo.ModulePublic.Path
2023/12/22 01:53:17 finding module path for import cmp: finding module path for import cmp: template: main:1:9: executing "main" at [.Module.Path](https://app.slack.com/client/.Module.Path): nil pointer evaluating *modinfo.ModulePublic.Path
```

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
