### PR TITLE
chore: add before and after task hook examples

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -8,6 +8,11 @@ tasks:
   - configure:
       queue: aspect-small-arm64
   - test:
+      hooks:
+        - type: before_task
+          command: vmstat -a -S M -t 5 2>&1 > /tmp/vmstat_out &
+        - type: after_task
+          command: cat /tmp/vmstat_out
   - delivery:
       always_deliver: true
       branches:


### PR DESCRIPTION
Low tech way to monitor and output resource usage on runners during a task.