### PR TITLE
chore: configure Aspect Workflows external remote cache for local development

### DIFF
--- a/.aspect/bazelrc/.gitignore
+++ b/.aspect/bazelrc/.gitignore
@@ -1,0 +1,2 @@
+user.bazelrc
+remote-cache.bazelrc

--- a/.aspect/workflows/terraform/workflows.tf
+++ b/.aspect/workflows/terraform/workflows.tf
@@ -197,3 +197,9 @@ module "aspect_workflows_grafana_dashboards" {
   grafana_url                 = module.managed_grafana.grafana_endpoint
   managed_prometheus_endpoint = module.aspect_workflows.managed_prometheus_endpoint
 }
+
+resource "aws_ssm_parameter" "external_cache_endpoint" {
+  name  = "aw_external_cache_endpoint"
+  type  = "String"
+  value = module.aspect_workflows.external_remote_cache_endpoint
+}

--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,13 @@ common --noincompatible_disallow_empty_glob
 common --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 common --incompatible_enable_cc_toolchain_resolution
 
+# Load any settings & overrides specific to the external remote cache from `.aspect/bazelrc/remote-cache.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+# Setup of this file is automated by running the setup_remote_cache.sh Bash script.
+try-import %workspace%/.aspect/bazelrc/remote-cache.bazelrc
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/setup_remote_cache.sh
+++ b/setup_remote_cache.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Fetch the external remote cache configuration and add it to the user's Bazel RC file.
+
+set -o errexit -o nounset -o pipefail
+
+ENDPOINT=$(aws ssm get-parameter --region us-west-2 --name "aw_external_cache_endpoint" --query Parameter.Value --output text)
+AUTH_STRING=$(aws ssm get-parameter --region us-west-2 --with-decryption --name "aw_external_cache_auth_header" --query Parameter.Value --output text)
+SELF_PATH=$(dirname "${BASH_SOURCE[0]:-"$(command -v -- "$0")"}")
+
+echo -e "build --remote_cache=\"grpcs://${ENDPOINT}:8980\" --remote_header=\"Authorization=Basic ${AUTH_STRING}\" --remote_accept_cached --remote_upload_local_results" >"${SELF_PATH}/.aspect/bazelrc/remote-cache.bazelrc"


### PR DESCRIPTION
```
$ bazel build //...
INFO: Invocation ID: 9224f5e5-b3ae-40f1-b748-3a0131712b5f
INFO: Analyzed 620 targets (675 packages loaded, 101976 targets configured).
INFO: Found 620 targets...
INFO: Elapsed time: 241.535s, Critical Path: 169.79s
INFO: 5070 processes: 3285 remote cache hit, 1193 internal, 578 darwin-sandbox, 14 local.
INFO: Build completed successfully, 5070 total actions
```