### PR TITLE
chore: stash output of vmstat in artifacts

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -11,9 +11,11 @@ tasks:
   - test:
       hooks:
         - type: before_task
-          command: vmstat -a -S M -t 5 2>&1 > /tmp/vmstat_out &
+          command: vmstat -a -S M -t 1 2>&1 > vmstat.out &
         - type: after_task
-          command: cat /tmp/vmstat_out
+          command: cat vmstat.out
+      artifact_paths:
+        - vmstat.out
   - delivery:
       auto_deliver: true
       rules:

--- a/.aspect/workflows/deps.bzl
+++ b/.aspect/workflows/deps.bzl
@@ -4,12 +4,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archi
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 # TODO: move this to a rule set so repositories on Aspect Workflows can avoid this boilerplate
-rosetta_version = "5.9.22"
+rosetta_version = "5.9.23"
 rosetta_integrity = {
-    "darwin_aarch64": "sha256-EXjXWBWQPa2l7QQTz3XbUXo2sz0aPHqxioT+LiOesyw=",
-    "darwin_x86_64": "sha256-6+BVUK8oKFNWZtFPW9pSnPvnSd9doDLecNsWdl7zHuk=",
-    "linux_aarch64": "sha256-TBHcq62DXuBW2rATy5KGlBmgKnldAT3A6iDSYCt2UBE=",
-    "linux_x86_64": "sha256-X4M8I9gBapSkUHlu85/Vi6Gz3qWZv9M06mWW3jAXyfY=",
+    "darwin_aarch64": "sha256-PDPqg71zILLpI3Ty4p+OxfqyZYE1cB4t8wAF/4A6e/E=",
+    "darwin_x86_64": "sha256-ZEKTyj+N3In/OqkIPKb1PSodMjf8BTfoowaCuE3IWDM=",
+    "linux_aarch64": "sha256-eceTIsiZ7gylU355flUe94R1ZU21fQ3fmHseOWcN2MU=",
+    "linux_x86_64": "sha256-pICGFRNJn/nVTuEb1DpOm8BPDasjNEVH4nceiF1e2aQ=",
 }
 
 # https://github.com/suzuki-shunsuke/circleci-config-merge/releases

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,6 +410,8 @@ jobs:
         path: /workflows/testlogs
     - store_artifacts:
         path: /workflows/artifacts
+    - store_artifacts:
+        path: vmstat.out
     - run:
         command: rosetta run finalization
         environment:


### PR DESCRIPTION
Also upgrade to Workflows v5.9.23 which adds support for `artifact_paths` to CircleCI