### PR TITLE
Cache bazel flags proto

### DIFF
--- a/cmd/aspect/main.go
+++ b/cmd/aspect/main.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"time"
 
 	"aspect.build/cli/cmd/aspect/root"
 	"aspect.build/cli/pkg/aspect/root/config"
@@ -32,7 +30,6 @@ import (
 )
 
 func main() {
-	start := time.Now()
 	// Convenience for local development: under `bazel run <aspect binary target>` respect the
 	// users working directory, don't run in the execroot
 	if wd, exists := os.LookupEnv("BUILD_WORKING_DIRECTORY"); exists {
@@ -55,33 +52,26 @@ func main() {
 	// Re-enter another aspect if version running is not the configured version
 	bazelVersion, reentered, err := bzl.HandleReenteringAspect(streams, os.Args[1:], root.CheckAspectLockVersionFlag(os.Args[1:]))
 	if reentered {
-		fmt.Println("REENTER")
 		if err != nil {
 			aspecterrors.HandleError(err)
 		}
 		os.Exit(0)
 	}
 
-	fmt.Println("0 ELAPSED", time.Since(start))
-
 	err = bzl.InitializeBazelFlags(bazelVersion)
 	if err != nil {
 		aspecterrors.HandleError(err)
 	}
 
-	fmt.Println("A ELAPSED", time.Since(start))
 	args, startupFlags, err := bazel.InitializeStartupFlags(os.Args[1:])
 
 	if err != nil {
 		aspecterrors.HandleError(err)
 	}
 
-	fmt.Println("AA ELAPSED", time.Since(start))
 	if err = command(bzl, bazelVersion, streams, args, startupFlags); err != nil {
 		aspecterrors.HandleError(err)
 	}
-
-	fmt.Println("BB ELAPSED", time.Since(start))
 }
 
 func command(bzl bazel.Bazel, version string, streams ioutils.Streams, args []string, startupFlags []string) error {

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -26,7 +26,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"aspect.build/cli/bazel/analysis"
 	"aspect.build/cli/bazel/flags"
@@ -190,8 +189,6 @@ func InitializeStartupFlags(args []string) ([]string, []string, error) {
 
 // Flags fetches the metadata for Bazel's command line flag via `bazel help flags-as-proto`
 func (b *bazel) Flags(version string) (map[string]*flags.FlagInfo, error) {
-	start := time.Now()
-
 	if allFlags != nil {
 		return allFlags, nil
 	}
@@ -225,7 +222,6 @@ func (b *bazel) Flags(version string) (map[string]*flags.FlagInfo, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed write MODULE.bazel file in %s: %w", tmpdir, err)
 		}
-		fmt.Println("Flags elapsed 1", time.Since(start))
 
 		var stdout bytes.Buffer
 		var stderr bytes.Buffer
@@ -247,7 +243,6 @@ func (b *bazel) Flags(version string) (map[string]*flags.FlagInfo, error) {
 		}(tmpdir)
 
 		err = <-bazelErrs
-		fmt.Println("Flags elapsed 2", time.Since(start))
 
 		if err != nil {
 			var exitErr *aspecterrors.ExitError
@@ -269,20 +264,16 @@ func (b *bazel) Flags(version string) (map[string]*flags.FlagInfo, error) {
 		}
 	}
 
-	fmt.Println("Flags elapsed 3", time.Since(start))
-
 	flagCollection := &flags.FlagCollection{}
 	if err := proto.Unmarshal(helpProtoBytes, flagCollection); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal bazel flags: %w", err)
 	}
-	fmt.Println("Flags elapsed 4", time.Since(start))
 
 	allFlags = make(map[string]*flags.FlagInfo)
 
 	for i := range flagCollection.FlagInfos {
 		allFlags[*flagCollection.FlagInfos[i].Name] = flagCollection.FlagInfos[i]
 	}
-	fmt.Println("Flags elapsed 5", time.Since(start))
 
 	return allFlags, nil
 }

--- a/pkg/bazel/bazel.go
+++ b/pkg/bazel/bazel.go
@@ -258,9 +258,12 @@ func (b *bazel) Flags(version string) (map[string]*flags.FlagInfo, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read bazel flags: %w", err)
 		}
-		err = os.WriteFile(helpProtoFile, helpProtoBytes, 0644)
-		if err != nil {
-			return nil, fmt.Errorf("failed to cache bazel flags: %w", err)
+		// "latest" is not deterministic; do not cache.
+		if version != "latest" {
+			err = os.WriteFile(helpProtoFile, helpProtoBytes, 0644)
+			if err != nil {
+				return nil, fmt.Errorf("failed to cache bazel flags: %w", err)
+			}
 		}
 	}
 

--- a/pkg/bazel/bazel_flags.go
+++ b/pkg/bazel/bazel_flags.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"aspect.build/cli/bazel/flags"
 	rootFlags "aspect.build/cli/pkg/aspect/root/flags"
@@ -116,8 +117,9 @@ func addFlagToFlagSet(flag *flags.FlagInfo, flagSet *pflag.FlagSet, hidden bool)
 // the special startup "command" set). These are used later by SeparateBazelFlags
 // which is called by InitializeStartUp flags and some special-case commands
 // such as query, cquery and aquery.
-func (b *bazel) InitializeBazelFlags() error {
-	flags, err := b.Flags()
+func (b *bazel) InitializeBazelFlags(version string) error {
+	start := time.Now()
+	flags, err := b.Flags(version)
 	if err != nil {
 		return err
 	}
@@ -132,12 +134,13 @@ func (b *bazel) InitializeBazelFlags() error {
 			addFlagToFlagSet(flag, flagSet, true)
 		}
 	}
+	fmt.Println("Flags added", time.Since(start))
 	return nil
 }
 
 // AddBazelFlags will process the configured cobra commands and add bazel
 // flags to those commands.
-func (b *bazel) AddBazelFlags(cmd *cobra.Command) error {
+func (b *bazel) AddBazelFlags(cmd *cobra.Command, version string) error {
 	completionCommands := make(map[string]*cobra.Command)
 
 	commands := make(map[string]*cobra.Command)
@@ -146,7 +149,7 @@ func (b *bazel) AddBazelFlags(cmd *cobra.Command) error {
 		commands[name] = c
 	}
 
-	flags, err := b.Flags()
+	flags, err := b.Flags(version)
 	if err != nil {
 		return err
 	}

--- a/pkg/bazel/bazel_flags.go
+++ b/pkg/bazel/bazel_flags.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	"aspect.build/cli/bazel/flags"
 	rootFlags "aspect.build/cli/pkg/aspect/root/flags"
@@ -118,7 +117,6 @@ func addFlagToFlagSet(flag *flags.FlagInfo, flagSet *pflag.FlagSet, hidden bool)
 // which is called by InitializeStartUp flags and some special-case commands
 // such as query, cquery and aquery.
 func (b *bazel) InitializeBazelFlags(version string) error {
-	start := time.Now()
 	flags, err := b.Flags(version)
 	if err != nil {
 		return err
@@ -134,7 +132,6 @@ func (b *bazel) InitializeBazelFlags(version string) error {
 			addFlagToFlagSet(flag, flagSet, true)
 		}
 	}
-	fmt.Println("Flags added", time.Since(start))
 	return nil
 }
 

--- a/pkg/bazel/bazelisk.go
+++ b/pkg/bazel/bazelisk.go
@@ -308,6 +308,7 @@ func isAspectVersionMismatch(aspectRuntime *aspectRuntimeInfo, version string, b
 	return aspectRuntime.Version != version || aspectRuntime.BaseUrl != baseUrl
 }
 
+// getBazelVersion returns the version and the base URL to download from.
 func (bazelisk *Bazelisk) getBazelVersion() (string, string, error) {
 	// The logic in upstream Bazelisk v1.15.0
 	// (https://github.com/bazelbuild/bazelisk/blob/c9081741bc1420d601140a4232b5c48872370fdc/core/core.go#L318)


### PR DESCRIPTION
It takes around 65ms to execute the `bazel help` commands in the new workspace to grab the flags. We can cache the flags per-version to avoid that.

### Type of change
- Performance (a code change that improves performance)

```
➜  aspect-cli git:(zbarsky/version) hyperfine -i 'bazel build //:no-such-target'                                                                                                                                                                                                 ~/aspect-cli
Benchmark 1: bazel build //:no-such-target
  Time (mean ± σ):     285.6 ms ±   4.2 ms    [User: 56.3 ms, System: 31.2 ms]
  Range (min … max):   280.3 ms … 292.4 ms    10 runs

➜  aspect-cli git:(zbarsky/version) ✗ hyperfine -i 'bazel-bin/cmd/aspect/aspect_/aspect build //:no-such-target'                                                                                                                                                                 ~/aspect-cli
Benchmark 1: bazel-bin/cmd/aspect/aspect_/aspect build //:no-such-target
  Time (mean ± σ):     244.4 ms ±   4.4 ms    [User: 49.1 ms, System: 17.9 ms]
  Range (min … max):   238.2 ms … 251.1 ms    12 runs
```

### Test plan
The first commit adds timings so you can see how the cache helps. The second commit removes them to keep the code clean. (We should squash before merging)