### PR TITLE
refactor(gazelle): use local treesitter grammars

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,3 +41,8 @@ try-import %workspace%/.aspect/bazelrc/remote-cache.bazelrc
 # should be last statement in this config so the user configuration is able to overwrite flags from
 # this file. See https://bazel.build/configure/best-practices#bazelrc-file.
 try-import %workspace%/.aspect/bazelrc/user.bazelrc
+
+# Tell Bazel to pass the right flags for llvm-ar, not libtool, only needed on linux.
+# See https://github.com/bazelbuild/bazel/blob/5c75d0acec21459bbb13520817e3806e1507e907/tools/cpp/unix_cc_toolchain_config.bzl#L1000-L1024
+# TODO: maybe drop once we upgrade llvm toolchain, https://github.com/bazel-contrib/toolchains_llvm/pull/229
+build:linux --features=-libtool

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -169,6 +169,10 @@ _go_repositories()
 
 gazelle_dependencies()
 
+load("//gazelle/common/treesitter/grammars:grammars.bzl", "fetch_grammars")
+
+fetch_grammars()
+
 http_archive(
     name = "bazel_gomock",
     sha256 = "82a5fb946d2eb0fed80d3d70c2556784ec6cb5c35cd65a1b5e93e46f99681650",

--- a/gazelle/common/treesitter/BUILD.bazel
+++ b/gazelle/common/treesitter/BUILD.bazel
@@ -10,9 +10,9 @@ go_library(
     importpath = "aspect.build/cli/gazelle/common/treesitter",
     visibility = ["//visibility:public"],
     deps = [
+        "//gazelle/common/treesitter/grammars/kotlin",
+        "//gazelle/common/treesitter/grammars/tsx",
+        "//gazelle/common/treesitter/grammars/typescript",
         "@com_github_smacker_go_tree_sitter//:go-tree-sitter",
-        "@com_github_smacker_go_tree_sitter//kotlin",
-        "@com_github_smacker_go_tree_sitter//typescript/tsx",
-        "@com_github_smacker_go_tree_sitter//typescript/typescript",
     ],
 )

--- a/gazelle/common/treesitter/grammars/BUILD.bazel
+++ b/gazelle/common/treesitter/grammars/BUILD.bazel
@@ -1,0 +1,1 @@
+# gazelle:ignore *.bzl

--- a/gazelle/common/treesitter/grammars/grammars.bzl
+++ b/gazelle/common/treesitter/grammars/grammars.bzl
@@ -1,0 +1,39 @@
+"""
+Fetches and compiles tree-sitter grammars.
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def fetch_grammars():
+    http_archive(
+        name = "tree-sitter-kotlin",
+        sha256 = "f8d6f766ff2da1bd411e6d55f4394abbeab808163d5ea6df9daa75ad48eb0834",
+        strip_prefix = "tree-sitter-kotlin-0.3.5",
+        urls = ["https://github.com/fwcd/tree-sitter-kotlin/archive/0.3.5.tar.gz"],
+        build_file_content = """
+filegroup(
+    name = "srcs",
+    srcs = glob(["src/**/*.c", "src/**/*.h"]),
+    visibility = ["//visibility:public"],
+)
+""",
+    )
+
+    http_archive(
+        name = "tree-sitter-typescript",
+        sha256 = "fb95a7a78268b3c0aeca86cc376681f1f4f9a1ae97b9bd8167c633bfd41398c6",
+        strip_prefix = "tree-sitter-typescript-0.20.6",
+        urls = ["https://github.com/tree-sitter/tree-sitter-typescript/archive/v0.20.6.tar.gz"],
+        build_file_content = """
+filegroup(
+    name = "typescript-srcs",
+    srcs = glob(["**/*.c", "**/*.h"], exclude=["tsx/**"]),
+    visibility = ["//visibility:public"],
+)
+filegroup(
+    name = "tsx-srcs",
+    srcs = glob(["**/*.c", "**/*.h"], exclude=["typescript/**"]),
+    visibility = ["//visibility:public"],
+)
+""",
+    )

--- a/gazelle/common/treesitter/grammars/kotlin/BUILD.bazel
+++ b/gazelle/common/treesitter/grammars/kotlin/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+go_library(
+    name = "kotlin",
+    srcs = ["binding.go"],
+    cdeps = [":kotlin_cc"],
+    cgo = True,
+    copts = ["-Iexternal/tree-sitter-kotlin"],  #keep
+    importpath = "aspect.build/cli/gazelle/common/treesitter/grammars/kotlin",
+    visibility = ["//gazelle/common/treesitter:__subpackages__"],
+    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
+)
+
+cc_library(
+    name = "kotlin_cc",
+    srcs = ["@tree-sitter-kotlin//:srcs"],
+    copts = ["-Iexternal/tree-sitter-kotlin/src"],
+)

--- a/gazelle/common/treesitter/grammars/kotlin/binding.go
+++ b/gazelle/common/treesitter/grammars/kotlin/binding.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlin
+
+//#include "src/tree_sitter/parser.h"
+//TSLanguage *tree_sitter_kotlin();
+import "C"
+import (
+	"unsafe"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+func GetLanguage() *sitter.Language {
+	ptr := unsafe.Pointer(C.tree_sitter_kotlin())
+	return sitter.NewLanguage(ptr)
+}

--- a/gazelle/common/treesitter/grammars/tsx/BUILD.bazel
+++ b/gazelle/common/treesitter/grammars/tsx/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+go_library(
+    name = "tsx",
+    srcs = ["binding.go"],
+    cdeps = [":tsx_cc"],
+    cgo = True,
+    copts = ["-Iexternal/tree-sitter-typescript"],  #keep
+    importpath = "aspect.build/cli/gazelle/common/treesitter/grammars/tsx",
+    visibility = ["//gazelle/common/treesitter:__subpackages__"],
+    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
+)
+
+cc_library(
+    name = "tsx_cc",
+    srcs = ["@tree-sitter-typescript//:tsx-srcs"],
+    copts = ["-Iexternal/tree-sitter-typescript/tsx/src"],
+)

--- a/gazelle/common/treesitter/grammars/tsx/binding.go
+++ b/gazelle/common/treesitter/grammars/tsx/binding.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tsx
+
+//#include "tsx/src/tree_sitter/parser.h"
+//TSLanguage *tree_sitter_tsx();
+import "C"
+import (
+	"unsafe"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+func GetLanguage() *sitter.Language {
+	ptr := unsafe.Pointer(C.tree_sitter_tsx())
+	return sitter.NewLanguage(ptr)
+}

--- a/gazelle/common/treesitter/grammars/typescript/BUILD.bazel
+++ b/gazelle/common/treesitter/grammars/typescript/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+go_library(
+    name = "typescript",
+    srcs = ["binding.go"],
+    cdeps = [":typescript_cc"],
+    cgo = True,
+    copts = ["-Iexternal/tree-sitter-typescript"],  #keep
+    importpath = "aspect.build/cli/gazelle/common/treesitter/grammars/typescript",
+    visibility = ["//gazelle/common/treesitter:__subpackages__"],
+    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
+)
+
+cc_library(
+    name = "typescript_cc",
+    srcs = ["@tree-sitter-typescript//:typescript-srcs"],
+    copts = ["-Iexternal/tree-sitter-typescript/typescript/src"],
+)

--- a/gazelle/common/treesitter/grammars/typescript/binding.go
+++ b/gazelle/common/treesitter/grammars/typescript/binding.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package typescript
+
+//#include "typescript/src/tree_sitter/parser.h"
+//TSLanguage *tree_sitter_typescript();
+import "C"
+import (
+	"unsafe"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+func GetLanguage() *sitter.Language {
+	ptr := unsafe.Pointer(C.tree_sitter_typescript())
+	return sitter.NewLanguage(ptr)
+}

--- a/gazelle/common/treesitter/parser.go
+++ b/gazelle/common/treesitter/parser.go
@@ -1,13 +1,29 @@
+/*
+ * Copyright 2023 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package treesitter
 
 import (
 	"context"
 	"log"
 
+	"aspect.build/cli/gazelle/common/treesitter/grammars/kotlin"
+	"aspect.build/cli/gazelle/common/treesitter/grammars/tsx"
+	"aspect.build/cli/gazelle/common/treesitter/grammars/typescript"
 	sitter "github.com/smacker/go-tree-sitter"
-	"github.com/smacker/go-tree-sitter/kotlin"
-	"github.com/smacker/go-tree-sitter/typescript/tsx"
-	"github.com/smacker/go-tree-sitter/typescript/typescript"
 )
 
 type LanguageGrammar = int


### PR DESCRIPTION

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
