### PR TITLE
Reflect tsconfig `composite` and `incremental` to `ts_project()`

### DIFF
--- a/gazelle/js/generate.go
+++ b/gazelle/js/generate.go
@@ -541,6 +541,13 @@ func (ts *typeScriptLang) addProjectRule(cfg *JsGazelleConfig, tsconfigRel strin
 				existing.DelAttr("source_map")
 			}
 
+			// Reflect the tsconfig incremental in the ts_project rule
+			if tsconfig.Incremental != nil {
+				sourceRule.SetAttr("incremental", *tsconfig.Incremental)
+			} else if existing != nil {
+				existing.DelAttr(("incremental"))
+			}
+
 			// Reflect the tsconfig resolve_json_module in the ts_project rule
 			if tsconfig.ResolveJsonModule != nil {
 				sourceRule.SetAttr("resolve_json_module", *tsconfig.ResolveJsonModule)
@@ -575,6 +582,7 @@ func (ts *typeScriptLang) addProjectRule(cfg *JsGazelleConfig, tsconfigRel strin
 			existing.DelAttr("composite")
 			existing.DelAttr("declaration")
 			existing.DelAttr("declaration_map")
+			existing.DelAttr("incremental")
 			existing.DelAttr("out_dir")
 			existing.DelAttr("preserve_jsx")
 			existing.DelAttr("resolve_json_module")

--- a/gazelle/js/generate.go
+++ b/gazelle/js/generate.go
@@ -513,6 +513,13 @@ func (ts *typeScriptLang) addProjectRule(cfg *JsGazelleConfig, tsconfigRel strin
 				existing.DelAttr("allow_js")
 			}
 
+			// Reflect the tsconfig composite in the ts_project rule
+			if tsconfig.Composite != nil {
+				sourceRule.SetAttr("composite", *tsconfig.Composite)
+			} else if existing != nil {
+				existing.DelAttr("composite")
+			}
+
 			// Reflect the tsconfig declaration in the ts_project rule
 			if tsconfig.Declaration != nil {
 				sourceRule.SetAttr("declaration", *tsconfig.Declaration)
@@ -565,6 +572,7 @@ func (ts *typeScriptLang) addProjectRule(cfg *JsGazelleConfig, tsconfigRel strin
 			// Clear tsconfig related attributes if no tsconfig is found
 			existing.DelAttr("tsconfig")
 			existing.DelAttr("allow_js")
+			existing.DelAttr("composite")
 			existing.DelAttr("declaration")
 			existing.DelAttr("declaration_map")
 			existing.DelAttr("out_dir")

--- a/gazelle/js/tests/tsconfig_composite/BUILD.in
+++ b/gazelle/js/tests/tsconfig_composite/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_tsconfig enabled

--- a/gazelle/js/tests/tsconfig_composite/BUILD.out
+++ b/gazelle/js/tests/tsconfig_composite/BUILD.out
@@ -1,0 +1,15 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+
+# gazelle:js_tsconfig enabled
+
+ts_project(
+    name = "tsconfig_composite",
+    srcs = ["main.ts"],
+    composite = True,
+    tsconfig = ":tsconfig",
+)
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+)

--- a/gazelle/js/tests/tsconfig_composite/WORKSPACE
+++ b/gazelle/js/tests/tsconfig_composite/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "tsconfig_composite")

--- a/gazelle/js/tests/tsconfig_composite/main.ts
+++ b/gazelle/js/tests/tsconfig_composite/main.ts
@@ -1,0 +1,1 @@
+console.log('No Imports!');

--- a/gazelle/js/tests/tsconfig_composite/tsconfig.json
+++ b/gazelle/js/tests/tsconfig_composite/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "composite": true
+    }
+}

--- a/gazelle/js/tests/tsconfig_incremental/BUILD.in
+++ b/gazelle/js/tests/tsconfig_incremental/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_tsconfig enabled

--- a/gazelle/js/tests/tsconfig_incremental/BUILD.out
+++ b/gazelle/js/tests/tsconfig_incremental/BUILD.out
@@ -1,0 +1,15 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+
+# gazelle:js_tsconfig enabled
+
+ts_project(
+    name = "tsconfig_incremental",
+    srcs = ["main.ts"],
+    incremental = True,
+    tsconfig = ":tsconfig",
+)
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+)

--- a/gazelle/js/tests/tsconfig_incremental/WORKSPACE
+++ b/gazelle/js/tests/tsconfig_incremental/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "tsconfig_incremental")

--- a/gazelle/js/tests/tsconfig_incremental/main.ts
+++ b/gazelle/js/tests/tsconfig_incremental/main.ts
@@ -1,0 +1,1 @@
+console.log('No Imports!');

--- a/gazelle/js/tests/tsconfig_incremental/tsconfig.json
+++ b/gazelle/js/tests/tsconfig_incremental/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "incremental": true
+    }
+}

--- a/gazelle/js/typescript/tsconfig.go
+++ b/gazelle/js/typescript/tsconfig.go
@@ -32,6 +32,7 @@ type tsCompilerOptionsJSON struct {
 	Composite         *bool                `json:"composite"`
 	Declaration       *bool                `json:"declaration"`
 	DeclarationMap    *bool                `json:"declarationMap"`
+	Incremental       *bool                `json:"incremental"`
 	SourceMap         *bool                `json:"sourceMap"`
 	ResolveJsonModule *bool                `json:"resolveJsonModule"`
 	OutDir            *string              `json:"outDir"`
@@ -85,6 +86,7 @@ type TsConfig struct {
 	Composite         *bool
 	Declaration       *bool
 	DeclarationMap    *bool
+	Incremental       *bool
 	SourceMap         *bool
 	OutDir            string
 	RootDir           string
@@ -240,6 +242,13 @@ func parseTsConfigJSON(parsed map[string]*TsConfig, resolver TsConfigResolver, r
 		declarationMap = baseConfig.DeclarationMap
 	}
 
+	var incremental *bool
+	if c.CompilerOptions.Incremental != nil {
+		incremental = c.CompilerOptions.Incremental
+	} else if baseConfig != nil {
+		incremental = baseConfig.Incremental
+	}
+
 	var sourceMap *bool
 	if c.CompilerOptions.SourceMap != nil {
 		sourceMap = c.CompilerOptions.SourceMap
@@ -322,6 +331,7 @@ func parseTsConfigJSON(parsed map[string]*TsConfig, resolver TsConfigResolver, r
 		Composite:         composite,
 		Declaration:       declaration,
 		DeclarationMap:    declarationMap,
+		Incremental:       incremental,
 		SourceMap:         sourceMap,
 		ResolveJsonModule: resolveJsonModule,
 		OutDir:            OutDir,

--- a/gazelle/js/typescript/tsconfig.go
+++ b/gazelle/js/typescript/tsconfig.go
@@ -29,6 +29,7 @@ import (
 
 type tsCompilerOptionsJSON struct {
 	AllowJs           *bool                `json:"allowJs"`
+	Composite         *bool                `json:"composite"`
 	Declaration       *bool                `json:"declaration"`
 	DeclarationMap    *bool                `json:"declarationMap"`
 	SourceMap         *bool                `json:"sourceMap"`
@@ -81,6 +82,7 @@ type TsConfig struct {
 
 	AllowJs           *bool
 	ResolveJsonModule *bool
+	Composite         *bool
 	Declaration       *bool
 	DeclarationMap    *bool
 	SourceMap         *bool
@@ -217,6 +219,13 @@ func parseTsConfigJSON(parsed map[string]*TsConfig, resolver TsConfigResolver, r
 		allowJs = baseConfig.AllowJs
 	}
 
+	var composite *bool
+	if c.CompilerOptions.Composite != nil {
+		composite = c.CompilerOptions.Composite
+	} else if baseConfig != nil {
+		composite = baseConfig.Composite
+	}
+
 	var declaration *bool
 	if c.CompilerOptions.Declaration != nil {
 		declaration = c.CompilerOptions.Declaration
@@ -310,6 +319,7 @@ func parseTsConfigJSON(parsed map[string]*TsConfig, resolver TsConfigResolver, r
 		ConfigDir:         configDir,
 		ConfigName:        configName,
 		AllowJs:           allowJs,
+		Composite:         composite,
 		Declaration:       declaration,
 		DeclarationMap:    declarationMap,
 		SourceMap:         sourceMap,


### PR DESCRIPTION
I noticed that `bazel configure` is creating `BUILD.bazel` files that would result in the following error: 

```
ERROR: ts_project rule @@//pkgs/foo-lib:typescript was configured with attributes that don't match the tsconfig
 - attribute composite=false does not match compilerOptions.composite=true
 - attribute incremental=false does not match compilerOptions.incremental=true
You can automatically fix this by running:
    npx @bazel/buildozer 'set composite True' 'set incremental True' @@//pkgs/foo-lib:typescript
Or to suppress this error, either:
 - pass --norun_validations to Bazel to turn off the feature completely, or
 - disable validation for this target by running:
    npx @bazel/buildozer 'set validate False' @@//pkgs/foo-lib:typescript
```

It would be nice for these `compilerOptions` to be automatically mirrored into the `ts_project()`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- New test cases added
