### PR TITLE
Handle non `@types` imports from tsconfig `compilerOptions.types`

### DIFF
--- a/gazelle/js/generate.go
+++ b/gazelle/js/generate.go
@@ -316,14 +316,15 @@ func (ts *typeScriptLang) collectTsConfigImports(cfg *JsGazelleConfig, args lang
 	}
 
 	for _, t := range tsconfig.Types {
-		if typesImport := toAtTypesPackage(t); !cfg.IsImportIgnored(typesImport) {
+		if !cfg.IsImportIgnored(t) {
 			imports = append(imports, ImportStatement{
 				ImportSpec: resolve.ImportSpec{
 					Lang: LanguageName,
-					Imp:  typesImport,
+					Imp:  t,
 				},
 				ImportPath: t,
 				SourcePath: SourcePath,
+				TypesOnly:  true,
 			})
 		}
 	}

--- a/gazelle/js/resolve.go
+++ b/gazelle/js/resolve.go
@@ -326,7 +326,7 @@ func (ts *typeScriptLang) resolveImports(
 			deps.Add(typesDep)
 		}
 
-		if dep != nil {
+		if dep != nil && (!imp.TypesOnly || len(types) == 0) {
 			deps.Add(dep)
 		}
 

--- a/gazelle/js/target.go
+++ b/gazelle/js/target.go
@@ -23,6 +23,10 @@ type ImportStatement struct {
 
 	// If the import is optional and failure to resolve should not be an error
 	Optional bool
+
+	// If the import is explicitly for types, in which case prefer @types package
+	// dependencies when types are shipped separately
+	TypesOnly bool
 }
 
 // Npm link-all rule import data

--- a/gazelle/js/tests/tsconfig_deps/pnpm-lock.yaml
+++ b/gazelle/js/tests/tsconfig_deps/pnpm-lock.yaml
@@ -4,10 +4,12 @@ specifiers:
   '@testing-library/jest-dom': ^5.16.5
   '@types/jquery': 3.5.14
   '@types/testing-library__jest-dom': ^5.14.5
+  cypress: ^13.16.0
   jquery: 3.6.1
 
 dependencies:
   '@testing-library/jest-dom': 5.16.5
   '@types/jquery': 3.5.14
   '@types/testing-library__jest-dom': 5.14.5
+  cypress: 13.16.0
   jquery: 3.6.1

--- a/gazelle/js/tests/tsconfig_deps/types/BUILD.in
+++ b/gazelle/js/tests/tsconfig_deps/types/BUILD.in
@@ -1,2 +1,2 @@
-# gazelle:js_ignore_imports @types/ignored
-# gazelle:js_ignore_imports @types/test__ignored
+# gazelle:js_ignore_imports ignored
+# gazelle:js_ignore_imports @test/ignored

--- a/gazelle/js/tests/tsconfig_deps/types/BUILD.out
+++ b/gazelle/js/tests/tsconfig_deps/types/BUILD.out
@@ -9,6 +9,7 @@ ts_config(
     deps = [
         "//:node_modules/@types/jquery",
         "//:node_modules/@types/testing-library__jest-dom",
+        "//:node_modules/cypress",
         "//:tsconfig",
     ],
 )

--- a/gazelle/js/tests/tsconfig_deps/types/BUILD.out
+++ b/gazelle/js/tests/tsconfig_deps/types/BUILD.out
@@ -1,7 +1,7 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 
-# gazelle:js_ignore_imports @types/ignored
-# gazelle:js_ignore_imports @types/test__ignored
+# gazelle:js_ignore_imports ignored
+# gazelle:js_ignore_imports @test/ignored
 
 ts_config(
     name = "tsconfig",

--- a/gazelle/js/tests/tsconfig_deps/types/tsconfig.json
+++ b/gazelle/js/tests/tsconfig_deps/types/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["jquery", "@testing-library/jest-dom", "ignored", "@test/ignored"]
+    "types": ["jquery", "@testing-library/jest-dom", "cypress"]
   }
 }

--- a/gazelle/js/tests/tsconfig_deps/types/tsconfig.json
+++ b/gazelle/js/tests/tsconfig_deps/types/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["jquery", "@testing-library/jest-dom", "cypress"]
+    "types": ["jquery", "@testing-library/jest-dom", "ignored", "@test/ignored", "cypress"]
   }
 }


### PR DESCRIPTION
The TypeScript docs for `compilerOptions.types` make it sound like `compilerOptions.types` only applies to `@types` packages, but in practice it can also be used to include types from non `@types` in the global scope. For example, `cypress` recommends this in their [docs](https://docs.cypress.io/app/tooling/typescript-support#Configure-tsconfigjson): 

```json
{
  "compilerOptions": {
    "target": "es5",
    "lib": ["es5", "dom"],
    "types": ["cypress", "node"]
  },
  "include": ["**/*.ts"]
}
```

From what I can tell, if you don't specify `compilerOptions.types`, TypeScript will **not** automatically include types from a visible non `@types` package like `cypress` (`describe`,  `beforeEach`, etc). But you can include non `@types` packages in `compilerOptions.types`  to allow list them into the global scope. 

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes/no

### Test plan
I updated the existing test case for `compilerOptions.types`. 

- Covered by existing test cases
- New test cases added


