### PR TITLE
Handle `/// <reference lib="..." />` comments

### DIFF
--- a/gazelle/js/parser/parser.go
+++ b/gazelle/js/parser/parser.go
@@ -53,7 +53,10 @@ var importQueries = map[string]string{
 	`,
 }
 
-var tripleSlashRe = regexp.MustCompile(`^///\s*<reference\s+(?P<attr>lib|path|types)\s*=\s*"(?P<lib>[^"]+)"`)
+// Note that we intentionally omit "lib" here since these directives do not result in a separate dependency
+// See: https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-lib-
+// > This directive allows a file to explicitly include an existing built-in lib file
+var tripleSlashRe = regexp.MustCompile(`^///\s*<reference\s+(?:path|types)\s*=\s*"(?P<lib>[^"]+)"`)
 
 func ParseSource(filePath string, sourceCode []byte) (ParseResult, []error) {
 	imports := make([]string, 0, 5)
@@ -112,12 +115,8 @@ func ParseSource(filePath string, sourceCode []byte) (ParseResult, []error) {
 				}
 			} else if nodeType == "comment" {
 				comment := node.Content(sourceCode)
-				if attr, typesImport, isTripleSlash := getTripleSlashDirectiveModule(comment); isTripleSlash {
-					// See: https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-lib-
-					// > This directive allows a file to explicitly include an existing built-in lib file
-					if attr != "lib" {
-						imports = append(imports, typesImport)
-					}
+				if typesImport, isTripleSlash := getTripleSlashDirectiveModule(comment); isTripleSlash {
+					imports = append(imports, typesImport)
 				}
 			}
 		}
@@ -157,19 +156,18 @@ func ParseSource(filePath string, sourceCode []byte) (ParseResult, []error) {
 //
 // Note: could also potentially use a treesitter query such as:
 // /  `(program (comment) @result (#match? @c "^///\\s*<reference\\s+(lib|types|path)\\s*=\\s*\"[^\"]+\""))`
-func getTripleSlashDirectiveModule(comment string) (string, string, bool) {
+func getTripleSlashDirectiveModule(comment string) (string, bool) {
 	if !strings.HasPrefix(comment, "///") {
-		return "", "", false
+		return "", false
 	}
 
 	submatches := tripleSlashRe.FindAllStringSubmatchIndex(comment, -1)
 	if len(submatches) != 1 {
-		return "", "", false
+		return "", false
 	}
 
-	attr := tripleSlashRe.ExpandString(make([]byte, 0), "$attr", comment, submatches[0])
 	lib := tripleSlashRe.ExpandString(make([]byte, 0), "$lib", comment, submatches[0])
-	return string(attr), string(lib), len(attr) > 0 && len(lib) > 0
+	return string(lib), len(lib) > 0
 }
 
 // Determine if a node is an import/export statement that may contain a `from` value.

--- a/gazelle/js/tests/npm_types_package/triple_slash/ref.ts
+++ b/gazelle/js/tests/npm_types_package/triple_slash/ref.ts
@@ -1,5 +1,8 @@
-/// References to npm packages, via both "lib" and "types"
-/// <reference lib="jquery">
+// References to built-in libs
+/// <reference lib="webworker">
+
+// References to npm packages via "types"
+/// <reference types="jquery">
 /// <reference types="@testing-library/jest-dom">
 
 // Transpiled .ts files, referenced both with and without the .d.ts extension.

--- a/gazelle/js/tests/npm_types_package/triple_slash_syntaxes/ref.ts
+++ b/gazelle/js/tests/npm_types_package/triple_slash_syntaxes/ref.ts
@@ -1,7 +1,7 @@
 // triple-slash references with various odd syntaxes/spacing
 
 // No space
-///<reference lib="jquery">
+///<reference types="jquery">
 
 // Random extra spaces
 ///     <reference   types = "@testing-library/jest-dom"  >


### PR DESCRIPTION
According to the TypeScript docs ([here](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-lib-)): 

> This directive allows a file to explicitly include an existing built-in lib file.
>
> Built-in lib files are referenced in the same fashion as the [lib](https://www.typescriptlang.org/tsconfig#lib) compiler option in tsconfig.json (e.g. use lib="es2015" and not lib="lib.es2015.d.ts", etc.).

I think `bazel configure` is currently attempting to interpret them as types imports, leading to errors like this: 

```
Import "webworker" from "pkgs/foo-lib/src/worker.ts" is an unknown dependency. Possible solutions:
	1. Instruct Gazelle to resolve to a known dependency using a directive:
		# gazelle:resolve [src-lang] js import-string label
		   or
		# gazelle:js_resolve import-string-glob label
	2. Ignore the dependency using the '# gazelle:js_ignore_imports webworker' directive.
	3. Disable Gazelle resolution validation using '# gazelle:js_validate_import_statements off'
```

`pkgs/foo-lib/src/worker.ts`:

```ts
/// <reference lib="webworker" />

postMessage({ message: "Hello, world" });
```

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes (I guess if somebody was accidentally using `lib` instead of `types`?)
- Suggested release notes appear below: yes

    `aspect configure` handles `/// <reference lib="..." />` comments correctly

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases (I updated the existing test) 
