### PR TITLE
Do not log a warning on `null` subpath exports

### DIFF
--- a/gazelle/js/node/package.go
+++ b/gazelle/js/node/package.go
@@ -59,6 +59,16 @@ func ParsePackageJsonImportsFile(rootDir, packageJsonPath string) ([]string, err
 				case string:
 					// Regular subpath export
 					imports = append(imports, path.Clean(e))
+				case nil:
+					// According to https://nodejs.org/api/packages.html#subpath-patterns, to exclude
+					// private subfolders from patterns, null targets can be used:
+					// {
+					//   "exports": {
+					// 	   "./features/*.js": "./src/features/*.js",
+					// 	   "./features/private-internal/*": null
+					// 	 }
+					// }
+					break
 				case map[string]interface{}:
 					// Conditional subpath export
 					for subEKey, subE := range e {

--- a/gazelle/js/tests/npm_package_deps/exports-ts/package.json
+++ b/gazelle/js/tests/npm_package_deps/exports-ts/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "exports": {
     ".": "./src/main.js",
-    "./stars/*": "./other/*.js"
+    "./stars/*": "./other/*.js",
+    "./stars/internal/*": null
   }
 }


### PR DESCRIPTION
Small quality of life improvement to stop logging a warning on `null` subpath exports in `package.json`: 

```json
{
  "exports": {
    "./features/*.js": "./src/features/*.js",
    "./features/private-internal/*": null
  }
}
```

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:
