### PR TITLE
Check for query_file when running queries

### DIFF
--- a/pkg/aspect/aquery/aquery.go
+++ b/pkg/aspect/aquery/aquery.go
@@ -69,7 +69,7 @@ func (runner *AQuery) Run(ctx context.Context, cmd *cobra.Command, args []string
 		return shared.GetPrettyError(cmd, err)
 	}
 
-	command, query, runReplacements, err := shared.SelectQuery(cmd.CalledAs(), presets, runner.Presets, presetNames, runner.Streams, nonFlags, runner.Select)
+	command, query, runReplacements, err := shared.SelectQuery(cmd.CalledAs(), presets, runner.Presets, presetNames, runner.Streams, nonFlags, flags, runner.Select)
 	if err != nil {
 		return shared.GetPrettyError(cmd, err)
 	}

--- a/pkg/aspect/cquery/cquery.go
+++ b/pkg/aspect/cquery/cquery.go
@@ -69,7 +69,7 @@ func (runner *CQuery) Run(ctx context.Context, cmd *cobra.Command, args []string
 		return shared.GetPrettyError(cmd, err)
 	}
 
-	command, query, runReplacements, err := shared.SelectQuery(cmd.CalledAs(), presets, runner.Presets, presetNames, runner.Streams, nonFlags, runner.Select)
+	command, query, runReplacements, err := shared.SelectQuery(cmd.CalledAs(), presets, runner.Presets, presetNames, runner.Streams, nonFlags, flags, runner.Select)
 	if err != nil {
 		return shared.GetPrettyError(cmd, err)
 	}

--- a/pkg/aspect/query/query.go
+++ b/pkg/aspect/query/query.go
@@ -97,7 +97,7 @@ func (runner *Query) Run(ctx context.Context, cmd *cobra.Command, args []string)
 		return shared.GetPrettyError(cmd, err)
 	}
 
-	command, query, runReplacements, err := shared.SelectQuery(cmd.CalledAs(), presets, runner.Presets, presetNames, runner.Streams, nonFlags, runner.Select)
+	command, query, runReplacements, err := shared.SelectQuery(cmd.CalledAs(), presets, runner.Presets, presetNames, runner.Streams, nonFlags, flags, runner.Select)
 	if err != nil {
 		return shared.GetPrettyError(cmd, err)
 	}

--- a/pkg/aspect/query/shared/query.go
+++ b/pkg/aspect/query/shared/query.go
@@ -206,16 +206,16 @@ func SelectQuery(
 	s func(presetNames []string) SelectRunner,
 ) (string, string, bool, error) {
 
-	hasToolTag := false
+	hasQueryFile := false
 	for _, flag := range flags {
-		if strings.Contains(flag, "--tool_tag") {
-			hasToolTag = true
+		if strings.Contains(flag, "--query_file") {
+			hasQueryFile = true
 			break
 		}
 	}
 
 	var preset *PresetQuery
-	if len(args) == 0 && !hasToolTag {
+	if len(args) == 0 && !hasQueryFile {
 		selectQueryPrompt := s(presetNames)
 
 		i, _, err := selectQueryPrompt.Run()

--- a/pkg/aspect/query/shared/query.go
+++ b/pkg/aspect/query/shared/query.go
@@ -202,11 +202,20 @@ func SelectQuery(
 	presetNames []string,
 	streams ioutils.Streams,
 	args []string,
+	flags []string,
 	s func(presetNames []string) SelectRunner,
 ) (string, string, bool, error) {
 
+	hasToolTag := false
+	for _, flag := range flags {
+		if strings.Contains(flag, "--tool_tag") {
+			hasToolTag = true
+			break
+		}
+	}
+
 	var preset *PresetQuery
-	if len(args) == 0 {
+	if len(args) == 0 && !hasToolTag {
 		selectQueryPrompt := s(presetNames)
 
 		i, _, err := selectQueryPrompt.Run()
@@ -217,7 +226,10 @@ func SelectQuery(
 
 		preset = rawPresets[i]
 	} else {
-		maybeQueryOrPreset := args[0]
+		maybeQueryOrPreset := ""
+		if len(args) > 0 {
+			maybeQueryOrPreset = args[0]
+		}
 		if value, ok := processedPresets[maybeQueryOrPreset]; ok {
 			// Treat this as the name of the preset query, so don't prompt for it.
 			fmt.Fprintf(streams.Stdout, "Preset query \"%s\" selected\n", value.Name)


### PR DESCRIPTION
IntelliJ IDE uses a query with no arguments which seems to cause havoc when this is run via aspect.

I added support to check for `--tool_tag` and not prompt the user for a query selection to better handle this usecase.

fixes #813

### Test plan

```
> /Users/fzakaria/code/github.com/aspect-build/aspect-cli/bazel-bin/cmd/aspect/aspect_/aspect query --tool_tag=ijwb:IDEA:ultimate "--override_repository=intellij_aspect=/Users/fzakaria/Library/Application Support/JetBrains/IntelliJIdea2024.1/plugins/ijwb/aspect" --override_repository=intellij_aspect_template=/Users/fzakaria/code/github.com/confluentinc/ce-kafka/.ijwb/aspect --output=label_kind --keep_going --query_file=/Users/fzakaria/code/github.com/confluentinc/ce-kafka/.ijwb/queries/query-13438905584701813446
> echo $?
2
```