### PR TITLE
fix: correct glob for exporting patch files

### DIFF
--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -1,1 +1,1 @@
-exports_files(["**"])
+exports_files(glob(["**/*.patch"]))


### PR DESCRIPTION
Fix the `export_files` statement to be a correct glob so files can be copied into another repo.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below:

Fix patches `export_files` glob.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Used in an internal repo.
