### PR TITLE
Add --quiet flag for `bazel lint`

### DIFF
--- a/docs/aspect_lint.md
+++ b/docs/aspect_lint.md
@@ -25,7 +25,7 @@ aspect lint <target patterns> [flags]
       --fix            Auto-apply all fixes
       --fixes          Request fixes from linters (where supported) (default true)
   -h, --help           help for lint
-      --hide-success   Hie successful lint results
+      --hide-success   Hide successful lint results
       --machine        Request machine readable lint reports from linters (where supported)
       --report         Request lint reports from linters (default true)
 ```

--- a/docs/aspect_lint.md
+++ b/docs/aspect_lint.md
@@ -25,7 +25,7 @@ aspect lint <target patterns> [flags]
       --fix            Auto-apply all fixes
       --fixes          Request fixes from linters (where supported) (default true)
   -h, --help           help for lint
-      --hide-success   Hide successful lint results
+      --quiet          Hide successful lint results
       --machine        Request machine readable lint reports from linters (where supported)
       --report         Request lint reports from linters (default true)
 ```

--- a/docs/aspect_lint.md
+++ b/docs/aspect_lint.md
@@ -21,13 +21,13 @@ aspect lint <target patterns> [flags]
 ### Options
 
 ```
-      --diff           Show unified diff instead of diff stats for fixes
-      --fix            Auto-apply all fixes
-      --fixes          Request fixes from linters (where supported) (default true)
-  -h, --help           help for lint
-      --quiet          Hide successful lint results
-      --machine        Request machine readable lint reports from linters (where supported)
-      --report         Request lint reports from linters (default true)
+      --diff      Show unified diff instead of diff stats for fixes
+      --fix       Auto-apply all fixes
+      --fixes     Request fixes from linters (where supported) (default true)
+  -h, --help      help for lint
+      --machine   Request machine readable lint reports from linters (where supported)
+      --quiet     Hide successful lint results
+      --report    Request lint reports from linters (default true)
 ```
 
 ### Options inherited from parent commands

--- a/docs/aspect_lint.md
+++ b/docs/aspect_lint.md
@@ -21,12 +21,13 @@ aspect lint <target patterns> [flags]
 ### Options
 
 ```
-      --diff      Show unified diff instead of diff stats for fixes
-      --fix       Auto-apply all fixes
-      --fixes     Request fixes from linters (where supported) (default true)
-  -h, --help      help for lint
-      --machine   Request machine readable lint reports from linters (where supported)
-      --report    Request lint reports from linters (default true)
+      --diff           Show unified diff instead of diff stats for fixes
+      --fix            Auto-apply all fixes
+      --fixes          Request fixes from linters (where supported) (default true)
+  -h, --help           help for lint
+      --hide-success   Hie successful lint results
+      --machine        Request machine readable lint reports from linters (where supported)
+      --report         Request lint reports from linters (default true)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/aspect/lint/lint.go
+++ b/pkg/aspect/lint/lint.go
@@ -91,7 +91,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.RegisterNoableBoolP(flagSet, "fixes", "", true, "Request fixes from linters (where supported)")
 	flags.RegisterNoableBoolP(flagSet, "report", "", true, "Request lint reports from linters")
 	flags.RegisterNoableBoolP(flagSet, "machine", "", false, "Request machine readable lint reports from linters (where supported)")
-	flags.RegisterNoableBoolP(flagSet, "hide-success", "", false, "Hie successful lint results")
+	flags.RegisterNoableBoolP(flagSet, "hide-success", "", false, "Hide successful lint results")
 }
 
 // TODO: hoist this to a flags package so it can be used by other commands that require this functionality

--- a/pkg/aspect/lint/lint.go
+++ b/pkg/aspect/lint/lint.go
@@ -91,6 +91,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.RegisterNoableBoolP(flagSet, "fixes", "", true, "Request fixes from linters (where supported)")
 	flags.RegisterNoableBoolP(flagSet, "report", "", true, "Request lint reports from linters")
 	flags.RegisterNoableBoolP(flagSet, "machine", "", false, "Request machine readable lint reports from linters (where supported)")
+	flags.RegisterNoableBoolP(flagSet, "hide-success", "", false, "Hie successful lint results")
 }
 
 // TODO: hoist this to a flags package so it can be used by other commands that require this functionality
@@ -166,6 +167,7 @@ lint:
 	requestFixes, _ := cmd.Flags().GetBool("fixes")
 	requestReports, _ := cmd.Flags().GetBool("report")
 	machineReports, _ := cmd.Flags().GetBool("machine")
+	hideSuccess, _ := cmd.Flags().GetBool("hide-success")
 
 	// Separate out the lint command specific flags from the list of args to
 	// pass to `bazel build`
@@ -352,7 +354,7 @@ lint:
 		}
 
 		printHeader := true
-		if len(r.Report) > 0 {
+		if len(r.Report) > 0 && (r.ExitCode > 0 || !hideSuccess) {
 			if printHeader {
 				runner.printLintResultsHeader(r.Label)
 				printHeader = false

--- a/pkg/aspect/lint/lint.go
+++ b/pkg/aspect/lint/lint.go
@@ -91,7 +91,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.RegisterNoableBoolP(flagSet, "fixes", "", true, "Request fixes from linters (where supported)")
 	flags.RegisterNoableBoolP(flagSet, "report", "", true, "Request lint reports from linters")
 	flags.RegisterNoableBoolP(flagSet, "machine", "", false, "Request machine readable lint reports from linters (where supported)")
-	flags.RegisterNoableBoolP(flagSet, "hide-success", "", false, "Hide successful lint results")
+	flags.RegisterNoableBoolP(flagSet, "quiet", "", false, "Hide successful lint results")
 }
 
 // TODO: hoist this to a flags package so it can be used by other commands that require this functionality
@@ -167,7 +167,7 @@ lint:
 	requestFixes, _ := cmd.Flags().GetBool("fixes")
 	requestReports, _ := cmd.Flags().GetBool("report")
 	machineReports, _ := cmd.Flags().GetBool("machine")
-	hideSuccess, _ := cmd.Flags().GetBool("hide-success")
+	hideSuccess, _ := cmd.Flags().GetBool("quiet")
 
 	// Separate out the lint command specific flags from the list of args to
 	// pass to `bazel build`


### PR DESCRIPTION
Currently, the `bazel lint` command prints all lint results, making it difficult to read when there are many files.

Before the change: 

For example, the logs from a successful lint result using checkstyle do not provide much useful information. We would prefer to add a flag to hide these logs and only show error messages.

```
Lint results for //core:src/test/java/io/Test3:

Audit started
Starting audit...
[ERROR] /private/var/tmp/_bazel_nalou/54456b41c0397f1af3a7ca068f37ad86/sandbox/darwin-sandbox/4830/execroot/__main__/core/src/test/java/io/test/utils/CommandBuilder.java:8:1: Disallowed import - org.apache.kafka.tools.AclCommand. [ImportControl]
Audit finished
Audit done.

Lint results for //core:src/test/java/io/Test1:

Audit started
Starting audit...
Audit finished
Audit done.

Lint results for //core:src/test/java/io/Test2:

Audit started
Starting audit...
Audit finished
Audit done. 
```

After the change:

```
/Users/nalou/workspace/aspect_cli/bazel-bin/cmd/aspect/aspect_/aspect lint //core/... --hide-success=true 
INFO: Invocation ID: 5ac63ff0-5be9-4bd8-9781-896a6dc60d9f
INFO: Analyzed 155 targets (0 packages loaded, 0 targets configured).
INFO: Found 155 targets...
INFO: Elapsed time: 0.506s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
Lint results for //core:src/test/java/io/Test3:

Audit started
Starting audit...
[ERROR] /private/var/tmp/_bazel_nalou/54456b41c0397f1af3a7ca068f37ad86/sandbox/darwin-sandbox/4830/execroot/__main__/core/src/test/java/io/test/utils/CommandBuilder.java:8:1: Disallowed import - org.apache.kafka.tools.AclCommand. [ImportControl]
Audit finished
Audit done.

```