### PR TITLE
Fix multiple linters bug

### DIFF
--- a/pkg/aspect/lint/bep.go
+++ b/pkg/aspect/lint/bep.go
@@ -235,8 +235,11 @@ func (runner *LintBEPHandler) bepEventHandler(event *buildeventstream.BuildEvent
 					// go through the fileSet and create a result for each mnemonic
 					for _, file := range fileSet.GetFiles() {
 						if mnemonic := parseLinterMnemonicFromFilename(file.Name); mnemonic != "" {
-							result := &ResultForLabelAndMnemonic{label: label, mnemonic: mnemonic}
-							runner.resultsByLabelByMnemonic[label+mnemonic] = result
+							if _, ok := runner.resultsByLabelByMnemonic[label+mnemonic]; !ok {
+								// create a new result for this label and mnemonic
+								result := &ResultForLabelAndMnemonic{label: label, mnemonic: mnemonic}
+								runner.resultsByLabelByMnemonic[label+mnemonic] = result
+							}
 						}
 					}
 

--- a/pkg/aspect/lint/bep.go
+++ b/pkg/aspect/lint/bep.go
@@ -126,17 +126,17 @@ func (runner *LintBEPHandler) readBEPFile(file *buildeventstream.File) ([]byte, 
 
 func parseLinterMnemonicFromFilename(filename string) string {
 	// Parse the filename convention that rules_lint has for output files.
-	// path/to/<target_name>.<mnemonic>.<suffix> -> linter
+	// path/to/<target_name>.<mnemonic>.<suffixes> -> linter
 	// See https://github.com/aspect-build/rules_lint/blob/6df14f0e5dae0c9a9c0e8e6f69e25bbdb3aa7394/lint/private/lint_aspect.bzl#L28.
 	s := strings.Split(filepath.Base(filename), ".")
 	if len(s) < 3 {
 		return ""
 	}
 	// Filter out mnemonics that don't start with AspectRulesLint, which is the rules_lint convention
-	if !strings.HasPrefix(s[len(s)-2], "AspectRulesLint") {
+	if !strings.HasPrefix(s[1], "AspectRulesLint") {
 		return ""
 	}
-	return s[len(s)-2]
+	return s[1]
 }
 
 func (runner *LintBEPHandler) bepEventCallback(event *buildeventstream.BuildEvent, sequenceNumber int64) error {

--- a/pkg/aspect/lint/bep.go
+++ b/pkg/aspect/lint/bep.go
@@ -30,8 +30,8 @@ import (
 	"github.com/aspect-build/aspect-cli/bazel/buildeventstream"
 )
 
-// ResultForLabel aggregates the relevant files we find in the BEP for
-type ResultForLabel struct {
+// ResultForLabelAndMnemonic aggregates the relevant files we find in the BEP for
+type ResultForLabelAndMnemonic struct {
 	label        string
 	mnemonic     string
 	exitCodeFile *buildeventstream.File
@@ -40,11 +40,11 @@ type ResultForLabel struct {
 }
 
 type LintBEPHandler struct {
-	namedSets      map[string]*buildeventstream.NamedSetOfFiles
-	workspaceRoot  string
-	localExecRoot  string
-	besCompleted   chan<- struct{}
-	resultsByLabel map[string]*ResultForLabel
+	namedSets                map[string]*buildeventstream.NamedSetOfFiles
+	workspaceRoot            string
+	localExecRoot            string
+	besCompleted             chan<- struct{}
+	resultsByLabelByMnemonic map[string]*ResultForLabelAndMnemonic
 
 	besOnce             sync.Once
 	besChan             chan OrderedBuildEvent
@@ -58,11 +58,11 @@ type OrderedBuildEvent struct {
 
 func newLintBEPHandler(workspaceRoot string, besCompleted chan<- struct{}) *LintBEPHandler {
 	return &LintBEPHandler{
-		namedSets:      make(map[string]*buildeventstream.NamedSetOfFiles),
-		resultsByLabel: make(map[string]*ResultForLabel),
-		workspaceRoot:  workspaceRoot,
-		besCompleted:   besCompleted,
-		besChan:        make(chan OrderedBuildEvent, 100),
+		namedSets:                make(map[string]*buildeventstream.NamedSetOfFiles),
+		resultsByLabelByMnemonic: make(map[string]*ResultForLabelAndMnemonic),
+		workspaceRoot:            workspaceRoot,
+		besCompleted:             besCompleted,
+		besChan:                  make(chan OrderedBuildEvent, 100),
 	}
 }
 
@@ -231,21 +231,27 @@ func (runner *LintBEPHandler) bepEventHandler(event *buildeventstream.BuildEvent
 			for _, fileSetId := range outputGroup.FileSets {
 				if fileSet := runner.namedSets[fileSetId.Id]; fileSet != nil {
 					runner.namedSets[fileSetId.Id] = nil
-					result := runner.resultsByLabel[label]
-					if result == nil {
-						result = &ResultForLabel{label: label}
-						runner.resultsByLabel[label] = result
-					}
+					result := &ResultForLabelAndMnemonic{label: label}
 
 					for _, file := range fileSet.GetFiles() {
 						if outputGroup.Name == LINT_PATCH_GROUP {
 							if mnemonic := parseLinterMnemonicFromFilename(file.Name); mnemonic != "" {
 								result.mnemonic = mnemonic
+
+								savedResult := runner.resultsByLabelByMnemonic[label+mnemonic]
+								if savedResult == nil {
+									runner.resultsByLabelByMnemonic[label+mnemonic] = result
+								}
 							}
 							result.patchFile = file
 						} else if outputGroup.Name == LINT_REPORT_GROUP_MACHINE {
 							if mnemonic := parseLinterMnemonicFromFilename(file.Name); mnemonic != "" {
 								result.mnemonic = mnemonic
+
+								savedResult := runner.resultsByLabelByMnemonic[label+mnemonic]
+								if savedResult == nil {
+									runner.resultsByLabelByMnemonic[label+mnemonic] = result
+								}
 							}
 							if strings.HasSuffix(file.Name, ".report") {
 								result.reportFile = file
@@ -255,6 +261,11 @@ func (runner *LintBEPHandler) bepEventHandler(event *buildeventstream.BuildEvent
 						} else if outputGroup.Name == LINT_REPORT_GROUP_HUMAN {
 							if mnemonic := parseLinterMnemonicFromFilename(file.Name); mnemonic != "" {
 								result.mnemonic = mnemonic
+
+								savedResult := runner.resultsByLabelByMnemonic[label+mnemonic]
+								if savedResult == nil {
+									runner.resultsByLabelByMnemonic[label+mnemonic] = result
+								}
 							}
 							if strings.HasSuffix(file.Name, ".out") {
 								result.reportFile = file

--- a/pkg/aspect/lint/lint.go
+++ b/pkg/aspect/lint/lint.go
@@ -295,8 +295,8 @@ lint:
 	}
 
 	// Convert raw results to list of LintResult structs
-	results := make([]*LintResult, 0, len(lintBEPHandler.resultsByLabel))
-	for _, r := range lintBEPHandler.resultsByLabel {
+	results := make([]*LintResult, 0, len(lintBEPHandler.resultsByLabelByMnemonic))
+	for _, r := range lintBEPHandler.resultsByLabelByMnemonic {
 		result := &LintResult{
 			Mnemonic: r.mnemonic,
 			Label:    r.label,


### PR DESCRIPTION
Putting this out here in case others have faced this issue.

We found `bazel lint` incorrectly records **successful** when multiple linters are configured to the same label
One of the Aspect engineers offered a patch (first in the series) but it needed a few more tweaks to flush out.

fixes #828 

Be sure to also make sure you have [ab7f016fd43f550dcfabb2d55a1d092d57f768c5](https://github.com/aspect-build/rules_lint/pull/511) incorporated.