### PR TITLE
chore: Add forwarder for bazel vendor cmd

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.0
+    rev: v1.5.5
     hooks:
       - id: insert-license
         files: \.go$
@@ -50,6 +50,7 @@ repos:
           # https://github.com/Lucas-C/pre-commit-hooks#removing-old-license-and-replacing-it-with-a-new-one
           - --license-filepath
           - hooks/license_header
+          - --use-current-year
           - --comment-style
           - /*| *| */
   - repo: local

--- a/cmd/aspect/root/BUILD.bazel
+++ b/cmd/aspect/root/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//cmd/aspect/shutdown",
         "//cmd/aspect/sync",
         "//cmd/aspect/test",
+        "//cmd/aspect/vendor",
         "//cmd/aspect/version",
         "//pkg/aspect/root/flags",
         "//pkg/aspecterrors",

--- a/cmd/aspect/root/root.go
+++ b/cmd/aspect/root/root.go
@@ -52,6 +52,7 @@ import (
 	"github.com/aspect-build/aspect-cli/cmd/aspect/shutdown"
 	"github.com/aspect-build/aspect-cli/cmd/aspect/sync"
 	"github.com/aspect-build/aspect-cli/cmd/aspect/test"
+	"github.com/aspect-build/aspect-cli/cmd/aspect/vendor"
 	"github.com/aspect-build/aspect-cli/cmd/aspect/version"
 	"github.com/aspect-build/aspect-cli/pkg/aspect/root/flags"
 	"github.com/aspect-build/aspect-cli/pkg/aspecterrors"
@@ -159,6 +160,7 @@ func NewCmd(
 	cmd.AddCommand(sync.NewDefaultCmd())
 	cmd.AddCommand(shutdown.NewDefaultCmd())
 	cmd.AddCommand(test.NewDefaultCmd(pluginSystem))
+	cmd.AddCommand(vendor.NewDefaultCmd())
 	cmd.AddCommand(version.NewDefaultCmd())
 	cmd.AddCommand(outputs.NewDefaultCmd())
 	cmd.SetHelpCommand(help.NewCmd())

--- a/cmd/aspect/vendor/BUILD.bazel
+++ b/cmd/aspect/vendor/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "vendor",
+    srcs = ["vendor.go"],
+    importmap = "github.com/aspect-build/aspect-cli/cmd/aspect/vendor",
+    importpath = "",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/aspect/root/flags",
+        "//pkg/bazel",
+        "//pkg/interceptors",
+        "//pkg/ioutils",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/cmd/aspect/vendor/vendor.go
+++ b/cmd/aspect/vendor/vendor.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vendor
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/aspect-build/aspect-cli/pkg/aspect/root/flags"
+	"github.com/aspect-build/aspect-cli/pkg/aspect/vendor"
+	"github.com/aspect-build/aspect-cli/pkg/bazel"
+	"github.com/aspect-build/aspect-cli/pkg/interceptors"
+	"github.com/aspect-build/aspect-cli/pkg/ioutils"
+)
+
+func NewDefaultCmd() *cobra.Command {
+	return NewCmd(ioutils.DefaultStreams, bazel.WorkspaceFromWd)
+}
+
+func NewCmd(streams ioutils.Streams, bzl bazel.Bazel) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "vendor <subcommand> [<options>] [<args> ...]",
+		Short:   "Downloads external repositories into a folder specified by the flag --vendor_dir. Only works with bzlmod.",
+		Long:    `See https://bazel.build/external/vendor`,
+		GroupID: "built-in",
+		RunE: interceptors.Run(
+			[]interceptors.Interceptor{
+				flags.FlagsInterceptor(streams),
+			},
+			vendor.New(streams, bzl).Run,
+		),
+	}
+
+	return cmd
+}

--- a/docs/command_list.bzl
+++ b/docs/command_list.bzl
@@ -24,5 +24,6 @@ COMMAND_LIST = [
     "run",
     "shutdown",
     "test",
+    "vendor",
     "version",
 ]

--- a/pkg/aspect/vendor/BUILD.bazel
+++ b/pkg/aspect/vendor/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "vendor",
+    srcs = ["vendor.go"],
+    importmap = "github.com/aspect-build/aspect-cli/pkg/aspect/vendor",
+    importpath = "",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/bazel",
+        "//pkg/ioutils",
+        "@com_github_spf13_cobra//:cobra",
+    ],
+)

--- a/pkg/aspect/vendor/vendor.go
+++ b/pkg/aspect/vendor/vendor.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vendor
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aspect-build/aspect-cli/pkg/bazel"
+	"github.com/aspect-build/aspect-cli/pkg/ioutils"
+)
+
+type Vendor struct {
+	ioutils.Streams
+	bzl bazel.Bazel
+}
+
+func New(streams ioutils.Streams, bzl bazel.Bazel) *Vendor {
+	return &Vendor{
+		Streams: streams,
+		bzl:     bzl,
+	}
+}
+
+func (runner *Vendor) Run(ctx context.Context, _ *cobra.Command, args []string) error {
+	bazelCmd := []string{"vendor"}
+	bazelCmd = append(bazelCmd, args...)
+	return runner.bzl.RunCommand(runner.Streams, nil, bazelCmd...)
+}


### PR DESCRIPTION
Added a forwarder to Bazel's vendor command.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Added support for vendor command.

### Test plan

- Manual testing; please provide instructions so we can reproduce: run `aspect vendor` in a bzlmod enabled tree.
