### PR TITLE
fix: allow config file to silence successful linters

### DIFF
--- a/pkg/aspect/lint/lint.go
+++ b/pkg/aspect/lint/lint.go
@@ -186,6 +186,9 @@ lint:
 	requestReports, _ := cmd.Flags().GetBool("report")
 	machineReports, _ := cmd.Flags().GetBool("machine")
 	hideSuccess, _ := cmd.Flags().GetBool("quiet")
+	if viper.GetBool("lint.quiet") {
+		hideSuccess = true
+	}
 
 	// Separate out the lint command specific flags from the list of args to
 	// pass to `bazel build`


### PR DESCRIPTION
Makes it possible to have `--quiet` behavior in a repo by default, rather than setting via individual command-line flag
