### PR TITLE
fix: fail run--watch startup when watch protocol explicitly supported but fails to connect

### DIFF
--- a/pkg/aspect/run/aspect_watch.bzl
+++ b/pkg/aspect/run/aspect_watch.bzl
@@ -31,17 +31,17 @@ cp {info_file} {aspect_watch_watch_manifest}
         arguments = [
             default.files_to_run.executable.path,
             str(ctx.label),
-            " ".join(ctx.rule.attr.tags),
+            ",".join(ctx.rule.attr.tags),
         ],
         outputs = [watch_manifest],
         mnemonic = "AspectWatchTargetInfo",
         execution_requirements = {
-            # prevents the action or test from being executed remotely or cached remotely
-            "no-remote": "1",
-            # keyword results in the action or test never being cached (locally or remotely)
-            "no-cache": "1",
             # precludes the action from being remotely cached, remotely executed, or run inside the sandbox
             "local": "1",
+            # keyword results in the action or test never being cached (locally or remotely)
+            "no-cache": "1",
+            # prevents the action or test from being executed remotely or cached remotely
+            "no-remote": "1",
         },
     )
 


### PR DESCRIPTION
Close https://github.com/aspect-build/aspect-cli-legacy/issues/4

### Changes are visible to end-users: no

### Test plan

- Manual testing:
  1. run `aspect run --watch` on a random target and ensure the "fallback to restart" logic occurs
  2. add the `supports_incremental_build_protocol` tag and ensure the run stops with a fatal error

