### PR TITLE
feat: allow setting default lint interactive mode in config.yaml

### DIFF
--- a/docs/aspect_lint.md
+++ b/docs/aspect_lint.md
@@ -25,6 +25,7 @@ aspect lint <target patterns> [flags]
       --fix                    Auto-apply all fixes
       --fixes                  Request fixes from linters (where supported) (default true)
   -h, --help                   help for lint
+      --interactive            Enable or disable interactive mode for applying fixes
       --lint:aspects strings   A set of lint aspects to use. Overriding, appending or removing from those set in the Aspect CLI config.
       --machine                Request machine readable lint reports from linters (where supported)
       --quiet                  Hide successful lint results

--- a/pkg/aspect/lint/lint.go
+++ b/pkg/aspect/lint/lint.go
@@ -94,6 +94,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.RegisterNoableBoolP(flagSet, "report", "", true, "Request lint reports from linters")
 	flags.RegisterNoableBoolP(flagSet, "machine", "", false, "Request machine readable lint reports from linters (where supported)")
 	flags.RegisterNoableBoolP(flagSet, "quiet", "", false, "Hide successful lint results")
+	flags.RegisterNoableBoolP(flagSet, "interactive", "", false, "Enable or disable interactive mode for applying fixes")
 }
 
 // TODO: hoist this to a flags package so it can be used by other commands that require this functionality
@@ -159,6 +160,11 @@ func (runner *Linter) Run(ctx context.Context, cmd *cobra.Command, args []string
 	linters := viper.GetStringSlice("lint.aspects")
 	hideSuccess := viper.GetBool("lint.quiet")
 
+	// Allow overriding lint interactive mode via config file
+	if viper.IsSet("lint.interactive") {
+		isInteractiveMode = isInteractiveMode && viper.GetBool("lint.interactive")
+	}
+
 	if len(linters) == 0 {
 		fmt.Fprintf(runner.streams.Stdout, `No aspects enabled for linting.
 		
@@ -190,6 +196,11 @@ lint:
 	// This flag overrides the config file if set
 	if cmd.Flags().Changed("quiet") {
 		hideSuccess, _ = cmd.Flags().GetBool("quiet")
+	}
+
+	// This flag overrides the config file if set
+	if cmd.Flags().Changed("interactive") {
+		isInteractiveMode, _ = cmd.Flags().GetBool("interactive")
 	}
 
 	// Separate out the lint command specific flags from the list of args to


### PR DESCRIPTION
Close https://github.com/aspect-build/rules_lint/issues/638

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Allow setting a default value for `lint` command interactivity in `.aspect/cli/config.yaml` as well as overriding with `lint --[no]interactive`.

### Test plan

- Manual testing
