### PR TITLE
fix: use --build_event_binary_file for lint command

### DIFF
--- a/cmd/aspect/lint/lint.go
+++ b/cmd/aspect/lint/lint.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Aspect Build Systems, Inc.
+ * Copyright 2023 Aspect Build Systems, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ In addition to flags listed below, flags accepted by the 'bazel build' command a
 		RunE: interceptors.Run(
 			[]interceptors.Interceptor{
 				flags.FlagsInterceptor(streams),
-				pluginSystem.BESBackendSubscriberInterceptor(),
+				pluginSystem.BESSocketInterceptor(),
 			},
 			lint.New(streams, hstreams, bzl, lintHandlers).Run,
 		),

--- a/pkg/aspect/lint/lint.go
+++ b/pkg/aspect/lint/lint.go
@@ -266,10 +266,9 @@ lint:
 	// we could build this support into the Aspect CLI and post on that issue
 	// that using the Aspect CLI resolves it.
 	var lintBEPHandler *LintBEPHandler
-	if bep.HasBESBackend(ctx) {
-		besBackend := bep.BESBackendFromContext(ctx)
-		besBackendFlag := fmt.Sprintf("--bes_backend=%s", besBackend.Addr())
-		bazelCmd = flags.AddFlagToCommand(bazelCmd, besBackendFlag)
+	if bep.HasBESSocket(ctx) {
+		besBackend := bep.BESSocketFromContext(ctx)
+		bazelCmd = flags.AddFlagToCommand(bazelCmd, besBackend.Args()...)
 
 		workingDirectory, err := os.Getwd()
 		if err != nil {
@@ -282,7 +281,7 @@ lint:
 		}
 
 		lintBEPHandler = newLintBEPHandler(workspaceRoot, besCompleted)
-		besBackend.RegisterSubscriber(lintBEPHandler.bepEventCallback, false)
+		besBackend.RegisterSubscriber(lintBEPHandler.bepEventCallback)
 	}
 
 	if postTerminateArgs != nil {
@@ -318,7 +317,7 @@ lint:
 	}
 
 	// Check for subscriber errors
-	subscriberErrors := bep.BESErrors(ctx)
+	subscriberErrors := bep.BESSocketErrors(ctx)
 	if len(subscriberErrors) > 0 {
 		for _, err := range subscriberErrors {
 			fmt.Fprintf(runner.streams.Stderr, "Error: failed to run lint command: %v\n", err)

--- a/pkg/plugin/system/bep/BUILD.bazel
+++ b/pkg/plugin/system/bep/BUILD.bazel
@@ -5,8 +5,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "bep",
-    srcs = ["bes_backend.go"],
-    importpath = "github.com/aspect-build/aspect-cli/pkg/plugin/system/bep",
+    srcs = [
+        "bes_backend.go",
+        "bes_socket.go",
+    ],
+    importpath = "github.com/aspect-build/aspect-cli-legacy/pkg/plugin/system/bep",
     visibility = ["//visibility:public"],
     deps = [
         "//bazel/buildeventstream",
@@ -20,6 +23,7 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//encoding/protodelim",
         "@org_golang_google_protobuf//types/known/emptypb",
         "@org_golang_x_sync//errgroup",
     ],

--- a/pkg/plugin/system/bep/bes_socket.go
+++ b/pkg/plugin/system/bep/bes_socket.go
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2023 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bep
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sync"
+	"syscall"
+	"time"
+
+	buildeventstream "github.com/aspect-build/aspect-cli/bazel/buildeventstream"
+	"github.com/aspect-build/aspect-cli/pkg/aspecterrors"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/encoding/protodelim"
+)
+
+const besSocketInterceptorKey besBackendInterceptorKeyType = 0x00
+
+type BESSocket interface {
+	Setup() error
+	ServeWait(ctx context.Context) error
+	GracefulStop()
+	Args() []string
+	RegisterSubscriber(callback CallbackFn)
+	Errors() []error
+}
+
+func BESSocketFromContext(ctx context.Context) BESSocket {
+	return ctx.Value(besSocketInterceptorKey).(BESSocket)
+}
+
+func HasBESSocket(ctx context.Context) bool {
+	return ctx.Value(besSocketInterceptorKey) != nil
+}
+
+func BESSocketErrors(ctx context.Context) []error {
+	if !HasBESSocket(ctx) {
+		return []error{}
+	}
+	return BESSocketFromContext(ctx).Errors()
+}
+
+// InjectBESSocket injects the given BESSocket into the context.
+func InjectBESSocket(ctx context.Context, besSocket BESSocket) context.Context {
+	return context.WithValue(ctx, besSocketInterceptorKey, besSocket)
+}
+
+func NewBESSocket(ctx context.Context) (BESSocket, error) {
+	return &besSocket{
+		ctx:         ctx,
+		socketPath:  path.Join(os.TempDir(), fmt.Sprintf("aspect-cli-%v-bes.bin", os.Getpid())),
+		errors:      &aspecterrors.ErrorList{},
+		subscribers: &subscriberList{},
+	}, nil
+}
+
+type besSocket struct {
+	ctx         context.Context
+	socketPath  string
+	errors      *aspecterrors.ErrorList
+	errorsMutex sync.RWMutex
+	subscribers *subscriberList
+}
+
+var _ BESSocket = (*besSocket)(nil)
+
+func (bb *besSocket) Setup() error {
+	err := syscall.Mknod(bb.socketPath, syscall.S_IFIFO|0666, 0)
+	if err != nil {
+		return fmt.Errorf("failed to create BES socket %s: %w", bb.socketPath, err)
+	}
+	return nil
+}
+
+func (bb *besSocket) ServeWait(ctx context.Context) error {
+	go func() {
+		conn, err := os.OpenFile(bb.socketPath, os.O_RDONLY, os.ModeNamedPipe)
+		if err != nil {
+			bb.errorsMutex.Lock()
+			defer bb.errorsMutex.Unlock()
+			bb.errors.Insert(fmt.Errorf("failed to accept connection on BES socket %s: %w", bb.socketPath, err))
+			return
+		}
+
+		defer conn.Close()
+
+		if err := bb.streamBesEvents(ctx, conn); err != nil {
+			bb.errorsMutex.Lock()
+			defer bb.errorsMutex.Unlock()
+			bb.errors.Insert(fmt.Errorf("failed to stream BES events: %w", err))
+			return
+		}
+	}()
+	return nil
+}
+
+func (bb *besSocket) streamBesEvents(ctx context.Context, r io.Reader) error {
+	reader := bufio.NewReader(r)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		event := buildeventstream.BuildEvent{}
+
+		if err := protodelim.UnmarshalFrom(reader, &event); err != nil {
+			if errors.Is(err, io.EOF) {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(50):
+					// throttle the reading of the BES file when no new data is available
+					continue
+				}
+			}
+
+			return fmt.Errorf("failed to parse BES event: %w", err)
+		}
+
+		if err := bb.publishBesEvent(&event); err != nil {
+			return fmt.Errorf("failed to publish BES event: %w", err)
+		}
+
+		if event.LastMessage {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (bb *besSocket) publishBesEvent(event *buildeventstream.BuildEvent) error {
+	eg := errgroup.Group{}
+
+	for s := bb.subscribers.head; s != nil; s = s.next {
+		cb := s.callback
+		eg.Go(
+			func() error {
+				return cb(event, -1)
+			},
+		)
+	}
+
+	return eg.Wait()
+}
+
+func (bb *besSocket) Args() []string {
+	return []string{
+		"--build_event_publish_all_actions",
+		// TODO: when bazel6 dropped
+		// "--build_event_binary_file_upload_mode=fully_async",
+		"--build_event_binary_file",
+		bb.socketPath,
+	}
+}
+
+func (bb *besSocket) RegisterSubscriber(callback CallbackFn) {
+	bb.subscribers.Insert(callback)
+}
+
+func (bb *besSocket) Errors() []error {
+	bb.errorsMutex.RLock()
+	defer bb.errorsMutex.RUnlock()
+	return bb.errors.Errors()
+}
+
+func (bb *besSocket) GracefulStop() {
+	os.Remove(bb.socketPath)
+}


### PR DESCRIPTION
Switch the `lint` command to use a new `--build_event_binary_file`-based source of BES info to avoid all the `--bes_backend` proxying complications and bugs.

We may want to replace all `--bes_backend` usage, for now we'll only do `lint`.

Fix https://github.com/aspect-build/aspect-cli-legacy/issues/5

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
