### PR TITLE
feat: expose more http information

### DIFF
--- a/.aspect/download.axl
+++ b/.aspect/download.axl
@@ -5,7 +5,6 @@ def  _impl(ctx):
         mode = 0o777
     ).block();
 
-    print(cmd.body)
 
 download = task(
     implementation = _impl,

--- a/crates/axl-runtime/src/engine/async/future_stream.rs
+++ b/crates/axl-runtime/src/engine/async/future_stream.rs
@@ -20,7 +20,7 @@ pub struct FutureStream {
     #[allocative(skip)]
     pub(super) rt: AsyncRuntime,
     #[allocative(skip)]
-    pub(super) stream: Arc<RwLock<JoinSet<Box<dyn super::future::FutureAlloc>>>>,
+    pub(super) stream: Arc<RwLock<JoinSet<super::future::FutOutput>>>,
 }
 
 impl std::fmt::Debug for FutureStream {
@@ -83,7 +83,8 @@ impl<'v> values::StarlarkValue<'v> for FutureStream {
             .unwrap()
         });
         let value = out?.ok()?;
-        Some(value.alloc_value_fut(heap))
+        // TODO: Should stream stop when any of the futures result in error?
+        Some(value.ok()?.alloc_value_fut(heap))
     }
     unsafe fn iter_stop(&self) {
         // TODO: destroy the joinset, ensure nothing is left behind.


### PR DESCRIPTION
- Adds `status` `headers` to http_response type.
- Clean up the future generation to reduce boilerplate. 
- Futures are now must return `Result<dyn FutureAlloc, anyhow::Error>`.  `.block()` will now halt the execution if the future results in error and `futures.iter` will halt the iterator if any of the futures fail. 

