### PR TITLE
chore: mark legacy cli go.mod as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
----
-title: Aspect CLI
-sidebar_label: Overview
----
+> [!IMPORTANT]
+> **Maintenance Mode Notice**<br>
+> This branch contains the legacy Go implementation of the legacy Aspect CLI and is now in maintenance mode at https://github.com/aspect-build/aspect-cli-legacy
 
 Aspect CLI (`aspect`) is wrapper for [Bazel], built on top of [Bazelisk], that adds additional features and extensibility to the popular polyglot build system from Google.
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/aspect-build/aspect-cli-legacy instead.
 module github.com/aspect-build/aspect-cli
 
 go 1.24.5


### PR DESCRIPTION
Marking the go module as deprecated so it states that on the go module registry page. See https://go.dev/ref/mod#go-mod-file-module-deprecation and https://pkg.go.dev/aspect.build/cli

This will require a tag as well and hopefully the go module registry picks up tags even when not on `main`?

### Changes are visible to end-users: no

### Test plan

- Manual testing; guessing based on docs
