### PR TITLE
chore: remove outdated plans for November

### DIFF
--- a/.github/workflows/install_snippet.sh
+++ b/.github/workflows/install_snippet.sh
@@ -7,10 +7,6 @@ set -o errexit -o nounset -o pipefail
 TAG=${GITHUB_REF_NAME}
 
 cat <<EOF
-> [!WARNING]
-> **Early Preview Release**<br>
-> This is an early preview release of the Aspect CLI rewritten in Rust. It is under active development, and API changes are expected. We plan to stabilize the API and release a stable version in November 2025.
-
 ### Install Aspect CLI (MacOS and Linux)
 
 \`\`\`sh


### PR DESCRIPTION
Remove early preview warning from install script

It's December and I think we should stop warning.

If we do keep a warning, we should be more specific about what users should take caution (i.e. AXL apis not stable)
