### PR TITLE
fix(release): provide explicit triggering

### DIFF
--- a/.github/workflows/install_snippet.sh
+++ b/.github/workflows/install_snippet.sh
@@ -2,10 +2,6 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Set by GH actions, see
-# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-TAG=${GITHUB_REF_NAME}
-
 cat <<EOF
 ### Install Aspect CLI (MacOS and Linux)
 

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -1,6 +1,12 @@
 name: Publish Release
 
 on:
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'The tag name for the release (e.g., v2024.1.0)'
+        required: true
+        type: string
   push:
     tags:
       - 'v202[0-9].[0-9]+.[0-9]+'
@@ -18,10 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_release_artifacts
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-
+      - uses: actions/checkout@v6
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
@@ -34,11 +37,14 @@ jobs:
         run: shasum -a 256 assets/* > sha256
 
       - name: Prepare workspace snippet
+        env:
+          TAG: ${{ inputs.tag_name || github.ref_name }}
         run: .github/workflows/install_snippet.sh > release_notes.txt
 
       - name: Create GitHub draft release and upload artifacts
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag_name || github.ref_name }}
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -13,12 +13,28 @@ jobs:
     permissions:
       contents: write # allow create tag
     runs-on: ubuntu-latest
+    outputs:
+      new-tag: ${{ steps.push_tag.outputs.new-tag }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Need enough history to find the prior weekly tag
           fetch-depth: 0
-      - run: |
+      - id: push_tag
+        run: |
           tag="v$(./bazel/workspace_status.sh | grep STABLE_MONOREPO_SHORT_VERSION | cut -d' ' -f2)"
-          git tag "$tag"
-          git push origin "$tag"
+          curl --request POST \
+              --url https://api.github.com/repos/${{ github.repository }}/git/refs \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --data @- << EOF
+          {
+              "ref": "refs/tags/${tag}",
+              "sha": "${{ github.sha }}"
+          }
+          EOF
+          echo "new-tag=${tag}" >> $GITHUB_OUTPUT
+  release:
+    needs: tag
+    uses: ./.github/workflows/publish_release.yaml
+    with:
+      tag_name: ${{ needs.tag.outputs.new-tag }}


### PR DESCRIPTION
Earlier attempts relied on GitHub triggering the release on creation of a tag. This new way matches the rules releases I've been maintaining.