### PR TITLE
Fix task description defined in path

### DIFF
--- a/crates/axl-runtime/src/engine/config/task_list/value.rs
+++ b/crates/axl-runtime/src/engine/config/task_list/value.rs
@@ -26,6 +26,8 @@ use starlark::values::ValueLike;
 use super::r#ref::TaskListMut;
 use super::task_mut::TaskMut;
 
+use crate::engine::store::AxlStore;
+
 #[derive(Clone, Default, Trace, Debug, ProvidesStaticType, NoSerialize, Allocative)]
 pub(crate) struct TaskListGen<T>(pub(crate) T);
 
@@ -44,11 +46,11 @@ pub(crate) fn task_list_methods(registry: &mut MethodsBuilder) {
         #[starlark[require = named, default = UnpackList::default()]] group: UnpackList<String>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> starlark::Result<NoneType> {
+        let store = AxlStore::from_eval(eval)?;
         let mut this = TaskListMut::from_value(this)?;
-
         this.aref.content.push(eval.heap().alloc(TaskMut::new(
             eval.module(),
-            String::new(),
+            store.script_path.to_string_lossy().to_string(),
             name,
             group.items,
             task,

--- a/crates/axl-runtime/src/engine/std/env.rs
+++ b/crates/axl-runtime/src/engine/std/env.rs
@@ -226,7 +226,10 @@ pub(crate) fn env_methods(registry: &mut MethodsBuilder) {
     ///
     /// Returns a string describing the operating system in use, such as
     /// "linux", "macos", "windows", etc.
-    fn os<'v>(#[allow(unused)] this: values::Value<'v>, _heap: &'v Heap) -> anyhow::Result<&'v str> {
+    fn os<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        _heap: &'v Heap,
+    ) -> anyhow::Result<&'v str> {
         Ok(std::env::consts::OS)
     }
 

--- a/crates/axl-runtime/src/eval/task.rs
+++ b/crates/axl-runtime/src/eval/task.rs
@@ -23,7 +23,7 @@ pub trait TaskModuleLike {
     fn get_task(&self, symbol: &str) -> Result<&dyn TaskLike, EvalError>;
     fn execute_task<'v>(
         &'v self,
-        store: &AxlStore,
+        store: AxlStore,
         task: &TaskMut<'v>,
         args: impl FnOnce(&Heap) -> TaskArgs,
     ) -> Result<Option<u8>, EvalError>;
@@ -68,7 +68,7 @@ impl TaskModuleLike for Module {
     /// Executes a task from the module by symbol, providing arguments and returning the exit code.
     fn execute_task<'v>(
         &'v self,
-        store: &AxlStore,
+        store: AxlStore,
         task: &TaskMut<'v>,
         args: impl FnOnce(&Heap) -> TaskArgs,
     ) -> Result<Option<u8>, EvalError> {
@@ -86,6 +86,7 @@ impl TaskModuleLike for Module {
                 "expected value of type Task"
             )));
         };
+        drop(eval);
         Ok(ret.unpack_i32().map(|ex| ex as u8))
     }
 }

--- a/crates/axl-runtime/src/module/eval.rs
+++ b/crates/axl-runtime/src/module/eval.rs
@@ -263,15 +263,11 @@ impl AxlModuleEvaluator {
 
         if module_boundary_path.exists() {
             let contents = fs::read_to_string(module_boundary_path)?;
-
             let ast = AstModule::parse(&axl_filename, contents, &self.dialect)?;
-
-            {
-                let module = Module::new();
-                let mut eval = Evaluator::new(&module);
-                eval.extra = Some(&store);
-                eval.eval_module(ast, &self.globals)?;
-            }
+            let module = Module::new();
+            let mut eval = Evaluator::new(&module);
+            eval.extra = Some(&store);
+            eval.eval_module(ast, &self.globals)?;
         }
 
         Ok(store)


### PR DESCRIPTION
Fix the "defined in" path used for the default task description seen in the help string. It regressed in #905.