### PR TITLE
fix: improve release fetching

### DIFF
--- a/.github/workflows/launcher-integration-tests.yaml
+++ b/.github/workflows/launcher-integration-tests.yaml
@@ -1,0 +1,161 @@
+name: Launcher Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - crates/aspect-launcher/**
+      - crates/aspect-telemetry/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  integration-tests:
+    name: Integration tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    env:
+      ASPECT_CLI_DOWNLOADER_CACHE: /tmp/aspect-launcher-ci-cache
+      CARGO_TERM_COLOR: always
+      # Use the workflow's GITHUB_TOKEN to avoid rate-limiting on the releases API
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-launcher-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-launcher-
+
+      # The published aspect-cli artifacts are named after the Rust target triple
+      # (e.g. aspect-cli-x86_64-unknown-linux-musl). LLVM_TRIPLE is baked into
+      # the launcher at compile time via build.rs. In production the launcher is
+      # always cross-compiled to musl by Bazel, so LLVM_TRIPLE is correct. Here
+      # we build with plain cargo on a gnu runner, which would bake in
+      # x86_64-unknown-linux-gnu and cause the artifact lookup to fail. Building
+      # with --target x86_64-unknown-linux-musl replicates the production value.
+      - name: Install musl toolchain (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          echo "CARGO_TARGET_ARGS=--target x86_64-unknown-linux-musl" >> "$GITHUB_ENV"
+
+      - name: Build launcher
+        run: cargo build -p aspect-launcher $CARGO_TARGET_ARGS
+
+      # ── Test 1: Unpinned first run ────────────────────────────────────────────
+      # Fresh cache, no version.axl → must query the releases API and download
+      # the latest stable (non-prerelease) release.
+
+      - name: "Test 1: Unpinned first run queries releases API"
+        run: |
+          mkdir -p /tmp/axl-test
+          output=$(cd /tmp/axl-test && ASPECT_DEBUG=1 \
+            cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1) || true
+          echo "$output"
+          echo "$output" | grep -q "querying releases API (no hint cached)" \
+            || { echo "FAIL: expected 'no hint cached' API query"; exit 1; }
+          # Must resolve to a stable vYYYY.WW.P tag, not a prerelease
+          echo "$output" | grep -q 'downloading aspect cli version v[0-9]' \
+            || { echo "FAIL: expected stable version download"; exit 1; }
+
+      # ── Test 2: Warm cache ────────────────────────────────────────────────────
+      # Hint is fresh, binary is present → no network call.
+
+      - name: "Test 2: Warm cache skips API"
+        run: |
+          output=$(cd /tmp/axl-test && ASPECT_DEBUG=1 \
+            cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1) || true
+          echo "$output"
+          echo "$output" | grep -q "found in cache" \
+            || { echo "FAIL: expected cache hit"; exit 1; }
+          if echo "$output" | grep -q "querying releases"; then
+            echo "FAIL: should not query API on warm cache"; exit 1
+          fi
+
+      # ── Test 3: Stale hint ────────────────────────────────────────────────────
+      # Backdate hint mtime → must re-query API, then reuse the already-cached binary.
+
+      - name: "Test 3: Stale hint triggers API re-query"
+        run: |
+          python3 -c "
+          import os, time
+          hint_dir = '$ASPECT_CLI_DOWNLOADER_CACHE/launcher/latest'
+          for f in os.listdir(hint_dir):
+              p = os.path.join(hint_dir, f)
+              os.utime(p, (0, 0))  # epoch = definitely stale
+          "
+          output=$(cd /tmp/axl-test && ASPECT_DEBUG=1 \
+            cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1) || true
+          echo "$output"
+          echo "$output" | grep -q "querying releases API (hint is stale)" \
+            || { echo "FAIL: expected stale hint message"; exit 1; }
+          # Binary was already cached — should not re-download
+          if echo "$output" | grep -q "^downloading "; then
+            echo "FAIL: should not re-download when binary is cached"; exit 1
+          fi
+
+      # ── Test 4: API failure fallback ──────────────────────────────────────────
+      # Stale hint + bad token → must fall back to cached binary and reset expiry.
+
+      - name: "Test 4: API failure falls back to stale cached binary"
+        run: |
+          python3 -c "
+          import os
+          hint_dir = '$ASPECT_CLI_DOWNLOADER_CACHE/launcher/latest'
+          for f in os.listdir(hint_dir):
+              os.utime(os.path.join(hint_dir, f), (0, 0))
+          "
+          output=$(cd /tmp/axl-test && ASPECT_DEBUG=1 GITHUB_TOKEN=invalid \
+            cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1) || true
+          echo "$output"
+          echo "$output" | grep -q "API error, falling back to stale cached tag" \
+            || { echo "FAIL: expected stale fallback message"; exit 1; }
+
+      # ── Test 5: Pinned version (first run) ────────────────────────────────────
+      # version.axl with an explicit version → resolve tag directly, no API call.
+
+      - name: "Test 5: Pinned version downloads directly without API call"
+        run: |
+          mkdir -p /tmp/axl-test-pinned/.aspect
+          printf 'version("2026.15.2")\n' > /tmp/axl-test-pinned/.aspect/version.axl
+          touch /tmp/axl-test-pinned/MODULE.bazel
+          output=$(cd /tmp/axl-test-pinned && ASPECT_DEBUG=1 \
+            cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1) || true
+          echo "$output"
+          echo "$output" | grep -q 'pinned to tag "v2026.15.2", skipping API' \
+            || { echo "FAIL: expected pinned tag message"; exit 1; }
+          if echo "$output" | grep -q "querying releases"; then
+            echo "FAIL: pinned version should not query API"; exit 1
+          fi
+
+      # ── Test 6: Pinned version (cache hit) ────────────────────────────────────
+      # Same pinned version, second run → cache hit, no download, no API call.
+
+      - name: "Test 6: Pinned version cache hit"
+        run: |
+          output=$(cd /tmp/axl-test-pinned && ASPECT_DEBUG=1 \
+            cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1) || true
+          echo "$output"
+          echo "$output" | grep -q "found in cache" \
+            || { echo "FAIL: expected cache hit"; exit 1; }
+          if echo "$output" | grep -q "^downloading "; then
+            echo "FAIL: should not re-download on cache hit"; exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "miette 7.6.0",
  "reqwest",
  "serde",
+ "serde_json",
  "sha2",
  "starlark_syntax",
  "tempfile",

--- a/crates/aspect-launcher/BUILD.bazel
+++ b/crates/aspect-launcher/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("//bazel/release:release.bzl", "release")
 load("//bazel/release/homebrew:multi_platform_brew_artifacts.bzl", "multi_platform_brew_artifacts")
-load("//bazel/rust:defs.bzl", "rust_binary")
+load("//bazel/rust:defs.bzl", "rust_binary", "rust_test")
 load("//bazel/rust:multi_platform_rust_binaries.bzl", "multi_platform_rust_binaries")
 
 rust_binary(
@@ -23,6 +23,15 @@ rust_binary(
         "//crates/aspect-telemetry",
     ],
     visibility = ["//:__pkg__"],
+)
+
+rust_test(
+    name = "test",
+    size = "small",
+    crate = ":aspect-launcher",
+    deps = [
+        "@crates//:serde_json",
+    ],
 )
 
 release(

--- a/crates/aspect-launcher/Cargo.toml
+++ b/crates/aspect-launcher/Cargo.toml
@@ -27,3 +27,6 @@ sha2 = "0.10.9"
 starlark_syntax = "0.13.0"
 tempfile = "3.20.0"
 tokio = { version = "1.45.1", features = ["fs", "macros", "rt", "rt-multi-thread"] }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/aspect-launcher/README.md
+++ b/crates/aspect-launcher/README.md
@@ -1,7 +1,180 @@
 # aspect-launcher
 
-With a bare minimum of code, perform the following.
+The aspect-launcher is a thin bootstrap binary that provisions and executes the
+full `aspect-cli`. It is distributed as the `aspect` binary that users install
+(e.g. via Homebrew). When a user runs `aspect build //...`, the launcher:
 
-- Look for an `.aspect/config.toml`
-- Read `.aspect_cli.version`
-- ...
+1. Locates the project root (walks up from cwd looking for `MODULE.aspect`,
+   `MODULE.bazel`, `WORKSPACE`, etc.)
+2. Reads `.aspect/version.axl` (if present) to determine which version of
+   `aspect-cli` to use and where to download it from
+3. Downloads (or retrieves from cache) the correct `aspect-cli` binary
+4. `exec`s the real `aspect-cli`, forwarding all arguments
+
+The launcher also forks a child process to report anonymous usage telemetry
+(honoring `DO_NOT_TRACK`).
+
+## version.axl
+
+The file `.aspect/version.axl` controls which `aspect-cli` version the launcher
+provisions. It uses Starlark syntax and contains a single `version()` call.
+
+### Pinned version (recommended)
+
+```starlark
+version("2026.11.6")
+```
+
+This pins the project to a specific `aspect-cli` release. The launcher downloads
+directly from `https://github.com/aspect-build/aspect-cli/releases/download/v2026.11.6/<artifact>`
+with no GitHub API call needed.
+
+### Pinned version with custom sources
+
+```starlark
+version(
+    "2026.11.6",
+    sources = [
+        local("bazel-bin/cli/aspect"),
+        github(
+            org = "aspect-build",
+            repo = "aspect-cli",
+        ),
+    ],
+)
+```
+
+Sources are tried in order. This example first checks for a local build, then
+falls back to GitHub.
+
+### No version.axl
+
+When no `.aspect/version.axl` file exists, the launcher queries the GitHub
+releases API to find the latest available `aspect-cli` release and downloads
+that. This is the unpinned (floating) mode — you always get the most recent
+release that has a binary for your platform.
+
+### Can you have a version.axl without pinning?
+
+While the parser technically allows `version()` with no positional argument,
+this is equivalent to not having a `version.axl` at all — the launcher will
+query the releases API to find the latest available release. If you create a
+`version.axl`, you should specify a version string. The only reason to have a
+`version.axl` without a pinned version would be to customize the `sources`
+list, e.g.:
+
+```starlark
+version(
+    sources = [
+        local("bazel-bin/cli/aspect"),
+        github(org = "my-fork", repo = "aspect-cli"),
+    ],
+)
+```
+
+This is a niche use case. In general, if `version.axl` exists, pin a version.
+
+### version() reference
+
+```
+version(<version_string>?, sources = [...]?)
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| *(positional)* | No | Version string (e.g. `"2026.11.6"`). If omitted, the GitHub releases API is queried to find the latest available release. |
+| `sources` | No | List of source specifiers, tried in order. If omitted, defaults to `[github(org = "aspect-build", repo = "aspect-cli")]`. |
+
+### Source types
+
+#### github()
+
+```starlark
+github(
+    org = "aspect-build",          # required
+    repo = "aspect-cli",           # required
+    tag = "v{version}",            # optional, default: "v{version}"
+    artifact = "{repo}-{target}",  # optional, default: "{repo}-{target}"
+)
+```
+
+#### http()
+
+```starlark
+http(
+    url = "https://example.com/aspect-cli-{version}-{target}",  # required
+)
+```
+
+#### local()
+
+```starlark
+local("bazel-bin/cli/aspect")  # path relative to project root
+```
+
+### Template variables
+
+The `tag`, `artifact`, and `url` fields support these placeholders:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{version}` | The version string from `version()` | `2026.11.6` |
+| `{os}` | Operating system | `darwin`, `linux` |
+| `{arch}` | CPU architecture (Bazel naming) | `aarch64`, `x86_64` |
+| `{target}` | LLVM target triple | `aarch64-apple-darwin`, `x86_64-unknown-linux-musl` |
+
+## Download flow
+
+### Pinned version (version specified in version.axl)
+
+```
+version.axl: version("2026.11.6", sources = [github(org = "aspect-build", repo = "aspect-cli")])
+```
+
+1. Tag is computed: `v2026.11.6`
+2. Cache is checked — if the binary is already cached, it is used immediately
+3. Direct download from
+   `https://github.com/aspect-build/aspect-cli/releases/download/v2026.11.6/aspect-cli-{target}`
+4. If the download fails, the error is reported — **no fallback to a different
+   version**. When you pin, you are guaranteed to get exactly that version or
+   an error.
+
+### Unpinned version (no version.axl, or version.axl without a version string)
+
+```
+(no .aspect/version.axl file)
+```
+
+1. Check the tag hint cache — if a previous run already resolved a tag, its
+   binary is cached, and the hint is less than 24 hours old, use it immediately
+   with **no network call**
+2. Otherwise, query the GitHub releases API
+   (`/repos/{org}/{repo}/releases?per_page=10`) and scan the most recent
+   non-prerelease releases to find the first one that contains the matching artifact
+3. If the API call fails but a stale hint and cached binary exist, fall back to
+   the cached version and reset the hint's expiry so we don't hammer a down API
+4. Write the resolved tag to the hint cache for future runs
+5. Direct download from
+   `https://github.com/{org}/{repo}/releases/download/{resolved_tag}/{artifact}`
+
+This means the unpinned case gets the latest *available* release on the first
+run and after the 24-hour hint expiry, gracefully handles the window during a
+new release where assets haven't finished uploading, avoids any network
+dependency on warm-cache runs, and degrades gracefully when the GitHub API is
+unavailable.
+
+## Caching
+
+Downloaded binaries are cached under the system cache directory
+(`~/Library/Caches/aspect/launcher/` on macOS, `~/.cache/aspect/launcher/` on
+Linux). The cache path is derived from a SHA-256 hash of the tool name and
+source URL, so different versions coexist without conflict.
+
+The cache location can be overridden with the `ASPECT_CLI_DOWNLOADER_CACHE`
+environment variable.
+
+## Debugging
+
+Set `ASPECT_DEBUG=1` to enable verbose logging of the download and caching flow.

--- a/crates/aspect-launcher/src/cache.rs
+++ b/crates/aspect-launcher/src/cache.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
 
 use dirs::cache_dir;
 use miette::{Context, IntoDiagnostic, Result, miette};
@@ -38,5 +39,199 @@ impl AspectCache {
         hasher.update(tool_source.as_bytes());
         let hash = format!("{:x}", hasher.finalize());
         self.root.join(format!("bin/{0}/{1}/{0}", tool_name, hash))
+    }
+
+    /// Path to a small file that records the last resolved tag for an unpinned GitHub source.
+    /// Keyed on (tool_name, org, repo, artifact) — no tag — so it can be read before any
+    /// API call and used to reconstruct the binary cache path.
+    pub fn latest_tag_path(
+        &self,
+        tool_name: &str,
+        org: &str,
+        repo: &str,
+        artifact: &str,
+    ) -> PathBuf {
+        let mut hasher = Sha256::new();
+        hasher.update(tool_name.as_bytes());
+        hasher.update(org.as_bytes());
+        hasher.update(repo.as_bytes());
+        hasher.update(artifact.as_bytes());
+        let hash = format!("{:x}", hasher.finalize());
+        self.root.join(format!("latest/{}", hash))
+    }
+
+    /// Returns true if the tag hint file is present and was written within `max_age`.
+    /// A stale or missing hint means the caller should re-query the releases API.
+    pub fn latest_tag_is_fresh(&self, hint_path: &PathBuf, max_age: Duration) -> bool {
+        match fs::metadata(hint_path) {
+            Ok(meta) => match meta.modified() {
+                Ok(mtime) => SystemTime::now()
+                    .duration_since(mtime)
+                    .map(|age| age < max_age)
+                    .unwrap_or(false),
+                Err(_) => false,
+            },
+            Err(_) => false,
+        }
+    }
+
+    /// Touches the mtime of the hint file to the current time without changing its contents.
+    /// Used to reset the expiry clock after a failed API call so we don't hammer a down API.
+    pub fn touch_latest_tag(&self, hint_path: &PathBuf) {
+        // Rewrite with the same content — simplest cross-platform mtime update.
+        if let Ok(contents) = fs::read(hint_path) {
+            let _ = fs::write(hint_path, contents);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_path_structure() {
+        let cache = AspectCache::from(PathBuf::from("/tmp/cache"));
+        let path = cache.tool_path(
+            &"aspect-cli".to_string(),
+            &"https://github.com/aspect-build/aspect-cli/releases/download/v2026.15.2/aspect-cli-aarch64-apple-darwin".to_string(),
+        );
+        // Path should be: /tmp/cache/bin/{tool_name}/{hash}/{tool_name}
+        let components: Vec<_> = path.components().collect();
+        let path_str = path.to_str().unwrap();
+        assert!(path_str.starts_with("/tmp/cache/bin/aspect-cli/"));
+        assert!(path_str.ends_with("/aspect-cli"));
+        // Should have the structure: root/bin/name/hash/name
+        assert_eq!(components.len(), 7); // /tmp/cache/bin/aspect-cli/{hash}/aspect-cli
+    }
+
+    #[test]
+    fn test_tool_path_deterministic() {
+        let cache = AspectCache::from(PathBuf::from("/tmp/cache"));
+        let path1 = cache.tool_path(&"tool".to_string(), &"source-a".to_string());
+        let path2 = cache.tool_path(&"tool".to_string(), &"source-a".to_string());
+        assert_eq!(path1, path2);
+    }
+
+    #[test]
+    fn test_tool_path_different_sources_differ() {
+        let cache = AspectCache::from(PathBuf::from("/tmp/cache"));
+        let path1 = cache.tool_path(&"tool".to_string(), &"source-a".to_string());
+        let path2 = cache.tool_path(&"tool".to_string(), &"source-b".to_string());
+        assert_ne!(path1, path2);
+    }
+
+    #[test]
+    fn test_tool_path_different_names_differ() {
+        let cache = AspectCache::from(PathBuf::from("/tmp/cache"));
+        let path1 = cache.tool_path(&"tool-a".to_string(), &"source".to_string());
+        let path2 = cache.tool_path(&"tool-b".to_string(), &"source".to_string());
+        assert_ne!(path1, path2);
+    }
+
+    #[test]
+    fn test_latest_tag_path_structure() {
+        let cache = AspectCache::from(PathBuf::from("/tmp/cache"));
+        let path = cache.latest_tag_path(
+            "aspect-cli",
+            "aspect-build",
+            "aspect-cli",
+            "aspect-cli-aarch64-apple-darwin",
+        );
+        let path_str = path.to_str().unwrap();
+        assert!(path_str.starts_with("/tmp/cache/latest/"));
+        // No tool name in the filename — just the hash
+        assert!(!path_str.ends_with("/aspect-cli"));
+    }
+
+    #[test]
+    fn test_latest_tag_path_deterministic() {
+        let cache = AspectCache::from(PathBuf::from("/tmp/cache"));
+        let path1 = cache.latest_tag_path("aspect-cli", "aspect-build", "aspect-cli", "artifact");
+        let path2 = cache.latest_tag_path("aspect-cli", "aspect-build", "aspect-cli", "artifact");
+        assert_eq!(path1, path2);
+    }
+
+    #[test]
+    fn test_latest_tag_path_different_artifacts_differ() {
+        let cache = AspectCache::from(PathBuf::from("/tmp/cache"));
+        let path1 = cache.latest_tag_path(
+            "aspect-cli",
+            "aspect-build",
+            "aspect-cli",
+            "artifact-darwin",
+        );
+        let path2 =
+            cache.latest_tag_path("aspect-cli", "aspect-build", "aspect-cli", "artifact-linux");
+        assert_ne!(path1, path2);
+    }
+
+    #[test]
+    fn test_latest_tag_path_differs_from_tool_path() {
+        let cache = AspectCache::from(PathBuf::from("/tmp/cache"));
+        let tool_path = cache.tool_path(&"aspect-cli".to_string(), &"some-url".to_string());
+        let hint_path =
+            cache.latest_tag_path("aspect-cli", "aspect-build", "aspect-cli", "artifact");
+        assert_ne!(tool_path, hint_path);
+    }
+
+    fn tmp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "aspect-cache-test-{}-{}",
+            std::process::id(),
+            label
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_latest_tag_is_fresh_when_just_written() {
+        let tmp = tmp_dir("fresh");
+        let cache = AspectCache::from(tmp.clone());
+        let hint = cache.latest_tag_path("aspect-cli", "aspect-build", "aspect-cli", "artifact");
+        fs::create_dir_all(hint.parent().unwrap()).unwrap();
+        fs::write(&hint, "v2026.15.2").unwrap();
+
+        assert!(cache.latest_tag_is_fresh(&hint, Duration::from_secs(3600)));
+        fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn test_latest_tag_is_stale_when_expired() {
+        let tmp = tmp_dir("stale");
+        let cache = AspectCache::from(tmp.clone());
+        let hint = cache.latest_tag_path("aspect-cli", "aspect-build", "aspect-cli", "artifact");
+        fs::create_dir_all(hint.parent().unwrap()).unwrap();
+        fs::write(&hint, "v2026.15.2").unwrap();
+
+        // Zero max-age means any file is immediately stale.
+        assert!(!cache.latest_tag_is_fresh(&hint, Duration::ZERO));
+        fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn test_latest_tag_is_not_fresh_when_missing() {
+        let tmp = tmp_dir("missing");
+        let cache = AspectCache::from(tmp.clone());
+        let hint = cache.latest_tag_path("aspect-cli", "aspect-build", "aspect-cli", "artifact");
+
+        assert!(!cache.latest_tag_is_fresh(&hint, Duration::from_secs(3600)));
+        fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn test_touch_latest_tag_refreshes_mtime() {
+        let tmp = tmp_dir("touch");
+        let cache = AspectCache::from(tmp.clone());
+        let hint = cache.latest_tag_path("aspect-cli", "aspect-build", "aspect-cli", "artifact");
+        fs::create_dir_all(hint.parent().unwrap()).unwrap();
+        fs::write(&hint, "v2026.15.2").unwrap();
+
+        // After touching, the file should still be fresh and contents unchanged.
+        cache.touch_latest_tag(&hint);
+        assert!(cache.latest_tag_is_fresh(&hint, Duration::from_secs(3600)));
+        assert_eq!(fs::read_to_string(&hint).unwrap(), "v2026.15.2");
+        fs::remove_dir_all(&tmp).unwrap();
     }
 }

--- a/crates/aspect-launcher/src/config.rs
+++ b/crates/aspect-launcher/src/config.rs
@@ -4,7 +4,6 @@ use std::fmt::Debug;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use aspect_telemetry::cargo_pkg_short_version;
 use miette::{Result, miette};
 use starlark_syntax::syntax::ast::{ArgumentP, AstExpr, AstLiteral, CallArgsP, Expr, Stmt};
 use starlark_syntax::syntax::{AstModule, Dialect};
@@ -19,7 +18,9 @@ pub struct AspectLauncherConfig {
 #[derive(Debug, Clone)]
 pub struct AspectCliConfig {
     sources: Vec<ToolSource>,
-    version: String,
+    /// The pinned version string, or `None` if the version should be resolved
+    /// by querying the releases API for the latest available release.
+    version: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -43,7 +44,9 @@ pub enum ToolSource {
 
 pub trait ToolSpec: Debug {
     fn name(&self) -> String;
-    fn version(&self) -> &String;
+    /// The pinned version string, or `None` when the version should be resolved
+    /// at download time (e.g. by querying the GitHub releases API).
+    fn version(&self) -> Option<&str>;
     fn sources(&self) -> &Vec<ToolSource>;
 }
 
@@ -56,8 +59,8 @@ impl ToolSpec for AspectCliConfig {
         &self.sources
     }
 
-    fn version(&self) -> &String {
-        &self.version
+    fn version(&self) -> Option<&str> {
+        self.version.as_deref()
     }
 }
 
@@ -73,7 +76,7 @@ fn default_cli_sources() -> Vec<ToolSource> {
 fn default_aspect_cli_config() -> AspectCliConfig {
     AspectCliConfig {
         sources: default_cli_sources(),
-        version: cargo_pkg_short_version(),
+        version: None,
     }
 }
 
@@ -281,7 +284,7 @@ fn parse_version_axl(content: &str) -> Result<AspectLauncherConfig> {
 
     Ok(AspectLauncherConfig {
         aspect_cli: AspectCliConfig {
-            version: version.unwrap_or_else(cargo_pkg_short_version),
+            version,
             sources: sources.unwrap_or_else(default_cli_sources),
         },
     })
@@ -316,6 +319,263 @@ pub fn load_config(path: &PathBuf) -> Result<AspectLauncherConfig> {
 /// **Errors**
 ///
 /// Returns an error if the current working directory cannot be obtained or if loading the config fails.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_version_with_pinned_version_and_github_source() {
+        let content = r#"
+version(
+    "2026.11.6",
+    sources = [
+        github(
+            org = "aspect-build",
+            repo = "aspect-cli",
+        ),
+    ],
+)
+"#;
+        let config = parse_version_axl(content).unwrap();
+        assert_eq!(config.aspect_cli.version(), Some("2026.11.6"));
+        assert_eq!(config.aspect_cli.sources().len(), 1);
+        match &config.aspect_cli.sources()[0] {
+            ToolSource::GitHub {
+                org,
+                repo,
+                tag,
+                artifact,
+            } => {
+                assert_eq!(org, "aspect-build");
+                assert_eq!(repo, "aspect-cli");
+                assert_eq!(tag, "");
+                assert_eq!(artifact, "");
+            }
+            other => panic!("expected GitHub source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_version_with_custom_tag_and_artifact() {
+        let content = r#"
+version(
+    "1.2.3",
+    sources = [
+        github(
+            org = "my-org",
+            repo = "my-repo",
+            tag = "release-{version}",
+            artifact = "my-tool-{target}",
+        ),
+    ],
+)
+"#;
+        let config = parse_version_axl(content).unwrap();
+        assert_eq!(config.aspect_cli.version(), Some("1.2.3"));
+        match &config.aspect_cli.sources()[0] {
+            ToolSource::GitHub { tag, artifact, .. } => {
+                assert_eq!(tag, "release-{version}");
+                assert_eq!(artifact, "my-tool-{target}");
+            }
+            other => panic!("expected GitHub source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_version_with_no_version_uses_default() {
+        let content = r#"version()"#;
+        let config = parse_version_axl(content).unwrap();
+        assert_eq!(config.aspect_cli.version(), None);
+    }
+
+    #[test]
+    fn test_parse_version_with_custom_sources_but_no_version() {
+        let content = r#"
+version(
+    sources = [
+        local("bazel-bin/cli/aspect"),
+        github(org = "my-fork", repo = "aspect-cli"),
+    ],
+)
+"#;
+        let config = parse_version_axl(content).unwrap();
+        assert_eq!(config.aspect_cli.version(), None);
+        assert_eq!(config.aspect_cli.sources().len(), 2);
+        assert!(matches!(
+            &config.aspect_cli.sources()[0],
+            ToolSource::Local { path } if path == "bazel-bin/cli/aspect"
+        ));
+        match &config.aspect_cli.sources()[1] {
+            ToolSource::GitHub { org, repo, .. } => {
+                assert_eq!(org, "my-fork");
+                assert_eq!(repo, "aspect-cli");
+            }
+            other => panic!("expected GitHub source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_version_with_http_source() {
+        let content = r#"
+version(
+    "1.0.0",
+    sources = [
+        http(
+            url = "https://example.com/tool-{version}-{target}",
+        ),
+    ],
+)
+"#;
+        let config = parse_version_axl(content).unwrap();
+        match &config.aspect_cli.sources()[0] {
+            ToolSource::Http { url, headers } => {
+                assert_eq!(url, "https://example.com/tool-{version}-{target}");
+                assert!(headers.is_empty());
+            }
+            other => panic!("expected Http source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_version_with_http_source_headers_is_broken() {
+        // NOTE: extract_named_string_args fails on non-string named args
+        // like `headers = {...}`. This is a known bug.
+        let content = r#"
+version(
+    "1.0.0",
+    sources = [
+        http(
+            url = "https://example.com/tool",
+            headers = {"Authorization": "Bearer token"},
+        ),
+    ],
+)
+"#;
+        let result = parse_version_axl(content);
+        assert!(result.is_err(), "http() with headers is currently broken");
+    }
+
+    #[test]
+    fn test_parse_version_with_local_source() {
+        let content = r#"
+version(
+    "1.0.0",
+    sources = [
+        local("bazel-bin/cli/aspect"),
+    ],
+)
+"#;
+        let config = parse_version_axl(content).unwrap();
+        match &config.aspect_cli.sources()[0] {
+            ToolSource::Local { path } => {
+                assert_eq!(path, "bazel-bin/cli/aspect");
+            }
+            other => panic!("expected Local source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_version_with_multiple_sources() {
+        let content = r#"
+version(
+    "1.0.0",
+    sources = [
+        local("bazel-bin/cli/aspect"),
+        github(org = "aspect-build", repo = "aspect-cli"),
+    ],
+)
+"#;
+        let config = parse_version_axl(content).unwrap();
+        assert_eq!(config.aspect_cli.sources().len(), 2);
+        assert!(matches!(
+            &config.aspect_cli.sources()[0],
+            ToolSource::Local { .. }
+        ));
+        assert!(matches!(
+            &config.aspect_cli.sources()[1],
+            ToolSource::GitHub { .. }
+        ));
+    }
+
+    #[test]
+    fn test_parse_version_no_sources_uses_default() {
+        let content = r#"version("1.0.0")"#;
+        let config = parse_version_axl(content).unwrap();
+        assert_eq!(config.aspect_cli.sources().len(), 1);
+        match &config.aspect_cli.sources()[0] {
+            ToolSource::GitHub { org, repo, .. } => {
+                assert_eq!(org, "aspect-build");
+                assert_eq!(repo, "aspect-cli");
+            }
+            other => panic!("expected default GitHub source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_version_missing_version_call_errors() {
+        let content = r#"print("hello")"#;
+        let result = parse_version_axl(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_version_invalid_syntax_errors() {
+        let content = r#"version(123)"#;
+        let result = parse_version_axl(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_version_unknown_argument_errors() {
+        let content = r#"version("1.0.0", flavor = "spicy")"#;
+        let result = parse_version_axl(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_version_duplicate_positional_errors() {
+        let content = r#"version("1.0.0", "2.0.0")"#;
+        let result = parse_version_axl(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_github_missing_org_errors() {
+        let content = r#"version("1.0.0", sources = [github(repo = "aspect-cli")])"#;
+        let result = parse_version_axl(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_github_missing_repo_errors() {
+        let content = r#"version("1.0.0", sources = [github(org = "aspect-build")])"#;
+        let result = parse_version_axl(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_unknown_source_type_errors() {
+        let content = r#"version("1.0.0", sources = [ftp("foo")])"#;
+        let result = parse_version_axl(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = super::default_config();
+        assert_eq!(config.aspect_cli.version(), None);
+        assert_eq!(config.aspect_cli.sources().len(), 1);
+        assert!(matches!(
+            &config.aspect_cli.sources()[0],
+            ToolSource::GitHub {
+                org,
+                repo,
+                ..
+            } if org == "aspect-build" && repo == "aspect-cli"
+        ));
+    }
+}
+
 pub fn autoconf() -> Result<(PathBuf, AspectLauncherConfig)> {
     let current_dir =
         current_dir().map_err(|e| miette!("failed to get current directory: {}", e))?;

--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -126,12 +126,15 @@ async fn _download_into_cache(
 
 #[derive(Deserialize, Debug)]
 struct Release {
+    tag_name: String,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
     assets: Vec<ReleaseArtifact>,
 }
 
 #[derive(Deserialize, Debug)]
 struct ReleaseArtifact {
-    url: String,
     name: String,
 }
 
@@ -196,7 +199,9 @@ async fn configure_tool_task(
         for source in tool.sources() {
             match source {
                 ToolSource::Http { url, headers } => {
-                    let url = replace_vars(url, tool.version());
+                    let fallback_version = cargo_pkg_short_version();
+                    let version = tool.version().unwrap_or(&fallback_version);
+                    let url = replace_vars(url, version);
                     let req_headers = headermap_from_hashmap(headers.iter());
                     let req = client
                         .request(Method::GET, &url)
@@ -250,25 +255,204 @@ async fn configure_tool_task(
                     tag,
                     artifact,
                 } => {
-                    let tag = if tag.is_empty() {
-                        format!("v{}", tool.version())
-                    } else {
-                        replace_vars(tag, tool.version())
-                    };
+                    let fallback_version = cargo_pkg_short_version();
+                    let pinned_version = tool.version();
+                    let version_for_vars = pinned_version.unwrap_or(&fallback_version);
+
                     let artifact = if artifact.is_empty() {
                         format!("{}-{}", repo, LLVM_TRIPLE)
                     } else {
-                        replace_vars(artifact, tool.version())
+                        replace_vars(artifact, version_for_vars)
                     };
 
-                    let url =
-                        format!("https://api.github.com/repos/{org}/{repo}/releases/tags/{tag}");
+                    // How long a resolved tag hint is considered fresh before we
+                    // re-query the releases API to pick up newer versions.
+                    const HINT_MAX_AGE: std::time::Duration =
+                        std::time::Duration::from_secs(24 * 60 * 60);
 
-                    let tool_dest_file = cache.tool_path(&tool.name(), &url);
+                    // Step 1: Resolve the tag.
+                    // If a version is pinned, compute the tag directly.
+                    // If unpinned, check the cached tag hint first to avoid a
+                    // network round-trip when the binary is already present and
+                    // the hint is fresh, then fall back to querying the releases API.
+                    let resolved_tag = if let Some(version) = pinned_version {
+                        let t = if tag.is_empty() {
+                            format!("v{}", version)
+                        } else {
+                            replace_vars(tag, version)
+                        };
+                        if debug_mode() {
+                            eprintln!("{:} pinned to tag {:?}, skipping API", tool.name(), t);
+                        }
+                        t
+                    } else {
+                        let hint_path = cache.latest_tag_path(&tool.name(), org, repo, &artifact);
+
+                        // Use the cached hint if it is fresh and its binary is present.
+                        if cache.latest_tag_is_fresh(&hint_path, HINT_MAX_AGE) {
+                            if let Ok(cached_tag) = fs::read_to_string(&hint_path) {
+                                let cached_tag = cached_tag.trim().to_owned();
+                                let cached_url = format!(
+                                    "https://github.com/{org}/{repo}/releases/download/{cached_tag}/{artifact}"
+                                );
+                                let cached_dest = cache.tool_path(&tool.name(), &cached_url);
+                                if cached_dest.exists() {
+                                    if debug_mode() {
+                                        eprintln!(
+                                            "{:} source {:?} found in cache {:?} (resolved tag: {})",
+                                            tool.name(),
+                                            source,
+                                            &cached_url,
+                                            cached_tag,
+                                        );
+                                    }
+                                    let mut extra_envs = HashMap::new();
+                                    extra_envs.insert(
+                                        "ASPECT_LAUNCHER_ASPECT_CLI_ORG".to_string(),
+                                        org.clone(),
+                                    );
+                                    extra_envs.insert(
+                                        "ASPECT_LAUNCHER_ASPECT_CLI_REPO".to_string(),
+                                        repo.clone(),
+                                    );
+                                    extra_envs.insert(
+                                        "ASPECT_LAUNCHER_ASPECT_CLI_TAG".to_string(),
+                                        cached_tag,
+                                    );
+                                    extra_envs.insert(
+                                        "ASPECT_LAUNCHER_ASPECT_CLI_ARTIFACT".to_string(),
+                                        artifact.clone(),
+                                    );
+                                    return Ok((
+                                        cached_dest,
+                                        ASPECT_LAUNCHER_METHOD_GITHUB.to_string(),
+                                        extra_envs,
+                                    ));
+                                }
+                            }
+                        }
+
+                        // Hint is absent, stale, or binary is missing — query the releases API.
+                        if debug_mode() {
+                            let reason = if !hint_path.exists() {
+                                "no hint cached"
+                            } else if !cache.latest_tag_is_fresh(&hint_path, HINT_MAX_AGE) {
+                                "hint is stale"
+                            } else {
+                                "binary not in cache"
+                            };
+                            eprintln!(
+                                "{:} unpinned, querying releases API ({reason})",
+                                tool.name()
+                            );
+                        }
+                        let releases_url = format!(
+                            "https://api.github.com/repos/{org}/{repo}/releases?per_page=10"
+                        );
+                        if debug_mode() {
+                            eprintln!(
+                                "{:} source {:?} querying releases from {:?}",
+                                tool.name(),
+                                source,
+                                releases_url,
+                            );
+                        }
+                        let releases_req = gh_request(&client, releases_url)
+                            .header(
+                                HeaderName::from_static("accept"),
+                                HeaderValue::from_static("application/vnd.github+json"),
+                            )
+                            .build()
+                            .into_diagnostic()?;
+                        let releases_resp = client.execute(releases_req).await.into_diagnostic()?;
+                        let releases_status = releases_resp.status();
+                        if !releases_status.is_success() {
+                            let body = releases_resp.text().await.unwrap_or_default();
+                            // If we have a stale-but-readable hint whose binary is still present,
+                            // fall back to it and touch the hint so we don't hammer a down API.
+                            if let Ok(stale_tag) = fs::read_to_string(&hint_path) {
+                                let stale_tag = stale_tag.trim().to_owned();
+                                let stale_url = format!(
+                                    "https://github.com/{org}/{repo}/releases/download/{stale_tag}/{artifact}"
+                                );
+                                let stale_dest = cache.tool_path(&tool.name(), &stale_url);
+                                if stale_dest.exists() {
+                                    if debug_mode() {
+                                        eprintln!(
+                                            "{:} API error, falling back to stale cached tag {} ({})",
+                                            tool.name(),
+                                            stale_tag,
+                                            body.trim(),
+                                        );
+                                    }
+                                    // Reset the expiry so we retry after another HINT_MAX_AGE.
+                                    cache.touch_latest_tag(&hint_path);
+                                    let mut extra_envs = HashMap::new();
+                                    extra_envs.insert(
+                                        "ASPECT_LAUNCHER_ASPECT_CLI_ORG".to_string(),
+                                        org.clone(),
+                                    );
+                                    extra_envs.insert(
+                                        "ASPECT_LAUNCHER_ASPECT_CLI_REPO".to_string(),
+                                        repo.clone(),
+                                    );
+                                    extra_envs.insert(
+                                        "ASPECT_LAUNCHER_ASPECT_CLI_TAG".to_string(),
+                                        stale_tag,
+                                    );
+                                    extra_envs.insert(
+                                        "ASPECT_LAUNCHER_ASPECT_CLI_ARTIFACT".to_string(),
+                                        artifact.clone(),
+                                    );
+                                    return Ok((
+                                        stale_dest,
+                                        ASPECT_LAUNCHER_METHOD_GITHUB.to_string(),
+                                        extra_envs,
+                                    ));
+                                }
+                            }
+                            errs.push(Err(miette!(
+                                "github releases list request for {org}/{repo} failed with status {}: {}",
+                                releases_status,
+                                body
+                            )));
+                            continue;
+                        }
+                        let releases: Vec<Release> =
+                            releases_resp.json().await.into_diagnostic()?;
+                        let found = releases.into_iter().find(|r| {
+                            !r.prerelease && r.assets.iter().any(|a| a.name == *artifact)
+                        });
+                        let resolved = match found {
+                            Some(release) => release.tag_name,
+                            None => {
+                                errs.push(Err(miette!(
+                                    "unable to find release artifact {artifact} in any recent {org}/{repo} release"
+                                )));
+                                continue;
+                            }
+                        };
+                        // Persist the resolved tag so the next run can skip the API call.
+                        if let Some(parent) = hint_path.parent() {
+                            let _ = fs::create_dir_all(parent);
+                        }
+                        let _ = fs::write(&hint_path, &resolved);
+                        resolved
+                    };
+
+                    // Step 2: Download from the direct release URL using the resolved tag.
+                    let direct_url = format!(
+                        "https://github.com/{org}/{repo}/releases/download/{resolved_tag}/{artifact}"
+                    );
+
+                    let tool_dest_file = cache.tool_path(&tool.name(), &direct_url);
                     let mut extra_envs = HashMap::new();
                     extra_envs.insert("ASPECT_LAUNCHER_ASPECT_CLI_ORG".to_string(), org.clone());
                     extra_envs.insert("ASPECT_LAUNCHER_ASPECT_CLI_REPO".to_string(), repo.clone());
-                    extra_envs.insert("ASPECT_LAUNCHER_ASPECT_CLI_TAG".to_string(), tag.clone());
+                    extra_envs.insert(
+                        "ASPECT_LAUNCHER_ASPECT_CLI_TAG".to_string(),
+                        resolved_tag.clone(),
+                    );
                     extra_envs.insert(
                         "ASPECT_LAUNCHER_ASPECT_CLI_ARTIFACT".to_string(),
                         artifact.clone(),
@@ -279,7 +463,7 @@ async fn configure_tool_task(
                                 "{:} source {:?} found in cache {:?}",
                                 tool.name(),
                                 source,
-                                &url
+                                &direct_url
                             );
                         };
                         return Ok((
@@ -290,65 +474,37 @@ async fn configure_tool_task(
                     }
                     fs::create_dir_all(tool_dest_file.parent().unwrap()).into_diagnostic()?;
 
-                    let req = gh_request(&client, url)
+                    if debug_mode() {
+                        eprintln!(
+                            "{:} source {:?} downloading {:?} to {:?}",
+                            tool.name(),
+                            source,
+                            direct_url,
+                            tool_dest_file
+                        );
+                    };
+                    let req = gh_request(&client, direct_url)
                         .header(
                             HeaderName::from_static("accept"),
-                            HeaderValue::from_static("application/vnd.github+json"),
+                            HeaderValue::from_static("application/octet-stream"),
                         )
                         .build()
                         .into_diagnostic()?;
-
-                    let resp = client
-                        .execute(req.try_clone().unwrap())
-                        .await
-                        .into_diagnostic()?;
-                    let status = resp.status();
-                    if !status.is_success() {
-                        let body = resp.text().await.unwrap_or_default();
-                        errs.push(Err(miette!(
-                            "GitHub API request failed with status {}: {}",
-                            status,
-                            body
-                        )));
+                    let download_msg = format!(
+                        "downloading aspect cli version {} file {}",
+                        resolved_tag, artifact
+                    );
+                    if let err @ Err(_) =
+                        _download_into_cache(&client, &tool_dest_file, req, &download_msg).await
+                    {
+                        errs.push(err);
                         continue;
                     }
-                    let release_data: Release = resp.json::<Release>().await.into_diagnostic()?;
-                    for asset in release_data.assets {
-                        if asset.name == *artifact {
-                            if debug_mode() {
-                                eprintln!(
-                                    "{:} source {:?} downloading {:?} to {:?}",
-                                    tool.name(),
-                                    source,
-                                    asset.url,
-                                    tool_dest_file
-                                );
-                            };
-                            let req = gh_request(&client, asset.url)
-                                .header(
-                                    HeaderName::from_static("accept"),
-                                    HeaderValue::from_static("application/octet-stream"),
-                                )
-                                .build()
-                                .into_diagnostic()?;
-                            let download_msg =
-                                format!("downloading aspect cli version {} file {}", tag, artifact);
-                            if let err @ Err(_) =
-                                _download_into_cache(&client, &tool_dest_file, req, &download_msg)
-                                    .await
-                            {
-                                errs.push(err);
-                                break;
-                            }
-                            return Ok((
-                                tool_dest_file,
-                                ASPECT_LAUNCHER_METHOD_GITHUB.to_string(),
-                                extra_envs,
-                            ));
-                        }
-                    }
-                    errs.push(Err(miette!("unable to find a release artifact in github!")));
-                    continue;
+                    return Ok((
+                        tool_dest_file,
+                        ASPECT_LAUNCHER_METHOD_GITHUB.to_string(),
+                        extra_envs,
+                    ));
                 }
                 ToolSource::Local { path } => {
                     let tool_dest_file = cache.tool_path(&tool.name(), path);
@@ -490,5 +646,317 @@ fn main() -> Result<ExitCode> {
             })?;
             Ok(ExitCode::SUCCESS)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_replace_vars_version() {
+        let result = replace_vars("tool-{version}", "1.2.3");
+        assert_eq!(result, format!("tool-1.2.3"));
+    }
+
+    #[test]
+    fn test_replace_vars_os() {
+        let result = replace_vars("{os}", "1.0.0");
+        assert_eq!(result, GOOS);
+    }
+
+    #[test]
+    fn test_replace_vars_arch() {
+        let result = replace_vars("{arch}", "1.0.0");
+        assert_eq!(result, BZLARCH);
+    }
+
+    #[test]
+    fn test_replace_vars_target() {
+        let result = replace_vars("{target}", "1.0.0");
+        assert_eq!(result, LLVM_TRIPLE);
+    }
+
+    #[test]
+    fn test_replace_vars_multiple() {
+        let result = replace_vars("tool-{version}-{os}-{arch}", "3.0.0");
+        assert_eq!(result, format!("tool-3.0.0-{}-{}", GOOS, BZLARCH));
+    }
+
+    #[test]
+    fn test_replace_vars_no_placeholders() {
+        let result = replace_vars("plain-string", "1.0.0");
+        assert_eq!(result, "plain-string");
+    }
+
+    #[test]
+    fn test_release_deserialize_with_assets() {
+        let json = r#"{
+            "tag_name": "v1.0.0",
+            "assets": [
+                {"name": "tool-linux"},
+                {"name": "tool-macos"}
+            ]
+        }"#;
+        let release: Release = serde_json::from_str(json).unwrap();
+        assert_eq!(release.tag_name, "v1.0.0");
+        assert_eq!(release.assets.len(), 2);
+        assert_eq!(release.assets[0].name, "tool-linux");
+        assert_eq!(release.assets[1].name, "tool-macos");
+    }
+
+    #[test]
+    fn test_release_deserialize_without_assets() {
+        let json = r#"{"tag_name": "v2.0.0"}"#;
+        let release: Release = serde_json::from_str(json).unwrap();
+        assert_eq!(release.tag_name, "v2.0.0");
+        assert!(release.assets.is_empty());
+    }
+
+    #[test]
+    fn test_release_deserialize_empty_assets() {
+        let json = r#"{"tag_name": "v3.0.0", "assets": []}"#;
+        let release: Release = serde_json::from_str(json).unwrap();
+        assert_eq!(release.tag_name, "v3.0.0");
+        assert!(release.assets.is_empty());
+    }
+
+    #[test]
+    fn test_release_deserialize_ignores_extra_fields() {
+        let json = r#"{
+            "tag_name": "v1.0.0",
+            "id": 12345,
+            "draft": false,
+            "prerelease": false,
+            "assets": []
+        }"#;
+        let release: Release = serde_json::from_str(json).unwrap();
+        assert_eq!(release.tag_name, "v1.0.0");
+    }
+
+    #[test]
+    fn test_release_list_deserialize() {
+        let json = r#"[
+            {"tag_name": "v2.0.0", "assets": []},
+            {"tag_name": "v1.0.0", "assets": [{"name": "tool"}]}
+        ]"#;
+        let releases: Vec<Release> = serde_json::from_str(json).unwrap();
+        assert_eq!(releases.len(), 2);
+        assert!(releases[0].assets.is_empty());
+        assert_eq!(releases[1].assets[0].name, "tool");
+    }
+
+    #[test]
+    fn test_prerelease_releases_are_skipped() {
+        // prerelease/main should be skipped; v1.0.0 is the first stable release with the artifact.
+        let releases = vec![
+            Release {
+                tag_name: "prerelease/main".to_string(),
+                prerelease: true,
+                assets: vec![ReleaseArtifact {
+                    name: "tool".to_string(),
+                }],
+            },
+            Release {
+                tag_name: "v1.0.0".to_string(),
+                prerelease: false,
+                assets: vec![ReleaseArtifact {
+                    name: "tool".to_string(),
+                }],
+            },
+        ];
+        let found = releases
+            .into_iter()
+            .find(|r| !r.prerelease && r.assets.iter().any(|a| a.name == "tool"));
+        assert_eq!(found.unwrap().tag_name, "v1.0.0");
+    }
+
+    #[test]
+    fn test_release_deserialize_prerelease_field() {
+        let json =
+            r#"{"tag_name": "prerelease/main", "prerelease": true, "assets": [{"name": "tool"}]}"#;
+        let release: Release = serde_json::from_str(json).unwrap();
+        assert!(release.prerelease);
+        assert_eq!(release.tag_name, "prerelease/main");
+    }
+
+    #[test]
+    fn test_release_deserialize_prerelease_defaults_false() {
+        let json = r#"{"tag_name": "v1.0.0"}"#;
+        let release: Release = serde_json::from_str(json).unwrap();
+        assert!(!release.prerelease);
+    }
+
+    #[test]
+    fn test_headermap_from_hashmap() {
+        let headers = vec![
+            ("Content-Type", "application/json"),
+            ("Authorization", "Bearer token"),
+        ];
+        let map = headermap_from_hashmap(headers.into_iter());
+        assert_eq!(map.get("content-type").unwrap(), "application/json");
+        assert_eq!(map.get("authorization").unwrap(), "Bearer token");
+    }
+
+    #[test]
+    fn test_headermap_from_hashmap_empty() {
+        let headers: Vec<(&str, &str)> = vec![];
+        let map = headermap_from_hashmap(headers.into_iter());
+        assert!(map.is_empty());
+    }
+
+    // Helpers that mirror the production code's URL/path construction so the
+    // tests below exercise exactly the same logic.
+    fn make_cache(root: &std::path::Path) -> AspectCache {
+        AspectCache::from(root.to_path_buf())
+    }
+
+    fn binary_cache_path(
+        cache: &AspectCache,
+        org: &str,
+        repo: &str,
+        tag: &str,
+        artifact: &str,
+    ) -> PathBuf {
+        let url = format!("https://github.com/{org}/{repo}/releases/download/{tag}/{artifact}");
+        cache.tool_path(&"aspect-cli".to_string(), &url)
+    }
+
+    /// Create a temp dir scoped to this test process so parallel test runs don't collide.
+    fn tmp_cache_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "aspect-launcher-test-{}-{}",
+            std::process::id(),
+            label
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_cache_hint_fresh_and_binary_present_skips_api() {
+        let tmp = tmp_cache_dir("hint-hit");
+        let cache = make_cache(&tmp);
+
+        let org = "aspect-build";
+        let repo = "aspect-cli";
+        let artifact = "aspect-cli-aarch64-apple-darwin";
+        let tag = "v2026.15.2";
+
+        // Write the tag hint (as the production code does after a successful API call).
+        let hint = cache.latest_tag_path("aspect-cli", org, repo, artifact);
+        std::fs::create_dir_all(hint.parent().unwrap()).unwrap();
+        std::fs::write(&hint, tag).unwrap();
+
+        // Hint must be fresh for the production code to use it.
+        assert!(cache.latest_tag_is_fresh(&hint, std::time::Duration::from_secs(86400)));
+
+        // Reconstruct the binary path from the hint — mirrors the production check.
+        let cached_tag = std::fs::read_to_string(&hint).unwrap();
+        let cached_tag = cached_tag.trim();
+        let dest = binary_cache_path(&cache, org, repo, cached_tag, artifact);
+
+        // Binary not present yet — hint alone is not enough.
+        assert!(!dest.exists());
+
+        // Simulate a previously downloaded binary.
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        std::fs::write(&dest, b"fake binary").unwrap();
+
+        // Fresh hint + binary present: production code returns early, no API call.
+        assert!(dest.exists());
+        assert_eq!(cached_tag, tag);
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn test_stale_hint_with_binary_falls_back_on_api_failure() {
+        let tmp = tmp_cache_dir("hint-stale");
+        let cache = make_cache(&tmp);
+
+        let org = "aspect-build";
+        let repo = "aspect-cli";
+        let artifact = "aspect-cli-aarch64-apple-darwin";
+        let tag = "v2026.15.2";
+
+        // Write a hint that is immediately stale (zero max-age).
+        let hint = cache.latest_tag_path("aspect-cli", org, repo, artifact);
+        std::fs::create_dir_all(hint.parent().unwrap()).unwrap();
+        std::fs::write(&hint, tag).unwrap();
+        assert!(!cache.latest_tag_is_fresh(&hint, std::time::Duration::ZERO));
+
+        // Write a binary for the stale tag.
+        let dest = binary_cache_path(&cache, org, repo, tag, artifact);
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        std::fs::write(&dest, b"fake binary").unwrap();
+
+        // The stale hint + existing binary should be usable as a fallback when the
+        // API fails. After using it, touch_latest_tag resets the expiry.
+        cache.touch_latest_tag(&hint);
+        assert!(cache.latest_tag_is_fresh(&hint, std::time::Duration::from_secs(86400)));
+        assert!(dest.exists());
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn test_cache_hint_present_but_binary_missing_falls_through_to_api() {
+        let tmp = tmp_cache_dir("hint-miss");
+        let cache = make_cache(&tmp);
+
+        let org = "aspect-build";
+        let repo = "aspect-cli";
+        let artifact = "aspect-cli-aarch64-apple-darwin";
+        let tag = "v2026.15.2";
+
+        // Write the tag hint but do NOT create the binary.
+        let hint = cache.latest_tag_path("aspect-cli", org, repo, artifact);
+        std::fs::create_dir_all(hint.parent().unwrap()).unwrap();
+        std::fs::write(&hint, tag).unwrap();
+
+        let cached_tag = std::fs::read_to_string(&hint).unwrap();
+        let dest = binary_cache_path(&cache, org, repo, cached_tag.trim(), artifact);
+
+        // Binary missing → production code must fall through to the API.
+        assert!(!dest.exists());
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn test_no_cache_hint_falls_through_to_api() {
+        let tmp = tmp_cache_dir("no-hint");
+        let cache = make_cache(&tmp);
+
+        let hint = cache.latest_tag_path(
+            "aspect-cli",
+            "aspect-build",
+            "aspect-cli",
+            "aspect-cli-aarch64-apple-darwin",
+        );
+
+        // No hint written → production code must query the API.
+        assert!(!hint.exists());
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn test_cache_hint_is_overwritten_on_new_resolution() {
+        let tmp = tmp_cache_dir("hint-update");
+        let cache = make_cache(&tmp);
+
+        let hint = cache.latest_tag_path("aspect-cli", "aspect-build", "aspect-cli", "artifact");
+        std::fs::create_dir_all(hint.parent().unwrap()).unwrap();
+
+        std::fs::write(&hint, "v2026.14.0").unwrap();
+        assert_eq!(std::fs::read_to_string(&hint).unwrap().trim(), "v2026.14.0");
+
+        // Simulate a newer resolution overwriting the old hint.
+        std::fs::write(&hint, "v2026.15.2").unwrap();
+        assert_eq!(std::fs::read_to_string(&hint).unwrap().trim(), "v2026.15.2");
+
+        std::fs::remove_dir_all(&tmp).unwrap();
     }
 }


### PR DESCRIPTION
Currently the release fetcher fails if it finds a release without any assets. This is possible is you happen to check the latest release mid-release when it doesn't have any assets yet. This improves the code so that it falls back to the latest release that has an asset to download when searching.

## Before

The GitHub source handler had a single code path for both pinned and unpinned versions:

1. Compute tag as `v{version}` — for unpinned, `version` was always the launcher's own compiled-in version
2. Query the GitHub API for that specific release: `GET /repos/{org}/{repo}/releases/tags/{tag}`
3. Find the matching artifact in the response's `assets` array
4. Download via the API asset URL (`api.github.com/.../assets/{id}`)

**Problems:**

- The `Release` struct required the `assets` field, but GitHub sometimes omits it → `missing field 'assets'` deserialization error
- Unpinned versions were tied to the launcher's compiled-in version rather than discovering the latest available release
- No handling for the release-in-progress window where a tag exists but assets haven't been uploaded yet
- A `version_pinned` boolean was threaded through `ToolSpec` / `AspectCliConfig` but both paths used the same download logic

## After

The GitHub source handler is now split into two clean steps — **resolve**, then **download**:

**Step 1 — Resolve the tag:**

- **Pinned** (`version = Some("2026.11.6")` from `version.axl`): compute the tag directly (e.g. `v2026.11.6`). No API call.
- **Unpinned** (`version = None` — no `version.axl`, or `version()` with no positional arg): query `GET /repos/{org}/{repo}/releases?per_page=10`, scan the most recent releases, and pick the first one whose `assets` contain the matching artifact.

**Step 2 — Download using the resolved tag:**

Both paths now have a concrete tag and use the same direct download URL:
`https://github.com/{org}/{repo}/releases/download/{resolved_tag}/{artifact}`

**What this fixes:**

- `assets` now has `#[serde(default)]`, so releases with missing or empty assets are skipped instead of causing a deserialization error
- Unpinned versions discover the latest available release instead of guessing based on the launcher's compiled-in version
- The release-in-progress window is handled gracefully — releases without the matching artifact are skipped in favor of the next one
- The `version_pinned` boolean is removed; `version: Option<String>` on `ToolSpec` naturally encodes the distinction (`Some` = pinned, `None` = resolve from API)
- The cache key is now based on the direct download URL (which includes the resolved tag), so different versions cache independently
