### PR TITLE
fix: ctx.bazel.query inherits startup_flags

### DIFF
--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -387,8 +387,9 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///     .kind("source file")
     ///     .eval()
     /// ```
-    fn query<'v>(#[allow(unused)] this: values::Value<'v>) -> anyhow::Result<query::Query> {
-        Ok(query::Query::new())
+    fn query<'v>(this: values::Value<'v>) -> anyhow::Result<query::Query> {
+        let startup_flags = read_startup_flags(this)?;
+        Ok(query::Query::new(startup_flags))
     }
 
     /// Run `bazel info` and return all key/value pairs as a dict.

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -146,17 +146,21 @@ impl<'v> values::StarlarkValue<'v> for TargetSet {
 pub struct Query {
     #[allocative(skip)]
     expr: RefCell<String>,
+    #[allocative(skip)]
+    startup_flags: Vec<String>,
 }
 
 impl Query {
-    pub fn new() -> Self {
+    pub fn new(startup_flags: Vec<String>) -> Self {
         Self {
             expr: RefCell::new(String::new()),
+            startup_flags,
         }
     }
 
-    pub fn query(expr: &str) -> anyhow::Result<TargetSet> {
+    pub fn query(expr: &str, startup_flags: &[String]) -> anyhow::Result<TargetSet> {
         let mut cmd = Command::new(super::bazel_binary());
+        cmd.args(startup_flags);
         cmd.arg("query");
         cmd.arg(expr);
         cmd.arg("--output=streamed_proto");
@@ -233,9 +237,10 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
         this: values::Value<'v>,
         #[starlark(require = pos)] expr: values::StringValue,
     ) -> anyhow::Result<Query> {
-        let _query = this.downcast_ref_err::<Query>().into_anyhow_result()?;
+        let query = this.downcast_ref_err::<Query>().into_anyhow_result()?;
         Ok(Query {
             expr: RefCell::new(expr.as_str().to_string()),
+            startup_flags: query.startup_flags.clone(),
         })
     }
 
@@ -263,6 +268,6 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     fn eval<'v>(this: values::Value<'v>) -> anyhow::Result<TargetSet> {
         let this = this.downcast_ref_err::<Query>().into_anyhow_result()?;
         let expr = this.expr.borrow();
-        Query::query(&expr)
+        Query::query(&expr, &this.startup_flags)
     }
 }


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

Testing needed