### PR TITLE
Unify args & attrs + AXL naming conventions (snake_case tasks, CamelCase features/traits, kebab-case CLI)

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -1,5 +1,4 @@
 load("./lambda.axl", "lambda_with_global_bind")
-load("./user-task.axl", "UserTaskConfig")
 
 def _user_task_impl(ctx: TaskContext) -> int:
     print("I am a task added by .aspect/config.axl")
@@ -19,11 +18,12 @@ def config(ctx: ConfigContext):
     # assert we can call a lambda with a global bind from another module in a config script
     lambda_with_global_bind()("assert")
 
-    # Configure the UserTaskConfig trait globally
-    user_config = ctx.traits[UserTaskConfig]
-    user_config.message = "hello axl"
-    user_config.count = 2
-    user_config.customize_message = lambda s: _customize_message(s, "!")
-
     # add a new task
     ctx.tasks.add(_user_task)
+
+    # configure user_task's attrs by path (group/name).
+    t = ctx.tasks["user/nested/user-task"]
+    t.args.message = "hello axl"
+    t.args.run_count = 2
+    t.args.customize_message = lambda s: _customize_message(s, "!")
+

--- a/.aspect/user-task.axl
+++ b/.aspect/user-task.axl
@@ -1,31 +1,26 @@
 load("./lambda.axl", "lambda_with_global_bind")
 
-UserTaskConfig = trait(
-    message=attr(str, "hello world"),
-    count=attr(int, 1),
-    customize_message = attr(typing.Callable[[str], str], lambda s: s),
-)
-
 def _impl(ctx: TaskContext) -> int:
     print("I am a task that is auto-discovered as it is defined in an .axl file in the root of the root .aspect directory")
 
     # assert we can call a lambda with a global bind from another module in a task script
     lambda_with_global_bind()("assert")
 
-    # do something that makes uses the task config
-    config = ctx.traits[UserTaskConfig]
     print(ctx)
-    print(config)
-    print(config.count)
-    print(config.message)
-    print(config.customize_message)
-    for i in range(config.count):
-        print(config.customize_message(config.message))
+    print(ctx.args.run_count)
+    print(ctx.args.message)
+    print(ctx.args.customize_message)
+    for i in range(ctx.args.run_count):
+        msg = ctx.args.customize_message(ctx.args.message) if ctx.args.customize_message != None else ctx.args.message
+        print(msg)
     return 0
 
 user_task = task(
     group = ["user", "nested"],
     implementation = _impl,
-    args = {},
-    traits = [UserTaskConfig],
+    args = {
+        "message": args.custom(str, default = "hello world", description = "The message string to print on each iteration"),
+        "run_count": args.int(default = 1, description = "Number of times to print the message", short = "r", long = "run_count"),
+        "customize_message": args.custom(typing.Callable[[str], str], default = lambda s: s, description = "Transform applied to the message before printing; receives and returns a string"),
+    },
 )

--- a/.aspect/user/user-task-manual.axl
+++ b/.aspect/user/user-task-manual.axl
@@ -3,7 +3,7 @@ def _impl(ctx: TaskContext) -> int:
     return 0
 
 user_task_manual = task(
-    name = "user-task-manual",
+    name = "user-task-man",
     group = ["user"],
     implementation = _impl,
     args = {},

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -79,12 +79,12 @@ steps:
       CLI=$$WORKSPACE_ROOT/$$(bazel $$BAZEL_STARTUP_OPTS cquery $$BAZEL_BUILD_OPTS --output=files //crates/aspect-cli)
       echo "--- :aspect: aspect demo template-demo"
       $$LAUNCHER demo template-demo
-      echo "--- :aspect: aspect user nested user_task"
-      $$LAUNCHER user nested user_task
-      echo "--- :aspect: aspect user nested user_task_reexport"
-      $$LAUNCHER user nested user_task_reexport
-      echo "--- :aspect: aspect user user-task-manual"
-      $$LAUNCHER user user-task-manual
+      echo "--- :aspect: aspect user nested user=task"
+      $$LAUNCHER user nested user-task --run_count 5
+      echo "--- :aspect: aspect user nested user-task-reexport"
+      $$LAUNCHER user nested user-task-reexport
+      echo "--- :aspect: aspect user user-task-man"
+      $$LAUNCHER user user-task-man
       echo "--- :aspect: aspect user user-task-added-by-config"
       $$LAUNCHER user user-task-added-by-config
       echo "--- :aspect: aspect user user-task-subdir (in crates/aspect-cli)"
@@ -206,5 +206,5 @@ steps:
         - exit_status: 78 # unhealthy signal from .buildkite/hooks/pre-command
           limit: 1
     command: |
-      ASPECT_DEBUG=1 aspect delivery --build_url $BUILDKITE_BUILD_URL --commit_sha $BUILDKITE_COMMIT //examples/deliverable
-      aspect delivery --task-key delivery-bk --build_url $BUILDKITE_BUILD_URL --commit_sha $BUILDKITE_COMMIT  //examples/deliverable
+      ASPECT_DEBUG=1 aspect delivery --build-url $BUILDKITE_BUILD_URL --commit-sha $BUILDKITE_COMMIT //examples/deliverable
+      aspect delivery --task-key delivery-bk --build-url $BUILDKITE_BUILD_URL --commit-sha $BUILDKITE_COMMIT  //examples/deliverable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           command: .aspect/bootstrap.sh
       - run:
           name: Delivery Task (ASPECT_DEBUG=1)
-          command: ASPECT_DEBUG=1 aspect delivery --build_url $CIRCLE_BUILD_URL --commit_sha $CIRCLE_SHA1 //examples/deliverable
+          command: ASPECT_DEBUG=1 aspect delivery --build-url $CIRCLE_BUILD_URL --commit-sha $CIRCLE_SHA1 //examples/deliverable
       - run:
           name: Delivery Task
-          command: aspect delivery --task-key delivery-cci --build_url $CIRCLE_BUILD_URL --commit_sha $CIRCLE_SHA1 //examples/deliverable
+          command: aspect delivery --task-key delivery-cci --build-url $CIRCLE_BUILD_URL --commit-sha $CIRCLE_SHA1 //examples/deliverable

--- a/.github/workflows/aspect-workflows.yaml
+++ b/.github/workflows/aspect-workflows.yaml
@@ -55,6 +55,6 @@ jobs:
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Delivery Task (ASPECT_DEBUG=1)
-        run: ASPECT_DEBUG=1 aspect delivery --build_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" --commit_sha $GITHUB_SHA //examples/deliverable
+        run: ASPECT_DEBUG=1 aspect delivery --build-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" --commit-sha $GITHUB_SHA //examples/deliverable
       - name: Delivery Task
-        run: aspect delivery --task-key delivery-gha --build_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" --commit_sha $GITHUB_SHA //examples/deliverable
+        run: aspect delivery --task-key delivery-gha --build-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" --commit-sha $GITHUB_SHA //examples/deliverable

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,5 +45,5 @@ delivery-task:
     - aspect-default
   script:
     - .aspect/bootstrap.sh
-    - ASPECT_DEBUG=1 aspect delivery --build_url $CI_PIPELINE_URL --commit_sha $CI_COMMIT_SHA //examples/deliverable
-    - aspect delivery --task-key delivery-gl --build_url $CI_PIPELINE_URL --commit_sha $CI_COMMIT_SHA //examples/deliverable
+    - ASPECT_DEBUG=1 aspect delivery --build-url $CI_PIPELINE_URL --commit-sha $CI_COMMIT_SHA //examples/deliverable
+    - aspect delivery --task-key delivery-gl --build-url $CI_PIPELINE_URL --commit-sha $CI_COMMIT_SHA //examples/deliverable

--- a/crates/aspect-cli/src/builtins/aspect/MODULE.aspect
+++ b/crates/aspect-cli/src/builtins/aspect/MODULE.aspect
@@ -7,6 +7,6 @@ use_task("test.axl", "test")
 use_task("axl_add.axl", "add")
 use_task("delivery.axl", "delivery")
 
-use_feature("feature/defaults.axl", "bazel_defaults")
+use_feature("feature/defaults.axl", "BazelDefaults")
 use_feature("feature/artifacts.axl", "ArtifactUpload")
 use_feature("feature/gh_status_checks.axl", "GithubStatusChecks")

--- a/crates/aspect-cli/src/builtins/aspect/axl_add.axl
+++ b/crates/aspect-cli/src/builtins/aspect/axl_add.axl
@@ -330,7 +330,7 @@ def impl(ctx: TaskContext) -> int:
 
 add = task(
     group = ["axl"],
-    description = "Add an AXL dependency to MODULE.aspect",
+    summary = "Add an AXL dependency to MODULE.aspect",
     implementation = impl,
     args = {
         "dep_spec": args.positional(),

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1,5 +1,5 @@
 """
-Delivery task that coordinates artifact delivery via deliveryd.
+Delivery task that coordinates artifact delivery.
 
 Delivers each target via bazel run with stamping enabled, and signs artifacts
 to prevent re-delivery.
@@ -415,13 +415,16 @@ def _delivery_impl(ctx):
 
 delivery = task(
     name = "delivery",
-    description = "Build and deliver binary targets via deliveryd. Targets are built with stamping, deduplicated by action digest, and delivered exactly once per commit unless forced.",
+    summary = "Build and deliver binary targets. Targets are built with stamping, deduplicated by action digest, and delivered exactly once per commit unless forced.",
+    description = """Build and deliver binary targets. Targets are built with stamping, deduplicated by action digest, and delivered exactly once per commit unless forced.
+    
+Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support for generic CI runners is planned. Contact Aspect support <support@aspect.build> for more info.""",
     implementation = _delivery_impl,
     traits = [BazelTrait, DeliveryTrait, HealthCheckTrait],
     args = {
         "ci_host": args.string(
             default = "bk",
-            description = "CI host identifier reported to deliveryd (e.g. bk, gh, circle).",
+            description = "CI host identifier (e.g. bk, gh, circle).",
         ),
         "commit_sha": args.string(
             required = True,

--- a/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
@@ -192,6 +192,8 @@ def _artifact_upload_impl(ctx: FeatureContext):
 
 
 ArtifactUpload = feature(
+    display_name = "Artifact Upload",
+    summary = "Automatically upload build artifacts to CI. Supports GitHub Actions, Buildkite, CircleCI, and GitLab.",
     implementation = _artifact_upload_impl,
-    attrs = {}
+    args = {}
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
@@ -50,7 +50,7 @@ def _default_bazel_behavior(ctx: FeatureContext):
         bazel_trait.build_event_sinks.extend(bessie_sinks)
 
 
-bazel_defaults = feature(
+BazelDefaults = feature(
     implementation = _default_bazel_behavior,
-    attrs = {}
+    args = {}
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/gh_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gh_status_checks.axl
@@ -41,5 +41,10 @@ def _github_status_checks(ctx: FeatureContext):
 
 GithubStatusChecks = feature(
     implementation = _github_status_checks,
-    attrs = {}
+    args = {
+        "mode": args.string(
+            default = "ci-only",
+            description = "When to create GitHub Status Checks",
+        ),
+    },
 )

--- a/crates/aspect-cli/src/builtins/aspect/traits.axl
+++ b/crates/aspect-cli/src/builtins/aspect/traits.axl
@@ -4,31 +4,31 @@ load("./bazel.axl", "default_retry")
 
 BazelTrait = trait(
     # Declarative data — composable, zero-cost reads
-    extra_flags = attr(list[str], []),
-    extra_startup_flags = attr(list[str], []),
-    build_event_sinks = attr(list[bazel.build.BuildEventSink], []),
-    execution_log_sinks = attr(list[bazel.execution_log.ExecLogSink], []),
+    extra_flags = attr(list[str], default = [], description = "Additional Bazel flags appended to every build/test invocation"),
+    extra_startup_flags = attr(list[str], default = [], description = "Additional Bazel startup flags prepended before the command"),
+    build_event_sinks = attr(list[bazel.build.BuildEventSink], default = [], description = "Build Event Protocol sinks to stream events to during the build"),
+    execution_log_sinks = attr(list[bazel.execution_log.ExecLogSink], default = [], description = "Execution log sinks to receive the Bazel execution log after the build"),
 
     # Optional transforms — only called when set
-    flags = attr(typing.Callable[[list[str]], list[str]] | None, None),
-    startup_flags = attr(typing.Callable[[list[str]], list[str]] | None, None),
+    flags = attr(typing.Callable[[list[str]], list[str]] | None, default = None, description = "Transform function called with the full flag list; return value replaces the list"),
+    startup_flags = attr(typing.Callable[[list[str]], list[str]] | None, default = None, description = "Transform function called with the full startup flag list; return value replaces the list"),
 
     # Lifecycle hooks — lists of callables; callers close over their own state
-    build_start = attr(list[typing.Callable[[TaskContext], None]], []),
-    build_event = attr(list[typing.Callable[[TaskContext, dict], None]], []),
-    build_retry = attr(typing.Callable[[int], bool], default_retry),
-    build_end = attr(list[typing.Callable[[TaskContext, int], None]], []),
+    build_start = attr(list[typing.Callable[[TaskContext], None]], default = [], description = "Hooks called once before the Bazel invocation starts"),
+    build_event = attr(list[typing.Callable[[TaskContext, dict], None]], default = [], description = "Hooks called for each Build Event Protocol event received during the build"),
+    build_retry = attr(typing.Callable[[int], bool], default = default_retry, description = "Predicate called with the exit code; return True to retry the build"),
+    build_end = attr(list[typing.Callable[[TaskContext, int], None]], default = [], description = "Hooks called once after the Bazel invocation completes, with the exit code"),
 )
 
 
 HealthCheckTrait = trait(
-    pre_health_check = attr(list[typing.Callable[[TaskContext], None]], []),
-    post_health_check = attr(list[typing.Callable[[TaskContext], str | None]], []),
+    pre_health_check = attr(list[typing.Callable[[TaskContext], None]], default = [], description = "Hooks called before the build to validate preconditions (e.g. auth, connectivity)"),
+    post_health_check = attr(list[typing.Callable[[TaskContext], str | None]], default = [], description = "Hooks called after the build; return a non-None string to report a warning"),
 )
 
 
 DeliveryTrait = trait(
-    delivery_start = attr(typing.Callable[[], None], lambda: None),
-    delivery_end = attr(typing.Callable[[], None], lambda: None),
-    deliver_target = attr(typing.Callable[[str, bool], None], lambda label, is_forced: None),
+    delivery_start = attr(typing.Callable[[], None], default = lambda: None, description = "Hook called once at the start of a delivery run, before any targets are delivered"),
+    delivery_end = attr(typing.Callable[[], None], default = lambda: None, description = "Hook called once at the end of a delivery run, after all targets are delivered"),
+    deliver_target = attr(typing.Callable[[str, bool], None], default = lambda label, is_forced: None, description = "Hook called for each target being delivered; receives the label and a forced-delivery flag"),
 )

--- a/crates/aspect-cli/src/cmd_tree.rs
+++ b/crates/aspect-cli/src/cmd_tree.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
+use axl_runtime::engine::arg::Arg;
 use axl_runtime::engine::task::{MAX_TASK_GROUPS, TaskLike};
-use clap::{Arg, ArgMatches, Command, value_parser};
+use axl_runtime::engine::types::feature::to_display_name;
+use clap::{Arg as ClapArg, ArgMatches, Command, value_parser};
+use starlark::collections::SmallMap;
 use thiserror::Error;
 
 const TASK_ID: &'static str = "@@@$'__AXL_TASK_ID__'$@@@";
@@ -51,14 +54,14 @@ impl CommandTree {
         name: &str,
         group: &[String],
         subgroup: &[String],
-        path: &String,
+        path: &str,
         cmd: Command,
     ) -> Result<(), TreeError> {
         if group.len() > MAX_TASK_GROUPS {
             // This error is a defence-in-depth as the task evaluator should check for MAX_TASK_GROUPS
             return Err(TreeError::TooManyGroups(
                 name.to_string(),
-                path.clone(),
+                path.to_owned(),
                 MAX_TASK_GROUPS,
             ));
         }
@@ -67,14 +70,14 @@ impl CommandTree {
                 return Err(TreeError::TaskGroupConflict(
                     name.to_string(),
                     group.to_vec(),
-                    path.clone(),
+                    path.to_owned(),
                 ));
             }
             if self.tasks.insert(name.to_string(), cmd).is_some() {
                 return Err(TreeError::TaskConflict(
                     name.to_string(),
                     group.to_vec(),
-                    path.clone(),
+                    path.to_owned(),
                 ));
             }
         } else {
@@ -84,7 +87,7 @@ impl CommandTree {
                     first.clone(),
                     name.to_string(),
                     group.to_vec(),
-                    path.clone(),
+                    path.to_owned(),
                 ));
             }
             let subtree = self.subgroups.entry(first.clone()).or_default();
@@ -116,10 +119,7 @@ impl CommandTree {
                 template.push_str("\n\n\x1b[1;4mTask Groups:\x1b[0m\n");
                 for gname in &sub_group_names {
                     let padding = " ".repeat(max_len - gname.len() + 2);
-                    template.push_str(&format!(
-                        "  \x1b[1m{}\x1b[0m{}\x1b[3m{}\x1b[0m task group\n",
-                        gname, padding, gname
-                    ));
+                    template.push_str(&format!("  \x1b[1m{}\x1b[0m{}task group\n", gname, padding));
                 }
             }
 
@@ -169,27 +169,70 @@ impl CommandTree {
     }
 }
 
+/// Build a Clap subcommand for a task, including any args contributed by active features.
+///
+/// `feature_args` is a slice of `(args_map, heading, description_line, prefix)` tuples —
+/// one per feature that declares CLI args. Each feature's args are prefixed with the
+/// feature's kebab name (`prefix`) and grouped under a Clap help heading.
+///
+/// `effective_defaults` maps CLI arg names to their post-config.axl effective default
+/// strings, overriding the task definition defaults in `--help`.
 pub fn make_command_from_task(
     name: &String,
     defined_in: &str,
     indice: String,
     task: &dyn TaskLike<'_>,
+    feature_args: &[(SmallMap<String, Arg>, String, String, String)],
+    effective_defaults: &HashMap<String, Vec<String>>,
 ) -> Command {
-    // Generate a default task description if none was provided by task
-    let about = if task.description().is_empty() {
-        format!(
-            "\x1b[3m{}\x1b[0m task defined in \x1b[3m{}\x1b[0m",
-            name, defined_in,
-        )
+    let task_display = if !task.display_name().is_empty() {
+        task.display_name().clone()
     } else {
-        task.description().clone()
+        to_display_name(name)
+    };
+
+    let context_line = format!(
+        "\x1b[3m{}\x1b[0m task defined in \x1b[3m{}\x1b[0m",
+        name, defined_in,
+    );
+    // `about` — single-line shown in the task list (and in --help when no custom template).
+    // We avoid `long_about`/`before_long_help`/`after_long_help` entirely: setting any of those
+    // switches Clap into "long help" mode for `--help`, which renders all option descriptions on
+    // separate lines with extra blank lines between flags (verbose format).
+    //
+    // Instead, when there is a description or a summary+context to show in `--help`, we build a
+    // custom help_template that hardcodes the header text and keeps compact option rendering.
+    //
+    //   summary  description  | about (list)   --help header
+    //   -------  -----------  | ------------   -------------
+    //   unset    unset        | context_line   (no custom template — about reused)
+    //   set      unset        | summary        summary + blank + context_line
+    //   set      set          | summary        description + blank + context_line
+    //   unset    set          | context_line   description + blank + context_line
+    let about = if task.summary().is_empty() {
+        context_line.clone()
+    } else {
+        task.summary().clone()
+    };
+
+    // Build the header shown at the top of `--help`, or None to use the default (about).
+    let help_header: Option<String> = if task.summary().is_empty() && task.description().is_empty()
+    {
+        None
+    } else {
+        let body = if !task.description().is_empty() {
+            task.description().clone()
+        } else {
+            task.summary().clone()
+        };
+        Some(format!("{}\n\n{}", body, context_line))
     };
 
     let mut cmd = Command::new(name)
         .about(about)
         .display_order(TASK_COMMAND_DISPLAY_ORDER)
         .arg(
-            Arg::new(TASK_ID)
+            ClapArg::new(TASK_ID)
                 .long(TASK_ID)
                 .hide(true)
                 .hide_default_value(true)
@@ -200,9 +243,70 @@ pub fn make_command_from_task(
                 .default_value(indice),
         );
 
-    for (name, arg) in task.args() {
-        let arg = crate::flags::convert_arg(&name, arg);
-        cmd = cmd.arg(arg);
+    for (arg_name, arg) in task.cli_args() {
+        let heading = format!("{} Options", task_display);
+        let long_name = match arg.long_override() {
+            Some(lo) => lo.to_string(),
+            None => arg_name.replace('_', "-"),
+        };
+        let mut clap_arg =
+            crate::flags::convert_arg(arg_name, &long_name, arg).help_heading(heading);
+        if let Some(effective) = effective_defaults.get(arg_name) {
+            clap_arg = match arg {
+                Arg::StringList { .. }
+                | Arg::BooleanList { .. }
+                | Arg::IntList { .. }
+                | Arg::UIntList { .. }
+                | Arg::TrailingVarArgs { .. } => clap_arg.default_values(effective.clone()),
+                _ => {
+                    // Scalar args always produce a single-element vec; use first() defensively.
+                    if let Some(v) = effective.first() {
+                        clap_arg.default_value(v.clone())
+                    } else {
+                        clap_arg
+                    }
+                }
+            };
+        }
+        cmd = cmd.arg(clap_arg);
+    }
+
+    for (args, heading, description_line, prefix) in feature_args {
+        let full_heading = if description_line.is_empty() {
+            heading.clone()
+        } else {
+            // Clap always appends ":\n" after the heading string, so the colon lands
+            // at the end of the description line. We manually add the colon after the
+            // section title on the first line to keep it looking like a normal heading.
+            format!("{}:\n{}", heading, description_line)
+        };
+        for (arg_name, arg) in args.iter() {
+            // If the arg has an explicit long override, use it directly (no prefix).
+            // Otherwise prefix with the feature's kebab name so args never collide:
+            // `mode` in `artifact-upload` becomes `--artifact-upload:mode`.
+            let clap_id = if let Some(lo) = arg.long_override() {
+                lo.to_string()
+            } else {
+                let long_form = arg_name.replace('_', "-");
+                if prefix.is_empty() {
+                    long_form
+                } else {
+                    format!("{}:{}", prefix, long_form)
+                }
+            };
+            let clap_arg = crate::flags::convert_arg(&clap_id, &clap_id, arg)
+                .help_heading(full_heading.clone());
+            cmd = cmd.arg(clap_arg);
+        }
+    }
+
+    // Apply a custom help template when we have header content beyond the one-line `about`.
+    // The template hardcodes the header so Clap never enters "long help" mode, keeping
+    // option rendering compact (descriptions inline, no blank lines between flags).
+    if let Some(header) = help_header {
+        cmd = cmd.help_template(format!(
+            "{header}\n\n{{usage-heading}} {{usage}}\n\n{{all-args}}\n"
+        ));
     }
 
     cmd

--- a/crates/aspect-cli/src/flags.rs
+++ b/crates/aspect-cli/src/flags.rs
@@ -1,23 +1,32 @@
-use axl_runtime::engine::task_arg::TaskArg;
+use axl_runtime::engine::arg::Arg;
 use clap::builder::{PossibleValuesParser, Resettable, StyledStr};
-use clap::{Arg, ArgAction, value_parser};
+use clap::{Arg as ClapArg, ArgAction, value_parser};
 
-pub(crate) fn convert_arg(name: &String, arg: &TaskArg) -> Arg {
+/// Build a Clap [`ClapArg`] from an [`Arg`] definition.
+///
+/// - `id` — the Clap internal identifier used to retrieve the value from `ArgMatches`
+///   (e.g. `"upload_bucket"` for task args, `"artifact-upload-mode"` for feature args).
+/// - `long_name` — the `--flag-name` shown on the CLI (e.g. `"upload-bucket"` or
+///   `"artifact-upload-mode"`).
+pub(crate) fn convert_arg(id: &str, long_name: &str, arg: &Arg) -> ClapArg {
     match arg {
-        TaskArg::String {
+        Arg::String {
             required,
             default,
             short,
             values,
             description,
+            ..
         } => {
-            let mut it = Arg::new(name)
-                .long(name)
-                .value_name(name)
+            // Clap requires 'static data for .long(), .value_name(), and .default_value(),
+            // so we pass owned Strings throughout.
+            let mut it = ClapArg::new(id.to_string())
+                .long(long_name.to_string())
+                .value_name(long_name.to_string())
                 .short(short_option(short))
                 .help(help_text(description))
-                .required(required.to_owned())
-                .default_value(default.to_string());
+                .required(*required)
+                .default_value(default.clone());
             if let Some(values) = values {
                 it = it.value_parser(PossibleValuesParser::new(values))
             } else {
@@ -25,99 +34,106 @@ pub(crate) fn convert_arg(name: &String, arg: &TaskArg) -> Arg {
             }
             it
         }
-        TaskArg::Boolean {
+        Arg::Boolean {
             required,
             default,
             short,
             description,
-        } => Arg::new(name)
-            .long(name)
-            .value_name(name)
+            ..
+        } => ClapArg::new(id.to_string())
+            .long(long_name.to_string())
+            .value_name(long_name.to_string())
             .short(short_option(short))
             .help(help_text(description))
-            .required(required.to_owned())
-            .default_value(default.to_string())
+            .required(*required)
+            // Use static string literals — no allocation, and Clap's bool parser expects lowercase.
+            .default_value(if *default { "true" } else { "false" })
             .value_parser(value_parser!(bool))
             .num_args(0..=1)
             .require_equals(true)
             .default_missing_value("true"),
-        TaskArg::Int {
+        Arg::Int {
             required,
             default,
             short,
             description,
-        } => Arg::new(name)
-            .long(name)
-            .value_name(name)
+            ..
+        } => ClapArg::new(id.to_string())
+            .long(long_name.to_string())
+            .value_name(long_name.to_string())
             .short(short_option(short))
             .help(help_text(description))
-            .required(required.to_owned())
+            .required(*required)
             .default_value(default.to_string())
             .value_parser(value_parser!(i32)),
-        TaskArg::UInt {
+        Arg::UInt {
             required,
             default,
             short,
             description,
-        } => Arg::new(name)
-            .long(name)
-            .value_name(name)
+            ..
+        } => ClapArg::new(id.to_string())
+            .long(long_name.to_string())
+            .value_name(long_name.to_string())
             .short(short_option(short))
             .help(help_text(description))
-            .required(required.to_owned())
+            .required(*required)
             .default_value(default.to_string())
             .value_parser(value_parser!(u32)),
-        TaskArg::Positional {
+        Arg::Positional {
             minimum,
             maximum,
             default,
             description,
         } => {
-            let mut it = Arg::new(name)
+            let mut it = ClapArg::new(id.to_string())
                 .value_parser(value_parser!(String))
-                .value_name(name)
+                .value_name(id.to_string())
                 .help(help_text(description))
-                .num_args(minimum.to_owned() as usize..=maximum.to_owned() as usize);
+                .num_args(*minimum as usize..=*maximum as usize);
             if let Some(default) = default {
                 it = it.default_values(default);
             }
             it
         }
-        TaskArg::TrailingVarArgs { description } => Arg::new(name)
+        Arg::TrailingVarArgs { description } => ClapArg::new(id.to_string())
             .value_parser(value_parser!(String))
-            .value_name(name)
+            .value_name(id.to_string())
             .help(help_text(description))
             .allow_hyphen_values(true)
             .last(true)
             .num_args(0..),
-        TaskArg::StringList {
+        Arg::StringList {
             required,
             default,
             short,
             description,
+            ..
         } => {
-            let mut it = Arg::new(name)
-                .long(name)
-                .value_name(name)
+            let mut it = ClapArg::new(id.to_string())
+                .long(long_name.to_string())
+                .value_name(long_name.to_string())
                 .short(short_option(short))
                 .help(help_text(description))
                 .action(ArgAction::Append)
                 .required(*required)
                 .value_parser(value_parser!(String));
             if !default.is_empty() {
-                it = it.default_values(default.clone());
+                // Pass an iterator of cloned Strings — avoids allocating an intermediate Vec.
+                it = it.default_values(default.iter().cloned());
             }
             it
         }
-        TaskArg::BooleanList {
+        Arg::BooleanList {
             required,
             default,
             short,
             description,
+            ..
         } => {
-            let mut it = Arg::new(name)
-                .long(name)
-                .value_name(name)
+            let mut it = ClapArg::new(id.to_string())
+                .long(long_name.to_string())
+                .value_name(long_name.to_string())
                 .short(short_option(short))
                 .help(help_text(description))
                 .action(ArgAction::Append)
@@ -126,50 +142,55 @@ pub(crate) fn convert_arg(name: &String, arg: &TaskArg) -> Arg {
                 .num_args(0..=1)
                 .default_missing_value("true");
             if !default.is_empty() {
-                let default: Vec<String> = default.iter().map(|&b| b.to_string()).collect();
-                it = it.default_values(default);
+                // Static string literals — no allocation, and Clap's bool parser expects lowercase.
+                it = it.default_values(default.iter().map(|&b| if b { "true" } else { "false" }));
             }
             it
         }
-        TaskArg::IntList {
+        Arg::IntList {
             required,
             default,
             short,
             description,
+            ..
         } => {
-            let mut it = Arg::new(name)
-                .long(name)
-                .value_name(name)
+            let mut it = ClapArg::new(id.to_string())
+                .long(long_name.to_string())
+                .value_name(long_name.to_string())
                 .short(short_option(short))
                 .help(help_text(description))
                 .action(ArgAction::Append)
                 .required(*required)
                 .value_parser(value_parser!(i32));
             if !default.is_empty() {
-                let default: Vec<String> = default.iter().map(|&i| i.to_string()).collect();
-                it = it.default_values(default);
+                it = it.default_values(default.iter().map(|i| i.to_string()));
             }
             it
         }
-        TaskArg::UIntList {
+        Arg::UIntList {
             required,
             default,
             short,
             description,
+            ..
         } => {
-            let mut it = Arg::new(name)
-                .long(name)
-                .value_name(name)
+            let mut it = ClapArg::new(id.to_string())
+                .long(long_name.to_string())
+                .value_name(long_name.to_string())
                 .short(short_option(short))
                 .help(help_text(description))
                 .action(ArgAction::Append)
                 .required(*required)
                 .value_parser(value_parser!(u32));
             if !default.is_empty() {
-                let default: Vec<String> = default.iter().map(|&u| u.to_string()).collect();
-                it = it.default_values(default);
+                it = it.default_values(default.iter().map(|u| u.to_string()));
             }
             it
+        }
+        Arg::Custom { .. } => {
+            // Custom args are config.axl-only and never exposed on the CLI.
+            // convert_arg should never be called with a Custom arg.
+            unreachable!("Custom args are not CLI-exposed")
         }
     }
 }

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -9,14 +9,21 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use aspect_telemetry::{cargo_pkg_short_version, do_not_track, send_telemetry};
+use axl_runtime::engine::arg::Arg;
+use axl_runtime::engine::cli_args::CliArgs;
 use axl_runtime::engine::config::ConfiguredTask;
-use axl_runtime::engine::task_arg::TaskArg;
-use axl_runtime::engine::task_args::TaskArgs;
+use axl_runtime::engine::types::feature::{
+    extract_feature_args, extract_feature_description, extract_feature_display_name,
+    extract_feature_identifier, extract_feature_name, extract_feature_summary,
+};
 use axl_runtime::eval::{self, ModuleEnv, ModuleScope, ModuleTaskSpec, MultiPhaseEval};
 use axl_runtime::module::AXL_ROOT_MODULE_NAME;
 use axl_runtime::module::{DiskStore, ModuleEvaluator};
-use clap::{Arg, ArgAction, Command};
+use clap::parser::ValueSource;
+use clap::{Arg as ClapArg, ArgAction, Command};
+use starlark::collections::SmallMap;
 use starlark::values::ValueLike;
+use starlark::values::list::ListRef;
 use tokio::task;
 use tokio::task::spawn_blocking;
 use tracing::info_span;
@@ -175,6 +182,68 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                 .eval_config(&configs, &task_values, &root_scope)
                 .map_err(anyhow::Error::from)?;
 
+            // Build feature flag specs for command help.
+            // Each entry is (args_map, heading, description_line, prefix); features with no args are skipped.
+            let feature_arg_specs_for_cmd: Vec<(SmallMap<String, Arg>, String, String, String)> =
+                mpe.feature_types_with_paths()
+                    .iter()
+                    .filter_map(|(_, val, path)| {
+                        let args = extract_feature_args(*val)?;
+                        if args.is_empty() {
+                            return None;
+                        }
+                        let display_name = extract_feature_display_name(*val).unwrap_or_default();
+                        let identifier = extract_feature_identifier(*val).unwrap_or_default();
+                        let rel_path = match path.strip_prefix(&repo_root) {
+                            Ok(p) => p.to_path_buf(),
+                            Err(_) => path.clone(),
+                        };
+                        let mut label = None;
+                        for (module_name, module_root) in &module_roots_for_clap {
+                            if path.starts_with(module_root) {
+                                if module_name == AXL_ROOT_MODULE_NAME {
+                                    continue;
+                                }
+                                let module_rel = match path.strip_prefix(module_root) {
+                                    Ok(p) => p.to_path_buf(),
+                                    Err(_) => path.clone(),
+                                };
+                                label = Some(format!("@{}//{}", module_name, module_rel.display()));
+                                break;
+                            }
+                        }
+                        let defined_in = label.unwrap_or_else(|| format!("{}", rel_path.display()));
+                        let heading = format!("{} Options", display_name);
+                        let user_summary = extract_feature_summary(*val).unwrap_or_default();
+                        let user_description =
+                            extract_feature_description(*val).unwrap_or_default();
+                        let context = format!(
+                            "\x1b[3m{}\x1b[0m feature defined in \x1b[3m{}\x1b[0m",
+                            identifier, defined_in
+                        );
+                        // Build the text shown under the section heading, following the same
+                        // matrix as tasks: summary → description → context line, blank-line separated.
+                        // Clap wraps the whole heading in bold+underline including \n continuations,
+                        // so \x1b[0m right after \n resets that before our indented lines.
+                        // \x1b[8m (conceal) hides the ":" clap appends after the heading.
+                        let body = if !user_description.is_empty() {
+                            user_description
+                        } else if !user_summary.is_empty() {
+                            user_summary
+                        } else {
+                            String::new()
+                        };
+                        let desc_text = if body.is_empty() {
+                            context
+                        } else {
+                            format!("{}\n\n      {}", body, context)
+                        };
+                        let description_line = format!("\x1b[0m      {}\n\x1b[8m", desc_text);
+                        let prefix = extract_feature_name(*val).unwrap_or_default();
+                        Some((args, heading, description_line, prefix))
+                    })
+                    .collect();
+
             // Build the command tree from ALL tasks (including dynamically added ones).
             let mut tree = CommandTree::default();
 
@@ -187,14 +256,14 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                 .version(cargo_pkg_short_version())
                 .disable_version_flag(true)
                 .arg(
-                    Arg::new("version")
+                    ClapArg::new("version")
                         .short('v')
                         .long("version")
                         .action(ArgAction::Version)
                         .help("Print version"),
                 )
                 .arg(
-                    Arg::new("task-key")
+                    ClapArg::new("task-key")
                         .long("task-key")
                         .value_name("KEY")
                         .global(true)
@@ -208,7 +277,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                         .help("A short key identifying this task invocation. Allowed characters: A-Za-z0-9, _, -. Useful when the same task runs multiple times in one pipeline (e.g. 'backend', 'frontend'). Auto-generated if not set."),
                 )
                 .arg(
-                    Arg::new("task-id")
+                    ClapArg::new("task-id")
                         .long("task-id")
                         .value_name("UUID")
                         .global(true)
@@ -265,7 +334,50 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                     format!("{}", rel_path.display())
                 };
 
-                let cmd = make_command_from_task(&name, &defined_in, i.to_string(), def);
+                // Compute effective defaults: config_overrides as typed string slices for Clap.
+                //
+                // Scalar values (string, int, bool) become a single-element Vec<String>.
+                // List values are expanded into their individual element strings.
+                // Booleans are lowercased because Clap's `value_parser!(bool)` expects
+                // "true"/"false" while Starlark's to_string() gives "True"/"False".
+                let effective_defaults: std::collections::HashMap<String, Vec<String>> = ct
+                    .config_overrides
+                    .borrow()
+                    .iter()
+                    .map(|(k, owned)| {
+                        let v = owned.value();
+                        let elements: Vec<String> = if let Some(list) = ListRef::from_value(v) {
+                            list.iter()
+                                .map(|elem| {
+                                    let s = elem.to_string();
+                                    if elem.get_type() == "bool" {
+                                        s.to_lowercase()
+                                    } else {
+                                        s
+                                    }
+                                })
+                                .collect()
+                        } else {
+                            let s = v.to_string();
+                            let s = if v.get_type() == "bool" {
+                                s.to_lowercase()
+                            } else {
+                                s
+                            };
+                            vec![s]
+                        };
+                        (k.clone(), elements)
+                    })
+                    .collect();
+
+                let cmd = make_command_from_task(
+                    &name,
+                    &defined_in,
+                    i.to_string(),
+                    def,
+                    &feature_arg_specs_for_cmd,
+                    &effective_defaults,
+                );
                 tree.insert(&name, group, group, &defined_in, cmd)?;
             }
 
@@ -352,77 +464,172 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
             let span = info_span!("task", name = name);
             let _enter = span.enter();
 
-            // Phase 4: run enabled feature implementations
-            mpe.eval_feature_impls().map_err(anyhow::Error::from)?;
+            // Build per-feature arg specs (type_id, prefix, args) for the Phase 4 args builder.
+            // Cloned once here so the closure below can capture by value.
+            let feature_specs_for_args: Vec<(u64, String, SmallMap<String, Arg>)> = mpe
+                .feature_types_with_paths()
+                .iter()
+                .filter_map(|(id, val, _)| {
+                    let args = extract_feature_args(*val)?;
+                    let prefix = extract_feature_name(*val).unwrap_or_default();
+                    Some((*id, prefix, args))
+                })
+                .collect();
+
+            // Phase 4: run enabled feature implementations, supplying parsed CLI args per feature.
+            mpe.eval_feature_impls(|type_id, heap| {
+                let mut args = CliArgs::new();
+                let Some((_, prefix, spec)) = feature_specs_for_args
+                    .iter()
+                    .find(|(id, _, _)| *id == type_id)
+                else {
+                    return args;
+                };
+                for (k, v) in spec.iter() {
+                    // Look up the value by the Clap ID (respecting long override if set)
+                    // but store it under the short key (e.g. "mode") for ctx.args access.
+                    let clap_key = if let Some(lo) = v.long_override() {
+                        lo.to_string()
+                    } else if prefix.is_empty() {
+                        k.replace('_', "-")
+                    } else {
+                        format!("{}:{}", prefix, k.replace('_', "-"))
+                    };
+                    let val = match v {
+                        Arg::String { .. } => heap
+                            .alloc_str(
+                                cmdargs
+                                    .get_one::<String>(&clap_key)
+                                    .unwrap_or(&String::new()),
+                            )
+                            .to_value(),
+                        Arg::Int { .. } => heap
+                            .alloc(*cmdargs.get_one::<i32>(&clap_key).unwrap_or(&0))
+                            .to_value(),
+                        Arg::UInt { .. } => heap
+                            .alloc(*cmdargs.get_one::<u32>(&clap_key).unwrap_or(&0))
+                            .to_value(),
+                        Arg::Boolean { .. } => {
+                            heap.alloc(*cmdargs.get_one::<bool>(&clap_key).unwrap_or(&false))
+                        }
+                        Arg::Positional { .. } => heap.alloc(CliArgs::alloc_list(
+                            cmdargs
+                                .get_many::<String>(&clap_key)
+                                .map_or(vec![], |f| f.map(|s| s.as_str()).collect()),
+                        )),
+                        Arg::TrailingVarArgs { .. } => heap.alloc(CliArgs::alloc_list(
+                            cmdargs
+                                .get_many::<String>(&clap_key)
+                                .map_or(vec![], |f| f.map(|s| s.as_str()).collect()),
+                        )),
+                        Arg::StringList { .. } => heap.alloc(CliArgs::alloc_list(
+                            cmdargs
+                                .get_many::<String>(&clap_key)
+                                .unwrap_or_default()
+                                .map(|s| s.as_str())
+                                .collect::<Vec<_>>(),
+                        )),
+                        Arg::BooleanList { .. } => heap.alloc(CliArgs::alloc_list(
+                            cmdargs
+                                .get_many::<bool>(&clap_key)
+                                .unwrap_or_default()
+                                .copied()
+                                .collect::<Vec<_>>(),
+                        )),
+                        Arg::IntList { .. } => heap.alloc(CliArgs::alloc_list(
+                            cmdargs
+                                .get_many::<i32>(&clap_key)
+                                .unwrap_or_default()
+                                .copied()
+                                .collect::<Vec<_>>(),
+                        )),
+                        Arg::UIntList { .. } => heap.alloc(CliArgs::alloc_list(
+                            cmdargs
+                                .get_many::<u32>(&clap_key)
+                                .unwrap_or_default()
+                                .copied()
+                                .collect::<Vec<_>>(),
+                        )),
+                        Arg::Custom { .. } => {
+                            // Custom args are not CLI-exposed; extract_feature_args filters them out.
+                            continue;
+                        }
+                    };
+                    args.insert(k.clone(), val);
+                }
+                args
+            })
+            .map_err(anyhow::Error::from)?;
 
             // Phase 5: execute the selected task
 
             let exit_code = mpe
                 .execute_with_args(task_val, task_key, task_id, |heap| {
-                    let mut args = TaskArgs::new();
-                    for (k, v) in definition.args().iter() {
+                    let mut all_args = CliArgs::new();
+                    let mut explicit_args = CliArgs::new();
+                    for (k, v) in definition.cli_args() {
                         let val = match v {
-                            TaskArg::String { .. } => heap
-                                .alloc_str(
-                                    cmdargs
-                                        .get_one::<String>(k.as_str())
-                                        .unwrap_or(&String::new()),
-                                )
+                            Arg::String { .. } => heap
+                                .alloc_str(cmdargs.get_one::<String>(k).unwrap_or(&String::new()))
                                 .to_value(),
-                            TaskArg::Int { .. } => heap
-                                .alloc(cmdargs.get_one::<i32>(k.as_str()).unwrap_or(&0).to_owned())
+                            Arg::Int { .. } => heap
+                                .alloc(*cmdargs.get_one::<i32>(k).unwrap_or(&0))
                                 .to_value(),
-                            TaskArg::UInt { .. } => heap
-                                .alloc(cmdargs.get_one::<u32>(k.as_str()).unwrap_or(&0).to_owned())
+                            Arg::UInt { .. } => heap
+                                .alloc(*cmdargs.get_one::<u32>(k).unwrap_or(&0))
                                 .to_value(),
-                            TaskArg::Boolean { .. } => heap.alloc(
+                            Arg::Boolean { .. } => {
+                                heap.alloc(*cmdargs.get_one::<bool>(k).unwrap_or(&false))
+                            }
+                            Arg::Positional { .. } => heap.alloc(CliArgs::alloc_list(
                                 cmdargs
-                                    .get_one::<bool>(k.as_str())
-                                    .unwrap_or(&false)
-                                    .to_owned(),
-                            ),
-                            TaskArg::Positional { .. } => heap.alloc(TaskArgs::alloc_list(
-                                cmdargs
-                                    .get_many::<String>(k.as_str())
+                                    .get_many::<String>(k)
                                     .map_or(vec![], |f| f.map(|s| s.as_str()).collect()),
                             )),
-                            TaskArg::TrailingVarArgs { .. } => heap.alloc(TaskArgs::alloc_list(
+                            Arg::TrailingVarArgs { .. } => heap.alloc(CliArgs::alloc_list(
                                 cmdargs
-                                    .get_many::<String>(k.as_str())
+                                    .get_many::<String>(k)
                                     .map_or(vec![], |f| f.map(|s| s.as_str()).collect()),
                             )),
-                            TaskArg::StringList { .. } => heap.alloc(TaskArgs::alloc_list(
+                            Arg::StringList { .. } => heap.alloc(CliArgs::alloc_list(
                                 cmdargs
-                                    .get_many::<String>(k.as_str())
+                                    .get_many::<String>(k)
                                     .unwrap_or_default()
                                     .map(|s| s.as_str())
                                     .collect::<Vec<_>>(),
                             )),
-                            TaskArg::BooleanList { .. } => heap.alloc(TaskArgs::alloc_list(
+                            Arg::BooleanList { .. } => heap.alloc(CliArgs::alloc_list(
                                 cmdargs
-                                    .get_many::<bool>(k.as_str())
+                                    .get_many::<bool>(k)
                                     .unwrap_or_default()
-                                    .cloned()
+                                    .copied()
                                     .collect::<Vec<_>>(),
                             )),
-                            TaskArg::IntList { .. } => heap.alloc(TaskArgs::alloc_list(
+                            Arg::IntList { .. } => heap.alloc(CliArgs::alloc_list(
                                 cmdargs
-                                    .get_many::<i32>(k.as_str())
+                                    .get_many::<i32>(k)
                                     .unwrap_or_default()
-                                    .cloned()
+                                    .copied()
                                     .collect::<Vec<_>>(),
                             )),
-                            TaskArg::UIntList { .. } => heap.alloc(TaskArgs::alloc_list(
+                            Arg::UIntList { .. } => heap.alloc(CliArgs::alloc_list(
                                 cmdargs
-                                    .get_many::<u32>(k.as_str())
+                                    .get_many::<u32>(k)
                                     .unwrap_or_default()
-                                    .cloned()
+                                    .copied()
                                     .collect::<Vec<_>>(),
                             )),
+                            Arg::Custom { .. } => {
+                                // Custom args are not CLI-exposed; cli_args() filters them out.
+                                continue;
+                            }
                         };
-                        args.insert(k.clone(), val);
+                        all_args.insert(k.to_owned(), val);
+                        if cmdargs.value_source(k) == Some(ValueSource::CommandLine) {
+                            explicit_args.insert(k.to_owned(), val);
+                        }
                     }
-                    args
+                    (all_args, explicit_args)
                 })
                 .map_err(anyhow::Error::from)?;
 

--- a/crates/axl-runtime/src/engine/arg.rs
+++ b/crates/axl-runtime/src/engine/arg.rs
@@ -8,6 +8,7 @@ use starlark::environment::GlobalsBuilder;
 use starlark::eval::Evaluator;
 use starlark::starlark_module;
 use starlark::starlark_simple_value;
+use starlark::values::FrozenValue;
 use starlark::values::NoSerialize;
 use starlark::values::ProvidesStaticType;
 use starlark::values::StarlarkValue;
@@ -20,11 +21,12 @@ use starlark::values::starlark_value;
 use starlark::values::starlark_value_as_type::StarlarkValueAsType;
 
 #[derive(Clone, Debug, ProvidesStaticType, NoSerialize, Allocative)]
-pub enum TaskArg {
+pub enum Arg {
     String {
         required: bool,
         default: String,
         short: Option<String>,
+        long: Option<String>,
         values: Option<Vec<String>>,
         description: Option<String>,
     },
@@ -32,18 +34,21 @@ pub enum TaskArg {
         required: bool,
         default: bool,
         short: Option<String>,
+        long: Option<String>,
         description: Option<String>,
     },
     Int {
         required: bool,
         default: i32,
         short: Option<String>,
+        long: Option<String>,
         description: Option<String>,
     },
     UInt {
         required: bool,
         default: u32,
         short: Option<String>,
+        long: Option<String>,
         description: Option<String>,
     },
     Positional {
@@ -59,54 +64,113 @@ pub enum TaskArg {
         required: bool,
         default: Vec<String>,
         short: Option<String>,
+        long: Option<String>,
         description: Option<String>,
     },
     BooleanList {
         required: bool,
         default: Vec<bool>,
         short: Option<String>,
+        long: Option<String>,
         description: Option<String>,
     },
     IntList {
         required: bool,
         default: Vec<i32>,
         short: Option<String>,
+        long: Option<String>,
         description: Option<String>,
     },
     UIntList {
         required: bool,
         default: Vec<u32>,
         short: Option<String>,
+        long: Option<String>,
+        description: Option<String>,
+    },
+    /// Config-only arg — not exposed on the CLI. Set via config.axl only.
+    ///
+    /// `typ_value` is `Some` when the type annotation is a frozen Starlark value
+    /// (e.g. `str`, `int`, `bool`, `list[str]`). For parameterized types like
+    /// `typing.Callable[[str], str]` that produce live values, it is `None` and
+    /// type-checking is skipped at invocation time.
+    Custom {
+        #[allocative(skip)]
+        typ_value: Option<FrozenValue>,
+        #[allocative(skip)]
+        default: Option<FrozenValue>,
         description: Option<String>,
     },
 }
 
-/// Documentation here
-#[starlark_value(type = "args.TaskArg")]
-impl<'v> StarlarkValue<'v> for TaskArg {}
+/// A CLI argument definition — the result of calling `args.string(...)`, `args.int(...)`, etc.
+#[starlark_value(type = "args.Arg")]
+impl<'v> StarlarkValue<'v> for Arg {}
 
-starlark_simple_value!(TaskArg);
+starlark_simple_value!(Arg);
 
-impl Display for TaskArg {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Arg {
+    /// Returns `true` if this arg was declared with `required = true`.
+    ///
+    /// Positional, TrailingVarArgs, and Custom do not carry a `required` field — callers
+    /// should disallow those in contexts where required args are not acceptable.
+    pub fn is_required(&self) -> bool {
         match self {
-            Self::String { .. } => write!(f, "<args.TaskArg: string>"),
-            Self::Boolean { .. } => write!(f, "<args.TaskArg: boolean>"),
-            Self::Int { .. } => write!(f, "<args.TaskArg: int>"),
-            Self::UInt { .. } => write!(f, "<args.TaskArg: uint>"),
-            Self::Positional { .. } => write!(f, "<args.TaskArg: positional>"),
-            Self::TrailingVarArgs { .. } => {
-                write!(f, "<args.TaskArg: trailing variable arguments>")
-            }
-            Self::StringList { .. } => write!(f, "<args.TaskArg: string_list>"),
-            Self::BooleanList { .. } => write!(f, "<args.TaskArg: boolean_list>"),
-            Self::IntList { .. } => write!(f, "<args.TaskArg: int_list>"),
-            Self::UIntList { .. } => write!(f, "<args.TaskArg: uint_list>"),
+            Self::String { required, .. }
+            | Self::Boolean { required, .. }
+            | Self::Int { required, .. }
+            | Self::UInt { required, .. }
+            | Self::StringList { required, .. }
+            | Self::BooleanList { required, .. }
+            | Self::IntList { required, .. }
+            | Self::UIntList { required, .. } => *required,
+            Self::Positional { .. } | Self::TrailingVarArgs { .. } | Self::Custom { .. } => false,
+        }
+    }
+
+    /// Returns `true` if this arg is exposed on the CLI (flags, positional, or trailing).
+    /// Only `Custom` is not CLI-exposed (config.axl only).
+    pub fn is_cli_exposed(&self) -> bool {
+        !matches!(self, Self::Custom { .. })
+    }
+
+    /// Returns the `long` override if set, otherwise `None`.
+    pub fn long_override(&self) -> Option<&str> {
+        match self {
+            Self::String { long, .. }
+            | Self::Boolean { long, .. }
+            | Self::Int { long, .. }
+            | Self::UInt { long, .. }
+            | Self::StringList { long, .. }
+            | Self::BooleanList { long, .. }
+            | Self::IntList { long, .. }
+            | Self::UIntList { long, .. } => long.as_deref(),
+            Self::Positional { .. } | Self::TrailingVarArgs { .. } | Self::Custom { .. } => None,
         }
     }
 }
 
-impl<'v> UnpackValue<'v> for TaskArg {
+impl Display for Arg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::String { .. } => write!(f, "<args.Arg: string>"),
+            Self::Boolean { .. } => write!(f, "<args.Arg: boolean>"),
+            Self::Int { .. } => write!(f, "<args.Arg: int>"),
+            Self::UInt { .. } => write!(f, "<args.Arg: uint>"),
+            Self::Positional { .. } => write!(f, "<args.Arg: positional>"),
+            Self::TrailingVarArgs { .. } => {
+                write!(f, "<args.Arg: trailing variable arguments>")
+            }
+            Self::StringList { .. } => write!(f, "<args.Arg: string_list>"),
+            Self::BooleanList { .. } => write!(f, "<args.Arg: boolean_list>"),
+            Self::IntList { .. } => write!(f, "<args.Arg: int_list>"),
+            Self::UIntList { .. } => write!(f, "<args.Arg: uint_list>"),
+            Self::Custom { .. } => write!(f, "<args.Arg: custom>"),
+        }
+    }
+}
+
+impl<'v> UnpackValue<'v> for Arg {
     type Error = Infallible;
 
     fn unpack_value_impl(value: Value<'v>) -> Result<Option<Self>, Self::Error> {
@@ -114,37 +178,50 @@ impl<'v> UnpackValue<'v> for TaskArg {
     }
 }
 
+/// Validate and unwrap the `long` override into `Option<String>`.
+///
+/// Accepts `[a-z][a-z0-9_-]*(:[a-z][a-z0-9_-]*)?`: one or two lowercase
+/// kebab/snake segments separated by at most one colon. The colon form
+/// (`feature-name:flag-name`) is used by feature args to carry the namespace;
+/// task args reject it at task definition time.
+fn validated_long(long: NoneOr<String>) -> starlark::Result<Option<String>> {
+    if let NoneOr::Other(ref s) = long {
+        fn valid_segment(seg: &str) -> bool {
+            let mut chars = seg.chars();
+            matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+                && chars
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
+        }
+        let valid = match s.split_once(':') {
+            None => valid_segment(s),
+            Some((prefix, suffix)) => valid_segment(prefix) && valid_segment(suffix),
+        };
+        if !valid {
+            return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
+                anyhow::anyhow!(
+                    "`long` must match [a-z][a-z0-9_-]*(:[a-z][a-z0-9_-]*)?; got {:?}",
+                    s
+                ),
+            )));
+        }
+    }
+    Ok(long.into_option())
+}
+
 #[starlark_module]
 pub fn register_globals(globals: &mut GlobalsBuilder) {
-    const Args: StarlarkValueAsType<TaskArg> = StarlarkValueAsType::new();
+    const Args: StarlarkValueAsType<Arg> = StarlarkValueAsType::new();
 
-    /// Defines a positional argument that accepts a range of values, with a required minimum
-    /// number of values and an optional maximum number of values.
-    ///
-    ///
-    /// **Examples**
-    /// ```python
-    /// **Take** one positional argument with no dashes.
-    /// task(
-    ///  args = { "named": args.positional() }
-    /// )
-    /// ```
-    ///
-    /// ```python
-    /// **Take** two positional argument with no dashes.
-    /// task(
-    ///  args = { "named": args.positional(minimum = 2, maximum = 2) }
-    /// )
-    /// ```
+    /// Defines a positional argument that accepts a range of values.
     fn positional<'v>(
         #[starlark(require = named, default = 0)] minimum: u32,
         #[starlark(require = named, default = 1)] maximum: u32,
         #[starlark(require = named, default = NoneOr::None)] default: NoneOr<UnpackList<String>>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
-    ) -> anyhow::Result<TaskArg> {
-        Ok(TaskArg::Positional {
-            minimum: minimum,
-            maximum: maximum,
+    ) -> anyhow::Result<Arg> {
+        Ok(Arg::Positional {
+            minimum,
+            maximum,
             default: default.into_option().map(|it| it.items),
             description: description.into_option(),
         })
@@ -152,43 +229,25 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
 
     /// Defines a trailing variable argument that captures the remaining arguments without further parsing.
     /// Only one such argument is permitted, and it must be the last in the sequence.
-    ///
-    /// **Examples**
-    /// ```python
-    /// task(
-    ///   args = {
-    ///     # take one positional argument with no dashes.
-    ///     "target": args.positional(minimum = 0, maximum = 1),
-    ///     # take rest of the commandline
-    ///     "run_args": args.trailing_var_args()
-    ///   }
-    /// )
-    /// ```
     fn trailing_var_args<'v>(
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
-    ) -> anyhow::Result<TaskArg> {
-        Ok(TaskArg::TrailingVarArgs {
+    ) -> anyhow::Result<Arg> {
+        Ok(Arg::TrailingVarArgs {
             description: description.into_option(),
         })
     }
 
     /// Defines a string flag that can be specified as `--flag_name=flag_value`.
     ///
-    /// **Examples**
-    /// ```python
-    /// task(
-    ///   args = {
-    ///     "bes_backend": args.string(),
-    ///   }
-    /// )
-    /// ```
+    /// Use `long = "override-name"` to override the default kebab-case derivation.
     fn string<'v>(
         #[starlark(require = named, default = false)] required: bool,
         #[starlark(require = named)] default: Option<String>,
         #[starlark(require = named, default = NoneOr::None)] short: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] long: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] values: NoneOr<UnpackList<String>>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
-    ) -> starlark::Result<TaskArg> {
+    ) -> starlark::Result<Arg> {
         if required && default.is_some() {
             return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
                 anyhow::anyhow!("`required` and `default` are both set."),
@@ -199,31 +258,26 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 anyhow::anyhow!("`short` must be a 1-character string."),
             )));
         }
-        Ok(TaskArg::String {
+        Ok(Arg::String {
             required,
             default: default.unwrap_or_default(),
             short: short.into_option(),
+            long: validated_long(long)?,
             values: values.into_option().map(|it| it.items),
             description: description.into_option(),
         })
     }
 
-    /// Defines a string list flag that can be specified multiple times as `--flag_name=flag_value`.
+    /// Defines a string list flag that can be specified multiple times.
     ///
-    /// **Examples**
-    /// ```python
-    /// task(
-    ///   args = {
-    ///     "bes_headers": args.string_list(),
-    ///   }
-    /// )
-    /// ```
+    /// Use `long = "override-name"` to override the default kebab-case derivation.
     fn string_list<'v>(
         #[starlark(require = named, default = false)] required: bool,
         #[starlark(require = named, default = NoneOr::None)] default: NoneOr<UnpackList<String>>,
         #[starlark(require = named, default = NoneOr::None)] short: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] long: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
-    ) -> starlark::Result<TaskArg> {
+    ) -> starlark::Result<Arg> {
         if required && !default.is_none() {
             return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
                 anyhow::anyhow!("`required` and `default` are both set."),
@@ -234,32 +288,26 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 anyhow::anyhow!("`short` must be a 1-character string."),
             )));
         }
-        Ok(TaskArg::StringList {
+        Ok(Arg::StringList {
             required,
             default: default.into_option().map(|it| it.items).unwrap_or_default(),
             short: short.into_option(),
+            long: validated_long(long)?,
             description: description.into_option(),
         })
     }
 
-    /// Defines a boolean flag that can be specified as `--flag_name=true|false`
-    /// or simply `--flag_name`, which is equivalent to `--flag_name=true`.
+    /// Defines a boolean flag. Use `--flag_name` (true) or `--flag_name=false`.
     ///
-    /// **Examples**
-    /// ```python
-    /// task(
-    ///   args = {
-    ///     "color": args.boolean(),
-    ///   }
-    /// )
-    /// ```
+    /// Use `long = "override-name"` to override the default kebab-case derivation.
     fn boolean<'v>(
         #[starlark(require = named, default = false)] required: bool,
-        #[starlark(require = named )] default: Option<bool>,
+        #[starlark(require = named)] default: Option<bool>,
         #[starlark(require = named, default = NoneOr::None)] short: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] long: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
         _eval: &mut Evaluator<'v, '_, '_>,
-    ) -> starlark::Result<TaskArg> {
+    ) -> starlark::Result<Arg> {
         if required && default.is_some() {
             return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
                 anyhow::anyhow!("`required` and `default` are both set."),
@@ -270,30 +318,25 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 anyhow::anyhow!("`short` must be a 1-character string."),
             )));
         }
-        Ok(TaskArg::Boolean {
+        Ok(Arg::Boolean {
             required,
             default: default.unwrap_or_default(),
             short: short.into_option(),
+            long: validated_long(long)?,
             description: description.into_option(),
         })
     }
 
-    /// Defines a boolean list flag that can be specified multiple times as `--flag_name=true|false`.
+    /// Defines a boolean list flag that can be specified multiple times.
     ///
-    /// **Examples**
-    /// ```python
-    /// task(
-    ///   args = {
-    ///     "flags": args.boolean_list(),
-    ///   }
-    /// )
-    /// ```
+    /// Use `long = "override-name"` to override the default kebab-case derivation.
     fn boolean_list<'v>(
         #[starlark(require = named, default = false)] required: bool,
         #[starlark(require = named, default = NoneOr::None)] default: NoneOr<UnpackList<bool>>,
         #[starlark(require = named, default = NoneOr::None)] short: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] long: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
-    ) -> starlark::Result<TaskArg> {
+    ) -> starlark::Result<Arg> {
         if required && !default.is_none() {
             return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
                 anyhow::anyhow!("`required` and `default` are both set."),
@@ -304,31 +347,25 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 anyhow::anyhow!("`short` must be a 1-character string."),
             )));
         }
-        Ok(TaskArg::BooleanList {
+        Ok(Arg::BooleanList {
             required,
             default: default.into_option().map(|it| it.items).unwrap_or_default(),
             short: short.into_option(),
+            long: validated_long(long)?,
             description: description.into_option(),
         })
     }
 
-    /// Creates an integer flag that can be set as `--flag_name=flag_value`
-    /// or `--flag_name=flag_value`.
+    /// Defines an integer flag.
     ///
-    /// **Examples**
-    /// ```python
-    /// task(
-    ///   args = {
-    ///     "color": args.int(),
-    ///   }
-    /// )
-    /// ```
+    /// Use `long = "override-name"` to override the default kebab-case derivation.
     fn int<'v>(
         #[starlark(require = named, default = false)] required: bool,
         #[starlark(require = named)] default: Option<i32>,
         #[starlark(require = named, default = NoneOr::None)] short: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] long: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
-    ) -> starlark::Result<TaskArg> {
+    ) -> starlark::Result<Arg> {
         if required && default.is_some() {
             return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
                 anyhow::anyhow!("`required` and `default` are both set."),
@@ -339,30 +376,25 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 anyhow::anyhow!("`short` must be a 1-character string."),
             )));
         }
-        Ok(TaskArg::Int {
+        Ok(Arg::Int {
             required,
             default: default.unwrap_or_default(),
             short: short.into_option(),
+            long: validated_long(long)?,
             description: description.into_option(),
         })
     }
 
-    /// Defines an integer list flag that can be specified multiple times as `--flag_name=flag_value`.
+    /// Defines an integer list flag that can be specified multiple times.
     ///
-    /// **Examples**
-    /// ```python
-    /// task(
-    ///   args = {
-    ///     "numbers": args.int_list(),
-    ///   }
-    /// )
-    /// ```
+    /// Use `long = "override-name"` to override the default kebab-case derivation.
     fn int_list<'v>(
         #[starlark(require = named, default = false)] required: bool,
         #[starlark(require = named, default = NoneOr::None)] default: NoneOr<UnpackList<i32>>,
         #[starlark(require = named, default = NoneOr::None)] short: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] long: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
-    ) -> starlark::Result<TaskArg> {
+    ) -> starlark::Result<Arg> {
         if required && !default.is_none() {
             return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
                 anyhow::anyhow!("`required` and `default` are both set."),
@@ -373,30 +405,25 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 anyhow::anyhow!("`short` must be a 1-character string."),
             )));
         }
-        Ok(TaskArg::IntList {
+        Ok(Arg::IntList {
             required,
             default: default.into_option().map(|it| it.items).unwrap_or_default(),
             short: short.into_option(),
+            long: validated_long(long)?,
             description: description.into_option(),
         })
     }
 
-    /// Defines an unsigned integer flag that can be specified using the format `--flag_name=flag_value`.
+    /// Defines an unsigned integer flag.
     ///
-    /// **Examples**
-    /// ```python
-    /// task(
-    ///   args = {
-    ///     "color": args.uint(),
-    ///   }
-    /// )
-    /// ```
+    /// Use `long = "override-name"` to override the default kebab-case derivation.
     fn uint<'v>(
         #[starlark(require = named, default = false)] required: bool,
         #[starlark(require = named)] default: Option<u32>,
         #[starlark(require = named, default = NoneOr::None)] short: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] long: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
-    ) -> starlark::Result<TaskArg> {
+    ) -> starlark::Result<Arg> {
         if required && default.is_some() {
             return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
                 anyhow::anyhow!("`required` and `default` are both set."),
@@ -407,30 +434,25 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 anyhow::anyhow!("`short` must be a 1-character string."),
             )));
         }
-        Ok(TaskArg::UInt {
+        Ok(Arg::UInt {
             required,
             default: default.unwrap_or_default(),
             short: short.into_option(),
+            long: validated_long(long)?,
             description: description.into_option(),
         })
     }
 
-    /// Defines an unsigned integer list flag that can be specified multiple times as `--flag_name=flag_value`.
+    /// Defines an unsigned integer list flag that can be specified multiple times.
     ///
-    /// **Examples**
-    /// ```python
-    /// task(
-    ///   args = {
-    ///     "ports": args.uint_list(),
-    ///   }
-    /// )
-    /// ```
+    /// Use `long = "override-name"` to override the default kebab-case derivation.
     fn uint_list<'v>(
         #[starlark(require = named, default = false)] required: bool,
         #[starlark(require = named, default = NoneOr::None)] default: NoneOr<UnpackList<u32>>,
         #[starlark(require = named, default = NoneOr::None)] short: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] long: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
-    ) -> starlark::Result<TaskArg> {
+    ) -> starlark::Result<Arg> {
         if required && !default.is_none() {
             return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
                 anyhow::anyhow!("`required` and `default` are both set."),
@@ -441,10 +463,66 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 anyhow::anyhow!("`short` must be a 1-character string."),
             )));
         }
-        Ok(TaskArg::UIntList {
+        Ok(Arg::UIntList {
             required,
             default: default.into_option().map(|it| it.items).unwrap_or_default(),
             short: short.into_option(),
+            long: validated_long(long)?,
+            description: description.into_option(),
+        })
+    }
+
+    /// Defines a config-only arg — not exposed on the CLI. Set via config.axl only.
+    ///
+    /// The `type` argument must be a built-in or otherwise frozen type (e.g. `str`, `int`,
+    /// `bool`, `list[str]`). If provided, `default` must match the declared type.
+    ///
+    /// Example:
+    /// ```starlark
+    /// my_task = task(
+    ///     implementation = _impl,
+    ///     args = {
+    ///         "mode": args.string(default = "auto"),
+    ///         "bucket": args.custom(str | None, default = None),  # config.axl only
+    ///     },
+    /// )
+    /// ```
+    fn custom<'v>(
+        #[starlark(require = pos)] typ: Value<'v>,
+        #[starlark(require = named)] default: Option<Value<'v>>,
+        #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Arg> {
+        // Try to store the type as a frozen value (enables type-checking at invoke time).
+        // Parameterized types like `typing.Callable[[str], str]` are live values and cannot
+        // be frozen here — in that case we store None and skip runtime type-checking.
+        let typ_value = typ.unpack_frozen();
+
+        // Always build TypeCompiled from the live value so we can validate the default.
+        let compiled = starlark::values::typing::TypeCompiled::new(typ, eval.heap())
+            .map_err(|e| anyhow::anyhow!("{:?}", e))?;
+
+        // Validate and freeze the default. Live values (e.g. lambdas defined inline) cannot be
+        // stored in Arg which requires FrozenValue; silently store None in that case.
+        // Type validation still runs when the type is compilable, so mismatches are caught.
+        let default_frozen = match default {
+            None => None,
+            Some(d) => {
+                if !compiled.matches(d) {
+                    return Err(anyhow::anyhow!(
+                        "args.custom() default `{}` does not match type `{}`",
+                        d,
+                        compiled
+                    ));
+                }
+                // Live values (e.g. inline lambdas) cannot be frozen here — store None.
+                d.unpack_frozen()
+            }
+        };
+
+        Ok(Arg::Custom {
+            typ_value,
+            default: default_frozen,
             description: description.into_option(),
         })
     }

--- a/crates/axl-runtime/src/engine/cli_args.rs
+++ b/crates/axl-runtime/src/engine/cli_args.rs
@@ -14,20 +14,20 @@ use starlark::values::list::AllocList;
 use starlark::values::starlark_value;
 
 #[derive(Debug, Clone, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
-#[display("<TaskArgs>")]
-pub struct TaskArgs<'v> {
+#[display("<CliArgs>")]
+pub struct CliArgs<'v> {
     #[allocative(skip)]
     args: SmallMap<String, values::Value<'v>>,
 }
 
-impl<'v> TaskArgs<'v> {
+impl<'v> CliArgs<'v> {
     pub fn new() -> Self {
         Self {
             args: SmallMap::new(),
         }
     }
 
-    /// Creates TaskArgs from a HashMap of string key-value pairs, allocating strings on the heap.
+    /// Creates CliArgs from a HashMap of string key-value pairs, allocating strings on the heap.
     pub fn from_map(map: std::collections::HashMap<String, String>, heap: Heap<'v>) -> Self {
         let mut args = SmallMap::new();
         for (key, value) in map {
@@ -42,28 +42,33 @@ impl<'v> TaskArgs<'v> {
     }
 
     #[inline]
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.args.contains_key(key)
+    }
+
+    #[inline]
     pub fn alloc_list<L>(items: L) -> AllocList<L> {
         AllocList(items)
     }
 }
 
-#[starlark_value(type = "TaskArgs")]
-impl<'v> StarlarkValue<'v> for TaskArgs<'v> {
+#[starlark_value(type = "CliArgs")]
+impl<'v> StarlarkValue<'v> for CliArgs<'v> {
     fn get_attr(&self, key: &str, _heap: Heap<'v>) -> Option<Value<'v>> {
         self.args.get(key).cloned()
     }
 }
 
-impl<'v> values::AllocValue<'v> for TaskArgs<'v> {
+impl<'v> values::AllocValue<'v> for CliArgs<'v> {
     fn alloc_value(self, heap: values::Heap<'v>) -> Value<'v> {
         heap.alloc_complex(self)
     }
 }
 
-impl<'v> values::Freeze for TaskArgs<'v> {
-    type Frozen = FrozenTaskArgs;
+impl<'v> values::Freeze for CliArgs<'v> {
+    type Frozen = FrozenCliArgs;
     fn freeze(self, freezer: &values::Freezer) -> values::FreezeResult<Self::Frozen> {
-        Ok(FrozenTaskArgs {
+        Ok(FrozenCliArgs {
             args: self
                 .args
                 .iter()
@@ -74,17 +79,17 @@ impl<'v> values::Freeze for TaskArgs<'v> {
 }
 
 #[derive(Debug, Display, ProvidesStaticType, NoSerialize, Allocative)]
-#[display("<TaskArgs {args:?}>")]
-pub struct FrozenTaskArgs {
+#[display("<CliArgs {args:?}>")]
+pub struct FrozenCliArgs {
     #[allocative(skip)]
     args: SmallMap<String, values::FrozenValue>,
 }
 
-starlark_simple_value!(FrozenTaskArgs);
+starlark_simple_value!(FrozenCliArgs);
 
-#[starlark_value(type = "TaskArgs")]
-impl<'v> StarlarkValue<'v> for FrozenTaskArgs {
-    type Canonical = TaskArgs<'v>;
+#[starlark_value(type = "CliArgs")]
+impl<'v> StarlarkValue<'v> for FrozenCliArgs {
+    type Canonical = CliArgs<'v>;
 
     fn get_attr(&self, key: &str, _heap: Heap<'v>) -> Option<Value<'v>> {
         self.args.get(key).cloned().map(|x| x.to_value())

--- a/crates/axl-runtime/src/engine/config/context.rs
+++ b/crates/axl-runtime/src/engine/config/context.rs
@@ -28,7 +28,7 @@ use super::super::template;
 use super::super::wasm::Wasm;
 
 use super::tasks::configured_task::ConfiguredTask;
-use super::tasks::value::TaskList;
+use super::tasks::value::TaskMap;
 
 /// Config context for evaluating config.axl files.
 ///
@@ -58,7 +58,7 @@ impl<'v> ConfigContext<'v> {
             .map(|task| task.alloc_value(heap))
             .collect();
         Self {
-            tasks: heap.alloc(TaskList::new(tasks)),
+            tasks: heap.alloc(TaskMap::new(tasks)),
             trait_map,
             feature_map,
         }
@@ -75,7 +75,7 @@ impl<'v> ConfigContext<'v> {
         heap: Heap<'v>,
     ) -> Self {
         Self {
-            tasks: heap.alloc(TaskList::new(tasks)),
+            tasks: heap.alloc(TaskMap::new(tasks)),
             trait_map,
             feature_map,
         }
@@ -84,7 +84,7 @@ impl<'v> ConfigContext<'v> {
     /// Get references to the tasks.
     pub fn tasks(&self) -> Vec<&ConfiguredTask> {
         self.tasks
-            .downcast_ref::<TaskList>()
+            .downcast_ref::<TaskMap>()
             .unwrap()
             .content
             .borrow()
@@ -95,7 +95,7 @@ impl<'v> ConfigContext<'v> {
 
     /// Get task values for iteration (used during config evaluation).
     pub fn task_values(&self) -> Vec<values::Value<'v>> {
-        self.tasks.downcast_ref::<TaskList>().unwrap().values()
+        self.tasks.downcast_ref::<TaskMap>().unwrap().values()
     }
 
     /// Get the trait map value.

--- a/crates/axl-runtime/src/engine/config/feature_context.rs
+++ b/crates/axl-runtime/src/engine/config/feature_context.rs
@@ -14,16 +14,16 @@ use crate::engine::std::Std;
 /// Context passed to a feature's `implementation` function.
 ///
 /// Runs after all config.axl files have been evaluated.
-/// - `ctx.attr` — the feature's own configured instance (read its user-set fields)
-/// - `ctx.fragments` — the full mutable fragment map (inject hooks into fragments)
+/// - `ctx.args` — the feature's resolved args (config values and CLI args merged)
+/// - `ctx.traits` — the full mutable fragment map (inject hooks into fragments)
 /// - `ctx.std` — standard library
 /// - `ctx.http` — HTTP client
 #[derive(Debug, ProvidesStaticType, NoSerialize, Allocative, Display)]
 #[display("<FeatureContext>")]
 pub struct FeatureContext<'v> {
-    /// The feature instance (read-only at implementation time — config phase is done).
+    /// Resolved args: config-only args from the feature instance, plus CLI args.
     #[allocative(skip)]
-    pub(crate) attr: Value<'v>,
+    pub(crate) args: Value<'v>,
     /// The full mutable fragment map — inject hooks here.
     #[allocative(skip)]
     pub(crate) fragments: Value<'v>,
@@ -31,14 +31,14 @@ pub struct FeatureContext<'v> {
 
 unsafe impl<'v> Trace<'v> for FeatureContext<'v> {
     fn trace(&mut self, tracer: &Tracer<'v>) {
-        self.attr.trace(tracer);
+        self.args.trace(tracer);
         self.fragments.trace(tracer);
     }
 }
 
 impl<'v> FeatureContext<'v> {
-    pub fn new(attr: Value<'v>, fragments: Value<'v>) -> Self {
-        Self { attr, fragments }
+    pub fn new(args: Value<'v>, fragments: Value<'v>) -> Self {
+        Self { args, fragments }
     }
 }
 
@@ -53,7 +53,7 @@ impl<'v> Freeze for FeatureContext<'v> {
 
     fn freeze(self, freezer: &Freezer) -> Result<Self::Frozen, FreezeError> {
         Ok(FrozenFeatureContext {
-            attr: self.attr.freeze(freezer)?,
+            args: self.args.freeze(freezer)?,
             fragments: self.fragments.freeze(freezer)?,
         })
     }
@@ -71,7 +71,7 @@ impl<'v> StarlarkValue<'v> for FeatureContext<'v> {
 #[display("<FeatureContext>")]
 pub struct FrozenFeatureContext {
     #[allocative(skip)]
-    attr: FrozenValue,
+    args: FrozenValue,
     #[allocative(skip)]
     fragments: FrozenValue,
 }
@@ -92,13 +92,14 @@ impl<'v> StarlarkValue<'v> for FrozenFeatureContext {
 
 #[starlark_module]
 fn feature_context_methods(builder: &mut MethodsBuilder) {
-    /// The feature's own configured instance. Read field values via `ctx.attr.field_name`.
+    /// Resolved args for this feature: config-only values and CLI args merged.
+    /// Access via `ctx.args.arg_name`.
     #[starlark(attribute)]
-    fn attr<'v>(this: Value<'v>) -> anyhow::Result<Value<'v>> {
+    fn args<'v>(this: Value<'v>) -> anyhow::Result<Value<'v>> {
         let ctx = this
             .downcast_ref_err::<FeatureContext>()
             .map_err(|e| anyhow::anyhow!("{}", e))?;
-        Ok(ctx.attr)
+        Ok(ctx.args)
     }
 
     /// The full mutable trait map. Inject into traits via `ctx.traits[TraitType].hook.append(...)`.

--- a/crates/axl-runtime/src/engine/config/feature_map.rs
+++ b/crates/axl-runtime/src/engine/config/feature_map.rs
@@ -119,9 +119,17 @@ impl<'v> StarlarkValue<'v> for FeatureMap<'v> {
             Some((_, instance)) => Ok(*instance),
             None => {
                 let type_name = if let Some(ft) = index.downcast_ref::<FeatureType>() {
-                    ft.name.as_deref().unwrap_or("anon")
+                    ft.export_name.as_deref().unwrap_or(if ft.name.is_empty() {
+                        "anon"
+                    } else {
+                        &ft.name
+                    })
                 } else if let Some(ft) = index.downcast_ref::<FrozenFeatureType>() {
-                    ft.name.as_deref().unwrap_or("anon")
+                    ft.export_name.as_deref().unwrap_or(if ft.name.is_empty() {
+                        "anon"
+                    } else {
+                        &ft.name
+                    })
                 } else {
                     "unknown"
                 };
@@ -191,9 +199,17 @@ impl<'v> StarlarkValue<'v> for FrozenFeatureMap {
             Some((_, instance)) => Ok(instance.to_value()),
             None => {
                 let type_name = if let Some(ft) = index.downcast_ref::<FeatureType>() {
-                    ft.name.as_deref().unwrap_or("anon")
+                    ft.export_name.as_deref().unwrap_or(if ft.name.is_empty() {
+                        "anon"
+                    } else {
+                        &ft.name
+                    })
                 } else if let Some(ft) = index.downcast_ref::<FrozenFeatureType>() {
-                    ft.name.as_deref().unwrap_or("anon")
+                    ft.export_name.as_deref().unwrap_or(if ft.name.is_empty() {
+                        "anon"
+                    } else {
+                        &ft.name
+                    })
                 } else {
                     "unknown"
                 };

--- a/crates/axl-runtime/src/engine/config/tasks/configured_task.rs
+++ b/crates/axl-runtime/src/engine/config/tasks/configured_task.rs
@@ -6,18 +6,21 @@ use std::path::PathBuf;
 use allocative::Allocative;
 use anyhow::anyhow;
 use derive_more::Display;
+use starlark::collections::SmallMap;
 use starlark::environment::Methods;
 use starlark::environment::MethodsBuilder;
 use starlark::environment::MethodsStatic;
 use starlark::starlark_module;
 use starlark::starlark_simple_value;
 use starlark::values;
+use starlark::values::AllocValue;
 use starlark::values::Freeze;
 use starlark::values::FreezeError;
 use starlark::values::Freezer;
 use starlark::values::FrozenValue;
 use starlark::values::Heap;
 use starlark::values::NoSerialize;
+use starlark::values::OwnedFrozenValue;
 use starlark::values::ProvidesStaticType;
 use starlark::values::Trace;
 use starlark::values::UnpackValue;
@@ -28,8 +31,12 @@ use starlark::values::list::AllocList;
 use starlark::values::list::UnpackList;
 use starlark::values::starlark_value;
 
+use crate::engine::arg::Arg;
+use crate::engine::config::tasks::frozen::freeze_value;
+use crate::engine::config::tasks::value::task_key;
 use crate::engine::task::FrozenTask;
 use crate::engine::task::TaskLike;
+use crate::engine::types::feature::{to_command_name, validate_command_name};
 use crate::eval::EvalError;
 
 /// A task bundled with its trait type IDs.
@@ -54,6 +61,9 @@ pub struct ConfiguredTask {
     pub symbol: String,
     /// Path to the .axl file
     pub path: PathBuf,
+    /// Config-only attr overrides set from config.axl via `ctx.tasks` iteration.
+    #[allocative(skip)]
+    pub config_overrides: RefCell<SmallMap<String, OwnedFrozenValue>>,
 }
 
 unsafe impl Trace<'_> for ConfiguredTask {
@@ -79,10 +89,17 @@ impl ConfiguredTask {
             .ok_or_else(|| EvalError::UnknownError(anyhow!("symbol '{}' is not a Task", symbol)))?;
 
         let name = if frozen_task.name.is_empty() {
-            symbol.to_string()
+            to_command_name(symbol)
         } else {
             frozen_task.name.clone()
         };
+        validate_command_name(&name, "task").map_err(|e| {
+            EvalError::UnknownError(anyhow!(e).context(format!(
+                "symbol {:?} in {}",
+                symbol,
+                path.display()
+            )))
+        })?;
         let group = frozen_task.group.clone();
         let trait_type_ids = frozen_task.trait_type_ids();
         // Extract the bare FrozenValue; the heap stays alive via AxlLoader::loaded_modules.
@@ -98,6 +115,7 @@ impl ConfiguredTask {
             trait_type_ids,
             symbol: symbol.to_string(),
             path,
+            config_overrides: RefCell::new(SmallMap::new()),
         })
     }
 
@@ -120,6 +138,7 @@ impl ConfiguredTask {
             trait_type_ids,
             symbol,
             path,
+            config_overrides: RefCell::new(SmallMap::new()),
         }
     }
 
@@ -154,14 +173,23 @@ impl<'v> values::StarlarkValue<'v> for ConfiguredTask {
     fn set_attr(&self, attribute: &str, value: Value<'v>) -> starlark::Result<()> {
         match attribute {
             "name" => {
-                self.name.replace(value.to_str());
+                let name = value.to_str();
+                validate_command_name(&name, "task")
+                    .map_err(|e| starlark::Error::new_other(anyhow!(e)))?;
+                self.name.replace(name);
             }
             "group" => {
                 let unpack: UnpackList<String> = UnpackList::unpack_value(value)?
                     .ok_or_else(|| anyhow!("groups must be a list of strings"))?;
+                for g in &unpack.items {
+                    validate_command_name(g, "group")
+                        .map_err(|e| starlark::Error::new_other(anyhow!(e)))?;
+                }
                 self.group.replace(unpack.items);
             }
-            _ => return ValueError::unsupported(self, &format!(".{}=", attribute)),
+            _ => {
+                return ValueError::unsupported(self, &format!(".{}=", attribute));
+            }
         };
         Ok(())
     }
@@ -170,19 +198,40 @@ impl<'v> values::StarlarkValue<'v> for ConfiguredTask {
         match attribute {
             "name" => Some(heap.alloc_str(&self.name.borrow()).to_value()),
             "group" => Some(heap.alloc(AllocList(self.group.borrow().iter()))),
+            "key" => Some(
+                heap.alloc_str(&task_key(&self.group.borrow(), &self.name.borrow()))
+                    .to_value(),
+            ),
             "symbol" => Some(heap.alloc_str(&self.symbol).to_value()),
             "path" => Some(heap.alloc_str(&self.path.to_string_lossy()).to_value()),
-            _ => None,
+            attr => {
+                // Return any config override set from config.axl.
+                self.config_overrides
+                    .borrow()
+                    .get(attr)
+                    .and_then(|owned| owned.value().unpack_frozen())
+                    .map(|fv| fv.to_value())
+            }
         }
     }
 
     fn dir_attr(&self) -> Vec<String> {
-        vec![
+        let mut attrs = vec![
             "name".into(),
             "group".into(),
+            "key".into(),
             "symbol".into(),
             "path".into(),
-        ]
+        ];
+        // Include custom arg names from the underlying task definition.
+        if let Some(task) = self.task_def.downcast_ref::<FrozenTask>() {
+            for (k, arg) in task.args() {
+                if matches!(arg, Arg::Custom { .. }) {
+                    attrs.push(k.clone());
+                }
+            }
+        }
+        attrs
     }
 
     fn get_methods() -> Option<&'static Methods> {
@@ -192,8 +241,28 @@ impl<'v> values::StarlarkValue<'v> for ConfiguredTask {
 }
 
 #[starlark_module]
-fn configured_task_methods(_builder: &mut MethodsBuilder) {
-    // Methods can be added here if needed
+fn configured_task_methods(builder: &mut MethodsBuilder) {
+    /// Arg accessor for overriding and reading task args from `config.axl`.
+    ///
+    /// **Writing** stores an override in `config_overrides` that is injected at execution
+    /// time (after the task default but before any explicit CLI flag):
+    /// ```starlark
+    /// ctx.tasks["group/name"].args.message = "hello"
+    /// ```
+    ///
+    /// **Reading** returns the current effective value — the config override if one was set,
+    /// otherwise the task definition's default:
+    /// ```starlark
+    /// current = ctx.tasks["group/name"].args.message  # "hello" or the task's default
+    /// ```
+    ///
+    /// Precedence at execution time: explicit CLI flag > config.axl override > task default.
+    #[starlark(attribute)]
+    fn args<'v>(this: Value<'v>) -> anyhow::Result<ConfiguredTaskArgs<'v>> {
+        this.downcast_ref::<ConfiguredTask>()
+            .ok_or_else(|| anyhow!("internal: not a ConfiguredTask"))?;
+        Ok(ConfiguredTaskArgs { task: this })
+    }
 }
 
 impl<'v> values::AllocValue<'v> for ConfiguredTask {
@@ -213,6 +282,7 @@ impl Freeze for ConfiguredTask {
             trait_type_ids: self.trait_type_ids,
             symbol: self.symbol,
             path: self.path,
+            config_overrides: self.config_overrides.into_inner(),
         })
     }
 }
@@ -228,6 +298,8 @@ pub struct FrozenConfiguredTask {
     pub trait_type_ids: Vec<u64>,
     pub symbol: String,
     pub path: PathBuf,
+    #[allocative(skip)]
+    pub config_overrides: SmallMap<String, OwnedFrozenValue>,
 }
 
 unsafe impl Trace<'_> for FrozenConfiguredTask {
@@ -244,18 +316,232 @@ impl<'v> values::StarlarkValue<'v> for FrozenConfiguredTask {
         match attribute {
             "name" => Some(heap.alloc_str(&self.name).to_value()),
             "group" => Some(heap.alloc(AllocList(self.group.iter()))),
+            "key" => Some(
+                heap.alloc_str(&task_key(&self.group, &self.name))
+                    .to_value(),
+            ),
             "symbol" => Some(heap.alloc_str(&self.symbol).to_value()),
             "path" => Some(heap.alloc_str(&self.path.to_string_lossy()).to_value()),
-            _ => None,
+            attr => self
+                .config_overrides
+                .get(attr)
+                .and_then(|owned| owned.value().unpack_frozen())
+                .map(|fv| fv.to_value()),
         }
     }
 
     fn dir_attr(&self) -> Vec<String> {
-        vec![
+        let mut attrs = vec![
             "name".into(),
             "group".into(),
+            "key".into(),
             "symbol".into(),
             "path".into(),
-        ]
+        ];
+        if let Some(task) = self.task_def.downcast_ref::<FrozenTask>() {
+            for (k, arg) in task.args() {
+                if matches!(arg, Arg::Custom { .. }) {
+                    attrs.push(k.clone());
+                }
+            }
+        }
+        attrs
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Default-value materialisation for Arg
+// ---------------------------------------------------------------------------
+
+/// Allocate the default value for a `Arg` onto `heap`.
+///
+/// Used to satisfy reads of unset args in config.axl.
+fn cli_arg_default_value<'v>(arg: &Arg, heap: Heap<'v>) -> Value<'v> {
+    match arg {
+        Arg::Custom { default, .. } => default
+            .map(|fv| fv.to_value())
+            .unwrap_or_else(|| heap.alloc(starlark::values::none::NoneType)),
+        Arg::String { default, .. } => heap.alloc_str(default).to_value(),
+        Arg::Boolean { default, .. } => heap.alloc(*default),
+        Arg::Int { default, .. } => heap.alloc(*default),
+        Arg::UInt { default, .. } => heap.alloc(*default),
+        Arg::Positional { default, .. } => {
+            let items: Vec<&str> = default
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
+            heap.alloc(AllocList(items))
+        }
+        Arg::TrailingVarArgs { .. } => heap.alloc(AllocList(Vec::<&str>::new())),
+        Arg::StringList { default, .. } => heap.alloc(AllocList(
+            default.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+        )),
+        Arg::BooleanList { default, .. } => heap.alloc(AllocList(default.iter().copied())),
+        Arg::IntList { default, .. } => heap.alloc(AllocList(default.iter().copied())),
+        Arg::UIntList { default, .. } => heap.alloc(AllocList(default.iter().copied())),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ConfiguredTaskArgs — mutable accessor returned by `t.args` in config.axl
+// ---------------------------------------------------------------------------
+
+/// Accessor returned by `t.args` on a `ConfiguredTask`.
+///
+/// Holds a back-reference to the task so that arg writes (`t.args.x = v`)
+/// are stored in `ConfiguredTask::config_overrides` and injected at execution time.
+#[derive(Debug, ProvidesStaticType, Display, NoSerialize, Allocative)]
+#[display("<ConfiguredTaskArgs>")]
+pub struct ConfiguredTaskArgs<'v> {
+    #[allocative(skip)]
+    task: Value<'v>,
+}
+
+unsafe impl<'v> Trace<'v> for ConfiguredTaskArgs<'v> {
+    fn trace(&mut self, tracer: &values::Tracer<'v>) {
+        self.task.trace(tracer);
+    }
+}
+
+#[starlark_value(type = "ConfiguredTaskArgs")]
+impl<'v> values::StarlarkValue<'v> for ConfiguredTaskArgs<'v> {
+    fn set_attr(&self, attribute: &str, value: Value<'v>) -> starlark::Result<()> {
+        let ct = self
+            .task
+            .downcast_ref::<ConfiguredTask>()
+            .ok_or_else(|| starlark::Error::new_other(anyhow!("internal: not a ConfiguredTask")))?;
+
+        let arg = ct
+            .task_def
+            .downcast_ref::<FrozenTask>()
+            .and_then(|t| t.args().get(attribute));
+
+        let arg = match arg {
+            Some(a) => a,
+            None => return ValueError::unsupported(self, &format!(".{}=", attribute)),
+        };
+
+        // Type-check the value against the declared arg type before storing.
+        match arg {
+            Arg::Custom { .. } => {
+                // Detailed type check for Custom args happens at feature invoke time.
+            }
+            cli_arg => {
+                let expected = match cli_arg {
+                    Arg::Custom { .. } => unreachable!(),
+                    Arg::String { .. } | Arg::Positional { .. } => "string",
+                    Arg::Boolean { .. } => "bool",
+                    Arg::Int { .. } | Arg::UInt { .. } => "int",
+                    Arg::StringList { .. } | Arg::TrailingVarArgs { .. } => "list",
+                    Arg::BooleanList { .. } | Arg::IntList { .. } | Arg::UIntList { .. } => "list",
+                };
+                let actual = value.get_type();
+                if actual != expected {
+                    return Err(starlark::Error::new_other(anyhow!(
+                        "task arg {:?}: expected type `{}`, got `{}`",
+                        attribute,
+                        expected,
+                        actual
+                    )));
+                }
+            }
+        }
+
+        let frozen =
+            freeze_value(value).map_err(|e| starlark::Error::new_other(anyhow!("{:?}", e)))?;
+        ct.config_overrides
+            .borrow_mut()
+            .insert(attribute.to_owned(), frozen);
+        Ok(())
+    }
+
+    fn get_attr(&self, attribute: &str, heap: Heap<'v>) -> Option<Value<'v>> {
+        let ct = self.task.downcast_ref::<ConfiguredTask>()?;
+
+        // 1. Return the config_override if one has been set.
+        if let Some(val) = ct
+            .config_overrides
+            .borrow()
+            .get(attribute)
+            .and_then(|owned| owned.value().unpack_frozen())
+            .map(|fv| fv.to_value())
+        {
+            return Some(val);
+        }
+
+        // 2. Fall back to the task definition default.
+        let task = ct.task_def.downcast_ref::<FrozenTask>()?;
+        let arg = task.args().get(attribute)?;
+        Some(cli_arg_default_value(arg, heap))
+    }
+
+    fn dir_attr(&self) -> Vec<String> {
+        if let Some(ct) = self.task.downcast_ref::<ConfiguredTask>() {
+            if let Some(task) = ct.task_def.downcast_ref::<FrozenTask>() {
+                return task.args().keys().cloned().collect();
+            }
+        }
+        vec![]
+    }
+}
+
+impl<'v> AllocValue<'v> for ConfiguredTaskArgs<'v> {
+    fn alloc_value(self, heap: Heap<'v>) -> Value<'v> {
+        heap.alloc_complex(self)
+    }
+}
+
+impl<'v> Freeze for ConfiguredTaskArgs<'v> {
+    type Frozen = FrozenConfiguredTaskArgs;
+
+    fn freeze(self, freezer: &Freezer) -> Result<Self::Frozen, FreezeError> {
+        Ok(FrozenConfiguredTaskArgs {
+            task: self.task.freeze(freezer)?,
+        })
+    }
+}
+
+/// Frozen version of `ConfiguredTaskArgs` — read-only after freezing.
+#[derive(Debug, ProvidesStaticType, Display, NoSerialize, Allocative)]
+#[display("<ConfiguredTaskArgs>")]
+pub struct FrozenConfiguredTaskArgs {
+    #[allocative(skip)]
+    task: FrozenValue,
+}
+
+starlark_simple_value!(FrozenConfiguredTaskArgs);
+
+#[starlark_value(type = "ConfiguredTaskArgs")]
+impl<'v> values::StarlarkValue<'v> for FrozenConfiguredTaskArgs {
+    type Canonical = ConfiguredTaskArgs<'v>;
+
+    fn get_attr(&self, attribute: &str, heap: Heap<'v>) -> Option<Value<'v>> {
+        let ct = self.task.downcast_ref::<FrozenConfiguredTask>()?;
+
+        // 1. Return the config_override if one has been set.
+        if let Some(val) = ct
+            .config_overrides
+            .get(attribute)
+            .and_then(|owned| owned.value().unpack_frozen())
+            .map(|fv| fv.to_value())
+        {
+            return Some(val);
+        }
+
+        // 2. Fall back to the task definition default.
+        let task = ct.task_def.downcast_ref::<FrozenTask>()?;
+        let arg = task.args().get(attribute)?;
+        Some(cli_arg_default_value(arg, heap))
+    }
+
+    fn dir_attr(&self) -> Vec<String> {
+        if let Some(ct) = self.task.downcast_ref::<FrozenConfiguredTask>() {
+            if let Some(task) = ct.task_def.downcast_ref::<FrozenTask>() {
+                return task.args().keys().cloned().collect();
+            }
+        }
+        vec![]
     }
 }

--- a/crates/axl-runtime/src/engine/config/tasks/value.rs
+++ b/crates/axl-runtime/src/engine/config/tasks/value.rs
@@ -25,24 +25,45 @@ use starlark::values::ValueLike;
 use starlark::values::none::NoneType;
 use starlark::values::starlark_value;
 
-use super::configured_task::ConfiguredTask;
+use super::configured_task::{ConfiguredTask, FrozenConfiguredTask};
 use crate::engine::store::AxlStore;
 use crate::engine::task::{FrozenTask, TaskLike};
 
-/// Live (mutable) task list, exposed to Starlark as `ctx.tasks`.
+/// Compute the canonical path key for a task.
+///
+/// - group=`[]`, name=`"bar"` → `"bar"`
+/// - group=`["foo"]`, name=`"bar"` → `"foo/bar"`
+/// - group=`["foo","fum"]`, name=`"bar"` → `"foo/fum/bar"`
+pub fn task_key(group: &[String], name: &str) -> String {
+    if group.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{}/{}", group.join("/"), name)
+    }
+}
+
+/// Live (mutable) task map, exposed to Starlark as `ctx.tasks` in `config.axl`.
+///
+/// Supports both iteration (`for t in ctx.tasks`) and map-style key access
+/// (`ctx.tasks["group/name"]`). The key is the task's canonical path:
+/// a root-level task named `"foo"` is at `"foo"`; a task named `"bar"` in
+/// group `["grp", "sub"]` is at `"grp/sub/bar"`. See `task_key()`.
+///
+/// Use `ctx.tasks.add(my_task)` to register a new task from `config.axl`.
+/// Use `ctx.tasks["key"].args.x = val` to override a task arg.
 #[derive(Debug, ProvidesStaticType, NoSerialize, Allocative)]
-pub struct TaskList<'v> {
+pub struct TaskMap<'v> {
     #[allocative(skip)]
     pub(crate) content: RefCell<Vec<Value<'v>>>,
 }
 
-impl<'v> fmt::Display for TaskList<'v> {
+impl<'v> fmt::Display for TaskMap<'v> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "tasks")
     }
 }
 
-unsafe impl<'v> Trace<'v> for TaskList<'v> {
+unsafe impl<'v> Trace<'v> for TaskMap<'v> {
     fn trace(&mut self, tracer: &Tracer<'v>) {
         for v in self.content.get_mut().iter_mut() {
             v.trace(tracer);
@@ -50,29 +71,29 @@ unsafe impl<'v> Trace<'v> for TaskList<'v> {
     }
 }
 
-impl<'v> AllocValue<'v> for TaskList<'v> {
+impl<'v> AllocValue<'v> for TaskMap<'v> {
     fn alloc_value(self, heap: Heap<'v>) -> Value<'v> {
         heap.alloc_complex(self)
     }
 }
 
-impl<'v> Freeze for TaskList<'v> {
-    type Frozen = FrozenTaskList;
+impl<'v> Freeze for TaskMap<'v> {
+    type Frozen = FrozenTaskMap;
 
-    fn freeze(self, freezer: &Freezer) -> Result<FrozenTaskList, FreezeError> {
+    fn freeze(self, freezer: &Freezer) -> Result<FrozenTaskMap, FreezeError> {
         let content = self
             .content
             .into_inner()
             .into_iter()
             .map(|v| v.freeze(freezer))
             .collect::<Result<Vec<FrozenValue>, FreezeError>>()?;
-        Ok(FrozenTaskList { content })
+        Ok(FrozenTaskMap { content })
     }
 }
 
-impl<'v> TaskList<'v> {
+impl<'v> TaskMap<'v> {
     pub fn new(content: Vec<Value<'v>>) -> Self {
-        TaskList {
+        TaskMap {
             content: RefCell::new(content),
         }
     }
@@ -84,24 +105,47 @@ impl<'v> TaskList<'v> {
 }
 
 #[starlark_value(type = "tasks")]
-impl<'v> StarlarkValue<'v> for TaskList<'v> {
+impl<'v> StarlarkValue<'v> for TaskMap<'v> {
     fn get_methods() -> Option<&'static Methods> {
         static RES: MethodsStatic = MethodsStatic::new();
-        RES.methods(task_list_methods)
+        RES.methods(task_map_methods)
     }
 
     fn iterate_collect(&self, _heap: Heap<'v>) -> starlark::Result<Vec<Value<'v>>> {
         Ok(self.content.borrow().clone())
     }
+
+    fn at(&self, index: Value<'v>, _heap: Heap<'v>) -> starlark::Result<Value<'v>> {
+        let key = index.unpack_str().ok_or_else(|| {
+            starlark::Error::new_other(anyhow::anyhow!(
+                "ctx.tasks key must be a string, got {}",
+                index.get_type()
+            ))
+        })?;
+        for val in self.content.borrow().iter() {
+            if let Some(ct) = val.downcast_ref::<ConfiguredTask>() {
+                if task_key(&ct.get_group(), &ct.get_name()) == key {
+                    return Ok(*val);
+                }
+            }
+        }
+        Err(starlark::Error::new_other(anyhow::anyhow!(
+            "no task found at path {:?}",
+            key
+        )))
+    }
 }
 
 #[starlark_module]
-fn task_list_methods(registry: &mut MethodsBuilder) {
-    /// Add a task to the task list.
+fn task_map_methods(registry: &mut MethodsBuilder) {
+    /// Add a task to the task map.
     ///
-    /// The task value must be a `FrozenTask` (i.e. defined at module level, not inside
-    /// a function). Since config files are frozen before their `config()` function is
-    /// called, module-level task definitions are always frozen by the time `add` runs.
+    /// The task value must be a `FrozenTask` (i.e. defined at module level, not inside a
+    /// function). Since config files are frozen before their `config()` function is called,
+    /// module-level task definitions are always frozen by the time `add` runs.
+    ///
+    /// After adding, the task is accessible via iteration and by key:
+    /// `ctx.tasks["group/name"].args.x = val`.
     fn add<'v>(
         this: Value<'v>,
         #[starlark(require = pos)] task: Value<'v>,
@@ -121,17 +165,37 @@ fn task_list_methods(registry: &mut MethodsBuilder) {
             return Err(anyhow::anyhow!("ctx.tasks.add: task must have a non-empty name").into());
         }
 
+        let key = task_key(&frozen_task.group(), &name);
+        {
+            let content = this
+                .downcast_ref::<TaskMap>()
+                .ok_or_else(|| anyhow::anyhow!("ctx.tasks is not a task map"))?
+                .content
+                .try_borrow()
+                .map_err(|_| anyhow::anyhow!("cannot read ctx.tasks while mutating it"))?;
+            if content.iter().any(|v| {
+                v.downcast_ref::<ConfiguredTask>()
+                    .map(|ct| task_key(&ct.get_group(), &ct.get_name()) == key)
+                    .unwrap_or(false)
+            }) {
+                return Err(anyhow::anyhow!("ctx.tasks.add: task {:?} already exists", key).into());
+            }
+        }
+
+        // `symbol` and `name` start as the same string; name is mutable (config.axl can
+        // override it) while symbol stays fixed as the Starlark variable name.
+        let symbol = name.clone();
         let configured = ConfiguredTask::new_with_traits(
             task.unpack_frozen().expect("FrozenTask is always frozen"),
             name,
             frozen_task.group().to_vec(),
             frozen_task.trait_type_ids(),
-            frozen_task.name().to_owned(),
+            symbol,
             PathBuf::from(store.script_path.to_string_lossy().as_ref()),
         );
 
-        this.downcast_ref::<TaskList>()
-            .ok_or_else(|| anyhow::anyhow!("ctx.tasks is not a task list"))?
+        this.downcast_ref::<TaskMap>()
+            .ok_or_else(|| anyhow::anyhow!("ctx.tasks is not a task map"))?
             .content
             .try_borrow_mut()
             .map_err(|_| anyhow::anyhow!("cannot mutate ctx.tasks while iterating over it"))?
@@ -141,29 +205,49 @@ fn task_list_methods(registry: &mut MethodsBuilder) {
     }
 }
 
-/// Frozen task list — read-only after freeze.
+/// Frozen task map — read-only after freeze.
 #[derive(Debug, ProvidesStaticType, NoSerialize, Allocative)]
-pub struct FrozenTaskList {
+pub struct FrozenTaskMap {
     content: Vec<FrozenValue>,
 }
 
-impl fmt::Display for FrozenTaskList {
+impl fmt::Display for FrozenTaskMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "tasks")
     }
 }
 
-unsafe impl<'v> Trace<'v> for FrozenTaskList {
+unsafe impl<'v> Trace<'v> for FrozenTaskMap {
     fn trace(&mut self, _tracer: &Tracer<'v>) {}
 }
 
-starlark_simple_value!(FrozenTaskList);
+starlark_simple_value!(FrozenTaskMap);
 
 #[starlark_value(type = "tasks")]
-impl<'v> StarlarkValue<'v> for FrozenTaskList {
-    type Canonical = TaskList<'v>;
+impl<'v> StarlarkValue<'v> for FrozenTaskMap {
+    type Canonical = TaskMap<'v>;
 
     fn iterate_collect(&self, _heap: Heap<'v>) -> starlark::Result<Vec<Value<'v>>> {
         Ok(self.content.iter().map(|v| v.to_value()).collect())
+    }
+
+    fn at(&self, index: Value<'v>, _heap: Heap<'v>) -> starlark::Result<Value<'v>> {
+        let key = index.unpack_str().ok_or_else(|| {
+            starlark::Error::new_other(anyhow::anyhow!(
+                "ctx.tasks key must be a string, got {}",
+                index.get_type()
+            ))
+        })?;
+        for fv in self.content.iter() {
+            if let Some(ct) = fv.downcast_ref::<FrozenConfiguredTask>() {
+                if task_key(&ct.group, &ct.name) == key {
+                    return Ok(fv.to_value());
+                }
+            }
+        }
+        Err(starlark::Error::new_other(anyhow::anyhow!(
+            "no task found at path {:?}",
+            key
+        )))
     }
 }

--- a/crates/axl-runtime/src/engine/mod.rs
+++ b/crates/axl-runtime/src/engine/mod.rs
@@ -14,12 +14,12 @@ mod template;
 pub mod types;
 mod wasm;
 
+pub mod arg;
 pub mod r#async;
+pub mod cli_args;
 pub mod config;
 pub mod store;
 pub mod task;
-pub mod task_arg;
-pub mod task_args;
 pub mod task_context;
 pub mod task_info;
 
@@ -30,8 +30,8 @@ fn register_types(globals: &mut GlobalsBuilder) {
     const Http: StarlarkValueAsType<http::Http> = StarlarkValueAsType::new();
     const HttpResponse: StarlarkValueAsType<http::HttpResponse> = StarlarkValueAsType::new();
     const Task: StarlarkValueAsType<task::Task> = StarlarkValueAsType::new();
-    const TaskArg: StarlarkValueAsType<task_arg::TaskArg> = StarlarkValueAsType::new();
-    const TaskArgs: StarlarkValueAsType<task_args::TaskArgs> = StarlarkValueAsType::new();
+    const Arg: StarlarkValueAsType<arg::Arg> = StarlarkValueAsType::new();
+    const Args: StarlarkValueAsType<cli_args::CliArgs> = StarlarkValueAsType::new();
     const TaskContext: StarlarkValueAsType<task_context::TaskContext> = StarlarkValueAsType::new();
     const TaskInfo: StarlarkValueAsType<task_info::TaskInfo> = StarlarkValueAsType::new();
     const Template: StarlarkValueAsType<template::Template> = StarlarkValueAsType::new();
@@ -45,7 +45,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
     types::feature::register_globals(globals);
     types::r#trait::register_globals(globals);
 
-    globals.namespace("args", task_arg::register_globals);
+    globals.namespace("args", arg::register_globals);
     globals.namespace("bazel", bazel::register_globals);
     globals.namespace("remote", |g| {
         g.namespace("execution", |g| {

--- a/crates/axl-runtime/src/engine/task.rs
+++ b/crates/axl-runtime/src/engine/task.rs
@@ -1,7 +1,8 @@
+use crate::engine::arg::Arg;
 use crate::engine::task_context::TaskContext;
+use crate::engine::types::names::{to_display_name, validate_arg_name, validate_command_name};
 use crate::engine::types::r#trait::{FrozenTraitType, TraitType, extract_trait_type_id};
 
-use super::task_arg::TaskArg;
 use allocative::Allocative;
 use derive_more::Display;
 use starlark::collections::SmallMap;
@@ -25,8 +26,13 @@ use starlark::values::typing::StarlarkCallableParamSpec;
 pub const MAX_TASK_GROUPS: usize = 5;
 
 pub trait TaskLike<'v>: 'v {
-    fn args(&self) -> &SmallMap<String, TaskArg>;
+    /// Returns only the CLI-exposed args (non-Custom Arg entries), as (name, &Arg) pairs.
+    fn cli_args(&self) -> Vec<(&str, &Arg)>;
+    /// One-line summary shown in the task list. Empty means use the "defined in" fallback.
+    fn summary(&self) -> &String;
+    /// Extended description shown only in `--help`, after the summary. Empty means omit.
     fn description(&self) -> &String;
+    fn display_name(&self) -> &String;
     fn group(&self) -> &Vec<String>;
     fn name(&self) -> &String;
 }
@@ -49,8 +55,10 @@ where
 pub struct Task<'v> {
     r#impl: values::Value<'v>,
     #[allocative(skip)]
-    pub(super) args: SmallMap<String, TaskArg>,
+    pub(super) args: SmallMap<String, Arg>,
+    pub(super) summary: String,
     pub(super) description: String,
+    pub(super) display_name: String,
     pub(super) group: Vec<String>,
     pub(super) name: String,
     pub(super) traits: Vec<values::Value<'v>>,
@@ -60,11 +68,17 @@ impl<'v> Task<'v> {
     pub fn implementation(&self) -> values::Value<'v> {
         self.r#impl
     }
-    pub fn args(&self) -> &SmallMap<String, TaskArg> {
+    pub fn args(&self) -> &SmallMap<String, Arg> {
         &self.args
+    }
+    pub fn summary(&self) -> &String {
+        &self.summary
     }
     pub fn description(&self) -> &String {
         &self.description
+    }
+    pub fn display_name(&self) -> &String {
+        &self.display_name
     }
     pub fn group(&self) -> &Vec<String> {
         &self.group
@@ -78,11 +92,21 @@ impl<'v> Task<'v> {
 }
 
 impl<'v> TaskLike<'v> for Task<'v> {
-    fn args(&self) -> &SmallMap<String, TaskArg> {
-        &self.args
+    fn cli_args(&self) -> Vec<(&str, &Arg)> {
+        self.args
+            .iter()
+            .filter(|(_, v)| v.is_cli_exposed())
+            .map(|(k, v)| (k.as_str(), v))
+            .collect()
+    }
+    fn summary(&self) -> &String {
+        &self.summary
     }
     fn description(&self) -> &String {
         &self.description
+    }
+    fn display_name(&self) -> &String {
+        &self.display_name
     }
     fn group(&self) -> &Vec<String> {
         &self.group
@@ -110,7 +134,9 @@ impl<'v> values::Freeze for Task<'v> {
         Ok(FrozenTask {
             args: self.args,
             r#impl: frozen_impl,
+            summary: self.summary,
             description: self.description,
+            display_name: self.display_name,
             group: self.group,
             name: self.name,
             traits: frozen_traits?,
@@ -123,8 +149,10 @@ impl<'v> values::Freeze for Task<'v> {
 pub struct FrozenTask {
     r#impl: values::FrozenValue,
     #[allocative(skip)]
-    pub(super) args: SmallMap<String, TaskArg>,
+    pub(super) args: SmallMap<String, Arg>,
+    pub(super) summary: String,
     pub(super) description: String,
+    pub(super) display_name: String,
     pub(super) group: Vec<String>,
     pub(super) name: String,
     pub(super) traits: Vec<values::FrozenValue>,
@@ -141,6 +169,9 @@ impl FrozenTask {
     pub fn implementation(&self) -> values::FrozenValue {
         self.r#impl
     }
+    pub fn args(&self) -> &SmallMap<String, Arg> {
+        &self.args
+    }
     pub fn traits(&self) -> &[values::FrozenValue] {
         &self.traits
     }
@@ -154,11 +185,21 @@ impl FrozenTask {
 }
 
 impl<'v> TaskLike<'v> for FrozenTask {
-    fn args(&self) -> &SmallMap<String, TaskArg> {
-        &self.args
+    fn cli_args(&self) -> Vec<(&str, &Arg)> {
+        self.args
+            .iter()
+            .filter(|(_, v)| v.is_cli_exposed())
+            .map(|(k, v)| (k.as_str(), v))
+            .collect()
+    }
+    fn summary(&self) -> &String {
+        &self.summary
     }
     fn description(&self) -> &String {
         &self.description
+    }
+    fn display_name(&self) -> &String {
+        &self.display_name
     }
     fn group(&self) -> &Vec<String> {
         &self.group
@@ -185,21 +226,49 @@ impl StarlarkCallableParamSpec for TaskImpl {
 
 #[starlark_module]
 pub fn register_globals(globals: &mut GlobalsBuilder) {
-    /// Task type representing a Task.
+    /// Declares a task — a named CLI command with an implementation function.
     ///
-    /// ```python
-    /// def _task_impl(ctx):
-    ///     pass
+    /// ## Naming
     ///
-    /// build = task(
-    ///     name = "build",
-    ///     group = [],
-    ///     impl = _task_impl,
-    ///     description = "build task",
-    ///     task_args = {
-    ///         "target": args.string(),
+    /// Assign the result to a **snake_case** variable. The CLI command name is derived
+    /// automatically by converting `_` to `-` (`axl_add` → `axl-add`).
+    /// Use `name = "explicit-name"` to override.
+    /// Command names must match `[a-z][a-z0-9-]*`.
+    ///
+    /// ## Args
+    ///
+    /// Arg keys must be `snake_case` (`[a-z][a-z0-9_]*`). There are two kinds:
+    ///
+    /// - **CLI args** (`args.string(...)`, `args.int(...)`, etc.) — exposed as `--kebab-flags` on
+    ///   the CLI and accessible as `ctx.args.arg_name` in the implementation. Can be overridden
+    ///   in `config.axl`; an explicit CLI flag always wins over a config override.
+    ///
+    /// - **Config-only args** (`args.custom(type, default = …)`) — not shown in help; set by repo
+    ///   maintainers in `config.axl` via `ctx.tasks["group/name"].args.arg_name = value`.
+    ///
+    /// All args are read as `ctx.args.arg_name` in the implementation regardless of kind.
+    ///
+    /// ## Help text
+    ///
+    /// - `summary` — one-liner shown in the task list; falls back to `"<name> task defined in <file>"`.
+    /// - `description` — extended prose shown in `--help` (replaces summary in that view).
+    /// - `display_name` — Title Case name for help section headings; auto-derived from command name.
+    ///
+    /// ## Example
+    ///
+    /// ```starlark
+    /// def _impl(ctx: TaskContext) -> int:
+    ///     ctx.std.io.stdout.write("Hello, " + ctx.args.recipient + "\n")
+    ///     return 0
+    ///
+    /// greet = task(
+    ///     group = ["utils"],
+    ///     summary = "Say hello",
+    ///     implementation = _impl,
+    ///     args = {
+    ///         "recipient": args.string(default = "world", description = "Who to greet"),
+    ///         "greeting":  args.custom(str, default = "Hello", description = "Greeting word (config.axl only)"),
     ///     },
-    ///     traits = [BazelTrait]  # Optional list of trait types
     /// )
     /// ```
     fn task<'v>(
@@ -208,11 +277,15 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             TaskImpl,
             NoneType,
         >,
-        #[starlark(require = named)] args: values::dict::UnpackDictEntries<&'v str, TaskArg>,
+        #[starlark(require = named, default = values::dict::UnpackDictEntries::default())]
+        args: values::dict::UnpackDictEntries<String, Value<'v>>,
+        #[starlark(require = named, default = String::new())] summary: String,
         #[starlark(require = named, default = String::new())] description: String,
+        #[starlark(require = named, default = String::new())] display_name: String,
         #[starlark(require = named, default = UnpackList::default())] group: UnpackList<String>,
         #[starlark(require = named, default = String::new())] name: String,
         #[starlark(require = named, default = UnpackList::default())] traits: UnpackList<Value<'v>>,
+        _eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<Task<'v>> {
         if group.items.len() > MAX_TASK_GROUPS {
             return Err(anyhow::anyhow!(
@@ -221,12 +294,48 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             )
             .into());
         }
-        let mut args_ = SmallMap::new();
-        for (arg, def) in args.entries {
-            args_.insert(arg.to_owned(), def.clone());
+        // Validate name if explicitly set (empty means "derive from variable name via to_command_name").
+        if !name.is_empty() {
+            validate_command_name(&name, "task").map_err(|e| anyhow::anyhow!(e))?;
         }
 
-        // Validate each element is a TraitType or FrozenTraitType
+        // Validate group elements.
+        for g in &group.items {
+            validate_command_name(g, "group").map_err(|e| anyhow::anyhow!(e))?;
+        }
+
+        let display_name = if !display_name.is_empty() {
+            display_name
+        } else if !name.is_empty() {
+            to_display_name(&name)
+        } else {
+            String::new()
+        };
+
+        // Parse and validate args.
+        let mut args_ = SmallMap::new();
+        for (arg_name, value) in args.entries {
+            validate_arg_name(&arg_name).map_err(|e| anyhow::anyhow!("task {}", e))?;
+            let cli_arg = value.downcast_ref::<Arg>().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "task arg {:?}: expected args.string/boolean/int/uint/... or args.custom(...), got '{}'",
+                    arg_name,
+                    value.get_type()
+                )
+            })?.clone();
+            if let Some(lo) = cli_arg.long_override() {
+                if lo.contains(':') {
+                    return Err(anyhow::anyhow!(
+                        "task arg {:?}: `long` override may not contain ':'; \
+                         namespaced overrides (e.g. \"feature:flag\") are only valid for feature args",
+                        arg_name
+                    ).into());
+                }
+            }
+            args_.insert(arg_name, cli_arg);
+        }
+
+        // Validate each element is a TraitType or FrozenTraitType.
         let all_traits = traits.items;
         for t in &all_traits {
             if t.downcast_ref::<TraitType>().is_none()
@@ -243,7 +352,9 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         Ok(Task {
             args: args_,
             r#impl: implementation.0,
+            summary,
             description,
+            display_name,
             group: group.items,
             name,
             traits: all_traits,

--- a/crates/axl-runtime/src/engine/task_context.rs
+++ b/crates/axl-runtime/src/engine/task_context.rs
@@ -16,9 +16,9 @@ use starlark::values::ValueLike;
 use starlark::values::starlark_value;
 
 use super::aspect::Aspect;
+use super::cli_args::CliArgs;
 use super::http::Http;
 use super::std::Std;
-use super::task_args::TaskArgs;
 use super::task_info::TaskInfo;
 use super::template;
 use super::wasm::Wasm;
@@ -26,7 +26,7 @@ use super::wasm::Wasm;
 #[derive(Debug, Clone, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
 #[display("<TaskContext>")]
 pub struct TaskContext<'v> {
-    pub args: TaskArgs<'v>,
+    pub args: CliArgs<'v>,
     pub traits: values::Value<'v>,
     #[trace(unsafe_ignore)]
     pub task: TaskInfo,
@@ -35,7 +35,7 @@ pub struct TaskContext<'v> {
 
 impl<'v> TaskContext<'v> {
     pub fn new(
-        args: TaskArgs<'v>,
+        args: CliArgs<'v>,
         traits: values::Value<'v>,
         task: TaskInfo,
         bazel: values::Value<'v>,
@@ -101,9 +101,9 @@ pub(crate) fn task_context_methods(registry: &mut MethodsBuilder) {
         Ok(ctx.task.clone())
     }
 
-    /// Access to arguments provided by the caller.
+    /// Access to args provided by the caller (CLI flags and config.axl values).
     #[starlark(attribute)]
-    fn args<'v>(#[allow(unused)] this: values::Value<'v>) -> anyhow::Result<TaskArgs<'v>> {
+    fn args<'v>(#[allow(unused)] this: values::Value<'v>) -> anyhow::Result<CliArgs<'v>> {
         let ctx = this
             .downcast_ref_err::<TaskContext>()
             .into_anyhow_result()?;

--- a/crates/axl-runtime/src/engine/types/feature.rs
+++ b/crates/axl-runtime/src/engine/types/feature.rs
@@ -1,6 +1,6 @@
 //! FeatureType and FeatureInstance — behavior-injection units for the fragment system.
 //!
-//! A feature is declared with `feature(implementation=fn, attrs={...})`, configured
+//! A feature is declared with `feature(implementation=fn, args={...})`, configured
 //! by users in config.axl via `ctx.features[FeatureType].field = value`, and run
 //! after all config.axl files have been evaluated. The `implementation` function
 //! receives a `FeatureContext` and injects closures into fragment hook lists.
@@ -14,7 +14,6 @@ use std::fmt::{self, Display, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use allocative::Allocative;
-use dupe::Dupe;
 
 use starlark::environment::{GlobalsBuilder, Methods, MethodsBuilder, MethodsStatic};
 use starlark::starlark_module;
@@ -27,8 +26,11 @@ use starlark::values::{
 };
 use starlark_map::small_map::SmallMap;
 
-use crate::engine::types::r#trait::{
-    Field, FieldValue, FrozenField, FrozenFieldValue, build_type_checkers, copy_default_value,
+use crate::engine::arg::Arg;
+use crate::engine::cli_args::CliArgs;
+pub use crate::engine::types::names::{
+    camel_to_display_name, to_command_name, to_display_name, validate_arg_name,
+    validate_command_name, validate_type_name,
 };
 
 static FEATURE_TYPE_ID: AtomicU64 = AtomicU64::new(0);
@@ -41,16 +43,30 @@ fn next_feature_type_id() -> u64 {
 // FeatureType
 // -----------------------------------------------------------------------------
 
-/// The type of a feature, created by `feature(implementation=fn, attrs={...})`.
+/// The type of a feature, created by `feature(implementation=fn, args={...})`.
 /// Calling this type (internally) creates a `FeatureInstance` with default field values.
 #[derive(Debug, ProvidesStaticType, NoSerialize, Allocative)]
 pub struct FeatureType<'v> {
     /// Unique identifier for this feature type.
     pub(crate) id: u64,
-    /// Name of the feature type (set when assigned to a variable).
-    pub(crate) name: Option<String>,
-    /// User-configurable fields declared via `attrs = {"field": attr(...)}`.
-    pub(crate) fields: SmallMap<String, Field<'v>>,
+    /// Kebab-case slug used as the CLI arg prefix, e.g. `"artifact-upload"`.
+    /// Set by the `name` parameter in `feature()`, or auto-derived from `export_name`
+    /// via `to_command_name` when the value is assigned to a module-level variable.
+    /// Empty until `export_as` fires when no explicit `name` was given.
+    pub(crate) name: String,
+    /// CamelCase Starlark variable name, set when the value is assigned to a module-level
+    /// variable via `export_as` (e.g. `"ArtifactUpload"`). `None` for anonymous features.
+    pub(crate) export_name: Option<String>,
+    /// Human-readable display name, e.g. `"Artifact Upload"`. Derived from `export_name`
+    /// if not set explicitly.
+    pub(crate) display_name: String,
+    /// One-line summary shown in the task list. Empty means use the "defined in" fallback.
+    pub(crate) summary: String,
+    /// Extended description shown in `--help` after the summary. Empty means omit.
+    pub(crate) description: String,
+    /// Unified arg map. CLI-exposed entries are shown in help; `Custom` entries are
+    /// config.axl-only and not shown in help.
+    pub(crate) args: SmallMap<String, Arg>,
     /// The injection function called after config.axl with a `FeatureContext`.
     #[allocative(skip)]
     pub(crate) implementation_fn: Option<Value<'v>>,
@@ -58,18 +74,19 @@ pub struct FeatureType<'v> {
 
 impl<'v> Display for FeatureType<'v> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.name {
-            Some(name) => write!(f, "feature[{}]", name),
-            None => write!(f, "feature[anon]"),
+        if let Some(ref n) = self.export_name {
+            write!(f, "feature[{}]", n)
+        } else if !self.name.is_empty() {
+            write!(f, "feature[{}]", self.name)
+        } else {
+            write!(f, "feature[anon]")
         }
     }
 }
 
 unsafe impl<'v> Trace<'v> for FeatureType<'v> {
     fn trace(&mut self, tracer: &Tracer<'v>) {
-        for (_, field) in self.fields.iter_mut() {
-            field.trace(tracer);
-        }
+        // Arg has no Value<'v> fields; nothing to trace there.
         if let Some(ref mut f) = self.implementation_fn {
             f.trace(tracer);
         }
@@ -93,9 +110,15 @@ impl<'v> StarlarkValue<'v> for FeatureType<'v> {
         variable_name: &str,
         _eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> starlark::Result<()> {
+        validate_type_name(variable_name, "feature")
+            .map_err(|e| starlark::Error::new_other(anyhow::anyhow!(e)))?;
         let this = self as *const Self as *mut Self;
         unsafe {
-            (*this).name = Some(variable_name.to_string());
+            (*this).export_name = Some(variable_name.to_string());
+            // Derive the kebab slug from the export name when no explicit name was given.
+            if (&(*this).name).is_empty() {
+                (*this).name = to_command_name(variable_name);
+            }
         }
         Ok(())
     }
@@ -106,33 +129,53 @@ impl<'v> StarlarkValue<'v> for FeatureType<'v> {
         args: &starlark::eval::Arguments<'v, '_>,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> starlark::Result<Value<'v>> {
-        let type_checkers =
-            build_type_checkers(self.fields.values().map(|f| f.typ_value), eval.heap())?;
+        // Only Custom args are stored in the FeatureInstance; CLI args come from the CLI.
+        let custom_args: Vec<(&str, Option<FrozenValue>, Option<FrozenValue>)> = self
+            .args
+            .iter()
+            .filter_map(|(k, v)| match v {
+                Arg::Custom {
+                    typ_value, default, ..
+                } => Some((k.as_str(), *typ_value, *default)),
+                _ => None,
+            })
+            .collect();
+
+        // Build type checkers where possible; None when typ_value wasn't frozen.
+        let type_checkers: Vec<Option<TypeCompiled<Value<'v>>>> = custom_args
+            .iter()
+            .map(|(_, typ_value, _)| {
+                typ_value
+                    .map(|fv| TypeCompiled::new(fv.to_value(), eval.heap()))
+                    .transpose()
+                    .map_err(|e| starlark::Error::new_other(anyhow::anyhow!("{:?}", e)))
+            })
+            .collect::<starlark::Result<_>>()?;
 
         args.no_positional_args(eval.heap())?;
         let kwargs = args.names_map()?;
 
-        let mut values: Vec<Cell<Value<'v>>> = Vec::with_capacity(self.fields.len());
-        for ((field_name, field), tc) in self.fields.iter().zip(type_checkers.iter()) {
-            let value = if let Some(v) = kwargs.get(field_name.as_str()) {
+        let mut values: Vec<Cell<Value<'v>>> = Vec::with_capacity(custom_args.len());
+        for ((field_name, _, default), tc) in custom_args.iter().zip(type_checkers.iter()) {
+            let value = if let Some(v) = kwargs.get(*field_name) {
                 *v
-            } else if let Some(default) = field.default {
-                copy_default_value(default, eval.heap())?
+            } else if let Some(default_fv) = default {
+                default_fv.to_value()
             } else {
-                return Err(starlark::Error::new_other(anyhow::anyhow!(
-                    "Missing required field `{}` for {}",
-                    field_name,
-                    self
-                )));
+                // No storable default (e.g. lambda default was dropped at definition time).
+                // Fall back to None so the arg is accessible as ctx.args.name.
+                eval.heap().alloc(starlark::values::none::NoneType)
             };
 
-            if !tc.matches(value) {
-                return Err(starlark::Error::new_other(anyhow::anyhow!(
-                    "Field `{}` expected type `{}`, got `{}`",
-                    field_name,
-                    tc,
-                    value.get_type()
-                )));
+            if let Some(tc) = tc {
+                if !tc.matches(value) {
+                    return Err(starlark::Error::new_other(anyhow::anyhow!(
+                        "Arg `{}` expected type `{}`, got `{}`",
+                        field_name,
+                        tc,
+                        value.get_type()
+                    )));
+                }
             }
 
             values.push(Cell::new(value));
@@ -163,16 +206,23 @@ fn feature_type_methods(_builder: &mut MethodsBuilder) {}
 #[derive(Debug, ProvidesStaticType, NoSerialize, Allocative)]
 pub struct FrozenFeatureType {
     pub(crate) id: u64,
-    pub(crate) name: Option<String>,
-    pub(crate) fields: SmallMap<String, FrozenField>,
+    pub(crate) name: String,
+    pub(crate) export_name: Option<String>,
+    pub(crate) display_name: String,
+    pub(crate) summary: String,
+    pub(crate) description: String,
+    pub(crate) args: SmallMap<String, Arg>,
     pub(crate) implementation_fn: Option<FrozenValue>,
 }
 
 impl Display for FrozenFeatureType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.name {
-            Some(name) => write!(f, "feature[{}]", name),
-            None => write!(f, "feature[anon]"),
+        if let Some(ref n) = self.export_name {
+            write!(f, "feature[{}]", n)
+        } else if !self.name.is_empty() {
+            write!(f, "feature[{}]", self.name)
+        } else {
+            write!(f, "feature[anon]")
         }
     }
 }
@@ -201,35 +251,52 @@ impl<'v> StarlarkValue<'v> for FrozenFeatureType {
         args: &starlark::eval::Arguments<'v, '_>,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> starlark::Result<Value<'v>> {
-        let type_checkers = build_type_checkers(
-            self.fields.values().map(|f| f.typ_value.to_value()),
-            eval.heap(),
-        )?;
+        // Only Custom args are stored in the FeatureInstance.
+        let custom_args: Vec<(&str, Option<FrozenValue>, Option<FrozenValue>)> = self
+            .args
+            .iter()
+            .filter_map(|(k, v)| match v {
+                Arg::Custom {
+                    typ_value, default, ..
+                } => Some((k.as_str(), *typ_value, *default)),
+                _ => None,
+            })
+            .collect();
+
+        let type_checkers: Vec<Option<TypeCompiled<Value<'v>>>> = custom_args
+            .iter()
+            .map(|(_, typ_value, _)| {
+                typ_value
+                    .map(|fv| TypeCompiled::new(fv.to_value(), eval.heap()))
+                    .transpose()
+                    .map_err(|e| starlark::Error::new_other(anyhow::anyhow!("{:?}", e)))
+            })
+            .collect::<starlark::Result<_>>()?;
 
         args.no_positional_args(eval.heap())?;
         let kwargs = args.names_map()?;
 
-        let mut values: Vec<Cell<Value<'v>>> = Vec::with_capacity(self.fields.len());
-        for ((field_name, field), tc) in self.fields.iter().zip(type_checkers.iter()) {
-            let value = if let Some(v) = kwargs.get(field_name.as_str()) {
+        let mut values: Vec<Cell<Value<'v>>> = Vec::with_capacity(custom_args.len());
+        for ((field_name, _, default), tc) in custom_args.iter().zip(type_checkers.iter()) {
+            let value = if let Some(v) = kwargs.get(*field_name) {
                 *v
-            } else if let Some(default) = field.default {
-                copy_default_value(default.to_value(), eval.heap())?
+            } else if let Some(default_fv) = default {
+                default_fv.to_value()
             } else {
-                return Err(starlark::Error::new_other(anyhow::anyhow!(
-                    "Missing required field `{}` for {}",
-                    field_name,
-                    self
-                )));
+                // No storable default (e.g. lambda default was dropped at definition time).
+                // Fall back to None so the arg is accessible as ctx.args.name.
+                eval.heap().alloc(starlark::values::none::NoneType)
             };
 
-            if !tc.matches(value) {
-                return Err(starlark::Error::new_other(anyhow::anyhow!(
-                    "Field `{}` expected type `{}`, got `{}`",
-                    field_name,
-                    tc,
-                    value.get_type()
-                )));
+            if let Some(tc) = tc {
+                if !tc.matches(value) {
+                    return Err(starlark::Error::new_other(anyhow::anyhow!(
+                        "Arg `{}` expected type `{}`, got `{}`",
+                        field_name,
+                        tc,
+                        value.get_type()
+                    )));
+                }
             }
 
             values.push(Cell::new(value));
@@ -254,20 +321,39 @@ impl Freeze for FeatureType<'_> {
     type Frozen = FrozenFeatureType;
 
     fn freeze(self, freezer: &Freezer) -> Result<Self::Frozen, FreezeError> {
-        let mut frozen_fields = SmallMap::with_capacity(self.fields.len());
-        for (name, field) in self.fields.into_iter() {
-            frozen_fields.insert(name, field.freeze(freezer)?);
-        }
         Ok(FrozenFeatureType {
             id: self.id,
             name: self.name,
-            fields: frozen_fields,
+            export_name: self.export_name,
+            display_name: self.display_name,
+            summary: self.summary,
+            description: self.description,
+            args: self.args, // Arg is Clone+simple, no freeze needed
             implementation_fn: self
                 .implementation_fn
                 .map(|f| f.freeze(freezer))
                 .transpose()?,
         })
     }
+}
+
+// -----------------------------------------------------------------------------
+// Custom arg index helper
+// -----------------------------------------------------------------------------
+
+/// Return the index of `name` within the Custom-only subset of the args map.
+/// Custom args are stored as `FeatureInstance.values[i]` in their iteration order.
+fn custom_arg_index(args: &SmallMap<String, Arg>, name: &str) -> Option<usize> {
+    let mut idx = 0;
+    for (k, v) in args.iter() {
+        if matches!(v, Arg::Custom { .. }) {
+            if k.as_str() == name {
+                return Some(idx);
+            }
+            idx += 1;
+        }
+    }
+    None
 }
 
 // -----------------------------------------------------------------------------
@@ -282,9 +368,10 @@ pub struct FeatureInstance<'v> {
     /// Field values in the same order as the type's field definitions.
     #[allocative(skip)]
     pub(crate) values: Box<[Cell<Value<'v>>]>,
-    /// Fresh type checkers created at construction time.
+    /// Fresh type checkers created at construction time. `None` when the type annotation
+    /// could not be frozen (e.g. `typing.Callable[[str], str]`) — type checking is skipped.
     #[allocative(skip)]
-    pub(crate) type_checkers: Box<[TypeCompiled<Value<'v>>]>,
+    pub(crate) type_checkers: Box<[Option<TypeCompiled<Value<'v>>>]>,
     /// Built-in enabled flag. Runtime skips `implementation` if false.
     #[allocative(skip)]
     pub(crate) enabled: Cell<bool>,
@@ -294,11 +381,21 @@ impl<'v> Display for FeatureInstance<'v> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}(enabled={}", self.typ, self.enabled.get())?;
         if let Some(feat_type) = self.typ.downcast_ref::<FeatureType>() {
-            for ((name, _), value) in feat_type.fields.iter().zip(self.values.iter()) {
+            let custom_names = feat_type
+                .args
+                .iter()
+                .filter(|(_, v)| matches!(v, Arg::Custom { .. }))
+                .map(|(k, _)| k.as_str());
+            for (name, value) in custom_names.zip(self.values.iter()) {
                 write!(f, ", {}={}", name, value.get())?;
             }
         } else if let Some(frozen_type) = self.typ.downcast_ref::<FrozenFeatureType>() {
-            for ((name, _), value) in frozen_type.fields.iter().zip(self.values.iter()) {
+            let custom_names = frozen_type
+                .args
+                .iter()
+                .filter(|(_, v)| matches!(v, Arg::Custom { .. }))
+                .map(|(k, _)| k.as_str());
+            for (name, value) in custom_names.zip(self.values.iter()) {
                 write!(f, ", {}={}", name, value.get())?;
             }
         }
@@ -315,7 +412,9 @@ unsafe impl<'v> Trace<'v> for FeatureInstance<'v> {
             cell.set(v);
         }
         for tc in self.type_checkers.iter_mut() {
-            tc.trace(tracer);
+            if let Some(tc) = tc {
+                tc.trace(tracer);
+            }
         }
     }
 }
@@ -336,16 +435,14 @@ impl<'v> StarlarkValue<'v> for FeatureInstance<'v> {
         if attribute == "enabled" {
             return Some(heap.alloc(self.enabled.get()));
         }
-        if let Some(feat_type) = self.typ.downcast_ref::<FeatureType>() {
-            if let Some(idx) = feat_type.fields.get_index_of(attribute) {
-                return Some(self.values[idx].get());
-            }
+        let idx = if let Some(feat_type) = self.typ.downcast_ref::<FeatureType>() {
+            custom_arg_index(&feat_type.args, attribute)
         } else if let Some(frozen_type) = self.typ.downcast_ref::<FrozenFeatureType>() {
-            if let Some(idx) = frozen_type.fields.get_index_of(attribute) {
-                return Some(self.values[idx].get());
-            }
-        }
-        None
+            custom_arg_index(&frozen_type.args, attribute)
+        } else {
+            None
+        };
+        idx.map(|i| self.values[i].get())
     }
 
     fn set_attr(&self, attribute: &str, value: Value<'v>) -> starlark::Result<()> {
@@ -361,34 +458,32 @@ impl<'v> StarlarkValue<'v> for FeatureInstance<'v> {
         }
 
         let idx = if let Some(feat_type) = self.typ.downcast_ref::<FeatureType>() {
-            feat_type.fields.get_index_of(attribute)
+            custom_arg_index(&feat_type.args, attribute)
         } else if let Some(frozen_type) = self.typ.downcast_ref::<FrozenFeatureType>() {
-            frozen_type.fields.get_index_of(attribute)
+            custom_arg_index(&frozen_type.args, attribute)
         } else {
             return Err(starlark::Error::new_other(anyhow::anyhow!(
                 "Invalid feature type"
             )));
         };
 
-        let idx = match idx {
-            Some(idx) => idx,
-            None => {
+        let idx = idx.ok_or_else(|| {
+            starlark::Error::new_other(anyhow::anyhow!(
+                "Feature {} has no attr `{}`",
+                self.typ,
+                attribute
+            ))
+        })?;
+
+        if let Some(tc) = &self.type_checkers[idx] {
+            if !tc.matches(value) {
                 return Err(starlark::Error::new_other(anyhow::anyhow!(
-                    "Feature {} has no field `{}`",
-                    self.typ,
-                    attribute
+                    "Arg `{}` expected type `{}`, got `{}`",
+                    attribute,
+                    tc,
+                    value.get_type()
                 )));
             }
-        };
-
-        let tc = &self.type_checkers[idx];
-        if !tc.matches(value) {
-            return Err(starlark::Error::new_other(anyhow::anyhow!(
-                "Field `{}` expected type `{}`, got `{}`",
-                attribute,
-                tc,
-                value.get_type()
-            )));
         }
 
         self.values[idx].set(value);
@@ -400,22 +495,34 @@ impl<'v> StarlarkValue<'v> for FeatureInstance<'v> {
             return true;
         }
         if let Some(feat_type) = self.typ.downcast_ref::<FeatureType>() {
-            feat_type.fields.contains_key(attribute)
+            custom_arg_index(&feat_type.args, attribute).is_some()
         } else if let Some(frozen_type) = self.typ.downcast_ref::<FrozenFeatureType>() {
-            frozen_type.fields.contains_key(attribute)
+            custom_arg_index(&frozen_type.args, attribute).is_some()
         } else {
             false
         }
     }
 
     fn dir_attr(&self) -> Vec<String> {
-        let mut attrs = vec!["enabled".to_string()];
+        let mut result = vec!["enabled".to_string()];
         if let Some(feat_type) = self.typ.downcast_ref::<FeatureType>() {
-            attrs.extend(feat_type.fields.keys().map(|s| s.clone()));
+            result.extend(
+                feat_type
+                    .args
+                    .iter()
+                    .filter(|(_, v)| matches!(v, Arg::Custom { .. }))
+                    .map(|(k, _)| k.clone()),
+            );
         } else if let Some(frozen_type) = self.typ.downcast_ref::<FrozenFeatureType>() {
-            attrs.extend(frozen_type.fields.keys().map(|s| s.clone()));
+            result.extend(
+                frozen_type
+                    .args
+                    .iter()
+                    .filter(|(_, v)| matches!(v, Arg::Custom { .. }))
+                    .map(|(k, _)| k.clone()),
+            );
         }
-        attrs
+        result
     }
 }
 
@@ -434,7 +541,12 @@ impl Display for FrozenFeatureInstance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}(enabled={}", self.typ, self.enabled)?;
         if let Some(frozen_type) = self.typ.downcast_ref::<FrozenFeatureType>() {
-            for ((name, _), value) in frozen_type.fields.iter().zip(self.values.iter()) {
+            let custom_names = frozen_type
+                .args
+                .iter()
+                .filter(|(_, v)| matches!(v, Arg::Custom { .. }))
+                .map(|(k, _)| k.as_str());
+            for (name, value) in custom_names.zip(self.values.iter()) {
                 write!(f, ", {}={}", name, value)?;
             }
         }
@@ -465,7 +577,7 @@ impl<'v> StarlarkValue<'v> for FrozenFeatureInstance {
             return Some(heap.alloc(self.enabled));
         }
         if let Some(frozen_type) = self.typ.downcast_ref::<FrozenFeatureType>() {
-            if let Some(idx) = frozen_type.fields.get_index_of(attribute) {
+            if let Some(idx) = custom_arg_index(&frozen_type.args, attribute) {
                 return Some(self.values[idx].to_value());
             }
         }
@@ -477,18 +589,24 @@ impl<'v> StarlarkValue<'v> for FrozenFeatureInstance {
             return true;
         }
         if let Some(frozen_type) = self.typ.downcast_ref::<FrozenFeatureType>() {
-            frozen_type.fields.contains_key(attribute)
+            custom_arg_index(&frozen_type.args, attribute).is_some()
         } else {
             false
         }
     }
 
     fn dir_attr(&self) -> Vec<String> {
-        let mut attrs = vec!["enabled".to_string()];
+        let mut result = vec!["enabled".to_string()];
         if let Some(frozen_type) = self.typ.downcast_ref::<FrozenFeatureType>() {
-            attrs.extend(frozen_type.fields.keys().map(|s| s.clone()));
+            result.extend(
+                frozen_type
+                    .args
+                    .iter()
+                    .filter(|(_, v)| matches!(v, Arg::Custom { .. }))
+                    .map(|(k, _)| k.clone()),
+            );
         }
-        attrs
+        result
     }
 }
 
@@ -513,6 +631,141 @@ impl Freeze for FeatureInstance<'_> {
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
+
+/// Extract the display name from a FeatureType or FrozenFeatureType value.
+/// Falls back to splitting the CamelCase export name into Title Case words if no explicit
+/// `display_name` was given (e.g. `"ArtifactUpload"` → `"Artifact Upload"`).
+pub fn extract_feature_display_name(value: Value<'_>) -> Option<String> {
+    if let Some(ft) = value.downcast_ref::<FeatureType>() {
+        if !ft.display_name.is_empty() {
+            return Some(ft.display_name.clone());
+        }
+        return ft.export_name.as_deref().map(camel_to_display_name);
+    }
+    if let Some(ft) = value.downcast_ref::<FrozenFeatureType>() {
+        if !ft.display_name.is_empty() {
+            return Some(ft.display_name.clone());
+        }
+        return ft.export_name.as_deref().map(camel_to_display_name);
+    }
+    None
+}
+
+/// Extract the CamelCase export variable name (e.g. `"ArtifactUpload"`).
+/// Used in help text context lines like "feature defined in ...".
+pub fn extract_feature_identifier(value: Value<'_>) -> Option<String> {
+    if let Some(ft) = value.downcast_ref::<FeatureType>() {
+        return ft.export_name.clone();
+    }
+    if let Some(ft) = value.downcast_ref::<FrozenFeatureType>() {
+        return ft.export_name.clone();
+    }
+    None
+}
+
+/// Extract the kebab-case name used as the CLI arg prefix (e.g. `"artifact-upload"`).
+/// Returns `None` for anonymous features where `export_as` was never called and no
+/// explicit `name` was given.
+pub fn extract_feature_name(value: Value<'_>) -> Option<String> {
+    if let Some(ft) = value.downcast_ref::<FeatureType>() {
+        if !ft.name.is_empty() {
+            return Some(ft.name.clone());
+        }
+        return None;
+    }
+    if let Some(ft) = value.downcast_ref::<FrozenFeatureType>() {
+        if !ft.name.is_empty() {
+            return Some(ft.name.clone());
+        }
+        return None;
+    }
+    None
+}
+
+/// Extract the one-line summary from a FeatureType or FrozenFeatureType value.
+pub fn extract_feature_summary(value: Value<'_>) -> Option<String> {
+    if let Some(ft) = value.downcast_ref::<FeatureType>() {
+        return Some(ft.summary.clone());
+    }
+    if let Some(ft) = value.downcast_ref::<FrozenFeatureType>() {
+        return Some(ft.summary.clone());
+    }
+    None
+}
+
+/// Extract the extended description from a FeatureType or FrozenFeatureType value.
+pub fn extract_feature_description(value: Value<'_>) -> Option<String> {
+    if let Some(ft) = value.downcast_ref::<FeatureType>() {
+        return Some(ft.description.clone());
+    }
+    if let Some(ft) = value.downcast_ref::<FrozenFeatureType>() {
+        return Some(ft.description.clone());
+    }
+    None
+}
+
+/// Extract the CLI args from a FeatureType or FrozenFeatureType value.
+/// Filters the args map to return only CLI-exposed entries (excludes Custom args).
+/// Returns None if the value is not a feature type, Some (possibly empty map) otherwise.
+pub fn extract_feature_args(value: Value<'_>) -> Option<SmallMap<String, Arg>> {
+    if let Some(ft) = value.downcast_ref::<FeatureType>() {
+        Some(
+            ft.args
+                .iter()
+                .filter(|(_, v)| v.is_cli_exposed())
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        )
+    } else if let Some(ft) = value.downcast_ref::<FrozenFeatureType>() {
+        Some(
+            ft.args
+                .iter()
+                .filter(|(_, v)| v.is_cli_exposed())
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        )
+    } else {
+        None
+    }
+}
+
+/// Populate `Custom` arg values from a feature instance into the CLI-sourced `Args` map.
+///
+/// `cli_args` is pre-populated with CLI-parsed values for CLI-exposed args. This function
+/// inserts the values of `Custom` args (set in `config.axl`) so that the feature
+/// implementation can read all args uniformly through a single `ctx.args` map.
+pub fn populate_feature_custom_args<'v>(
+    type_value: Value<'v>,
+    instance_value: Value<'v>,
+    mut cli_args: CliArgs<'v>,
+) -> CliArgs<'v> {
+    if let Some(ft) = type_value.downcast_ref::<FeatureType>() {
+        if let Some(inst) = instance_value.downcast_ref::<FeatureInstance>() {
+            let custom_names: Vec<&str> = ft
+                .args
+                .iter()
+                .filter(|(_, v)| matches!(v, Arg::Custom { .. }))
+                .map(|(k, _)| k.as_str())
+                .collect();
+            for (name, cell) in custom_names.into_iter().zip(inst.values.iter()) {
+                cli_args.insert(name.to_owned(), cell.get());
+            }
+        }
+    } else if let Some(ft) = type_value.downcast_ref::<FrozenFeatureType>() {
+        if let Some(inst) = instance_value.downcast_ref::<FrozenFeatureInstance>() {
+            let custom_names: Vec<&str> = ft
+                .args
+                .iter()
+                .filter(|(_, v)| matches!(v, Arg::Custom { .. }))
+                .map(|(k, _)| k.as_str())
+                .collect();
+            for (name, fv) in custom_names.into_iter().zip(inst.values.iter()) {
+                cli_args.insert(name.to_owned(), fv.to_value());
+            }
+        }
+    }
+    cli_args
+}
 
 /// Extract the feature type ID from a Value that is a FeatureType or FrozenFeatureType.
 pub fn extract_feature_type_id(value: Value) -> Option<u64> {
@@ -548,66 +801,354 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
     /// config.axl files have been evaluated. It can inject closures into fragment
     /// hook lists via `ctx.fragments[FragmentType].hook.append(...)`.
     ///
+    /// Feature CLI args are injected into every task subcommand on the CLI. Only named
+    /// optional flags are supported — positional args and `required = true` are not
+    /// allowed because features apply globally and would break any task that doesn't
+    /// supply the flag.
+    ///
     /// Every feature instance automatically has an `enabled` field (default `True`).
     /// Set `ctx.features[MyFeature].enabled = False` in config.axl to disable it.
     ///
-    /// Example:
+    /// ## Naming
+    ///
+    /// Features must be exported as **CamelCase** (`ArtifactUpload`, `GithubStatusChecks`).
+    /// This is enforced at definition time. Features are referenced as type keys
+    /// (`ctx.features[ArtifactUpload]`), mirroring Bazel's provider convention
+    /// (`dep[CcInfo]`); CamelCase signals this type-key role.
+    ///
+    /// The `name` field sets the kebab-case slug used as a prefix for every CLI arg this
+    /// feature declares: a feature named `"artifact-upload"` with arg `mode` exposes
+    /// `--artifact-upload-mode`. The name is auto-derived from the CamelCase export name
+    /// via `to_command_name` (`ArtifactUpload` → `artifact-upload`) if not set explicitly.
+    /// Override with `name = "s3"` when the auto-derived form is undesirable (e.g. for
+    /// acronym-heavy names like `GitHubActions` → `git-hub-actions`).
+    ///
+    /// `display_name` overrides the Title Case name shown in CLI help section headings.
+    ///
+    /// ## Arg names
+    ///
+    /// Arg keys must be `snake_case` (`[a-z][a-z0-9_]*`). There are two kinds:
+    ///
+    /// - **CLI args** (`args.string(...)`, `args.boolean(...)`, etc.) — exposed as
+    ///   `--{name}-{arg}` flags on every task subcommand; must be optional (no `required = true`).
+    /// - **Config-only args** (`args.custom(type, default = …)`) — set in `config.axl` only, not shown in help.
+    ///
+    /// Both kinds are accessible as `ctx.args.arg_name` in the implementation.
+    ///
+    /// ## Example
+    ///
     /// ```starlark
     /// def _impl(ctx: FeatureContext):
-    ///     owner = ctx.attr.owner
-    ///     ctx.fragments[BazelFragment].build_start.append(
-    ///         lambda task_ctx, state: github.create_check(task_ctx, owner)
+    ///     ctx.fragments[BazelFragment].build_end.append(
+    ///         lambda task_ctx, state: upload_artifacts(
+    ///             task_ctx, ctx.args.bucket, ctx.args.mode
+    ///         )
     ///     )
     ///
-    /// GithubStatusChecks = feature(
+    /// ArtifactUpload = feature(
+    ///     # name auto-derived as "artifact-upload"; override with name = "s3" if preferred
+    ///     display_name = "Artifact Upload",
+    ///     summary = "Upload build artifacts to S3 storage",
     ///     implementation = _impl,
-    ///     attrs = {
-    ///         "owner": attr(str | None, None),
-    ///         "repo":  attr(str | None, None),
-    ///     }
+    ///     args = {
+    ///         "bucket": args.custom(str | None, default = None),  # config.axl only
+    ///         "mode":   args.string(default = "auto"),             # CLI flag: --artifact-upload-mode
+    ///     },
     /// )
     /// ```
     fn feature<'v>(
         #[starlark(require = named)] implementation: Value<'v>,
+        #[starlark(require = named, default = String::new())] name: String,
+        #[starlark(require = named, default = String::new())] display_name: String,
+        #[starlark(require = named, default = String::new())] summary: String,
+        #[starlark(require = named, default = String::new())] description: String,
         #[starlark(require = named, default = UnpackDictEntries::default())]
-        attrs: UnpackDictEntries<String, Value<'v>>,
-        eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
+        args: UnpackDictEntries<String, Value<'v>>,
+        _eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<FeatureType<'v>> {
-        let mut fields = SmallMap::with_capacity(attrs.entries.len());
+        // Validate explicit name; derivation from the export name happens in export_as.
+        if !name.is_empty() {
+            validate_command_name(&name, "feature name").map_err(|e| anyhow::anyhow!(e))?;
+        }
 
-        for (name, value) in attrs.entries.into_iter() {
-            let field = if let Some(field_value) = value.downcast_ref::<FieldValue>() {
-                Field {
-                    typ: field_value.typ.dupe(),
-                    typ_value: field_value.typ_value,
-                    default: field_value.default,
-                }
-            } else if let Some(field_value) = value.downcast_ref::<FrozenFieldValue>() {
-                let typ_value = field_value.typ_value.to_value();
-                let typ = TypeCompiled::new(typ_value, eval.heap())
-                    .map_err(|e| anyhow::anyhow!("{:?}", e))?;
-                Field {
-                    typ,
-                    typ_value,
-                    default: field_value.default.map(|v| v.to_value()),
-                }
-            } else {
-                let typ = TypeCompiled::new(value, eval.heap())
-                    .map_err(|e| anyhow::anyhow!("{:?}", e))?;
-                Field {
-                    typ,
-                    typ_value: value,
-                    default: None,
-                }
-            };
-            fields.insert(name, field);
+        let mut args_ = SmallMap::with_capacity(args.entries.len());
+
+        for (arg_name, value) in args.entries.into_iter() {
+            validate_arg_name(&arg_name).map_err(|e| anyhow::anyhow!("feature {}", e))?;
+            let cli_arg = value.downcast_ref::<Arg>().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "feature arg {:?}: expected args.string/boolean/... or args.custom(...), got '{}'. \
+                     All feature args must have a default — use args.custom(type, default = …) for config-only args \
+                     or args.string(default = …) etc. for CLI flags",
+                    arg_name,
+                    value.get_type()
+                )
+            })?;
+            if matches!(
+                cli_arg,
+                Arg::Positional { .. } | Arg::TrailingVarArgs { .. }
+            ) {
+                return Err(anyhow::anyhow!(
+                    "feature arg {:?}: positional args are not allowed in features",
+                    arg_name
+                ));
+            }
+            if cli_arg.is_required() {
+                return Err(anyhow::anyhow!(
+                    "feature arg {:?}: CLI args in features must be optional (required = true is not allowed); \
+                     features inject args into every task subcommand so required flags would break all tasks",
+                    arg_name
+                ));
+            }
+            args_.insert(arg_name, cli_arg.clone());
         }
 
         Ok(FeatureType {
             id: next_feature_type_id(),
-            name: None,
-            fields,
+            name,
+            export_name: None,
+            display_name,
+            summary,
+            description,
+            args: args_,
             implementation_fn: Some(implementation),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── to_command_name ──────────────────────────────────────────────────────
+
+    #[test]
+    fn command_name_snake_case() {
+        assert_eq!(to_command_name("axl_add"), "axl-add");
+        assert_eq!(to_command_name("remote_cache"), "remote-cache");
+        assert_eq!(to_command_name("bazel_startup_flag"), "bazel-startup-flag");
+    }
+
+    #[test]
+    fn command_name_single_word() {
+        assert_eq!(to_command_name("build"), "build");
+        assert_eq!(to_command_name("Build"), "build");
+    }
+
+    #[test]
+    fn command_name_camel_case() {
+        assert_eq!(to_command_name("AxlAdd"), "axl-add");
+        assert_eq!(to_command_name("DeliveryTask"), "delivery-task");
+        assert_eq!(to_command_name("UserTaskManual"), "user-task-manual");
+    }
+
+    #[test]
+    fn command_name_acronym_prefix() {
+        assert_eq!(to_command_name("CIBuild"), "ci-build");
+        assert_eq!(to_command_name("ACKey"), "ac-key");
+    }
+
+    #[test]
+    fn command_name_acronym_run() {
+        assert_eq!(to_command_name("HTTPSRedirect"), "https-redirect");
+        assert_eq!(to_command_name("XMLParser"), "xml-parser");
+    }
+
+    #[test]
+    fn command_name_digit_boundary() {
+        assert_eq!(to_command_name("S3Upload"), "s3-upload");
+        assert_eq!(to_command_name("x86_64"), "x86-64");
+        assert_eq!(to_command_name("task1"), "task1");
+    }
+
+    #[test]
+    fn command_name_leading_underscore_stripped() {
+        // _-prefixed names are private in Starlark and won't be exported,
+        // but to_command_name strips them gracefully rather than panicking.
+        assert_eq!(to_command_name("_private"), "private");
+    }
+
+    // ── to_display_name ──────────────────────────────────────────────────────
+
+    #[test]
+    fn display_name_from_kebab() {
+        assert_eq!(to_display_name("axl-add"), "Axl Add");
+        assert_eq!(to_display_name("ci-build"), "Ci Build");
+        assert_eq!(to_display_name("s3-upload"), "S3 Upload");
+    }
+
+    #[test]
+    fn display_name_from_snake() {
+        assert_eq!(to_display_name("artifact_upload"), "Artifact Upload");
+        assert_eq!(to_display_name("bazel_defaults"), "Bazel Defaults");
+    }
+
+    #[test]
+    fn display_name_single_word() {
+        assert_eq!(to_display_name("build"), "Build");
+    }
+
+    // ── camel_to_display_name ────────────────────────────────────────────────
+
+    #[test]
+    fn camel_display_name_basic() {
+        assert_eq!(camel_to_display_name("ArtifactUpload"), "Artifact Upload");
+        assert_eq!(
+            camel_to_display_name("GithubStatusChecks"),
+            "Github Status Checks"
+        );
+        assert_eq!(camel_to_display_name("BazelDefaults"), "Bazel Defaults");
+    }
+
+    #[test]
+    fn camel_display_name_acronym() {
+        assert_eq!(camel_to_display_name("CIBuild"), "Ci Build");
+        assert_eq!(camel_to_display_name("S3Upload"), "S3 Upload");
+    }
+
+    #[test]
+    fn camel_display_name_single_word() {
+        assert_eq!(camel_to_display_name("Build"), "Build");
+        assert_eq!(camel_to_display_name("MyConfig"), "My Config");
+    }
+
+    // ── validate_arg_name ────────────────────────────────────────────────────
+
+    #[test]
+    fn arg_name_valid() {
+        for name in &[
+            "a",
+            "foo",
+            "foo_bar",
+            "foo123",
+            "bazel_flag",
+            "remote_cache",
+        ] {
+            assert!(
+                validate_arg_name(name).is_ok(),
+                "expected {:?} to be valid",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn arg_name_invalid_start() {
+        assert!(validate_arg_name("").is_err());
+        assert!(validate_arg_name("1foo").is_err());
+        assert!(validate_arg_name("_foo").is_err());
+        assert!(validate_arg_name("Foo").is_err());
+        assert!(validate_arg_name("FOO").is_err());
+    }
+
+    #[test]
+    fn arg_name_invalid_chars() {
+        assert!(validate_arg_name("foo-bar").is_err()); // dashes not allowed (use snake_case)
+        assert!(validate_arg_name("fooBar").is_err()); // uppercase mid-name
+        assert!(validate_arg_name("foo.bar").is_err());
+        assert!(validate_arg_name("foo bar").is_err());
+    }
+
+    // ── validate_command_name ────────────────────────────────────────────────
+
+    #[test]
+    fn command_name_valid() {
+        for name in &["build", "axl-add", "ci-build", "s3-upload", "a", "z9"] {
+            assert!(
+                validate_command_name(name, "task").is_ok(),
+                "expected {:?} to be valid",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn command_name_invalid_start() {
+        assert!(validate_command_name("", "task").is_err());
+        assert!(validate_command_name("1foo", "task").is_err());
+        assert!(validate_command_name("-foo", "task").is_err());
+        assert!(validate_command_name("Foo", "task").is_err());
+        assert!(validate_command_name("_foo", "task").is_err());
+    }
+
+    #[test]
+    fn command_name_invalid_chars() {
+        assert!(validate_command_name("foo_bar", "task").is_err()); // underscores not allowed
+        assert!(validate_command_name("fooBar", "task").is_err()); // uppercase
+        assert!(validate_command_name("foo bar", "task").is_err());
+    }
+
+    #[test]
+    fn command_name_no_trailing_or_consecutive_dashes() {
+        assert!(validate_command_name("axl-add", "task").is_ok());
+        assert!(validate_command_name("a-b-c", "task").is_ok());
+        assert!(validate_command_name("axl-", "task").is_err()); // trailing dash
+        assert!(validate_command_name("axl--add", "task").is_err()); // consecutive dashes
+    }
+
+    #[test]
+    fn command_name_error_includes_kind() {
+        let err = validate_command_name("foo_bar", "group").unwrap_err();
+        assert!(
+            err.contains("group"),
+            "error should mention 'group': {}",
+            err
+        );
+        let err = validate_command_name("foo_bar", "task").unwrap_err();
+        assert!(err.contains("task"), "error should mention 'task': {}", err);
+    }
+
+    // ── validate_type_name ───────────────────────────────────────────────────
+
+    #[test]
+    fn type_name_valid() {
+        for name in &[
+            "A",
+            "Foo",
+            "FooBar",
+            "ArtifactUpload",
+            "MyConfig",
+            "CcInfo",
+            "S3Upload",
+            "CIBuild",
+        ] {
+            assert!(
+                validate_type_name(name, "feature").is_ok(),
+                "expected {:?} to be valid",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn type_name_invalid_start() {
+        assert!(validate_type_name("", "feature").is_err());
+        assert!(validate_type_name("foo", "feature").is_err()); // lowercase start
+        assert!(validate_type_name("1Foo", "feature").is_err()); // digit start
+        assert!(validate_type_name("_Foo", "feature").is_err()); // underscore start
+    }
+
+    #[test]
+    fn type_name_invalid_chars() {
+        assert!(validate_type_name("Foo_Bar", "feature").is_err()); // underscore
+        assert!(validate_type_name("Foo-Bar", "feature").is_err()); // dash
+        assert!(validate_type_name("Foo Bar", "feature").is_err()); // space
+        assert!(validate_type_name("Foo.Bar", "feature").is_err()); // dot
+    }
+
+    #[test]
+    fn type_name_error_includes_kind() {
+        let err = validate_type_name("bad_name", "feature").unwrap_err();
+        assert!(
+            err.contains("feature"),
+            "error should mention 'feature': {}",
+            err
+        );
+        let err = validate_type_name("bad_name", "trait").unwrap_err();
+        assert!(
+            err.contains("trait"),
+            "error should mention 'trait': {}",
+            err
+        );
     }
 }

--- a/crates/axl-runtime/src/engine/types/mod.rs
+++ b/crates/axl-runtime/src/engine/types/mod.rs
@@ -1,2 +1,3 @@
 pub mod feature;
+pub mod names;
 pub mod r#trait;

--- a/crates/axl-runtime/src/engine/types/names.rs
+++ b/crates/axl-runtime/src/engine/types/names.rs
@@ -1,0 +1,182 @@
+/// Name validation and conversion utilities for task, feature, trait, arg, and command names.
+
+/// Convert a snake_case or CamelCase identifier to a kebab-case CLI command name.
+///
+/// | Variable name    | CLI command      |
+/// |------------------|------------------|
+/// | `axl_add`        | `axl-add`        |
+/// | `AxlAdd`         | `axl-add`        |
+/// | `ci_build`       | `ci-build`       |
+/// | `CIBuild`        | `ci-build`       |
+/// | `s3_upload`      | `s3-upload`      |
+/// | `S3Upload`       | `s3-upload`      |
+/// | `https_redirect` | `https-redirect` |
+/// | `HTTPSRedirect`  | `https-redirect` |
+pub fn to_command_name(var_name: &str) -> String {
+    var_name
+        .split('_')
+        .flat_map(camel_to_kebab_words)
+        .filter(|w| !w.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+/// Convert a snake_case or kebab-case identifier to a Title Case display name.
+/// `"artifact_upload"` → `"Artifact Upload"`, `"github-status-checks"` → `"Github Status Checks"`.
+pub fn to_display_name(name: &str) -> String {
+    name.split(|c| c == '_' || c == '-')
+        .filter(|seg| !seg.is_empty())
+        .map(|seg| {
+            let mut chars = seg.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => {
+                    let upper: String = first.to_uppercase().collect();
+                    upper + chars.as_str()
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Convert a CamelCase identifier to a Title Case display name with spaces.
+/// `"ArtifactUpload"` → `"Artifact Upload"`, `"CIBuild"` → `"Ci Build"`.
+pub fn camel_to_display_name(camel: &str) -> String {
+    camel_to_kebab_words(camel)
+        .into_iter()
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => {
+                    let upper: String = first.to_uppercase().collect();
+                    upper + chars.as_str()
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+pub(crate) fn camel_to_kebab_words(s: &str) -> Vec<String> {
+    if s.is_empty() {
+        return vec![];
+    }
+    let chars: Vec<char> = s.chars().collect();
+    let mut words: Vec<String> = Vec::new();
+    let mut current = String::new();
+
+    for (i, &c) in chars.iter().enumerate() {
+        if c.is_ascii_uppercase() {
+            let prev = if i > 0 { Some(chars[i - 1]) } else { None };
+            let next = chars.get(i + 1).copied();
+            let split = match prev {
+                None => false,
+                Some(p) => {
+                    p.is_ascii_lowercase()
+                        || p.is_ascii_digit()
+                        || (p.is_ascii_uppercase()
+                            && next.map_or(false, |n| n.is_ascii_lowercase()))
+                }
+            };
+            if split && !current.is_empty() {
+                words.push(current.to_lowercase());
+                current = String::new();
+            }
+            current.push(c);
+        } else {
+            current.push(c);
+        }
+    }
+    if !current.is_empty() {
+        words.push(current.to_lowercase());
+    }
+    words
+}
+
+/// Validate that a feature or trait export name conforms to `[A-Z][A-Za-z0-9]*` (CamelCase).
+///
+/// Features and traits are referenced as map keys (`ctx.features[ArtifactUpload]`,
+/// `ctx.traits[MyConfig]`), which reads like a type key. CamelCase is enforced to
+/// match Bazel's provider convention (`dep[CcInfo]`) and signal this type-key role.
+pub fn validate_type_name(name: &str, kind: &str) -> Result<(), String> {
+    let mut chars = name.chars();
+    match chars.next() {
+        None => return Err(format!("{kind} name cannot be empty")),
+        Some(c) if !c.is_ascii_uppercase() => {
+            return Err(format!(
+                "{kind} name {:?} must start with an uppercase letter (CamelCase required)",
+                name
+            ));
+        }
+        _ => {}
+    }
+    for c in chars {
+        if !c.is_ascii_alphanumeric() {
+            return Err(format!(
+                "{kind} name {:?} contains invalid character {:?} (allowed: A-Z, a-z, 0-9)",
+                name, c
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate that an arg name conforms to `[a-z][a-z0-9_]*`.
+pub fn validate_arg_name(name: &str) -> Result<(), String> {
+    let mut chars = name.chars();
+    match chars.next() {
+        None => return Err("arg name cannot be empty".to_string()),
+        Some(c) if !c.is_ascii_lowercase() => {
+            return Err(format!(
+                "arg name {:?} must start with a lowercase letter",
+                name
+            ));
+        }
+        _ => {}
+    }
+    for c in chars {
+        if !c.is_ascii_lowercase() && !c.is_ascii_digit() && c != '_' {
+            return Err(format!(
+                "arg name {:?} contains invalid character {:?} (allowed: a-z, 0-9, _)",
+                name, c
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate that a command/group name conforms to `[a-z][a-z0-9-]*` with no
+/// trailing dash and no consecutive dashes.
+pub fn validate_command_name(name: &str, kind: &str) -> Result<(), String> {
+    let mut chars = name.chars();
+    match chars.next() {
+        None => return Err(format!("{kind} name cannot be empty")),
+        Some(c) if !c.is_ascii_lowercase() => {
+            return Err(format!(
+                "{kind} name {:?} must start with a lowercase letter",
+                name
+            ));
+        }
+        _ => {}
+    }
+    for c in chars {
+        if !c.is_ascii_lowercase() && !c.is_ascii_digit() && c != '-' {
+            return Err(format!(
+                "{kind} name {:?} contains invalid character {:?} (allowed: a-z, 0-9, -)",
+                name, c
+            ));
+        }
+    }
+    if name.ends_with('-') {
+        return Err(format!("{kind} name {:?} cannot end with a dash", name));
+    }
+    if name.contains("--") {
+        return Err(format!(
+            "{kind} name {:?} cannot contain consecutive dashes",
+            name
+        ));
+    }
+    Ok(())
+}

--- a/crates/axl-runtime/src/engine/types/trait.rs
+++ b/crates/axl-runtime/src/engine/types/trait.rs
@@ -9,6 +9,7 @@ use starlark::environment::{GlobalsBuilder, Methods, MethodsBuilder, MethodsStat
 use starlark::starlark_module;
 use starlark::values::dict::AllocDict;
 use starlark::values::list::AllocList;
+use starlark::values::none::NoneOr;
 use starlark::values::typing::TypeCompiled;
 use starlark::values::{
     AllocFrozenValue, AllocValue, Freeze, FreezeError, Freezer, FrozenHeap, FrozenValue, Heap,
@@ -17,30 +18,37 @@ use starlark::values::{
 };
 use starlark_map::small_map::SmallMap;
 
+use crate::engine::types::names::validate_type_name;
+
 static TRAIT_TYPE_ID: AtomicU64 = AtomicU64::new(0);
 
 fn next_trait_type_id() -> u64 {
     TRAIT_TYPE_ID.fetch_add(1, Ordering::SeqCst)
 }
 
-/// A field definition for a trait, containing a type and optional default value.
+// ---------------------------------------------------------------------------
+// Attr / FrozenAttr — stored inside trait definitions (field descriptors)
+// ---------------------------------------------------------------------------
+
+/// A field definition for a trait, containing a type, optional default value, and optional description.
 #[derive(Debug, Clone, ProvidesStaticType, Allocative)]
-pub struct Field<'v> {
+pub struct Attr<'v> {
     pub(crate) typ: TypeCompiled<Value<'v>>,
     pub(crate) typ_value: Value<'v>,
     pub(crate) default: Option<Value<'v>>,
+    pub(crate) description: Option<String>,
 }
 
-impl<'v> Display for Field<'v> {
+impl<'v> fmt::Display for Attr<'v> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.default {
-            None => write!(f, "field({})", self.typ),
-            Some(d) => write!(f, "field({}, {})", self.typ, d),
+            None => write!(f, "attr({})", self.typ),
+            Some(d) => write!(f, "attr({}, default = {})", self.typ, d),
         }
     }
 }
 
-unsafe impl<'v> Trace<'v> for Field<'v> {
+unsafe impl<'v> Trace<'v> for Attr<'v> {
     fn trace(&mut self, tracer: &Tracer<'v>) {
         self.typ.trace(tracer);
         self.typ_value.trace(tracer);
@@ -50,50 +58,57 @@ unsafe impl<'v> Trace<'v> for Field<'v> {
     }
 }
 
-impl<'v> Field<'v> {
-    pub fn freeze(self, freezer: &Freezer) -> Result<FrozenField, FreezeError> {
-        Ok(FrozenField {
+impl<'v> Attr<'v> {
+    pub fn freeze(self, freezer: &Freezer) -> Result<FrozenAttr, FreezeError> {
+        Ok(FrozenAttr {
             typ: self.typ.freeze(freezer)?,
             typ_value: self.typ_value.freeze(freezer)?,
             default: self.default.map(|d| d.freeze(freezer)).transpose()?,
+            description: self.description,
         })
     }
 }
 
-/// A frozen field definition.
+/// A frozen field definition for a trait.
 #[derive(Debug, Clone, ProvidesStaticType, Allocative)]
-pub struct FrozenField {
+pub struct FrozenAttr {
     pub(crate) typ: TypeCompiled<FrozenValue>,
     pub(crate) typ_value: FrozenValue,
     pub(crate) default: Option<FrozenValue>,
+    pub(crate) description: Option<String>,
 }
 
-impl Display for FrozenField {
+impl fmt::Display for FrozenAttr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.default {
-            None => write!(f, "field({})", self.typ),
-            Some(d) => write!(f, "field({}, {})", self.typ, d),
+            None => write!(f, "attr({})", self.typ),
+            Some(d) => write!(f, "attr({}, default = {})", self.typ, d),
         }
     }
 }
 
+// ---------------------------------------------------------------------------
+// ConfigAttrValue / FrozenConfigAttrValue — the Starlark `attr()` return value
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, ProvidesStaticType, NoSerialize, Allocative)]
-pub struct FieldValue<'v> {
+pub struct ConfigAttrValue<'v> {
     pub(crate) typ: TypeCompiled<Value<'v>>,
     pub(crate) typ_value: Value<'v>,
     pub(crate) default: Option<Value<'v>>,
+    pub(crate) description: Option<String>,
 }
 
-impl<'v> Display for FieldValue<'v> {
+impl<'v> fmt::Display for ConfigAttrValue<'v> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.default {
-            None => write!(f, "field({})", self.typ),
-            Some(d) => write!(f, "field({}, {})", self.typ, d),
+            None => write!(f, "attr({})", self.typ),
+            Some(d) => write!(f, "attr({}, default = {})", self.typ, d),
         }
     }
 }
 
-unsafe impl<'v> Trace<'v> for FieldValue<'v> {
+unsafe impl<'v> Trace<'v> for ConfigAttrValue<'v> {
     fn trace(&mut self, tracer: &Tracer<'v>) {
         self.typ.trace(tracer);
         self.typ_value.trace(tracer);
@@ -103,76 +118,75 @@ unsafe impl<'v> Trace<'v> for FieldValue<'v> {
     }
 }
 
-impl<'v> AllocValue<'v> for FieldValue<'v> {
+impl<'v> AllocValue<'v> for ConfigAttrValue<'v> {
     fn alloc_value(self, heap: Heap<'v>) -> Value<'v> {
         heap.alloc_complex(self)
     }
 }
 
-#[starlark_value(type = "field")]
-impl<'v> StarlarkValue<'v> for FieldValue<'v> {
+#[starlark_value(type = "attr")]
+impl<'v> StarlarkValue<'v> for ConfigAttrValue<'v> {
     fn collect_repr(&self, collector: &mut String) {
         write!(collector, "{}", self).unwrap();
     }
 }
 
-/// Frozen version of FieldValue.
+/// Frozen version of ConfigAttrValue.
 #[derive(Debug, ProvidesStaticType, NoSerialize, Allocative)]
-pub struct FrozenFieldValue {
+pub struct FrozenConfigAttrValue {
     pub(crate) typ: TypeCompiled<FrozenValue>,
     pub(crate) typ_value: FrozenValue,
     pub(crate) default: Option<FrozenValue>,
+    pub(crate) description: Option<String>,
 }
 
-impl Display for FrozenFieldValue {
+impl fmt::Display for FrozenConfigAttrValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.default {
-            None => write!(f, "field({})", self.typ),
-            Some(d) => write!(f, "field({}, {})", self.typ, d),
+            None => write!(f, "attr({})", self.typ),
+            Some(d) => write!(f, "attr({}, default = {})", self.typ, d),
         }
     }
 }
 
-unsafe impl<'v> Trace<'v> for FrozenFieldValue {
-    fn trace(&mut self, _tracer: &Tracer<'v>) {
-        // Frozen values don't need tracing
-    }
+unsafe impl<'v> Trace<'v> for FrozenConfigAttrValue {
+    fn trace(&mut self, _tracer: &Tracer<'v>) {}
 }
 
-impl AllocFrozenValue for FrozenFieldValue {
+impl AllocFrozenValue for FrozenConfigAttrValue {
     fn alloc_frozen_value(self, heap: &FrozenHeap) -> FrozenValue {
         heap.alloc_simple(self)
     }
 }
 
-#[starlark_value(type = "field")]
-impl<'v> StarlarkValue<'v> for FrozenFieldValue {
-    type Canonical = FieldValue<'v>;
+#[starlark_value(type = "attr")]
+impl<'v> StarlarkValue<'v> for FrozenConfigAttrValue {
+    type Canonical = ConfigAttrValue<'v>;
 
     fn collect_repr(&self, collector: &mut String) {
         write!(collector, "{}", self).unwrap();
     }
 }
 
-impl Freeze for FieldValue<'_> {
-    type Frozen = FrozenFieldValue;
+impl Freeze for ConfigAttrValue<'_> {
+    type Frozen = FrozenConfigAttrValue;
 
     fn freeze(self, freezer: &Freezer) -> Result<Self::Frozen, FreezeError> {
-        Ok(FrozenFieldValue {
+        Ok(FrozenConfigAttrValue {
             typ: self.typ.freeze(freezer)?,
             typ_value: self.typ_value.freeze(freezer)?,
             default: self.default.map(|d| d.freeze(freezer)).transpose()?,
+            description: self.description,
         })
     }
 }
 
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
 /// Deep-copy a default value if it's a mutable container (list or dict).
-/// This ensures each trait instance gets its own mutable copy rather than
-/// sharing the (potentially frozen) default.
-pub(crate) fn copy_default_value<'v>(
-    value: Value<'v>,
-    heap: Heap<'v>,
-) -> anyhow::Result<Value<'v>> {
+pub fn copy_default_value<'v>(value: Value<'v>, heap: Heap<'v>) -> anyhow::Result<Value<'v>> {
     match value.get_type() {
         "list" => {
             let items: Vec<Value<'v>> = value.iterate(heap).map_err(|e| e.into_anyhow())?.collect();
@@ -194,9 +208,7 @@ pub(crate) fn copy_default_value<'v>(
 }
 
 /// Create fresh TypeCompiled values from field type values at runtime.
-/// This ensures type checking works correctly for types like starlark Records
-/// whose frozen TypeCompiled matchers may not function properly.
-pub(crate) fn build_type_checkers<'v>(
+pub fn build_type_checkers<'v>(
     fields: impl Iterator<Item = Value<'v>>,
     heap: Heap<'v>,
 ) -> starlark::Result<Vec<TypeCompiled<Value<'v>>>> {
@@ -204,6 +216,10 @@ pub(crate) fn build_type_checkers<'v>(
         .map(|typ_value| TypeCompiled::new(typ_value, heap).map_err(starlark::Error::new_other))
         .collect()
 }
+
+// ---------------------------------------------------------------------------
+// TraitType
+// ---------------------------------------------------------------------------
 
 /// The type of a trait, created by `trait(field1=type1, field2=type2, ...)`.
 /// Calling this type creates a `TraitInstance` instance.
@@ -214,7 +230,7 @@ pub struct TraitType<'v> {
     /// Name of the trait type (set when assigned to a variable)
     pub(crate) name: Option<String>,
     /// Fields with their types and optional defaults
-    pub(crate) fields: SmallMap<String, Field<'v>>,
+    pub(crate) fields: SmallMap<String, Attr<'v>>,
 }
 
 impl<'v> Display for TraitType<'v> {
@@ -251,7 +267,8 @@ impl<'v> StarlarkValue<'v> for TraitType<'v> {
         variable_name: &str,
         _eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> starlark::Result<()> {
-        // This is called when the trait type is assigned to a variable.
+        validate_type_name(variable_name, "trait")
+            .map_err(|e| starlark::Error::new_other(anyhow::anyhow!(e)))?;
         // We use unsafe to mutate the name, which is safe because this is only
         // called during module loading.
         let this = self as *const Self as *mut Self;
@@ -338,7 +355,7 @@ fn trait_type_methods(_builder: &mut MethodsBuilder) {}
 pub struct FrozenTraitType {
     pub(crate) id: u64,
     pub(crate) name: Option<String>,
-    pub(crate) fields: SmallMap<String, FrozenField>,
+    pub(crate) fields: SmallMap<String, FrozenAttr>,
 }
 
 impl Display for FrozenTraitType {
@@ -811,10 +828,6 @@ impl Freeze for TraitInstance<'_> {
 // -----------------------------------------------------------------------------
 
 /// Construct a default instance of a trait type using only the heap.
-///
-/// Equivalent to calling `TraitType()` with no arguments from Starlark, but does
-/// not require a full `Evaluator`. Every field must have a default value; if any
-/// required field has no default this returns an error.
 pub fn construct_default_instance<'v>(
     type_val: Value<'v>,
     heap: Heap<'v>,
@@ -900,24 +913,30 @@ pub fn extract_trait_type_id(value: Value) -> Option<u64> {
 }
 
 // -----------------------------------------------------------------------------
-// Global functions
+// Global functions: trait() and attr()
 // -----------------------------------------------------------------------------
 
 #[starlark_module]
 pub fn register_globals(globals: &mut GlobalsBuilder) {
-    /// Creates a trait type with the given fields.
+    /// Creates a trait type — a shared configuration object that tasks opt into.
     ///
-    /// Each field can be a bare type (required, no default) or an `attr()`
-    /// definition (with type and optional default).
+    /// ## Naming
     ///
-    /// Mutable defaults (lists, dicts) are deep-copied per instance, so each
-    /// instance gets its own independent copy. No `default_factory` needed.
+    /// Traits must be exported as **CamelCase** (`MyConfig`, `BazelTrait`). This is
+    /// enforced at definition time.
     ///
-    /// Example:
+    /// ## Fields
+    ///
+    /// Each field must be an `attr()` definition with a `default` value. The default is used
+    /// to construct the initial trait instance lazily on first access — there is no mechanism
+    /// to inject values before that construction, so all fields must have defaults.
+    ///
+    /// ## Example
+    ///
     /// ```starlark
     /// BazelTrait = trait(
-    ///     extra_flags = attr(list[str], []),
-    ///     extra_startup_flags = attr(list[str], []),
+    ///     extra_flags    = attr(list[str], default = [], description = "Extra Bazel flags for every build"),
+    ///     profile_upload = attr(bool,      default = False, description = "Upload Bazel profile after build"),
     /// )
     /// ```
     fn r#trait<'v>(
@@ -927,20 +946,22 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         let mut fields = SmallMap::with_capacity(kwargs.len());
 
         for (name, value) in kwargs.into_iter() {
-            let field = if let Some(field_value) = value.downcast_ref::<FieldValue>() {
-                // It's already a field() definition
-                Field {
-                    typ: field_value.typ.dupe(),
-                    typ_value: field_value.typ_value,
-                    default: field_value.default,
+            let field = if let Some(attr_value) = value.downcast_ref::<ConfigAttrValue>() {
+                // It's already an attr() definition
+                Attr {
+                    typ: attr_value.typ.dupe(),
+                    typ_value: attr_value.typ_value,
+                    default: attr_value.default,
+                    description: attr_value.description.clone(),
                 }
             } else {
-                // It's a type, convert to a field without default
+                // It's a type, convert to an attr without default
                 let typ = TypeCompiled::new(value, eval.heap())?;
-                Field {
+                Attr {
                     typ,
                     typ_value: value,
                     default: None,
+                    description: None,
                 }
             };
             fields.insert(name.to_string(), field);
@@ -953,38 +974,41 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         })
     }
 
-    /// Creates a field definition with a type and optional default value.
+    /// Creates a field definition for a trait, with a type, optional default value,
+    /// and optional description.
     ///
-    /// Mutable defaults (lists, dicts) are deep-copied when a trait instance is
-    /// created, so each instance gets its own independent copy.
+    /// `default` must match the declared type. Mutable defaults (lists, dicts) are deep-copied
+    /// when a trait instance is created, so each instance gets its own independent copy.
     ///
     /// Example:
     /// ```starlark
-    /// BazelTrait = trait(host=str, port=attr(int, 80))
+    /// BazelTrait = trait(host=str, port=attr(int, default = 80))
     /// r = BazelTrait(host="localhost")  # port defaults to 80
     /// ```
     fn attr<'v>(
         #[starlark(require = pos)] typ: Value<'v>,
-        #[starlark(require = pos)] default: Option<Value<'v>>,
+        #[starlark(require = named)] default: Option<Value<'v>>,
+        #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
-    ) -> anyhow::Result<FieldValue<'v>> {
+    ) -> anyhow::Result<ConfigAttrValue<'v>> {
         let compiled_type = TypeCompiled::new(typ, eval.heap())?;
+        let description = description.into_option();
 
-        // Validate that the default matches the type if provided
         if let Some(d) = default {
             if !compiled_type.matches(d) {
                 return Err(anyhow::anyhow!(
-                    "Default value `{}` does not match field type `{}`",
+                    "Default value `{}` does not match attr type `{}`",
                     d,
                     compiled_type
                 ));
             }
         }
 
-        Ok(FieldValue {
+        Ok(ConfigAttrValue {
             typ: compiled_type,
             typ_value: typ,
             default,
+            description,
         })
     }
 }

--- a/crates/axl-runtime/src/eval/api.rs
+++ b/crates/axl-runtime/src/eval/api.rs
@@ -1,6 +1,8 @@
 use crate::engine;
+use crate::eval::multi_phase::ModuleEnv;
 use starlark::environment::{GlobalsBuilder, LibraryExtension};
-use starlark::syntax::{Dialect, DialectTypes};
+use starlark::eval::Evaluator;
+use starlark::syntax::{AstModule, Dialect, DialectTypes};
 
 /// Returns a GlobalsBuilder for AXL globals, extending various Starlark library extensions
 /// with custom top-level functions registered from the engine module.
@@ -73,6 +75,20 @@ pub fn eval_expr(src: &str) -> anyhow::Result<String> {
             .eval_module(ast, &loader.globals)
             .map_err(|e| anyhow::anyhow!("{}", e))?;
         Ok(val.to_repr())
+    })
+}
+
+/// Evaluate an AXL code snippet with the full set of AXL globals.
+///
+/// Useful in tests and tooling that need to evaluate inline Starlark without
+/// touching the filesystem. Returns `Ok(())` if evaluation succeeds, or a
+/// `starlark::Error` describing the failure.
+pub fn eval_snippet(code: &str) -> starlark::Result<()> {
+    let ast = AstModule::parse("<snippet>", code.to_owned(), &dialect())?;
+    let globals = get_globals().build();
+    ModuleEnv::with(|env| {
+        let mut eval = Evaluator::new(&env.0);
+        eval.eval_module(ast, &globals).map(|_| ())
     })
 }
 

--- a/crates/axl-runtime/src/eval/mod.rs
+++ b/crates/axl-runtime/src/eval/mod.rs
@@ -6,7 +6,7 @@ mod load_path;
 mod multi_phase;
 pub mod task;
 
-pub use api::get_globals;
+pub use api::{eval_snippet, get_globals};
 pub use error::EvalError;
 pub use load::AxlLoader as Loader;
 pub use load::ModuleScope;

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -9,15 +9,16 @@ use starlark::values::{Heap, Value, ValueLike};
 use uuid::Uuid;
 
 use crate::engine::bazel::Bazel;
+use crate::engine::cli_args::CliArgs;
 use crate::engine::config::feature_context::FeatureContext;
 use crate::engine::config::feature_map::{FeatureMap, construct_features};
 use crate::engine::config::trait_map::TraitMap;
 use crate::engine::config::{ConfigContext, ConfiguredTask};
-use crate::engine::task_args::TaskArgs;
+use crate::engine::task::FrozenTask;
 use crate::engine::task_context::TaskContext;
 use crate::engine::task_info::TaskInfo;
 use crate::engine::types::feature::{
-    FeatureInstance, extract_feature_impl_fn, extract_feature_type_id,
+    FeatureInstance, extract_feature_impl_fn, extract_feature_type_id, populate_feature_custom_args,
 };
 use crate::engine::types::r#trait::extract_trait_type_id;
 use crate::eval::error::EvalError;
@@ -63,7 +64,8 @@ pub struct MultiPhaseEval<'v, 'loader> {
     env: &'loader ModuleEnv<'v>,
     loader: &'loader AxlLoader,
     /// Feature type values on the shared heap, collected during Phase 1.
-    feature_types: Vec<(u64, Value<'v>)>,
+    /// Tuple: (type_id, feature_type_value, source_path)
+    feature_types: Vec<(u64, Value<'v>, PathBuf)>,
     /// Global feature map allocated on the shared heap during Phase 2.
     feature_map_value: Option<Value<'v>>,
     /// Global trait map allocated on the shared heap during Phase 3.
@@ -167,11 +169,19 @@ impl<'v, 'loader> MultiPhaseEval<'v, 'loader> {
                 // access_owned_frozen_value registers the frozen heap as a dependency of the
                 // live heap (keeping it alive) and returns Value<'v>.
                 let feature_val = heap.access_owned_frozen_value(&owned);
-                self.feature_types.push((type_id, feature_val));
+                self.feature_types
+                    .push((type_id, feature_val, abs_path.clone()));
             }
         }
 
         Ok(task_values)
+    }
+
+    /// Returns feature types with their source paths, collected during Phase 1.
+    /// Each entry is `(type_id, feature_type_value, source_path)`.
+    /// Used by the CLI layer to build per-feature arg specs and help headings.
+    pub fn feature_types_with_paths(&self) -> &[(u64, Value<'v>, PathBuf)] {
+        &self.feature_types
     }
 
     /// Phase 2: construct feature instances from the feature types collected in Phase 1.
@@ -179,12 +189,18 @@ impl<'v, 'loader> MultiPhaseEval<'v, 'loader> {
     /// Allocates a `FeatureMap` on the shared heap so Phase 3 can reference and mutate it.
     pub fn eval_features(&mut self) -> Result<(), EvalError> {
         let heap = self.heap();
+        // construct_features needs (id, value) pairs; strip the PathBuf.
+        let id_val_pairs: Vec<(u64, Value<'v>)> = self
+            .feature_types
+            .iter()
+            .map(|(id, val, _)| (*id, *val))
+            .collect();
         let feature_map = {
             let store = self.loader.new_store(self.loader.repo_root.clone());
             let mut eval = Evaluator::new(&self.env.0);
             eval.set_loader(self.loader);
             eval.extra = Some(&store);
-            construct_features(&self.feature_types, &mut eval)?
+            construct_features(&id_val_pairs, &mut eval)?
         };
         self.feature_map_value = Some(heap.alloc(feature_map));
         Ok(())
@@ -276,7 +292,15 @@ impl<'v, 'loader> MultiPhaseEval<'v, 'loader> {
     /// Must be called after `eval_config` so that config files have had the opportunity
     /// to enable or disable feature instances. Each enabled feature whose type carries
     /// an `impl` function is invoked with a `FeatureContext` on the shared heap.
-    pub fn eval_feature_impls(&mut self) -> Result<(), EvalError> {
+    ///
+    /// `args_builder` is called once per enabled feature, receiving the feature's type_id
+    /// and the shared heap, and returning a `Args` containing the parsed CLI values for
+    /// that feature's declared args. Use `extract_feature_args` on the type value (available
+    /// via `feature_types_with_paths`) to know which args belong to which feature.
+    pub fn eval_feature_impls(
+        &mut self,
+        args_builder: impl Fn(u64, Heap<'v>) -> CliArgs<'v>,
+    ) -> Result<(), EvalError> {
         let heap = self.heap();
 
         let feature_map_value = self.feature_map_value.ok_or_else(|| {
@@ -306,7 +330,11 @@ impl<'v, 'loader> MultiPhaseEval<'v, 'loader> {
             }
 
             if let Some(impl_fn) = extract_feature_impl_fn(type_value) {
-                let fctx = heap.alloc(FeatureContext::new(instance_value, trait_map_value));
+                let type_id = extract_feature_type_id(type_value).unwrap_or(0);
+                let cli_args = args_builder(type_id, heap);
+                let merged = populate_feature_custom_args(type_value, instance_value, cli_args);
+                let attrs_value = heap.alloc(merged);
+                let fctx = heap.alloc(FeatureContext::new(attrs_value, trait_map_value));
                 let store = self.loader.new_store(self.loader.repo_root.clone());
                 let mut eval = Evaluator::new(&self.env.0);
                 eval.set_loader(self.loader);
@@ -324,12 +352,22 @@ impl<'v, 'loader> MultiPhaseEval<'v, 'loader> {
     ///
     /// The `TaskContext` is allocated on the shared heap. The task implementation
     /// is called via `eval_function` on a fresh evaluator over the shared module.
+    /// Phase 5: execute the selected task with pre-built args.
+    ///
+    /// `args_builder` returns a pair of `Args`:
+    /// - `all_args`: all CLI arg values, including Clap defaults.
+    /// - `explicit_args`: only values the user explicitly provided on the command line.
+    ///
+    /// Precedence (highest to lowest):
+    ///   1. Explicit CLI flag (`--count 5`)
+    ///   2. `config.axl` override (`t.args.count = 2`)
+    ///   3. Task definition default (`args.int(default = 1)`)
     pub fn execute_with_args(
         &mut self,
         task: Value<'v>,
         task_key: String,
         task_id: Option<String>,
-        args_builder: impl FnOnce(Heap<'v>) -> TaskArgs<'v>,
+        args_builder: impl FnOnce(Heap<'v>) -> (CliArgs<'v>, CliArgs<'v>),
     ) -> Result<Option<u8>, EvalError> {
         let ct = task
             .downcast_ref::<ConfiguredTask>()
@@ -346,7 +384,38 @@ impl<'v, 'loader> MultiPhaseEval<'v, 'loader> {
 
         let task_id = task_id.unwrap_or_else(|| Uuid::new_v4().to_string());
 
-        let task_args = args_builder(heap);
+        // Build args with proper precedence:
+        // 1. Start with config-only attr defaults from the task definition.
+        // 2. Apply config_overrides (from config.axl) for keys the user did NOT set on the CLI.
+        // 3. CLI args (with their own defaults) are already in all_args and win implicitly.
+        let (mut task_args, explicit_args) = args_builder(heap);
+
+        // Seed config-only arg defaults. These never go through Clap so they must be
+        // injected here. We only insert if not already present (config_overrides below
+        // may overwrite, and explicit CLI flags from args_builder already win).
+        // Custom args with no storable default (e.g. lambda defaults) are seeded as None
+        // so that `ctx.args.name` is always accessible.
+        if let Some(frozen_task) = ct.task_def.downcast_ref::<FrozenTask>() {
+            for (name, arg) in frozen_task.args().iter() {
+                if let crate::engine::arg::Arg::Custom { default, .. } = arg {
+                    if !task_args.contains_key(name.as_str()) {
+                        let value = default
+                            .map(|fv| fv.to_value())
+                            .unwrap_or_else(|| heap.alloc(starlark::values::none::NoneType));
+                        task_args.insert(name.clone(), value);
+                    }
+                }
+            }
+        }
+
+        // Apply config.axl overrides, skipping keys the user explicitly set on the CLI.
+        for (k, owned) in ct.config_overrides.borrow().iter() {
+            if !explicit_args.contains_key(k) {
+                if let Some(fv) = owned.value().unpack_frozen() {
+                    task_args.insert(k.clone(), fv.to_value());
+                }
+            }
+        }
         let task_info = TaskInfo {
             name: ct.get_name(),
             group: ct.get_group(),

--- a/crates/axl-runtime/tests/naming_validation.rs
+++ b/crates/axl-runtime/tests/naming_validation.rs
@@ -1,0 +1,408 @@
+/// Integration tests for task(), feature(), and arg naming validation.
+///
+/// These tests evaluate real Starlark snippets through the AXL eval stack and assert
+/// on the resulting errors or successful outcomes, covering the full path from
+/// Starlark source → validation → ConfiguredTask name derivation.
+use axl_runtime::eval::eval_snippet;
+
+fn eval(code: &str) -> Result<(), String> {
+    eval_snippet(code).map_err(|e| e.to_string())
+}
+
+fn eval_err(code: &str) -> String {
+    eval(code).expect_err("expected evaluation to fail")
+}
+
+// ── Minimal valid Starlark snippets ─────────────────────────────────────────
+
+const VALID_TASK: &str = r#"
+def _impl(ctx):
+    pass
+
+ValidTask = task(implementation = _impl, args = {})
+"#;
+
+const VALID_FEATURE: &str = r#"
+def _impl(ctx):
+    pass
+
+ValidFeature = feature(implementation = _impl)
+"#;
+
+// ── task() — name validation ─────────────────────────────────────────────────
+
+#[test]
+fn task_valid_explicit_name() {
+    assert!(
+        eval(
+            r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {}, name = "my-task")
+"#
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn task_name_underscore_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {}, name = "bad_name")
+"#,
+    );
+    assert!(
+        err.contains("invalid character") || err.contains("_"),
+        "expected underscore error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn task_name_uppercase_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {}, name = "BadName")
+"#,
+    );
+    assert!(
+        err.contains("lowercase"),
+        "expected lowercase error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn task_name_leading_digit_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {}, name = "1task")
+"#,
+    );
+    assert!(
+        err.contains("lowercase"),
+        "expected lowercase error, got: {}",
+        err
+    );
+}
+
+// ── task() — group validation ─────────────────────────────────────────────────
+
+#[test]
+fn task_valid_group() {
+    assert!(
+        eval(
+            r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {}, group = ["axl", "tools"])
+"#
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn task_group_underscore_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {}, group = ["bad_group"])
+"#,
+    );
+    assert!(
+        err.contains("invalid character") || err.contains("_"),
+        "expected underscore error in group, got: {}",
+        err
+    );
+}
+
+#[test]
+fn task_group_uppercase_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {}, group = ["BadGroup"])
+"#,
+    );
+    assert!(
+        err.contains("lowercase"),
+        "expected lowercase error in group, got: {}",
+        err
+    );
+}
+
+// ── task() — arg name validation ─────────────────────────────────────────────
+
+#[test]
+fn task_valid_args() {
+    assert!(eval(VALID_TASK).is_ok());
+    assert!(
+        eval(
+            r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {
+    "target_pattern": args.string(),
+    "bazel_flag": args.string_list(),
+    "dry_run": args.boolean(default = False),
+})
+"#
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn task_arg_uppercase_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {"BadArg": args.string()})
+"#,
+    );
+    assert!(
+        err.contains("lowercase"),
+        "expected lowercase error for arg name, got: {}",
+        err
+    );
+}
+
+#[test]
+fn task_arg_dash_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {"bad-arg": args.string()})
+"#,
+    );
+    assert!(
+        err.contains("invalid character"),
+        "expected invalid character error for dash in arg name, got: {}",
+        err
+    );
+}
+
+#[test]
+fn task_arg_leading_digit_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {"1arg": args.string()})
+"#,
+    );
+    assert!(
+        err.contains("lowercase"),
+        "expected lowercase error for digit-leading arg name, got: {}",
+        err
+    );
+}
+
+#[test]
+fn task_arg_leading_underscore_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+T = task(implementation = _impl, args = {"_private": args.string()})
+"#,
+    );
+    assert!(
+        err.contains("lowercase"),
+        "expected lowercase error for underscore-leading arg name, got: {}",
+        err
+    );
+}
+
+// ── feature() — arg name validation ──────────────────────────────────────────
+
+#[test]
+fn feature_valid() {
+    assert!(eval(VALID_FEATURE).is_ok());
+    assert!(
+        eval(
+            r#"
+def _impl(ctx): pass
+F = feature(implementation = _impl, args = {"upload_bucket": args.string()})
+"#
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn feature_arg_uppercase_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+F = feature(implementation = _impl, args = {"UploadBucket": args.string()})
+"#,
+    );
+    assert!(
+        err.contains("lowercase"),
+        "expected lowercase error for feature arg, got: {}",
+        err
+    );
+}
+
+#[test]
+fn feature_arg_dash_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+F = feature(implementation = _impl, args = {"upload-bucket": args.string()})
+"#,
+    );
+    assert!(
+        err.contains("invalid character"),
+        "expected invalid character error for dash in feature arg, got: {}",
+        err
+    );
+}
+
+#[test]
+fn feature_positional_arg_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+F = feature(implementation = _impl, args = {"target": args.positional()})
+"#,
+    );
+    assert!(
+        err.contains("positional"),
+        "expected positional-not-allowed error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn feature_trailing_var_args_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+F = feature(implementation = _impl, args = {"rest": args.trailing_var_args()})
+"#,
+    );
+    assert!(
+        err.contains("positional"),
+        "expected positional-not-allowed error for trailing_var_args, got: {}",
+        err
+    );
+}
+
+// ── feature() — CamelCase export name enforcement ────────────────────────────
+
+#[test]
+fn feature_camelcase_export_valid() {
+    assert!(
+        eval(
+            r#"
+def _impl(ctx): pass
+ArtifactUpload = feature(implementation = _impl)
+"#
+        )
+        .is_ok()
+    );
+    assert!(
+        eval(
+            r#"
+def _impl(ctx): pass
+BazelDefaults = feature(implementation = _impl)
+"#
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn feature_snake_case_export_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+artifact_upload = feature(implementation = _impl)
+"#,
+    );
+    assert!(
+        err.contains("uppercase"),
+        "expected uppercase error for snake_case feature export, got: {}",
+        err
+    );
+}
+
+#[test]
+fn feature_lowercase_export_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+myfeature = feature(implementation = _impl)
+"#,
+    );
+    assert!(
+        err.contains("uppercase"),
+        "expected uppercase error for lowercase feature export, got: {}",
+        err
+    );
+}
+
+#[test]
+fn feature_export_underscore_rejected() {
+    let err = eval_err(
+        r#"
+def _impl(ctx): pass
+Artifact_Upload = feature(implementation = _impl)
+"#,
+    );
+    assert!(
+        err.contains("invalid character"),
+        "expected invalid character error for underscore in feature export, got: {}",
+        err
+    );
+}
+
+// ── trait() — CamelCase export name enforcement ───────────────────────────────
+
+#[test]
+fn trait_camelcase_export_valid() {
+    assert!(
+        eval(
+            r#"
+MyConfig = trait(
+    message = attr(str, "default"),
+)
+"#
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn trait_snake_case_export_rejected() {
+    let err = eval_err(
+        r#"
+my_config = trait(
+    message = attr(str, "default"),
+)
+"#,
+    );
+    assert!(
+        err.contains("uppercase"),
+        "expected uppercase error for snake_case trait export, got: {}",
+        err
+    );
+}
+
+#[test]
+fn trait_export_underscore_rejected() {
+    let err = eval_err(
+        r#"
+My_Config = trait(
+    message = attr(str, "default"),
+)
+"#,
+    );
+    assert!(
+        err.contains("invalid character"),
+        "expected invalid character error for underscore in trait export, got: {}",
+        err
+    );
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -43,7 +43,7 @@ When multiple config sources set the same trait field, last-write-wins based on 
 
 Task execution occurs when a user explicitly invokes a task (e.g., `aspect run <task>`). The runtime calls the task's `implementation` function with a `TaskContext` providing the full set of capabilities:
 
-- `ctx.args` — parsed CLI arguments as declared by the task
+- `ctx.attrs` — parsed CLI arguments as declared by the task
 - `ctx.bazel` — Bazel build, test, query, and info
 - `ctx.std.fs` — filesystem operations (read, write, copy, rename, mkdir, etc.)
 - `ctx.std.process` — subprocess execution
@@ -62,25 +62,58 @@ AXL files (`.axl`) are Starlark files discovered in the `.aspect/` directory at 
 
 ### Task Files
 
-Any `.axl` file in `.aspect/` can define tasks. A task is declared at the top level using the `task()` function:
+Any `.axl` file in `.aspect/` can define tasks. A task is declared at the top level using the `task()` function and exported as a **snake_case** variable:
 
 ```python
 def _impl(ctx: TaskContext) -> int:
-    ctx.std.io.stdout.write("hello\n")
+    name = ctx.attrs.recipient
+    ctx.std.io.stdout.write("Hello, " + name + "\n")
     return 0
 
-my_task = task(
-    name = "greet",           # optional, defaults to variable name
-    group = ["utils"],        # CLI grouping
-    implementation = _impl,   # the function to execute
-    args = {                  # CLI argument declarations
-        "name": args.string(default = "world"),
+greet = task(
+    group = ["utils"],             # CLI grouping: `aspect utils greet`
+    summary = "Say hello",         # one-liner shown in the task list
+    description = """
+Say hello to someone. Defaults to the world.
+""",                               # extended text shown in --help
+    implementation = _impl,
+    attrs = {
+        "recipient": args.string(default = "world", description = "Who to greet"),
     },
-    traits = [MyConfig],      # opt-in to trait types
+    traits = [MyConfig],           # opt-in to trait types
 )
 ```
 
-Tasks define their own CLI arguments using the `args` module. Argument types include `args.string()`, `args.int()`, `args.uint()`, `args.boolean()`, their list variants, `args.positional()`, and `args.trailing_var_args()`. Each supports `required` and `default` parameters.
+#### Naming
+
+**Export name (snake_case) → CLI command (kebab-case).** The idiomatic convention is snake_case, matching BXL/Bazel rule convention (`cc_library`, `py_binary`). Underscores become dashes automatically:
+
+| Export name | CLI command |
+|---|---|
+| `greet` | `greet` |
+| `axl_add` | `axl-add` |
+| `ci_build` | `ci-build` |
+| `s3_upload` | `s3-upload` |
+
+CamelCase exports are also handled and produce the same command name (`AxlAdd` → `axl-add`, `CIBuild` → `ci-build`), but snake_case is preferred.
+
+Use `name = "explicit-name"` to override the derived command name. Command names must match `[a-z][a-z0-9-]*`.
+
+**Group names** follow the same `[a-z][a-z0-9-]*` constraint: `group = ["axl"]`, `group = ["ci", "build"]`.
+
+**Attr names** use `snake_case` (`[a-z][a-z0-9_]*`) because they are accessed directly in Starlark as `ctx.attrs.attr_name`. CLI-typed attrs (`args.string(...)`, etc.) are automatically converted to `--kebab-flags` on the CLI: `"remote_cache"` → `--remote-cache`.
+
+#### Help text fields
+
+| Field | Where shown | Notes |
+|---|---|---|
+| `summary` | Task list and `--help` header | One line. Falls back to `"<name> task defined in <file>"`. |
+| `description` | `--help` header only | Extended prose. Replaces `summary` in `--help` when set. |
+| `display_name` | Help section headings | Title Case. Auto-derived from command name (`axl-add` → `Axl Add`). |
+
+#### CLI arguments
+
+Argument types: `args.string()`, `args.int()`, `args.uint()`, `args.boolean()`, their `_list` variants, `args.positional()`, and `args.trailing_var_args()`. All support `required`, `default`, `description`, and (for scalar types) `short` for a single-character alias.
 
 ### Config File
 
@@ -94,6 +127,40 @@ def config(ctx: ConfigContext):
     cfg.some_field = "value"
 ```
 
+### Feature Files
+
+Features are composable behavior injectors. They run after all config files have been evaluated and inject closures into fragment hook lists. They also contribute CLI flags to every task subcommand.
+
+```python
+def _impl(ctx: FeatureContext):
+    bazel_trait = ctx.traits[BazelTrait]
+    channels = ctx.attrs.channels   # dict set in config.axl: {"failure": "#alerts", "success": "#releases"}
+
+    def _on_build_end(task_ctx, exit_code):
+        if ctx.attrs.silent or not channels:
+            return
+        event = "success" if exit_code == 0 else "failure"
+        channel = channels.get(event)
+        if channel:
+            slack.post(channel, "Build %s: %s" % (task_ctx.task.name, event))
+
+    bazel_trait.build_end.append(_on_build_end)
+
+SlackNotify = feature(
+    implementation = _impl,
+    attrs = {
+        "channels": attr(dict[str, str], {}),  # config.axl: route outcomes to channels
+        "silent":   args.boolean(default = False, description = "Suppress notifications for this run"),
+    },
+)
+```
+
+Both config-only attrs (`attr(...)`) and CLI flags (`args.boolean(...)`, `args.string(...)`, etc.) live in a single `attrs` dict — accessed uniformly as `ctx.attrs.name` in the implementation. Config-only attrs (here, a dict) are set in `config.axl` by repo maintainers and can hold complex types; CLI-typed attrs are exposed as flags on every task subcommand so developers can pass `--silent` at invocation time. Only named flags are allowed in features — positional args are not supported.
+
+**Naming:** features must be exported as **CamelCase** (`ArtifactUpload`, `GithubStatusChecks`). This is enforced at definition time. The convention mirrors Bazel providers (`CcInfo`, `DefaultInfo`) — features are referenced as type keys (`ctx.features[ArtifactUpload]`), and CamelCase signals this role. `display_name` overrides the auto-derived Title Case heading name. The `summary` and `description` fields work identically to tasks.
+
+Features are disabled per-task via `ctx.features[ArtifactUpload].enabled = False` in `config.axl`.
+
 ### Trait Definitions
 
 Traits are global configuration objects shared across tasks that opt in. A trait type is defined using `trait()` with typed attributes:
@@ -105,6 +172,8 @@ MyConfig = trait(
     callback = attr(typing.Callable[[str], str], lambda s: s),
 )
 ```
+
+**Naming:** traits must be exported as **CamelCase** (`MyConfig`, `BazelTrait`). This is enforced at definition time. Like features, traits are used as type keys (`ctx.traits[MyConfig]`), and CamelCase signals this role — consistent with Bazel's provider convention (`dep[CcInfo]`).
 
 Trait types are defined at evaluation time (pure). Trait instances are populated during config execution (mutable) and then frozen before being passed to task execution (read-only via `ctx.traits[MyConfig]`).
 


### PR DESCRIPTION
## Summary

This PR consolidates the task/feature argument system under a single `args` namespace and establishes clear boundaries between the three types of definition objects.

### `args` everywhere for tasks and features

Tasks and features now use `args = {}` exclusively. CLI-typed args use `args.string/int/bool/…`; config-only args use the new `args.custom()`. Both are accessed uniformly via `ctx.args.name` in implementations.

```python
greet = task(
    group = ["utils"],
    summary = "Say hello to someone",
    implementation = _impl,
    args = {
        # CLI arg — set via --recipient on the command line or in config.axl; CLI wins
        "recipient": args.string(default = "world", description = "Who to greet"),
        # Config-only arg — not shown in --help; configurable in config.axl only
        "greeting":  args.custom(str, default = "Hello", description = "Greeting word"),
    },
)

def _impl(ctx: TaskContext) -> int:
    ctx.std.io.stdout.write(ctx.args.greeting + ", " + ctx.args.recipient + "\n")
    return 0
```

Features work the same way — the separate `attrs` (config-only) and `args` (CLI) parameters are merged into a single `args` dict:

```python
ArtifactUpload = feature(
    implementation = _impl,
    args = {
        # Config-only arg — not shown in --help; configurable in config.axl
        "bucket": args.custom(str | None, default = None, description = "S3 bucket name"),
        # CLI arg — injected as --artifact-upload-mode on every task subcommand
        "mode":   args.string(default = "auto", description = "Upload mode"),
    },
)
```

### `attr()` is traits-only

`attr()` is now restricted to `trait()` field definitions and no longer used by Features.

```python
BazelTrait = trait(
    extra_flags    = attr(list[str], default = [],    description = "Extra Bazel flags for every build"),
    profile_upload = attr(bool,      default = False, description = "Upload Bazel profile after build"),
)
```

### `args.custom()` — new config-only arg

`args.custom(type, default=..., description=...)` is the tasks/features equivalent of `attr()`. It accepts any Starlark type expression, is never surfaced as a CLI flag, and can only be set via `config.axl`. In the future, we plan to support setting custom de-marshalers so that users can add custom flags types to their CLI.

### Configuring tasks from `config.axl`

`ctx.tasks` in `config.axl` is a map keyed by task path. The path is the task's group and name joined with `/`:

| Task definition | Key |
|---|---|
| `foo = task(...)` (root) | `"foo"` |
| `bar = task(group = ["grp"], ...)` | `"grp/bar"` |
| `baz = task(group = ["a", "b"], ...)` | `"a/b/baz"` |

```python
def config(ctx: ConfigContext):
    t = ctx.tasks["user/nested/greet"]
    t.args.greeting = "Bonjour"     # override a custom (config-only) arg
    t.args.recipient = "monde"      # override a CLI arg's effective default

    for t in ctx.tasks:
        if t.key.startswith("ci/"):
            t.args.upload_bucket = "ci-artifacts"
```

**Precedence at execution time** (highest wins):

```
explicit --flag on CLI  >  config.axl override  >  task definition default
```

`--help` shows effective defaults *after* `config.axl` runs — overrides are reflected in the help output.

### `long` override for CLI args

All `args.string/int/bool/…` functions accept an optional `long = "override_name"` parameter to control the `--flag-name` shown on the CLI, bypassing the default snake_case → kebab-case derivation.

### Feature CLI arg constraints

Feature CLI args are injected into **every** task subcommand:

- **Positional args** are not allowed — they collide with task-level positional args.
- **`required = true` is not allowed** — it would make every task fail unless the flag is always provided.
