### PR TITLE
fix: bazelrc config ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "starlark_derive",
  "starlark_map",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/crates/axl-runtime/BUILD.bazel
+++ b/crates/axl-runtime/BUILD.bazel
@@ -73,6 +73,9 @@ rust_library(
 rust_test(
     name = "axl-runtime-unit-tests",
     crate = ":axl-runtime",
+    deps = [
+        "@crates//:tempfile",
+    ],
 )
 
 rust_test(

--- a/crates/axl-runtime/Cargo.toml
+++ b/crates/axl-runtime/Cargo.toml
@@ -80,3 +80,6 @@ tar = "0.4.44"
 tonic = "0.14.2"
 tracing = "0.1.41"
 uuid = { version = "1.18.1", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/axl-runtime/src/engine/bazel/rc.rs
+++ b/crates/axl-runtime/src/engine/bazel/rc.rs
@@ -130,11 +130,15 @@ fn bazelrc_methods(registry: &mut MethodsBuilder) {
 
         // Split opts: common section → --default_override flags (prepended so user flags win),
         // everything else → direct flags.
-        let (override_strings, flag_strings) = partition_expand_all(&opts);
+        let (override_flags, regular_flags) = partition_expand_all(&opts);
 
         let mut flags: Vec<Value<'v>> = Vec::new();
-        for s in override_strings.iter().chain(flag_strings.iter()) {
-            flags.push(eval.heap().alloc(s.as_str()));
+        for (value, version_condition) in override_flags.iter().chain(regular_flags.iter()) {
+            let v = match version_condition {
+                None => eval.heap().alloc(value.as_str()),
+                Some(cond) => eval.heap().alloc((value.as_str(), cond.as_str())),
+            };
+            flags.push(v);
         }
         Ok((startup_flags, flags))
     }
@@ -179,15 +183,23 @@ fn bazelrc_methods(registry: &mut MethodsBuilder) {
 /// `common` section options are converted to `--default_override=0:common=<value>` strings and
 /// returned first so they appear before user-specified flags in the final `flags` output.
 /// This preserves last-write-wins semantics: user flags (which come later) override the defaults.
-fn partition_expand_all(opts: &[bazelrc::RcOption]) -> (Vec<String>, Vec<String>) {
+///
+/// Each entry is `(value, version_condition)` so that version-gated options retain their
+/// semver constraint and are not silently promoted to unconditional flags.
+fn partition_expand_all(
+    opts: &[bazelrc::RcOption],
+) -> (Vec<(String, Option<String>)>, Vec<(String, Option<String>)>) {
     let mut default_override_flags = Vec::new();
     let mut flags = Vec::new();
     for opt in opts {
         let base = opt.command.split(':').next().unwrap_or(&opt.command);
         if base == "common" {
-            default_override_flags.push(format!("--default_override=0:common={}", opt.value));
+            default_override_flags.push((
+                format!("--default_override=0:common={}", opt.value),
+                opt.version_condition.clone(),
+            ));
         } else {
-            flags.push(opt.value.clone());
+            flags.push((opt.value.clone(), opt.version_condition.clone()));
         }
     }
     (default_override_flags, flags)
@@ -235,7 +247,7 @@ mod tests {
         let all: Vec<&str> = overrides
             .iter()
             .chain(regular.iter())
-            .map(String::as_str)
+            .map(|(value, _)| value.as_str())
             .collect();
 
         let first_override = all
@@ -266,8 +278,8 @@ mod tests {
         assert_eq!(
             overrides,
             vec![
-                "--default_override=0:common=--foo",
-                "--default_override=0:common=--bar",
+                ("--default_override=0:common=--foo".to_string(), None),
+                ("--default_override=0:common=--bar".to_string(), None),
             ]
         );
         assert!(regular.is_empty());

--- a/crates/axl-runtime/src/engine/bazel/rc.rs
+++ b/crates/axl-runtime/src/engine/bazel/rc.rs
@@ -117,7 +117,6 @@ fn bazelrc_methods(registry: &mut MethodsBuilder) {
             .map_err(|e| anyhow::anyhow!("{}", e))?;
 
         let mut startup_flags: Vec<Value<'v>> = Vec::new();
-        let mut flags: Vec<Value<'v>> = Vec::new();
 
         for opt in this.inner.raw_options("startup") {
             let v = match &opt.version_condition {
@@ -129,29 +128,14 @@ fn bazelrc_methods(registry: &mut MethodsBuilder) {
             startup_flags.push(v);
         }
 
-        for opt in &opts {
-            let base = opt.command.split(':').next().unwrap_or(&opt.command);
+        // Split opts: common section → --default_override flags (prepended so user flags win),
+        // everything else → direct flags.
+        let (override_strings, flag_strings) = partition_expand_all(&opts);
 
-            if base == "common" {
-                let override_str = format!("--default_override=0:common={}", opt.value);
-                let v = match &opt.version_condition {
-                    None => eval.heap().alloc(override_str.as_str()),
-                    Some(cond) => eval
-                        .heap()
-                        .alloc((override_str.as_str() as &str, cond.as_str() as &str)),
-                };
-                flags.push(v);
-            } else {
-                let v = match &opt.version_condition {
-                    None => eval.heap().alloc(opt.value.as_str()),
-                    Some(cond) => eval
-                        .heap()
-                        .alloc((opt.value.as_str() as &str, cond.as_str() as &str)),
-                };
-                flags.push(v);
-            }
+        let mut flags: Vec<Value<'v>> = Vec::new();
+        for s in override_strings.iter().chain(flag_strings.iter()) {
+            flags.push(eval.heap().alloc(s.as_str()));
         }
-
         Ok((startup_flags, flags))
     }
 
@@ -187,5 +171,105 @@ fn bazelrc_methods(registry: &mut MethodsBuilder) {
             result.push(eval.heap().alloc(p.display().to_string()));
         }
         Ok(result)
+    }
+}
+
+/// Split an expanded option list into `(default_override_flags, regular_flags)`.
+///
+/// `common` section options are converted to `--default_override=0:common=<value>` strings and
+/// returned first so they appear before user-specified flags in the final `flags` output.
+/// This preserves last-write-wins semantics: user flags (which come later) override the defaults.
+fn partition_expand_all(opts: &[bazelrc::RcOption]) -> (Vec<String>, Vec<String>) {
+    let mut default_override_flags = Vec::new();
+    let mut flags = Vec::new();
+    for opt in opts {
+        let base = opt.command.split(':').next().unwrap_or(&opt.command);
+        if base == "common" {
+            default_override_flags.push(format!("--default_override=0:common={}", opt.value));
+        } else {
+            flags.push(opt.value.clone());
+        }
+    }
+    (default_override_flags, flags)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use bazelrc::{BazelRC, RcOption};
+    use tempfile::tempdir;
+
+    use super::partition_expand_all;
+
+    const ISOLATE: &[&str] = &["--nosystem_rc", "--nohome_rc"];
+
+    fn cli_flag(value: &str) -> RcOption {
+        RcOption {
+            value: value.to_string(),
+            command: "always".to_string(),
+            ..RcOption::default()
+        }
+    }
+
+    // ── expand_all ordering (Bug #2) ─────────────────────────────────────────
+
+    #[test]
+    fn default_override_flags_precede_user_flags() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::write(
+            root.join(".bazelrc"),
+            "common --remote_cache=grpc://cache\nbuild --jobs=4\n",
+        )
+        .unwrap();
+
+        // Simulate a user passing a CLI flag; it is stored as `always`.
+        let rc = BazelRC::new(root, ISOLATE, &[cli_flag("--user-flag")]).unwrap();
+        let opts = rc.expand_configs("build", &[]).unwrap();
+
+        let (overrides, regular) = partition_expand_all(&opts);
+
+        // --default_override flags must all appear before any regular flag so
+        // that user-specified flags (coming later) take precedence.
+        let all: Vec<&str> = overrides
+            .iter()
+            .chain(regular.iter())
+            .map(String::as_str)
+            .collect();
+
+        let first_override = all
+            .iter()
+            .position(|s| s.starts_with("--default_override"))
+            .expect("--default_override flag missing");
+        let first_user = all
+            .iter()
+            .position(|s| *s == "--user-flag")
+            .expect("--user-flag missing");
+
+        assert!(
+            first_override < first_user,
+            "--default_override must come before user-specified flags; got: {all:?}"
+        );
+    }
+
+    #[test]
+    fn common_flags_become_default_override_entries() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join(".bazelrc"), "common --foo\ncommon --bar\n").unwrap();
+
+        let rc = BazelRC::new(root, ISOLATE, &[]).unwrap();
+        let opts = rc.expand_configs("build", &[]).unwrap();
+        let (overrides, regular) = partition_expand_all(&opts);
+
+        assert_eq!(
+            overrides,
+            vec![
+                "--default_override=0:common=--foo",
+                "--default_override=0:common=--bar",
+            ]
+        );
+        assert!(regular.is_empty());
     }
 }

--- a/crates/bazelrc/src/expand.rs
+++ b/crates/bazelrc/src/expand.rs
@@ -60,16 +60,9 @@ fn expand_args(
     implicit_platform_config: bool,
     skip_config_if_missing: &[&str],
 ) -> Result<(), BazelRcError> {
-    // First pass: emit all non-config flags so they appear before config expansions.
-    // This ensures config-specific flags (expanded below) come later in the list and
-    // thus override non-config-specific flags under last-write-wins semantics.
-    for opt in args {
-        if !opt.value.starts_with("--config=") {
-            result.push(opt.clone());
-        }
-    }
-
-    // Second pass: expand --config= flags, appending after all non-config flags.
+    // Single pass: emit non-config flags in-place and expand --config= flags recursively
+    // at the position where they appear, matching Bazel's in-place expansion semantics.
+    // See https://bazel.build/versions/9.0.0/run/bazelrc#option-defaults.
     for opt in args {
         if let Some(config_name) = opt.value.strip_prefix("--config=") {
             // Cycle detection
@@ -132,6 +125,8 @@ fn expand_args(
                 skip_config_if_missing,
             )?;
             ancestor_chain.pop();
+        } else {
+            result.push(opt.clone());
         }
     }
     Ok(())

--- a/crates/bazelrc/src/expand.rs
+++ b/crates/bazelrc/src/expand.rs
@@ -60,6 +60,16 @@ fn expand_args(
     implicit_platform_config: bool,
     skip_config_if_missing: &[&str],
 ) -> Result<(), BazelRcError> {
+    // First pass: emit all non-config flags so they appear before config expansions.
+    // This ensures config-specific flags (expanded below) come later in the list and
+    // thus override non-config-specific flags under last-write-wins semantics.
+    for opt in args {
+        if !opt.value.starts_with("--config=") {
+            result.push(opt.clone());
+        }
+    }
+
+    // Second pass: expand --config= flags, appending after all non-config flags.
     for opt in args {
         if let Some(config_name) = opt.value.strip_prefix("--config=") {
             // Cycle detection
@@ -122,8 +132,6 @@ fn expand_args(
                 skip_config_if_missing,
             )?;
             ancestor_chain.pop();
-        } else {
-            result.push(opt.clone());
         }
     }
     Ok(())

--- a/crates/bazelrc/src/lib.rs
+++ b/crates/bazelrc/src/lib.rs
@@ -1137,6 +1137,106 @@ mod tests {
         assert_eq!(values, vec!["--deep-flag"]);
     }
 
+    // ── Config vs non-config ordering (Bug #1) ───────────────────────────────
+
+    #[test]
+    fn config_flags_come_after_non_config_flags() {
+        // Non-config flags that appear *after* --config= in the rc file must not
+        // override config-specific flags.  Under last-write-wins, config flags must
+        // land later in the expanded list than any plain non-config flags.
+        let dir = make_workspace();
+        let root = dir.path();
+        fs::write(
+            root.join(".bazelrc"),
+            "build:opt --config-flag\nbuild --non-config-before\nbuild --config=opt\nbuild --non-config-after\n",
+        )
+        .unwrap();
+
+        let rc = BazelRC::new(root, ISOLATE, &[]).unwrap();
+        let expanded = rc.expand_configs("build", &[]).unwrap();
+        let values: Vec<&str> = expanded.iter().map(|o| o.value.as_str()).collect();
+
+        let config_pos = values
+            .iter()
+            .position(|s| *s == "--config-flag")
+            .expect("--config-flag missing");
+        let after_pos = values
+            .iter()
+            .position(|s| *s == "--non-config-after")
+            .expect("--non-config-after missing");
+
+        assert!(
+            config_pos > after_pos,
+            "--config-flag must come after --non-config-after; got: {values:?}"
+        );
+    }
+
+    #[test]
+    fn config_flags_preserve_file_ordering() {
+        // When the same config section is defined in two files, the flag from the
+        // later file must appear last in the expansion so it wins (last-write-wins).
+        let dir = make_workspace();
+        let root = dir.path();
+
+        let second = root.join("second.bazelrc");
+        fs::write(&second, "build:opt --flag=from-second\n").unwrap();
+
+        fs::write(
+            root.join(".bazelrc"),
+            format!("build:opt --flag=from-first\nimport {}\n", second.display()),
+        )
+        .unwrap();
+
+        let rc = BazelRC::new(root, ISOLATE, &flags(&["--config=opt"])).unwrap();
+        let expanded = rc.expand_configs("build", &[]).unwrap();
+        let values: Vec<&str> = expanded.iter().map(|o| o.value.as_str()).collect();
+
+        let first_pos = values
+            .iter()
+            .position(|s| *s == "--flag=from-first")
+            .expect("--flag=from-first missing");
+        let second_pos = values
+            .iter()
+            .position(|s| *s == "--flag=from-second")
+            .expect("--flag=from-second missing");
+
+        assert!(
+            first_pos < second_pos,
+            "flag from first file must precede flag from second file; got: {values:?}"
+        );
+    }
+
+    #[test]
+    fn multiple_configs_each_come_after_non_config_flags() {
+        // When multiple --config= flags are present, all their expansions must
+        // appear after all non-config flags, and the configs' relative order is
+        // the order the --config= flags appear in the rc file.
+        let dir = make_workspace();
+        let root = dir.path();
+        fs::write(
+            root.join(".bazelrc"),
+            "build:foo --foo-flag\nbuild:bar --bar-flag\nbuild --non-config\nbuild --config=foo\nbuild --config=bar\n",
+        )
+        .unwrap();
+
+        let rc = BazelRC::new(root, ISOLATE, &[]).unwrap();
+        let expanded = rc.expand_configs("build", &[]).unwrap();
+        let values: Vec<&str> = expanded.iter().map(|o| o.value.as_str()).collect();
+
+        let non_config_pos = values.iter().position(|s| *s == "--non-config").unwrap();
+        let foo_pos = values.iter().position(|s| *s == "--foo-flag").unwrap();
+        let bar_pos = values.iter().position(|s| *s == "--bar-flag").unwrap();
+
+        assert!(
+            non_config_pos < foo_pos,
+            "--non-config must precede --foo-flag; got: {values:?}"
+        );
+        assert!(
+            foo_pos < bar_pos,
+            "--foo-flag must precede --bar-flag (config order preserved); got: {values:?}"
+        );
+    }
+
     #[test]
     fn enable_platform_specific_config() {
         let dir = make_workspace();

--- a/crates/bazelrc/src/lib.rs
+++ b/crates/bazelrc/src/lib.rs
@@ -8,12 +8,13 @@ pub(crate) mod tokenize;
 /// ordered from most general to most specific (excluding `common` / `always`).
 ///
 /// Mirrors Bazel's own command graph:
-/// - `test`, `run`, `mobile-install`, `print_action` → `build`
-/// - `coverage` → `build`, `test`
+/// - `test`, `run`, `clean`, `mobile-install`, `info`, `print_action`, `config`, `cquery`, `aquery` → `build`
+/// - `coverage`, `fetch`, `vendor` → `build`, `test`
 pub(crate) fn command_ancestors(command: &str) -> &'static [&'static str] {
     match command {
-        "test" | "run" | "mobile-install" | "print_action" => &["build"],
-        "coverage" => &["build", "test"],
+        "test" | "run" | "clean" | "mobile-install" | "info" | "print_action" | "config"
+        | "cquery" | "aquery" => &["build"],
+        "coverage" | "fetch" | "vendor" => &["build", "test"],
         _ => &[],
     }
 }
@@ -1140,10 +1141,11 @@ mod tests {
     // ── Config vs non-config ordering (Bug #1) ───────────────────────────────
 
     #[test]
-    fn config_flags_come_after_non_config_flags() {
-        // Non-config flags that appear *after* --config= in the rc file must not
-        // override config-specific flags.  Under last-write-wins, config flags must
-        // land later in the expanded list than any plain non-config flags.
+    fn config_expands_in_place() {
+        // Bazel expands --config=foo in-place at the position it appears.
+        // Flags that come *after* --config=opt in the rc file appear after the
+        // expansion, so they win under last-write-wins — matching Bazel's spec:
+        // https://bazel.build/versions/9.0.0/run/bazelrc#option-defaults
         let dir = make_workspace();
         let root = dir.path();
         fs::write(
@@ -1156,18 +1158,11 @@ mod tests {
         let expanded = rc.expand_configs("build", &[]).unwrap();
         let values: Vec<&str> = expanded.iter().map(|o| o.value.as_str()).collect();
 
-        let config_pos = values
-            .iter()
-            .position(|s| *s == "--config-flag")
-            .expect("--config-flag missing");
-        let after_pos = values
-            .iter()
-            .position(|s| *s == "--non-config-after")
-            .expect("--non-config-after missing");
-
-        assert!(
-            config_pos > after_pos,
-            "--config-flag must come after --non-config-after; got: {values:?}"
+        // Expected in-place order: before, <config expansion>, after
+        assert_eq!(
+            values,
+            vec!["--non-config-before", "--config-flag", "--non-config-after"],
+            "got: {values:?}"
         );
     }
 


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Config specific sections from `.bazelrc` added last  and common ones first to follow last-write-wins semantics

### Test plan

- New test cases added

