### PR TITLE
feat: enable color and curses output on GitHub Actions

### DIFF
--- a/.aspect/bootstrap.sh
+++ b/.aspect/bootstrap.sh
@@ -54,7 +54,7 @@ if [ -n "${ASPECT_WORKFLOWS_RUNNER:-}" ]; then
 fi
 
 export BAZEL_STARTUP_OPTS
-export BAZEL_BUILD_OPTS="--config=ci --announce_rc ${BAZEL_REMOTE_FLAGS}"
+export BAZEL_BUILD_OPTS="--config=ci ${BAZEL_REMOTE_FLAGS}"
 export DISABLE_PLUGINS_FLAG
 
 echo "Startup opts: ${BAZEL_STARTUP_OPTS}"

--- a/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
@@ -55,6 +55,14 @@ def _default_bazel_behavior(ctx: FeatureContext):
             # Here to ensure we restart the Bazel server.
             bazel_trait.extra_startup_flags.append("--host_jvm_args=-DRUNNER_TRACKING_ID=noop")
 
+    # On GitHub Actions, Bazel runs without a TTY so --color=auto disables
+    # colored output. GHA's log viewer does render ANSI color codes though,
+    # so force --color=yes. We don't force --curses=yes because GHA's log
+    # viewer is line-oriented and doesn't handle cursor-control sequences,
+    # so curses output would appear garbled instead of updating in place.
+    if ctx.std.env.var("GITHUB_ACTIONS"):
+        bazel_trait.extra_flags.extend(["--color=yes"])
+
 
 BazelDefaults = feature(
     implementation = _default_bazel_behavior,


### PR DESCRIPTION
On GitHub Actions, Bazel runs without a TTY so --color=auto disables colored output. GHA's log viewer does render ANSI color codes though, so force --color=yes. We don't force --curses=yes because GHA's log viewer is line-oriented and ignores cursor-control sequences
