### PR TITLE
Redact secrets from BES events before sending to sinks

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -1,4 +1,5 @@
 load("./lambda.axl", "lambda_with_global_bind")
+load("@aspect//feature/artifacts.axl", "ArtifactUpload")
 load("@aspect//feature/github_status_checks.axl", "GithubStatusChecks")
 load("@aspect//lib/bazel_results_test.axl", "template_snapshot_tests")
 load("@aspect//traits.axl", "BazelTrait")
@@ -23,6 +24,17 @@ def config(ctx: ConfigContext):
 
     # enable Github Status Checks
     ctx.features[GithubStatusChecks].enabled = True
+
+    # Enable artifact uploads for testlogs, profile, and BEP. All four channels
+    # default to off so operators opt in per repo. The compact execution log stays
+    # off because on-disk redaction isn't implemented yet — re-enable once Bazel's
+    # zstd execlog passes through the same redactor as the BEP stream.
+    #
+    # upload_test_logs="failed" — the logs from passing tests are noise;
+    # failing/flaky tests' logs are the ones anyone would actually open.
+    ctx.features[ArtifactUpload].args.upload_test_logs = "failed"
+    ctx.features[ArtifactUpload].args.upload_profile   = True
+    ctx.features[ArtifactUpload].args.upload_bep       = True
 
     # add a new task
     ctx.tasks.add(_user_task)

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -141,10 +141,7 @@ steps:
       # world-readable. java.log / command.log / jvm.out / cmdline can capture
       # `--announce_rc` output and error messages that quote flag values
       # verbatim (--remote_header=, --action_env=TOKEN=, URL creds …) — none
-      # of which go through the Rust BES redactor. If this test ever flakes
-      # and needs diagnostics, SSH to the Workflows runner or re-run locally
-      # with ASPECT_DEBUG=1. Long-term fix (crash handler with redaction) is
-      # tracked in ARTIFACT_REDACTION_AND_UPLOAD_PLAN.md §2.
+      # of which go through the Rust BES redactor.
       if [ "$$BEFORE_PID" != "$$AFTER_PID" ]; then
         echo "^^^ +++"
         echo "ERROR: Bazel server was restarted (PID $$BEFORE_PID → $$AFTER_PID)"

--- a/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
@@ -8,6 +8,48 @@ a successful upload (rolling replacement where applicable).
 Also configures Bazel profiling flags and uploads the profile/execlog/BEP at
 build_end.
 
+What the feature does, and doesn't, control:
+
+Turning on an opt-in (upload_testlogs / upload_profile / upload_bep /
+upload_exec_log) is only *half* of what it takes for a file to exist on
+disk and get uploaded. Per kind, upload requires:
+
+  profile   — Bazel writes a JSON trace profile by default on every
+              command (`$output_base/command.profile.gz`) regardless of
+              flags. What this feature controls is *where* — our
+              `--profile=<path>` on upload_profile=True redirects Bazel
+              to our tmpdir so we know the path to upload. With
+              upload_profile=False the profile still gets written, just
+              to $output_base; we don't discover/upload it from there.
+
+  bep       — a sink-based artifact: the BES stream has to be actively
+              attached to the specific Bazel invocation via
+              `bazel_trait.build_event_sinks`. No sink on the invocation,
+              no file.
+
+  exec log  — sink-based, same story: requires the sink on
+              `bazel_trait.execution_log_sinks` to be attached to the
+              specific invocation.
+
+  testlogs  — event-derived: the task must run a Bazel command that
+              emits `test_result` BES events (`bazel test` /
+              `bazel coverage`) and route those events through
+              `bazel_trait.build_event` so this feature sees them. Build-
+              only commands never emit test_result — strategy can't
+              conjure testlogs that Bazel didn't produce.
+
+Everything above assumes the task's impl actually runs Bazel and plumbs
+those trait fields through. A task that bypasses BazelTrait, or an
+invocation that crashes before the relevant phase, leaves nothing on
+disk; the upload loop's `fs.exists(src)` guard skips missing files
+silently rather than failing the task.
+
+Secret redaction is also not this feature's job. BEP events are redacted
+at the stream source (crates/axl-runtime/src/engine/bazel/stream/redaction.rs);
+profile and testlogs are not redacted and may echo environment values; the
+compact exec log has no on-disk redaction yet, which is why upload_exec_log
+defaults to off.
+
 As uploads complete, the following ArtifactsTrait fields are populated so
 features like GithubStatusChecks can surface download links:
   - artifacts_browse_url — CI "Artifacts" page/tab for the current job
@@ -94,13 +136,56 @@ def _file_uri_to_path(uri):
     return uri
 
 
-def _collect_test_files(ctx, state, event):
+# Statuses that count as "not passed" for upload_test_logs="failed". Matches
+# the `_FAILED_STATUSES` set in lib/bazel_results.axl plus flaky — a flaky
+# test's log is exactly as interesting as a failing one.
+_NOT_PASSED_STATUSES = [
+    "failed",
+    "timeout",
+    "failed_to_build",
+    "remote_failure",
+    "blaze_halted_before_testing",
+    "flaky",
+    "incomplete",
+    "no_status",
+]
+
+
+def _should_collect_test(strategy, status, cached_locally):
+    """Return True if the test's logs should be collected for upload.
+
+    strategy:
+      "none"     — never (treated as upstream short-circuit; included here for
+                   completeness in case this helper is called directly)
+      "failed"   — any status other than "passed"
+      "executed" — any test that actually ran (not served from local cache)
+      "all"      — every test, including cached passes
+    """
+    if strategy == "none":
+        return False
+    if strategy == "all":
+        return True
+    if strategy == "executed":
+        return not cached_locally
+    if strategy == "failed":
+        return status in _NOT_PASSED_STATUSES
+    # Unknown strategy — fail closed so an operator typo doesn't leak logs.
+    return False
+
+
+def _collect_test_files(ctx, state, event, strategy):
     """Collect test output file paths from a test_result event.
 
     Records source paths and desired archive paths in state without copying.
-    The archive is built later via mtree + bsdtar.
+    The archive is built later via mtree + bsdtar. `strategy` controls which
+    test results' files get collected — see _should_collect_test.
     """
     if event.kind != "test_result":
+        return
+
+    status = event.payload.status or ""
+    cached_locally = bool(event.payload.cached_locally)
+    if not _should_collect_test(strategy, status, cached_locally):
         return
 
     label = event.id.label
@@ -230,44 +315,59 @@ def _artifact_upload_impl(ctx: FeatureContext):
     debug = bool(ctx.std.env.var("ASPECT_DEBUG"))
 
     uuid = _make_uuid(ctx)
+    upload_test_logs = ctx.args.upload_test_logs
+    upload_testlogs  = upload_test_logs != "none"   # convenience for the gate below
+    upload_profile   = ctx.args.upload_profile
+    upload_bep       = ctx.args.upload_bep
+    upload_exec_log  = ctx.args.upload_exec_log
 
-    # Profile / execlog / BEP can carry sensitive data: action env vars, command
-    # lines, and full event streams. Prefer the Aspect Workflows per-job tmpdir
-    # (auto-cleaned between jobs) over shared /tmp, which is world-readable on
-    # most systems. Matches the strategy used by lib/artifacts.axl for archives.
+    # Staging paths for the four uploadable artifact kinds. Prefer the Aspect
+    # Workflows per-job tmpdir (auto-cleaned between jobs) over shared /tmp,
+    # which is world-readable on most systems. Matches lib/artifacts.axl.
     tmpdir = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR") or ctx.std.env.temp_dir()
     profile_path = tmpdir + "/" + uuid + ".profile.gz"
     execlog_path = tmpdir + "/" + uuid + ".execlog.zstd"
     bep_path     = tmpdir + "/" + uuid + ".bep.bin"
 
-    bazel_trait.extra_flags.extend([
-        "--generate_json_trace_profile",
-        "--experimental_profile_include_target_label",
-        "--profile=" + profile_path,
-        "--heap_dump_on_oom",
-    ])
+    # Only generate the profile when opt-in. --generate_json_trace_profile +
+    # --profile=path cost wall-clock and write a file we'd otherwise leave on
+    # disk. Skip them entirely when upload_profile is off.
+    if upload_profile:
+        bazel_trait.extra_flags.extend([
+            "--generate_json_trace_profile",
+            "--experimental_profile_include_target_label",
+            "--profile=" + profile_path,
+        ])
 
-    bazel_trait.execution_log_sinks.append(
-        bazel.execution_log.compact_file(path = execlog_path),
-    )
-    bazel_trait.build_event_sinks.append(
-        bazel.build_events.file(path = bep_path),
-    )
+    # Register sinks only when their upload is opt-in. When off, Bazel never
+    # writes the file at all — no leaked bytes on disk, no wasted I/O, and the
+    # matching upload branch below finds nothing to publish.
+    if upload_exec_log:
+        bazel_trait.execution_log_sinks.append(
+            bazel.execution_log.compact_file(path = execlog_path),
+        )
+    if upload_bep:
+        bazel_trait.build_event_sinks.append(
+            bazel.build_events.file(path = bep_path),
+        )
 
     state = {}
 
     def _on_build_event(ctx, event):
-        _collect_test_files(ctx, state, event)
-        if not is_local:
-            _init_upload_state(state)
-            entries = state.get("_test_entries", [])
-            if len(entries) >= state["_artifact_upload"]["testlogs"]["last_count"] + _BATCH_SIZE:
-                name = artifact_name(ci, ctx.task.name, ctx.task.key, "testlogs")
-                success = uploader.upload_testlogs(ctx, state["_artifact_upload"]["testlogs"], entries, name)
-                # Surface the artifact URL and per-file label URLs as soon as the first
-                # batch is available so GithubStatusChecks can add download links quickly.
-                if success:
-                    _update_testlogs_trait(artifacts_trait, state, ctx.std.env, ci)
+        # Skip collection entirely when testlog upload is opt-out — no point
+        # scanning test_result events and stashing paths we'll never read.
+        if not upload_testlogs or is_local:
+            return
+        _collect_test_files(ctx, state, event, upload_test_logs)
+        _init_upload_state(state)
+        entries = state.get("_test_entries", [])
+        if len(entries) >= state["_artifact_upload"]["testlogs"]["last_count"] + _BATCH_SIZE:
+            name = artifact_name(ci, ctx.task.name, ctx.task.key, "testlogs")
+            success = uploader.upload_testlogs(ctx, state["_artifact_upload"]["testlogs"], entries, name)
+            # Surface the artifact URL and per-file label URLs as soon as the first
+            # batch is available so GithubStatusChecks can add download links quickly.
+            if success:
+                _update_testlogs_trait(artifacts_trait, state, ctx.std.env, ci)
 
     def _on_build_end(ctx, exit_code):
         if not is_local:
@@ -275,44 +375,54 @@ def _artifact_upload_impl(ctx: FeatureContext):
             if warning:
                 print("\nwarning: artifact upload skipped — " + warning)
             else:
-                _init_upload_state(state)
-                entries = state.get("_test_entries", [])
-                name = artifact_name(ci, ctx.task.name, ctx.task.key, "testlogs")
-                success = uploader.upload_testlogs(ctx, state["_artifact_upload"]["testlogs"], entries, name)
-                # Always update after final upload so both the archive URL and per-file
-                # label URLs reflect the complete set of uploaded files.
-                if success:
-                    _update_testlogs_trait(artifacts_trait, state, ctx.std.env, ci)
+                if upload_testlogs:
+                    _init_upload_state(state)
+                    entries = state.get("_test_entries", [])
+                    name = artifact_name(ci, ctx.task.name, ctx.task.key, "testlogs")
+                    success = uploader.upload_testlogs(ctx, state["_artifact_upload"]["testlogs"], entries, name)
+                    # Always update after final upload so both the archive URL and
+                    # per-file label URLs reflect the complete set of uploaded files.
+                    if success:
+                        _update_testlogs_trait(artifacts_trait, state, ctx.std.env, ci)
 
-                # Upload profile/execlog/bep. `download_url` is an HTTP URL on
+                # Upload profile/bep/execlog. `download_url` is an HTTP URL on
                 # GitHub/GitLab/CircleCI (empty on Buildkite) — record it so
                 # status checks can link directly to the downloads. Remove the
                 # source on BOTH success and failure: a failed upload does not
                 # get a retry in this pipeline, so keeping the file just leaks
-                # a potentially-sensitive artifact (profile.gz contains Bazel
-                # action env; execlog.zstd contains command lines) into /tmp.
+                # a potentially-sensitive artifact into /tmp.
+                #
+                # Each kind is included only when its corresponding opt-in
+                # arg is set on the feature.
                 task_name = ctx.task.name
                 task_key = ctx.task.key
-                for kind, src, aname in [
-                    ("profile", profile_path, artifact_name(ci, task_name, task_key, "profile.gz")),
-                    ("execlog", execlog_path, artifact_name(ci, task_name, task_key, "execlog.zstd")),
-                    ("bep",     bep_path,     artifact_name(ci, task_name, task_key, "bep.bin")),
-                ]:
+                uploads = []
+                if upload_profile:
+                    uploads.append(("profile", profile_path, artifact_name(ci, task_name, task_key, "profile.gz")))
+                if upload_bep:
+                    uploads.append(("bep", bep_path, artifact_name(ci, task_name, task_key, "bep.bin")))
+                if upload_exec_log:
+                    uploads.append(("execlog", execlog_path, artifact_name(ci, task_name, task_key, "execlog.zstd")))
+                uploaded_any = False
+                for kind, src, aname in uploads:
                     if ctx.std.fs.exists(src):
                         result = uploader.upload_file(ctx, src, aname)
                         if result["success"]:
                             _record_artifact_url(artifacts_trait, kind, result.get("download_url", ""))
+                            uploaded_any = True
                         else:
                             for err in result["errors"]:
                                 print("artifact upload error (" + aname + "): " + err)
                         ctx.std.fs.remove_file(src)
 
-                # Build tasks (no tests) never hit _update_testlogs_trait, so
-                # artifacts_browse_url would stay empty — but profile/execlog/bep
-                # uploaded successfully and the CI artifacts tab is still the right
-                # place to point users. Set the browse URL here if any artifact
-                # made it and it hasn't been set yet.
-                if artifacts_trait.artifact_urls and not artifacts_trait.artifacts_browse_url:
+                # Set the "Artifacts" browse URL whenever ANY upload succeeded
+                # in this impl — not just when artifact_urls is populated.
+                # Buildkite returns empty download_urls (short-lived), so
+                # _record_artifact_url skips them and artifact_urls stays empty
+                # even though the upload itself landed. Keying off
+                # `uploaded_any` covers that path; testlogs still take the
+                # earlier branch via _update_testlogs_trait.
+                if uploaded_any and not artifacts_trait.artifacts_browse_url:
                     browse = _make_artifacts_browse_url(ctx.std.env, ci)
                     if browse:
                         artifacts_trait.artifacts_browse_url = browse
@@ -360,5 +470,68 @@ ArtifactUpload = feature(
     display_name = "Artifact Upload",
     summary = "Automatically upload build artifacts to CI. Supports GitHub Actions, Buildkite, CircleCI, and GitLab.",
     implementation = _artifact_upload_impl,
-    args = {}
+    args = {
+        # All uploads are opt-in. An artifact published to CI is downloadable
+        # by anyone with read access to the job, so "secrets never leave the
+        # machine" means defaulting every channel to off and letting the
+        # operator enable the ones they want for their threat model.
+        #
+        # Risk level, highest to lowest:
+        #   upload_exec_log — carries action env vars + command lines; on-disk
+        #                     redaction not yet implemented. Highest risk.
+        #   upload_testlogs — test stdout/stderr and XML output may echo env
+        #                     vars or print-debugged secrets.
+        #   upload_bep      — BES events are redacted at the stream source
+        #                     (see stream/redaction.rs), so on-disk contents
+        #                     match the redacted form downstream consumers
+        #                     see. Low risk but not zero (gaps in redaction
+        #                     coverage land here).
+        #   upload_profile  — JSON trace profile: target labels, file paths,
+        #                     timing counters. Does not include env values
+        #                     or command lines. Low risk; labels can still
+        #                     leak internal project structure.
+        # `upload_test_logs` selects which test.log / test.xml / test.outputs.zip
+        # files get collected and uploaded:
+        #   none      (default) — no test logs uploaded.
+        #   failed    — only tests that didn't pass (failed, flaky, timeout,
+        #               failed_to_build, remote_failure, incomplete, ...).
+        #               Is the usual sensible choice — passing-test logs are noise.
+        #   executed  — every test that actually ran (cached passes skipped).
+        #   all       — everything, including cached passes.
+        # Off by default — test output can echo env vars or print-debugged
+        # secrets, and on public-repo CI any uploaded file is downloadable by
+        # anyone with repo read access. When off, GithubStatusChecks will not
+        # have download links for failed test logs.
+        "upload_test_logs": args.string(
+            default = "none",
+            values = ["none", "failed", "executed", "all"],
+            description = "Which test logs to upload as artifacts. " +
+                          "'none' (default) uploads nothing. 'failed' uploads " +
+                          "only non-passing tests. 'executed' uploads every test" +
+                          "that ran (skips cached passes). 'all' uploads everything.",
+        ),
+        "upload_profile": args.boolean(
+            default = False,
+            description = "Upload Bazel's JSON trace profile as an artifact. Off by " +
+                          "default. The profile does not typically contain env values " +
+                          "or command lines, but target labels and file paths may " +
+                          "reveal internal project structure.",
+        ),
+        "upload_bep": args.boolean(
+            default = False,
+            description = "Upload the Build Event Protocol binary file as an artifact. " +
+                          "Off by default. The on-disk file is redacted at the stream " +
+                          "source (headers, URL creds, non-allowlisted env vars), so " +
+                          "risk is lower than the other channels — but gaps in redaction " +
+                          "coverage would land here.",
+        ),
+        "upload_exec_log": args.boolean(
+            default = False,
+            description = "Upload Bazel's compact execution log as an artifact. " +
+                          "Off by default — the log contains action env vars and " +
+                          "command lines that may carry secrets; on-disk redaction " +
+                          "is not yet implemented. Set to true on private-repo CI " +
+                          "where artifact access is controlled.",
+        ),
+    }
 )

--- a/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
@@ -13,6 +13,7 @@ use std::{
 use thiserror::Error;
 
 use super::broadcaster::{Broadcaster, Subscriber};
+use super::redaction::redact_event;
 use super::util::{MultiWriter, read_varint};
 
 #[derive(Error, Debug)]
@@ -21,6 +22,8 @@ pub enum BuildEventStreamError {
     IO(#[from] std::io::Error),
     #[error("prost decode error: {0}")]
     ProstDecode(#[from] prost::DecodeError),
+    #[error("prost encode error: {0}")]
+    ProstEncode(#[from] prost::EncodeError),
 }
 
 #[derive(Debug)]
@@ -60,7 +63,14 @@ impl BuildEventStream {
             // Initial size for reading a varint
             buf.resize(10, 0);
 
+            // Scratch buffer for re-encoding redacted events. Reused across
+            // iterations to avoid per-event allocation. Only populated on the
+            // rare modified-event path (the common case writes the original
+            // bytes straight through).
+            let mut reencode_buf: Vec<u8> = Vec::with_capacity(1024);
+
             let read_event = |buf: &mut Vec<u8>,
+                              reencode_buf: &mut Vec<u8>,
                               raw_out: &mut MultiWriter<BufWriter<File>>,
                               reader: &mut galvanize::Pipe|
              -> Result<BuildEvent, BuildEventStreamError> {
@@ -68,14 +78,30 @@ impl BuildEventStream {
                 if size > buf.len() {
                     buf.resize(size, 0);
                 }
-                raw_out.write(vbuf.as_slice())?;
                 reader.read_exact(&mut buf[0..size])?;
+                let mut event = BuildEvent::decode(&buf[0..size])?;
+                // Redact secrets (headers, env passthrough, URL creds) BEFORE
+                // anything downstream sees the event. Raw file sinks, gRPC
+                // forwarders, and AXL iterators all read from the post-redact
+                // stream — secrets never leave this process.
+                //
+                // `redact_event` only mutates a small set of payload kinds
+                // (StructuredCommandLine, UnstructuredCommandLine, BuildMetadata,
+                // etc.); for the common case it returns false and we write the
+                // original bytes straight through with no re-encode cost.
+                let modified = redact_event(&mut event);
                 // These can be extremely slow and expensive calls depending
                 // on the destination that we are writing to.
                 // TODO: Ensure we have a dedicated thread where the writing
                 // happens to avoid stalling.
-                raw_out.write_all(&buf[0..size])?;
-                let event = BuildEvent::decode(&buf[0..size])?;
+                if modified {
+                    reencode_buf.clear();
+                    event.encode_length_delimited(reencode_buf)?;
+                    raw_out.write_all(reencode_buf.as_slice())?;
+                } else {
+                    raw_out.write(vbuf.as_slice())?;
+                    raw_out.write_all(&buf[0..size])?;
+                }
                 Ok(event)
             };
 
@@ -87,7 +113,7 @@ impl BuildEventStream {
             let mut expecting_retry = false;
 
             loop {
-                match read_event(&mut buf, &mut raw_out, &mut reader) {
+                match read_event(&mut buf, &mut reencode_buf, &mut raw_out, &mut reader) {
                     Ok(event) => {
                         let last_message = event.last_message;
 

--- a/crates/axl-runtime/src/engine/bazel/stream/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/mod.rs
@@ -1,6 +1,7 @@
 pub mod broadcaster;
 pub mod build_event;
 pub mod execlog;
+pub mod redaction;
 mod util;
 pub mod workspace_event;
 

--- a/crates/axl-runtime/src/engine/bazel/stream/redaction.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/redaction.rs
@@ -1,0 +1,878 @@
+//! Secret redaction for Build Event Protocol events.
+//!
+//! Bazel's BEP stream faithfully echoes back every command-line flag the user
+//! (or CI) passed, including values that frequently carry credentials:
+//! `--remote_header=Authorization: Bearer <token>`,
+//! `--bes_backend=grpcs://user:password@host:port`,
+//! `--action_env=DEPLOY_TOKEN=<secret>`, etc. Without redaction, those secrets
+//! flow downstream to every BES sink — the gRPC forwarder, file dumps uploaded
+//! as artifacts, the AXL `build_events()` iterator. We don't want that.
+//!
+//! This module rewrites events in place before fan-out, so every downstream
+//! consumer sees a scrubbed stream. Secrets never leave the process.
+//!
+//! The rule set mirrors the AXL-side redaction in `bazel_results.axl`
+//! (`_redact_arg` / `_strip_url_creds`). Any change here should be reflected
+//! there, or vice versa — we should move both to share a single source of
+//! truth once the API surface settles.
+//!
+//! User-configurable allowlist: the user can pass
+//! `--build_metadata=ALLOW_ENV=MY_VAR,OTHER_*` on the Bazel command to extend
+//! (not replace) the default allowlist. We extract that flag from the same
+//! event we're redacting — command-line events carry the flag in their own
+//! args list, so there's no ordering dependency on BuildMetadata arrival.
+//! Glob patterns (`*`, `?`) are supported, matching the AXL semantics.
+
+use axl_proto::build_event_stream::BuildEvent;
+use axl_proto::build_event_stream::build_event::Payload;
+use axl_proto::command_line::command_line_section::SectionType;
+use axl_proto::command_line::{CommandLine, Option as CmdOption};
+use std::borrow::Cow;
+
+pub const REDACTED: &str = "<REDACTED>";
+
+/// Bazel flag names whose values carry gRPC/HTTP headers — always redacted
+/// since headers routinely carry bearer tokens, API keys, cookies, etc.
+const HEADER_OPTION_NAMES: &[&str] = &[
+    "remote_header",
+    "remote_cache_header",
+    "remote_exec_header",
+    "remote_downloader_header",
+    "bes_header",
+];
+
+/// Bazel flag names of the `--foo=KEY=VALUE` env-passthrough form. The VALUE
+/// portion is redacted unless the KEY matches the ALLOW_ENV allowlist.
+const ENV_VAR_OPTION_NAMES: &[&str] = &[
+    "action_env",
+    "client_env",
+    "host_action_env",
+    "repo_env",
+    "test_env",
+];
+
+/// Env var names whose value is expected to be a git repository URL. The URL
+/// itself is informative, but any user:password prefix gets scrubbed.
+const KNOWN_GIT_REPO_URL_KEYS: &[&str] = &[
+    "REPO_URL",
+    "GIT_URL",
+    "TRAVIS_REPO_SLUG",
+    "BUILDKITE_REPO",
+    "GIT_REPOSITORY_URL",
+    "CIRCLE_REPOSITORY_URL",
+    "GITHUB_REPOSITORY",
+    "CI_REPOSITORY_URL",
+];
+
+/// Metadata key used by some CI runners to store the original command line
+/// as a JSON-encoded list of strings. When present, we decode, redact each
+/// flag, and re-encode — otherwise any secrets nested inside
+/// (`--remote_header=...`, `--action_env=TOKEN=...`) slip through on the
+/// BuildMetadata event untouched.
+const EXPLICIT_COMMAND_LINE_KEY: &str = "EXPLICIT_COMMAND_LINE";
+
+/// Curated CI/VCS identifiers that are publicly safe to surface (commit SHA,
+/// branch, PR number, run ID, repo URL — the kind of info that typically ends
+/// up in the commit message or CI job name anyway). Values of env vars we
+/// don't recognize are redacted by default.
+const DEFAULT_ALLOW_ENV: &[&str] = &[
+    // Who ran the build.
+    "USER",
+    "GITHUB_ACTOR",
+    "BUILDKITE_BUILD_CREATOR",
+    "GITLAB_USER_NAME",
+    "CIRCLE_USERNAME",
+    // Repo URLs (stripped of credentials separately).
+    "GITHUB_REPOSITORY",
+    "BUILDKITE_REPO",
+    "TRAVIS_REPO_SLUG",
+    "GIT_URL",
+    "GIT_REPOSITORY_URL",
+    "CI_REPOSITORY_URL",
+    "REPO_URL",
+    "CIRCLE_REPOSITORY_URL",
+    // Commit SHAs.
+    "GITHUB_SHA",
+    "CIRCLE_SHA1",
+    "BUILDKITE_COMMIT",
+    "TRAVIS_COMMIT",
+    "BITRISE_GIT_COMMIT",
+    "GIT_COMMIT",
+    "VOLATILE_GIT_COMMIT",
+    "CI_COMMIT_SHA",
+    "COMMIT_SHA",
+    // Run identifiers.
+    "GITHUB_RUN_ID",
+    "BUILDKITE_BUILD_URL",
+    "BUILDKITE_JOB_ID",
+    // Branches / refs.
+    "GITHUB_HEAD_REF",
+    "GITHUB_REF",
+    "CIRCLE_BRANCH",
+    "BUILDKITE_BRANCH",
+    "TRAVIS_BRANCH",
+    "BITRISE_GIT_BRANCH",
+    "GIT_BRANCH",
+    "CI_COMMIT_BRANCH",
+    "CI_MERGE_REQUEST_SOURCE_BRANCH_NAME",
+    // Generic CI flags.
+    "CI",
+    "CI_RUNNER",
+];
+
+/// Values that are always safe to surface regardless of allowlist: no-op
+/// markers and booleans that never carry secrets.
+const SAFE_ENV_VALUES: &[&str] = &[
+    "", "0", "1", "true", "false", "True", "False", "TRUE", "FALSE",
+];
+
+/// Case-insensitive glob match with `*` and `?` support. Iterative with
+/// backtracking — no regex dependency. Matches the AXL `_glob_match`
+/// semantics so a pattern that works in AXL works here too.
+fn glob_match(pattern: &str, name: &str) -> bool {
+    let pat: Vec<char> = pattern.to_lowercase().chars().collect();
+    let nm: Vec<char> = name.to_lowercase().chars().collect();
+    let mut pi = 0usize;
+    let mut ni = 0usize;
+    let mut star_pi: Option<usize> = None;
+    let mut star_ni = 0usize;
+    loop {
+        if ni < nm.len() && pi < pat.len() && (pat[pi] == '?' || pat[pi] == nm[ni]) {
+            pi += 1;
+            ni += 1;
+        } else if pi < pat.len() && pat[pi] == '*' {
+            star_pi = Some(pi);
+            star_ni = ni;
+            pi += 1;
+        } else if let Some(sp) = star_pi {
+            pi = sp + 1;
+            star_ni += 1;
+            ni = star_ni;
+        } else {
+            return false;
+        }
+        if ni >= nm.len() {
+            // Eat any trailing '*'s in the pattern.
+            while pi < pat.len() && pat[pi] == '*' {
+                pi += 1;
+            }
+            return pi == pat.len();
+        }
+    }
+}
+
+/// True if `name` matches any allowlist entry (exact or glob).
+fn is_allowed_env(name: &str, allow_env: &[&str]) -> bool {
+    allow_env.iter().any(|pat| {
+        if pat.contains('*') || pat.contains('?') {
+            glob_match(pat, name)
+        } else {
+            pat.eq_ignore_ascii_case(name)
+        }
+    })
+}
+
+/// Extract the user's `--build_metadata=ALLOW_ENV=...` patterns from any flag
+/// string that looks like `--build_metadata=ALLOW_ENV=A,B,C_*`. Case-insensitive
+/// on the key portion because Bazel preserves user casing.
+fn parse_allow_env_flag(flag: &str) -> Option<Vec<String>> {
+    let rest = flag.strip_prefix("--build_metadata=")?;
+    let (key, value) = rest.split_once('=')?;
+    if !key.eq_ignore_ascii_case("ALLOW_ENV") {
+        return None;
+    }
+    Some(
+        value
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+    )
+}
+
+/// Walk an iterator of flag strings and return every ALLOW_ENV pattern the
+/// user supplied (later --build_metadata=ALLOW_ENV=... flags accumulate rather
+/// than replace, matching Bazel's own repeated-flag semantics).
+fn collect_allow_env<'a>(flags: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    let mut out = Vec::new();
+    for f in flags {
+        if let Some(v) = parse_allow_env_flag(f) {
+            out.extend(v);
+        }
+    }
+    out
+}
+
+/// Build the effective allowlist for a single event: default + user-provided.
+/// The resulting Vec is owned but short-lived (one allocation per redacted
+/// event; typically ~1-2 user patterns on top of the default set).
+fn effective_allow_env<'a>(user_patterns: &'a [String]) -> Vec<&'a str> {
+    let mut out: Vec<&str> = DEFAULT_ALLOW_ENV.to_vec();
+    out.extend(user_patterns.iter().map(|s| s.as_str()));
+    out
+}
+
+/// Rewrite `event` in place with credentials/secrets redacted. Returns true
+/// if any field was modified (caller can skip re-encode on false).
+///
+/// Only a small set of event payload types carry sensitive values, so the
+/// common case is a cheap payload-kind check that returns false immediately.
+pub fn redact_event(event: &mut BuildEvent) -> bool {
+    let Some(payload) = event.payload.as_mut() else {
+        return false;
+    };
+    match payload {
+        Payload::Started(started) => {
+            // options_description is a free-form shell-style summary of non-
+            // default options, including quoted values with embedded spaces
+            // (`--repo_env='JAVA_HOME=../bazel_tools/jdk'`). Token-level
+            // redaction here would need a real shell-quote-aware tokenizer,
+            // which is brittle and error-prone — a miss leaks a secret.
+            //
+            // StructuredCommandLine and OptionsParsed carry the same flags in
+            // structured form, which we do redact precisely. No consumer in
+            // this codebase reads options_description, so clearing it is the
+            // simplest safe choice.
+            if started.options_description.is_empty() {
+                false
+            } else {
+                started.options_description = String::new();
+                true
+            }
+        }
+        Payload::UnstructuredCommandLine(ucl) => {
+            let user_patterns = collect_allow_env(ucl.args.iter().map(|s| s.as_str()));
+            let allow_env = effective_allow_env(&user_patterns);
+            redact_string_vec(&mut ucl.args, &allow_env)
+        }
+        Payload::StructuredCommandLine(cl) => {
+            let user_patterns = collect_allow_env_from_command_line(cl);
+            let allow_env = effective_allow_env(&user_patterns);
+            redact_command_line(cl, &allow_env)
+        }
+        Payload::OptionsParsed(op) => {
+            // ALLOW_ENV can appear in any of the four lists; collect from all.
+            let user_patterns: Vec<String> = {
+                let mut v = collect_allow_env(op.startup_options.iter().map(|s| s.as_str()));
+                v.extend(collect_allow_env(
+                    op.explicit_startup_options.iter().map(|s| s.as_str()),
+                ));
+                v.extend(collect_allow_env(op.cmd_line.iter().map(|s| s.as_str())));
+                v.extend(collect_allow_env(
+                    op.explicit_cmd_line.iter().map(|s| s.as_str()),
+                ));
+                v
+            };
+            let allow_env = effective_allow_env(&user_patterns);
+            let a = redact_string_vec(&mut op.startup_options, &allow_env);
+            let b = redact_string_vec(&mut op.explicit_startup_options, &allow_env);
+            let c = redact_string_vec(&mut op.cmd_line, &allow_env);
+            let d = redact_string_vec(&mut op.explicit_cmd_line, &allow_env);
+            a || b || c || d
+        }
+        Payload::WorkspaceStatus(ws) => {
+            // Workspace status is user-provided via the workspace_status_command.
+            // Keys (usually BUILD_*, STABLE_*) aren't secrets; values typically
+            // carry git info. Strip URL credentials but leave values intact —
+            // redacting them entirely would break the Aspect Web UI which reads
+            // these for display.
+            let mut modified = false;
+            for item in ws.item.iter_mut() {
+                if let Cow::Owned(s) = strip_url_creds(&item.value) {
+                    item.value = s;
+                    modified = true;
+                }
+            }
+            modified
+        }
+        Payload::BuildMetadata(bm) => {
+            // User-provided --build_metadata=KEY=VALUE entries. Two passes:
+            //
+            //   1. Only scrub URL creds from keys known to carry git URLs.
+            //      Doing it unconditionally risks false positives on arbitrary
+            //      metadata values that happen to contain `://...@`.
+            //   2. Special-case EXPLICIT_COMMAND_LINE: some CI runners stuff
+            //      the original command line into metadata as a JSON-encoded
+            //      list of strings. Decode, redact each flag, re-encode —
+            //      otherwise nested secrets (--remote_header=, --action_env=)
+            //      slip through untouched.
+            //
+            // Users who put a bare secret in `--build_metadata=X=secret`
+            // accepted that risk by passing it explicitly; we don't have
+            // enough signal to redact arbitrary values.
+            let mut modified = false;
+            for key in KNOWN_GIT_REPO_URL_KEYS {
+                if let Some(value) = bm.metadata.get_mut(*key) {
+                    if let Cow::Owned(s) = strip_url_creds(value) {
+                        *value = s;
+                        modified = true;
+                    }
+                }
+            }
+            if let Some(raw) = bm.metadata.get_mut(EXPLICIT_COMMAND_LINE_KEY) {
+                // Parse ALLOW_ENV from the embedded command line first so user
+                // overrides apply to this payload (same self-describing pattern
+                // as the command-line events).
+                if let Ok(mut tokens) = serde_json::from_str::<Vec<String>>(raw) {
+                    let user_patterns = collect_allow_env(tokens.iter().map(|s| s.as_str()));
+                    let allow_env = effective_allow_env(&user_patterns);
+                    let mut tokens_modified = false;
+                    for t in tokens.iter_mut() {
+                        if let Cow::Owned(new) = redact_flag(t, &allow_env) {
+                            *t = new;
+                            tokens_modified = true;
+                        }
+                    }
+                    if tokens_modified {
+                        if let Ok(encoded) = serde_json::to_string(&tokens) {
+                            *raw = encoded;
+                            modified = true;
+                        }
+                    }
+                }
+            }
+            modified
+        }
+        _ => false,
+    }
+}
+
+/// Extract ALLOW_ENV patterns from a structured command line by walking the
+/// `--build_metadata` options nested inside OptionList sections.
+fn collect_allow_env_from_command_line(cl: &CommandLine) -> Vec<String> {
+    let mut out = Vec::new();
+    for section in &cl.sections {
+        let Some(section_type) = section.section_type.as_ref() else {
+            continue;
+        };
+        match section_type {
+            SectionType::ChunkList(cl) => {
+                out.extend(collect_allow_env(cl.chunk.iter().map(|s| s.as_str())));
+            }
+            SectionType::OptionList(ol) => {
+                for opt in &ol.option {
+                    if let Some(v) = parse_allow_env_flag(&opt.combined_form) {
+                        out.extend(v);
+                    }
+                    // Also check option_name/option_value in case combined_form
+                    // is empty (e.g. canonical form).
+                    if opt.option_name.eq_ignore_ascii_case("build_metadata") {
+                        if let Some((key, val)) = opt.option_value.split_once('=') {
+                            if key.eq_ignore_ascii_case("ALLOW_ENV") {
+                                out.extend(
+                                    val.split(',')
+                                        .map(|s| s.trim().to_string())
+                                        .filter(|s| !s.is_empty()),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn redact_string_vec(v: &mut Vec<String>, allow_env: &[&str]) -> bool {
+    let mut modified = false;
+    for s in v.iter_mut() {
+        if let Cow::Owned(new) = redact_flag(s, allow_env) {
+            *s = new;
+            modified = true;
+        }
+    }
+    modified
+}
+
+fn redact_command_line(cl: &mut CommandLine, allow_env: &[&str]) -> bool {
+    let mut modified = false;
+    for section in cl.sections.iter_mut() {
+        let Some(section_type) = section.section_type.as_mut() else {
+            continue;
+        };
+        match section_type {
+            SectionType::ChunkList(cl) => {
+                if redact_string_vec(&mut cl.chunk, allow_env) {
+                    modified = true;
+                }
+            }
+            SectionType::OptionList(ol) => {
+                for opt in ol.option.iter_mut() {
+                    if redact_option(opt, allow_env) {
+                        modified = true;
+                    }
+                }
+            }
+        }
+    }
+    modified
+}
+
+fn redact_option(opt: &mut CmdOption, allow_env: &[&str]) -> bool {
+    let name = opt.option_name.as_str();
+    let new_value = redact_option_value(name, &opt.option_value, allow_env);
+    let new_combined = redact_flag(&opt.combined_form, allow_env);
+
+    let mut modified = false;
+    if let Cow::Owned(s) = new_value {
+        opt.option_value = s;
+        modified = true;
+    }
+    if let Cow::Owned(s) = new_combined {
+        opt.combined_form = s;
+        modified = true;
+    }
+    modified
+}
+
+/// Scrub a single flag string (`--name=value` / `--name value` / positional).
+///
+/// - Name-only flags (no `=`): leave untouched.
+/// - `--header-like=VALUE`: redact entire VALUE.
+/// - `--env-like=KEY=VALUE`: redact VALUE unless KEY is on `allow_env` or
+///   is a known-safe literal; strip URL creds when KEY is a known git URL var.
+/// - Other `--name=value`: strip URL creds from VALUE.
+pub fn redact_flag<'a>(arg: &'a str, allow_env: &[&str]) -> Cow<'a, str> {
+    // Positional / non-flag: only URL-creds scrub.
+    if !arg.starts_with("--") {
+        return strip_url_creds(arg);
+    }
+    let Some(eq) = arg.find('=') else {
+        // `--flag` with no value — nothing to redact.
+        return Cow::Borrowed(arg);
+    };
+    let name = &arg[2..eq];
+    let value = &arg[eq + 1..];
+
+    if HEADER_OPTION_NAMES.contains(&name) {
+        return Cow::Owned(format!("--{}={}", name, REDACTED));
+    }
+    if ENV_VAR_OPTION_NAMES.contains(&name) {
+        let new_value = redact_env_value(value, allow_env);
+        return match new_value {
+            Cow::Owned(v) => Cow::Owned(format!("--{}={}", name, v)),
+            Cow::Borrowed(_) => Cow::Borrowed(arg),
+        };
+    }
+    // Other flags: strip URL creds from the value.
+    match strip_url_creds(value) {
+        Cow::Owned(v) => Cow::Owned(format!("--{}={}", name, v)),
+        Cow::Borrowed(_) => Cow::Borrowed(arg),
+    }
+}
+
+/// The raw value portion of a structured command-line option. Uses the same
+/// rules as `redact_flag` but starting from the `option_value` directly, so
+/// we don't have to reconstruct `--name=value`.
+fn redact_option_value<'a>(name: &str, value: &'a str, allow_env: &[&str]) -> Cow<'a, str> {
+    if HEADER_OPTION_NAMES.contains(&name) {
+        return Cow::Owned(REDACTED.to_string());
+    }
+    if ENV_VAR_OPTION_NAMES.contains(&name) {
+        return redact_env_value(value, allow_env);
+    }
+    strip_url_creds(value)
+}
+
+/// For `KEY=VALUE` env-passthrough values: redact VALUE unless KEY is on the
+/// allowlist, or the value is a known safe literal, or KEY is a known git-URL
+/// var (in which case we just strip URL creds).
+fn redact_env_value<'a>(value: &'a str, allow_env: &[&str]) -> Cow<'a, str> {
+    let Some(eq) = value.find('=') else {
+        // No KEY=VALUE shape — just strip URL creds from the whole thing.
+        return strip_url_creds(value);
+    };
+    let key = &value[..eq];
+    let val = &value[eq + 1..];
+
+    if SAFE_ENV_VALUES.contains(&val) {
+        return Cow::Borrowed(value);
+    }
+    if is_allowed_env(key, allow_env) {
+        // Allowlisted — keep the value, but still scrub URL creds from it.
+        return match strip_url_creds(val) {
+            Cow::Owned(v) => Cow::Owned(format!("{}={}", key, v)),
+            Cow::Borrowed(_) => Cow::Borrowed(value),
+        };
+    }
+    if KNOWN_GIT_REPO_URL_KEYS.contains(&key) {
+        return match strip_url_creds(val) {
+            Cow::Owned(v) => Cow::Owned(format!("{}={}", key, v)),
+            Cow::Borrowed(_) => Cow::Borrowed(value),
+        };
+    }
+    Cow::Owned(format!("{}={}", key, REDACTED))
+}
+
+/// Replace `scheme://user:password@host/...` with `scheme://<REDACTED>@host/...`.
+/// No-op when the input doesn't contain `://` or the authority has no `@`.
+pub fn strip_url_creds(s: &str) -> Cow<'_, str> {
+    let Some(scheme_end) = s.find("://") else {
+        return Cow::Borrowed(s);
+    };
+    // Look for `user[:pass]@` between `scheme://` and the next `/` (authority section).
+    let authority_start = scheme_end + 3;
+    let rest = &s[authority_start..];
+    let authority_end = rest.find('/').unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    let Some(at) = authority.find('@') else {
+        return Cow::Borrowed(s);
+    };
+    // Reconstruct with creds replaced.
+    let mut out = String::with_capacity(s.len());
+    out.push_str(&s[..authority_start]);
+    out.push_str(REDACTED);
+    out.push_str(&rest[at..]); // includes the `@` and everything after
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axl_proto::build_event_stream::{
+        BuildEvent as ProtoBuildEvent, BuildMetadata as ProtoBuildMetadata,
+        BuildStarted as ProtoBuildStarted, UnstructuredCommandLine as ProtoUnstructured,
+    };
+    use prost::Message;
+
+    #[test]
+    fn event_roundtrip_unstructured_command_line_redacts_and_reencodes() {
+        let mut ev = ProtoBuildEvent {
+            payload: Some(Payload::UnstructuredCommandLine(ProtoUnstructured {
+                args: vec![
+                    "--remote_header=Authorization: Bearer abc".to_string(),
+                    "--config=ci".to_string(),
+                    "--bes_backend=grpcs://alice:swordfish@bes.example.com:443".to_string(),
+                ],
+            })),
+            ..Default::default()
+        };
+        let modified = redact_event(&mut ev);
+        assert!(modified);
+        // Re-encode + decode the redacted event; assert the decoded form matches.
+        let mut buf = Vec::new();
+        ev.encode(&mut buf).unwrap();
+        let decoded = ProtoBuildEvent::decode(&buf[..]).unwrap();
+        let Some(Payload::UnstructuredCommandLine(ucl)) = decoded.payload else {
+            panic!("unexpected payload");
+        };
+        assert_eq!(
+            ucl.args,
+            vec![
+                "--remote_header=<REDACTED>".to_string(),
+                "--config=ci".to_string(),
+                "--bes_backend=grpcs://<REDACTED>@bes.example.com:443".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn event_build_metadata_strips_url_creds_only_on_known_git_keys() {
+        let mut bm_map = std::collections::HashMap::new();
+        bm_map.insert("COMMIT_SHA".to_string(), "abc123".to_string());
+        bm_map.insert(
+            "REPO_URL".to_string(),
+            "https://ci:token@github.com/acme/repo".to_string(),
+        );
+        // Non-git-URL key with a value that looks URL-ish — should be left
+        // alone so we don't mangle unrelated metadata.
+        bm_map.insert(
+            "WEIRD_KEY".to_string(),
+            "not-really://a:b@url.example/path".to_string(),
+        );
+        let mut ev = ProtoBuildEvent {
+            payload: Some(Payload::BuildMetadata(ProtoBuildMetadata {
+                metadata: bm_map,
+            })),
+            ..Default::default()
+        };
+        let modified = redact_event(&mut ev);
+        assert!(modified);
+        let Some(Payload::BuildMetadata(bm)) = &ev.payload else {
+            panic!("unexpected payload");
+        };
+        // COMMIT_SHA preserved verbatim.
+        assert_eq!(bm.metadata.get("COMMIT_SHA").unwrap(), "abc123");
+        // REPO_URL has user:pass stripped (known git-URL key).
+        assert_eq!(
+            bm.metadata.get("REPO_URL").unwrap(),
+            "https://<REDACTED>@github.com/acme/repo"
+        );
+        // Unknown key left alone.
+        assert_eq!(
+            bm.metadata.get("WEIRD_KEY").unwrap(),
+            "not-really://a:b@url.example/path"
+        );
+    }
+
+    #[test]
+    fn event_build_metadata_redacts_explicit_command_line() {
+        // A CI runner stashes the original command line as JSON in metadata.
+        // Secrets nested inside need to be redacted just like they are in the
+        // top-level command-line events.
+        let json = r#"["--config=ci","--remote_header=Authorization: Bearer sekrit","--action_env=API_TOKEN=xyz","--action_env=GITHUB_SHA=abc"]"#;
+        let mut bm_map = std::collections::HashMap::new();
+        bm_map.insert(EXPLICIT_COMMAND_LINE_KEY.to_string(), json.to_string());
+        let mut ev = ProtoBuildEvent {
+            payload: Some(Payload::BuildMetadata(ProtoBuildMetadata {
+                metadata: bm_map,
+            })),
+            ..Default::default()
+        };
+        let modified = redact_event(&mut ev);
+        assert!(modified);
+        let Some(Payload::BuildMetadata(bm)) = &ev.payload else {
+            panic!("unexpected payload");
+        };
+        let redacted: Vec<String> =
+            serde_json::from_str(bm.metadata.get(EXPLICIT_COMMAND_LINE_KEY).unwrap()).unwrap();
+        assert_eq!(
+            redacted,
+            vec![
+                "--config=ci".to_string(),
+                "--remote_header=<REDACTED>".to_string(),
+                "--action_env=API_TOKEN=<REDACTED>".to_string(),
+                "--action_env=GITHUB_SHA=abc".to_string(), // allowlisted
+            ]
+        );
+    }
+
+    #[test]
+    fn event_build_metadata_explicit_command_line_honors_user_allow_env() {
+        // ALLOW_ENV embedded in the explicit command line itself should be
+        // extracted and applied to that same list.
+        let json = r#"["--build_metadata=ALLOW_ENV=DEPLOY_ENV","--action_env=DEPLOY_ENV=prod","--action_env=OTHER=secret"]"#;
+        let mut bm_map = std::collections::HashMap::new();
+        bm_map.insert(EXPLICIT_COMMAND_LINE_KEY.to_string(), json.to_string());
+        let mut ev = ProtoBuildEvent {
+            payload: Some(Payload::BuildMetadata(ProtoBuildMetadata {
+                metadata: bm_map,
+            })),
+            ..Default::default()
+        };
+        redact_event(&mut ev);
+        let Some(Payload::BuildMetadata(bm)) = &ev.payload else {
+            panic!("unexpected payload");
+        };
+        let redacted: Vec<String> =
+            serde_json::from_str(bm.metadata.get(EXPLICIT_COMMAND_LINE_KEY).unwrap()).unwrap();
+        assert_eq!(redacted[1], "--action_env=DEPLOY_ENV=prod");
+        assert_eq!(redacted[2], "--action_env=OTHER=<REDACTED>");
+    }
+
+    #[test]
+    fn event_started_clears_options_description() {
+        // options_description contains a quoted-value flag — we don't even try
+        // to tokenize, we just clear. The structured command-line events carry
+        // the same info in redacted form.
+        let mut ev = ProtoBuildEvent {
+            payload: Some(Payload::Started(ProtoBuildStarted {
+                options_description: "--remote_header='Authorization: Bearer s3kret' --config=ci"
+                    .to_string(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let modified = redact_event(&mut ev);
+        assert!(modified);
+        let Some(Payload::Started(bs)) = &ev.payload else {
+            panic!("unexpected payload");
+        };
+        assert_eq!(bs.options_description, "");
+    }
+
+    #[test]
+    fn event_started_empty_options_description_is_not_modified() {
+        let mut ev = ProtoBuildEvent {
+            payload: Some(Payload::Started(ProtoBuildStarted::default())),
+            ..Default::default()
+        };
+        assert!(!redact_event(&mut ev));
+    }
+
+    #[test]
+    fn event_without_sensitive_payload_is_not_modified() {
+        let mut ev = ProtoBuildEvent::default();
+        assert!(!redact_event(&mut ev));
+    }
+
+    #[test]
+    fn strips_url_creds_with_user_and_password() {
+        assert_eq!(
+            strip_url_creds("grpcs://alice:swordfish@bes.example.com:443"),
+            "grpcs://<REDACTED>@bes.example.com:443"
+        );
+    }
+
+    #[test]
+    fn strips_url_creds_user_only() {
+        assert_eq!(
+            strip_url_creds("https://token@github.com/acme/repo.git"),
+            "https://<REDACTED>@github.com/acme/repo.git"
+        );
+    }
+
+    #[test]
+    fn leaves_url_without_creds_untouched() {
+        let s = "grpcs://bes.example.com:443";
+        assert!(matches!(strip_url_creds(s), Cow::Borrowed(_)));
+        assert_eq!(strip_url_creds(s), s);
+    }
+
+    #[test]
+    fn leaves_non_url_strings_untouched() {
+        let s = "hello world";
+        assert!(matches!(strip_url_creds(s), Cow::Borrowed(_)));
+    }
+
+    fn default_allow() -> Vec<&'static str> {
+        DEFAULT_ALLOW_ENV.to_vec()
+    }
+
+    #[test]
+    fn redacts_header_flag() {
+        assert_eq!(
+            redact_flag(
+                "--remote_header=Authorization: Bearer abc",
+                &default_allow()
+            ),
+            "--remote_header=<REDACTED>"
+        );
+    }
+
+    #[test]
+    fn redacts_env_passthrough_unknown_key() {
+        assert_eq!(
+            redact_flag("--client_env=GITHUB_TOKEN=ghp_deadbeef", &default_allow()),
+            "--client_env=GITHUB_TOKEN=<REDACTED>"
+        );
+    }
+
+    #[test]
+    fn allows_env_passthrough_known_safe() {
+        // CI=true is safe literal
+        let s = "--action_env=CI=true";
+        assert_eq!(redact_flag(s, &default_allow()), s);
+    }
+
+    #[test]
+    fn allows_env_passthrough_allowlisted_key() {
+        let s = "--action_env=GITHUB_SHA=abc123def";
+        assert_eq!(redact_flag(s, &default_allow()), s);
+    }
+
+    #[test]
+    fn strips_url_creds_in_env_passthrough_repo_url() {
+        assert_eq!(
+            redact_flag(
+                "--repo_env=GIT_URL=https://user:token@github.com/acme/repo",
+                &default_allow()
+            ),
+            "--repo_env=GIT_URL=https://<REDACTED>@github.com/acme/repo"
+        );
+    }
+
+    #[test]
+    fn strips_url_creds_in_generic_flag() {
+        assert_eq!(
+            redact_flag(
+                "--bes_backend=grpcs://alice:swordfish@bes.example.com:443",
+                &default_allow()
+            ),
+            "--bes_backend=grpcs://<REDACTED>@bes.example.com:443"
+        );
+    }
+
+    #[test]
+    fn leaves_benign_flag_untouched() {
+        let s = "--config=ci";
+        assert!(matches!(redact_flag(s, &default_allow()), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn leaves_positional_target_untouched() {
+        let s = "//foo:bar";
+        assert!(matches!(redact_flag(s, &default_allow()), Cow::Borrowed(_)));
+    }
+
+    // --- User-configurable ALLOW_ENV ---------------------------------------
+
+    #[test]
+    fn glob_match_basics() {
+        assert!(glob_match("GITHUB_*", "GITHUB_SHA"));
+        assert!(glob_match("GITHUB_*", "github_actor")); // case-insensitive
+        assert!(glob_match("*_TOKEN", "MY_TOKEN"));
+        assert!(glob_match("A?C", "abc"));
+        assert!(!glob_match("GITHUB_*", "CIRCLE_SHA"));
+        assert!(glob_match("*", "anything"));
+    }
+
+    #[test]
+    fn parse_allow_env_flag_extracts_patterns() {
+        assert_eq!(
+            parse_allow_env_flag("--build_metadata=ALLOW_ENV=MY_VAR,OTHER_*"),
+            Some(vec!["MY_VAR".to_string(), "OTHER_*".to_string()])
+        );
+        assert_eq!(
+            parse_allow_env_flag("--build_metadata=COMMIT_SHA=abc"),
+            None
+        );
+        assert_eq!(parse_allow_env_flag("--config=ci"), None);
+    }
+
+    #[test]
+    fn user_allow_env_keeps_custom_var_visible() {
+        // Without user override, DEPLOY_ENV would be redacted.
+        let baseline = redact_flag("--action_env=DEPLOY_ENV=staging", &default_allow());
+        assert_eq!(baseline, "--action_env=DEPLOY_ENV=<REDACTED>");
+
+        // Event is self-describing — we redact using the ALLOW_ENV from the
+        // same event. Simulate what redact_event does with UnstructuredCommandLine.
+        let mut args = vec![
+            "--build_metadata=ALLOW_ENV=DEPLOY_ENV,MY_*".to_string(),
+            "--action_env=DEPLOY_ENV=staging".to_string(),
+            "--action_env=MY_REGION=us-west-2".to_string(),
+            "--action_env=SECRET_TOKEN=sk_abc".to_string(),
+        ];
+        let user_patterns = collect_allow_env(args.iter().map(|s| s.as_str()));
+        assert_eq!(user_patterns, vec!["DEPLOY_ENV", "MY_*"]);
+        let allow_env = effective_allow_env(&user_patterns);
+        let modified = redact_string_vec(&mut args, &allow_env);
+        assert!(modified);
+        assert_eq!(args[1], "--action_env=DEPLOY_ENV=staging"); // kept
+        assert_eq!(args[2], "--action_env=MY_REGION=us-west-2"); // kept via glob
+        assert_eq!(args[3], "--action_env=SECRET_TOKEN=<REDACTED>"); // redacted
+    }
+
+    #[test]
+    fn multiple_allow_env_flags_accumulate() {
+        let args = vec![
+            "--build_metadata=ALLOW_ENV=A,B",
+            "--build_metadata=ALLOW_ENV=C",
+        ];
+        let patterns = collect_allow_env(args.iter().copied());
+        assert_eq!(patterns, vec!["A", "B", "C"]);
+    }
+
+    #[test]
+    fn event_honors_user_allow_env() {
+        let mut ev = ProtoBuildEvent {
+            payload: Some(Payload::UnstructuredCommandLine(ProtoUnstructured {
+                args: vec![
+                    "--build_metadata=ALLOW_ENV=DEPLOY_ENV".to_string(),
+                    "--action_env=DEPLOY_ENV=prod".to_string(),
+                    "--action_env=MY_SECRET=xyz".to_string(),
+                ],
+            })),
+            ..Default::default()
+        };
+        let modified = redact_event(&mut ev);
+        assert!(modified);
+        let Some(Payload::UnstructuredCommandLine(ucl)) = &ev.payload else {
+            panic!("unexpected payload");
+        };
+        assert_eq!(ucl.args[1], "--action_env=DEPLOY_ENV=prod"); // kept via user allowlist
+        assert_eq!(ucl.args[2], "--action_env=MY_SECRET=<REDACTED>"); // redacted
+    }
+}


### PR DESCRIPTION
## Summary

The BEP stream Bazel sends us echoes back every flag the user (or CI) passed, including values that routinely carry credentials — `--remote_header=Authorization: Bearer ...`, `--bes_backend=grpcs://user:password@host`, `--action_env=DEPLOY_TOKEN=...`. Without redaction, those secrets flow downstream to every BES sink: the gRPC forwarder to Aspect Web UI, on-disk BEP dumps uploaded as CI artifacts, and the AXL `build_events()` iterator.

This PR adds Rust-side redaction at the stream source (before fan-out) so every downstream consumer sees a scrubbed stream. Secrets never leave the process.

Related: makes all artifact uploads (test logs, profile, BEP, exec log) opt-in — previously they were auto-uploaded, which on public-repo CI is a leak risk.

## BES redaction (new Rust module)

`crates/axl-runtime/src/engine/bazel/stream/redaction.rs` — intercepts `BuildEvent` messages after decode, before the raw-file sink write and the broadcaster fan-out:

- **Fast-path**: returns `false` immediately for event kinds that don't carry secrets; common case has zero re-encode cost.
- **Event kinds redacted**:
  - `BuildStarted.options_description` — cleared entirely (quoted-value flags need a shell-aware tokenizer to redact safely, and the structured command-line events carry the same info in precise form).
  - `UnstructuredCommandLine.args` — token-by-token redaction.
  - `StructuredCommandLine` — walks `OptionList` sections, redacts each `Option.option_value` / `combined_form`.
  - `OptionsParsed.{startup_options, explicit_startup_options, cmd_line, explicit_cmd_line}` — same token-level redactor.
  - `WorkspaceStatus.item[*].value` — URL credential stripping.
  - `BuildMetadata` — URL credential stripping on known git-URL keys (`REPO_URL`, `GITHUB_REPOSITORY`, `CI_REPOSITORY_URL`, etc.) only, plus special handling for `EXPLICIT_COMMAND_LINE` (decodes the JSON-encoded arg list, redacts each flag, re-encodes).
- **Rules** mirror the AXL-side redaction in `bazel_results.axl`:
  - Header flags (`--remote_header`, `--bes_header`, …) → full value → `<REDACTED>`.
  - Env-passthrough flags (`--action_env=KEY=VALUE`, …) → VALUE → `<REDACTED>` unless KEY is on the allowlist or the value is a safe literal (`""`, `"0"`, `"1"`, booleans).
  - URL credentials (`scheme://user:pass@host`) → `scheme://<REDACTED>@host` everywhere.
- **User-configurable allowlist** — `--build_metadata=ALLOW_ENV=MY_VAR,OTHER_*` extends the default allowlist per event. Self-describing: each command-line event contains its own ALLOW_ENV flag, so extraction and redaction happen on the same payload — no cross-event state or ordering assumption. Glob patterns (`*`, `?`) supported, matching the existing AXL semantics.
- **Tests**: 24 unit tests covering flag-level redaction, URL credential stripping, glob matching, ALLOW_ENV extraction/accumulation, and full event encode-decode roundtrips for `UnstructuredCommandLine` / `BuildMetadata` / `BuildStarted`.

AXL-side redaction in `bazel_results.axl` stays in place as defense-in-depth — it runs over already-redacted data, which is a no-op in the normal case but catches any gaps in the Rust layer before rendering into GitHub check runs.

## Artifact uploads — all opt-in

`ArtifactUpload` feature now exposes four args, all default off:

- `upload_test_logs` — string enum matching the rosetta `UploadTestLogStrategy`:
  - `"none"` (default) — skip
  - `"failed"` — only non-passing tests (failed, flaky, timeout, failed_to_build, remote_failure, incomplete, ...). Matches rosetta's default.
  - `"executed"` — any test that actually ran (skips cached passes)
  - `"all"` — every test, including cached passes
- `upload_profile` — Bazel JSON trace profile. When off, `--generate_json_trace_profile` / `--profile=path` aren't even passed to Bazel.
- `upload_bep` — BES binary file. When off, the file sink isn't registered — nothing on disk.
- `upload_exec_log` — Compact execution log. Stays off until on-disk redaction lands (the file is zstd-compressed and doesn't pass through the new redactor).

For each channel, "off" means Bazel never writes the file in the first place: no disk I/O, no bytes to leak, no upload branch to skip.

`aspect-cli/.aspect/config.axl` opts this repo into `upload_test_logs = "failed"` + `upload_profile = True` + `upload_bep = True`. Exec log stays off.

## Test plan

- [x] `cargo test -p axl-runtime --lib redaction` — 24/24 pass
- [x] `cargo build` — clean on full workspace
- [x] AXL template snapshot tests still render correctly
- [x] Live verification on CI with dummy secrets (`--client_env=DUMMY_API_TOKEN=...`, `--action_env=DUMMY_DB_PASSWORD=...`, `--action_env=GIT_URL=https://ci:verysecret@...`) — confirmed all values redacted in BEP output