### PR TITLE
Fix GHA artifacts upload

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
@@ -327,7 +327,11 @@ def _artifact_upload_impl(ctx: FeatureContext):
     tmpdir = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR") or ctx.std.env.temp_dir()
     profile_path = tmpdir + "/" + uuid + ".profile.gz"
     execlog_path = tmpdir + "/" + uuid + ".execlog.zstd"
-    bep_path     = tmpdir + "/" + uuid + ".bep.bin"
+    # `.binpb` is Google's canonical extension for binary-encoded protobuf
+    # (docs use it alongside `.textpb` / `.jsonpb`). We avoid `.bep.bin`
+    # because macOS Finder's Archive Utility heuristic treats `.bin` as
+    # potentially-compressed and auto-expands on double-click.
+    bep_path     = tmpdir + "/" + uuid + ".bep.binpb"
 
     # Only generate the profile when opt-in. --generate_json_trace_profile +
     # --profile=path cost wall-clock and write a file we'd otherwise leave on
@@ -379,7 +383,13 @@ def _artifact_upload_impl(ctx: FeatureContext):
                     _init_upload_state(state)
                     entries = state.get("_test_entries", [])
                     name = artifact_name(ci, ctx.task.name, ctx.task.key, "testlogs")
-                    success = uploader.upload_testlogs(ctx, state["_artifact_upload"]["testlogs"], entries, name)
+                    # final = True: publish under the plain `{name}` (no
+                    # `.partial.N` suffix) so the user-facing artifact has a
+                    # clean filename. Rolling-delete still removes the last
+                    # partial via provider.delete_artifact(prev_ref).
+                    success = uploader.upload_testlogs(
+                        ctx, state["_artifact_upload"]["testlogs"], entries, name, final = True,
+                    )
                     # Always update after final upload so both the archive URL and
                     # per-file label URLs reflect the complete set of uploaded files.
                     if success:
@@ -400,7 +410,7 @@ def _artifact_upload_impl(ctx: FeatureContext):
                 if upload_profile:
                     uploads.append(("profile", profile_path, artifact_name(ci, task_name, task_key, "profile.gz")))
                 if upload_bep:
-                    uploads.append(("bep", bep_path, artifact_name(ci, task_name, task_key, "bep.bin")))
+                    uploads.append(("bep", bep_path, artifact_name(ci, task_name, task_key, "bep.binpb")))
                 if upload_exec_log:
                     uploads.append(("execlog", execlog_path, artifact_name(ci, task_name, task_key, "execlog.zstd")))
                 uploaded_any = False

--- a/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
@@ -11,7 +11,7 @@ CI-specific upload primitives live in their respective lib files:
 load("./github.axl", "github")
 load("./buildkite.axl", "buildkite")
 load("./circleci.axl", "circleci")
-load("./tar.axl", "tar_create")
+load("./tar.axl", "tar_create", "zip_create")
 
 
 def detect_ci(env):
@@ -112,13 +112,19 @@ def _print_upload_error(group, err):
         seen[err] = True
         group["_printed_errors"] = seen
 
-def _upload_testlogs_tar(ctx, provider, group, entries, name):
+def _upload_testlogs_tar(ctx, provider, group, entries, name, final = False):
     """Build tar archive and upload via provider.upload_artifact, with rolling delete.
 
-    Used for GitHub and GitLab — their artifact UIs work best with a single archive.
+    Used for GitHub and GitLab — their artifact UIs work best with a single
+    archive. When `final = False` (mid-build batch), uploads under a versioned
+    `.partial.N` name so incremental snapshots don't collide. When `final =
+    True` (build_end), uploads under the plain unversioned name so the
+    artifact a user downloads is `{name}.tar.gz`, not `{name}.partial.9.tar.gz`.
     """
     count = len(entries)
-    if count == 0 or count == group["last_count"]:
+    if count == 0:
+        return False
+    if not final and count == group["last_count"]:
         return False
 
     _parent = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR") or ctx.std.env.temp_dir()
@@ -137,8 +143,11 @@ def _upload_testlogs_tar(ctx, provider, group, entries, name):
         print("artifact upload: failed to create archive for " + name)
         return False
 
-    group["version"] += 1
-    artifact_name = name + "-v" + str(group["version"])
+    if final:
+        artifact_name = name
+    else:
+        group["version"] += 1
+        artifact_name = name + ".partial." + str(group["version"])
     result = provider.upload_artifact(ctx, archive_path, artifact_name)
 
     if ctx.std.fs.exists(archive_path):
@@ -152,7 +161,62 @@ def _upload_testlogs_tar(ctx, provider, group, entries, name):
         group["last_count"]   = count
         return True
     else:
-        group["version"] -= 1
+        if not final:
+            group["version"] -= 1
+        for err in result["errors"]:
+            _print_upload_error(group, err)
+        return False
+
+
+def _upload_testlogs_zip(ctx, provider, group, entries, name, final = False):
+    """Build a ZIP archive and upload via provider.upload_artifact.
+
+    Used for GitHub: the v2 artifact API requires ZIP-formatted uploads, so
+    packaging test logs as a tarball first and letting the provider rewrap
+    produces a nested `.zip` containing a `.tar.gz` — double unpack on
+    download. Building the ZIP directly here keeps the user-facing unzip to
+    one step. `final` has the same meaning as in _upload_testlogs_tar.
+    """
+    count = len(entries)
+    if count == 0:
+        return False
+    if not final and count == group["last_count"]:
+        return False
+
+    _parent = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR") or ctx.std.env.temp_dir()
+    artifacts_root = ctx.std.fs.mkdtemp(prefix = "aspect-artifacts-", parent = _parent)
+    archive_path = artifacts_root + "/" + name + ".zip"
+    ctx.std.fs.create_dir_all(archive_path.rsplit("/", 1)[0])
+
+    lines = ["#mtree"]
+    for entry in entries:
+        lines.append("./" + entry["dest"] + " type=file contents=" + entry["src"])
+    mtree = "\n".join(lines) + "\n"
+
+    if not zip_create(ctx, archive_path, mtree):
+        print("artifact upload: failed to create zip for " + name)
+        return False
+
+    if final:
+        artifact_name = name
+    else:
+        group["version"] += 1
+        artifact_name = name + ".partial." + str(group["version"])
+    result = provider.upload_artifact(ctx, archive_path, artifact_name)
+
+    if ctx.std.fs.exists(archive_path):
+        ctx.std.fs.remove_file(archive_path)
+
+    if result["success"]:
+        if group["prev_ref"]:
+            provider.delete_artifact(ctx, group["prev_ref"])
+        group["prev_ref"]     = result["artifact_ref"]
+        group["download_url"] = result.get("download_url", "")
+        group["last_count"]   = count
+        return True
+    else:
+        if not final:
+            group["version"] -= 1
         for err in result["errors"]:
             _print_upload_error(group, err)
         return False
@@ -287,13 +351,24 @@ def create_uploader(env):
     def delete_artifact(ctx, name):
         return provider.delete_artifact(ctx, name)
 
-    def upload_testlogs(ctx, group, entries, name):
+    def upload_testlogs(ctx, group, entries, name, final = False):
+        # `final = True` on the build_end call so the published artifact lands
+        # under `{name}` (no version suffix); mid-build batches during
+        # build_event use `{name}.partial.{N}` to avoid name collisions with
+        # each rolling replacement. Only GitHub / GitLab (archive-based)
+        # actually version — buildkite / circleci upload per-file and ignore
+        # the flag.
         if ci == "buildkite":
             return _upload_testlogs_buildkite(ctx, group, entries, name)
         elif ci == "circleci":
             return _upload_testlogs_per_file(ctx, provider, group, entries, name)
+        elif ci == "github":
+            # GitHub's v2 artifact API requires ZIP-format uploads; go
+            # straight to .zip to avoid nested .zip(.tar.gz) on download.
+            return _upload_testlogs_zip(ctx, provider, group, entries, name, final = final)
         else:
-            return _upload_testlogs_tar(ctx, provider, group, entries, name)
+            # GitLab accepts any bytes; .tar.gz is compact and extracts in one step.
+            return _upload_testlogs_tar(ctx, provider, group, entries, name, final = final)
 
     return struct(
         check = check,

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -1,5 +1,6 @@
 """GitHub API client library."""
 load("@std//base64.axl", "base64")
+load("./tar.axl", "zip_create")
 
 DEFAULT_GITHUB_API = "https://api.github.com"
 
@@ -424,16 +425,42 @@ def _upload_artifact(ctx, path, name):
     if not signed_url:
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["no signed_upload_url returned"]}
 
-    file_size = ctx.std.fs.metadata(path).size
+    # GitHub's v2 artifact API requires a ZIP-formatted blob on the client
+    # side. v1 (where GitHub wrapped server-side) was turned off April 2024.
+    # Uploading raw bytes results in a "download" that fails to unzip — the
+    # file gets served with a .zip suffix but the content isn't a valid
+    # archive. actions/upload-artifact@v4 does the same thing.
+    #
+    # If `path` is already a .zip (e.g. lib/artifacts.axl::_upload_testlogs_zip
+    # built a multi-entry testlogs archive), upload it verbatim. Otherwise
+    # wrap the single file in a .zip with its basename as the entry name so
+    # `unzip` produces a predictable filename instead of the /tmp/<uuid> path.
+    if path.endswith(".zip"):
+        zip_path = path
+        owns_zip = False
+    else:
+        basename = path.rsplit("/", 1)[-1]
+        zip_path = path + ".upload.zip"
+        mtree = "#mtree\n./" + basename + " type=file contents=" + path + "\n"
+        if not zip_create(ctx, zip_path, mtree):
+            return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["failed to create zip"]}
+        owns_zip = True
+
+    zip_size = ctx.std.fs.metadata(zip_path).size
     upload_resp = ctx.http().put(
         url = signed_url,
         headers = {
             "x-ms-blob-type": "BlockBlob",
-            "Content-Type": "application/octet-stream",
-            "Content-Length": str(file_size),
+            "Content-Type": "application/zip",
+            "Content-Length": str(zip_size),
         },
-        data = ctx.std.fs.open(path),
+        data = ctx.std.fs.open(zip_path),
     ).block()
+
+    # Only remove the zip if we owned it — if the caller passed a pre-zipped
+    # path, they're responsible for its cleanup (see _upload_testlogs_zip).
+    if owns_zip and ctx.std.fs.exists(zip_path):
+        ctx.std.fs.remove_file(zip_path)
 
     if upload_resp.status < 200 or upload_resp.status >= 300:
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["blob upload: HTTP " + str(upload_resp.status)]}
@@ -442,7 +469,9 @@ def _upload_artifact(ctx, path, name):
         "workflowRunBackendId": run_id,
         "workflowJobRunBackendId": job_id,
         "name": name,
-        "size": str(ctx.std.fs.metadata(path).size),
+        # `size` is the uploaded blob size, which is now the ZIP size, not the
+        # raw file size. @actions/artifact reports this same value.
+        "size": str(zip_size),
     })
     if not ok:
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": [err or "FinalizeArtifact failed"]}

--- a/crates/aspect-cli/src/builtins/aspect/lib/tar.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tar.axl
@@ -155,3 +155,35 @@ def tar_create(ctx, archive_path, mtree_spec):
         ctx.std.fs.remove_file(mtree_path)
 
     return status.code == 0
+
+
+def zip_create(ctx, archive_path, mtree_spec):
+    """Create a .zip archive from an mtree spec string.
+
+    Mirrors `tar_create` but asks bsdtar for `--format=zip`. Motivating use
+    case: GitHub's v2 artifact API (`CreateArtifact` / `FinalizeArtifact`)
+    requires ZIP-formatted uploads — raw uploads land as a `{name}.zip`
+    download that fails `unzip` because the bytes aren't a valid archive.
+
+    Args:
+        ctx: TaskContext
+        archive_path: str - output .zip path
+        mtree_spec: str - mtree spec content mapping archive paths to source files
+
+    Returns:
+        bool - True on success
+    """
+    bin_path = bsdtar(ctx)
+    mtree_path = archive_path + ".mtree"
+
+    ctx.std.fs.write(mtree_path, mtree_spec)
+
+    child = ctx.std.process.command(bin_path).args([
+        "--format=zip", "-cf", archive_path, "@" + mtree_path,
+    ]).stdout("inherit").stderr("inherit").spawn()
+    status = child.wait()
+
+    if ctx.std.fs.exists(mtree_path):
+        ctx.std.fs.remove_file(mtree_path)
+
+    return status.code == 0


### PR DESCRIPTION
## Summary

The `bep.bin` / `profile.gz` artifacts we upload to GitHub Actions couldn't be unzipped — users got "not a zipfile" from `unzip`. GitHub's v2 artifact API (the only one available since v1 was turned off in April 2024) requires the **client** to upload ZIP-formatted bytes; GitHub no longer wraps server-side. Every download is served as `{name}.zip` regardless, and raw uploads produce a broken archive.

Fixes:

- **`github._upload_artifact` wraps uploads in a ZIP.** Single-file inputs (profile, BEP, execlog) get a one-entry archive with the file's basename as the entry name so `unzip` produces a predictable filename. Pre-zipped inputs (see next point) upload verbatim.
- **Testlogs skip the double-wrap.** Previously: `.tar.gz` of test logs → wrapped in `.zip` → user needs two-step extract. Now: `_upload_testlogs_zip` builds a `.zip` directly from the mtree, and `github._upload_artifact` detects the `.zip` input and uploads it as-is. GitLab testlogs stay on `.tar.gz` (their API accepts any bytes).
- **Zip creation uses bsdtar** (`--format=zip`) reusing the same binary we already download for tar archives — no new Rust dep, and it keeps the pattern consistent with `tar_create` (mtree-driven).
- **Testlog artifact naming: `.partial.{N}` mid-build, unversioned on final.** Rolling-replace uploads during the build used to land as `{name}-v{N}`, leaking the implementation detail into the user-facing filename. Now mid-build batches upload as `{name}.partial.{N}` and `build_end` publishes a final `{name}` (no suffix). A fresh download from a completed job is `test.test-gha.testlogs.zip` — clean, canonical.
- **Browse URL fallback fix.** On Buildkite with `upload_test_logs="failed"` and a fully-cached build, the "Artifacts" link on the GitHub check run wasn't appearing even when profile + BEP uploaded successfully. Track `uploaded_any` locally and key the fallback off that instead of `artifacts_trait.artifact_urls` (which Buildkite leaves empty because its download URLs expire).
- **Rename `.bep.bin` → `.bep.binpb`.** macOS Finder treats `.bin` as a potentially-compressed archive and tries to auto-expand on double-click. `.binpb` is Google's canonical binary-protobuf extension (from the official protobuf docs) and doesn't match any macOS UTI.

## Test plan

- [x] `cargo build` + `bazel build //crates/aspect-cli:aspect-cli` — green
- [x] `bsdtar --format=zip -cf archive.zip @mtree` sanity-checked locally; `unzip` extracts with the expected entry name
- [x] End-to-end CI run on GitHub Actions — download artifact, `unzip`, verify contents extract in one step
- [x] End-to-end on Buildkite — verify "Artifacts" link appears on the check run even when testlogs are all cached
- [x] Confirm final testlogs artifact lands at the unversioned `{task}.{key}.testlogs.zip` name (not `.partial.N`)
