### PR TITLE
Align naming of targets position arg

### DIFF
--- a/.aspect/modules/dev/build.axl
+++ b/.aspect/modules/dev/build.axl
@@ -9,7 +9,7 @@ def _build_impl(ctx: TaskContext) -> int:
         build_events = True,
         flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))],
         inherit_stderr = False,
-        *ctx.args.target_pattern
+        *ctx.args.targets
     )
     return tui(ctx, build)
 
@@ -17,6 +17,6 @@ build = task(
     implementation = _build_impl,
     group = ["dev"],
     args = {
-        "target_pattern": args.positional(minimum = 1, maximum = 512, default = ["..."]),
+        "targets": args.positional(minimum = 1, maximum = 512, default = ["..."]),
     }
 )

--- a/.aspect/modules/dev/test.axl
+++ b/.aspect/modules/dev/test.axl
@@ -9,7 +9,7 @@ def _test_impl(ctx: TaskContext) -> int:
         build_events = True,
         flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))],
         inherit_stderr = False,
-        *ctx.args.target_pattern
+        *ctx.args.targets
     )
     return tui(ctx, test)
 
@@ -17,6 +17,6 @@ test = task(
     implementation = _test_impl,
     group = ["dev"],
     args = {
-        "target_pattern": args.positional(minimum = 1, maximum = 512, default = ["..."]),
+        "targets": args.positional(minimum = 1, maximum = 512, default = ["..."]),
     }
 )

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -19,7 +19,7 @@ build = task(
         ArtifactsTrait,
     ],
     args = {
-        "target_pattern": args.positional(minimum = 1, maximum = 512, default = ["..."]),
+        "targets": args.positional(minimum = 1, maximum = 512, default = ["..."]),
         "bazel_flag": args.string_list(),
         "bazel_startup_flag": args.string_list(),
         "remote_executor": args.string(),

--- a/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
@@ -24,7 +24,7 @@ def _default_bazel_behavior(ctx: FeatureContext):
     if environment:
         def _buildkite_bazel_section(ctx):
             if environment.ci.host == "buildkite":
-                targets = getattr(ctx.args, "target_pattern", None) or getattr(ctx.args, "targets", [])
+                targets = getattr(ctx.args, "targets", [])
                 print("--- :bazel: Running bazel %s %s" % (ctx.task.name, " ".join(targets)))
 
         bazel_trait.build_start.append(_buildkite_bazel_section)

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -36,7 +36,7 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
     """Shared impl for build/test tasks.
 
     Args:
-        ctx:     TaskContext with the standard build/test args (target_pattern,
+        ctx:     TaskContext with the standard build/test args (targets,
                  bazel_flag, bazel_startup_flag, bes_backend, bes_header,
                  cancel, output_base). Task-specific args (e.g. build's
                  remote_executor) are not touched here — tasks can still read
@@ -92,7 +92,7 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
         build_events = True if need_bes else False
 
     for handler in lifecycle.task_started:
-        handler(ctx, " ".join(ctx.args.target_pattern))
+        handler(ctx, " ".join(ctx.args.targets))
 
     for handler in bazel_trait.build_start:
         handler(ctx)
@@ -120,14 +120,14 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
                 flags = flags,
-                *ctx.args.target_pattern,
+                *ctx.args.targets,
             )
         else:
             invocation = ctx.bazel.build(
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
                 flags = flags,
-                *ctx.args.target_pattern,
+                *ctx.args.targets,
             )
 
         if need_bes:

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -21,7 +21,7 @@ test = task(
     args = {
         # TODO: Support a long --pattern_file like bazel does (@./targets)
         # TODO: Support - (list from stdin)
-        "target_pattern": args.positional(minimum = 1, maximum = 512, default = ["..."]),
+        "targets": args.positional(minimum = 1, maximum = 512, default = ["..."]),
         "bazel_flag": args.string_list(),
         "bazel_startup_flag": args.string_list(),
         "bes_backend": args.string_list(),


### PR DESCRIPTION
lint task already uses `targets` which is more consistent with bazel docs:

### Bazel's terminology — from their docs:

- CLI help synopsis: `<targets>` (e.g. `bazel help build` shows Usage: `bazel build <options> <targets>`)
- Reference docs synopsis: `[<target patterns>]`
- Concept docs ("Specifying build targets"): "_target patterns_"