### PR TITLE
Enable GitHub Status Checks by default

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/gh_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gh_lint_comments.axl
@@ -252,6 +252,14 @@ def _github_lint_impl(ctx: FeatureContext):
             }
         else:
             gh_inactive_reason = "authentication failed: %s" % auth_reason.get("reason", "unknown")
+            # We are demonstrably in a GitHub Actions PR context (env_vars
+            # validated) but auth failed — surface that to the build log so the
+            # user knows why no comments are appearing. Other inactive paths
+            # ("missing env var(s)", "not a PR merge ref") stay silent because
+            # they mean the feature doesn't apply, not that it failed.
+            print("GitHub lint comments: authentication failed for %s/%s — %s" % (
+                env_vars["owner"], env_vars["repo"], auth_reason.get("reason", "unknown"),
+            ))
 
     if not gh and not debug:
         return

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -222,14 +222,18 @@ def _github_status_checks(ctx: FeatureContext):
         # Authenticate first so we can reuse the Aspect App token to resolve the
         # running job URL. actions.read is only needed for the job deep-link —
         # the API call fails gracefully if the App isn't granted the permission.
+        auth_reason = {}
         token = github.authenticate(
             ctx,
             owner = owner,
             repo = repo,
             roles = ["checks.write", "actions.read"],
+            _reason = auth_reason,
         )
         if not token:
-            print("GitHub status check: authentication failed for %s/%s (no token available)" % (owner, repo))
+            print("GitHub status check: authentication failed for %s/%s — %s" % (
+                owner, repo, auth_reason.get("reason", "unknown"),
+            ))
             return
         _state["_github_token"] = token
 
@@ -330,7 +334,7 @@ def _github_status_checks(ctx: FeatureContext):
 
 GithubStatusChecks = feature(
     implementation = _github_status_checks,
-    enabled = False,
+    enabled = True,
     args = {
         "mode": args.string(
             default = "ci-only",

--- a/crates/aspect-cli/src/builtins/aspect/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/github.axl
@@ -44,7 +44,7 @@ def _token_impl(ctx: TaskContext) -> int:
         print("Error: access denied. %s" % resp.body)
         return 1
     if resp.status == 404:
-        print("Error: GitHub App not installed. See https://docs.aspect.build/github-app")
+        print("Error: GitHub App not installed. See https://docs.aspect.build/cli/authentication")
         return 1
     if resp.status < 200 or resp.status >= 300:
         print("Error: API request failed (HTTP " + str(resp.status) + "): " + resp.body)

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -16,15 +16,22 @@ def _do_request(ctx, method, url, token, payload = None):
     }
     data = json.encode(payload) if payload else None
     if method == "GET":
-        response = ctx.http().get(url = url, headers = headers).block()
+        fut = ctx.http().get(url = url, headers = headers)
     elif method == "POST":
-        response = ctx.http().post(url = url, headers = headers, data = data).block()
+        fut = ctx.http().post(url = url, headers = headers, data = data)
     elif method == "PATCH":
-        response = ctx.http().patch(url = url, headers = headers, data = data).block()
+        fut = ctx.http().patch(url = url, headers = headers, data = data)
     elif method == "DELETE":
-        response = ctx.http().delete(url = url, headers = headers).block()
+        fut = ctx.http().delete(url = url, headers = headers)
     else:
         return (False, 0, "unsupported method: " + method)
+    # Convert transport errors (DNS failure, TLS error, connection refused, …)
+    # to a string result. Without this, the underlying anyhow error would
+    # propagate up through any lifecycle hook calling into github.* and fail
+    # the parent task. Callers detect transport errors via type-check.
+    response = fut.map_err(lambda e: str(e)).block()
+    if type(response) == "string":
+        return (False, 0, "transport error: " + response)
     success = response.status >= 200 and response.status < 300
     body = response.body
     if body:
@@ -54,11 +61,14 @@ def validate_role(role):
 def _missing_credentials_reason(ctx):
     """Human-readable explanation for `ctx.aspect.auth.credentials()` returning
     None, tailored to the environment the CLI is running in."""
+    setup_url = "https://docs.aspect.build/cli/authentication"
     if ctx.std.env.var("BUILDKITE_AGENT_ACCESS_TOKEN"):
-        return "no Aspect credentials — set ASPECT_API_TOKEN in the job env or provision it as a Buildkite secret (https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets)"
-    if ctx.std.env.var("CI"):
-        return "no Aspect credentials — set ASPECT_API_TOKEN (client_id:secret) in the job env"
-    return "not logged in — run `aspect auth login`"
+        msg = "no Aspect credentials — set ASPECT_API_TOKEN in the job env or provision it as a Buildkite secret (https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets)"
+    elif ctx.std.env.var("CI"):
+        msg = "no Aspect credentials — set ASPECT_API_TOKEN (client_id:secret) in the job env"
+    else:
+        msg = "not logged in — run `aspect auth login`"
+    return msg + ". Setup guide: " + setup_url
 
 
 def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None):
@@ -87,6 +97,9 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
     url = ctx.aspect.auth.api_url + "/github/token"
     if roles:
         url = url + "?roles=" + ",".join(roles)
+    # Transport errors are converted to a string here so they don't bubble up
+    # as exceptions and fail the parent task (e.g. when this is called from a
+    # lifecycle hook in a feature like GithubStatusChecks).
     resp = ctx.http().post(
         url = url,
         headers = {
@@ -94,7 +107,12 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
             "Content-Type": "application/json",
         },
         data = json.encode({"owner": owner, "repo": repo}),
-    ).block()
+    ).map_err(lambda e: str(e)).block()
+
+    if type(resp) == "string":
+        if _reason != None:
+            _reason["reason"] = "Aspect API request failed (transport error): %s" % resp
+        return None
 
     if resp.status >= 200 and resp.status < 300:
         return json.decode(resp.body)["token"]
@@ -105,7 +123,7 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
         elif resp.status == 403:
             _reason["reason"] = "access denied: %s" % resp.body
         elif resp.status == 404:
-            _reason["reason"] = "GitHub App not installed (see https://docs.aspect.build/github-app)"
+            _reason["reason"] = "GitHub App not installed (see https://docs.aspect.build/cli/authentication)"
         else:
             _reason["reason"] = "API request failed (HTTP %d): %s" % (resp.status, resp.body)
     return None


### PR DESCRIPTION
They are still gated on the user installing the GitHub Actions Workflows app and setting up ASPECT_API_TOKEN