### PR TITLE
Auto-detect --commit-sha and --build-url in aspect delivery

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -207,5 +207,5 @@ steps:
         - exit_status: 78 # unhealthy signal from .buildkite/hooks/pre-command
           limit: 1
     command: |
-      ASPECT_DEBUG=1 aspect delivery --task-key delivery-bk-debug --build-url $BUILDKITE_BUILD_URL --commit-sha $BUILDKITE_COMMIT //examples/deliverable
-      aspect delivery --task-key delivery-bk --build-url $BUILDKITE_BUILD_URL --commit-sha $BUILDKITE_COMMIT  //examples/deliverable
+      ASPECT_DEBUG=1 aspect delivery --task-key delivery-bk-debug //examples/deliverable
+      aspect delivery --task-key delivery-bk //examples/deliverable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           command: .aspect/bootstrap.sh
       - run:
           name: Delivery Task (ASPECT_DEBUG=1)
-          command: ASPECT_DEBUG=1 aspect delivery --task-key delivery-cci-debug --build-url $CIRCLE_BUILD_URL --commit-sha $CIRCLE_SHA1 //examples/deliverable
+          command: ASPECT_DEBUG=1 aspect delivery --task-key delivery-cci-debug //examples/deliverable
       - run:
           name: Delivery Task
-          command: aspect delivery --task-key delivery-cci --build-url $CIRCLE_BUILD_URL --commit-sha $CIRCLE_SHA1 //examples/deliverable
+          command: aspect delivery --task-key delivery-cci //examples/deliverable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,6 @@ jobs:
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Delivery Task (ASPECT_DEBUG=1)
-        run: ASPECT_DEBUG=1 aspect delivery --task-key delivery-gha --build-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" --commit-sha $GITHUB_SHA //examples/deliverable
+        run: ASPECT_DEBUG=1 aspect delivery --task-key delivery-gha //examples/deliverable
       - name: Delivery Task
-        run: aspect delivery --task-key delivery-gha --build-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" --commit-sha $GITHUB_SHA //examples/deliverable
+        run: aspect delivery --task-key delivery-gha //examples/deliverable

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,5 +52,5 @@ delivery-task:
     - aspect-default
   script:
     - .aspect/bootstrap.sh
-    - ASPECT_DEBUG=1 aspect delivery --task-key delivery-gl-debug --build-url $CI_PIPELINE_URL --commit-sha $CI_COMMIT_SHA //examples/deliverable
-    - aspect delivery --task-key delivery-gl --build-url $CI_PIPELINE_URL --commit-sha $CI_COMMIT_SHA //examples/deliverable
+    - ASPECT_DEBUG=1 aspect delivery --task-key delivery-gl-debug //examples/deliverable
+    - aspect delivery --task-key delivery-gl //examples/deliverable

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -73,6 +73,9 @@ Failure modes
   --mode=selective --track-state=false            hard fail() at startup
   --track-state=true and the state backend
     endpoint env var is not set                   hard fail() at startup
+  --commit-sha unset and no CI env var
+    exposes one (GITHUB_SHA, BUILDKITE_COMMIT,
+    CIRCLE_SHA1, CI_COMMIT_SHA)                   hard fail() at startup
   No --remote_cache configured (most modes)       graceful return 1 with error
   No --remote_cache configured for the
     --mode=always --dry-run --track-state=false   prints NOTE; continues
@@ -117,6 +120,7 @@ User-facing migration guide: https://docs.aspect.build/cli/migration/delivery
 """
 
 load("@aspect//traits.axl", "BazelTrait", "DeliveryTrait", "HealthCheckTrait")
+load("@aspect//lib/github.axl", "detect_build_url", "detect_commit_sha")
 load("@aspect//lib/runnable.axl", "runnable")
 load("@std//time.axl", "time")
 
@@ -337,10 +341,14 @@ def _delivery_impl(ctx):
     if not endpoint and track_state:
         fail("ASPECT_WORKFLOWS_DELIVERY_API_ENDPOINT is not set. The delivery state backend must be running. (Pass --track-state=false to run without state tracking; allowed in combination with --dry-run or --mode=always.)")
 
-    # Delivery context
+    # Delivery context. --commit-sha and --build-url are auto-detected from
+    # common CI env vars (GITHUB_*, BUILDKITE_*, CIRCLE_*, CI_* for GitLab)
+    # when the user doesn't pass them explicitly.
     ci_host = ctx.args.ci_host
-    build_url = ctx.args.build_url
-    commit_sha = ctx.args.commit_sha
+    commit_sha = ctx.args.commit_sha or detect_commit_sha(ctx.std)
+    if not commit_sha:
+        fail("Could not determine commit SHA. Pass --commit-sha=<sha>, or run on a CI host that exposes GITHUB_SHA, BUILDKITE_COMMIT, CIRCLE_SHA1, or CI_COMMIT_SHA.")
+    build_url = ctx.args.build_url or detect_build_url(ctx) or "-"
 
     # Change-detection prefix: always anchored to --task-key, optionally extended by --salt
     if ctx.args.salt:
@@ -670,12 +678,12 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
             description = "CI host identifier (e.g. bk, gh, circle).",
         ),
         "commit_sha": args.string(
-            required = True,
-            description = "Git commit SHA being delivered. Used as the change-detection key.",
+            default = "",
+            description = "Git commit SHA being delivered. Used as the change-detection key. Auto-detected from CI env vars (GITHUB_SHA / BUILDKITE_COMMIT / CIRCLE_SHA1 / CI_COMMIT_SHA, with PR-head resolution for GitHub Actions pull_request events) when unset or empty; pass a non-empty value to override.",
         ),
         "build_url": args.string(
-            default = "-",
-            description = "URL of the CI build that produced the artifacts.",
+            default = "",
+            description = "URL of the CI build that produced the artifacts. Auto-detected from CI env vars when unset or empty; pass a non-empty value to override.",
         ),
         "query": args.string(
             default = "",

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -206,6 +206,44 @@ def detect_commit_sha(std):
     )
 
 
+def detect_build_url(ctx):
+    """Detect the CI build URL from common environment variables.
+
+    Returns the URL of the running CI build (the page a developer would visit
+    to see logs/status), or "" if no recognized CI host is detected.
+
+    On GitHub Actions, transparently upgrades the run URL
+    (`/actions/runs/<run_id>`) to the specific job URL
+    (`/actions/runs/<run_id>/job/<job_id>`) when the Aspect Workflows GitHub
+    App is installed and the active ASPECT_API_TOKEN has the `actions:read`
+    scope. Silently falls back to the run URL on any failure (no app,
+    missing scope, API error).
+    """
+    env = ctx.std.env
+    if env.var("GITHUB_ACTIONS"):
+        server = env.var("GITHUB_SERVER_URL") or "https://github.com"
+        repository = env.var("GITHUB_REPOSITORY") or ""
+        run_id = env.var("GITHUB_RUN_ID") or ""
+        if not (repository and run_id):
+            return ""
+        run_url = server + "/" + repository + "/actions/runs/" + run_id
+        owner, repo = detect_github_repo(ctx.std)
+        if owner and repo:
+            token = _authenticate(ctx, owner = owner, repo = repo, roles = ["actions.read"])
+            if token:
+                job_url = _resolve_current_job_url(ctx, token, owner, repo, run_id)
+                if job_url:
+                    return job_url
+        return run_url
+    if env.var("BUILDKITE"):
+        return env.var("BUILDKITE_BUILD_URL") or ""
+    if env.var("CIRCLECI"):
+        return env.var("CIRCLE_BUILD_URL") or ""
+    if env.var("GITLAB_CI"):
+        return env.var("CI_JOB_URL") or ""
+    return ""
+
+
 def _extract_host(url):
     """Extract host from a git remote URL (SSH or HTTPS)."""
     if not url:


### PR DESCRIPTION
## Summary

- `--commit-sha` and `--build-url` become optional in `aspect delivery`. When unset, they're auto-detected from common CI env vars (`GITHUB_*` / `BUILDKITE_*` / `CIRCLE_*` / `CI_*`). Pass explicitly to override.
- The build-URL helper (`detect_build_url` in `lib/github.axl`) transparently upgrades the GitHub Actions run URL (`/actions/runs/<id>`) to the specific job URL (`/actions/runs/<id>/job/<job_id>`) when the Aspect Workflows GitHub App is authed with `actions:read`. Silent fallback to the run URL on any failure.
- Folded the upgrade into `detect_build_url` itself so any future task that calls it gets the deep link for free.
