### PR TITLE
Accept ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS env var alongside --force-target

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -195,10 +195,32 @@ steps:
       ASPECT_DEBUG=1 aspect test --task-key test-bk-debug //...
       aspect test --task-key test-bk //...
 
+  # Manual break-glass input — only shown on UI-triggered builds. Users
+  # can fill this to force-deliver specific targets without editing the
+  # pipeline. The delivery step reads it via meta-data and pipes the value
+  # into ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS. Non-UI builds skip the
+  # input entirely so webhook/PR builds aren't blocked.
+  - key: force-targets-input
+    if: build.source == "ui"
+    input: ":package: Delivery: force-target overrides (optional)"
+    fields:
+      - text: FORCE_TARGETS
+        hint: "Space-separated Bazel labels to force-deliver. Example: //examples/deliverable. Leave empty for normal selective delivery."
+        required: false
+        default: ""
+        key: force_targets
+        # Validate the input against Bazel's label grammar so a typo
+        # is caught at job-trigger time rather than during the build.
+        # Allows whitespace (including empty), one or more labels, and
+        # the full label syntax — repository, package path, and target name.
+        format: ^\s*$|^\s*(?:([@]{1,2}[\w.~-]*|[@]{0})\/\/(?:[\w.@-]+\/)*[\w.@-]*(?::(?:[\w\[\]!%@^"#\$&'()*+,;<=>?{|}~.-]+\/)*[\w\[\]!%@^"#\$&'()*+,;<=>?{|}~.-]*)?(?!\/)(?:\s+)?)+\s*$
+
   - key: delivery-task
     label: ":package: Delivery Task"
     depends_on:
       - pre-build
+      - force-targets-input
+    allow_dependency_failure: true # input step is skipped on non-UI builds
     agents:
       queue: aspect-default
     timeout_in_minutes: 20
@@ -207,5 +229,6 @@ steps:
         - exit_status: 78 # unhealthy signal from .buildkite/hooks/pre-command
           limit: 1
     command: |
+      export ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS=$$(buildkite-agent meta-data get force_targets --default '')
       ASPECT_DEBUG=1 aspect delivery --task-key delivery-bk-debug //examples/deliverable
       aspect delivery --task-key delivery-bk //examples/deliverable

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -219,8 +219,10 @@ steps:
     label: ":package: Delivery Task"
     depends_on:
       - pre-build
-      - force-targets-input
-    allow_dependency_failure: true # input step is skipped on non-UI builds
+      # Per-dep allow_failure so a skipped input on non-UI builds doesn't
+      # bypass pre-build failures.
+      - step: force-targets-input
+        allow_failure: true
     agents:
       queue: aspect-default
     timeout_in_minutes: 20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,14 @@
 version: 2.1
 
+# Manual break-glass override for `aspect delivery`. Settable via the
+# CircleCI "Trigger Pipeline" UI or API; default empty means normal
+# selective delivery on every other build.
+parameters:
+  force_targets:
+    type: string
+    default: ""
+    description: "Bazel targets to force-deliver (space-separated). Example: //examples/deliverable. Leave empty for normal selective delivery."
+
 workflows:
   ci:
     jobs:
@@ -60,6 +69,8 @@ jobs:
     machine: true
     resource_class: aspect-build/aspect-default
     working_directory: /mnt/ephemeral/workdir
+    environment:
+      ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS: << pipeline.parameters.force_targets >>
     steps:
       - checkout
       - run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,11 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      force_targets:
+        description: "Bazel targets to force-deliver (space-separated). Example: //examples/deliverable. Leave empty for normal selective delivery."
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -72,6 +77,7 @@ jobs:
     needs: [pre-build]
     env:
       ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
+      ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS: ${{ inputs.force_targets }}
     steps:
       - uses: actions/checkout@v6
       - name: Bootstrap

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,12 @@ variables:
   # right owner/repo from it) and status-check rendering (build_metadata
   # derives REPO_URL / REPO_OWNER / REPO_NAME / VCS from it).
   ASPECT_VCS_URL: "https://github.com/aspect-build/aspect-cli"
+  # Manual break-glass override for `aspect delivery`. Default empty —
+  # appears as an editable field on the "Run pipeline" page so users can
+  # force-deliver specific targets without editing the pipeline.
+  FORCE_TARGETS:
+    value: ""
+    description: "Bazel targets to force-deliver (space-separated). Example: //examples/deliverable. Leave empty for normal selective delivery."
 
 stages:
   - CI
@@ -50,6 +56,8 @@ delivery-task:
   tags:
     - aspect-workflows
     - aspect-default
+  variables:
+    ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS: $FORCE_TARGETS
   script:
     - .aspect/bootstrap.sh
     - ASPECT_DEBUG=1 aspect delivery --task-key delivery-gl-debug //examples/deliverable

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -433,7 +433,16 @@ def _delivery_impl(ctx):
             targets = targets[:limit]
     else:
         targets = ctx.args.targets
-    forced_targets = ctx.args.force_target
+    # Accept --force-target plus ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS
+    # (whitespace-separated) so CI systems can wire a parameter field to
+    # the env var without templating the flag itself. Whitespace is the
+    # only safe separator: Bazel's label grammar allows commas in target
+    # names, so a comma-split would collide with valid labels.
+    forced_targets = list(ctx.args.force_target)
+    env_forced = ctx.std.env.var("ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS") or ""
+    for tok in env_forced.split():
+        if tok and tok not in forced_targets:
+            forced_targets.append(tok)
 
     if not targets:
         print(_style("No targets to deliver", _BOLD + _YELLOW, is_tty))
@@ -707,7 +716,7 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         ),
         "force_target": args.string_list(
             default = [],
-            description = "Re-deliver these targets even if they have already been delivered for this commit. Use as a break-glass override when a previous delivery needs to be repeated.",
+            description = "Re-deliver these targets even if they have already been delivered for this commit. Use as a break-glass override when a previous delivery needs to be repeated. The ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS env var (whitespace-separated labels) is merged in addition to this flag — convenient for CI parameter fields that don't easily template into a flag.",
         ),
         "mode": args.string(
             default = "selective",


### PR DESCRIPTION
## Summary

Mirrors the legacy `ASPECT_WORKFLOWS_DELIVERY_TARGETS` ergonomics: `aspect delivery` now reads `ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS ` (whitespace-separated Bazel labels) and merges those labels with anything passed via `--force-target`.

## Why

CI systems generally make it easier to wire a user-supplied parameter field (workflow_dispatch input, Buildkite input step, GitLab pipeline variable, CircleCI pipeline parameter) to an env var than to template it into a flag. Previously a user had to edit the CI config to force-deliver an ad-hoc target list; now the CI job can declare a parameter once and accept the target list at trigger time.

Behavior:
- Empty / unset env var → no-op, behaves identically to today.
- Tokens are merged with `--force-target` (deduplicated) before change-detection runs.
