### PR TITLE
Hard-fail when --force-target labels aren't in the resolved delivery set

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -448,6 +448,17 @@ def _delivery_impl(ctx):
         print(_style("No targets to deliver", _BOLD + _YELLOW, is_tty))
         return 0
 
+    # --force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS only flip
+    # change detection for labels already in the resolved target set —
+    # they don't add labels. Warn if any forced labels are unmatched so
+    # the user isn't silently surprised when their override is a no-op.
+    unmatched_forced = [t for t in forced_targets if t not in targets]
+    if unmatched_forced:
+        print(_style("WARNING:", _BOLD + _YELLOW, is_tty) +
+              " --force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS labels not in the resolved delivery set (will be ignored): " +
+              ", ".join(unmatched_forced))
+        print("  Force-target re-delivers labels already selected by --query or positional args; it does not add new labels. Update --query / positional targets to include them.")
+
     _print_header(is_tty, endpoint, ci_host, commit_sha, prefix, prefix_source, build_url, flags, targets, forced_targets, mode, dry_run, track_state)
 
     run_tracker = runnable(ctx, targets)

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -76,6 +76,9 @@ Failure modes
   --commit-sha unset and no CI env var
     exposes one (GITHUB_SHA, BUILDKITE_COMMIT,
     CIRCLE_SHA1, CI_COMMIT_SHA)                   hard fail() at startup
+  --force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS
+    contains a label not in the resolved
+    delivery set (from --query / positional)      hard fail() at startup
   No --remote_cache configured (most modes)       graceful return 1 with error
   No --remote_cache configured for the
     --mode=always --dry-run --track-state=false   prints NOTE; continues
@@ -450,14 +453,14 @@ def _delivery_impl(ctx):
 
     # --force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS only flip
     # change detection for labels already in the resolved target set —
-    # they don't add labels. Warn if any forced labels are unmatched so
-    # the user isn't silently surprised when their override is a no-op.
+    # they don't add labels. Hard-fail on any unmatched forced label so
+    # typos and stale labels are caught at startup rather than silently
+    # ignored.
     unmatched_forced = [t for t in forced_targets if t not in targets]
     if unmatched_forced:
-        print(_style("WARNING:", _BOLD + _YELLOW, is_tty) +
-              " --force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS labels not in the resolved delivery set (will be ignored): " +
-              ", ".join(unmatched_forced))
-        print("  Force-target re-delivers labels already selected by --query or positional args; it does not add new labels. Update --query / positional targets to include them.")
+        fail("--force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS labels not in the resolved delivery set: " +
+             ", ".join(unmatched_forced) +
+             ". Force-target re-delivers labels already selected by --query or positional args; it does not add new labels. Either fix the typo or update --query / positional targets to include them.")
 
     _print_header(is_tty, endpoint, ci_host, commit_sha, prefix, prefix_source, build_url, flags, targets, forced_targets, mode, dry_run, track_state)
 
@@ -727,7 +730,7 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         ),
         "force_target": args.string_list(
             default = [],
-            description = "Re-deliver these targets even if they have already been delivered for this commit. Use as a break-glass override when a previous delivery needs to be repeated. The ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS env var (whitespace-separated labels) is merged in addition to this flag — convenient for CI parameter fields that don't easily template into a flag.",
+            description = "Re-deliver these targets even if they have already been delivered for this commit. Use as a break-glass override when a previous delivery needs to be repeated. Each label must already be in the resolved delivery set (from --query or positional args) — force-target only flips the change-detection skip, it does not add labels; an unmatched label hard-fails at startup so typos are caught early. The ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS env var (whitespace-separated labels) is merged in addition to this flag — convenient for CI parameter fields that don't easily template into a flag.",
         ),
         "mode": args.string(
             default = "selective",


### PR DESCRIPTION
## Summary

`--force-target` (and the `ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS` env var from #1027) only flip the change-detection skip for labels already selected by `--query` or positional args — they don't add new labels to the delivery set.

Previously, unmatched force-target labels were silently ignored. This PR hard-fails at startup listing the unmatched labels, with a hint pointing at `--query` / positional args.

## Why

This came up immediately after #1027 landed: a user wired `ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS` to a Buildkite UI input expecting drop-in replacement of the legacy `ASPECT_WORKFLOWS_DELIVERY_TARGETS` (which was an *override*, not a force). They passed `//foo:bar` but the header still showed only `//examples/deliverable` — no error, no warning, no clue why.

A typo or stale label silently turning a force-deliver into a no-op is a footgun, so we surface it loudly. Hard fail beats warn here because force-target is a break-glass operation and a silent miss is worse than a visible startup error.
