### PR TITLE
Extract long fail() messages to local var for cleaner stack traces

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/axl_add.axl
+++ b/crates/aspect-cli/src/builtins/aspect/axl_add.axl
@@ -137,10 +137,12 @@ def fetch_latest_release(ctx: TaskContext, owner: str, repo: str) -> dict:
     response = ctx.http().get(url = url, headers = get_github_headers()).block()
 
     if response.status == 404:
-        fail("Repository " + owner + "/" + repo + " not found or has no releases")
+        msg = "Repository " + owner + "/" + repo + " not found or has no releases"
+        fail(msg)
 
     if response.status != 200:
-        fail("Failed to fetch release info: HTTP " + str(response.status))
+        msg = "Failed to fetch release info: HTTP " + str(response.status)
+        fail(msg)
 
     if not response.body:
         fail("Empty response body from GitHub API")
@@ -157,7 +159,8 @@ def fetch_release_by_tag(ctx: TaskContext, owner: str, repo: str, tag: str) -> d
         return fetch_tag_as_release(ctx, owner, repo, tag)
 
     if response.status != 200:
-        fail("Failed to fetch release info: HTTP " + str(response.status))
+        msg = "Failed to fetch release info: HTTP " + str(response.status)
+        fail(msg)
 
     return json.decode(response.body)
 
@@ -168,10 +171,12 @@ def fetch_tag_as_release(ctx: TaskContext, owner: str, repo: str, tag: str) -> d
     response = ctx.http().get(url = url, headers = get_github_headers()).block()
 
     if response.status == 404:
-        fail("Tag " + tag + " not found in " + owner + "/" + repo)
+        msg = "Tag " + tag + " not found in " + owner + "/" + repo
+        fail(msg)
 
     if response.status != 200:
-        fail("Failed to fetch tag info: HTTP " + str(response.status))
+        msg = "Failed to fetch tag info: HTTP " + str(response.status)
+        fail(msg)
 
     # Create a synthetic release object with the tag name
     return {

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -326,7 +326,8 @@ def _delivery_impl(ctx):
     track_state = ctx.args.track_state
 
     if mode == "selective" and not track_state:
-        fail("--mode=selective requires --track-state=true. Change detection cannot decide what to deliver without persisted state. Either use --track-state=true (the default), or switch to --mode=always to deliver without change detection (combine with --dry-run for a preview).")
+        msg = "--mode=selective requires --track-state=true. Change detection cannot decide what to deliver without persisted state. Either use --track-state=true (the default), or switch to --mode=always to deliver without change detection (combine with --dry-run for a preview)."
+        fail(msg)
 
     # Derived: phase 1/2 (action-digest computation) runs whenever digests are
     # useful — i.e. anywhere they'll be recorded (--track-state=true) or
@@ -343,7 +344,8 @@ def _delivery_impl(ctx):
     # automatically and expose its Unix socket via the env var below.
     endpoint = ctx.std.env.var("ASPECT_WORKFLOWS_DELIVERY_API_ENDPOINT")
     if not endpoint and track_state:
-        fail("ASPECT_WORKFLOWS_DELIVERY_API_ENDPOINT is not set. The delivery state backend must be running. (Pass --track-state=false to run without state tracking; allowed in combination with --dry-run or --mode=always.)")
+        msg = "ASPECT_WORKFLOWS_DELIVERY_API_ENDPOINT is not set. The delivery state backend must be running. (Pass --track-state=false to run without state tracking; allowed in combination with --dry-run or --mode=always.)"
+        fail(msg)
 
     # Delivery context. --commit-sha and --build-url are auto-detected from
     # common CI env vars (GITHUB_*, BUILDKITE_*, CIRCLE_*, CI_* for GitLab)
@@ -351,7 +353,8 @@ def _delivery_impl(ctx):
     ci_host = ctx.args.ci_host
     commit_sha = ctx.args.commit_sha or detect_commit_sha(ctx.std)
     if not commit_sha:
-        fail("Could not determine commit SHA. Pass --commit-sha=<sha>, or run on a CI host that exposes GITHUB_SHA, BUILDKITE_COMMIT, CIRCLE_SHA1, or CI_COMMIT_SHA.")
+        msg = "Could not determine commit SHA. Pass --commit-sha=<sha>, or run on a CI host that exposes GITHUB_SHA, BUILDKITE_COMMIT, CIRCLE_SHA1, or CI_COMMIT_SHA."
+        fail(msg)
     build_url = ctx.args.build_url or detect_build_url(ctx) or "-"
 
     # Change-detection prefix: always anchored to --task-key, optionally extended by --salt
@@ -459,9 +462,8 @@ def _delivery_impl(ctx):
     # ignored.
     unmatched_forced = [t for t in forced_targets if t not in targets]
     if unmatched_forced:
-        fail("--force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS labels not in the resolved delivery set: " +
-             ", ".join(unmatched_forced) +
-             ". Force-target re-delivers labels already selected by --query or positional args; it does not add new labels. Either fix the typo or update --query / positional targets to include them.")
+        msg = "--force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS labels not in the resolved delivery set: " + ", ".join(unmatched_forced) + ". Force-target re-delivers labels already selected by --query or positional args; it does not add new labels. Either fix the typo or update --query / positional targets to include them."
+        fail(msg)
 
     _print_header(ansi, endpoint, ci_host, commit_sha, prefix, prefix_source, build_url, flags, targets, forced_targets, mode, dry_run, track_state)
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/deliveryd.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/deliveryd.axl
@@ -18,7 +18,8 @@ def _parse_endpoint(endpoint):
         return ("http://localhost", endpoint[len("unix://"):])
     if endpoint.startswith("http://") or endpoint.startswith("https://"):
         return (endpoint, None)
-    fail("Invalid deliveryd endpoint '{}': must start with unix://, http://, or https://".format(endpoint))
+    msg = "Invalid deliveryd endpoint '{}': must start with unix://, http://, or https://".format(endpoint)
+    fail(msg)
 
 def _post(http, endpoint, path, data):
     """Make a POST request to deliveryd, handling unix:// endpoints."""
@@ -62,7 +63,8 @@ def query(ctx, endpoint, ci_host, commit_sha, workspace):
 
 
     if response.status < 200 or response.status >= 300:
-        fail("deliveryd query failed: " + response.body)
+        msg = "deliveryd query failed: " + response.body
+        fail(msg)
 
     data = json.decode(response.body)
 
@@ -91,7 +93,8 @@ def deliver(ctx, endpoint, ci_host, output_sha, workspace, build_url):
     }).block()
 
     if response.status < 200 or response.status >= 300:
-        fail("deliveryd deliver failed: " + response.body)
+        msg = "deliveryd deliver failed: " + response.body
+        fail(msg)
 
 def record(ctx, endpoint, ci_host, commit_sha, workspace, label, output_sha):
     """
@@ -108,10 +111,12 @@ def record(ctx, endpoint, ci_host, commit_sha, workspace, label, output_sha):
     }).map_err(lambda e: e).block()
 
     if type(response) == "string":
-        fail("deliveryd record failed: " + response)
+        msg = "deliveryd record failed: " + response
+        fail(msg)
 
     if response.status < 200 or response.status >= 300:
-        fail("deliveryd record failed: " + response.body)
+        msg = "deliveryd record failed: " + response.body
+        fail(msg)
 
 def delete_artifact(ctx, endpoint, ci_host, output_sha, workspace):
     """
@@ -125,4 +130,5 @@ def delete_artifact(ctx, endpoint, ci_host, output_sha, workspace):
     }).block()
 
     if response.status < 200 or response.status >= 300:
-        fail("deliveryd artifact delete failed: " + response.body)
+        msg = "deliveryd artifact delete failed: " + response.body
+        fail(msg)

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -92,7 +92,8 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
     if roles:
         for role in roles:
             if not validate_role(role):
-                fail("unknown role %r, valid roles: %s" % (role, ", ".join(VALID_ROLES)))
+                msg = "unknown role %r, valid roles: %s" % (role, ", ".join(VALID_ROLES))
+                fail(msg)
 
     url = ctx.aspect.auth.api_url + "/github/token"
     if roles:

--- a/crates/aspect-cli/src/builtins/aspect/lib/tar.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tar.axl
@@ -24,7 +24,8 @@ def _platform_key(ctx):
     os = _OS_MAP.get(ctx.std.env.os())
     arch = _ARCH_MAP.get(ctx.std.env.arch())
     if not os or not arch:
-        fail("unsupported platform: " + ctx.std.env.os() + "/" + ctx.std.env.arch())
+        msg = "unsupported platform: " + ctx.std.env.os() + "/" + ctx.std.env.arch()
+        fail(msg)
     return os, arch
 
 


### PR DESCRIPTION
## Summary

Starlark renders the **literal source text** of a `fail()` call inside the traceback frame. Long inline messages — especially multi-line string concatenations — bury the actual error message in repeated source quoting, e.g.:

```
461 |           fail("--force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS labels not in ...
462 | |              ", ".join(unmatched_forced) +
463 | |              ". Force-target re-delivers labels already selected by --query or positional args; ...
    | |_________________________________________________________________________________________________________^
```

Extracting the message to a local first keeps the `fail()` line short, so the traceback frame is readable and the message prints once cleanly after.
