### PR TITLE
delivery: drop unused --config=delivery injection

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -390,9 +390,8 @@ def _delivery_impl(ctx):
     # Expand .bazelrc so remote cache config flows in automatically
     rc = ctx.bazel.parse_rc(
         root = ctx.std.env.root_dir(),
-        flags = flags + ["--config=delivery"],
+        flags = flags,
         startup_flags = startup_flags,
-        skip_config_if_missing = ["delivery"]
     )
     rc_startup_flags, expanded_flags = rc.expand_all(command = "build")
     ctx.bazel.startup_flags.extend(startup_flags + rc_startup_flags + ["--ignore_all_rc_files"])


### PR DESCRIPTION
## Summary

Removes the implicit `--config=delivery` injection (and the paired `skip_config_if_missing = ["delivery"]`) from `aspect delivery`. Audit showed nothing in this repo, the docs repo, or silo references a `:delivery` bazelrc section, so the injection was a no-op everywhere.

Leftover from an earlier version of the task. Mirrors the [`--config=lint` removal](https://github.com/aspect-build/aspect-cli/pull/1031) for the same reasons:

- Hidden bazelrc prerequisite was a silent footgun.
- Users wanting delivery-specific flags should pass `--bazel-flag=--config=…` or `--bazel-flag=<flag>` explicitly.