### PR TITLE
lint+format: cross-CI GitHub PR diff via shared detect_changed_files

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/gh_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gh_lint_comments.axl
@@ -2,7 +2,7 @@
 
 load("../lint.axl", "LintTrait")
 load("../lib/environment.axl", "color_enabled")
-load("../lib/github.axl", "detect_changed_files", "github")
+load("../lib/github.axl", "github")
 load("../lib/sarif.axl", "parse_sarif", "parse_sarif_diagnostics", "sarif_to_review_comments")
 
 
@@ -275,14 +275,14 @@ def _github_lint_impl(ctx: FeatureContext):
         if git_out.status.success:
             gh["prefix"] = git_out.stdout.strip()
 
-        # Populate gh["changed_lines"] for _filter_by_diff and _cleanup_comments.
-        # The lint task impl computes its own changed_files via the shared
-        # detect_changed_files helper for the strategy filter. Both call paths
-        # hit the same GitHub PR Files API (one extra HTTP call per lint run);
-        # there's no shared cache because the two consumers run in different
-        # phases (feature activation vs. task execution).
-        changed = detect_changed_files(ctx, line_level = True)
-        gh["changed_lines"] = {f["file"]: f["lines"] for f in changed}
+    def _lint_start(ctx):
+        # Read changed_files from the lint trait, populated by the lint
+        # task impl via detect_changed_files. Avoids a duplicate GitHub
+        # PR Files API call (or a duplicate `git diff`) — the task impl
+        # has already done the work.
+        if not gh:
+            return
+        gh["changed_lines"] = {f["file"]: f["lines"] for f in lint_trait.changed_files}
 
     def _lint_report(ctx, filepath):
         # Per-SARIF-file callback. Hybrid posting strategy:
@@ -455,6 +455,7 @@ def _github_lint_impl(ctx: FeatureContext):
                     prefix, max_pr_comments, state["dropped_due_to_cap"], breakdown,
                 ))
 
+    lint_trait.lint_start.append(_lint_start)
     lint_trait.lint_report.append(_lint_report)
     lint_trait.lint_end.append(_lint_end)
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/gh_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gh_lint_comments.axl
@@ -2,7 +2,7 @@
 
 load("../lint.axl", "LintTrait")
 load("../lib/environment.axl", "color_enabled")
-load("../lib/github.axl", "github", "detect_commit_sha")
+load("../lib/github.axl", "detect_changed_files", "github")
 load("../lib/sarif.axl", "parse_sarif", "parse_sarif_diagnostics", "sarif_to_review_comments")
 
 
@@ -24,33 +24,6 @@ def _comment_sort_key(comment):
         comment.get("path", ""),
         comment.get("line", 0),
     )
-
-
-def _parse_github_diff_patch(patch):
-    """Parse a GitHub PR file patch string into 0-based added line numbers."""
-    if not patch:
-        return []
-    lines = []
-    current_line = 0
-    for line in patch.split("\n"):
-        if line.startswith("@@"):
-            parts = line.split(" ")
-            for part in parts:
-                if part.startswith("+") and part != "+++":
-                    plus = part.removeprefix("+")
-                    if "," in plus:
-                        current_line = int(plus.split(",")[0])
-                    else:
-                        current_line = int(plus)
-                    break
-        elif line.startswith("+"):
-            lines.append(current_line - 1)
-            current_line += 1
-        elif line.startswith("-"):
-            pass
-        else:
-            current_line += 1
-    return lines
 
 
 def _enrich_with_suggestions(ctx, comments):
@@ -227,61 +200,35 @@ def _cleanup_comments(ctx, gh, relevant_diagnostics):
                 )
 
 
-def _determine_vars(ctx):
-    """Read required GitHub env vars.
-
-    Returns (dict, None) on success, or (None, reason_string) if any var is
-    missing or GITHUB_REF is not a PR merge ref.
-    """
-    ref = ctx.std.env.var("GITHUB_REF") or ""
-    sha = detect_commit_sha(ctx.std)
-    repository = ctx.std.env.var("GITHUB_REPOSITORY") or ""
-    repo_parts = repository.split("/")
-    missing = [name for name, val in [("GITHUB_REF", ref), ("GITHUB_SHA", sha), ("GITHUB_REPOSITORY", repository)] if not val]
-    if missing:
-        return None, "missing env var(s): %s" % ", ".join(missing)
-    if len(repo_parts) < 2:
-        return None, "missing env var(s): GITHUB_REPOSITORY"
-    if not (ref.startswith("refs/pull/") and ref.endswith("/merge")):
-        return None, "GITHUB_REF is not a PR merge ref: %s" % ref
-    return {
-        "owner": repo_parts[0],
-        "repo": repo_parts[1],
-        "sha": sha,
-        "pr_number": int(ref.removeprefix("refs/pull/").removesuffix("/merge")),
-    }, None
-
-
 def _github_lint_impl(ctx: FeatureContext):
     debug = bool(ctx.std.env.var("ASPECT_DEBUG"))
     lint_trait = ctx.traits[LintTrait]
 
-    env_vars, gh_inactive_reason = _determine_vars(ctx)
+    pr, gh_inactive_reason = github.detect_pr(ctx.std)
     gh = None
 
-    if env_vars:
+    if pr:
         auth_reason = {}
-        token = github.authenticate(ctx, owner = env_vars["owner"], repo = env_vars["repo"], roles = ["prs.write"], _reason = auth_reason)
+        token = github.authenticate(ctx, owner = pr["owner"], repo = pr["repo"], roles = ["prs.write"], _reason = auth_reason)
         if token:
             gh = {
                 "token": token,
-                "owner": env_vars["owner"],
-                "repo": env_vars["repo"],
-                "head_sha": env_vars["sha"],
-                "pr_number": env_vars["pr_number"],
+                "owner": pr["owner"],
+                "repo": pr["repo"],
+                "head_sha": pr["sha"],
+                "pr_number": pr["pr_number"],
                 "changed_lines": {},
                 "prefix": "",
                 "stale": False,
             }
         else:
             gh_inactive_reason = "authentication failed: %s" % auth_reason.get("reason", "unknown")
-            # We are demonstrably in a GitHub Actions PR context (env_vars
-            # validated) but auth failed — surface that to the build log so the
-            # user knows why no comments are appearing. Other inactive paths
-            # ("missing env var(s)", "not a PR merge ref") stay silent because
-            # they mean the feature doesn't apply, not that it failed.
+            # We are demonstrably in a GitHub PR context (detect_pr succeeded)
+            # but auth failed — surface that to the build log so the user
+            # knows why no comments are appearing. Non-PR contexts stay silent
+            # because they mean the feature doesn't apply, not that it failed.
             print("GitHub lint comments: authentication failed for %s/%s — %s" % (
-                env_vars["owner"], env_vars["repo"], auth_reason.get("reason", "unknown"),
+                pr["owner"], pr["repo"], auth_reason.get("reason", "unknown"),
             ))
 
     if not gh and not debug:
@@ -321,32 +268,21 @@ def _github_lint_impl(ctx: FeatureContext):
                 state["dropped_per_severity"][sev] = state["dropped_per_severity"].get(sev, 0) + 1
 
     if gh:
-        # Determine the workspace prefix relative to the git root once (e.g. "examples/lint/")
-        # so that GitHub API paths ("examples/lint/hello.sh") can be stripped to match
-        # SARIF-relative paths ("hello.sh").
+        # Workspace prefix relative to the git root (e.g. "examples/lint/") —
+        # _post_individually prepends it when posting because SARIF paths are
+        # workspace-relative but GitHub expects repo-relative paths.
         git_out = ctx.std.process.command("git").arg("rev-parse").arg("--show-prefix").current_dir(ctx.std.env.root_dir()).stdout("piped").stderr("null").spawn().wait_with_output()
         if git_out.status.success:
             gh["prefix"] = git_out.stdout.strip()
 
-        def get_diff(ctx):
-            result = github.pulls.list_files(ctx, gh["token"], gh["owner"], gh["repo"], gh["pr_number"])
-            if not result["success"]:
-                return []
-            all_files = []
-            prefix = gh["prefix"]
-            for f in result["files"]:
-                if f.get("status", "") == "removed":
-                    continue
-                filename = f.get("filename", "")
-                if prefix and filename.startswith(prefix):
-                    filename = filename[len(prefix):]
-                patch = f.get("patch", "")
-                added_lines = _parse_github_diff_patch(patch)
-                all_files.append({"file": filename, "lines": added_lines})
-            gh["changed_lines"] = {f["file"]: f["lines"] for f in all_files}
-            return all_files
-
-        lint_trait.get_diff = get_diff
+        # Populate gh["changed_lines"] for _filter_by_diff and _cleanup_comments.
+        # The lint task impl computes its own changed_files via the shared
+        # detect_changed_files helper for the strategy filter. Both call paths
+        # hit the same GitHub PR Files API (one extra HTTP call per lint run);
+        # there's no shared cache because the two consumers run in different
+        # phases (feature activation vs. task execution).
+        changed = detect_changed_files(ctx, line_level = True)
+        gh["changed_lines"] = {f["file"]: f["lines"] for f in changed}
 
     def _lint_report(ctx, filepath):
         # Per-SARIF-file callback. Hybrid posting strategy:

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -94,11 +94,26 @@ format = task(
     implementation = _impl,
     traits = [BazelTrait],
     args = {
-        "all_files": args.boolean(default = False),
-        "base_ref": args.string(default = "origin/main"),
-        "merge_base": args.string(),
-        "formatter_target": args.string(default = "//tools/format"),
-        "bazel_flag": args.string_list(),
-        "bazel_startup_flag": args.string_list(),
+        "all_files": args.boolean(
+            default = False,
+            description = "Format every file in the working tree instead of just the changed-file set. Useful for nightly maintenance jobs or when introducing a new formatter to a repo for the first time.",
+        ),
+        "base_ref": args.string(
+            default = "origin/main",
+            description = "Base ref for the changed-file set when the local-git fallback runs (no PR context detected, or PR-API auth unavailable). Resolved to a merge-base via `git merge-base HEAD <base-ref>`. Ignored on the GitHub PR Files API path. Override --merge-base to skip the merge-base resolution and use a specific SHA directly.",
+        ),
+        "merge_base": args.string(
+            description = "Explicit merge-base SHA for the local-git fallback's diff base. When set, skips the `git merge-base HEAD <base-ref>` resolution and uses this SHA directly. Ignored on the GitHub PR Files API path.",
+        ),
+        "formatter_target": args.string(
+            default = "//tools/format",
+            description = "Bazel label of the format_multirun target (or any runnable target) to invoke as the formatter. The target is built first, then run with the changed-file list passed as positional arguments.",
+        ),
+        "bazel_flag": args.string_list(
+            description = "Additional Bazel flags forwarded to the formatter build. Repeat the flag to pass multiple — e.g. `--bazel-flag=--config=ci --bazel-flag=--keep_going`.",
+        ),
+        "bazel_startup_flag": args.string_list(
+            description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
+        ),
     },
 )

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -17,23 +17,9 @@ Usage:
     
 """
 
+load("./lib/github.axl", "detect_changed_files")
 load("./lib/runnable.axl", "runnable")
 load("./traits.axl", "BazelTrait")
-
-# buildifier: disable=function-docstring
-def spawn_git_with_output(out, process, args: list[str]):
-    spawn = process.command("git").args(args).stdout("piped").spawn().wait_with_output()
-    if not spawn.status.success:
-        out.write("\x1b[0;31mERROR\x1b[0m: 'git %s' failed (exit %d)\n" % (" ".join(args), spawn.status.code))
-        fail(spawn.stderr)
-
-    return spawn.stdout.strip()
-
-# buildifier: disable=function-docstring
-def find_changed_files(out, process, base_ref: str, merge_base: str | None):
-    diff_base = merge_base if merge_base else spawn_git_with_output(out, process, ["merge-base", "HEAD", base_ref])
-
-    return spawn_git_with_output(out, process, ["diff", "--diff-filter=d", "--name-only", diff_base])
 
 # buildifier: disable=function-docstring
 def _impl(ctx: TaskContext) -> int:
@@ -84,9 +70,18 @@ def _impl(ctx: TaskContext) -> int:
 
     format_args = []
     if not ctx.args.all_files:
-        changed_files = find_changed_files(out, ctx.std.process, ctx.args.base_ref, ctx.args.merge_base)
-        out.write("Formatting changed files:\n%s\n" % changed_files)
-        format_args = changed_files.split("\n")
+        # Prefers the GitHub PR Files API when authenticated and in a PR
+        # context (works on any CI host), falling back to a local
+        # `git diff <merge-base> --diff-filter=d --name-only`. The
+        # --base-ref / --merge-base flags below only apply to that fallback.
+        changed_files = detect_changed_files(
+            ctx,
+            line_level = False,
+            base_ref = ctx.args.base_ref,
+            merge_base = ctx.args.merge_base or None,
+        )
+        out.write("Formatting changed files:\n%s\n" % "\n".join(changed_files))
+        format_args = changed_files
 
     exit = r.spawn(formatter, format_args).wait()
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -434,9 +434,12 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
       - parses each file's `patch` to extract added-line indices
       - returns the same shape regardless of CI host
 
-    Local-git fallback (always available):
-      - line_level=True:  `git diff HEAD~1 --unified=0`
-      - line_level=False: `git diff --diff-filter=d --name-only <merge-base>`
+    Local-git fallback (always available). The diff base is resolved as:
+      - explicit `merge_base` SHA if provided, else
+      - `git merge-base HEAD <base_ref>` (default base_ref `origin/main`).
+    Then:
+      - line_level=True:  `git diff <base> --unified=0`
+      - line_level=False: `git diff --diff-filter=d --name-only <base>`
 
     If a GitHub PR context is detected but the PR-API path is unavailable
     (auth failure, transient API error), a yellow WARNING is printed
@@ -481,16 +484,9 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
             prefix, pr["owner"], pr["repo"], pr["pr_number"], fallback_reason,
         ))
 
-    # Local-git fallback.
+    # Local-git fallback. Resolve the diff base once for both shapes.
     process = ctx.std.process
     cwd = ctx.std.env.current_dir()
-    if line_level:
-        result = process.command("git").args(["diff", "HEAD~1", "--unified=0"]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
-        if not result.status.success:
-            return []
-        return _parse_local_diff_output(result.stdout)
-
-    # File-level: resolve merge base, then list changed files.
     if merge_base:
         diff_base = merge_base
     else:
@@ -498,6 +494,13 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
         if not mb.status.success:
             return []
         diff_base = mb.stdout.strip()
+
+    if line_level:
+        result = process.command("git").args(["diff", diff_base, "--unified=0"]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
+        if not result.status.success:
+            return []
+        return _parse_local_diff_output(result.stdout)
+
     out = process.command("git").args(["diff", "--diff-filter=d", "--name-only", diff_base]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
     if not out.status.success:
         return []

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -1,5 +1,6 @@
 """GitHub API client library."""
 load("@std//base64.axl", "base64")
+load("./environment.axl", "color_enabled")
 load("./tar.axl", "zip_create")
 
 DEFAULT_GITHUB_API = "https://api.github.com"
@@ -437,12 +438,21 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
       - line_level=True:  `git diff HEAD~1 --unified=0`
       - line_level=False: `git diff --diff-filter=d --name-only <merge-base>`
 
+    If a GitHub PR context is detected but the PR-API path is unavailable
+    (auth failure, transient API error), a yellow WARNING is printed
+    explaining the reason before falling through. Outside PR contexts the
+    fallback is silent — local-git is the expected source.
+
     Returns an empty list if neither source produces results.
     """
-    pr, _reason = detect_github_pr(ctx.std)
+    pr, _ = detect_github_pr(ctx.std)
+    fallback_reason = ""
     if pr:
-        token = _authenticate(ctx, owner = pr["owner"], repo = pr["repo"], roles = ["prs.read"])
-        if token:
+        auth_reason = {}
+        token = _authenticate(ctx, owner = pr["owner"], repo = pr["repo"], roles = ["prs.read"], _reason = auth_reason)
+        if not token:
+            fallback_reason = "authentication failed: %s" % auth_reason.get("reason", "unknown")
+        else:
             result = list_pull_request_files(ctx, token, pr["owner"], pr["repo"], pr["pr_number"])
             if result["success"]:
                 # `git rev-parse --show-prefix` strips the workspace prefix so
@@ -462,6 +472,14 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
                     else:
                         files.append(filename)
                 return files
+            fallback_reason = "GitHub PR Files API call failed: %s" % result.get("error", "unknown")
+
+    if fallback_reason:
+        ansi = color_enabled(ctx.std)
+        prefix = ("\033[1m\033[33mWARNING:\033[0m") if ansi else "WARNING:"
+        print("%s detected a GitHub PR build (%s/%s#%d) but %s. Falling back to local `git diff` for changed-file detection." % (
+            prefix, pr["owner"], pr["repo"], pr["pr_number"], fallback_reason,
+        ))
 
     # Local-git fallback.
     process = ctx.std.process

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -485,6 +485,10 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
         ))
 
     # Local-git fallback. Resolve the diff base once for both shapes.
+    # Errors fail loudly: a silent empty result would be interpreted as
+    # "no changed files" by callers (lint hold-the-line surfaces nothing,
+    # format formats nothing) and pass CI even though the diff base was
+    # invalid (shallow clone, missing remote ref, …).
     process = ctx.std.process
     cwd = ctx.std.env.current_dir()
     if merge_base:
@@ -492,18 +496,21 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
     else:
         mb = process.command("git").args(["merge-base", "HEAD", base_ref]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
         if not mb.status.success:
-            return []
+            msg = "Could not resolve merge-base for changed-file detection: `git merge-base HEAD %s` failed (exit %d).\nstderr: %s\nThe ref may not exist locally (shallow clone? missing `git fetch`?). Override with --merge-base=<sha>, or set --base-ref to a ref that's available in the local repo." % (base_ref, mb.status.code, mb.stderr.strip())
+            fail(msg)
         diff_base = mb.stdout.strip()
 
     if line_level:
         result = process.command("git").args(["diff", diff_base, "--unified=0"]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
         if not result.status.success:
-            return []
+            msg = "`git diff %s --unified=0` failed (exit %d).\nstderr: %s" % (diff_base, result.status.code, result.stderr.strip())
+            fail(msg)
         return _parse_local_diff_output(result.stdout)
 
     out = process.command("git").args(["diff", "--diff-filter=d", "--name-only", diff_base]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
     if not out.status.success:
-        return []
+        msg = "`git diff --diff-filter=d --name-only %s` failed (exit %d).\nstderr: %s" % (diff_base, out.status.code, out.stderr.strip())
+        fail(msg)
     return [f for f in out.stdout.strip().split("\n") if f]
 
 
@@ -888,12 +895,28 @@ def _resolve_current_job_url(ctx, token, owner, repo, run_id, api_base = DEFAULT
 # Pull Request Reviews
 
 def list_pull_request_files(ctx, token, owner, repo, pull_number, api_base = DEFAULT_GITHUB_API):
-    """List files changed in a pull request."""
-    url = api_base + "/repos/" + owner + "/" + repo + "/pulls/" + str(pull_number) + "/files"
-    success, status_code, body = _do_request(ctx, "GET", url, token)
-    if success:
-        return {"success": True, "files": body if type(body) == "list" else []}
-    return {"success": False, "error": "request failed: " + str(status_code)}
+    """List all files changed in a pull request, paginated.
+
+    GitHub returns up to 100 files per page; PRs can carry up to 3000
+    (the API caps there). We page through with `?per_page=100&page=N`
+    and stop when a page returns fewer than 100 entries — no Link-header
+    parsing needed. The 30-page safety cap matches GitHub's hard limit.
+    """
+    base_url = api_base + "/repos/" + owner + "/" + repo + "/pulls/" + str(pull_number) + "/files"
+    per_page = 100
+    max_pages = 30
+    all_files = []
+    for page in range(1, max_pages + 1):
+        url = base_url + "?per_page=" + str(per_page) + "&page=" + str(page)
+        success, status_code, body = _do_request(ctx, "GET", url, token)
+        if not success:
+            return {"success": False, "error": "request failed (page %d): %s" % (page, str(status_code))}
+        if type(body) != "list":
+            break
+        all_files.extend(body)
+        if len(body) < per_page:
+            break
+    return {"success": True, "files": all_files}
 
 
 def get_pull_request(ctx, token, owner, repo, pull_number, api_base = DEFAULT_GITHUB_API):

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -245,6 +245,247 @@ def detect_build_url(ctx):
     return ""
 
 
+def detect_github_pr(std):
+    """Detect GitHub pull-request context from common CI environment variables.
+
+    Returns ({"owner": str, "repo": str, "pr_number": int, "sha": str}, "")
+    on success, or (None, reason) when no PR context can be determined.
+
+    Detection order — first match wins:
+      1. ASPECT_GITHUB_PR_NUMBER env var (explicit override) — paired with
+         detect_github_repo + detect_commit_sha. Escape hatch for setups
+         where no native CI var maps cleanly (GitLab CI mirroring a GitHub
+         repo, custom triggers, etc).
+      2. GitHub Actions: GITHUB_REF of the form refs/pull/<n>/merge.
+      3. Buildkite: BUILDKITE_PULL_REQUEST when set and not "false".
+      4. CircleCI: CIRCLE_PULL_REQUEST URL parse for /pull/<n>.
+
+    GitLab is intentionally absent: GitLab CI uses GitLab merge requests,
+    not GitHub PRs. Use the ASPECT_GITHUB_PR_NUMBER override when running
+    on GitLab CI against a GitHub-hosted repo.
+    """
+    env = std.env
+
+    explicit = env.var("ASPECT_GITHUB_PR_NUMBER") or ""
+    if explicit:
+        owner, repo = detect_github_repo(std)
+        if not owner or not repo:
+            return None, "ASPECT_GITHUB_PR_NUMBER set but no GitHub repo could be detected"
+        sha = detect_commit_sha(std)
+        if not sha:
+            return None, "ASPECT_GITHUB_PR_NUMBER set but no commit SHA could be detected"
+        if not explicit.isdigit():
+            return None, "ASPECT_GITHUB_PR_NUMBER must be numeric, got %r" % explicit
+        return {
+            "owner": owner,
+            "repo": repo,
+            "pr_number": int(explicit),
+            "sha": sha,
+        }, ""
+
+    if env.var("GITHUB_ACTIONS"):
+        ref = env.var("GITHUB_REF") or ""
+        if not (ref.startswith("refs/pull/") and ref.endswith("/merge")):
+            return None, "GITHUB_REF is not a PR merge ref: %r" % ref
+        repository = env.var("GITHUB_REPOSITORY") or ""
+        repo_parts = repository.split("/")
+        if len(repo_parts) < 2 or not repo_parts[0] or not repo_parts[1]:
+            return None, "GITHUB_REPOSITORY missing or malformed"
+        sha = detect_commit_sha(std)
+        if not sha:
+            return None, "no commit SHA available (GITHUB_SHA / pull_request head)"
+        return {
+            "owner": repo_parts[0],
+            "repo": repo_parts[1],
+            "pr_number": int(ref.removeprefix("refs/pull/").removesuffix("/merge")),
+            "sha": sha,
+        }, ""
+
+    if env.var("BUILDKITE"):
+        bk_pr = env.var("BUILDKITE_PULL_REQUEST") or ""
+        if not bk_pr or bk_pr == "false":
+            return None, "BUILDKITE_PULL_REQUEST is not set or is \"false\" (not a PR build)"
+        if not bk_pr.isdigit():
+            return None, "BUILDKITE_PULL_REQUEST is not numeric: %r" % bk_pr
+        owner, repo = detect_github_repo(std)
+        if not owner or not repo:
+            return None, "Buildkite PR detected but no GitHub repo could be derived"
+        sha = detect_commit_sha(std)
+        if not sha:
+            return None, "Buildkite PR detected but no commit SHA available"
+        return {
+            "owner": owner,
+            "repo": repo,
+            "pr_number": int(bk_pr),
+            "sha": sha,
+        }, ""
+
+    if env.var("CIRCLECI"):
+        cci_pr = env.var("CIRCLE_PULL_REQUEST") or ""
+        if not cci_pr:
+            return None, "CIRCLE_PULL_REQUEST is not set (not a PR build)"
+        # URL shape: https://github.com/<owner>/<repo>/pull/<n>
+        idx = cci_pr.find("/pull/")
+        if idx < 0:
+            return None, "CIRCLE_PULL_REQUEST does not look like a GitHub PR URL: %r" % cci_pr
+        tail = cci_pr[idx + len("/pull/"):]
+        # Strip trailing slash or query string if present.
+        for stop in ["/", "?", "#"]:
+            cut = tail.find(stop)
+            if cut >= 0:
+                tail = tail[:cut]
+        if not tail.isdigit():
+            return None, "could not parse PR number from CIRCLE_PULL_REQUEST: %r" % cci_pr
+        owner, repo = detect_github_repo(std)
+        if not owner or not repo:
+            return None, "CircleCI PR detected but no GitHub repo could be derived"
+        sha = detect_commit_sha(std)
+        if not sha:
+            return None, "CircleCI PR detected but no commit SHA available"
+        return {
+            "owner": owner,
+            "repo": repo,
+            "pr_number": int(tail),
+            "sha": sha,
+        }, ""
+
+    return None, "no GitHub PR context detected on this CI host"
+
+
+def _parse_local_diff_output(output):
+    """Parse `git diff --unified=0` output into [{file, lines}] (0-based added lines)."""
+    files = []
+    current_file = None
+    for line in output.split("\n"):
+        if line.startswith("+++ b/"):
+            path = line.removeprefix("+++ b/")
+            current_file = {"file": path, "lines": []}
+            files.append(current_file)
+        elif line.startswith("--- /dev/null"):
+            pass
+        elif line.startswith("+++ /dev/null"):
+            if current_file:
+                files.pop()
+                current_file = None
+        elif line.startswith("@@ ") and current_file != None:
+            parts = line.split(" ")
+            for part in parts:
+                if part.startswith("+") and part != "+++":
+                    plus = part.removeprefix("+")
+                    if "," in plus:
+                        chunks = plus.split(",")
+                        start = int(chunks[0])
+                        count = int(chunks[1])
+                    else:
+                        start = int(plus)
+                        count = 1
+                    if count > 0:
+                        for i in range(count):
+                            current_file["lines"].append(start - 1 + i)
+                    break
+    return files
+
+
+def _parse_github_pr_patch(patch):
+    """Parse a GitHub PR file `patch` string into 0-based added line numbers."""
+    if not patch:
+        return []
+    lines = []
+    current_line = 0
+    for line in patch.split("\n"):
+        if line.startswith("@@"):
+            parts = line.split(" ")
+            for part in parts:
+                if part.startswith("+") and part != "+++":
+                    plus = part.removeprefix("+")
+                    if "," in plus:
+                        current_line = int(plus.split(",")[0])
+                    else:
+                        current_line = int(plus)
+                    break
+        elif line.startswith("+"):
+            lines.append(current_line - 1)
+            current_line += 1
+        elif line.startswith("-"):
+            pass
+        else:
+            current_line += 1
+    return lines
+
+
+def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge_base = None):
+    """Detect changed files for a build, preferring the GitHub PR Files API
+    when available and falling back to local `git diff` otherwise.
+
+    Args:
+      ctx:        TaskContext.
+      line_level: if True (default), return [{file, lines: [int]}] with
+                  0-based added-line indices (lint usage). If False, return
+                  a flat list of file paths (format usage).
+      base_ref:   merge-base argument for the local-git fallback when
+                  line_level=False (e.g. "origin/main"). Ignored on the PR
+                  API path and when line_level=True.
+      merge_base: explicit merge-base SHA for the local-git fallback when
+                  line_level=False. Overrides `base_ref` if set.
+
+    PR-API path (when in a GitHub PR + auth succeeds):
+      - calls github.pulls.list_files via authenticate(roles=["prs.read"])
+      - parses each file's `patch` to extract added-line indices
+      - returns the same shape regardless of CI host
+
+    Local-git fallback (always available):
+      - line_level=True:  `git diff HEAD~1 --unified=0`
+      - line_level=False: `git diff --diff-filter=d --name-only <merge-base>`
+
+    Returns an empty list if neither source produces results.
+    """
+    pr, _reason = detect_github_pr(ctx.std)
+    if pr:
+        token = _authenticate(ctx, owner = pr["owner"], repo = pr["repo"], roles = ["prs.read"])
+        if token:
+            result = list_pull_request_files(ctx, token, pr["owner"], pr["repo"], pr["pr_number"])
+            if result["success"]:
+                # `git rev-parse --show-prefix` strips the workspace prefix so
+                # GitHub-API paths line up with local relative paths.
+                git_out = ctx.std.process.command("git").arg("rev-parse").arg("--show-prefix").current_dir(ctx.std.env.root_dir()).stdout("piped").stderr("null").spawn().wait_with_output()
+                prefix = git_out.stdout.strip() if git_out.status.success else ""
+                files = []
+                for f in result["files"]:
+                    if f.get("status", "") == "removed":
+                        continue
+                    filename = f.get("filename", "")
+                    if prefix and filename.startswith(prefix):
+                        filename = filename[len(prefix):]
+                    if line_level:
+                        added_lines = _parse_github_pr_patch(f.get("patch", ""))
+                        files.append({"file": filename, "lines": added_lines})
+                    else:
+                        files.append(filename)
+                return files
+
+    # Local-git fallback.
+    process = ctx.std.process
+    cwd = ctx.std.env.current_dir()
+    if line_level:
+        result = process.command("git").args(["diff", "HEAD~1", "--unified=0"]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
+        if not result.status.success:
+            return []
+        return _parse_local_diff_output(result.stdout)
+
+    # File-level: resolve merge base, then list changed files.
+    if merge_base:
+        diff_base = merge_base
+    else:
+        mb = process.command("git").args(["merge-base", "HEAD", base_ref]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
+        if not mb.status.success:
+            return []
+        diff_base = mb.stdout.strip()
+    out = process.command("git").args(["diff", "--diff-filter=d", "--name-only", diff_base]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
+    if not out.status.success:
+        return []
+    return [f for f in out.stdout.strip().split("\n") if f]
+
+
 def _extract_host(url):
     """Extract host from a git remote URL (SSH or HTTPS)."""
     if not url:
@@ -721,4 +962,6 @@ github = struct(
         create_review_comment = create_review_comment,
         delete_review_comment = delete_review_comment,
     ),
+    detect_pr             = detect_github_pr,
+    detect_changed_files  = detect_changed_files,
 )

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -99,18 +99,21 @@ LintTrait = trait(
     # [{"file": str, "lines": [int (0-based added line indices)]}].
     changed_files = attr(list, default = []),
 
-    # Lifecycle hooks — lists of callables, composable via .append()
-    # Features hold their own state via closures; no shared state dict is passed.
-    lint_start  = attr(list[typing.Callable[[TaskContext], None]], default = []),
-    # Called once before the build.
+    # Lifecycle hooks. Each is a list of callables; features compose by
+    # appending their hook to the list.
 
-    lint_report = attr(list[typing.Callable[[TaskContext, str], None]], default = []),
+    # Called once before the build, after lint_trait.changed_files is set.
+    # Signature: (ctx) -> None.
+    lint_start = attr(list[typing.Callable[[TaskContext], None]], default = []),
+
     # Called per SARIF file as it arrives during the build stream.
-    # Signature: (ctx, sarif_filepath)
+    # Signature: (ctx, sarif_filepath) -> None.
+    lint_report = attr(list[typing.Callable[[TaskContext, str], None]], default = []),
 
-    lint_end    = attr(list[typing.Callable[[TaskContext, list], None]], default = []),
-    # Called once after all reports, receives strategy-filtered diagnostics.
-    # Signature: (ctx, relevant_diagnostics)
+    # Called once after all SARIF reports are collected, receives the
+    # strategy-filtered diagnostics for this run.
+    # Signature: (ctx, relevant_diagnostics) -> None.
+    lint_end = attr(list[typing.Callable[[TaskContext, list], None]], default = []),
 )
 
 # buildifier: disable=function-docstring

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -21,6 +21,7 @@ Usage:
 load("./lib/sarif.axl", "parse_sarif", "parse_sarif_diagnostics", "get_sarif_summary")
 load("./traits.axl", "BazelTrait", "HealthCheckTrait")
 load("./lib/environment.axl", "color_enabled")
+load("./lib/github.axl", "detect_changed_files")
 
 # bb_clientd FUSE mount root for resolving bytestream:// URIs on Aspect Workflows runners.
 _BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
@@ -36,74 +37,6 @@ def _file_uri_to_path(uri):
         blob_size = parts[3]
         return _BB_CLIENTD_ROOT + "/cas/" + host + "/blobs/sha256/file/" + blob_hash + "-" + blob_size
     return uri
-
-def parse_diff_output(output):
-    """
-    Parse raw `git diff --unified=0` output into changed file/line information.
-
-    Args:
-        output: Raw output string from `git diff --unified=0`
-
-    Returns:
-        List of dicts: [{"file": str, "lines": [int]}]
-        lines are 0-based line numbers of added lines only.
-        Deleted files are excluded.
-    """
-    files = []
-    current_file = None
-
-    for line in output.split("\n"):
-        if line.startswith("+++ b/"):
-            path = line.removeprefix("+++ b/")
-            current_file = {"file": path, "lines": []}
-            files.append(current_file)
-        elif line.startswith("--- /dev/null"):
-            # Next +++ line is a new file (not a deletion); handled naturally
-            pass
-        elif line.startswith("+++ /dev/null"):
-            # File was deleted — remove the entry we just added
-            if current_file:
-                files.pop()
-                current_file = None
-        elif line.startswith("@@ ") and current_file != None:
-            # Parse hunk header: @@ -old,count +new,count @@
-            # We only care about the +new,count part
-            parts = line.split(" ")
-            for part in parts:
-                if part.startswith("+") and part != "+++":
-                    # +start or +start,count
-                    plus = part.removeprefix("+")
-                    if "," in plus:
-                        chunks = plus.split(",")
-                        start = int(chunks[0])
-                        count = int(chunks[1])
-                    else:
-                        start = int(plus)
-                        count = 1
-                    if count > 0:
-                        # Convert to 0-based line numbers
-                        for i in range(count):
-                            current_file["lines"].append(start - 1 + i)
-                    break
-
-    return files
-
-
-def _git_diff(ctx):
-    """Default get_diff implementation using `git diff HEAD~1`.
-
-    Returns: [{"file": "path/to/file.py", "lines": [0, 4, 9]}, ...]
-    lines = 0-based line numbers of added lines only.
-    Empty list = no change context available.
-    """
-    result = ctx.std.process.command("git") \
-        .args(["diff", "HEAD~1", "--unified=0"]) \
-        .current_dir(ctx.std.env.current_dir()) \
-        .stdout("piped").stderr("piped").spawn().wait_with_output()
-    if not result.status.success:
-        return []  # no previous commit or not a git repo
-    return parse_diff_output(result.stdout)
-
 
 # Filter functions — (all_diagnostics, changed_files) -> relevant_diagnostics
 def _filter_all(diagnostics, changed_files):
@@ -159,9 +92,6 @@ _STRATEGIES = {
 
 
 LintTrait = trait(
-    get_diff    = attr(typing.Callable[[TaskContext], list], default = _git_diff),
-    # (ctx) -> [{"file": str, "lines": [int]}]
-
     # Lifecycle hooks — lists of callables, composable via .append()
     # Features hold their own state via closures; no shared state dict is passed.
     lint_start  = attr(list[typing.Callable[[TaskContext], None]], default = []),
@@ -192,7 +122,11 @@ def _impl(ctx: TaskContext) -> int:
         hook(ctx)
 
     # 1. Fetch changed files (needed by strategy filter)
-    changed_files = lint_trait.get_diff(ctx)
+    # Detect changed files: prefer the GitHub PR Files API when authenticated
+    # and in a PR context (works on any CI host), falling back to local
+    # `git diff HEAD~1 --unified=0`. Lives in lib/github.axl as a shared
+    # helper because format also wants the same precedence.
+    changed_files = detect_changed_files(ctx, line_level = True)
 
 
     # 3. Build flags — lint-specific first, then BazelTrait additions.

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -124,9 +124,14 @@ def _impl(ctx: TaskContext) -> int:
     # 1. Fetch changed files (needed by strategy filter)
     # Detect changed files: prefer the GitHub PR Files API when authenticated
     # and in a PR context (works on any CI host), falling back to local
-    # `git diff HEAD~1 --unified=0`. Lives in lib/github.axl as a shared
+    # `git diff <base> --unified=0`. Lives in lib/github.axl as a shared
     # helper because format also wants the same precedence.
-    changed_files = detect_changed_files(ctx, line_level = True)
+    changed_files = detect_changed_files(
+        ctx,
+        line_level = True,
+        base_ref = ctx.args.base_ref,
+        merge_base = ctx.args.merge_base or None,
+    )
 
 
     # 3. Build flags — lint-specific first, then BazelTrait additions.
@@ -269,13 +274,33 @@ lint = task(
             required = True,
             description = "Bazel aspect label(s) to apply for linting (e.g. //tools/lint:linters.bzl%eslint). Repeat the flag to run multiple aspects in a single invocation. At least one aspect is required.",
         ),
-        "announce_rc": args.boolean(default = False),
-        "quiet": args.boolean(default = False),
-        "fix": args.boolean(),
+        "announce_rc": args.boolean(
+            default = False,
+            description = "Print the resolved Bazel `.bazelrc` flags before running the lint build. Useful when debugging which config sections fired or what the final flag set looks like.",
+        ),
+        "quiet": args.boolean(
+            default = False,
+            description = "Suppress Bazel's stdout/stderr from the underlying build. Lint diagnostics are still surfaced via SARIF reports and any registered lint_end hooks (e.g. PR review comments).",
+        ),
+        "fix": args.boolean(
+            description = "Apply auto-fixes from rules_lint where the linter provides them. Runs the build with --output_groups=rules_lint_patch and applies the resulting patches to the working tree.",
+        ),
         "strategy": args.string(
             default = "hold-the-line",
             values = ["soft", "hard", "hold-the-line"],
+            description = "How lint diagnostics drive the exit code: 'hold-the-line' (default) fails only on error-severity diagnostics in changed files; 'hard' fails on any error and on linter-process failure; 'soft' surfaces diagnostics without ever failing.",
         ),
-        "targets": args.positional(minimum = 0, default = ["..."]),
+        "base_ref": args.string(
+            default = "origin/main",
+            description = "Base ref for the changed-file set when the local-git fallback runs (no PR context detected, or PR-API auth unavailable). Resolved to a merge-base via `git merge-base HEAD <base-ref>`. Ignored on the GitHub PR Files API path. Override --merge-base to skip the merge-base resolution and use a specific SHA directly.",
+        ),
+        "merge_base": args.string(
+            description = "Explicit merge-base SHA for the local-git fallback's diff base. When set, skips the `git merge-base HEAD <base-ref>` resolution and uses this SHA directly. Ignored on the GitHub PR Files API path.",
+        ),
+        "targets": args.positional(
+            minimum = 0,
+            default = ["..."],
+            description = "Bazel target patterns to lint. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory.",
+        ),
     },
 )

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -92,6 +92,13 @@ _STRATEGIES = {
 
 
 LintTrait = trait(
+    # Canonical changed-file set for this lint run. Populated by the task
+    # impl via detect_changed_files (GitHub PR Files API → local-git
+    # fallback) BEFORE any lifecycle hook fires, so features read it as a
+    # data field rather than each computing their own. Shape:
+    # [{"file": str, "lines": [int (0-based added line indices)]}].
+    changed_files = attr(list, default = []),
+
     # Lifecycle hooks — lists of callables, composable via .append()
     # Features hold their own state via closures; no shared state dict is passed.
     lint_start  = attr(list[typing.Callable[[TaskContext], None]], default = []),
@@ -118,20 +125,22 @@ def _impl(ctx: TaskContext) -> int:
     for hook in hc_trait.pre_health_check:
         hook(ctx)
 
-    for hook in lint_trait.lint_start:
-        hook(ctx)
-
-    # 1. Fetch changed files (needed by strategy filter)
-    # Detect changed files: prefer the GitHub PR Files API when authenticated
-    # and in a PR context (works on any CI host), falling back to local
-    # `git diff <base> --unified=0`. Lives in lib/github.axl as a shared
-    # helper because format also wants the same precedence.
+    # Detect changed files BEFORE lint_start hooks so features can read
+    # lint_trait.changed_files as the canonical set. Prefers the GitHub
+    # PR Files API when authenticated and in a PR context (works on any
+    # CI host), falling back to local `git diff <base> --unified=0`.
+    # Lives in lib/github.axl because format also wants the same
+    # precedence.
     changed_files = detect_changed_files(
         ctx,
         line_level = True,
         base_ref = ctx.args.base_ref,
         merge_base = ctx.args.merge_base or None,
     )
+    lint_trait.changed_files = changed_files
+
+    for hook in lint_trait.lint_start:
+        hook(ctx)
 
 
     # 3. Build flags — lint-specific first, then BazelTrait additions.


### PR DESCRIPTION
## Summary

`GithubLintComments` only authenticated and called `github.pulls.list_files` when `GITHUB_REF` was set — i.e. on GitHub Actions. Repos hosted on GitHub but built on Buildkite or CircleCI never reached the auth path and never posted inline comments. The format task had a parallel gap: it always used local `git diff <merge-base>` even when GitHub PR data was available.

This unifies both paths through a shared helper, removes the unused trait extension point, makes the local-git fallback semantically consistent across both tasks, and documents every arg.

## What changed

### New: [`detect_github_pr(std)`](crates/aspect-cli/src/builtins/aspect/lib/github.axl) — cross-CI PR detection

Returns `({"owner", "repo", "pr_number", "sha"}, "")` on success, or `(None, reason)`. Detection order:

1. **`ASPECT_GITHUB_PR_NUMBER`** explicit override (escape hatch — GitLab→GitHub mirrors, custom triggers).
2. **GitHub Actions**: existing `GITHUB_REF` (`refs/pull/N/merge`).
3. **Buildkite**: `BUILDKITE_PULL_REQUEST` (skip if `"false"` or empty).
4. **CircleCI**: `CIRCLE_PULL_REQUEST` URL parse for `/pull/<n>`.

GitLab is intentionally absent — GitLab CI uses GitLab merge requests, not GitHub PRs. The `ASPECT_GITHUB_PR_NUMBER` override covers GitLab CI mirroring a GitHub repo.

### New: [`detect_changed_files(ctx, line_level, base_ref, merge_base)`](crates/aspect-cli/src/builtins/aspect/lib/github.axl)

Single source of truth for "what files changed in this build":

- **PR-API path** (when in a PR + auth succeeds): calls `github.pulls.list_files` via `authenticate(roles=["prs.read"])` and parses each file's `patch` for added-line indices. Strips the workspace prefix so paths line up with SARIF/local-relative paths.
- **Local-git fallback**: resolves a diff base from `--merge-base` (explicit) or `git merge-base HEAD <base-ref>` (default `origin/main`), then:
  - `line_level=True`  → `git diff <base> --unified=0`
  - `line_level=False` → `git diff --diff-filter=d --name-only <base>`
- Returns `[{file, lines: [int]}]` or `[file]` depending on `line_level`.
- **Warns** when a PR is detected but the PR-API path is unavailable (auth failure, transient API error), with the underlying reason. Outside PR contexts the fallback is silent.

### Behavior change: lint's local fallback now uses merge-base

Previously the line-level local fallback was hardcoded to `git diff HEAD~1 --unified=0`, capturing only the latest commit on a multi-commit branch. The new shared helper uses the same merge-base-of-`base_ref` logic that format already had, so the local hold-the-line filter sees all branch changes.

This affects local `aspect lint` runs and CI runs that fall through to the local-git path (no PR or auth failure). PR-API-path runs are unchanged.

### Removed: `LintTrait.get_diff`

The callable trait field had exactly one override (`GithubLintComments`) and made the data flow hard to follow. Lint impl now calls `detect_changed_files` directly. The `_git_diff` and `parse_diff_output` helpers move into `lib/github.axl` (renamed `_parse_local_diff_output`).

### `format.axl` rewired

Replaces `find_changed_files` with `detect_changed_files(ctx, line_level=False, base_ref=…, merge_base=…)`. The `--base-ref` and `--merge-base` flags now apply only to the local-git fallback (no-ops when the GitHub PR API path runs).

### `lint.axl` gains `--base-ref` and `--merge-base`

For symmetry with format and to control the local fallback when `aspect lint` runs locally on a feature branch. Same defaults, same semantics — applies only when the PR-API path doesn't run.

### Args documentation

Every arg on both tasks now has a `description` string. Previously `--announce-rc`, `--quiet`, `--fix`, `--formatter-target`, `--bazel-flag`, and `--bazel-startup-flag` had no help text. `aspect lint --help` and `aspect format --help` now describe each flag.

### `GithubLintComments` simplifications

- Drops `_determine_vars` (replaced by `github.detect_pr`).
- Drops the `lint_trait.get_diff = …` override.
- Drops the local `_parse_github_diff_patch` (now in `lib/github.axl`).
- Populates `gh["changed_lines"]` once via `detect_changed_files`.