### PR TITLE
build/test: add arg descriptions; drop unused remote_executor/remote_cache from build

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -19,14 +19,31 @@ build = task(
         ArtifactsTrait,
     ],
     args = {
-        "targets": args.positional(minimum = 1, maximum = 512, default = ["..."]),
-        "bazel_flag": args.string_list(),
-        "bazel_startup_flag": args.string_list(),
-        "remote_executor": args.string(),
-        "remote_cache": args.string(),
-        "bes_backend": args.string_list(),
-        "bes_header": args.string_list(),
-        "cancel": args.boolean(default = False, description = "Cancel any running Bazel invocation before starting the build"),
-        "output_base": args.string(default = "", description = "Bazel output base path to target a specific server instance"),
+        "targets": args.positional(
+            minimum = 1,
+            maximum = 512,
+            default = ["..."],
+            description = "Bazel target patterns to build. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory.",
+        ),
+        "bazel_flag": args.string_list(
+            description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
+        ),
+        "bazel_startup_flag": args.string_list(
+            description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
+        ),
+        "bes_backend": args.string_list(
+            description = "Build Event Service backend(s) to stream BEP events to. Repeat the flag to pass multiple. Translated to --bes_backend=<value> on the Bazel command.",
+        ),
+        "bes_header": args.string_list(
+            description = "HTTP header(s) attached to BES streams (e.g. --bes-header=x-token=abc). Repeat the flag to pass multiple. Translated to --bes_header=<value> on the Bazel command.",
+        ),
+        "cancel": args.boolean(
+            default = False,
+            description = "Cancel any running Bazel invocation before starting the build.",
+        ),
+        "output_base": args.string(
+            default = "",
+            description = "Bazel output base path. Use to target a specific Bazel server instance — distinct paths run independent JVMs and cache contents.",
+        ),
     },
 )

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -21,12 +21,31 @@ test = task(
     args = {
         # TODO: Support a long --pattern_file like bazel does (@./targets)
         # TODO: Support - (list from stdin)
-        "targets": args.positional(minimum = 1, maximum = 512, default = ["..."]),
-        "bazel_flag": args.string_list(),
-        "bazel_startup_flag": args.string_list(),
-        "bes_backend": args.string_list(),
-        "bes_header": args.string_list(),
-        "cancel": args.boolean(default = False, description = "Cancel any running Bazel invocation before starting the test"),
-        "output_base": args.string(default = "", description = "Bazel output base path to target a specific server instance"),
+        "targets": args.positional(
+            minimum = 1,
+            maximum = 512,
+            default = ["..."],
+            description = "Bazel target patterns to test. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory.",
+        ),
+        "bazel_flag": args.string_list(
+            description = "Additional Bazel flags forwarded to the test invocation (e.g. --bazel-flag=--config=ci --bazel-flag=--test_filter=foo). Repeat the flag to pass multiple.",
+        ),
+        "bazel_startup_flag": args.string_list(
+            description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
+        ),
+        "bes_backend": args.string_list(
+            description = "Build Event Service backend(s) to stream BEP events to. Repeat the flag to pass multiple. Translated to --bes_backend=<value> on the Bazel command.",
+        ),
+        "bes_header": args.string_list(
+            description = "HTTP header(s) attached to BES streams (e.g. --bes-header=x-token=abc). Repeat the flag to pass multiple. Translated to --bes_header=<value> on the Bazel command.",
+        ),
+        "cancel": args.boolean(
+            default = False,
+            description = "Cancel any running Bazel invocation before starting the test.",
+        ),
+        "output_base": args.string(
+            default = "",
+            description = "Bazel output base path. Use to target a specific Bazel server instance — distinct paths run independent JVMs and cache contents.",
+        ),
     },
 )


### PR DESCRIPTION
## Summary

Two small cleanups:

1. **Drop unused args from build.** [`build.axl`](crates/aspect-cli/src/builtins/aspect/build.axl) declared `--remote-executor` and `--remote-cache` args, but no code path consumed them (a grep across `crates/` confirmed). Remove from the task definition.

2. **Add `description` strings to every arg on `build` and `test`.** Previously `--targets`, `--bazel-flag`, `--bazel-startup-flag`, `--bes-backend`, and `--bes-header` had no help text — `aspect build --help` / `aspect test --help` showed bare flag names. Now each arg has a description.