### PR TITLE
ci: don't cancel concurrent runs on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,13 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  # PRs share a group keyed by the head ref so a new push to the PR
+  # cancels the in-flight run. On push (main) and workflow_dispatch each
+  # run gets a unique group via run_id, so concurrent runs never cancel
+  # each other; cancel-in-progress is also gated to PRs as a safety
+  # double-check.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   pre-build:


### PR DESCRIPTION
## Summary

The previous concurrency block:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```

was meant to cancel only PR runs (where \`github.head_ref\` is the PR branch), falling back to \`github.run_id\` for pushes (which is unique per run, so no group collision → no cancel). In practice main runs have been getting cancelled.

## Fix

Explicit \`event_name == 'pull_request'\` gating on both knobs:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **PRs**: group keyed by \`head_ref\`, \`cancel-in-progress: true\` → a new push to the PR cancels the in-flight CI run.
- **Push (main)** and **workflow_dispatch**: group keyed by the unique \`run_id\`, \`cancel-in-progress: false\` → concurrent runs never share a group AND can't be cancelled even if they did.

Either gate alone would suffice; having both makes the misconfiguration unreachable.

## Test plan

- [ ] After merge, two concurrent pushes to main both run to completion (no cancellations).
- [ ] A new push to an open PR's branch cancels the previous CI run on that PR (preserves existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)