### PR TITLE
Cache ASPECT_API_TOKEN exchange results in process-level cache

### DIFF
--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -271,13 +271,20 @@ fn block_on<F: std::future::Future>(fut: F) -> F::Output {
 /// task can call `ctx.aspect.auth.credentials()` multiple times (once per
 /// `github.authenticate` call); without caching each call hits Frontegg's
 /// `/api-token` endpoint. The cache stores the most recently successful
-/// exchange keyed on the source token; entries are invalidated automatically
-/// once the JWT's `exp` claim falls inside the 60-second skew buffer
-/// (`is_expired_jwt`), so we don't hand out tokens that are about to be rejected.
+/// exchange keyed on the source token AND the resolved auth-environment
+/// domain; entries are invalidated automatically once the JWT's `exp` claim
+/// falls inside the 60-second skew buffer (`is_expired_jwt`), so we don't
+/// hand out tokens that are about to be rejected.
 struct ApiTokenCacheEntry {
     /// Source token (the raw `client_id:secret` value) the cached entry was
     /// minted from. If the env var changes mid-run we mint a fresh one.
     source_token: String,
+    /// Auth-environment domain the cached entry was exchanged against
+    /// (`https://auth.aspect.build`, `…staging…`, `…dev…`). Reusing a
+    /// staging-issued token after `__ASPECT_ENVIRONMENT__` flips to
+    /// production would hand back credentials minted by the wrong issuer,
+    /// so the env domain is part of the cache key.
+    auth_domain: &'static str,
     entry: CredentialsEntry,
 }
 
@@ -305,11 +312,19 @@ fn credentials_from_api_token_env() -> anyhow::Result<Option<CredentialsEntry>> 
         return Ok(None);
     };
 
-    // Fast path: a cached exchange for the same source token whose JWT
-    // hasn't entered the 60-second pre-expiry buffer.
+    // Resolve the env every call so __ASPECT_ENVIRONMENT__ changes within
+    // a single process (test harnesses, multi-step tooling) re-exchange
+    // against the new issuer instead of returning a stale token.
+    let env = resolve_aspect_env()?;
+
+    // Fast path: a cached exchange for the same source token AND auth env
+    // whose JWT hasn't entered the 60-second pre-expiry buffer.
     if let Ok(guard) = api_token_cache().lock() {
         if let Some(cached) = guard.as_ref() {
-            if cached.source_token == token && !is_expired_jwt(&cached.entry) {
+            if cached.source_token == token
+                && cached.auth_domain == env.domain
+                && !is_expired_jwt(&cached.entry)
+            {
                 return Ok(Some(cached.entry.clone()));
             }
         }
@@ -318,7 +333,6 @@ fn credentials_from_api_token_env() -> anyhow::Result<Option<CredentialsEntry>> 
     let (client_id, secret) = token
         .split_once(':')
         .ok_or_else(|| anyhow::anyhow!("ASPECT_API_TOKEN must be in 'client_id:secret' format"))?;
-    let env = resolve_aspect_env()?;
     let entry = block_on(exchange_api_token(client_id, secret, env))?;
 
     // Store for subsequent calls. Clearing on lock-poison is fine — the
@@ -326,6 +340,7 @@ fn credentials_from_api_token_env() -> anyhow::Result<Option<CredentialsEntry>> 
     if let Ok(mut guard) = api_token_cache().lock() {
         *guard = Some(ApiTokenCacheEntry {
             source_token: token,
+            auth_domain: env.domain,
             entry: entry.clone(),
         });
     }

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use allocative::Allocative;
@@ -267,12 +267,35 @@ fn block_on<F: std::future::Future>(fut: F) -> F::Output {
     Handle::current().block_on(fut)
 }
 
+/// Process-level cache for API-token-exchange results. A single `aspect`
+/// task can call `ctx.aspect.auth.credentials()` multiple times (once per
+/// `github.authenticate` call); without caching each call hits Frontegg's
+/// `/api-token` endpoint. The cache stores the most recently successful
+/// exchange keyed on the source token; entries are invalidated automatically
+/// once the JWT's `exp` claim falls inside the 60-second skew buffer
+/// (`is_expired_jwt`), so we don't hand out tokens that are about to be rejected.
+struct ApiTokenCacheEntry {
+    /// Source token (the raw `client_id:secret` value) the cached entry was
+    /// minted from. If the env var changes mid-run we mint a fresh one.
+    source_token: String,
+    entry: CredentialsEntry,
+}
+
+static API_TOKEN_CACHE: OnceLock<Mutex<Option<ApiTokenCacheEntry>>> = OnceLock::new();
+
+fn api_token_cache() -> &'static Mutex<Option<ApiTokenCacheEntry>> {
+    API_TOKEN_CACHE.get_or_init(|| Mutex::new(None))
+}
+
 /// Exchange an ASPECT_API_TOKEN from an explicit source — the env var or the
 /// Buildkite secret store — for a fresh credentials entry. Returns Ok(None)
 /// only when no such source is present; a malformed token or a failed
 /// exchange is surfaced as an error so CI misconfigurations fail loudly
 /// instead of falling through to whatever happens to be cached on disk
 /// (e.g. from a previous job on a persistent runner).
+///
+/// Subsequent calls within the same process reuse the cached exchange
+/// result until the JWT approaches expiry.
 fn credentials_from_api_token_env() -> anyhow::Result<Option<CredentialsEntry>> {
     let token = std::env::var("ASPECT_API_TOKEN")
         .ok()
@@ -281,11 +304,31 @@ fn credentials_from_api_token_env() -> anyhow::Result<Option<CredentialsEntry>> 
     let Some(token) = token else {
         return Ok(None);
     };
+
+    // Fast path: a cached exchange for the same source token whose JWT
+    // hasn't entered the 60-second pre-expiry buffer.
+    if let Ok(guard) = api_token_cache().lock() {
+        if let Some(cached) = guard.as_ref() {
+            if cached.source_token == token && !is_expired_jwt(&cached.entry) {
+                return Ok(Some(cached.entry.clone()));
+            }
+        }
+    }
+
     let (client_id, secret) = token
         .split_once(':')
         .ok_or_else(|| anyhow::anyhow!("ASPECT_API_TOKEN must be in 'client_id:secret' format"))?;
     let env = resolve_aspect_env()?;
     let entry = block_on(exchange_api_token(client_id, secret, env))?;
+
+    // Store for subsequent calls. Clearing on lock-poison is fine — the
+    // next caller will just miss and re-exchange.
+    if let Ok(mut guard) = api_token_cache().lock() {
+        *guard = Some(ApiTokenCacheEntry {
+            source_token: token,
+            entry: entry.clone(),
+        });
+    }
     Ok(Some(entry))
 }
 


### PR DESCRIPTION
## Summary

A single `aspect` task can call `ctx.aspect.auth.credentials()` many times — once per `github.authenticate` call (status checks, lint comments, build-URL deep-link upgrades, …). Without caching, each call shells through `credentials_from_api_token_env()` to Frontegg's `/identity/resources/auth/v1/api-token` endpoint, adding latency and load.

This adds a process-level cache for the token-exchange result.

## Design

- `static API_TOKEN_CACHE: OnceLock<Mutex<Option<ApiTokenCacheEntry>>>` in [auth.rs](crates/axl-runtime/src/engine/aspect/auth.rs).
- Entry holds the raw source token (`client_id:secret`) and the `CredentialsEntry` from the exchange.
- Fast path: lookup is keyed on the source token; cache miss if the env var changes mid-process (rare but worth handling correctly).
- Invalidation: reuses the existing `is_expired_jwt(entry)` predicate — true when the JWT's `exp` claim is within 60s of now. So we never hand back a token about to be rejected; no separate TTL knob to tune.
- Concurrency: `Mutex` is fine — Starlark/AXL evaluation is effectively single-threaded per task. Lock-poison failures fall through to a fresh exchange (correctness preserved).

Errors (malformed token, failed exchange) are not cached — the next call retries from scratch, matching the current "fail loudly" behavior.
