### PR TITLE
ci: pre-build :bins with toplevel before release-artifact run

### DIFF
--- a/.github/workflows/build_release_artifacts.yaml
+++ b/.github/workflows/build_release_artifacts.yaml
@@ -48,8 +48,23 @@ jobs:
           repository-cache: true
 
       - name: Build release artifacts
+        # `release.sh` (genrule output of //bazel/release:release.bzl) cps
+        # bazel-out paths directly without declaring the binaries / .sha256
+        # files as runfiles. The :ci default `--remote_download_outputs=minimal`
+        # leaves cache-hit outputs (notably the unstamped axl-docgen `hashes`
+        # actions) remote-only, so the cp step then fails with "cannot stat".
+        #
+        # Pre-build `:bins` (the filegroup whose DefaultInfo lists exactly
+        # the binaries + sha256 files) with `toplevel` so those land on
+        # local disk first; the subsequent `bazel run :release` cps from
+        # those already-materialized paths and doesn't need a broader
+        # download policy.
         run: |
           mkdir -p upload_root/assets
+          bazel build --config=release --config=ci --remote_download_outputs=toplevel \
+            //crates/aspect-launcher:bins \
+            //crates/aspect-cli:bins \
+            //crates/axl-docgen:bins
           bazel run --config=release --config=ci //crates/aspect-launcher:release -- "${PWD}/upload_root/assets"
           bazel run --config=release --config=ci //crates/aspect-cli:release -- "${PWD}/upload_root/assets"
           bazel run --config=release --config=ci //crates/axl-docgen:release -- "${PWD}/upload_root/assets"


### PR DESCRIPTION
## Diagnosis

The release-artifact workflow has been failing on:

```
Copying bazel-out/k8-opt/bin/crates/axl-docgen/axl-docgen-aarch64-apple-darwin to …/upload_root/assets
Copying bazel-out/k8-opt/bin/crates/axl-docgen/axl-docgen-aarch64-apple-darwin.sha256 to …/upload_root/assets
cp: cannot stat 'bazel-out/k8-opt/bin/crates/axl-docgen/axl-docgen-aarch64-apple-darwin.sha256': No such file or directory
```

Chain of events:

1. `.bazelrc` sets `common:ci --remote_download_outputs="minimal"` — only top-level outputs and runfiles are downloaded; cache-hit outputs stay remote-only.
2. The genrule built by [`//bazel/release:release.bzl`](bazel/release/release.bzl) emits a `release.sh` that `cp`s bazel-out paths directly. It doesn't list the binaries / .sha256 as runfiles, so `bazel run :release` has no reason to download them.
3. **aspect-launcher / aspect-cli are stamped** (`version_key = "STABLE_MONOREPO_VERSION"`) → unique action key per build → local execution → outputs materialize on disk.
4. **axl-docgen is unstamped** → reproducible content → its small `hashes` actions land in the remote cache → with `minimal` they're never pulled down → `cp` fails.

After [#1026 (axl-docgen as a release artifact)](https://github.com/aspect-build/aspect-cli/pull/1026) the workflow started invoking the `axl-docgen:release` step and the latent issue surfaced.

## Fix

Pre-build the `:bins` filegroup for each crate with `--remote_download_outputs=toplevel` so the binaries + sha256 files land on local disk first. The subsequent `bazel run :release` then `cp`s from those already-materialized paths without needing a broader download policy.

```yaml
bazel build --config=release --config=ci --remote_download_outputs=toplevel \
  //crates/aspect-launcher:bins //crates/aspect-cli:bins //crates/axl-docgen:bins
bazel run --config=release --config=ci //crates/aspect-launcher:release -- …
bazel run --config=release --config=ci //crates/aspect-cli:release -- …
bazel run --config=release --config=ci //crates/axl-docgen:release -- …
```

`toplevel` works here because `:bins` *is* a top-level requested target whose DefaultInfo is exactly the artifacts we need; we're not relying on transitive download from `:release`. Avoids `--remote_download_outputs=all` and its broader fetch.

## Why not restructure the release rule

Long-term, the macro should declare its referenced files as runfiles (or emit them as direct outputs) so plain `bazel run :release` would pull everything under `toplevel` automatically. That's a bigger refactor I'd file as a follow-up; this PR fixes the immediate breakage with minimal blast radius.

## Test plan

- [ ] Workflow re-run produces all three release artifacts on Linux CI.
- [ ] No regression in build cache hit rates for normal `:ci` builds (this PR only adds an extra pre-build step in the artifact workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
