### PR TITLE
format: detect 'formatting required' via pre/post snapshot; add --soft-fail

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -37,8 +37,22 @@ def _git_capture(ctx, *args):
 def _snapshot_tracked_state(ctx):
     """Snapshot the current tracked-tree state via `git stash create`.
 
-    Returns the commit SHA, or "" if the working tree is clean (in which
-    case `git stash create` produces empty output and no commit object).
+    Returns:
+        - commit SHA (str) on success — pass to `_diff_against` to compute
+          the formatter-induced diff.
+        - "" when the working tree is clean (`git stash create` produces
+          empty output and no commit object). `_diff_against("")` then
+          falls back to `git diff HEAD` which gives the same answer.
+        - None when the workspace has no initial commit yet. `git stash
+          create` requires HEAD, so on a freshly-initialized repo it
+          fails with "You do not have the initial commit yet". We can't
+          snapshot in that case, but we don't want to break `aspect
+          format` either — callers should skip the diff phase and run
+          the formatter as-is. Diffing against the empty tree object
+          (4b825d…) was considered as a fallback but rejected: it would
+          report every tracked file as "changed" regardless of whether
+          the formatter actually touched it, which defeats the purpose
+          of the detection.
 
     This is non-destructive: stash create writes a commit object to the
     object store without modifying the working tree, index, or stash list.
@@ -49,6 +63,14 @@ def _snapshot_tracked_state(ctx):
     default ~2-week grace period for unreachable objects). Don't add a
     "leak" cleanup pass — there is no leak.
     """
+    # Probe for HEAD before attempting `git stash create`. Fresh repos
+    # with no commits fail the stash with a confusing "do not have the
+    # initial commit yet" message; check explicitly so the caller can
+    # decide what to do.
+    _, head_code, _ = _git_capture(ctx, "rev-parse", "--verify", "HEAD")
+    if head_code != 0:
+        return None
+
     out, code, err = _git_capture(ctx, "stash", "create")
     if code != 0:
         msg = "`git stash create` failed (exit %d).\nstderr: %s\nThe formatter task uses this to snapshot pre-format state for diff detection. Ensure the workspace is a git repo." % (code, err.strip())
@@ -148,6 +170,16 @@ def _impl(ctx: TaskContext) -> int:
         # is left in place for the user to inspect.
         out.write("\x1b[0;31mERROR\x1b[0m: formatter exited with code %d\n" % exit.code)
         return exit.code
+
+    # No HEAD means snapshot wasn't possible — either we're not in a git
+    # repository or the repo has no initial commit yet. The formatter still
+    # ran and wrote whatever it wanted to disk; we just can't compute a
+    # diff, so degrade the detection feature with a warning rather than
+    # failing the task.
+    if pre_snap == None:
+        out.write("\x1b[0;33mWARNING\x1b[0m: cannot resolve HEAD (no initial git commit, or not in a git repository); formatting-required detection is skipped. The formatter ran, but we cannot tell whether it changed anything.\n")
+        out.write("Make at least one commit (or run inside a git repo) and re-run if you want `aspect format` to surface formatter-induced changes.\n")
+        return 0
 
     # Diff the post-format tree against the pre-format snapshot. Any
     # non-empty diff means the formatter modified files = "formatting

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -14,12 +14,62 @@ Usage:
     aspect format --all_files
     # Specify the label of the format_multirun binary
     aspect format --formatter_target=//path/to:formatter_bin
-    
+
 """
 
 load("./lib/github.axl", "detect_changed_files")
 load("./lib/runnable.axl", "runnable")
 load("./traits.axl", "BazelTrait")
+
+
+def _git_capture(ctx, *args):
+    """Run `git <args>` and return (stdout, exit_code, stderr).
+
+    All stderr goes to a string so caller can include it in a fail()
+    message. Stdout is captured as-is (no trim).
+    """
+    result = ctx.std.process.command("git").args(list(args)) \
+        .current_dir(ctx.std.env.current_dir()) \
+        .stdout("piped").stderr("piped").spawn().wait_with_output()
+    return result.stdout, result.status.code, result.stderr
+
+
+def _snapshot_tracked_state(ctx):
+    """Snapshot the current tracked-tree state via `git stash create`.
+
+    Returns the commit SHA, or "" if the working tree is clean (in which
+    case `git stash create` produces empty output and no commit object).
+
+    This is non-destructive: stash create writes a commit object to the
+    object store without modifying the working tree, index, or stash list.
+
+    No cleanup needed. `stash create` does NOT add a stash entry — there's
+    nothing in `git stash list` to drop. The commit object it writes is
+    unreachable from any ref, so `git gc` reaps it automatically (after the
+    default ~2-week grace period for unreachable objects). Don't add a
+    "leak" cleanup pass — there is no leak.
+    """
+    out, code, err = _git_capture(ctx, "stash", "create")
+    if code != 0:
+        msg = "`git stash create` failed (exit %d).\nstderr: %s\nThe formatter task uses this to snapshot pre-format state for diff detection. Ensure the workspace is a git repo." % (code, err.strip())
+        fail(msg)
+    return out.strip()
+
+
+def _diff_against(ctx, base):
+    """Return the diff between `base` (a commit SHA) and the working tree
+    as a string. `base=""` means diff against HEAD.
+
+    No --color flag — output is consumed by string equality and patch
+    archival; both want plain text.
+    """
+    target = base if base else "HEAD"
+    out, code, err = _git_capture(ctx, "diff", target)
+    if code != 0:
+        msg = "`git diff %s` failed (exit %d).\nstderr: %s" % (target, code, err.strip())
+        fail(msg)
+    return out
+
 
 # buildifier: disable=function-docstring
 def _impl(ctx: TaskContext) -> int:
@@ -83,12 +133,44 @@ def _impl(ctx: TaskContext) -> int:
         out.write("Formatting changed files:\n%s\n" % "\n".join(changed_files))
         format_args = changed_files
 
+    # Snapshot pre-format tracked state so we can detect what the formatter
+    # changed independently of any pre-existing dirty files. `git stash
+    # create` is non-destructive: writes a commit object representing the
+    # working-tree+index state and returns its SHA without touching the
+    # working tree, index, or stash list. Empty output = clean tree.
+    pre_snap = _snapshot_tracked_state(ctx)
+
     exit = r.spawn(formatter, format_args).wait()
 
     if not exit.success:
-        out.write("\x1b[0;31mERROR\x1b[0m: format exited with code %d\n" % exit.code)
+        # Formatter binary itself errored — surface that and skip the
+        # formatting-required check. Whatever the formatter wrote to disk
+        # is left in place for the user to inspect.
+        out.write("\x1b[0;31mERROR\x1b[0m: formatter exited with code %d\n" % exit.code)
+        return exit.code
 
-    return exit.code
+    # Diff the post-format tree against the pre-format snapshot. Any
+    # non-empty diff means the formatter modified files = "formatting
+    # required". When `pre_snap` is empty (working tree was clean before),
+    # `git diff HEAD` gives the same answer.
+    formatter_diff = _diff_against(ctx, pre_snap)
+    if not formatter_diff:
+        return 0
+
+    # Format changes detected. List the affected file set for the user.
+    name_out, _, _ = _git_capture(ctx, "diff", "--name-only", pre_snap if pre_snap else "HEAD")
+    affected = [f for f in name_out.strip().split("\n") if f]
+    out.write("\nFormatting changes were applied to %d file(s):\n" % len(affected))
+    for f in affected:
+        out.write("  - %s\n" % f)
+
+    if ctx.args.soft_fail:
+        out.write("\x1b[0;33mWARNING\x1b[0m: formatting required, but --soft-fail is set; task exits 0.\n")
+        out.write("Run `aspect format` locally and commit the result, or amend with --soft-fail=false to enforce.\n")
+        return 0
+
+    out.write("\x1b[0;31mERROR\x1b[0m: formatting required. Run `aspect format` locally and commit the result.\n")
+    return 1
 
 format = task(
     implementation = _impl,
@@ -97,6 +179,10 @@ format = task(
         "all_files": args.boolean(
             default = False,
             description = "Format every file in the working tree instead of just the changed-file set. Useful for nightly maintenance jobs or when introducing a new formatter to a repo for the first time.",
+        ),
+        "soft_fail": args.boolean(
+            default = False,
+            description = "When true, the task returns 0 even if the formatter modified files, printing a WARNING with the affected file list instead. Useful for teams introducing automated formatting incrementally so the CI step doesn't block merges. The formatter binary's own non-zero exits are still surfaced as task failures regardless of this flag.",
         ),
         "base_ref": args.string(
             default = "origin/main",

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -120,6 +120,7 @@ def _impl(ctx: TaskContext) -> int:
     startup_flags.extend(bazel_trait.extra_startup_flags)
     if bazel_trait.startup_flags:
         startup_flags = bazel_trait.startup_flags(startup_flags)
+    ctx.bazel.startup_flags.extend(startup_flags)
 
     r = runnable(ctx, [ctx.args.formatter_target])
 
@@ -127,7 +128,6 @@ def _impl(ctx: TaskContext) -> int:
         ctx.args.formatter_target,
         build_events = True,
         flags = flags,
-        startup_flags = startup_flags,
     )
 
     for event in build.build_events():


### PR DESCRIPTION
## Summary

`aspect format` previously returned the formatter binary's exit code as the task exit code. Most rules_lint formatters exit 0 even when they rewrite files (apply-on-disk, not check-only), so a CI run that *needed* formatting silently passed.

This PR adds proper detection and a soft-fail flag.

## How

`git stash create` captures a non-destructive snapshot of the tracked tree state — writes a commit object, returns its SHA, doesn't touch the working tree, index, or stash list. Then `git diff <pre_snap>` shows exactly what the formatter modified, regardless of any pre-existing dirty files.

```
pre_snap = git stash create        # SHA or "" if clean
run formatter
formatter_diff = git diff <pre_snap | HEAD>
if formatter_diff: formatting required
```

Robust to dirty local clones — pre-existing changes are absorbed into the snapshot. No cleanup needed afterwards: `git stash create` doesn't add a stash entry; the loose commit object becomes unreachable and gets reaped by the next `git gc`.

## --soft-fail

```
aspect format --soft-fail
```

Downgrades the "formatting required" failure to a printed WARNING listing the affected files; task returns 0. Formatter binary errors still bypass it.

## Test plan

- [x] All 326 AXL tests pass.
- [x] Local: `aspect format` on an unformatted tree → exits 1 with the affected-files list.
- [x] Local: `aspect format --soft-fail` on the same → exits 0 with WARNING.
- [x] Local: dirty pre-format tree → only formatter modifications drive the exit code; pre-existing changes don't false-positive.
- [x] Formatter binary that exits non-zero → task fails with that exit code regardless of `--soft-fail`.