### PR TITLE
github: status-gate JSON decode + add json.try_decode runtime helper

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -2180,6 +2180,56 @@ def test_process_bes_target_completed(ctx: TaskContext, tc: int) -> int:
     return tc
 
 
+def test_json_try_decode(tc: int) -> int:
+    """Coverage for the AXL runtime's `json.try_decode` — fallible JSON decode.
+
+    Replaces the body-prefix sniff in lib/github.axl with a real fallible
+    decoder so callers can recover from malformed JSON (HTML/text gateway
+    errors, truncated bodies, partial responses) without crashing the
+    parent task.
+    """
+    # Valid JSON inputs decode normally.
+    tc = test_case(tc, json.try_decode("{}") == {}, "try_decode: empty object")
+    tc = test_case(tc, json.try_decode("[]") == [], "try_decode: empty array")
+    tc = test_case(tc, json.try_decode('{"a": 1}') == {"a": 1}, "try_decode: simple object")
+    tc = test_case(tc, json.try_decode('{"k": "v"}') == {"k": "v"}, "try_decode: string value")
+    tc = test_case(tc, json.try_decode("[1, 2, 3]") == [1, 2, 3], "try_decode: array of ints")
+    tc = test_case(tc, json.try_decode("true") == True, "try_decode: literal true")
+    tc = test_case(tc, json.try_decode("false") == False, "try_decode: literal false")
+    tc = test_case(tc, json.try_decode("42") == 42, "try_decode: bare number")
+    tc = test_case(tc, json.try_decode('"hello"') == "hello", "try_decode: bare string")
+
+    # `null` decodes to Starlark None — same value as the default-on-failure,
+    # so callers wanting to disambiguate "valid null" from "parse failed"
+    # must pass an explicit sentinel default.
+    tc = test_case(tc, json.try_decode("null") == None, "try_decode: literal null → None")
+
+    # Parse-failure inputs return None by default.
+    tc = test_case(tc, json.try_decode("") == None, "try_decode: empty string → None")
+    tc = test_case(tc, json.try_decode("not json") == None, "try_decode: plain text → None")
+    tc = test_case(tc, json.try_decode("<html>oops</html>") == None, "try_decode: HTML body → None")
+    tc = test_case(tc, json.try_decode("<!DOCTYPE html>") == None, "try_decode: HTML doctype → None")
+    tc = test_case(tc, json.try_decode("{") == None, "try_decode: truncated object → None (the case the body sniff missed)")
+    tc = test_case(tc, json.try_decode('{"a": 1') == None, "try_decode: truncated mid-object → None")
+    tc = test_case(tc, json.try_decode("[1, 2, ") == None, "try_decode: truncated mid-array → None")
+    tc = test_case(tc, json.try_decode("rate limited") == None, "try_decode: rate-limit text → None")
+
+    # Custom default returned on failure.
+    tc = test_case(tc, json.try_decode("not json", {}) == {}, "try_decode: empty-dict default on failure")
+    tc = test_case(tc, json.try_decode("not json", []) == [], "try_decode: empty-list default on failure")
+    tc = test_case(tc, json.try_decode("not json", "FAIL") == "FAIL", "try_decode: sentinel string default on failure")
+    tc = test_case(tc, json.try_decode("not json", 0) == 0, "try_decode: zero default on failure")
+
+    # Custom default ignored when input is valid (even when the parsed value
+    # equals the default). Important: try_decode does NOT replace valid
+    # parses with the default.
+    tc = test_case(tc, json.try_decode("null", "MISS") == None, "try_decode: valid null parse not replaced by default")
+    tc = test_case(tc, json.try_decode("{}", {"x": 1}) == {}, "try_decode: valid empty-object parse beats default")
+    tc = test_case(tc, json.try_decode('{"a": 1}', None) == {"a": 1}, "try_decode: valid parse with explicit None default")
+
+    return tc
+
+
 def test_canonical_label(tc: int) -> int:
     """Coverage for runnable.canonical_label — Bazel label normalization."""
     cases = [
@@ -2437,6 +2487,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_artifacts_lib(ctx, tc)
     tc = test_sarif_lib(tc)
     tc = test_file_uri_to_path(tc)
+    tc = test_json_try_decode(tc)
     tc = test_canonical_label(tc)
     tc = test_process_bes_target_completed(ctx, tc)
     tc = test_validate_role(tc)

--- a/crates/aspect-cli/src/builtins/aspect/axl_add.axl
+++ b/crates/aspect-cli/src/builtins/aspect/axl_add.axl
@@ -147,7 +147,10 @@ def fetch_latest_release(ctx: TaskContext, owner: str, repo: str) -> dict:
     if not response.body:
         fail("Empty response body from GitHub API")
 
-    return json.decode(response.body)
+    parsed = json.try_decode(response.body, None)
+    if parsed == None:
+        fail("GitHub API returned 200 but body was not valid JSON: " + response.body[:200].replace("\n", " "))
+    return parsed
 
 def fetch_release_by_tag(ctx: TaskContext, owner: str, repo: str, tag: str) -> dict:
     """Fetch a specific release by tag from GitHub API."""
@@ -162,7 +165,10 @@ def fetch_release_by_tag(ctx: TaskContext, owner: str, repo: str, tag: str) -> d
         msg = "Failed to fetch release info: HTTP " + str(response.status)
         fail(msg)
 
-    return json.decode(response.body)
+    parsed = json.try_decode(response.body, None)
+    if parsed == None:
+        fail("GitHub API returned 200 but body was not valid JSON: " + (response.body or "")[:200].replace("\n", " "))
+    return parsed
 
 def fetch_tag_as_release(ctx: TaskContext, owner: str, repo: str, tag: str) -> dict:
     """Fetch tag info and create a synthetic release object for tags without releases."""

--- a/crates/aspect-cli/src/builtins/aspect/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/github.axl
@@ -50,7 +50,10 @@ def _token_impl(ctx: TaskContext) -> int:
         print("Error: API request failed (HTTP " + str(resp.status) + "): " + resp.body)
         return 1
 
-    parsed = json.decode(resp.body)
+    parsed = json.try_decode(resp.body, None)
+    if parsed == None or "token" not in parsed:
+        print("Error: API returned 2xx but the body was not a valid token response.")
+        return 1
     print(parsed["token"])
     return 0
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -18,7 +18,11 @@ def _get_token(ctx):
     child.wait()
     if not output:
         return None
-    return json.decode(output)
+    # Use try_decode rather than json.decode — the runner socket is shared
+    # infrastructure and a stray non-JSON response (early-EOF, daemon
+    # restart, partial read) shouldn't take down the parent task. Return
+    # None to mean "couldn't auth", same as the no-output case above.
+    return json.try_decode(output, None)
 
 
 def _runner_api(ctx, token, runner_host, method, path, body = None):
@@ -36,7 +40,10 @@ def _runner_api(ctx, token, runner_host, method, path, body = None):
         return None
     if resp.status < 200 or resp.status >= 300:
         return None
-    return json.decode(resp.body) if resp.body else None
+    # try_decode → None on parse failure mirrors the "no body" branch
+    # below; both surface as a soft auth failure rather than crashing
+    # the parent task on a malformed runner-API response.
+    return json.try_decode(resp.body, None) if resp.body else None
 
 
 def _upload_artifact(ctx, path, name):

--- a/crates/aspect-cli/src/builtins/aspect/lib/deliveryd.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/deliveryd.axl
@@ -66,7 +66,13 @@ def query(ctx, endpoint, ci_host, commit_sha, workspace):
         msg = "deliveryd query failed: " + response.body
         fail(msg)
 
-    data = json.decode(response.body)
+    # try_decode + fail with a clean message — protects `aspect delivery`
+    # from a corrupted/early-truncated 2xx response from deliveryd
+    # (rare, but the daemon shares state between many concurrent
+    # deliveries, so a defensive decode here costs nothing).
+    data = json.try_decode(response.body, None)
+    if data == None:
+        fail("deliveryd /query returned 2xx but body was not valid JSON: " + (response.body or "")[:200].replace("\n", " "))
 
     targets = data.get("targets", []) or []
     # Build lookup dict by label

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -35,23 +35,32 @@ def _do_request(ctx, method, url, token, payload = None):
         return (False, 0, "transport error: " + response)
     success = response.status >= 200 and response.status < 300
     body = response.body
-    if body:
-        # Sniff the body before json.decode. GitHub normally returns JSON
-        # for both successful and documented-error responses, but transient
-        # gateway flakes (502/503/504) can come back as HTML or plain text
-        # from edge proxies. `json.decode` is unrecoverable in Starlark
-        # (no try/except), so a non-JSON body here would crash the whole
-        # task — including any task that just calls into a github lifecycle
-        # hook (e.g. status checks via the github_status_checks feature).
-        # Treat any non-JSON body as a soft failure: return success=False
-        # with the raw snippet, letting callers fall back to status-driven
-        # error paths instead of bringing down the parent task.
-        stripped = body.lstrip()
-        if not stripped or stripped[0] not in ("{", "["):
-            snippet = body[:200].replace("\n", " ")
-            return (False, response.status, "non-JSON response (status %d): %s" % (response.status, snippet))
-        body = json.decode(body)
-    return (success, response.status, body)
+    if not body:
+        return (success, response.status, body)
+
+    # 5xx responses (and any other server-side error) often come back as
+    # HTML or plain text from edge proxies / rate limiters between us
+    # and GitHub. Don't attempt to decode them — surface a transport-
+    # style error snippet so callers fall back to status-driven error
+    # paths.
+    if response.status >= 500:
+        snippet = body[:200].replace("\n", " ")
+        return (False, response.status, "upstream error (status %d): %s" % (response.status, snippet))
+
+    # 2xx success and documented 4xx error envelopes use JSON.
+    # `json.try_decode` returns a sentinel on parse failure (truncated
+    # bodies, empty strings, or anything else malformed) — without it,
+    # a malformed body would crash the parent task (no try/except in
+    # Starlark), including unrelated tasks that only touch GitHub via
+    # a lifecycle hook (e.g. `aspect test` updating a status check).
+    # The sentinel has to be distinguishable from a valid `null` parse,
+    # which would also produce None.
+    _PARSE_FAILED = struct(_parse_failed = True)
+    parsed = json.try_decode(body, _PARSE_FAILED)
+    if parsed == _PARSE_FAILED:
+        snippet = body[:200].replace("\n", " ")
+        return (False, response.status, "non-JSON response (status %d): %s" % (response.status, snippet))
+    return (success, response.status, parsed)
 
 
 # Authentication
@@ -131,7 +140,17 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
         return None
 
     if resp.status >= 200 and resp.status < 300:
-        return json.decode(resp.body)["token"]
+        # Aspect's auth endpoint returns JSON on success. Use try_decode
+        # so a malformed/empty 2xx body (rare, but possible during partial
+        # outages) doesn't crash the parent task — falls through to the
+        # _reason error path instead.
+        parsed = json.try_decode(resp.body, None)
+        if parsed != None and "token" in parsed:
+            return parsed["token"]
+        if _reason != None:
+            snippet = (resp.body or "")[:200].replace("\n", " ")
+            _reason["reason"] = "Aspect API returned 2xx but body was unusable: %s" % snippet
+        return None
 
     if _reason != None:
         if resp.status == 401:

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -36,6 +36,20 @@ def _do_request(ctx, method, url, token, payload = None):
     success = response.status >= 200 and response.status < 300
     body = response.body
     if body:
+        # Sniff the body before json.decode. GitHub normally returns JSON
+        # for both successful and documented-error responses, but transient
+        # gateway flakes (502/503/504) can come back as HTML or plain text
+        # from edge proxies. `json.decode` is unrecoverable in Starlark
+        # (no try/except), so a non-JSON body here would crash the whole
+        # task — including any task that just calls into a github lifecycle
+        # hook (e.g. status checks via the github_status_checks feature).
+        # Treat any non-JSON body as a soft failure: return success=False
+        # with the raw snippet, letting callers fall back to status-driven
+        # error paths instead of bringing down the parent task.
+        stripped = body.lstrip()
+        if not stripped or stripped[0] not in ("{", "["):
+            snippet = body[:200].replace("\n", " ")
+            return (False, response.status, "non-JSON response (status %d): %s" % (response.status, snippet))
         body = json.decode(body)
     return (success, response.status, body)
 

--- a/crates/axl-runtime/src/engine/builtins.rs
+++ b/crates/axl-runtime/src/engine/builtins.rs
@@ -521,6 +521,65 @@ fn builtins_methods(registry: &mut MethodsBuilder) {
     }
 }
 
+/// Registers the `json` namespace with `encode`, `decode`, and the
+/// fallible `try_decode`. Replaces `LibraryExtension::Json` from the
+/// Starlark stdlib (whose namespace is otherwise replaced — not merged
+/// — when a second `globals.namespace("json", ...)` call lands).
+///
+/// `try_decode` is the reason this exists: Starlark has no try/except,
+/// so a normal `json.decode` failure crashes the entire task. Any I/O
+/// boundary that decodes an untrusted body (HTTP response, subprocess
+/// output, file content from a flaky source) should use `try_decode`
+/// and check the result rather than letting a malformed input bring
+/// down the whole evaluation.
+pub fn register_json(globals: &mut GlobalsBuilder) {
+    #[starlark_module]
+    fn json_members(globals: &mut GlobalsBuilder) {
+        /// Encode a value to a JSON string. Mirrors the Starlark stdlib's
+        /// `json.encode`.
+        fn encode(#[starlark(require = pos)] x: Value) -> anyhow::Result<String> {
+            x.to_json()
+        }
+
+        /// Decode a JSON string. Raises on parse failure. Mirrors the
+        /// Starlark stdlib's `json.decode`. Use `try_decode` instead at
+        /// I/O boundaries where a malformed input would otherwise crash
+        /// the caller.
+        fn decode<'v>(
+            #[starlark(require = pos)] x: &str,
+            heap: Heap<'v>,
+        ) -> anyhow::Result<Value<'v>> {
+            Ok(heap.alloc(serde_json::from_str::<serde_json::Value>(x)?))
+        }
+
+        /// Decode a JSON string. Returns `default` (None by default) on
+        /// parse failure instead of raising. Distinguishing "parse
+        /// failed" from "valid `null` parse": both produce None unless
+        /// the caller passes a sentinel `default`.
+        ///
+        /// # Examples
+        ///
+        /// ```python
+        /// json.try_decode('{"a": 1}')        # {"a": 1}
+        /// json.try_decode("not json")        # None
+        /// json.try_decode("not json", {})    # {}
+        /// json.try_decode("null")            # None  (valid parse)
+        /// json.try_decode("null", "MISS")    # None  (still valid; not the sentinel)
+        /// ```
+        fn try_decode<'v>(
+            #[starlark(require = pos)] x: &str,
+            #[starlark(require = pos)] default: Option<Value<'v>>,
+            heap: Heap<'v>,
+        ) -> anyhow::Result<Value<'v>> {
+            match serde_json::from_str::<serde_json::Value>(x) {
+                Ok(v) => Ok(heap.alloc(v)),
+                Err(_) => Ok(default.unwrap_or_else(Value::new_none)),
+            }
+        }
+    }
+    globals.namespace("json", json_members);
+}
+
 #[starlark_module]
 pub fn register_globals(globals: &mut GlobalsBuilder) {
     const __builtins__: Builtins = Builtins;

--- a/crates/axl-runtime/src/engine/mod.rs
+++ b/crates/axl-runtime/src/engine/mod.rs
@@ -6,7 +6,7 @@ use starlark::{
 
 pub mod aspect;
 pub mod bazel;
-mod builtins;
+pub mod builtins;
 mod hash;
 mod http;
 mod std;

--- a/crates/axl-runtime/src/eval/api.rs
+++ b/crates/axl-runtime/src/eval/api.rs
@@ -13,7 +13,11 @@ pub fn get_globals() -> GlobalsBuilder {
         LibraryExtension::Debug,
         LibraryExtension::EnumType,
         LibraryExtension::Filter,
-        LibraryExtension::Json,
+        // NB: `LibraryExtension::Json` is intentionally skipped — we
+        // register a custom `json` namespace below that adds `try_decode`
+        // alongside `encode`/`decode`. Calling `globals.namespace("json",
+        // ...)` after the stdlib extension would *replace* the namespace
+        // rather than merge, so we own it here in full.
         LibraryExtension::Map,
         LibraryExtension::NamespaceType,
         LibraryExtension::Partial,
@@ -26,6 +30,7 @@ pub fn get_globals() -> GlobalsBuilder {
         LibraryExtension::StructType,
         LibraryExtension::Typing,
     ]);
+    engine::builtins::register_json(&mut globals);
     engine::register_globals(&mut globals);
     globals
 }

--- a/crates/axl-runtime/src/module/eval.rs
+++ b/crates/axl-runtime/src/module/eval.rs
@@ -214,7 +214,9 @@ pub fn get_globals() -> Globals {
         LibraryExtension::Debug,
         LibraryExtension::EnumType,
         LibraryExtension::Filter,
-        LibraryExtension::Json,
+        // NB: `LibraryExtension::Json` is intentionally skipped — we
+        // register a custom `json` namespace below that adds `try_decode`
+        // alongside `encode`/`decode`. See engine::builtins::register_json.
         LibraryExtension::Map,
         LibraryExtension::NamespaceType,
         LibraryExtension::Partial,
@@ -227,7 +229,10 @@ pub fn get_globals() -> Globals {
         LibraryExtension::StructType,
         LibraryExtension::Typing,
     ]);
-    globals.with(register_globals).build()
+    globals
+        .with(crate::engine::builtins::register_json)
+        .with(register_globals)
+        .build()
 }
 
 /// Evaluator for MODULE.aspect


### PR DESCRIPTION
## Summary

Stops `aspect test` (and any other task) from crashing when GitHub returns a non-JSON body during a `github_status_checks` lifecycle hook — caught on a real flake on aspect-cli CI run [25046275556](https://github.com/aspect-build/aspect-cli/actions/runs/25046275556) where `json.decode` raised `expected value at line 1 column 1` on a gateway-flake response and took down the test task.

## Approach

- Add a `json.try_decode(s, default)` primitive to the AXL runtime — fallible variant of `json.decode` that returns `default` on parse failure instead of raising. Starlark has no try/except, so this is the first time we can recover from a malformed JSON body without crashing the caller.
- Status-gate the decode in `lib/github.axl::_do_request`: 5xx surfaces as an opaque error (HTML/text gateway bodies never reach `json.decode`); 2xx and documented 4xx use `try_decode` with a sentinel so even a truncated 200 body returns `success=False` with a snippet rather than crashing.
- Apply the same pattern to every other call site that decoded an HTTP / socket body: `_authenticate`, `axl_add.axl` release-fetch helpers, the `aspect github token` task, `lib/circleci.axl`, `lib/deliveryd.axl::query`.

## Test plan

- [x] 677 AXL tests pass (was 652; +25 new `try_decode` cases covering valid shapes, parse failures, truncated bodies, sentinel-default semantics).
- [x] Manual smoke tests unchanged in behavior — `aspect build`, `aspect test`, `aspect lint`, `aspect delivery` all pass on the rebased branch.
- [x] CI run on this PR.
