### PR TITLE
AXL: pluralize string_list field names; keep CLI flags singular

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -27,16 +27,20 @@ build = task(
             default = ["..."],
             description = "Bazel target patterns to build. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory.",
         ),
-        "bazel_flag": args.string_list(
+        "bazel_flags": args.string_list(
+            long = "bazel-flag",
             description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
         ),
-        "bazel_startup_flag": args.string_list(
+        "bazel_startup_flags": args.string_list(
+            long = "bazel-startup-flag",
             description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
         ),
-        "bes_backend": args.string_list(
+        "bes_backends": args.string_list(
+            long = "bes-backend",
             description = "Build Event Service backend(s) to stream BEP events to. Repeat the flag to pass multiple. Translated to --bes_backend=<value> on the Bazel command.",
         ),
-        "bes_header": args.string_list(
+        "bes_headers": args.string_list(
+            long = "bes-header",
             description = "HTTP header(s) attached to BES streams (e.g. --bes-header=x-token=abc). Repeat the flag to pass multiple. Translated to --bes_header=<value> on the Bazel command.",
         ),
         "cancel": args.boolean(

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -373,14 +373,14 @@ def _delivery_impl(ctx):
     # Flags: accumulate data, then optionally transform. --remote_download_outputs=minimal
     # is mandatory for phase 1/2 (we never want to download outputs while computing shas).
     flags = ["--remote_download_outputs=minimal"]
-    flags.extend(ctx.args.bazel_flag)
+    flags.extend(ctx.args.bazel_flags)
     flags.extend(bazel_trait.extra_flags)
-    if not ctx.args.bazel_flag:
+    if not ctx.args.bazel_flags:
         flags.append("--stamp")
     if bazel_trait.flags:
         flags = bazel_trait.flags(flags)
 
-    startup_flags = list(ctx.args.bazel_startup_flag)
+    startup_flags = list(ctx.args.bazel_startup_flags)
     startup_flags.extend(bazel_trait.extra_startup_flags)
     if bazel_trait.startup_flags:
         startup_flags = bazel_trait.startup_flags(startup_flags)
@@ -449,7 +449,7 @@ def _delivery_impl(ctx):
     # the env var without templating the flag itself. Whitespace is the
     # only safe separator: Bazel's label grammar allows commas in target
     # names, so a comma-split would collide with valid labels.
-    forced_targets = list(ctx.args.force_target)
+    forced_targets = list(ctx.args.force_targets)
     env_forced = ctx.std.env.var("ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS") or ""
     for tok in env_forced.split():
         if tok and tok not in forced_targets:
@@ -723,11 +723,13 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
             default = 0,
             description = "Maximum number of targets to deliver when using --query. 0 means no limit.",
         ),
-        "bazel_flag": args.string_list(
+        "bazel_flags": args.string_list(
+            long = "bazel-flag",
             default = [],
             description = "Additional Bazel flags passed to every build phase. When unset, --stamp is added automatically; passing any --bazel-flag replaces this default, so include --bazel-flag=--stamp explicitly if you still want stamping alongside your custom flags.",
         ),
-        "bazel_startup_flag": args.string_list(
+        "bazel_startup_flags": args.string_list(
+            long = "bazel-startup-flag",
             default = [],
             description = "Additional Bazel startup flags.",
         ),
@@ -735,7 +737,8 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
             default = "",
             description = "Additional string appended to --task-key to scope change detection (task-key:salt). Useful for scoping delivery to a specific environment or pipeline variant without changing --task-key.",
         ),
-        "force_target": args.string_list(
+        "force_targets": args.string_list(
+            long = "force-target",
             default = [],
             description = "Re-deliver these targets even if they have already been delivered for this commit. Use as a break-glass override when a previous delivery needs to be repeated. Each label must already be in the resolved delivery set (from --query or positional args) — force-target only flips the change-detection skip, it does not add labels; an unmatched label hard-fails at startup so typos are caught early. The ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS env var (whitespace-separated labels) is merged in addition to this flag — convenient for CI parameter fields that don't easily template into a flag.",
         ),

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -148,7 +148,7 @@ def _impl(ctx: TaskContext) -> int:
         "--experimental_build_event_upload_strategy=local",
         "--noallow_analysis_cache_discard",
     ]
-    flags.extend(ctx.args.bazel_flag)
+    flags.extend(ctx.args.bazel_flags)
     flags.extend(bazel_trait.extra_flags)
     # Task-time flag contributors — features register hooks that need ctx.task
     # (e.g. --build_metadata=ASPECT_TASK_NAME=...) which features can't produce
@@ -159,7 +159,7 @@ def _impl(ctx: TaskContext) -> int:
     if bazel_trait.flags:
         flags = bazel_trait.flags(flags)
 
-    startup_flags = list(ctx.args.bazel_startup_flag)
+    startup_flags = list(ctx.args.bazel_startup_flags)
     startup_flags.extend(bazel_trait.extra_startup_flags)
     if bazel_trait.startup_flags:
         startup_flags = bazel_trait.startup_flags(startup_flags)
@@ -183,7 +183,7 @@ def _impl(ctx: TaskContext) -> int:
     if not formatter:
         fail("Failed to determine the formatter entrypoint.")
 
-    ignore_patterns = list(ctx.args.ignore_pattern)
+    ignore_patterns = list(ctx.args.ignore_patterns)
 
     format_args = []
     if not ctx.args.all_files:
@@ -312,7 +312,8 @@ format = task(
             default = False,
             description = "When true, the task returns 0 even if the formatter modified files, printing a WARNING with the affected file list instead. Useful for teams introducing automated formatting incrementally so the CI step doesn't block merges. The formatter binary's own non-zero exits are still surfaced as task failures regardless of this flag.",
         ),
-        "ignore_pattern": args.string_list(
+        "ignore_patterns": args.string_list(
+            long = "ignore-pattern",
             description = "Glob pattern(s) of paths to exclude from formatting. Repeat the flag to pass multiple — e.g. `--ignore-pattern='vendor/**' --ignore-pattern='**/*.generated.go'`. Patterns match against repo-relative file paths. In the default (changed-files) mode, filtered files are dropped from the file list passed to the formatter. In --all-files mode the formatter discovers files itself, so ignored files may still be rewritten on disk; in either mode, ignored files are excluded from the post-format diff used to decide whether the task fails. Useful for nested Bazel workspaces (where running the parent's formatter would stomp the child's files) and for vendored / generated directories. Pattern syntax: `*` (one segment), `**` (zero or more segments), `?` (one char); case-sensitive.",
         ),
         "upload_format_diff": args.boolean(
@@ -330,10 +331,12 @@ format = task(
             default = "//tools/format",
             description = "Bazel label of the format_multirun target (or any runnable target) to invoke as the formatter. The target is built first, then run with the changed-file list passed as positional arguments.",
         ),
-        "bazel_flag": args.string_list(
+        "bazel_flags": args.string_list(
+            long = "bazel-flag",
             description = "Additional Bazel flags forwarded to the formatter build. Repeat the flag to pass multiple — e.g. `--bazel-flag=--config=ci --bazel-flag=--keep_going`.",
         ),
-        "bazel_startup_flag": args.string_list(
+        "bazel_startup_flags": args.string_list(
+            long = "bazel-startup-flag",
             description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
         ),
     },

--- a/crates/aspect-cli/src/builtins/aspect/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/github.axl
@@ -16,8 +16,8 @@ def _token_impl(ctx: TaskContext) -> int:
         print("Error: " + github.missing_credentials_reason(ctx))
         return 1
 
-    if ctx.args.role:
-        for role in ctx.args.role:
+    if ctx.args.roles:
+        for role in ctx.args.roles:
             if not github.validate_role(role):
                 print("Error: unknown role %r, valid roles: %s" % (role, ", ".join(github.VALID_ROLES)))
                 return 1
@@ -25,8 +25,8 @@ def _token_impl(ctx: TaskContext) -> int:
     body = json.encode({"owner": owner, "repo": repo_name})
 
     url = ctx.aspect.auth.api_url + "/github/token"
-    if ctx.args.role:
-        url = url + "?roles=" + ",".join(ctx.args.role)
+    if ctx.args.roles:
+        url = url + "?roles=" + ",".join(ctx.args.roles)
 
     resp = ctx.http().post(
         url = url,
@@ -66,7 +66,8 @@ token = task(
             maximum = 1,
             description = "GitHub repository in OWNER/REPO format",
         ),
-        "role": args.string_list(
+        "roles": args.string_list(
+            long = "role",
             description = "Restrict token to specific role(s). May be specified multiple times. Valid: checks.read, checks.write, statuses.read, statuses.write, prs.read, prs.write, issues.read",
         ),
         "profile": args.string(

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -17,11 +17,11 @@ load("./environment.axl", "color_enabled")
 
 
 def _collect_bes_from_args(ctx):
-    """Collect BES sinks from CLI args (--bes_backend/--bes_header)."""
+    """Collect BES sinks from CLI args (--bes-backend/--bes-header)."""
     sinks = []
-    for bes_backend in ctx.args.bes_backend:
+    for bes_backend in ctx.args.bes_backends:
         metadata = {}
-        for bes_header in ctx.args.bes_header:
+        for bes_header in ctx.args.bes_headers:
             (k, _, v) = bes_header.partition("=")
             metadata[k] = v
         sinks.append(
@@ -38,7 +38,7 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
 
     Args:
         ctx:     TaskContext with the standard build/test args (targets,
-                 bazel_flag, bazel_startup_flag, bes_backend, bes_header,
+                 bazel_flags, bazel_startup_flags, bes_backends, bes_headers,
                  cancel, output_base). Task-specific args (e.g. build's
                  remote_executor) are not touched here — tasks can still read
                  them from `ctx.args` before/after calling this function.
@@ -61,7 +61,7 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
 
     # Flags: accumulate data, then optionally transform.
     flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))]
-    flags.extend(ctx.args.bazel_flag)
+    flags.extend(ctx.args.bazel_flags)
     flags.extend(bazel_trait.extra_flags)
     # Task-time flag contributors — features register hooks that need
     # ctx.task (e.g. --build_metadata=ASPECT_TASK_NAME=...) which features
@@ -72,7 +72,7 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
     if bazel_trait.flags:
         flags = bazel_trait.flags(flags)
 
-    startup_flags = list(ctx.args.bazel_startup_flag)
+    startup_flags = list(ctx.args.bazel_startup_flags)
     startup_flags.extend(bazel_trait.extra_startup_flags)
     if ctx.args.output_base:
         startup_flags.insert(0, "--output_base=" + ctx.args.output_base)

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -171,7 +171,7 @@ def _impl(ctx: TaskContext) -> int:
     flags = [
         "--remote_download_regex='.*AspectRulesLint.*'",
     ]
-    for aspect in ctx.args.aspect:
+    for aspect in ctx.args.aspects:
         flags.append("--aspects=" + aspect)
     if ctx.args.fix:
         flags.append("--output_groups=rules_lint_patch")
@@ -305,7 +305,8 @@ lint = task(
     implementation = _impl,
     traits = [LintTrait, BazelTrait, HealthCheckTrait],
     args = {
-        "aspect": args.string_list(
+        "aspects": args.string_list(
+            long = "aspect",
             required = True,
             description = "Bazel aspect label(s) to apply for linting (e.g. //tools/lint:linters.bzl%eslint). Repeat the flag to run multiple aspects in a single invocation. At least one aspect is required.",
         ),

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -27,16 +27,20 @@ test = task(
             default = ["..."],
             description = "Bazel target patterns to test. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory.",
         ),
-        "bazel_flag": args.string_list(
+        "bazel_flags": args.string_list(
+            long = "bazel-flag",
             description = "Additional Bazel flags forwarded to the test invocation (e.g. --bazel-flag=--config=ci --bazel-flag=--test_filter=foo). Repeat the flag to pass multiple.",
         ),
-        "bazel_startup_flag": args.string_list(
+        "bazel_startup_flags": args.string_list(
+            long = "bazel-startup-flag",
             description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
         ),
-        "bes_backend": args.string_list(
+        "bes_backends": args.string_list(
+            long = "bes-backend",
             description = "Build Event Service backend(s) to stream BEP events to. Repeat the flag to pass multiple. Translated to --bes_backend=<value> on the Bazel command.",
         ),
-        "bes_header": args.string_list(
+        "bes_headers": args.string_list(
+            long = "bes-header",
             description = "HTTP header(s) attached to BES streams (e.g. --bes-header=x-token=abc). Repeat the flag to pass multiple. Translated to --bes_header=<value> on the Bazel command.",
         ),
         "cancel": args.boolean(

--- a/crates/axl-runtime/src/engine/types/feature.rs
+++ b/crates/axl-runtime/src/engine/types/feature.rs
@@ -1429,7 +1429,10 @@ mod tests {
     fn command_name_snake_case() {
         assert_eq!(to_command_name("axl_add"), "axl-add");
         assert_eq!(to_command_name("remote_cache"), "remote-cache");
-        assert_eq!(to_command_name("bazel_startup_flag"), "bazel-startup-flag");
+        assert_eq!(
+            to_command_name("bazel_startup_flags"),
+            "bazel-startup-flags"
+        );
     }
 
     #[test]
@@ -1520,7 +1523,7 @@ mod tests {
             "foo",
             "foo_bar",
             "foo123",
-            "bazel_flag",
+            "bazel_flags",
             "remote_cache",
         ] {
             assert!(

--- a/crates/axl-runtime/tests/naming_validation.rs
+++ b/crates/axl-runtime/tests/naming_validation.rs
@@ -145,7 +145,7 @@ fn task_valid_args() {
 def _impl(ctx): pass
 T = task(implementation = _impl, args = {
     "target_pattern": args.string(),
-    "bazel_flag": args.string_list(),
+    "bazel_flags": args.string_list(),
     "dry_run": args.boolean(default = False),
 })
 "#


### PR DESCRIPTION
Perhaps a bit sweeping of a change in the last minute before GA, but now is our last chance and I really care about code readability.

Singular flags:

- **Convention*.* When each invocation contributes one value, singular-repeated is the dominant pattern: Bazel itself (--copt, --define, --test_arg, --host_jvm_args, --build_event_json_file), Docker (--env, --volume), kubectl (--label), gcc (-D, -I), ssh (-o), curl (-H/--header). Your audience IS Bazel users — match what they already type.
- **Reads correctly when repeated.** --bazel-flag=--config=remote --bazel-flag=--jobs=100 reads as "another bazel flag." --bazel-flags=--config=remote --bazel-flags=--jobs=100 reads as "these bazel flags: ..." but each invocation only contributes one value — the plural label fights the singular content. It only stops feeling weird if the flag accepts multiple values per invocation (--bazel-flags=a,b,c), and Bazel flag values contain commas/spaces, so that path is a parsing minefield.

Plural AXL parameters:

- **AXL plural is fine and standard.** The CLI-singular / config-plural split is the default in argparse (dest='bazel_flags', flag --bazel-flag), Click, Cobra, Docker Compose (volumes: vs --volume). Users won't be surprised by args.bazel_flags = [...] paired with --bazel-flag=... — that's exactly what they expect.
So:

```
# AXL — natural list assignment, plural reads correctly
def config(ctx: ConfigContext):
    ctx.tasks["build"].args.bazel_flags = ["--config=remote", "--jobs=100"]
    ctx.tasks["build"].args.bazel_startup_flags = ["--host_jvm_args=-Xmx4g"]
```

```
# CLI — singular, repeatable
aspect build \
  --bazel-flag=--config=remote \
  --bazel-flag=--jobs=100 \
  --bazel-startup-flag=--host_jvm_args=-Xmx4g \
  //...
```

## Summary

For every `args.string_list()` built-in arg, the AXL field name is now plural and the user-facing CLI flag is kept singular via the existing `long = \"...\"` override on `args.string_list()`.

The pattern (matches argparse's `dest='bazel_flags'` + `--bazel-flag`):

\`\`\`python
\"bazel_flags\": args.string_list(
    long = \"bazel-flag\",   # CLI: --bazel-flag (repeatable, singular)
    description = \"...\",
),
\`\`\`

In AXL the field reads as a list (\`ctx.args.bazel_flags = [...]\`); on the CLI users repeat \`--bazel-flag=...\` per value — matching Bazel's own convention (\`--copt\`, \`--define\`, \`--test_arg\`, \`--host_jvm_args\`).

## Renames (AXL field — CLI flag unchanged)

| Task / command | AXL field (was → now) | CLI flag (singular) |
|---|---|---|
| build, test, format, delivery | \`bazel_flag\` → \`bazel_flags\` | \`--bazel-flag\` |
| build, test, format, delivery | \`bazel_startup_flag\` → \`bazel_startup_flags\` | \`--bazel-startup-flag\` |
| build, test | \`bes_backend\` → \`bes_backends\` | \`--bes-backend\` |
| build, test | \`bes_header\` → \`bes_headers\` | \`--bes-header\` |
| format | \`ignore_pattern\` → \`ignore_patterns\` | \`--ignore-pattern\` |
| lint | \`aspect\` → \`aspects\` | \`--aspect\` |
| delivery | \`force_target\` → \`force_targets\` | \`--force-target\` |
| github token | \`role\` → \`roles\` | \`--role\` |

Read sites in \`lib/bazel_runner.axl\`, \`format.axl\`, \`delivery.axl\`, \`lint.axl\`, \`github.axl\`, and the \`bazel_runner.axl\` docstring updated. Two illustrative naming-validation tests in \`axl-runtime\` track the same shift.

## Test plan

- [x] \`bazel build //...\` — clean
- [x] \`bazel test //...\` — 26/26 pass
- [x] \`aspect <task> --help\` for build/test/format/lint/delivery/github token — every renamed flag still renders singular