### PR TITLE
Log BES sink transport failures instead of panicking

### DIFF
--- a/crates/axl-runtime/src/engine/bazel/stream_sink.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream_sink.rs
@@ -52,13 +52,15 @@ impl GrpcEventStreamSink {
         invocation_id: String,
     ) -> JoinHandle<()> {
         thread::spawn(move || {
-            rt.block_on(async {
+            match rt.block_on(async {
                 GrpcEventStreamSink::task_spawn(recv, endpoint, headers, invocation_id)
                     .await
                     .await
-            })
-            .expect("failed to join")
-            .expect("failed to wait")
+            }) {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => tracing::warn!("gRPC BES sink failed: {}", err),
+                Err(err) => tracing::warn!("gRPC BES sink task failed to join: {}", err),
+            }
         })
     }
 
@@ -179,5 +181,43 @@ impl GrpcEventStreamSink {
             .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+
+    use crate::engine::r#async::rt::AsyncRuntime;
+
+    use super::*;
+
+    fn closed_endpoint() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = format!("https://{}", listener.local_addr().unwrap());
+        drop(listener);
+        endpoint
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn grpc_sink_transport_errors_do_not_panic_sink_thread() {
+        let (_sender, recv) = std::sync::mpsc::channel::<BuildEvent>();
+
+        let handle = GrpcEventStreamSink::spawn(
+            AsyncRuntime::new(),
+            recv,
+            closed_endpoint(),
+            HashMap::new(),
+            "test-invocation-id".to_string(),
+        );
+
+        let join_result = tokio::task::spawn_blocking(move || handle.join())
+            .await
+            .unwrap();
+
+        assert!(
+            join_result.is_ok(),
+            "gRPC sink transport errors should not panic the sink thread"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- stop panicking the background BES sink thread when the gRPC task returns a transport error or join error
- log those sink failures as warnings so the primary Aspect CLI process does not abort with exit 134
- add a focused regression under the existing `//crates/axl-runtime:axl-runtime-unit-tests` target

## Why
A transient BES transport failure such as tonic/h2 `Unavailable` was returned from the sink task, then unwrapped by `expect("failed to wait")` in the sink thread. That turned an auxiliary sink failure into a process panic.

This PR intentionally does not add retry/resume behavior; it is the minimal surgery fix for the panic.

## Validation
- cargo fmt --check
- cargo test -p axl-runtime grpc_sink_transport_errors_do_not_panic_sink_thread
- cargo test -p axl-runtime
- bazel test //crates/axl-runtime:axl-runtime-unit-tests --test_filter=grpc_sink_transport_errors_do_not_panic_sink_thread

Red check: temporarily restored the old `expect("failed to wait")` behavior and confirmed the new test fails with `ClientError(Status { code: Unavailable, message: "tcp connect error", ... })`.