### PR TITLE
axl/docs: bug fixes, doc cleanup, dead-code removal

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -48,7 +48,7 @@ def test_env(ctx: TaskContext, tc: int, temp_dir: str) -> int:
 
     # Test var for existing and non-existing variables
     path_var = ctx.std.env.var("PATH")
-    tc = test_case(tc, path_var != None and path_var != "", "PATH environment variable should exist and by non-empty")
+    tc = test_case(tc, path_var != None and path_var != "", "PATH environment variable should exist and be non-empty")
     tc = test_case(tc, type(path_var) == "string", "PATH should be a string")
     no_var = ctx.std.env.var("NO_SUCH_VAR_12345")
     tc = test_case(tc, no_var == None, "Non-existent variable should return None")
@@ -2439,7 +2439,7 @@ def impl(ctx: TaskContext) -> int:
 
     # Test aspect_cli_version (on CI only)
     if ctx.std.env.var("CI"):
-        print("CI enviroment detected")
+        print("CI environment detected")
         tc = test_case(tc, ctx.std.env.aspect_cli_version() == "0.0.0-dev", "aspect-cli version should be 0.0.0-dev")
         tc = test_case(tc, ctx.std.env.var("ASPECT_LAUNCHER") == "true", "ASPECT_LAUNCHER should be true")
         tc = test_case(tc, ctx.std.env.var("ASPECT_LAUNCHER_VERSION") == "0.0.0-dev", "ASPECT_LAUNCHER_VERSION should be 0.0.0-dev")
@@ -2451,7 +2451,7 @@ def impl(ctx: TaskContext) -> int:
         tc = test_case(tc, ctx.std.env.var("ASPECT_LAUNCHER_ASPECT_CLI_RELEASE") == None, "ASPECT_LAUNCHER_ASPECT_CLI_RELEASE should be None")
         tc = test_case(tc, ctx.std.env.var("ASPECT_LAUNCHER_ASPECT_CLI_ARTIFACT") == None, "ASPECT_LAUNCHER_ASPECT_CLI_ARTIFACT should be None")
     else:
-        print("local enviroment detected")
+        print("local environment detected")
         print("ASPECT_LAUNCHER_VERSION", ctx.std.env.var("ASPECT_LAUNCHER_VERSION"))
         print("ASPECT_LAUNCHER_ASPECT_CLI_METHOD", ctx.std.env.var("ASPECT_LAUNCHER_ASPECT_CLI_METHOD"))
         print("ASPECT_LAUNCHER_ASPECT_CLI_PATH", ctx.std.env.var("ASPECT_LAUNCHER_ASPECT_CLI_PATH"))

--- a/.aspect/modules/dev/lib/tui.axl
+++ b/.aspect/modules/dev/lib/tui.axl
@@ -11,7 +11,7 @@ def _fancy_tui(ctx: TaskContext, build: bazel.build.Build) -> int:
             print("\033[1A" * (last_drawn_lines) + "\033[J\033[1A")
 
     rate = 60
-    tick_ms = 1000 // 60
+    tick_ms = 1000 // rate
 
     for timer in sleep_iter(tick_ms):
         event = events.try_pop()
@@ -22,7 +22,8 @@ def _fancy_tui(ctx: TaskContext, build: bazel.build.Build) -> int:
 
             elif event.kind == "target_completed":
                 start = in_flight.pop(event.id.label, None)
-                print("Built {} in {} ticks".format(event.id.label, (timer - start)))
+                if start != None:
+                    print("Built {} in {} ticks".format(event.id.label, timer - start))
 
             elif event.kind == "progress":
                 clear()
@@ -38,11 +39,11 @@ def _fancy_tui(ctx: TaskContext, build: bazel.build.Build) -> int:
                 exit = build.wait()
                 return exit.code
 
-        elif timer % 60 == 0 and in_flight:
+        elif timer % rate == 0 and in_flight:
             clear()
 
             for k, t in in_flight.items():
-                print("-", k, ((timer - t) // 60))
+                print("-", k, ((timer - t) // rate))
 
             last_drawn_lines = len(in_flight)
             offset = (offset + 1) % len(in_flight)

--- a/crates/aspect-cli/src/builtins/aspect/axl_add.axl
+++ b/crates/aspect-cli/src/builtins/aspect/axl_add.axl
@@ -307,9 +307,11 @@ def _impl(ctx: TaskContext) -> int:
     # Clear progress display for confirmation
     clear_progress(ctx, len(phases) + 1)
 
-    # Get author info from release
-    author_login = release["author"]["login"] if "author" in release else "unknown"
-    author_url = release["author"]["html_url"] if "author" in release else ""
+    # Get author info from release. fetch_tag_as_release() returns a synthetic
+    # release with only `login`, so html_url may be absent — use .get() defaults.
+    author = release.get("author") or {}
+    author_login = author.get("login", "unknown")
+    author_url = author.get("html_url", "")
 
     # Confirmation (only for latest version, unless --yes flag is set)
     if version == "latest" and not ctx.args.yes:

--- a/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
@@ -517,7 +517,7 @@ ArtifactUpload = feature(
             values = ["none", "failed", "executed", "all"],
             description = "Which test logs to upload as artifacts. " +
                           "'none' (default) uploads nothing. 'failed' uploads " +
-                          "only non-passing tests. 'executed' uploads every test" +
+                          "only non-passing tests. 'executed' uploads every test " +
                           "that ran (skips cached passes). 'all' uploads everything.",
         ),
         "upload_profile": args.boolean(

--- a/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
@@ -60,7 +60,7 @@ def _default_bazel_behavior(ctx: FeatureContext):
         bazel_trait.build_event_sinks.extend(bessie_sinks)
 
         if environment.ci.host == "github":
-            # Prevent github actions from reaping the JVM server at the of a job.
+            # Prevent github actions from reaping the JVM server at the end of a job.
             ctx.std.env.set_var("RUNNER_TRACKING_ID", "")
             # Here to ensure we restart the Bazel server.
             bazel_trait.extra_startup_flags.append("--host_jvm_args=-DRUNNER_TRACKING_ID=noop")

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -306,7 +306,7 @@ format = task(
         "scope": args.string(
             default = "changed",
             values = ["changed", "all"],
-            description = "Which files to format. 'changed' (default) formats only files that differ from the merge base — the GitHub PR Files API in PR contexts, otherwise `git diff <merge-base>`. 'all' lets the formatter discover files itself across the working tree (subject to its own extension coverage). Useful nightly-job mode and when introducing a new formatter to a repo for the first time.",
+            description = "Which files to format. 'changed' (default) formats only files that differ from the merge base — the GitHub PR Files API in PR contexts, otherwise `git diff <merge-base>`. 'all' lets the formatter discover files itself across the working tree (subject to its own extension coverage). Useful as a nightly-job mode and when introducing a new formatter to a repo for the first time.",
         ),
         "soft_fail": args.boolean(
             default = False,

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -260,7 +260,7 @@ def init_results():
 
     Returns:
         dict to be stored in build state and passed to process_event /
-        resolve_stderr / compute_repro / render_markdown.
+        resolve_stderr / compute_repro.
     """
     return {
         # Failed build targets (not test-related): [{label}]
@@ -940,138 +940,6 @@ def compute_repro(results):
     results["test_repro_total"] = len(test_labels)
     cmd, _ = _make_repro("test", test_labels, MAX_REPRO_CHARS)
     results["test_repro"] = cmd
-
-
-_SUMMARY_TEMPLATE = """
-{%- assign has_failures = false -%}
-{%- if results.failed_actions.size > 0 -%}{%- assign has_failures = true -%}{%- endif -%}
-{%- if results.failed_tests.size > 0 -%}{%- assign has_failures = true -%}{%- endif -%}
-{%- if results.flaky_tests.size > 0 -%}{%- assign has_failures = true -%}{%- endif -%}
-
-{%- if results.aborted %}
-> **Build aborted**{% if results.abort_reason != "" %} (`{{ results.abort_reason }}`){% endif %}{% if results.abort_description != "" %}: {{ results.abort_description }}{% endif %}
-
-{% endif -%}
-
-{%- if results.failed_actions.size > 0 %}
-### Build failures
-
-{% for action in results.failed_actions -%}
-- `{{ action.label }}` (`{{ action.mnemonic }}`){% if action.stderr_content != "" %}
-<details><summary>Error output</summary>
-<pre>{{ action.stderr_content }}</pre>
-{%- if action.stderr_truncated > 0 %}
-_{{ action.stderr_truncated }} chars truncated._
-{%- endif %}
-</details>
-{%- endif %}
-{% endfor -%}
-{%- if results.failed_actions_total > results.failed_actions.size %}
-_{{ results.failed_actions_total | minus: results.failed_actions.size }} more action(s) failed._
-{% endif -%}
-{%- if results.build_repro != "" %}
-```
-{{ results.build_repro }}
-```
-{%- endif %}
-{%- endif -%}
-
-{%- if results.failed_tests.size > 0 %}
-<details{% if results.failed_tests.size <= 20 %} open{% endif %}>
-<summary>Failed tests ({{ results.failed_test_total }})</summary>
-<pre>
-{%- for t in results.failed_tests %}
-{{ t.label }}{% if t.duration_ms_fmt != "" %} ({{ t.duration_ms_fmt }}){% endif %}{% if t.cached %} [cached]{% endif %}
-{%- endfor %}
-</pre>
-</details>
-{%- if results.test_repro != "" %}
-```
-{{ results.test_repro }}
-```
-{%- endif %}
-{% endif -%}
-
-{%- if results.flaky_tests.size > 0 %}
-<details>
-<summary>Flaky tests ({{ results.flaky_test_total }})</summary>
-<pre>
-{%- for t in results.flaky_tests %}
-{{ t.label }}{% if t.duration_ms_fmt != "" %} ({{ t.duration_ms_fmt }}){% endif %}{% if t.cached %} [cached]{% endif %}
-{%- endfor %}
-</pre>
-</details>
-{% endif -%}
-
-{%- if results.passed_test_total > 0 and results.failed_test_total == 0 and results.flaky_test_total == 0 %}
-{{ results.passed_test_total }} test target{% if results.passed_test_total > 1 %}s{% endif %} passed{% if results.cached_test_total > 0 %} ({{ results.cached_test_total }} cached){% endif %}.
-{%- elsif results.passed_test_total > 0 %}
-{{ results.passed_test_total }} test target{% if results.passed_test_total > 1 %}s{% endif %} passed{% if results.cached_test_total > 0 %} ({{ results.cached_test_total }} cached){% endif %}.
-{%- endif -%}
-
-{%- assign has_stats = false -%}
-{%- if results.executed_test_total > 0 or results.cached_test_total > 0 or results.actions_total > 0 -%}
-{%- assign has_stats = true -%}
-{%- endif -%}
-
-{%- if has_stats %}
-
----
-
-{%- if results.executed_test_total > 0 %}
-_{{ results.executed_test_total }} test target{% if results.executed_test_total > 1 %}s{% endif %} executed{% if results.executed_duration != "" %} in {{ results.executed_duration }}{% endif %}._
-{%- endif %}
-{%- if results.cached_test_total > 0 %}
-_{{ results.cached_test_total }} test target{% if results.cached_test_total > 1 %}s{% endif %} cached{% if results.cached_duration != "" %} (saved {{ results.cached_duration }}){% endif %}._
-{%- endif %}
-{%- if results.actions_total > 0 %}
-{%- if results.actions_executed > 0 %}
-_{{ results.actions_executed }} build action{% if results.actions_executed > 1 %}s{% endif %} executed{% if results.actions_cached > 0 %}, {{ results.actions_cached }} cached{% endif %}._
-{%- elsif results.actions_cached > 0 %}
-_All {{ results.actions_cached }} build action{% if results.actions_cached > 1 %}s{% endif %} (100%) cached._
-{%- endif %}
-{%- endif %}
-{%- endif -%}
-
-{%- if links.ci_label != "" or links.aspect_url != "" %}
-
----
-
-{%- if links.ci_label != "" and links.ci_url != "" %}
-[View on {{ links.ci_label }}]({{ links.ci_url }}){% if links.aspect_url != "" %} · {% endif %}
-{%- endif %}
-{%- if links.aspect_url != "" %}
-[View invocation on Aspect]({{ links.aspect_url }})
-{%- endif %}
-{%- endif -%}
-"""
-
-
-def render_markdown(ctx, results, links = None):
-    """Render a Markdown summary from accumulated results.
-
-    Args:
-        ctx:     TaskContext (for ctx.template.liquid)
-        results: dict from init_results(), updated by process_event
-        links:   optional dict with keys ci_label, ci_url, aspect_url
-                 for a footer linking to the CI job and Aspect Web UI
-
-    Returns:
-        str — Markdown suitable for a GitHub check run summary field (max 65535 chars)
-    """
-    data = dict(results)
-    # Pre-format durations so the Liquid template can render them as plain strings.
-    data["executed_duration"] = _format_duration_ms(data["executed_duration_ms"]) if data["executed_duration_ms"] > 0 else ""
-    data["cached_duration"]   = _format_duration_ms(data["cached_duration_ms"])   if data["cached_duration_ms"]   > 0 else ""
-
-    # Pre-format per-test durations (Liquid has no duration filter).
-    for t in data.get("failed_tests", []):
-        t["duration_ms_fmt"] = _format_duration_ms(t.get("duration_ms", 0)) if t.get("duration_ms", 0) > 0 else ""
-    for t in data.get("flaky_tests", []):
-        t["duration_ms_fmt"] = _format_duration_ms(t.get("duration_ms", 0)) if t.get("duration_ms", 0) > 0 else ""
-
-    links_data = links or {"ci_label": "", "ci_url": "", "aspect_url": ""}
-    return ctx.template.liquid(_SUMMARY_TEMPLATE, data = {"results": data, "links": links_data})
 
 
 _TITLE_MAX_LEN     = 160

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -82,6 +82,6 @@ def runnable(ctx, targets: list[str]) -> struct:
 
     return struct(
         event = lambda event: _process_bes(state, event),
-        determine_entrypoint = lambda event: _determine_entrypoint(state, event),
+        determine_entrypoint = lambda target: _determine_entrypoint(state, target),
         spawn = lambda entrypoint, args, capture=False: _spawn(ctx, state, entrypoint, args, capture),
     )

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -144,10 +144,11 @@ def _impl(ctx: TaskContext) -> int:
     hc_trait = ctx.traits[HealthCheckTrait]
     strategy = _STRATEGIES[ctx.args.strategy]
 
+    # 1. Health checks
     for hook in hc_trait.pre_health_check:
         hook(ctx)
 
-    # Detect changed files BEFORE lint_start hooks so features can read
+    # 2. Detect changed files BEFORE lint_start hooks so features can read
     # lint_trait.changed_files as the canonical set. Prefers the GitHub
     # PR Files API when authenticated and in a PR context (works on any
     # CI host), falling back to local `git diff <base> --unified=0`.

--- a/crates/aspect-launcher/README.md
+++ b/crates/aspect-launcher/README.md
@@ -105,8 +105,13 @@ github(
 ```starlark
 http(
     url = "https://example.com/aspect-cli-{version}-{target}",  # required
+    headers = {                                                 # optional
+        "Authorization": "Bearer <token>",
+    },
 )
 ```
+
+`headers` is forwarded on the download request — useful for authenticated mirrors or private CDNs.
 
 #### local()
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -43,7 +43,7 @@ When multiple config sources set the same trait field, last-write-wins based on 
 
 Task execution occurs when a user explicitly invokes a task (e.g., `aspect run <task>`). The runtime calls the task's `implementation` function with a `TaskContext` providing the full set of capabilities:
 
-- `ctx.attrs` — parsed CLI arguments as declared by the task
+- `ctx.args` — parsed CLI arguments as declared by the task
 - `ctx.bazel` — Bazel build, test, query, and info
 - `ctx.std.fs` — filesystem operations (read, write, copy, rename, mkdir, etc.)
 - `ctx.std.process` — subprocess execution
@@ -66,7 +66,7 @@ Any `.axl` file in `.aspect/` can define tasks. A task is declared at the top le
 
 ```python
 def _impl(ctx: TaskContext) -> int:
-    name = ctx.attrs.recipient
+    name = ctx.args.recipient
     ctx.std.io.stdout.write("Hello, " + name + "\n")
     return 0
 
@@ -77,7 +77,7 @@ greet = task(
 Say hello to someone. Defaults to the world.
 """,                               # extended text shown in --help
     implementation = _impl,
-    attrs = {
+    args = {
         "recipient": args.string(default = "world", description = "Who to greet"),
     },
     traits = [MyConfig],           # opt-in to trait types
@@ -101,7 +101,7 @@ Use `name = "explicit-name"` to override the derived command name. Command names
 
 **Group names** follow the same `[a-z][a-z0-9-]*` constraint: `group = ["axl"]`, `group = ["ci", "build"]`.
 
-**Attr names** use `snake_case` (`[a-z][a-z0-9_]*`) because they are accessed directly in Starlark as `ctx.attrs.attr_name`. CLI-typed attrs (`args.string(...)`, etc.) are automatically converted to `--kebab-flags` on the CLI: `"remote_cache"` → `--remote-cache`.
+**Arg names** use `snake_case` (`[a-z][a-z0-9_]*`) because they are accessed directly in Starlark as `ctx.args.arg_name`. CLI-typed args (`args.string(...)`, etc.) are automatically converted to `--kebab-flags` on the CLI: `"remote_cache"` → `--remote-cache`. Use `long = "explicit-name"` on the arg constructor to override the derived flag name.
 
 #### Help text fields
 
@@ -113,7 +113,7 @@ Use `name = "explicit-name"` to override the derived command name. Command names
 
 #### CLI arguments
 
-Argument types: `args.string()`, `args.int()`, `args.uint()`, `args.boolean()`, their `_list` variants, `args.positional()`, and `args.trailing_var_args()`. All support `required`, `default`, `description`, and (for scalar types) `short` for a single-character alias.
+Argument types: `args.string()`, `args.int()`, `args.uint()`, `args.boolean()`, their `_list` variants, `args.positional()`, `args.trailing_var_args()`, and `args.custom(type, default = ...)` for non-CLI/config-only values (lambdas, dicts of complex shape, etc.). Scalar/list types support `required`, `default`, `description`, `long` (kebab-flag override), and (for scalar types) `short` for a single-character alias.
 
 ### Config File
 
@@ -134,10 +134,10 @@ Features are composable behavior injectors. They run after all config files have
 ```python
 def _impl(ctx: FeatureContext):
     bazel_trait = ctx.traits[BazelTrait]
-    channels = ctx.attrs.channels   # dict set in config.axl: {"failure": "#alerts", "success": "#releases"}
+    channels = ctx.args.channels   # dict set in config.axl: {"failure": "#alerts", "success": "#releases"}
 
     def _on_build_end(task_ctx, exit_code):
-        if ctx.attrs.silent or not channels:
+        if ctx.args.silent or not channels:
             return
         event = "success" if exit_code == 0 else "failure"
         channel = channels.get(event)
@@ -148,14 +148,14 @@ def _impl(ctx: FeatureContext):
 
 SlackNotify = feature(
     implementation = _impl,
-    attrs = {
-        "channels": attr(dict[str, str], {}),  # config.axl: route outcomes to channels
+    args = {
+        "channels": args.custom(dict[str, str], default = {}),  # config.axl: route outcomes to channels
         "silent":   args.boolean(default = False, description = "Suppress notifications for this run"),
     },
 )
 ```
 
-Both config-only attrs (`attr(...)`) and CLI flags (`args.boolean(...)`, `args.string(...)`, etc.) live in a single `attrs` dict — accessed uniformly as `ctx.attrs.name` in the implementation. Config-only attrs (here, a dict) are set in `config.axl` by repo maintainers and can hold complex types; CLI-typed attrs are exposed as flags on every task subcommand so developers can pass `--silent` at invocation time. Only named flags are allowed in features — positional args are not supported.
+Both config-only args (`args.custom(...)`) and CLI flags (`args.boolean(...)`, `args.string(...)`, etc.) live in a single `args` dict — accessed uniformly as `ctx.args.name` in the implementation. Config-only args (here, a dict) are set in `config.axl` by repo maintainers and can hold complex types; CLI-typed args are exposed as flags on every task subcommand so developers can pass `--silent` at invocation time. Only named flags are allowed in features — positional args are not supported, and feature CLI args must always have a default (`required = True` is rejected).
 
 **Naming:** features must be exported as **CamelCase** (`ArtifactUpload`). This is enforced at definition time. The convention mirrors Bazel providers (`CcInfo`, `DefaultInfo`) — features are referenced as type keys (`ctx.features[ArtifactUpload]`), and CamelCase signals this role. `display_name` overrides the auto-derived Title Case heading name. The `summary` and `description` fields work identically to tasks.
 
@@ -167,9 +167,9 @@ Traits are global configuration objects shared across tasks that opt in. A trait
 
 ```python
 MyConfig = trait(
-    message = attr(str, "default value"),
-    count = attr(int, 1),
-    callback = attr(typing.Callable[[str], str], lambda s: s),
+    message = attr(str, default = "default value"),
+    count = attr(int, default = 1),
+    callback = attr(typing.Callable[[str], str], default = lambda s: s),
 )
 ```
 

--- a/docs/load.md
+++ b/docs/load.md
@@ -7,7 +7,7 @@ AXL scripts use the `load` statement to import symbols from other `.axl` files, 
 - **Relative Paths**: Start with `./` or `../` (e.g., `load("./utils.axl")`).
   - Resolved relative to the directory of the current script.
   - Supports relative loads within the repository, but prevents escaping the repository root.
-  - Supports relative relative within a module, but prevents escaping the module root.
+  - Supports relative loads within a module, but prevents escaping the module root.
 
 - **Repository/Module-Root Relative Paths**: No leading `./` or `/` (e.g., `load("path/to/script.axl")`).
   - Treated as paths starting from the repository root or module root.

--- a/examples/large_bes/.aspect/remote_key.axl
+++ b/examples/large_bes/.aspect/remote_key.axl
@@ -68,7 +68,5 @@ ac_key = task(
     name = "key",
     group = ["remote"],
     implementation = _idea_impl,
-    args = {
-        "target": args.positional()
-    }
+    args = {},
 )

--- a/examples/large_bes/.aspect/remote_run.axl
+++ b/examples/large_bes/.aspect/remote_run.axl
@@ -31,7 +31,7 @@ def _fetch_blob(cas, instance_name, digest):
 def _impl(ctx):
     cfg = remote_config(ctx)
 
-    shell_cmd = ctx.args.command if ctx.args.command else "echo it works!"
+    shell_cmd = ctx.args.command[0] if ctx.args.command else "echo it works!"
     print("[1/4] Building action...")
     print("       Command:", shell_cmd)
     cmd = remote.execution.Command(

--- a/examples/lint/TESTING.md
+++ b/examples/lint/TESTING.md
@@ -6,7 +6,7 @@ This example uses [ShellCheck](https://www.shellcheck.net/) to lint `hello.sh`.
 
 ```sh
 cd examples/lint
-cli2 lint
+aspect lint
 ```
 
 ## Producing new violations


### PR DESCRIPTION
## Summary

Sweep of all `.axl` and `.md` files for bugs, doc inconsistencies, dead code, and typos.

### Real bugs
- **`axl_add`**: `fetch_tag_as_release()` returns a synthetic release with only `{login: "unknown"}`, so `release["author"]["html_url"]` raises a KeyError when adding a tag-without-release. Guarded with `.get()`.
- **`bazel_results`**: removed dead `render_markdown` + `_SUMMARY_TEMPLATE`. The Liquid template referenced fields that don't exist on `failed_actions` entries (`action.mnemonic` singular, `action.stderr_content`, `action.stderr_truncated`); the function had zero callers and would have crashed if invoked. -134 lines.
- **`examples/large_bes/remote_run`**: positional arg yields a list, but the code passed `ctx.args.command` straight into `Command(arguments=...)`. Index `[0]` before using it.
- **`examples/large_bes/remote_key`**: dropped a dead `target` positional arg the impl never read.

### Logic / API
- **`runnable.axl`**: lambda param named `event` was actually a target label string passed to `_determine_entrypoint(state, target)` — renamed.
- **`modules/dev/lib/tui.axl`**: `rate = 60` was unused; tick-math and throttle hardcoded `60`. Wired up `rate`, and added a `None` guard so `target_completed` without a prior `target_configured` doesn't blow up the format string.

### Documentation
- **`docs/design.md`**: the doc consistently said `attrs`/`ctx.attrs` and `attrs = {...}`, but the actual API is `args`/`ctx.args`. Updated throughout. Also added `args.custom(...)` and `long =` to the argument-types list, fixed the `feature()` example (was using `attr(...)` from the trait API instead of `args.custom(...)`), and corrected the trait example to use the keyword `default =` form (`require = named` in the Rust signature).
- **`docs/load.md`**: "Supports relative relative within a module" → "Supports relative loads".
- **`aspect-launcher/README`**: documented the optional `headers` param on `http()` (already supported by the parser).
- **`examples/lint/TESTING.md`**: replaced stale `cli2 lint` with `aspect lint`.

### Typos
- Two `enviroment` in `.aspect/axl.axl`.
- "should exist and **by** non-empty" (`.aspect/axl.axl`).
- Missing space joining "every test" + "that ran" (`feature/artifacts`).
- "at the of a job" (`feature/defaults`).
- "Useful nightly-job mode" (`format.axl` description).
- `lint.axl` numbered step comments started at "3." — added 1./2.

## Test plan

- [x] `cargo build --bin aspect-cli` clean
- [x] `aspect tests axl` — 677/677 passing
- [x] `aspect dev test-template-snapshots` — 12/12 scenarios render
- [x] `aspect format --help` shows the corrected wording
