### PR TITLE
fix(launcher): throttle download progress prints on CI

### DIFF
--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -50,6 +50,9 @@ const ASPECT_LAUNCHER_METHOD_HTTP: &str = "http";
 const ASPECT_LAUNCHER_METHOD_GITHUB: &str = "github";
 const ASPECT_LAUNCHER_METHOD_LOCAL: &str = "local";
 
+/// Minimum interval between download-progress prints when running on CI.
+const CI_DOWNLOAD_PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
 async fn _download_into_cache(
     client: &Client,
     cache_entry: &PathBuf,
@@ -83,6 +86,12 @@ async fn _download_into_cache(
 
     let mut downloaded: u64 = 0;
 
+    // On CI, terminals don't process `\r` line resets so per-chunk progress
+    // is spammy. Throttle update on its own line.
+    let is_ci = var("CI").map(|v| !v.is_empty()).unwrap_or(false);
+    let download_start = std::time::Instant::now();
+    let mut last_progress = download_start;
+
     while let Some(item) = byte_stream
         .try_next()
         .await
@@ -97,22 +106,44 @@ async fn _download_into_cache(
 
         downloaded += chunk_size;
 
-        if let Some(total) = total_size {
-            let percent = ((downloaded as f64 / total as f64) * 100.0) as u64;
-            eprint!(
-                "\r{:.0} / {:.0} KB ({}%)",
-                downloaded as f64 / 1024.0,
-                total as f64 / 1024.0,
-                percent
-            );
+        if !is_ci || last_progress.elapsed() >= CI_DOWNLOAD_PROGRESS_INTERVAL {
+            let line_start = if is_ci { "" } else { "\r" };
+            let line_end = if is_ci { "\n" } else { "" };
+            if let Some(total) = total_size {
+                let percent = ((downloaded as f64 / total as f64) * 100.0) as u64;
+                eprint!(
+                    "{line_start}{:.0} / {:.0} KB ({}%){line_end}",
+                    downloaded as f64 / 1024.0,
+                    total as f64 / 1024.0,
+                    percent
+                );
+            } else {
+                eprint!("{line_start}{:.0} KB{line_end}", downloaded as f64 / 1024.0);
+            }
             io::stderr().flush().into_diagnostic()?;
-        } else {
-            eprint!("\r{:.0} KB", downloaded as f64 / 1024.0);
-            io::stderr().flush().into_diagnostic()?;
+            last_progress = std::time::Instant::now();
         }
     }
 
-    eprintln!();
+    let elapsed = download_start.elapsed();
+    let kb = downloaded as f64 / 1024.0;
+    let size_str = if kb >= 1024.0 {
+        format!("{:.1} MB", kb / 1024.0)
+    } else {
+        format!("{:.0} KB", kb)
+    };
+    let time_str = if elapsed.as_secs_f64() >= 1.0 {
+        format!("{:.1}s", elapsed.as_secs_f64())
+    } else {
+        format!("{}ms", elapsed.as_millis())
+    };
+    if is_ci {
+        eprintln!("downloaded {size_str} in {time_str}");
+    } else {
+        // \r overwrites the in-progress KB line; \x1b[K clears any stale tail
+        // when the summary is shorter than the last progress print.
+        eprintln!("\rdownloaded {size_str} in {time_str}\x1b[K");
+    }
 
     // And move it into the cache
     tokio::fs::rename(&tmp_file, &cache_entry)


### PR DESCRIPTION
## Summary
- On CI the aspect-launcher's per-chunk download progress was spammy because terminals there don't process the `\r` line-reset, so every chunk appeared on its own line.
- When `CI` is set (non-empty), throttle progress prints to at most once every 30s and emit each on its own newline-terminated line. Interactive (non-CI) behavior is unchanged.
- Threshold lives in `CI_DOWNLOAD_PROGRESS_INTERVAL` for easy tuning.
- On completion, always print a one-line summary (`downloaded <N> MB in <T>`) in both modes. This also removes a stray blank line that appeared on CI when the download finished before the 30s throttle ever fired. In non-CI the summary uses `\r\x1b[K` to overwrite the last in-progress line, so the whole download is one line of stderr.

## Test plan
Tested locally on macOS aarch64 against the real aspect-cli release.

**CI mode** (`CI=1 ./target/debug/aspect version` after `rm -rf ~/Library/Caches/aspect`):
```
downloading aspect cli version v2026.18.43 file aspect-cli-aarch64-apple-darwin
downloaded 33.5 MB in 709ms
2026.18.43
```
- No per-chunk spam (download was <30s so the throttle never fired).
- No stray blank line between the "downloading…" header and the next line.
- Summary line shows total bytes + elapsed.

**Interactive mode** (no `CI` env, real TTY):
- Single live-updating progress line during the download (per-chunk `\r`-overwriting, unchanged from before this PR).
- On completion the line is replaced in place with `downloaded 33.5 MB in 1.0s` and a newline.

**Throttle behavior under a slow download** (CI mode):
Stretched the download to ~8 minutes via a temporary 200ms-per-chunk sleep (uncommitted local scaffold) so the 30s throttle would actually fire. Output was a clean one-line-every-30s ladder ending in the summary:
```
downloading aspect cli version v2026.18.43 file aspect-cli-aarch64-apple-darwin
2304 / 34316 KB (6%)
4368 / 34316 KB (12%)
6448 / 34316 KB (18%)
8523 / 34316 KB (24%)
10592 / 34316 KB (30%)
12672 / 34316 KB (36%)
14736 / 34316 KB (42%)
16816 / 34316 KB (49%)
18891 / 34316 KB (55%)
20960 / 34316 KB (61%)
23040 / 34316 KB (67%)
25104 / 34316 KB (73%)
27184 / 34316 KB (79%)
29259 / 34316 KB (85%)
31243 / 34316 KB (91%)
32971 / 34316 KB (96%)
downloaded 33.5 MB in 507.0s
2026.18.43
```
17 progress prints over ~8.5 minutes ≈ one every 30s. Confirms throttle gate, summary final line, and no `\r` artifacts on a non-tty stream.

- [x] `cargo check -p aspect-launcher` — clean, no warnings
- [x] CI-mode smoke, fast download (no spam, no blank line, summary present)
- [x] Non-CI-mode smoke (single line, summary replaces it)
- [x] CI-mode slow download (throttle fires on the 30s cadence, summary present)
