### PR TITLE
feat: route launcher and AXL caches via env vars

### DIFF
--- a/.github/workflows/launcher-integration-tests.yaml
+++ b/.github/workflows/launcher-integration-tests.yaml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     env:
-      ASPECT_CLI_DOWNLOADER_CACHE: /tmp/aspect-launcher-ci-cache
+      ASPECT_LAUNCHER_CACHE: /tmp/aspect-launcher-ci-cache
       CARGO_TERM_COLOR: always
       # Use the workflow's GITHUB_TOKEN to avoid rate-limiting on the releases API
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
         run: |
           python3 -c "
           import os, time
-          hint_dir = '$ASPECT_CLI_DOWNLOADER_CACHE/launcher/latest'
+          hint_dir = '$ASPECT_LAUNCHER_CACHE/downloader/latest'
           for f in os.listdir(hint_dir):
               p = os.path.join(hint_dir, f)
               os.utime(p, (0, 0))  # epoch = definitely stale
@@ -119,7 +119,7 @@ jobs:
         run: |
           python3 -c "
           import os
-          hint_dir = '$ASPECT_CLI_DOWNLOADER_CACHE/launcher/latest'
+          hint_dir = '$ASPECT_LAUNCHER_CACHE/downloader/latest'
           for f in os.listdir(hint_dir):
               os.utime(os.path.join(hint_dir, f), (0, 0))
           "

--- a/crates/aspect-launcher/README.md
+++ b/crates/aspect-launcher/README.md
@@ -173,12 +173,14 @@ unavailable.
 ## Caching
 
 Downloaded binaries are cached under the system cache directory
-(`~/Library/Caches/aspect/launcher/` on macOS, `~/.cache/aspect/launcher/` on
-Linux). The cache path is derived from a SHA-256 hash of the tool name and
-source URL, so different versions coexist without conflict.
+(`~/Library/Caches/aspect/launcher/downloader/` on macOS,
+`~/.cache/aspect/launcher/downloader/` on Linux). The cache path is derived
+from a SHA-256 hash of the tool name and source URL, so different versions
+coexist without conflict.
 
-The cache location can be overridden with the `ASPECT_CLI_DOWNLOADER_CACHE`
-environment variable.
+The launcher cache root can be overridden with the `ASPECT_LAUNCHER_CACHE`
+environment variable; the launcher writes its downloader cache to
+`${ASPECT_LAUNCHER_CACHE}/downloader/`.
 
 ## Debugging
 

--- a/crates/aspect-launcher/src/cache.rs
+++ b/crates/aspect-launcher/src/cache.rs
@@ -17,13 +17,13 @@ impl AspectCache {
     }
 
     pub fn default() -> Result<AspectCache> {
-        let aspect_data_dir = match std::env::var("ASPECT_CLI_DOWNLOADER_CACHE") {
-            Ok(val) if !val.is_empty() => PathBuf::from(val).join("launcher"),
+        let aspect_data_dir = match std::env::var("ASPECT_LAUNCHER_CACHE") {
+            Ok(val) if !val.is_empty() => PathBuf::from(val).join("downloader"),
             _ => {
                 let Some(data_dir) = cache_dir() else {
                     return Err(miette!("unable to identify the user's cache directory"));
                 };
-                data_dir.join(PathBuf::from("aspect/launcher"))
+                data_dir.join(PathBuf::from("aspect/launcher/downloader"))
             }
         };
         fs::create_dir_all(&aspect_data_dir)

--- a/crates/axl-runtime/src/module/disk_store.rs
+++ b/crates/axl-runtime/src/module/disk_store.rs
@@ -15,8 +15,7 @@ use super::module::Mod;
 use super::{AxlArchiveDep, AxlLocalDep, Dep};
 
 pub struct DiskStore {
-    #[allow(unused)]
-    root: PathBuf,
+    cache_root: PathBuf,
     root_sha: String,
 }
 
@@ -66,18 +65,28 @@ impl Processor {
 }
 
 impl DiskStore {
-    pub fn new(root: PathBuf) -> Self {
+    pub fn new(repo_root: PathBuf) -> Self {
+        // Cache root resolution:
+        //   1. ASPECT_CLI_CACHE env (non-empty) → ${ASPECT_CLI_CACHE}/axl
+        //   2. fallback             → ${cache_dir()}/aspect/axl
+        // CI runners point ASPECT_CLI_CACHE at an ephemeral mount that's
+        // included in the warming archive, so the AXL deps cache survives
+        // runner reboots.
+        let cache_root = match std::env::var("ASPECT_CLI_CACHE") {
+            Ok(val) if !val.is_empty() => PathBuf::from(val).join("axl"),
+            _ => cache_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join("aspect")
+                .join("axl"),
+        };
         Self {
-            root_sha: sha256::digest(root.as_os_str().as_bytes()),
-            root,
+            root_sha: sha256::digest(repo_root.as_os_str().as_bytes()),
+            cache_root,
         }
     }
 
     fn root(&self) -> PathBuf {
-        cache_dir()
-            .unwrap_or_else(|| PathBuf::from("/tmp"))
-            .join("aspect")
-            .join("axl")
+        self.cache_root.clone()
     }
 
     pub fn deps_path(&self) -> PathBuf {


### PR DESCRIPTION
## Summary
Two coordinated env-var changes that let the Aspect Workflows warming archive capture aspect-cli's on-disk caches. Cold-bootstrapped runners will then skip re-fetching the aspect-cli binary and any external AXL repositories from GitHub.

**1. Launcher cache env rename**
- `ASPECT_CLI_DOWNLOADER_CACHE` → `ASPECT_LAUNCHER_CACHE`. The previous name was undocumented and unused, so this is a free rename.
- The launcher writes its downloads under `${ASPECT_LAUNCHER_CACHE}/downloader/` so the env var names a *launcher-wide* cache root that can grow other concerns later.
- Default fallback: `${cache_dir()}/aspect/launcher/downloader/{bin,latest}/...`.

**2. AXL module store cache env override**
- New `ASPECT_CLI_CACHE` env. When set, `DiskStore` writes to `${ASPECT_CLI_CACHE}/axl/` instead of `${cache_dir()}/aspect/axl/`.
- CAS portion stays content-addressed and byte-portable across machines; `deps/<workspace-root-sha>/` re-expands cheaply from CAS without network on a fresh runner.

## Test plan
Tested locally on macOS aarch64.

- [x] `cargo check -p aspect-launcher -p axl-runtime` — clean
- [x] `cargo test -p aspect-launcher -p axl-runtime` — 50 + 24 passing
- [x] `ASPECT_LAUNCHER_CACHE=/tmp/test-launcher-cache aspect version` populates `/tmp/test-launcher-cache/downloader/bin/aspect-cli/<sha>/aspect-cli`
- [x] Old env name `ASPECT_CLI_DOWNLOADER_CACHE=/tmp/test-old` is no longer honored — `/tmp/test-old` is not created; default cache used instead
- [x] Default fallback writes to `~/Library/Caches/aspect/launcher/downloader/`
- [x] `ASPECT_CLI_CACHE=/tmp/cli-cache` smoke (via `aspect ci warming` from the sibling PR) populates `/tmp/cli-cache/axl/{cas,deps,builtins}/...`
