### PR TITLE
fix(test/build): pass bazel stdout through to the user

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -122,6 +122,7 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
                 flags = flags,
+                inherit_stdout = True,
                 *ctx.args.targets,
             )
         else:
@@ -129,6 +130,7 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
                 flags = flags,
+                inherit_stdout = True,
                 *ctx.args.targets,
             )
 


### PR DESCRIPTION
Bazel writes the test summary ("//foo:bar PASSED in 0.1s", "Executed N out of M tests…") and `bazel run` program output to stdout. `Build::spawn` defaults `inherit_stdout=false`, so the test/build runners were sending stdout to /dev/null and users only ever saw stderr (progress redraws + INFO/ERROR). With `--test_summary=short` correctly applied, the summary still appeared to be missing.

Pass `inherit_stdout=True` from `bazel_runner.axl` for both `test` and `build` invocations.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: aspect test //...
