### PR TITLE
feat: print Aspect CLI version in Workflows runner environment info

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/defaults.axl
@@ -29,7 +29,7 @@ def _default_bazel_behavior(ctx: FeatureContext):
                 print("--- :bazel: Running bazel %s %s" % (ctx.task.name, " ".join(targets)))
 
         bazel_trait.build_start.append(_buildkite_bazel_section)
-        health_check.pre_health_check.append(lambda ctx: print_environment_info(environment))
+        health_check.pre_health_check.append(lambda ctx: print_environment_info(ctx.std, environment))
         health_check.pre_health_check.append(lambda ctx: agent_health_check(ctx, environment))
 
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
@@ -315,7 +315,7 @@ def _url_encode(s: str) -> str:
     return result
 
 
-def _print_workflows_info(env: Environment) -> None:
+def _print_workflows_info(std, env: Environment) -> None:
     """Print Workflows version and warming status."""
     if env.ci.host == "buildkite":
         print("--- :aspect: Workflows Runner Environment")
@@ -324,6 +324,7 @@ def _print_workflows_info(env: Environment) -> None:
         print("\tVersion: " + env.runner.product_version)
     if env.runner.aspect_launcher_version:
         print("\tAspect Launcher Version: " + env.runner.aspect_launcher_version)
+    print("\tAspect CLI Version: " + std.env.aspect_cli_version())
     if env.runner.ci_agent_version:
         print("\tCI Agent Version: " + env.runner.ci_agent_version)
     print("\tWarming enabled: " + ("true" if env.runner.warming_enabled else "false"))
@@ -379,14 +380,15 @@ def _print_gcp_info(env: Environment) -> None:
         print("\tCLI: 'gcloud logging read --project " + env.runner.account + " \"resource.type=gce_instance resource.labels.instance_id=" + env.runner.instance_id + " log_name=projects/" + env.runner.account + "/logs/google_metadata_script_runner\" --format=\"value(jsonPayload.message)\" --freshness=30d | tac'")
 
 
-def print_environment_info(env: Environment) -> None:
+def print_environment_info(std, env: Environment) -> None:
     """
     Print debug/diagnostic information about the runner environment.
 
     Args:
+        std: Standard context (ctx.std)
         env: Environment
     """
-    _print_workflows_info(env)
+    _print_workflows_info(std, env)
 
     if env.runner.cloud_provider == "aws":
         _print_aws_info(env)


### PR DESCRIPTION
Print the Aspect CLI version (the version of the running CLI binary, via `std.env.aspect_cli_version()`) alongside the existing Workflows runner version, Aspect Launcher version, and CI Agent version in the Workflows Information block emitted at the start of every job's pre-health-check.

To thread `std` to the print helper, `print_environment_info` and `_print_workflows_info` now take `std` as their first parameter; the caller in `defaults.axl` passes `ctx.std`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- The Workflows Information block printed at the start of each job now includes the running Aspect CLI version.

### Test plan

- Covered by existing test cases
