### PR TITLE
fix(http): bound read and connect timeouts on the runtime HTTP client

### DIFF
--- a/crates/axl-runtime/src/engine/http.rs
+++ b/crates/axl-runtime/src/engine/http.rs
@@ -43,6 +43,23 @@ pub struct Http {
     client: reqwest::Client,
 }
 
+/// Maximum gap between successive reads on a single response. Resets
+/// every time bytes arrive, so a slow-but-progressing transfer (a
+/// large artifact upload on a 1 Mbps CI link) is fine — only stalls
+/// (hung peer, dropped connection without TCP RST, half-closed
+/// socket) trip the limit. AXL feature handlers run synchronously,
+/// so a stuck request would otherwise pin the whole task.
+///
+/// We deliberately do NOT set a total `timeout(...)`: that would cap
+/// every transfer regardless of whether bytes are flowing and would
+/// regress legitimate long uploads/downloads on slow CI links.
+const DEFAULT_HTTP_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// TCP/TLS handshake ceiling. Connection setup should never take
+/// long; DNS or handshake stalls fail fast instead of waiting for
+/// the read window to expire.
+const DEFAULT_HTTP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 impl Http {
     pub fn new() -> Self {
         Self {
@@ -50,6 +67,8 @@ impl Http {
                 .user_agent("AXL-Runtime")
                 // This is the default but lets be explicit.
                 .redirect(Policy::limited(10))
+                .read_timeout(DEFAULT_HTTP_READ_TIMEOUT)
+                .connect_timeout(DEFAULT_HTTP_CONNECT_TIMEOUT)
                 .build()
                 .expect("failed to build the http client"),
         }


### PR DESCRIPTION
## Summary

`ctx.http().*` had no timeout configured on the underlying reqwest `Client`, so a hung peer (slow GitHub, broken proxy, dropped connection without TCP RST) could pin a single request indefinitely. AXL feature handlers run synchronously, so one hung request wedges the whole task.

Adds two ceilings on the runtime HTTP client:

- `DEFAULT_HTTP_READ_TIMEOUT` = **120s** — maximum gap between successive reads on a single response. Resets every time bytes arrive, so a slow-but-progressing transfer (a large artifact upload on a 1 Mbps CI link) is fine; only stalls (hung peer, dropped connection without TCP RST, half-closed socket) trip the limit.
- `DEFAULT_HTTP_CONNECT_TIMEOUT` = **15s** — TCP/TLS handshake ceiling. Independent of the read window so DNS or handshake stalls fail fast.

We deliberately do **not** set a total `timeout(...)`: that would cap every transfer regardless of progress and regress legitimate long uploads/downloads on slow CI links.

No new API surface; defaults apply to every existing caller.

---

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: n/a
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- `cargo build -p aspect-cli` clean
- `cargo test -p axl-runtime` clean (no http-specific tests exist; the change is a Client-builder configuration with no behavioural branching)
- Manual: any AXL task using `ctx.http()` continues to work; a request to an unresponsive host now errors out around the 15s (connect) or 120s (read-stall) marks instead of hanging; a long-but-progressing upload/download still completes.
