### PR TITLE
fix: forward OS shutdown signals to bazel subprocesses

### DIFF
--- a/crates/aspect-cli/Cargo.toml
+++ b/crates/aspect-cli/Cargo.toml
@@ -31,7 +31,7 @@ sha256 = "1.6.0"
 uuid = { version = "1", features = ["v4"] }
 starlark = "0.13.0"
 thiserror = "2.0.17"
-tokio = { version = "1.47.1", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.47.1", features = ["macros", "rt", "rt-multi-thread", "signal", "time"] }
 tonic = "0.14"
 tracing = "0.1.41"
 tracing-core = "0.1.34"

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -5,8 +5,10 @@ mod trace;
 mod trace_buffer;
 
 use std::process::ExitCode;
+use std::time::Duration;
 
 use aspect_telemetry::{cargo_pkg_short_version, do_not_track, send_telemetry};
+use axl_runtime::bazel_live;
 use axl_runtime::eval::{Loader, ModuleEnv, MultiPhaseEval};
 use axl_runtime::module::{AXL_ROOT_MODULE_NAME, Mod};
 use axl_runtime::module::{DiskStore, ModEvaluator};
@@ -35,6 +37,16 @@ use crate::helpers::{find_repo_root, get_default_axl_search_paths, search_source
 // TODO: create a diagram of how all this ties together.
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 async fn run() -> Result<ExitCode, anyhow::Error> {
+    // Spawn the OS shutdown-signal handler before anything else can
+    // acquire long-running resources. Catches SIGINT / SIGTERM (the
+    // signals CI runners and humans use to cancel a job), forwards
+    // SIGINT to every live bazel client subprocess registered in
+    // `bazel_live`, and force-exits aspect-cli after a grace period
+    // so we don't outlive the cancellation. Without this, a CI cancel
+    // can leave bazel clients orphaned on warm runners — they hold
+    // the JVM-server lock and block every subsequent invocation.
+    install_shutdown_handler();
+
     if !do_not_track() {
         let _ = task::spawn(send_telemetry());
     }
@@ -167,4 +179,138 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+/// Tick between successive SIGINTs when we mimic bazel's 3-SIGINT
+/// cancel protocol. Short — bazel's signal handler just needs the
+/// signal delivered; it does its own dispatching from there.
+const SIGINT_TICK: Duration = Duration::from_millis(150);
+
+/// Time we wait for bazel clients to exit after the 3-SIGINT burst
+/// before escalating to SIGKILL. 5s matches `FORCE_KILL_TIMEOUT_MS`
+/// in `axl-runtime/src/engine/bazel/cancel.rs`, which is the timeout
+/// AXL's own programmatic 3-SIGINT path uses to wait for the client
+/// to exit before SIGKILL'ing. Reusing the same number here keeps
+/// the two cancellation paths consistent.
+const SIGINT_GRACE: Duration = Duration::from_secs(5);
+
+/// Time we wait after SIGKILL for the kernel to deliver the signal
+/// and the process accounting to settle before we exit. SIGKILL
+/// can't be ignored, but on busy systems the actual termination
+/// (and reaping by init) can lag a beat. A short final wait keeps
+/// us from racing the kernel and exiting before children are gone.
+const POST_KILL_GRACE: Duration = Duration::from_secs(1);
+
+/// Total wall time between receiving the OS signal and `exit()`:
+///   3 × SIGINT_TICK    (≈ 0.45s)  — emit the 3-SIGINT burst
+///   + SIGINT_GRACE     (5s)        — wait for graceful exit
+///   + POST_KILL_GRACE  (1s)        — let SIGKILL land if needed
+///   ≈ 6.5s
+/// Well under typical CI cancel grace periods (GHA gives ~7.5s
+/// between SIGTERM and SIGKILL on cancel; Buildkite is configurable
+/// but defaults higher), and well over what bazel needs for a clean
+/// graceful cancel.
+
+/// Watch for SIGINT / SIGTERM. On first signal:
+///
+///   1. Send SIGINT to every live bazel subprocess (registered in
+///      `bazel_live`).
+///   2. Sleep `SIGINT_TICK`, send 2nd SIGINT to the same set.
+///   3. Sleep `SIGINT_TICK`, send 3rd SIGINT.
+///
+/// Bazel responds to those three SIGINTs the same way it would to
+/// three Ctrl-Cs from a terminal:
+///
+///   1st  →  graceful cancel of the running command.
+///   2nd  →  still graceful (bazel allows a short cleanup window).
+///   3rd  →  bazel calls `KillServerProcess` and hard-exits the client.
+///
+/// (See https://bazel.build/run/cancellation)
+///
+/// We then sleep `SIGINT_GRACE` to let bazel's hard exit complete,
+/// SIGKILL anything still alive, sleep `POST_KILL_GRACE`, and finally
+/// `std::process::exit(N)` — 130 for SIGINT, 143 for SIGTERM (the
+/// "killed by signal N" shell convention is 128 + N).
+///
+/// **Why force-exit instead of letting Drop and unwind do their thing:**
+/// the AXL drain loop runs on a `spawn_blocking` thread. Blocking
+/// work in there (network calls in feature handlers, Starlark
+/// evaluation, etc.) doesn't yield to the tokio scheduler, so there's
+/// no clean way to ask it to stop cooperatively. Without force-exit,
+/// a single hung handler could keep aspect-cli alive past
+/// cancellation — which is exactly the CI hang this whole module is
+/// guarding against.
+///
+/// **Relationship to AXL's own 3-SIGINT path** (`engine/bazel/cancel.rs`):
+/// that one is invoked by AXL code via `ctx.bazel.cancel()` to cancel
+/// a specific in-flight build cooperatively; this one is invoked by
+/// the *operating system* signal to aspect-cli itself. They can fire
+/// independently — if both happen, bazel just sees a flurry of SIGINTs,
+/// which it handles per its own cancellation state machine. The shared
+/// `SIGINT_GRACE` constant keeps the timeouts aligned.
+///
+/// Runs as a detached tokio task; never returns (either it terminates
+/// the process or its host runtime dies first).
+fn install_shutdown_handler() {
+    #[cfg(unix)]
+    tokio::spawn(async {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("install_shutdown_handler: failed to install SIGINT handler: {e}");
+                return;
+            }
+        };
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("install_shutdown_handler: failed to install SIGTERM handler: {e}");
+                return;
+            }
+        };
+
+        let signal_name = tokio::select! {
+            _ = sigint.recv()  => "SIGINT",
+            _ = sigterm.recv() => "SIGTERM",
+        };
+        let exit_code = if signal_name == "SIGINT" { 130 } else { 143 };
+
+        run_shutdown_sequence(signal_name, exit_code).await;
+    });
+
+    #[cfg(not(unix))]
+    {
+        tokio::spawn(async {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                run_shutdown_sequence("Ctrl+C", 130).await;
+            }
+        });
+    }
+}
+
+async fn run_shutdown_sequence(signal_name: &str, exit_code: i32) {
+    eprintln!("aspect-cli: received {signal_name}, cancelling bazel subprocesses…");
+
+    // 3-SIGINT burst — mirrors bazel's expected interactive cancel
+    // sequence, escalating to KillServerProcess on the third SIGINT.
+    bazel_live::signal_all_for_shutdown();
+    tokio::time::sleep(SIGINT_TICK).await;
+    bazel_live::signal_all_for_shutdown();
+    tokio::time::sleep(SIGINT_TICK).await;
+    bazel_live::signal_all_for_shutdown();
+
+    // Wait for bazel clients to wind down on their own.
+    tokio::time::sleep(SIGINT_GRACE).await;
+
+    // Anything still alive after the grace window gets SIGKILL.
+    let killed = bazel_live::force_kill_all_remaining();
+    if killed > 0 {
+        eprintln!("aspect-cli: SIGKILL'd {killed} bazel subprocess(es) that didn't exit");
+        tokio::time::sleep(POST_KILL_GRACE).await;
+    }
+
+    eprintln!("aspect-cli: exiting with code {exit_code}");
+    std::process::exit(exit_code);
 }

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -270,17 +270,32 @@ fn install_shutdown_handler() {
                 return;
             }
         };
+        // If SIGTERM install fails, fall back to SIGINT-only — do NOT return.
+        // Per tokio's docs, dropping a `Signal` stream does not uninstall the
+        // OS-level handler, so returning here would leave SIGINT registered
+        // with no listener: tokio would swallow Ctrl-C and aspect-cli would
+        // appear unkillable except via an external SIGKILL — exactly the hang
+        // this whole module exists to prevent.
         let mut sigterm = match signal(SignalKind::terminate()) {
-            Ok(s) => s,
+            Ok(s) => Some(s),
             Err(e) => {
-                tracing::warn!("install_shutdown_handler: failed to install SIGTERM handler: {e}");
-                return;
+                tracing::warn!(
+                    "install_shutdown_handler: failed to install SIGTERM handler ({e}); \
+                     continuing with SIGINT-only shutdown"
+                );
+                None
             }
         };
 
-        let signal_name = tokio::select! {
-            _ = sigint.recv()  => "SIGINT",
-            _ = sigterm.recv() => "SIGTERM",
+        let signal_name = match sigterm.as_mut() {
+            Some(sigterm) => tokio::select! {
+                _ = sigint.recv()  => "SIGINT",
+                _ = sigterm.recv() => "SIGTERM",
+            },
+            None => {
+                sigint.recv().await;
+                "SIGINT"
+            }
         };
         let exit_code = if signal_name == "SIGINT" { 130 } else { 143 };
 

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -41,10 +41,21 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
     // acquire long-running resources. Catches SIGINT / SIGTERM (the
     // signals CI runners and humans use to cancel a job), forwards
     // SIGINT to every live bazel client subprocess registered in
-    // `bazel_live`, and force-exits aspect-cli after a grace period
-    // so we don't outlive the cancellation. Without this, a CI cancel
-    // can leave bazel clients orphaned on warm runners — they hold
-    // the JVM-server lock and block every subsequent invocation.
+    // `bazel_live`, and force-exits aspect-cli after a grace period.
+    //
+    // Without this, a CI cancel can hit bazel at a moment it can't
+    // gracefully recover from. Two known flakes — both rare per
+    // invocation, but bad when they fire on a warm runner:
+    //   1. *Potential sandbox-state corruption* (bazelbuild/bazel#23880):
+    //      if the bazel server is SIGKILL'd mid-sandbox-cleanup, it can
+    //      strand `_moved_trash_dir` / `sandbox_stash` in the sandbox
+    //      base. Every subsequent invocation on that runner then crashes
+    //      in `afterCommand` until runner is cleaned up.
+    //   2. *Potential orphaned bazel client*: the client outlives
+    //      aspect-cli briefly while still holding the JVM-server lock;
+    //      the next `aspect build` / `aspect test` on that runner hangs
+    //      at "Running Bazel server needs to be killed" until the
+    //      orphan exits on its own.
     install_shutdown_handler();
 
     if !do_not_track() {

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -5,8 +5,10 @@ mod trace;
 mod trace_buffer;
 
 use std::process::ExitCode;
+use std::time::Duration;
 
 use aspect_telemetry::{cargo_pkg_short_version, do_not_track, send_telemetry};
+use axl_runtime::bazel_live;
 use axl_runtime::eval::{Loader, ModuleEnv, MultiPhaseEval};
 use axl_runtime::module::{AXL_ROOT_MODULE_NAME, Mod};
 use axl_runtime::module::{DiskStore, ModEvaluator};
@@ -35,6 +37,16 @@ use crate::helpers::{find_repo_root, get_default_axl_search_paths, search_source
 // TODO: create a diagram of how all this ties together.
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 async fn run() -> Result<ExitCode, anyhow::Error> {
+    // Spawn the OS shutdown-signal handler before anything else can
+    // acquire long-running resources. Catches SIGINT / SIGTERM (the
+    // signals CI runners and humans use to cancel a job), forwards
+    // SIGINT to every live bazel client subprocess registered in
+    // `bazel_live`, and force-exits aspect-cli after a grace period
+    // so we don't outlive the cancellation. Without this, a CI cancel
+    // can leave bazel clients orphaned on warm runners — they hold
+    // the JVM-server lock and block every subsequent invocation.
+    install_shutdown_handler();
+
     if !do_not_track() {
         let _ = task::spawn(send_telemetry());
     }
@@ -174,4 +186,138 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+/// Tick between successive SIGINTs when we mimic bazel's 3-SIGINT
+/// cancel protocol. Short — bazel's signal handler just needs the
+/// signal delivered; it does its own dispatching from there.
+const SIGINT_TICK: Duration = Duration::from_millis(150);
+
+/// Time we wait for bazel clients to exit after the 3-SIGINT burst
+/// before escalating to SIGKILL. 5s matches `FORCE_KILL_TIMEOUT_MS`
+/// in `axl-runtime/src/engine/bazel/cancel.rs`, which is the timeout
+/// AXL's own programmatic 3-SIGINT path uses to wait for the client
+/// to exit before SIGKILL'ing. Reusing the same number here keeps
+/// the two cancellation paths consistent.
+const SIGINT_GRACE: Duration = Duration::from_secs(5);
+
+/// Time we wait after SIGKILL for the kernel to deliver the signal
+/// and the process accounting to settle before we exit. SIGKILL
+/// can't be ignored, but on busy systems the actual termination
+/// (and reaping by init) can lag a beat. A short final wait keeps
+/// us from racing the kernel and exiting before children are gone.
+const POST_KILL_GRACE: Duration = Duration::from_secs(1);
+
+/// Total wall time between receiving the OS signal and `exit()`:
+///   3 × SIGINT_TICK    (≈ 0.45s)  — emit the 3-SIGINT burst
+///   + SIGINT_GRACE     (5s)        — wait for graceful exit
+///   + POST_KILL_GRACE  (1s)        — let SIGKILL land if needed
+///   ≈ 6.5s
+/// Well under typical CI cancel grace periods (GHA gives ~7.5s
+/// between SIGTERM and SIGKILL on cancel; Buildkite is configurable
+/// but defaults higher), and well over what bazel needs for a clean
+/// graceful cancel.
+
+/// Watch for SIGINT / SIGTERM. On first signal:
+///
+///   1. Send SIGINT to every live bazel subprocess (registered in
+///      `bazel_live`).
+///   2. Sleep `SIGINT_TICK`, send 2nd SIGINT to the same set.
+///   3. Sleep `SIGINT_TICK`, send 3rd SIGINT.
+///
+/// Bazel responds to those three SIGINTs the same way it would to
+/// three Ctrl-Cs from a terminal:
+///
+///   1st  →  graceful cancel of the running command.
+///   2nd  →  still graceful (bazel allows a short cleanup window).
+///   3rd  →  bazel calls `KillServerProcess` and hard-exits the client.
+///
+/// (See https://bazel.build/run/cancellation)
+///
+/// We then sleep `SIGINT_GRACE` to let bazel's hard exit complete,
+/// SIGKILL anything still alive, sleep `POST_KILL_GRACE`, and finally
+/// `std::process::exit(N)` — 130 for SIGINT, 143 for SIGTERM (the
+/// "killed by signal N" shell convention is 128 + N).
+///
+/// **Why force-exit instead of letting Drop and unwind do their thing:**
+/// the AXL drain loop runs on a `spawn_blocking` thread. Blocking
+/// work in there (network calls in feature handlers, Starlark
+/// evaluation, etc.) doesn't yield to the tokio scheduler, so there's
+/// no clean way to ask it to stop cooperatively. Without force-exit,
+/// a single hung handler could keep aspect-cli alive past
+/// cancellation — which is exactly the CI hang this whole module is
+/// guarding against.
+///
+/// **Relationship to AXL's own 3-SIGINT path** (`engine/bazel/cancel.rs`):
+/// that one is invoked by AXL code via `ctx.bazel.cancel()` to cancel
+/// a specific in-flight build cooperatively; this one is invoked by
+/// the *operating system* signal to aspect-cli itself. They can fire
+/// independently — if both happen, bazel just sees a flurry of SIGINTs,
+/// which it handles per its own cancellation state machine. The shared
+/// `SIGINT_GRACE` constant keeps the timeouts aligned.
+///
+/// Runs as a detached tokio task; never returns (either it terminates
+/// the process or its host runtime dies first).
+fn install_shutdown_handler() {
+    #[cfg(unix)]
+    tokio::spawn(async {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("install_shutdown_handler: failed to install SIGINT handler: {e}");
+                return;
+            }
+        };
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("install_shutdown_handler: failed to install SIGTERM handler: {e}");
+                return;
+            }
+        };
+
+        let signal_name = tokio::select! {
+            _ = sigint.recv()  => "SIGINT",
+            _ = sigterm.recv() => "SIGTERM",
+        };
+        let exit_code = if signal_name == "SIGINT" { 130 } else { 143 };
+
+        run_shutdown_sequence(signal_name, exit_code).await;
+    });
+
+    #[cfg(not(unix))]
+    {
+        tokio::spawn(async {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                run_shutdown_sequence("Ctrl+C", 130).await;
+            }
+        });
+    }
+}
+
+async fn run_shutdown_sequence(signal_name: &str, exit_code: i32) {
+    eprintln!("aspect-cli: received {signal_name}, cancelling bazel subprocesses…");
+
+    // 3-SIGINT burst — mirrors bazel's expected interactive cancel
+    // sequence, escalating to KillServerProcess on the third SIGINT.
+    bazel_live::signal_all_for_shutdown();
+    tokio::time::sleep(SIGINT_TICK).await;
+    bazel_live::signal_all_for_shutdown();
+    tokio::time::sleep(SIGINT_TICK).await;
+    bazel_live::signal_all_for_shutdown();
+
+    // Wait for bazel clients to wind down on their own.
+    tokio::time::sleep(SIGINT_GRACE).await;
+
+    // Anything still alive after the grace window gets SIGKILL.
+    let killed = bazel_live::force_kill_all_remaining();
+    if killed > 0 {
+        eprintln!("aspect-cli: SIGKILL'd {killed} bazel subprocess(es) that didn't exit");
+        tokio::time::sleep(POST_KILL_GRACE).await;
+    }
+
+    eprintln!("aspect-cli: exiting with code {exit_code}");
+    std::process::exit(exit_code);
 }

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -169,13 +169,18 @@ pub struct Build {
     child: RefCell<Child>,
 
     /// RAII guard that registers the bazel client PID with `bazel::live`
-    /// for the lifetime of the build. Dropped when the `Build` is dropped
-    /// (typically when AXL releases its reference after `wait()`).
-    /// On OS-level shutdown signals to aspect-cli, the binary's signal
-    /// handler iterates the live registry and forwards SIGINT to each
-    /// registered client so bazel subprocesses don't outlive aspect-cli.
+    /// for the lifetime of the build. On OS-level shutdown signals to
+    /// aspect-cli, the binary's signal handler iterates the live registry
+    /// and forwards SIGINT to each registered client so bazel subprocesses
+    /// don't outlive aspect-cli.
+    ///
+    /// Wrapped in `RefCell<Option<…>>` so `wait()` / `try_wait()` can
+    /// `.take()` it the moment the child is observed exited. Otherwise the
+    /// PID stays in the registry until the Starlark `Build` object is
+    /// garbage-collected — and if the OS reuses the PID in that window,
+    /// the shutdown handler would SIGINT/SIGKILL an unrelated process.
     #[allocative(skip)]
-    _live_guard: super::live::LiveBazelGuard,
+    live_guard: RefCell<Option<super::live::LiveBazelGuard>>,
 
     #[allocative(skip)]
     span: RefCell<tracing::Span>,
@@ -387,7 +392,7 @@ impl Build {
             execlog_stream: RefCell::new(execlog_stream),
             sink_handles: RefCell::new(sink_handles),
             sink_invocation_id: RefCell::new(sink_invocation_id),
-            _live_guard: live_guard,
+            live_guard: RefCell::new(Some(live_guard)),
             span: RefCell::new(span),
         })
     }
@@ -467,10 +472,16 @@ pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
         let build = this.downcast_ref_err::<Build>().into_anyhow_result()?;
         let status = build.child.borrow_mut().try_wait()?;
         Ok(match status {
-            Some(status) => NoneOr::Other(BuildStatus {
-                success: status.success(),
-                code: status.code(),
-            }),
+            Some(status) => {
+                // Child has been reaped — release the PID registration
+                // immediately so a reused PID can't be targeted by a
+                // later shutdown-signal escalation.
+                build.live_guard.borrow_mut().take();
+                NoneOr::Other(BuildStatus {
+                    success: status.success(),
+                    code: status.code(),
+                })
+            }
             None => NoneOr::None,
         })
     }
@@ -493,6 +504,12 @@ pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
         let _enter = span.enter();
 
         let result = build.child.borrow_mut().wait()?;
+
+        // Child has been reaped — release the PID registration before any
+        // other work in this function. Otherwise the PID could be reused
+        // by the OS while we drain BES/execlog sinks, and a CI cancel in
+        // that window would target an unrelated process.
+        build.live_guard.borrow_mut().take();
 
         // Wait for BES stream to complete.
         // Note: We don't take() the stream here so that build_events() can still

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -168,6 +168,15 @@ pub struct Build {
     #[allocative(skip)]
     child: RefCell<Child>,
 
+    /// RAII guard that registers the bazel client PID with `bazel::live`
+    /// for the lifetime of the build. Dropped when the `Build` is dropped
+    /// (typically when AXL releases its reference after `wait()`).
+    /// On OS-level shutdown signals to aspect-cli, the binary's signal
+    /// handler iterates the live registry and forwards SIGINT to each
+    /// registered client so bazel subprocesses don't outlive aspect-cli.
+    #[allocative(skip)]
+    _live_guard: super::live::LiveBazelGuard,
+
     #[allocative(skip)]
     span: RefCell<tracing::Span>,
 }
@@ -297,6 +306,12 @@ impl Build {
             .spawn()
             .map_err(|e| io::Error::other(format!("failed to spawn bazel: {e}")))?;
 
+        // Register the bazel client with the live-subprocess registry so
+        // aspect-cli's OS-signal handler can forward SIGINT to it on
+        // CI cancellation. The guard is stored on `Self` and unregisters
+        // when the `Build` is dropped (after `wait()`).
+        let live_guard = super::live::register(child.id());
+
         // Now that we have the spawned child's pid, start the BES reader.
         // The child pid is the per-invocation liveness signal the BES thread
         // uses to detect aspect-build/aspect-cli#1060 — a hung post-
@@ -372,6 +387,7 @@ impl Build {
             execlog_stream: RefCell::new(execlog_stream),
             sink_handles: RefCell::new(sink_handles),
             sink_invocation_id: RefCell::new(sink_invocation_id),
+            _live_guard: live_guard,
             span: RefCell::new(span),
         })
     }

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -642,6 +642,20 @@ pub struct Build {
     #[allocative(skip)]
     child: RefCell<Child>,
 
+    /// RAII guard that registers the bazel client PID with `bazel::live`
+    /// for the lifetime of the build. On OS-level shutdown signals to
+    /// aspect-cli, the binary's signal handler iterates the live registry
+    /// and forwards SIGINT to each registered client so bazel subprocesses
+    /// don't outlive aspect-cli.
+    ///
+    /// Wrapped in `RefCell<Option<…>>` so `wait()` / `try_wait()` can
+    /// `.take()` it the moment the child is observed exited. Otherwise the
+    /// PID stays in the registry until the Starlark `Build` object is
+    /// garbage-collected — and if the OS reuses the PID in that window,
+    /// the shutdown handler would SIGINT/SIGKILL an unrelated process.
+    #[allocative(skip)]
+    live_guard: RefCell<Option<super::live::LiveBazelGuard>>,
+
     #[allocative(skip)]
     span: RefCell<tracing::Span>,
 }
@@ -764,11 +778,18 @@ impl Build {
             .spawn()
             .map_err(|e| io::Error::other(format!("failed to spawn bazel: {e}")))?;
 
-        // Pass `child.id()` (the per-invocation client pid) — the BES
-        // thread uses it to detect aspect-build/aspect-cli#1060, where a
-        // REMOTE_CACHE_EVICTED finish isn't followed by a retry. The
-        // server/daemon pid passed to galvanize stays alive across
-        // invocations and can't signal end-of-build.
+        // Register the bazel client with the live-subprocess registry so
+        // aspect-cli's OS-signal handler can forward SIGINT to it on
+        // CI cancellation. The guard is stored on `Self` and unregisters
+        // when the `Build` is dropped (after `wait()`).
+        let live_guard = super::live::register(child.id());
+
+        // Now that we have the spawned child's pid, start the BES reader.
+        // The child pid is the per-invocation liveness signal the BES thread
+        // uses to detect aspect-build/aspect-cli#1060 — a hung post-
+        // REMOTE_CACHE_EVICTED state. The server (daemon) pid passed to
+        // galvanize stays alive across invocations and cannot signal
+        // end-of-build, which is why we want a separate per-invocation pid.
         let build_event_stream = match bes_path {
             Some(p) => Some(BuildEventStream::spawn(p, pid, child.id(), file_sinks)?),
             None => None,
@@ -847,6 +868,7 @@ impl Build {
             workspace_event_stream: RefCell::new(workspace_event_stream),
             execlog_stream: RefCell::new(execlog_stream),
             sink_invocation_id: RefCell::new(sink_invocation_id),
+            live_guard: RefCell::new(Some(live_guard)),
             span: RefCell::new(span),
         })
     }
@@ -913,10 +935,16 @@ pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
         let build = this.downcast_ref_err::<Build>().into_anyhow_result()?;
         let status = build.child.borrow_mut().try_wait()?;
         Ok(match status {
-            Some(status) => NoneOr::Other(BuildStatus {
-                success: status.success(),
-                code: status.code(),
-            }),
+            Some(status) => {
+                // Child has been reaped — release the PID registration
+                // immediately so a reused PID can't be targeted by a
+                // later shutdown-signal escalation.
+                build.live_guard.borrow_mut().take();
+                NoneOr::Other(BuildStatus {
+                    success: status.success(),
+                    code: status.code(),
+                })
+            }
             None => NoneOr::None,
         })
     }
@@ -939,6 +967,12 @@ pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
         let _enter = span.enter();
 
         let result = build.child.borrow_mut().wait()?;
+
+        // Child has been reaped — release the PID registration before any
+        // other work in this function. Otherwise the PID could be reused
+        // by the OS while we drain BES/execlog sinks, and a CI cancel in
+        // that window would target an unrelated process.
+        build.live_guard.borrow_mut().take();
 
         // Wait for BES stream to complete.
         // Note: We don't take() the stream here so that build_events() can still

--- a/crates/axl-runtime/src/engine/bazel/health_check.rs
+++ b/crates/axl-runtime/src/engine/bazel/health_check.rs
@@ -78,15 +78,18 @@ struct CheckResult {
 
 /// Runs `bazel [startup_flags] --noblock_for_lock info server_pid` and returns the result.
 fn check_bazel_server(startup_flags: &[String]) -> CheckResult {
-    let output = Command::new(super::bazel_binary())
-        .args(startup_flags)
+    let mut cmd = Command::new(super::bazel_binary());
+    cmd.args(startup_flags)
         .arg("--noblock_for_lock")
         .arg("info")
         .arg("server_pid")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .stdin(Stdio::null())
-        .output();
+        .stdin(Stdio::null());
+    let output = match super::live::spawn_registered(&mut cmd) {
+        Ok((child, _guard)) => child.wait_with_output(),
+        Err(e) => Err(e),
+    };
 
     match output {
         Ok(output) => CheckResult {
@@ -121,15 +124,15 @@ fn extract_server_pid(server_pid_file: Option<&Path>) -> Option<u32> {
 
 /// Tries to determine the Bazel output base by running `bazel [startup_flags] info output_base`.
 fn get_output_base(startup_flags: &[String]) -> Option<PathBuf> {
-    let output = Command::new(super::bazel_binary())
-        .args(startup_flags)
+    let mut cmd = Command::new(super::bazel_binary());
+    cmd.args(startup_flags)
         .arg("info")
         .arg("output_base")
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .output()
-        .ok()?;
+        .stdin(Stdio::null());
+    let (child, _guard) = super::live::spawn_registered(&mut cmd).ok()?;
+    let output = child.wait_with_output().ok()?;
 
     if !output.status.success() {
         return None;

--- a/crates/axl-runtime/src/engine/bazel/info.rs
+++ b/crates/axl-runtime/src/engine/bazel/info.rs
@@ -21,10 +21,12 @@ pub fn server_info_with_startup_flags(
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
     cmd.stdin(Stdio::null());
-    let c = cmd
-        .spawn()
-        .map_err(|e| io::Error::other(format!("failed to spawn bazel: {e}")))?
-        .wait_with_output()?;
+    // `bazel info` (without --noblock_for_lock) can hang on a busy
+    // server. Register so the OS signal handler can SIGINT it on
+    // CI-cancel.
+    let (child, _guard) = super::live::spawn_registered(&mut cmd)
+        .map_err(|e| io::Error::other(format!("failed to spawn bazel: {e}")))?;
+    let c = child.wait_with_output()?;
     if !c.status.success() {
         let stderr = String::from_utf8_lossy(&c.stderr);
         let stderr = stderr.trim();
@@ -94,7 +96,8 @@ pub fn client_pid(startup_flags: &[String]) -> Option<u32> {
     cmd.stdout(Stdio::null());
     cmd.stderr(Stdio::piped());
     cmd.stdin(Stdio::null());
-    let output = cmd.output().ok()?;
+    let (child, _guard) = super::live::spawn_registered(&mut cmd).ok()?;
+    let output = child.wait_with_output().ok()?;
     // Exit code 9 means the lock is held — stderr contains the client PID.
     if output.status.code() != Some(9) {
         return None;
@@ -117,7 +120,10 @@ pub fn is_server_busy(startup_flags: &[String]) -> bool {
     cmd.stdout(Stdio::null());
     cmd.stderr(Stdio::null());
     cmd.stdin(Stdio::null());
-    matches!(cmd.output(), Ok(o) if o.status.code() == Some(9))
+    let Ok((child, _guard)) = super::live::spawn_registered(&mut cmd) else {
+        return false;
+    };
+    matches!(child.wait_with_output(), Ok(o) if o.status.code() == Some(9))
 }
 
 /// Query the server PID without blocking on the lock.
@@ -136,7 +142,8 @@ pub fn server_pid_nonblocking(startup_flags: &[String]) -> Option<u32> {
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::null());
     cmd.stdin(Stdio::null());
-    let output = cmd.output().ok()?;
+    let (child, _guard) = super::live::spawn_registered(&mut cmd).ok()?;
+    let output = child.wait_with_output().ok()?;
     if !output.status.success() {
         return None;
     }

--- a/crates/axl-runtime/src/engine/bazel/live.rs
+++ b/crates/axl-runtime/src/engine/bazel/live.rs
@@ -1,0 +1,135 @@
+//! Process-wide registry of live bazel client subprocesses.
+//!
+//! Every bazel `Command::spawn()` in this module registers the spawned
+//! child's PID via [`register`]. The returned [`LiveBazelGuard`]
+//! auto-unregisters the PID when dropped (typically when the build
+//! completes and the `Child` is dropped).
+//!
+//! On OS signal (SIGINT / SIGTERM to aspect-cli), the binary's signal
+//! handler iterates [`live_pids`] and sends SIGINT to each registered
+//! client so the bazel subprocesses don't outlive aspect-cli. Without
+//! this, a CI cancellation can leave bazel clients orphaned — they
+//! hold the JVM-server lock and block every subsequent invocation on
+//! that warm runner.
+
+use std::sync::Mutex;
+use std::sync::OnceLock;
+
+use super::process;
+
+fn registry() -> &'static Mutex<Vec<u32>> {
+    static REG: OnceLock<Mutex<Vec<u32>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Register a bazel client PID as live. The returned guard removes
+/// the PID from the registry when dropped — happens automatically
+/// when the `Child` handle owning the spawn falls out of scope.
+#[must_use = "drop the guard at the end of the bazel invocation; \
+              if you never bind it, the registry won't track the PID"]
+pub fn register(pid: u32) -> LiveBazelGuard {
+    if let Ok(mut g) = registry().lock() {
+        g.push(pid);
+    }
+    LiveBazelGuard { pid }
+}
+
+/// Spawn a `Command` and immediately register the resulting child's
+/// PID. Returns `(Child, LiveBazelGuard)`. Bind the guard to a name
+/// (typically `_guard`) for the lifetime of the subprocess —
+/// usually until `child.wait()` / `child.wait_with_output()`
+/// returns. On drop the PID is unregistered.
+///
+/// Wrapper around the standard `cmd.spawn()` flow that a CI-cancel
+/// signal handler can reach. Without registration, a hung bazel
+/// invocation won't receive the SIGINT/SIGKILL escalation when
+/// aspect-cli is told to shut down.
+pub fn spawn_registered(
+    cmd: &mut std::process::Command,
+) -> std::io::Result<(std::process::Child, LiveBazelGuard)> {
+    let child = cmd.spawn()?;
+    let guard = register(child.id());
+    Ok((child, guard))
+}
+
+/// Snapshot of currently-live bazel client PIDs. Used by the OS
+/// signal handler in `aspect-cli/src/main.rs` to forward cancellation.
+pub fn live_pids() -> Vec<u32> {
+    registry().lock().map(|g| g.clone()).unwrap_or_default()
+}
+
+/// Best-effort SIGINT to every registered bazel client. Non-blocking
+/// — this is meant to be called from a signal handler that has very
+/// little time to do work before forced exit. Idempotent — safe to
+/// call multiple times in succession to mimic bazel's 3-SIGINT
+/// cancel protocol (see [`bazel cancellation docs][1]):
+///
+///   1st SIGINT → graceful cancel of the in-flight command
+///   2nd SIGINT → still graceful; gives a short window for cleanup
+///   3rd SIGINT → triggers bazel's `KillServerProcess` and hard exit
+///
+/// [1]: https://bazel.build/run/cancellation
+pub fn signal_all_for_shutdown() {
+    for pid in live_pids() {
+        if process::is_pid_running(pid) {
+            tracing::warn!(
+                "received OS shutdown signal — sending SIGINT to live bazel client PID {pid}"
+            );
+            process::sigint(pid);
+        }
+    }
+}
+
+/// Best-effort SIGKILL to every registered bazel client that's still
+/// alive. Used as the post-grace escalation when SIGINT didn't get
+/// the client to exit. Returns the number of clients SIGKILL'd.
+pub fn force_kill_all_remaining() -> usize {
+    let mut killed = 0;
+    for pid in live_pids() {
+        if process::is_pid_running(pid) {
+            tracing::warn!(
+                "live bazel client PID {pid} did not exit after SIGINT grace — sending SIGKILL"
+            );
+            process::sigkill(pid);
+            killed += 1;
+        }
+    }
+    killed
+}
+
+/// RAII guard returned by [`register`]. Removes the PID from the
+/// registry on drop. Multiple registrations of the same PID are fine
+/// — drop removes the first matching entry.
+#[derive(Debug)]
+pub struct LiveBazelGuard {
+    pid: u32,
+}
+
+impl Drop for LiveBazelGuard {
+    fn drop(&mut self) {
+        if let Ok(mut g) = registry().lock() {
+            if let Some(idx) = g.iter().position(|p| *p == self.pid) {
+                g.swap_remove(idx);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registers_and_drops() {
+        let _g1 = register(111);
+        let _g2 = register(222);
+        let live = live_pids();
+        assert!(live.contains(&111));
+        assert!(live.contains(&222));
+        drop(_g1);
+        assert!(!live_pids().contains(&111));
+        assert!(live_pids().contains(&222));
+        drop(_g2);
+        assert!(!live_pids().contains(&222));
+    }
+}

--- a/crates/axl-runtime/src/engine/bazel/live.rs
+++ b/crates/axl-runtime/src/engine/bazel/live.rs
@@ -1,0 +1,150 @@
+//! Process-wide registry of live bazel client subprocesses.
+//!
+//! Every bazel `Command::spawn()` in this module registers the spawned
+//! child's PID via [`register`]. The returned [`LiveBazelGuard`]
+//! auto-unregisters the PID when dropped (typically when the build
+//! completes and the `Child` is dropped).
+//!
+//! On OS signal (SIGINT / SIGTERM to aspect-cli), the binary's signal
+//! handler iterates [`live_pids`] and sends SIGINT to each registered
+//! client so the bazel subprocesses don't outlive aspect-cli. Without
+//! this, a CI cancellation can leave bazel clients orphaned — they
+//! hold the JVM-server lock and block every subsequent invocation on
+//! that warm runner.
+
+use std::sync::Mutex;
+use std::sync::OnceLock;
+
+use super::process;
+
+fn registry() -> &'static Mutex<Vec<u32>> {
+    static REG: OnceLock<Mutex<Vec<u32>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Register a bazel client PID as live. The returned guard removes
+/// the PID from the registry when dropped — happens automatically
+/// when the `Child` handle owning the spawn falls out of scope.
+#[must_use = "drop the guard at the end of the bazel invocation; \
+              if you never bind it, the registry won't track the PID"]
+pub fn register(pid: u32) -> LiveBazelGuard {
+    if let Ok(mut g) = registry().lock() {
+        g.push(pid);
+    }
+    LiveBazelGuard { pid }
+}
+
+/// Spawn a `Command` and immediately register the resulting child's
+/// PID. Returns `(Child, LiveBazelGuard)`. Bind the guard to a name
+/// (typically `_guard`) for the lifetime of the subprocess —
+/// usually until `child.wait()` / `child.wait_with_output()`
+/// returns. On drop the PID is unregistered.
+///
+/// Wrapper around the standard `cmd.spawn()` flow that a CI-cancel
+/// signal handler can reach. Without registration, a hung bazel
+/// invocation won't receive the SIGINT/SIGKILL escalation when
+/// aspect-cli is told to shut down.
+pub fn spawn_registered(
+    cmd: &mut std::process::Command,
+) -> std::io::Result<(std::process::Child, LiveBazelGuard)> {
+    let child = cmd.spawn()?;
+    let guard = register(child.id());
+    Ok((child, guard))
+}
+
+/// Snapshot of currently-live bazel client PIDs. Used by the OS
+/// signal handler in `aspect-cli/src/main.rs` to forward cancellation.
+pub fn live_pids() -> Vec<u32> {
+    registry().lock().map(|g| g.clone()).unwrap_or_default()
+}
+
+/// Best-effort SIGINT to every registered bazel client. Non-blocking
+/// — this is meant to be called from a signal handler that has very
+/// little time to do work before forced exit. Idempotent — safe to
+/// call multiple times in succession to mimic bazel's 3-SIGINT
+/// cancel protocol (see [`bazel cancellation docs][1]):
+///
+///   1st SIGINT → graceful cancel of the in-flight command
+///   2nd SIGINT → still graceful; gives a short window for cleanup
+///   3rd SIGINT → triggers bazel's `KillServerProcess` and hard exit
+///
+/// [1]: https://bazel.build/run/cancellation
+pub fn signal_all_for_shutdown() {
+    for pid in live_pids() {
+        if process::is_pid_running(pid) {
+            tracing::warn!(
+                "received OS shutdown signal — sending SIGINT to live bazel client PID {pid}"
+            );
+            process::sigint(pid);
+        }
+    }
+}
+
+/// Best-effort SIGKILL to every registered bazel client that's still
+/// alive. Used as the post-grace escalation when SIGINT didn't get
+/// the client to exit. Returns the number of clients SIGKILL'd.
+pub fn force_kill_all_remaining() -> usize {
+    let mut killed = 0;
+    for pid in live_pids() {
+        if process::is_pid_running(pid) {
+            tracing::warn!(
+                "live bazel client PID {pid} did not exit after SIGINT grace — sending SIGKILL"
+            );
+            process::sigkill(pid);
+            killed += 1;
+        }
+    }
+    killed
+}
+
+/// RAII guard returned by [`register`]. Removes the PID from the
+/// registry on drop. Multiple registrations of the same PID are fine
+/// — drop removes the first matching entry.
+#[derive(Debug)]
+pub struct LiveBazelGuard {
+    pid: u32,
+}
+
+impl Drop for LiveBazelGuard {
+    fn drop(&mut self) {
+        if let Ok(mut g) = registry().lock() {
+            if let Some(idx) = g.iter().position(|p| *p == self.pid) {
+                g.swap_remove(idx);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registers_and_drops() {
+        let _g1 = register(111);
+        let _g2 = register(222);
+        let live = live_pids();
+        assert!(live.contains(&111));
+        assert!(live.contains(&222));
+        drop(_g1);
+        assert!(!live_pids().contains(&111));
+        assert!(live_pids().contains(&222));
+        drop(_g2);
+        assert!(!live_pids().contains(&222));
+    }
+
+    /// `Build` stores the guard inside `RefCell<Option<…>>` so it can
+    /// release the registration the moment the child is observed exited
+    /// (rather than waiting for the Starlark object to be GC'd). Verify
+    /// that `.take()` on the wrapped guard does in fact unregister the
+    /// PID — this is the pattern `build.rs::wait()` / `try_wait()` rely
+    /// on to keep us from SIGINT/SIGKILLing a reused PID.
+    #[test]
+    fn take_on_option_wrapped_guard_unregisters_pid() {
+        use std::cell::RefCell;
+        let cell = RefCell::new(Some(register(333)));
+        assert!(live_pids().contains(&333));
+        let _ = cell.borrow_mut().take();
+        assert!(!live_pids().contains(&333));
+    }
+}

--- a/crates/axl-runtime/src/engine/bazel/live.rs
+++ b/crates/axl-runtime/src/engine/bazel/live.rs
@@ -132,4 +132,19 @@ mod tests {
         drop(_g2);
         assert!(!live_pids().contains(&222));
     }
+
+    /// `Build` stores the guard inside `RefCell<Option<…>>` so it can
+    /// release the registration the moment the child is observed exited
+    /// (rather than waiting for the Starlark object to be GC'd). Verify
+    /// that `.take()` on the wrapped guard does in fact unregister the
+    /// PID — this is the pattern `build.rs::wait()` / `try_wait()` rely
+    /// on to keep us from SIGINT/SIGKILLing a reused PID.
+    #[test]
+    fn take_on_option_wrapped_guard_unregisters_pid() {
+        use std::cell::RefCell;
+        let cell = RefCell::new(Some(register(333)));
+        assert!(live_pids().contains(&333));
+        let _ = cell.borrow_mut().take();
+        assert!(!live_pids().contains(&333));
+    }
 }

--- a/crates/axl-runtime/src/engine/bazel/live.rs
+++ b/crates/axl-runtime/src/engine/bazel/live.rs
@@ -7,10 +7,18 @@
 //!
 //! On OS signal (SIGINT / SIGTERM to aspect-cli), the binary's signal
 //! handler iterates [`live_pids`] and sends SIGINT to each registered
-//! client so the bazel subprocesses don't outlive aspect-cli. Without
-//! this, a CI cancellation can leave bazel clients orphaned — they
-//! hold the JVM-server lock and block every subsequent invocation on
-//! that warm runner.
+//! client so the bazel subprocesses don't outlive aspect-cli.
+//!
+//! Without this, a CI cancellation can hit bazel at a moment it can't
+//! gracefully recover from. Two known flakes — both rare per
+//! invocation, but bad when they fire on a warm runner:
+//!   1. *Potential sandbox-state corruption* (bazelbuild/bazel#23880):
+//!      a SIGKILL during sandbox cleanup can strand `_moved_trash_dir`
+//!      / `sandbox_stash` in the sandbox base, and every subsequent
+//!      invocation on that runner crashes in `afterCommand`.
+//!   2. *Potential orphaned bazel client* holding the JVM-server lock:
+//!      the next invocation on that runner hangs at "Running Bazel
+//!      server needs to be killed" until the orphan exits.
 
 use std::sync::Mutex;
 use std::sync::OnceLock;

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -35,6 +35,7 @@ mod cancel;
 mod health_check;
 mod info;
 mod iter;
+pub mod live;
 mod process;
 mod query;
 mod rc;
@@ -416,9 +417,13 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::null());
         cmd.stdin(Stdio::null());
-        let output = cmd
-            .output()
+        // Register with the live-bazel registry so OS-signal cancellation
+        // can reach this `bazel info` even if the daemon is busy.
+        let (child, _guard) = live::spawn_registered(&mut cmd)
             .map_err(|e| anyhow::anyhow!("failed to spawn bazel: {}", e))?;
+        let output = child
+            .wait_with_output()
+            .map_err(|e| anyhow::anyhow!("failed to wait on bazel: {}", e))?;
 
         if !output.status.success() {
             anyhow::bail!(

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -37,6 +37,7 @@ mod cancel;
 mod health_check;
 mod info;
 mod iter;
+pub mod live;
 mod process;
 mod query;
 mod rc;
@@ -480,9 +481,13 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::null());
         cmd.stdin(Stdio::null());
-        let output = cmd
-            .output()
+        // Register with the live-bazel registry so OS-signal cancellation
+        // can reach this `bazel info` even if the daemon is busy.
+        let (child, _guard) = live::spawn_registered(&mut cmd)
             .map_err(|e| anyhow::anyhow!("failed to spawn bazel: {}", e))?;
+        let output = child
+            .wait_with_output()
+            .map_err(|e| anyhow::anyhow!("failed to wait on bazel: {}", e))?;
 
         if !output.status.success() {
             anyhow::bail!(

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -168,9 +168,13 @@ impl Query {
         cmd.stderr(Stdio::null());
         cmd.stdout(outfile);
         cmd.stdin(Stdio::null());
-        cmd.spawn()
-            .with_context(|| "failed to spawn bazel")?
-            .wait()?;
+        // Register with the live-bazel registry so a CI cancel
+        // (SIGINT/SIGTERM to aspect-cli) escalates to the bazel
+        // client. Large queries can run for many seconds; without
+        // registration they'd outlive an aborted aspect-cli.
+        let (mut child, _guard) =
+            super::live::spawn_registered(&mut cmd).with_context(|| "failed to spawn bazel")?;
+        child.wait()?;
 
         let mut buf = vec![];
         File::open(&out)?.read_to_end(&mut buf)?;

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -172,9 +172,13 @@ impl Query {
         cmd.stderr(Stdio::null());
         cmd.stdout(outfile);
         cmd.stdin(Stdio::null());
-        cmd.spawn()
-            .with_context(|| "failed to spawn bazel")?
-            .wait()?;
+        // Register with the live-bazel registry so a CI cancel
+        // (SIGINT/SIGTERM to aspect-cli) escalates to the bazel
+        // client. Large queries can run for many seconds; without
+        // registration they'd outlive an aborted aspect-cli.
+        let (mut child, _guard) =
+            super::live::spawn_registered(&mut cmd).with_context(|| "failed to spawn bazel")?;
+        child.wait()?;
 
         let mut buf = vec![];
         File::open(&out)?.read_to_end(&mut buf)?;

--- a/crates/axl-runtime/src/lib.rs
+++ b/crates/axl-runtime/src/lib.rs
@@ -6,6 +6,14 @@ pub mod eval;
 pub mod module;
 pub mod trace;
 
+/// Bazel subprocess live-tracking. Re-exported so `aspect-cli`'s
+/// signal handler can forward SIGINT / SIGTERM to in-flight bazel
+/// clients on shutdown without exposing the rest of the bazel
+/// engine internals.
+pub mod bazel_live {
+    pub use crate::engine::bazel::live::*;
+}
+
 #[cfg(test)]
 pub mod test;
 


### PR DESCRIPTION
## Problem

Two rare CI flakes, both triggered by the same precondition: a CI cancel reaches the bazel process at a moment bazel can't gracefully recover from. Listed by frequency, most common first.

1. **Potential sandbox-state corruption ([bazelbuild/bazel#23880](https://github.com/bazelbuild/bazel/issues/23880)).** If the bazel server gets killed at the wrong moment during sandbox cleanup (e.g. SIGKILL'd by the CI runner during the grace window, or killed by aspect-cli's health-check probe), it can strand `_moved_trash_dir` and `sandbox_stash` in the sandbox base. Every subsequent invocation then crashes in `afterCommand` with:

   ```
   java.lang.IllegalStateException: Found unexpected entries in sandbox base.
     The entries are: linux-sandbox, _moved_trash_dir, sandbox_stash
   ```

   That state lives on the runner's persistent disk, so once a runner enters it, every job on that runner fails the same way until a human cleans up. Rare per invocation, but the worst symptom — the runner is dead until someone notices.

2. **Potential orphaned bazel client.** aspect-cli can die on the signal before it cleanly shuts down its bazel child, or stay alive briefly (blocked in a `spawn_blocking` Starlark handler that doesn't yield to async cancellation) while the child keeps running. In the unlucky case where the orphan still holds the JVM-server lock when the next `aspect build` / `aspect test` starts on that runner, the next invocation hangs at `Running Bazel server needs to be killed`. Rarer than (1) and usually self-clears as the orphan exits on its own, but a flake when it happens.

Both modes share the same upstream cause: pre-cancellation, aspect-cli has no way to nudge bazel onto its [documented graceful-cancel path](https://bazel.build/run/cancellation) before the CI's SIGKILL deadline expires.


## Fix

Three coordinated pieces. None of them change `bazel`; they all just make sure cancellation reaches bazel via the path bazel is designed to handle.

### 1. `bazel_live` — process-wide registry of in-flight bazel clients

[`crates/axl-runtime/src/engine/bazel/live.rs`](crates/axl-runtime/src/engine/bazel/live.rs) — a `Mutex<Vec<u32>>` plus a `LiveBazelGuard` (RAII) and a `spawn_registered(cmd) -> (Child, Guard)` helper. Every bazel `Command::spawn()` in the runtime goes through `spawn_registered`:

| Call site | Why it must be reachable on cancel |
|---|---|
| `Build::spawn` (long-running `bazel build`/`test`) | The hang we're trying to prevent. |
| `info::server_info`, `info::client_pid`, `info::is_server_busy`, `info::server_pid_nonblocking` | All four can hang on a busy/wedged JVM server. |
| `mod.rs` `bazel info` (the Starlark `ctx.bazel.info()` API) | User-driven; can run during a hung server. |
| `query::Query::raw` (large `bazel query` runs) | Can take many seconds; would outlive an aborted aspect-cli without registration. |
| `health_check::check_bazel_server`, `health_check::get_output_base` | Health-check probes during pre-flight. |

The guard `.take()`s out of `wait()` / `try_wait()` in `Build` ([build.rs](crates/axl-runtime/src/engine/bazel/build.rs#L935)) to release the registration the *moment* the child is reaped, so a PID-reuse race can't have the shutdown handler signal an unrelated process. A unit test covers this exact `RefCell<Option<Guard>>::take()` path.

### 2. tokio SIGINT / SIGTERM handler in `aspect-cli/main.rs`

[`install_shutdown_handler`](crates/aspect-cli/src/main.rs#L223) runs at the top of `run()` — before any Starlark evaluation, before any bazel spawn. It uses `tokio::signal::unix::signal` so it intercepts the signal *cooperatively* (no default-action terminate) and runs an async shutdown sequence on the tokio runtime.

Required tokio features added to `crates/aspect-cli/Cargo.toml`: `signal`, `time`.

### 3. 3-SIGINT escalation that mirrors bazel's documented cancel state machine

Bazel's [cancellation docs](https://bazel.build/run/cancellation) define an interactive-Ctrl-C state machine:

```
SIGINT (1st) → graceful cancel of the in-flight command
SIGINT (2nd) → still graceful; allows a brief cleanup window
SIGINT (3rd) → calls KillServerProcess and hard-exits the client
```

`run_shutdown_sequence` ([main.rs:300](crates/aspect-cli/src/main.rs#L300)) drives that protocol against every registered client:

```
SIGINT_TICK = 150ms  — short; just needs the signal delivered
SIGINT_GRACE = 5s    — matches FORCE_KILL_TIMEOUT_MS in engine/bazel/cancel.rs
POST_KILL_GRACE = 1s — kernel-settle margin after SIGKILL

3 × SIGINT (150ms apart) → 5s grace → SIGKILL survivors → 1s settle → exit(130|143)
```

Total wall-clock budget: ~6.5s. Fits comfortably inside GHA's ~7.5s SIGTERM-to-SIGKILL grace; ample margin against bazel's typical cancel time.

Exit code follows the shell convention (`128 + signal_number`): `130` for SIGINT, `143` for SIGTERM.

**Why force-exit rather than unwind:** the AXL drain loop runs on `spawn_blocking` and may be doing synchronous network I/O, Starlark eval, etc. There's no cooperative cancellation path; without an explicit `process::exit` a single hung handler could pin aspect-cli past the CI cancel deadline — the exact hang this PR exists to prevent.

**Why this avoids the bazel #23880 corruption:** the shutdown handler signals only registered *clients*, never the server. When the client exits (cleanly via SIGINT, or as a last resort via SIGKILL), the orphaned server detects the client's death and aborts the build through its normal in-process abort path — the same path bazel runs for any client-side cancel. The server stays alive (subject to `RUNNER_TRACKING_ID=""`, which aspect-cli already sets on GHA) so its sandbox cleanup runs to completion under its own control. We never SIGKILL the server.

## Relationship to `ctx.bazel.cancel_invocation()` (engine/bazel/cancel.rs)

That AXL-level cancellation API is **unchanged** by this PR. Files diff stat confirms `cancel.rs` is not touched. The two paths coexist:

| | OS-signal path (this PR) | `cancel_invocation()` path (cancel.rs) |
|---|---|---|
| Trigger | CI cancel — SIGINT/SIGTERM to aspect-cli | AXL code calls `ctx.bazel.cancel_invocation()` |
| Target discovery | Live registry (in-process `Mutex<Vec<u32>>`) | `bazel --noblock_for_lock info` probe |
| Scope | All registered clients | The single client holding the server lock |
| Last-resort SIGKILL | Client only (server preserved) | Client *and* server |
| Terminal action | `process::exit(130\|143)` | Returns to AXL caller |
| Shared timeout | `SIGINT_GRACE = 5s` (matches `FORCE_KILL_TIMEOUT_MS`) |

If both fire (CI cancels while AXL is mid `cancel_invocation().wait()`), the OS path wins: it sweeps the registry, escalates, and `process::exit`s — terminating the AXL `.wait()` loop along with everything else. No deadlock, no double-kill problem; bazel just receives a flurry of SIGINTs from both senders and deduplicates them per its own state machine.

The one subtle interaction: cancel.rs's `force_kill` discovers the client PID via `info::client_pid` → which now goes through `spawn_registered`. If the OS handler is sweeping at exactly the moment that probe is running, the probe gets SIGINT'd, returns no PID, and cancel.rs falls through to the "client gone, SIGKILL server" branch. But the OS handler's `process::exit` is imminent at that point, so any work cancel.rs does in that window is moot.

## Trade-offs

- 6.5s grace is fixed. Hard-coded to balance "long enough for bazel's documented graceful cancel" against "short enough that a hung handler can't pin a CI job."
- Force-exit skips Drop / unwind. Anything that relies on Drop running during shutdown (e.g. async-flushed telemetry) needs to be set up to flush opportunistically before this point, not via destructors.
- The shutdown handler runs only once per signal — repeated Ctrl-C presses don't accelerate the sequence. Intentional: bazel's state machine handles the 3-SIGINT cadence itself; piling on extra signals just makes diagnostics noisier.
