### PR TITLE
fix(bazel): pre-subscribe AXL build_events() via local() sink

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
+++ b/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
@@ -158,18 +158,20 @@ A subtle but load-bearing design detail. The runtime exposes BES events via a *b
 - Subscribers register and get a private channel. The broadcaster dispatches every event to every subscriber's channel.
 - **Subscribers that join after an event has been broadcast do *not* receive that event.** There is no replay buffer.
 
-`ctx.bazel.build(...)` registers two subscribers internally before returning (a tracing sink and the gRPC sinks from `bazel_trait.build_event_sinks`). User code that wants its own iterator calls `build.build_events()`, which calls `event_stream.subscribe()` lazily.
+`ctx.bazel.build(...)` registers subscribers eagerly before returning: a tracing sink, the gRPC sinks from `bazel_trait.build_event_sinks`, AND — when the caller explicitly opts in via a `bazel.build_events.local(...)` sink in the list (or the `build_events=True` sugar, which expands to a single default local sink) — the AXL-facing receiver returned by the first `build.build_events()` call. The eager registration happens before bazel opens the BEP FIFO, so the early burst (`build_started`, `target_completed`, `named_set_of_files`) is buffered for the AXL task regardless of when it eventually calls `build_events()`.
 
-On a **warm bazel daemon** with a fully cached build, BES events stream within milliseconds. If the task does any meaningful work between `ctx.bazel.build(...)` returning and `build.build_events()` being called — including emitting a running `task_update` (which spawns `buildkite-agent annotate`, dozens of ms) — the user-side subscriber registers too late and the early burst (`build_started`, `target_completed`, `named_set_of_files`) is gone. `runnable.determine_entrypoint()` then can't find the target's executable, format/gazelle silently can't run their binary, lint can't read SARIF reports.
+If the caller passes only remote sinks (e.g. `build_events=[bazel.build_events.grpc(...)]`) without a local sink, `build.build_events()` errors at call time — the runtime won't subscribe behind the caller's back, because every undrained subscription is buffered memory.
 
-**The rule: call `build.build_events()` immediately after `ctx.bazel.build(...)` returns, before any other work.** Stash the iterator and use it later:
+The local sink carries a `buffer_cap` (default `10000` events): if the consumer falls behind by more than that, the broadcaster drops the subscription on the next overflow send and the AXL iterator sees `Disconnected`. This bounds memory growth when a task declares intent but stops draining.
+
+Call `build.build_events()` early after `ctx.bazel.build(...)` returns. Stash the iterator and use it later:
 
 ```python
 build = ctx.bazel.build(...)
-events = build.build_events()        # ← subscribe FIRST, the channel is now buffering
+events = build.build_events()        # ← first call returns the pre-subscribed channel
 
-# Now safe to do potentially-slow work — the broadcaster is feeding `events`'
-# channel from t=0 regardless of how slow we are below.
+# Safe to do potentially-slow work — the broadcaster has been feeding
+# `events`' channel from t=0 regardless of what we do here.
 data["sink_invocation_id"] = build.sink_invocation_id
 for handler in lifecycle.task_update:
     handler(ctx, TaskUpdate(kind = "...", status = "running", data = data))
@@ -178,7 +180,7 @@ for event in events:                  # iterate the already-buffered channel
     ...
 ```
 
-If you violate this rule, the failure mode is *intermittent* — cold-daemon runs work, warm-daemon runs fail — which is exactly the kind of bug that escapes local testing.
+Subsequent calls to `build.build_events()` fall back to fresh `subscribe()` (late-subscriber semantics — they will miss any events broadcast before the call). Tasks that need multiple iterators should subscribe each via `build.build_events()` upfront, in order, then drain them.
 
 ---
 
@@ -615,7 +617,7 @@ When a task you change works in snapshots but fails live (artifact URL malformed
 
 When writing a new task or modifying an existing one, sanity-check:
 
-- [ ] Subscribe to BES events (`build.build_events()`) **immediately** after `ctx.bazel.build(...)` returns, before any other work.
+- [ ] When the task needs to iterate BES events, declare intent by including `bazel.build_events.local()` in the `build_events=[...]` list (or pass `build_events=True` for the no-remote-sinks shorthand). Then call `build.build_events()` once, stashing the iterator. The runtime pre-registers your receiver before bazel opens the BEP FIFO; the cap on the local sink bounds memory if you stop draining.
 - [ ] Capture `data["sink_invocation_id"] = build.sink_invocation_id` right after, then emit a running `task_update` so the Aspect Workflows link surfaces live.
 - [ ] Iterate `bazel_trait.build_start` / `build_event` / `build_end` so features fire (BK section markers, artifact upload).
 - [ ] Iterate `hc_trait.pre_health_check` / `post_health_check` so the runner-env sections render and post-failures surface.

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -300,8 +300,6 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             *targets
         )
 
-        # Subscribe BEFORE emitting (broadcaster only delivers to pre-existing
-        # subscribers); a warm daemon can stream BES events within milliseconds.
         events = build.build_events()
 
         # Capture the sink-side invocation UUID from phase 1 (the
@@ -675,9 +673,9 @@ def _delivery_impl(ctx):
     if bazel_trait.startup_flags:
         startup_flags = bazel_trait.startup_flags(startup_flags)
 
-    # BES: delivery always needs the iterator for run_tracker, so pass trait sinks
-    # when available and fall back to True otherwise.
-    build_events = list(bazel_trait.build_event_sinks) if bazel_trait.build_event_sinks else True
+    # BES: delivery always needs the iterator for run_tracker — the
+    # local sink declares that intent. Trait sinks come after.
+    build_events = [bazel.build_events.local()] + list(bazel_trait.build_event_sinks)
 
     for handler in bazel_trait.build_start:
         handler(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -347,7 +347,11 @@ def _impl(ctx: TaskContext) -> int:
     # only — the runtime would still mint a sink_invocation_id, but the
     # Aspect backend would have no record under that UUID, leading to
     # the "invocation not found" 404 we observed live.
-    build_events = list(bazel_trait.build_event_sinks) if bazel_trait.build_event_sinks else True
+    # The local sink declares intent to iterate via build.build_events();
+    # the runtime pre-registers it before bazel opens the BEP FIFO so
+    # the early burst (target_completed for runnable.determine_entrypoint)
+    # is buffered regardless of remote-sink connect timing.
+    build_events = [bazel.build_events.local()] + list(bazel_trait.build_event_sinks)
 
     # Fire `bazel_trait.build_start` hooks before spawning bazel —
     # Workflows registers the BK `--- :bazel: Running bazel …`
@@ -376,11 +380,6 @@ def _impl(ctx: TaskContext) -> int:
         flags = flags,
     )
 
-    # Subscribe BEFORE emitting (broadcaster only delivers to pre-existing
-    # subscribers); a warm daemon can stream BES events within milliseconds,
-    # so any delay between `ctx.bazel.build` returning and the subscribe
-    # risks missing the early burst — including the target_completed for
-    # the formatter that `runnable.determine_entrypoint` needs.
     events = build.build_events()
 
     # `build.sink_invocation_id` is minted inside the runtime's `Build::spawn`

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -327,7 +327,10 @@ def _impl(ctx: TaskContext) -> int:
     # the gazelle check-run / annotation header resolves to a real
     # invocation. See the matching comment in format.axl for why bare
     # `build_events = True` isn't sufficient.
-    build_events = list(bazel_trait.build_event_sinks) if bazel_trait.build_event_sinks else True
+    # See the matching comment in format.axl: the local sink declares
+    # intent to iterate via build.build_events(); the runtime pre-
+    # registers it so we don't miss the early burst.
+    build_events = [bazel.build_events.local()] + list(bazel_trait.build_event_sinks)
 
     # Fire `bazel_trait.build_start` hooks before spawning bazel — features
     # like Workflows register the BK `--- :bazel: Running bazel …`
@@ -355,15 +358,6 @@ def _impl(ctx: TaskContext) -> int:
         flags = flags,
     )
 
-    # Subscribe to the BES stream BEFORE doing any potentially-slow work
-    # (e.g. emitting task_updates that spawn `buildkite-agent annotate`).
-    # The broadcaster only delivers events to subscribers that joined
-    # before the event was sent — on a warm bazel daemon (second
-    # `aspect gazelle` invocation in a step) BES events stream within
-    # milliseconds, so any delay between `ctx.bazel.build` returning and
-    # this `build_events()` call risks missing the early burst
-    # (`build_started`, `target_completed`, `named_set_of_files`) that
-    # `runnable` needs to determine the gazelle target's entrypoint.
     events = build.build_events()
 
     # `build.sink_invocation_id` is minted inside the runtime's `Build::spawn`

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -261,13 +261,17 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
     if bazel_trait.build_event_sinks:
         build_events.extend(bazel_trait.build_event_sinks)
 
-    # Coerce to bool/list for ctx.bazel.build/test:
-    # - non-empty list → stream to those sinks + build_events() iterator.
-    # - True → stream without explicit sinks (build_event handler + result tracking)
-    # - False → no BEP stream at all
+    # Prepend a local sink when this task needs the iterator (status
+    # surfaces or per-event hooks). The local sink declares intent so
+    # the runtime pre-registers the AXL receiver before bazel opens the
+    # BEP FIFO. Without need_bes, no local sink — `False` skips the
+    # stream entirely; non-empty `build_events` opens it for the remote
+    # sinks only.
     need_bes = bool(bazel_trait.build_event) or bool(lifecycle.task_update)
-    if not build_events:
-        build_events = True if need_bes else False
+    if need_bes:
+        build_events = [bazel.build_events.local()] + build_events
+    elif not build_events:
+        build_events = False
 
     for handler in bazel_trait.build_start:
         handler(ctx)
@@ -361,13 +365,6 @@ def run_bazel_task(ctx: TaskContext, command: str) -> int:
                 *ctx.args.targets
             )
 
-        # Subscribe BEFORE emitting any task_updates (the broadcaster only
-        # delivers to subscribers that joined before the event was sent).
-        # On a warm bazel daemon BES events stream within milliseconds, so
-        # the gap between `ctx.bazel.{build,test}` returning and the
-        # subscribe is enough to drop the early burst (`build_started`,
-        # `target_completed`, …) — which makes the running annotation
-        # render with stale/empty state.
         events = invocation.build_events() if need_bes else None
 
         # Capture the sink invocation ID (the UUID used by the Aspect

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -835,11 +835,10 @@ def _impl(ctx: TaskContext) -> int:
     if bazel_trait.startup_flags:
         startup_flags = bazel_trait.startup_flags(startup_flags)
 
-    # BES sinks: lint always needs the BEP stream for SARIF file collection;
-    # add any extra sinks from BazelTrait on top.
-    build_events = list(bazel_trait.build_event_sinks)
-    if not build_events:
-        build_events = True
+    # BES sinks: lint always needs the BEP stream for SARIF file
+    # collection. The local sink declares intent to iterate; add any
+    # extra sinks from BazelTrait on top.
+    build_events = [bazel.build_events.local()] + list(bazel_trait.build_event_sinks)
 
     # 4. BazelTrait.build_start hooks
     for hook in bazel_trait.build_start:
@@ -887,10 +886,6 @@ def _impl(ctx: TaskContext) -> int:
         *ctx.args.targets
     )
 
-    # Subscribe BEFORE emitting (broadcaster only delivers to pre-existing
-    # subscribers); a warm daemon can stream BES events within milliseconds,
-    # so any delay between `ctx.bazel.build` returning and the subscribe
-    # risks missing the early burst (build_started, build_metadata, …).
     events = build.build_events()
 
     # `build.sink_invocation_id` is minted inside the runtime's `Build::spawn`

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -184,9 +184,25 @@ pub struct Build {
     ///
     /// `None` when no Local sink was configured, or after the first
     /// `build_events()` call has consumed the receiver. Subsequent
-    /// calls error rather than silently subscribing late.
+    /// `build_events()` calls (with a Local sink configured) fall
+    /// back to a fresh `event_stream.subscribe()` — late-subscriber
+    /// semantics, missing any events already broadcast before that
+    /// fresh subscribe. The pre-subscribed receiver is the race-free
+    /// path; additional iterators are an explicit caller decision.
     #[allocative(skip)]
     early_event_subscriber: RefCell<Option<CappedSubscriber<BuildEvent>>>,
+
+    /// True iff a `BuildEventSink::Local` was configured at spawn
+    /// time. Drives the `build_events()` method's gating:
+    ///   - `had_local_sink == false`: error on every call (the caller
+    ///     didn't declare local-iteration intent).
+    ///   - `had_local_sink == true` + receiver still present: hand
+    ///     over the race-free pre-subscribed receiver.
+    ///   - `had_local_sink == true` + receiver already taken: fall
+    ///     back to a fresh late `subscribe()` so helper-style code
+    ///     that wants its own iterator handle still works.
+    #[allocative(skip)]
+    had_local_sink: bool,
 
     /// The shared invocation_id that every gRPC BES sink uses when forwarding
     /// this build's events. `None` when no BES sinks were configured; `Some`
@@ -444,6 +460,7 @@ impl Build {
             sink_handles: RefCell::new(sink_handles),
             sink_invocation_id: RefCell::new(sink_invocation_id),
             early_event_subscriber: RefCell::new(early_event_subscriber),
+            had_local_sink: local_sink_cap.is_some(),
             span: RefCell::new(span),
         })
     }
@@ -483,36 +500,42 @@ impl<'v> values::StarlarkValue<'v> for Build {
 #[starlark_module]
 pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
     // Creates an iterable `BuildEventIterator` type.
-    // Every call to this function will return a new iterator.
-    // TODO: explain backpressure and build events sinks falling behind on poor network conditions.
+    // Every call to this function returns a new iterator. The first
+    // call returns the receiver pre-subscribed inside `Build::spawn`
+    // (so the early burst was buffered before bazel opened the BEP
+    // FIFO — no late-subscribe race). Subsequent calls fall back to a
+    // fresh `event_stream.subscribe()` with normal late-subscriber
+    // semantics: each new iterator only sees events broadcast after
+    // its subscribe call. Helper-style code that hands a fresh
+    // iterator to each subroutine still works; the primary consumer
+    // (the one that calls `build_events()` first) gets the race-free
+    // path.
     fn build_events<'v>(this: values::Value<'v>) -> anyhow::Result<BuildEventIterator> {
         let build = this.downcast_ref::<Build>().unwrap();
-        let _ = build
-            .build_event_stream
-            .borrow()
-            .as_ref()
-            .ok_or(anyhow::anyhow!(
-                "call `ctx.bazel.build` with `build_events = True` (or include \
+        let event_stream = build.build_event_stream.borrow();
+        let event_stream = event_stream.as_ref().ok_or(anyhow::anyhow!(
+            "call `ctx.bazel.build` with `build_events = True` (or include \
              `bazel.build_events.local(...)` in the sink list) to receive build events."
-            ))?;
+        ))?;
 
-        // Hand over the pre-subscribed receiver created in `Build::spawn`.
-        // The intent was declared up-front via a `BuildEventSink::Local`
-        // entry, so the subscription registered before bazel opened the
-        // BEP FIFO. Calling this method twice is an error: the cap
-        // accounting belongs to one consumer; multi-consumer use needs
-        // the user to subscribe their own broadcaster on top.
-        let recv = build
-            .early_event_subscriber
-            .borrow_mut()
-            .take()
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "`build.build_events()` may be called at most once per build, and only when \
-                 `ctx.bazel.build` was called with `build_events = True` (or an explicit \
-                 `bazel.build_events.local(...)` in the sink list)."
-                )
-            })?;
+        if !build.had_local_sink {
+            anyhow::bail!(
+                "`build.build_events()` requires `bazel.build_events.local(...)` in the \
+                 `build_events` sink list (or the `build_events = True` shorthand). Without \
+                 it the runtime won't subscribe an AXL-side receiver, because every undrained \
+                 subscription is buffered memory."
+            );
+        }
+
+        let recv = match build.early_event_subscriber.borrow_mut().take() {
+            Some(c) => c,
+            // First handoff already happened — return an unbounded
+            // late-subscriber. Caller accepts the late-subscribe
+            // window for this extra iterator (the primary one used
+            // the pre-subscribed receiver and is already past the
+            // race window).
+            None => CappedSubscriber::from_unbounded(event_stream.subscribe()),
+        };
 
         Ok(BuildEventIterator::new(recv))
     }

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -36,8 +36,10 @@ use super::sink::grpc;
 use super::sink::retry::{ErrorStrategy, RetryConfig, SinkError, SinkOutcome};
 use super::sink::tracing as tracing_sink;
 use super::stream::BuildEventStream;
+use super::stream::CappedSubscriber;
 use super::stream::ExecLogStream;
 use super::stream::WorkspaceEventStream;
+use axl_proto::build_event_stream::BuildEvent;
 
 #[derive(Debug, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
 #[display("<bazel.build.BuildStatus>")]
@@ -86,6 +88,13 @@ pub enum BuildEventSink {
     File {
         path: String,
     },
+    /// AXL-side iterator subscription. Carries an explicit `buffer_cap`
+    /// so the runtime knows the consumer's intent and can drop the
+    /// subscription rather than buffer unboundedly if the AXL task
+    /// falls behind or never drains.
+    Local {
+        buffer_cap: usize,
+    },
 }
 
 starlark_simple_value!(BuildEventSink);
@@ -133,6 +142,9 @@ impl BuildEventSink {
             BuildEventSink::File { .. } => {
                 unreachable!("File sinks are handled as raw file paths, not subscriber threads")
             }
+            BuildEventSink::Local { .. } => {
+                unreachable!("Local sinks are popped out before sink.spawn() is called")
+            }
         }
     }
 }
@@ -154,6 +166,27 @@ pub struct Build {
     /// since their failures indicate a real bug rather than a flaky backend.
     #[allocative(skip)]
     sink_handles: RefCell<Vec<JoinHandle<SinkOutcome>>>,
+
+    /// Pre-subscribed receiver for the AXL-facing `build.build_events()`
+    /// iterator. Created inside `Build::spawn` when (and only when) the
+    /// caller declared intent via a `BuildEventSink::Local` entry — by
+    /// passing `build_events=True` (sugar for a default Local sink) or
+    /// `build_events=[bazel.build_events.local(...), ...]`. Subscribing
+    /// here, before bazel opens the BEP FIFO and before remote sinks
+    /// touch the network, guarantees the AXL receiver registers in time
+    /// for the early burst (`build_started`, `target_completed`,
+    /// `named_set_of_files`) regardless of subsequent task work.
+    ///
+    /// The subscription is capped: if the AXL consumer never starts
+    /// draining (or falls behind by more than `buffer_cap` events), the
+    /// broadcaster drops the subscription and the receiver sees
+    /// `Disconnected` — bounding memory growth for misbehaving tasks.
+    ///
+    /// `None` when no Local sink was configured, or after the first
+    /// `build_events()` call has consumed the receiver. Subsequent
+    /// calls error rather than silently subscribing late.
+    #[allocative(skip)]
+    early_event_subscriber: RefCell<Option<CappedSubscriber<BuildEvent>>>,
 
     /// The shared invocation_id that every gRPC BES sink uses when forwarding
     /// this build's events. `None` when no BES sinks were configured; `Some`
@@ -209,14 +242,27 @@ impl Build {
             cmd.current_dir(current_dir);
         }
 
-        // Split BES sinks: File sinks accumulate raw pipe bytes in memory and
-        // are written after the FIFO closes; subscriber sinks (Grpc, etc.) get
-        // a real-time channel subscription.
+        // Split BES sinks by kind:
+        //   File   — accumulate raw pipe bytes in memory, written after FIFO closes.
+        //   Local  — the AXL-side iterator subscription; at most one. Carries
+        //            the buffer_cap used to bound undrained accumulation.
+        //   Grpc/… — real-time broadcaster subscriptions; spawn their own threads.
         let mut bes_file_paths: Vec<String> = vec![];
         let mut bes_subscriber_sinks: Vec<BuildEventSink> = vec![];
+        let mut local_sink_cap: Option<usize> = None;
         for sink in sinks {
             match &sink {
                 BuildEventSink::File { path } => bes_file_paths.push(path.clone()),
+                BuildEventSink::Local { buffer_cap } => {
+                    if local_sink_cap.is_some() {
+                        return Err(io::Error::other(
+                            "ctx.bazel.build / ctx.bazel.test: multiple Local BES sinks \
+                             configured. Pass at most one `bazel.build_events.local(...)` \
+                             entry; the AXL task subscribes via `build.build_events()`.",
+                        ));
+                    }
+                    local_sink_cap = Some(*buffer_cap);
+                }
                 _ => bes_subscriber_sinks.push(sink),
             }
         }
@@ -322,6 +368,31 @@ impl Build {
         // end, which won't happen until bazel finishes JVM startup — well
         // after these subscribe calls land.
         let mut sink_handles: Vec<JoinHandle<SinkOutcome>> = vec![];
+
+        // Eagerly subscribe the AXL-facing receiver when the caller
+        // declared intent via a `BuildEventSink::Local` entry (either
+        // explicitly, or via the `build_events=True` sugar in the AXL
+        // surface). Subscribing here — before bazel's BEP FIFO opens
+        // and before remote sinks touch the network — closes the race
+        // window where the early burst (`build_started`,
+        // `target_completed`, `named_set_of_files`) was emitted before
+        // a lazy `build_events()` subscribe in the AXL task could
+        // register.
+        //
+        // The cap bounds memory growth: if the AXL task never drains
+        // (or falls behind by more than `buffer_cap` events), the
+        // broadcaster drops the subscription on the next overflow send
+        // and the AXL iterator sees `Disconnected`.
+        //
+        // No Local sink → no eager subscribe; tasks that only pass
+        // remote sinks pay nothing for buffering, and `build_events()`
+        // errors if called (the caller didn't ask for local delivery).
+        let early_event_subscriber: Option<CappedSubscriber<BuildEvent>> =
+            match (build_event_stream.as_ref(), local_sink_cap) {
+                (Some(s), Some(cap)) => Some(s.subscribe_capped(cap)),
+                _ => None,
+            };
+
         let sink_invocation_id: Option<String> = if !bes_subscriber_sinks.is_empty() {
             let invocation_id = uuid::Uuid::new_v4().to_string();
             let debug = std::env::var_os("ASPECT_DEBUG")
@@ -372,6 +443,7 @@ impl Build {
             execlog_stream: RefCell::new(execlog_stream),
             sink_handles: RefCell::new(sink_handles),
             sink_invocation_id: RefCell::new(sink_invocation_id),
+            early_event_subscriber: RefCell::new(early_event_subscriber),
             span: RefCell::new(span),
         })
     }
@@ -415,12 +487,34 @@ pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
     // TODO: explain backpressure and build events sinks falling behind on poor network conditions.
     fn build_events<'v>(this: values::Value<'v>) -> anyhow::Result<BuildEventIterator> {
         let build = this.downcast_ref::<Build>().unwrap();
-        let event_stream = build.build_event_stream.borrow();
-        let event_stream = event_stream.as_ref().ok_or(anyhow::anyhow!(
-            "call `ctx.bazel.build` with `build_events = true` in order to receive build events."
-        ))?;
+        let _ = build
+            .build_event_stream
+            .borrow()
+            .as_ref()
+            .ok_or(anyhow::anyhow!(
+                "call `ctx.bazel.build` with `build_events = True` (or include \
+             `bazel.build_events.local(...)` in the sink list) to receive build events."
+            ))?;
 
-        Ok(BuildEventIterator::new(event_stream.subscribe()))
+        // Hand over the pre-subscribed receiver created in `Build::spawn`.
+        // The intent was declared up-front via a `BuildEventSink::Local`
+        // entry, so the subscription registered before bazel opened the
+        // BEP FIFO. Calling this method twice is an error: the cap
+        // accounting belongs to one consumer; multi-consumer use needs
+        // the user to subscribe their own broadcaster on top.
+        let recv = build
+            .early_event_subscriber
+            .borrow_mut()
+            .take()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "`build.build_events()` may be called at most once per build, and only when \
+                 `ctx.bazel.build` was called with `build_events = True` (or an explicit \
+                 `bazel.build_events.local(...)` in the sink list)."
+                )
+            })?;
+
+        Ok(BuildEventIterator::new(recv))
     }
 
     // Creates an iterable `ExecutionLogIterator` type.

--- a/crates/axl-runtime/src/engine/bazel/iter/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/iter/build_event.rs
@@ -21,17 +21,17 @@ use starlark::values::starlark_value;
 use axl_proto::build_event_stream::BuildEvent;
 use derive_more::Display;
 
-use super::super::stream::Subscriber;
+use super::super::stream::CappedSubscriber;
 
 #[derive(Debug, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
 #[display("<build_event_iterator>")]
 pub struct BuildEventIterator {
     #[allocative(skip)]
-    recv: RefCell<Subscriber<BuildEvent>>,
+    recv: RefCell<CappedSubscriber<BuildEvent>>,
 }
 
 impl BuildEventIterator {
-    pub fn new(recv: Subscriber<BuildEvent>) -> Self {
+    pub fn new(recv: CappedSubscriber<BuildEvent>) -> Self {
         Self {
             recv: RefCell::new(recv),
         }

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -229,7 +229,14 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<build::Build> {
         let build_events = match build_events {
-            Either::Left(events) => (events, vec![]),
+            // `False` → no BEP stream; `True` → open the stream and add
+            // a default local sink so the AXL task can iterate via
+            // `build.build_events()` (the only point of `True`).
+            Either::Left(false) => (false, vec![]),
+            Either::Left(true) => (
+                true,
+                vec![build::BuildEventSink::Local { buffer_cap: 10_000 }],
+            ),
             Either::Right(sinks) => (true, sinks.items),
         };
         let execution_log = match execution_log {
@@ -332,7 +339,13 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<build::Build> {
         let build_events = match build_events {
-            Either::Left(events) => (events, vec![]),
+            // See the matching arm in `build` above — `True` is sugar
+            // for a default local sink.
+            Either::Left(false) => (false, vec![]),
+            Either::Left(true) => (
+                true,
+                vec![build::BuildEventSink::Local { buffer_cap: 10_000 }],
+            ),
             Either::Right(sinks) => (true, sinks.items),
         };
         let execution_log = match execution_log {
@@ -636,6 +649,35 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
 
     fn file(#[starlark(require = named)] path: String) -> anyhow::Result<build::BuildEventSink> {
         Ok(build::BuildEventSink::File { path })
+    }
+
+    /// Declare the AXL task's intent to subscribe to the BES stream via
+    /// `build.build_events()`. The runtime pre-registers a receiver
+    /// inside `ctx.bazel.build(...)` — before bazel opens the BEP FIFO
+    /// and before remote sinks touch the network — so the early burst
+    /// (`build_started`, `target_completed`, `named_set_of_files`) is
+    /// buffered for the consumer regardless of how slow the AXL task is
+    /// to call `build_events()` afterward.
+    ///
+    /// `buffer_cap` bounds undrained accumulation. If the consumer
+    /// falls behind by more than `buffer_cap` events, the broadcaster
+    /// drops the subscription on the next overflow send and the AXL
+    /// iterator sees `Disconnected`. Default `10000` is enough headroom
+    /// for tasks that emit progress every BES tick without leaking
+    /// memory if the consumer is buggy and never starts draining.
+    ///
+    /// `ctx.bazel.build(build_events = True)` is sugar for
+    /// `build_events = [bazel.build_events.local()]`.
+    #[starlark(as_type = build::BuildEventSink)]
+    fn local(
+        #[starlark(require = named, default = 10_000)] buffer_cap: i32,
+    ) -> anyhow::Result<build::BuildEventSink> {
+        if buffer_cap <= 0 {
+            anyhow::bail!("buffer_cap must be > 0, got {buffer_cap}");
+        }
+        Ok(build::BuildEventSink::Local {
+            buffer_cap: buffer_cap as usize,
+        })
     }
 }
 

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -506,7 +506,7 @@ async fn retry_lifecycle(
 
 fn finalize(strategy: ErrorStrategy, endpoint: &str, last_error: String) -> SinkError {
     if matches!(strategy, ErrorStrategy::Warn) {
-        eprintln!("WARN: BES sink {endpoint} giving up: {last_error}");
+        eprintln!("WARNING: BES sink {endpoint} giving up: {last_error}");
     }
     SinkError {
         strategy,

--- a/crates/axl-runtime/src/engine/bazel/stream/broadcaster.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/broadcaster.rs
@@ -180,8 +180,32 @@
 //! - Dead subscribers are cleaned up lazily on the next `send()`
 //! - The `close()` method immediately frees all sender resources
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
+
+/// A subscription on the broadcaster's fan-out list. Each kind tracks its
+/// own back-pressure policy:
+///
+/// - `Unbounded`: events queue forever on the receiver's channel. Used by
+///   sinks (tracing, gRPC) whose worker threads pull events as fast as
+///   they can — buffer growth is bounded by upload throughput.
+/// - `Capped`: subscribed via [`Broadcaster::subscribe_capped`]. The
+///   shared `queued` counter is incremented on each send and decremented
+///   on each receive (via [`CappedSubscriber::recv`] /
+///   [`CappedSubscriber::try_recv`]). When `queued >= cap` on a send,
+///   the broadcaster drops the subscription (removes its entry from
+///   `subscribers`), causing the receiver to see disconnect. Used to
+///   bound memory growth for slow / never-consumed AXL-side iterators.
+#[derive(Debug)]
+enum Subscription<T> {
+    Unbounded(mpsc::Sender<T>),
+    Capped {
+        tx: mpsc::Sender<T>,
+        queued: Arc<AtomicUsize>,
+        cap: usize,
+    },
+}
 
 /// Internal state shared between the broadcaster and its clones.
 ///
@@ -191,8 +215,9 @@ struct BroadcasterInner<T> {
     /// Active subscriber senders. Each sender corresponds to one subscriber's buffer.
     /// Senders are removed when:
     /// - The corresponding receiver is dropped (detected on next send)
+    /// - A capped subscription overflows its `cap`
     /// - The broadcaster is closed
-    subscribers: Vec<mpsc::Sender<T>>,
+    subscribers: Vec<Subscription<T>>,
 
     /// Whether the broadcaster has been explicitly closed.
     /// When true:
@@ -202,6 +227,34 @@ struct BroadcasterInner<T> {
 }
 
 pub type Subscriber<T> = mpsc::Receiver<T>;
+
+/// A subscription with a bounded queue depth. Wraps a [`mpsc::Receiver`]
+/// and a shared counter; each [`recv`](Self::recv) / [`try_recv`](Self::try_recv)
+/// decrements the counter so the broadcaster sees back-pressure. When
+/// `queued >= cap` on a send, the broadcaster drops this subscription
+/// and the receiver sees `Disconnected`.
+///
+/// Use for AXL-side iterators where the runtime needs to bound memory
+/// growth if the consumer falls behind or never drains.
+#[derive(Debug)]
+pub struct CappedSubscriber<T> {
+    rx: mpsc::Receiver<T>,
+    queued: Arc<AtomicUsize>,
+}
+
+impl<T> CappedSubscriber<T> {
+    pub fn recv(&self) -> Result<T, mpsc::RecvError> {
+        let v = self.rx.recv()?;
+        self.queued.fetch_sub(1, Ordering::Relaxed);
+        Ok(v)
+    }
+
+    pub fn try_recv(&self) -> Result<T, mpsc::TryRecvError> {
+        let v = self.rx.try_recv()?;
+        self.queued.fetch_sub(1, Ordering::Relaxed);
+        Ok(v)
+    }
+}
 
 /// A thread-safe broadcaster that fans out events to multiple subscribers.
 ///
@@ -309,8 +362,30 @@ impl<T: Clone> Broadcaster<T> {
         }
 
         let (tx, rx) = mpsc::channel();
-        inner.subscribers.push(tx);
+        inner.subscribers.push(Subscription::Unbounded(tx));
         rx
+    }
+
+    /// Subscribe with a bounded queue depth. When `queued >= cap` on a
+    /// send, the broadcaster drops this subscription — the receiver sees
+    /// `Disconnected` rather than the channel growing without limit. The
+    /// counter decrements on each [`CappedSubscriber::recv`] /
+    /// [`CappedSubscriber::try_recv`], so a consumer that drains at
+    /// least as fast as the producer sends never trips the cap.
+    pub fn subscribe_capped(&self, cap: usize) -> CappedSubscriber<T> {
+        let mut inner = self.inner.lock().unwrap();
+        let (tx, rx) = mpsc::channel();
+        let queued = Arc::new(AtomicUsize::new(0));
+        if inner.closed {
+            drop(tx);
+            return CappedSubscriber { rx, queued };
+        }
+        inner.subscribers.push(Subscription::Capped {
+            tx,
+            queued: queued.clone(),
+            cap,
+        });
+        CappedSubscriber { rx, queued }
     }
 
     /// Sends an event to all current subscribers.
@@ -352,13 +427,25 @@ impl<T: Clone> Broadcaster<T> {
     pub fn send(&self, event: T) {
         let mut inner = self.inner.lock().unwrap();
 
-        // Use retain to both send and clean up dead subscribers in one pass.
-        // - send() returns Ok if the receiver is still alive
-        // - send() returns Err if the receiver has been dropped
-        // We keep only the subscribers where send succeeded.
-        inner
-            .subscribers
-            .retain(|tx| tx.send(event.clone()).is_ok());
+        // Use retain to send, prune dead receivers, AND drop capped
+        // subscriptions whose queue depth exceeded `cap` (overflow).
+        inner.subscribers.retain(|sub| match sub {
+            Subscription::Unbounded(tx) => tx.send(event.clone()).is_ok(),
+            Subscription::Capped { tx, queued, cap } => {
+                if queued.load(Ordering::Relaxed) >= *cap {
+                    // Consumer fell behind / never started draining;
+                    // drop the subscription so we stop buffering and
+                    // the receiver sees Disconnected on its next recv.
+                    return false;
+                }
+                if tx.send(event.clone()).is_ok() {
+                    queued.fetch_add(1, Ordering::Relaxed);
+                    true
+                } else {
+                    false
+                }
+            }
+        });
     }
 
     /// Closes the broadcaster, disconnecting all subscribers.
@@ -1068,5 +1155,72 @@ mod tests {
             post_close_sub.recv().is_err(),
             "Subscriber after close should get no events"
         );
+    }
+
+    /// Capped subscribers receive every event while the consumer keeps
+    /// up — the cap only matters under sustained back-pressure.
+    #[test]
+    fn capped_subscriber_drains_normally() {
+        let broadcaster: Broadcaster<i32> = Broadcaster::new();
+        let sub = broadcaster.subscribe_capped(100);
+
+        for i in 0..50 {
+            broadcaster.send(i);
+            assert_eq!(sub.recv().unwrap(), i);
+        }
+    }
+
+    /// When the consumer never drains, the broadcaster drops the
+    /// subscription as soon as `queued >= cap` so memory doesn't grow
+    /// without limit. The receiver sees Disconnected on its next recv.
+    #[test]
+    fn capped_subscriber_dropped_on_overflow() {
+        let broadcaster: Broadcaster<i32> = Broadcaster::new();
+        let sub = broadcaster.subscribe_capped(3);
+
+        // Fill the buffer to the cap. Sends 0..3 succeed because
+        // queued goes 0→1→2→3 and the cap check is `>=` on the
+        // *next* send (i.e. after the third successful send the
+        // counter is at 3 and the fourth send trips the drop).
+        broadcaster.send(0);
+        broadcaster.send(1);
+        broadcaster.send(2);
+        // This one trips the drop.
+        broadcaster.send(3);
+
+        // Subsequent sends are no-ops for this subscriber; only the
+        // first three events are in the buffer.
+        broadcaster.send(4);
+        broadcaster.send(5);
+
+        assert_eq!(sub.recv().unwrap(), 0);
+        assert_eq!(sub.recv().unwrap(), 1);
+        assert_eq!(sub.recv().unwrap(), 2);
+        // Buffer drained — sender was dropped at overflow, so recv
+        // now sees Disconnected.
+        assert!(sub.recv().is_err());
+    }
+
+    /// Capped and unbounded subscribers can coexist; a capped overflow
+    /// must not affect other subscribers.
+    #[test]
+    fn capped_overflow_does_not_disturb_unbounded_peers() {
+        let broadcaster: Broadcaster<i32> = Broadcaster::new();
+        let capped = broadcaster.subscribe_capped(2);
+        let unbounded = broadcaster.subscribe();
+
+        for i in 0..10 {
+            broadcaster.send(i);
+        }
+
+        // Unbounded receives the full 10.
+        for i in 0..10 {
+            assert_eq!(unbounded.recv().unwrap(), i);
+        }
+
+        // Capped receives the first 2, then disconnects.
+        assert_eq!(capped.recv().unwrap(), 0);
+        assert_eq!(capped.recv().unwrap(), 1);
+        assert!(capped.recv().is_err());
     }
 }

--- a/crates/axl-runtime/src/engine/bazel/stream/broadcaster.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/broadcaster.rs
@@ -228,31 +228,51 @@ struct BroadcasterInner<T> {
 
 pub type Subscriber<T> = mpsc::Receiver<T>;
 
-/// A subscription with a bounded queue depth. Wraps a [`mpsc::Receiver`]
-/// and a shared counter; each [`recv`](Self::recv) / [`try_recv`](Self::try_recv)
-/// decrements the counter so the broadcaster sees back-pressure. When
-/// `queued >= cap` on a send, the broadcaster drops this subscription
-/// and the receiver sees `Disconnected`.
+/// A subscription with an optional bounded queue depth. Wraps a
+/// [`mpsc::Receiver`] and, when subscribed via
+/// [`Broadcaster::subscribe_capped`], a shared counter; each
+/// [`recv`](Self::recv) / [`try_recv`](Self::try_recv) decrements the
+/// counter so the broadcaster sees back-pressure. When `queued >= cap`
+/// on a send, the broadcaster drops this subscription and the receiver
+/// sees `Disconnected`.
 ///
 /// Use for AXL-side iterators where the runtime needs to bound memory
 /// growth if the consumer falls behind or never drains.
+///
+/// Late subscribers wrapped via [`from_unbounded`](Self::from_unbounded)
+/// hold `queued = None` — they're plain `Receiver` consumers on the
+/// broadcaster's `Subscription::Unbounded` path, so there's no shared
+/// counter to track, and `recv` / `try_recv` skip the decrement.
 #[derive(Debug)]
 pub struct CappedSubscriber<T> {
     rx: mpsc::Receiver<T>,
-    queued: Arc<AtomicUsize>,
+    queued: Option<Arc<AtomicUsize>>,
 }
 
 impl<T> CappedSubscriber<T> {
     pub fn recv(&self) -> Result<T, mpsc::RecvError> {
         let v = self.rx.recv()?;
-        self.queued.fetch_sub(1, Ordering::Relaxed);
+        if let Some(q) = &self.queued {
+            q.fetch_sub(1, Ordering::Relaxed);
+        }
         Ok(v)
     }
 
     pub fn try_recv(&self) -> Result<T, mpsc::TryRecvError> {
         let v = self.rx.try_recv()?;
-        self.queued.fetch_sub(1, Ordering::Relaxed);
+        if let Some(q) = &self.queued {
+            q.fetch_sub(1, Ordering::Relaxed);
+        }
         Ok(v)
+    }
+
+    /// Wrap a plain [`mpsc::Receiver`] (obtained from
+    /// [`Broadcaster::subscribe`]) as a [`CappedSubscriber`] with no
+    /// back-pressure tracking. Use for late-subscribe paths where the
+    /// caller has already taken the broadcaster's pre-subscribed
+    /// (capped) receiver but needs another iterator handle.
+    pub fn from_unbounded(rx: mpsc::Receiver<T>) -> Self {
+        Self { rx, queued: None }
     }
 }
 
@@ -378,14 +398,20 @@ impl<T: Clone> Broadcaster<T> {
         let queued = Arc::new(AtomicUsize::new(0));
         if inner.closed {
             drop(tx);
-            return CappedSubscriber { rx, queued };
+            return CappedSubscriber {
+                rx,
+                queued: Some(queued),
+            };
         }
         inner.subscribers.push(Subscription::Capped {
             tx,
             queued: queued.clone(),
             cap,
         });
-        CappedSubscriber { rx, queued }
+        CappedSubscriber {
+            rx,
+            queued: Some(queued),
+        }
     }
 
     /// Sends an event to all current subscribers.

--- a/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use thiserror::Error;
 
-use super::broadcaster::{Broadcaster, Subscriber};
+use super::broadcaster::{Broadcaster, CappedSubscriber, Subscriber};
 use super::redaction::redact_event;
 use super::util::{MultiWriter, read_varint};
 
@@ -253,6 +253,26 @@ impl BuildEventStream {
                 let (tx, rx) = std::sync::mpsc::channel();
                 drop(tx);
                 rx
+            }
+        }
+    }
+
+    /// Subscribe with a bounded queue depth. When the AXL consumer falls
+    /// behind and `queued >= cap`, the broadcaster drops this
+    /// subscription so memory doesn't grow without limit. The receiver
+    /// then sees `Disconnected` on its next recv.
+    pub fn subscribe_capped(&self, cap: usize) -> CappedSubscriber<BuildEvent> {
+        match self.broadcaster.as_ref() {
+            Some(b) => b.subscribe_capped(cap),
+            None => {
+                // Stream already joined; the broadcaster is gone but we
+                // still need to hand back a usable CappedSubscriber.
+                // Easiest: subscribe via a temp broadcaster, then drop
+                // it so the receiver sees disconnect immediately.
+                let temp = Broadcaster::<BuildEvent>::new();
+                let sub = temp.subscribe_capped(cap);
+                drop(temp);
+                sub
             }
         }
     }

--- a/crates/axl-runtime/src/engine/bazel/stream/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/mod.rs
@@ -5,7 +5,7 @@ pub mod redaction;
 mod util;
 pub mod workspace_event;
 
-pub use broadcaster::Subscriber;
+pub use broadcaster::{CappedSubscriber, Subscriber};
 pub use build_event::BuildEventStream;
 pub use execlog::ExecLogStream;
 pub use workspace_event::WorkspaceEventStream;


### PR DESCRIPTION
## Summary

Fixes an intermittent late-subscribe race in `ctx.bazel.build(...)`'s
event stream. The AXL-facing receiver returned by
`build.build_events()` was created **lazily**, only when the AXL task
called the method. On a warm bazel daemon with a fully cached build,
BES events stream within milliseconds — fast enough that any work
between `ctx.bazel.build(...)` returning and the subsequent
`build.build_events()` (a `task_update` emit, a `buildkite-agent
annotate` spawn, the gRPC sink's connect attempt) could let the
early burst (`build_started`, `target_completed`,
`named_set_of_files`) flow before the AXL subscriber registered.

Observed symptoms:

- `runnable.determine_entrypoint()` returned `None` → `Failed to
  determine the formatter entrypoint.` on `aspect format` (sister
  errors on `aspect gazelle` / `aspect lint`). Lint's SARIF
  collector missed reports → "0 findings" on runs that should have
  flagged.
- Live status surfaces stuck on "Spawning bazel build…" until the
  first non-burst event arrived.
- Cold-daemon runs passed; warm-daemon runs flaked. Race that
  escapes local testing.

Two fixes together:

### 1. Explicit local-iteration intent

New `BuildEventSink::Local` variant + AXL factory
`bazel.build_events.local(buffer_cap=10000)`. Callers declare
local-iteration intent up front instead of relying on the runtime
to guess from a subsequent `build.build_events()` call:

```python
build = ctx.bazel.build(
    "//target",
    build_events = [
        bazel.build_events.local(),                # AXL iterates
        bazel.build_events.grpc(uri = "..."),      # remote forwards
    ],
    flags = flags,
)

# Existing `build_events = True` continues to work — it now expands
# to `[bazel.build_events.local()]`.
```

`Build::spawn` registers the local subscriber **inside** the spawn,
before bazel opens the BEP FIFO and before remote gRPC sinks touch
the network. The first call to `build.build_events()` returns the
pre-subscribed receiver; events broadcast in between were already
buffered.

If no `Local` sink is configured, `build.build_events()` errors at
call time — the runtime won't subscribe behind the caller's back,
because every undrained subscription is buffered memory.

### 2. Capped buffer (memory bound)

A misbehaving task that subscribes but never drains would otherwise
grow the channel without bound. New `CappedSubscriber<T>` wraps a
`Receiver` + shared `Arc<AtomicUsize>`. The broadcaster's subscriber
list becomes `Vec<Subscription<T>>` with `Unbounded` (existing —
tracing sink, gRPC sinks) and `Capped { tx, queued, cap }` variants.
On each send the broadcaster checks the capped entries; when
`queued >= cap` it drops the subscription and the AXL iterator sees
`Disconnected` on its next recv. Default cap is 10000 events.

### Built-in tasks updated

Every built-in task that iterates BES events now prepends
`bazel.build_events.local()` to its sink list:

- `build` / `test` (via `lib/bazel_runner.axl`) — gated on
  `need_bes` (any `bazel_trait.build_event` handler or
  `lifecycle.task_update` handler registered).
- `lint`, `format`, `gazelle`, `delivery` — always (each calls
  `build.build_events()` unconditionally).

### Docs

`DEVELOPMENT.md` updated: the broadcaster section now describes the
explicit-intent contract, the buffer-cap semantics, and the
late-subscribe escape hatch. The contributor checklist is updated to
remind authors of new tasks to include `bazel.build_events.local()`
when they iterate.

### Relationship to `HANG_ANALYSIS.md` and PR #1071

`HANG_ANALYSIS.md` covers a separate GHA-cancel hang with three
root causes. PR #1071 (`fix(http): bound read and connect timeouts on
the runtime HTTP client`, already landed) handled one of them. The
remaining two (signal-handler / process-registry plumbing for
subprocess cleanup on cancel) are in a separate change set and not in
this PR. The two surface areas overlap (BES event-stream
plumbing / cancellation cleanup) but the fixes are independent.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- New `bazel.build_events.local(buffer_cap=10000)` AXL factory.
  Declare it explicitly in the `build_events=[...]` list of
  `ctx.bazel.build(...)` / `ctx.bazel.test(...)` when your task
  iterates the BES stream via `build.build_events()`. The runtime
  pre-registers your receiver before bazel opens the BEP FIFO,
  eliminating the warm-daemon late-subscribe race that caused
  intermittent `Failed to determine the formatter entrypoint.` and
  similar errors. `ctx.bazel.build(build_events = True)` continues to
  work — it now expands to `[bazel.build_events.local()]`.
- `build.build_events()` now errors when called against a build that
  was configured with remote BES sinks but no local sink. Callers
  that need to iterate locally must opt in via
  `bazel.build_events.local(...)`. Existing callers using the `True`
  shorthand are unaffected.

### Test plan

- New test cases added: 3 broadcaster unit tests covering
  normal-drain, overflow-drop, and capped-coexists-with-unbounded
  paths.
- Covered by existing test cases: every built-in task's snapshot
  suite (PR comment, BK annotation, template, lint, format, gazelle,
  delivery) — 727 AXL tests + 7 snapshot suites pass.
- Manual testing: ran each of `aspect build`, `aspect test`,
  `aspect lint`, `aspect format`, `aspect gazelle`, `aspect delivery`
  against a warm daemon and confirmed entrypoint resolution, SARIF
  collection, and live status-surface phase tags consistently see
  the early-burst events.
