### PR TITLE
fix(github): handle transport errors gracefully + retry transient HTTP failures

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
@@ -106,9 +106,8 @@ def _upload_file_gitlab(ctx, path, name):
     file_name = path.split("/")[-1]
     url = api_url + "/projects/" + project_id + "/packages/generic/" + safe_name + "/" + pipeline_id + "/" + file_name
 
-    # Transport errors → string result so a flaky GitLab API call
-    # doesn't propagate as an exception into the calling feature
-    # handler (ArtifactUpload) and fail the task.
+    # Transport errors → string result so the ArtifactUpload feature
+    # sees a soft `{success: False}`, not a task abort.
     resp = ctx.http().put(
         url = url,
         headers = {"JOB-TOKEN": token},

--- a/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
@@ -106,12 +106,17 @@ def _upload_file_gitlab(ctx, path, name):
     file_name = path.split("/")[-1]
     url = api_url + "/projects/" + project_id + "/packages/generic/" + safe_name + "/" + pipeline_id + "/" + file_name
 
+    # Transport errors → string result so a flaky GitLab API call
+    # doesn't propagate as an exception into the calling feature
+    # handler (ArtifactUpload) and fail the task.
     resp = ctx.http().put(
         url = url,
         headers = {"JOB-TOKEN": token},
         data = ctx.std.fs.open(path),
-    ).block()
+    ).map_err(lambda e: str(e)).block()
 
+    if type(resp) == "string":
+        return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["transport error: " + resp]}
     if resp.status < 200 or resp.status >= 300:
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["HTTP " + str(resp.status)]}
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
@@ -115,8 +115,13 @@ def _upload_file_gitlab(ctx, path, name):
     ).map_err(lambda e: str(e)).block()
 
     if type(resp) == "string":
+        warn(ctx.std, "GitLab PUT %s failed: transport error: %s" % (url, resp))
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["transport error: " + resp]}
     if resp.status < 200 or resp.status >= 300:
+        body_snippet = (resp.body or "").replace("\n", " ")
+        if len(body_snippet) > 200:
+            body_snippet = body_snippet[:200] + "..."
+        warn(ctx.std, "GitLab PUT %s failed: HTTP %d%s" % (url, resp.status, ": " + body_snippet if body_snippet else ""))
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["HTTP " + str(resp.status)]}
 
     # The upload URL is also the stable download URL.

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -37,9 +37,8 @@ def _runner_api(ctx, token, runner_host, method, path, body = None):
         fut = ctx.http().post(url = url, headers = headers, data = json.encode(body) if body else None)
     else:
         return None
-    # Convert transport errors to a `None` result so a flaky runner-
-    # API call surfaces as a soft auth failure rather than aborting
-    # the calling feature handler (and the task).
+    # Transport errors → None so a flaky runner-API call surfaces as
+    # a soft auth failure, not a task abort.
     resp = fut.map_err(lambda e: str(e)).block()
     if type(resp) == "string":
         return None

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -32,10 +32,16 @@ def _runner_api(ctx, token, runner_host, method, path, body = None):
         "Content-Type": "application/json",
     }
     if method == "GET":
-        resp = ctx.http().get(url = url, headers = headers).block()
+        fut = ctx.http().get(url = url, headers = headers)
     elif method == "POST":
-        resp = ctx.http().post(url = url, headers = headers, data = json.encode(body) if body else None).block()
+        fut = ctx.http().post(url = url, headers = headers, data = json.encode(body) if body else None)
     else:
+        return None
+    # Convert transport errors to a `None` result so a flaky runner-
+    # API call surfaces as a soft auth failure rather than aborting
+    # the calling feature handler (and the task).
+    resp = fut.map_err(lambda e: str(e)).block()
+    if type(resp) == "string":
         return None
     if resp.status < 200 or resp.status >= 300:
         return None

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -3,6 +3,8 @@
 Uses the CircleCI runner API (Unix socket + HTTP) to upload artifacts to S3.
 """
 
+load("./environment.axl", "warn")
+
 def _get_token(ctx):
     """Read auth credentials from the CircleCI runner Unix socket.
 
@@ -37,12 +39,15 @@ def _runner_api(ctx, token, runner_host, method, path, body = None):
         fut = ctx.http().post(url = url, headers = headers, data = json.encode(body) if body else None)
     else:
         return None
+
     # Transport errors → None so a flaky runner-API call surfaces as
     # a soft auth failure, not a task abort.
     resp = fut.map_err(lambda e: str(e)).block()
     if type(resp) == "string":
+        warn(ctx.std, "CircleCI runner API %s %s failed: transport error: %s" % (method, path, resp))
         return None
     if resp.status < 200 or resp.status >= 300:
+        warn(ctx.std, "CircleCI runner API %s %s failed: HTTP %d" % (method, path, resp.status))
         return None
 
     # try_decode → None on parse failure mirrors the "no body" branch

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -125,16 +125,32 @@ def _do_request_once(ctx, method, url, token, payload = None):
         return (False, response.status, "non-JSON response (status %d): %s" % (response.status, snippet))
     return (success, response.status, parsed)
 
-def _do_request(ctx, method, url, token, payload = None):
-    """`_do_request_once` wrapped in `_retry_http` — retries the call
-    on transient failures (transport errors, 5xx, 429) so a single
-    network flake doesn't surface as a feature-handler error.
+# HTTP methods that are idempotent per RFC 7231 — safe to retry
+# because re-executing them produces the same server-side effect.
+# Retrying POST is unsafe: a transient transport failure AFTER the
+# server has processed the first request would create a duplicate
+# resource on retry (extra check-runs, duplicate PR comments,
+# multiple reviews, etc.). Callers that POST and want retry need to
+# implement their own idempotency strategy (server-side dedup key,
+# read-after-write check, etc.).
+_IDEMPOTENT_METHODS = ["GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
 
-    All callers (`check_runs.update`, `issues.list_comments`,
-    `pulls.list_review_comments`, etc.) receive the same
-    `(success, status, body)` tuple shape as before.
+def _do_request(ctx, method, url, token, payload = None):
+    """`_do_request_once` with retry gated on HTTP idempotency.
+
+    GET / PUT / PATCH / DELETE retry on transient failures (transport
+    errors, 5xx, 429) via `_retry_http`. POST runs once — retrying it
+    after the server may have already accepted the first request
+    risks duplicate resources, which is a strictly worse failure mode
+    than the original error. Callers that need retry on POST should
+    use server-side idempotency keys or check-then-write patterns.
+
+    All callers receive the same `(success, status, body)` tuple
+    shape as before.
     """
-    return _retry_http(lambda: _do_request_once(ctx, method, url, token, payload))
+    if method in _IDEMPOTENT_METHODS:
+        return _retry_http(lambda: _do_request_once(ctx, method, url, token, payload))
+    return _do_request_once(ctx, method, url, token, payload)
 
 # Authentication
 
@@ -1293,13 +1309,31 @@ def _github_twirp_once(ctx, url, headers, payload):
         body = None if parsed == _PARSE_FAILED else parsed
     return (success, response.status, body)
 
+# Twirp methods that are safe to retry. Each entry is an
+# ArtifactService operation whose semantics make re-execution
+# idempotent:
+#   DeleteArtifact — DELETE-shaped; second call is a no-op or 4xx.
+# CreateArtifact and FinalizeArtifact are deliberately excluded
+# because each is non-idempotent (they create / transition server
+# state and a retry after a transient error would either duplicate
+# the resource or surface a confusing "already finalized" 4xx that
+# masks the original network flake).
+_TWIRP_IDEMPOTENT_METHODS = ["DeleteArtifact"]
+
 def _github_twirp(ctx, method, payload):
     """Make a Twirp RPC call to the GitHub Actions artifact service.
 
-    Retries on transient failures (transport errors, 5xx, 429) via
-    `_retry_http`. Returns `(ok, body_or_None, error_message_or_None)`
-    — the shape the existing `_upload_artifact` / `_delete_artifact`
-    callers already consume.
+    Retries on transient failures (transport errors, 5xx, 429) ONLY
+    for idempotent operations listed in `_TWIRP_IDEMPOTENT_METHODS`.
+    Non-idempotent operations (`CreateArtifact`, `FinalizeArtifact`)
+    run once — a transient transport error after the server has
+    processed the first request would create a duplicate or
+    half-finalized artifact on retry, which is strictly worse than
+    the original error.
+
+    Returns `(ok, body_or_None, error_message_or_None)` — the shape
+    the existing `_upload_artifact` / `_delete_artifact` callers
+    already consume.
     """
     token = (ctx.std.env.var("ACTIONS_RUNTIME_TOKEN") or
              ctx.std.env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
@@ -1319,13 +1353,16 @@ def _github_twirp(ctx, method, payload):
         "Content-Type": "application/json",
     }
 
-    success, status, body_or_err = _retry_http(
-        lambda: _github_twirp_once(ctx, url, headers, payload),
-    )
+    fn = lambda: _github_twirp_once(ctx, url, headers, payload)
+    if method in _TWIRP_IDEMPOTENT_METHODS:
+        success, status, body_or_err = _retry_http(fn)
+    else:
+        success, status, body_or_err = fn()
+
     if not success:
-        # `_retry_http` returns the final (failed) attempt unchanged.
-        # Surface the failure as `err` text so callers see why instead
-        # of silently swallowing the result.
+        # `_retry_http` (or the single attempt) returns the final
+        # failed result unchanged. Surface as `err` text so callers
+        # see why instead of silently swallowing it.
         if status == 0:
             err = body_or_err if type(body_or_err) == "string" else "transport error"
         else:

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -36,19 +36,43 @@ _HTTP_BACKOFF_BASE_MS = 250
 
 def _retry_http(fn):
     """Run `fn()` returning `(success, status, body)`, retrying transient
-    failures up to `_HTTP_MAX_ATTEMPTS` with exponential backoff."""
+    failures up to `_HTTP_MAX_ATTEMPTS` with exponential backoff. Returns
+    `(success, status, body, attempts)`."""
     result = fn()
+    attempts = 1
     success, status, _ = result
     backoff_ms = _HTTP_BACKOFF_BASE_MS
     for _ in range(_HTTP_MAX_ATTEMPTS - 1):
         if not _is_retryable_http(success, status):
-            return result
+            break
         time.sleep(backoff_ms)
         result = fn()
+        attempts += 1
         success, status, _ = result
+
         # Starlark lacks `**`; double each iteration instead.
         backoff_ms = backoff_ms * 2
-    return result
+    return (result[0], result[1], result[2], attempts)
+
+def _warn_http_failure(ctx, label, attempts, status, error):
+    """Emit a single WARNING line summarizing a terminal HTTP failure.
+
+    `label` is a short identifier (e.g. `"GitHub API POST /repos/.../check-runs"`).
+    `error` is the body or transport-error string from the response triple."""
+    if status == 0:
+        detail = error if error else "transport error"
+    else:
+        detail = "HTTP %d" % status
+        if error:
+            extra = error if type(error) == "string" else str(error)
+
+            # Keep one-line: collapse newlines, cap to 200 chars.
+            extra = extra.replace("\n", " ")
+            if len(extra) > 200:
+                extra = extra[:200] + "..."
+            detail = detail + ": " + extra
+    suffix = " after %d attempts" % attempts if attempts > 1 else ""
+    warn(ctx.std, "%s failed%s: %s" % (label, suffix, detail))
 
 def _do_request_once(ctx, method, url, token, payload = None):
     """Single HTTP attempt. See file docstring for failure contract."""
@@ -100,8 +124,13 @@ def _do_request(ctx, method, url, token, payload = None):
     """Single HTTP call, retried on transient failures for idempotent
     methods. POST runs exactly once. Returns `(success, status, body)`."""
     if method in _IDEMPOTENT_METHODS:
-        return _retry_http(lambda: _do_request_once(ctx, method, url, token, payload))
-    return _do_request_once(ctx, method, url, token, payload)
+        success, status, body, attempts = _retry_http(lambda: _do_request_once(ctx, method, url, token, payload))
+    else:
+        success, status, body = _do_request_once(ctx, method, url, token, payload)
+        attempts = 1
+    if not success:
+        _warn_http_failure(ctx, "GitHub API %s %s" % (method, url), attempts, status, body)
+    return (success, status, body)
 
 # Authentication
 
@@ -1263,6 +1292,7 @@ def _github_twirp(ctx, method, payload):
     `(ok, body_or_None, error_message_or_None)`."""
     token = (ctx.std.env.var("ACTIONS_RUNTIME_TOKEN") or
              ctx.std.env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
+
     # ACTIONS_RESULTS_URL is not injected by ScriptHandler — fall back to the well-known default.
     results_url = (ctx.std.env.var("ACTIONS_RESULTS_URL") or
                    "https://results-receiver.actions.githubusercontent.com/")
@@ -1280,11 +1310,13 @@ def _github_twirp(ctx, method, payload):
 
     fn = lambda: _github_twirp_once(ctx, url, headers, payload)
     if method in _TWIRP_IDEMPOTENT_METHODS:
-        success, status, body_or_err = _retry_http(fn)
+        success, status, body_or_err, attempts = _retry_http(fn)
     else:
         success, status, body_or_err = fn()
+        attempts = 1
 
     if not success:
+        _warn_http_failure(ctx, "GitHub Actions Twirp %s" % method, attempts, status, body_or_err)
         if status == 0:
             err = body_or_err if type(body_or_err) == "string" else "transport error"
         else:
@@ -1360,6 +1392,7 @@ def _upload_artifact(ctx, path, name, expires_at = ""):
         owns_zip = True
 
     zip_size = ctx.std.fs.metadata(zip_path).size
+
     # No retry: body is a non-replayable `fs.open()` stream. Transport
     # errors still convert to `success=False` so the upload fails
     # softly rather than aborting the task.
@@ -1379,8 +1412,10 @@ def _upload_artifact(ctx, path, name, expires_at = ""):
         ctx.std.fs.remove_file(zip_path)
 
     if type(upload_resp) == "string":
+        _warn_http_failure(ctx, "GitHub Actions artifact blob PUT", 1, 0, upload_resp)
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["blob upload transport error: " + upload_resp]}
     if upload_resp.status < 200 or upload_resp.status >= 300:
+        _warn_http_failure(ctx, "GitHub Actions artifact blob PUT", 1, upload_resp.status, upload_resp.body)
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["blob upload: HTTP " + str(upload_resp.status)]}
 
     ok, body, err = _github_twirp(ctx, "FinalizeArtifact", {

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -1,6 +1,7 @@
 """GitHub API client library."""
 
 load("@std//base64.axl", "base64")
+load("@std//time.axl", "time")
 load("./environment.axl", "color_enabled", "info", "warn")
 load("./tar.axl", "zip_create")
 
@@ -8,7 +9,68 @@ DEFAULT_GITHUB_API = "https://api.github.com"
 
 # Internal helpers
 
-def _do_request(ctx, method, url, token, payload = None):
+def _is_retryable_http(success, status):
+    """Decide whether an HTTP call result is worth retrying.
+
+    Retry on:
+      - transport-level failures (status == 0 from our `.map_err(str)`
+        guard — DNS resolution, TLS handshake, connection refused,
+        connection reset, request timeout).
+      - 5xx server errors (502 / 503 / 504 in particular are routinely
+        emitted by GitHub's edge during regional incidents and tend to
+        clear on the next attempt).
+      - 429 (rate limited) — GitHub asks us to back off; the retry's
+        exponential backoff is the simplest honor of that.
+
+    Do NOT retry on other 4xx — those are deterministic client-side
+    errors (auth, bad request, not found). Retrying just delays the
+    inevitable error report.
+    """
+    if success:
+        return False
+    if status == 0:
+        return True
+    if status >= 500:
+        return True
+    if status == 429:
+        return True
+    return False
+
+# Default retry knobs. Three attempts with exponential backoff so a
+# single network flake (the typical case) gets one or two free retries
+# before surfacing. Total worst-case wall time: ~1.6s (250ms + 500ms +
+# 1000ms) — well under the 120s `Http::new` timeout, so a deeply hung
+# peer still aborts within bounded time.
+_HTTP_MAX_ATTEMPTS = 3
+_HTTP_BACKOFF_BASE_MS = 250
+
+def _retry_http(fn):
+    """Run `fn()` with retry-on-transient-failure semantics.
+
+    `fn` is a zero-arg closure returning `(success, status, body)` —
+    the shape `_do_request` and `_github_twirp` already produce.
+    Retryable failures (transport / 5xx / 429) are retried up to
+    `_HTTP_MAX_ATTEMPTS` times with exponential backoff. The last
+    result is returned regardless — successful, deterministically
+    failed (4xx), or exhausted-retries (caller still gets the error
+    body and decides whether to log + continue or fail).
+    """
+    result = fn()
+    success, status, _ = result
+    # Accumulator for the exponential backoff — Starlark has no `**`
+    # operator, so we double each iteration.
+    backoff_ms = _HTTP_BACKOFF_BASE_MS
+    for _ in range(_HTTP_MAX_ATTEMPTS - 1):
+        if not _is_retryable_http(success, status):
+            return result
+        time.sleep(backoff_ms)
+        result = fn()
+        success, status, _ = result
+        backoff_ms = backoff_ms * 2
+    return result
+
+def _do_request_once(ctx, method, url, token, payload = None):
+    """Single HTTP attempt — see `_do_request` for the retrying wrapper."""
     headers = {
         "Authorization": "Bearer " + token,
         "Accept": "application/vnd.github+json",
@@ -62,6 +124,17 @@ def _do_request(ctx, method, url, token, payload = None):
         snippet = body[:200].replace("\n", " ")
         return (False, response.status, "non-JSON response (status %d): %s" % (response.status, snippet))
     return (success, response.status, parsed)
+
+def _do_request(ctx, method, url, token, payload = None):
+    """`_do_request_once` wrapped in `_retry_http` — retries the call
+    on transient failures (transport errors, 5xx, 429) so a single
+    network flake doesn't surface as a feature-handler error.
+
+    All callers (`check_runs.update`, `issues.list_comments`,
+    `pulls.list_review_comments`, etc.) receive the same
+    `(success, status, body)` tuple shape as before.
+    """
+    return _retry_http(lambda: _do_request_once(ctx, method, url, token, payload))
 
 # Authentication
 
@@ -1194,12 +1267,40 @@ To make it available, use one of the following options:
             ACTIONS_RUNTIME_TOKEN: ${{ secrets.ACTIONS_RUNTIME_TOKEN }}
 """
 
-def _github_twirp(ctx, method, payload):
-    """Make a Twirp RPC call to the GitHub Actions artifact service."""
+def _github_twirp_once(ctx, url, headers, payload):
+    """Single Twirp attempt — see `_github_twirp` for the retrying wrapper.
 
-    # ACTIONS_ID_TOKEN_REQUEST_TOKEN is the same credential as ACTIONS_RUNTIME_TOKEN —
-    # both come from systemConnection.Authorization.Parameters["AccessToken"] in the runner.
-    # ScriptHandler injects it into shell steps when permissions: id-token: write is set.
+    Returns `(success, status, body_or_err)`:
+      - On a 2xx with a JSON body: `(True, status, decoded_body)`.
+      - On a 2xx with an empty body: `(True, status, None)`.
+      - On a non-2xx: `(False, status, decoded_body_or_str_snippet)`.
+      - On a transport error: `(False, 0, "transport error: ...")` —
+        matches `_do_request_once`'s shape so `_is_retryable_http`
+        retries it the same way.
+    """
+    response = ctx.http().post(
+        url = url,
+        headers = headers,
+        data = json.encode(payload),
+    ).map_err(lambda e: str(e)).block()
+    if type(response) == "string":
+        return (False, 0, "transport error: " + response)
+    success = response.status >= 200 and response.status < 300
+    body = None
+    if response.body:
+        _PARSE_FAILED = struct(_parse_failed = True)
+        parsed = json.try_decode(response.body, _PARSE_FAILED)
+        body = None if parsed == _PARSE_FAILED else parsed
+    return (success, response.status, body)
+
+def _github_twirp(ctx, method, payload):
+    """Make a Twirp RPC call to the GitHub Actions artifact service.
+
+    Retries on transient failures (transport errors, 5xx, 429) via
+    `_retry_http`. Returns `(ok, body_or_None, error_message_or_None)`
+    — the shape the existing `_upload_artifact` / `_delete_artifact`
+    callers already consume.
+    """
     token = (ctx.std.env.var("ACTIONS_RUNTIME_TOKEN") or
              ctx.std.env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
 
@@ -1218,10 +1319,21 @@ def _github_twirp(ctx, method, payload):
         "Content-Type": "application/json",
     }
 
-    resp = ctx.http().post(url = url, headers = headers, data = json.encode(payload)).block()
-    success = resp.status >= 200 and resp.status < 300
-    body = json.decode(resp.body) if resp.body else None
-    return (success, body, None)
+    success, status, body_or_err = _retry_http(
+        lambda: _github_twirp_once(ctx, url, headers, payload),
+    )
+    if not success:
+        # `_retry_http` returns the final (failed) attempt unchanged.
+        # Surface the failure as `err` text so callers see why instead
+        # of silently swallowing the result.
+        if status == 0:
+            err = body_or_err if type(body_or_err) == "string" else "transport error"
+        else:
+            err = "HTTP %d" % status
+            if body_or_err:
+                err = err + ": " + str(body_or_err)
+        return (False, None, err)
+    return (True, body_or_err, None)
 
 def _upload_artifact(ctx, path, name, expires_at = ""):
     """Upload a single file to GitHub Actions using the Twirp artifact API.
@@ -1289,6 +1401,12 @@ def _upload_artifact(ctx, path, name, expires_at = ""):
         owns_zip = True
 
     zip_size = ctx.std.fs.metadata(zip_path).size
+    # Convert transport errors to a string result so a flaky PUT to
+    # the Azure Blob signed URL surfaces as a `success=False` return
+    # rather than propagating up as an exception that fails the
+    # parent task. No retry here — the PUT body is a `fs.open()`
+    # stream that can't be replayed safely, and a fresh
+    # CreateArtifact + signed-URL exchange is the proper retry path.
     upload_resp = ctx.http().put(
         url = signed_url,
         headers = {
@@ -1297,13 +1415,15 @@ def _upload_artifact(ctx, path, name, expires_at = ""):
             "Content-Length": str(zip_size),
         },
         data = ctx.std.fs.open(zip_path),
-    ).block()
+    ).map_err(lambda e: str(e)).block()
 
     # Only remove the zip if we owned it — if the caller passed a pre-zipped
     # path, they're responsible for its cleanup (see _upload_testlogs_zip).
     if owns_zip and ctx.std.fs.exists(zip_path):
         ctx.std.fs.remove_file(zip_path)
 
+    if type(upload_resp) == "string":
+        return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["blob upload transport error: " + upload_resp]}
     if upload_resp.status < 200 or upload_resp.status >= 300:
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["blob upload: HTTP " + str(upload_resp.status)]}
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -1,4 +1,20 @@
-"""GitHub API client library."""
+"""GitHub API client library.
+
+HTTP failure-handling contract (applies to every helper below):
+
+  - Transport errors (DNS / TLS / refused / reset / timeout) are
+    converted to a string result via `.map_err(lambda e: str(e)).block()`
+    and surfaced as `(False, 0, "transport error: ...")`. Feature
+    handlers that use these helpers stay graceful — flaky network
+    never propagates as a Starlark exception that aborts the task.
+  - Transient failures (transport, 5xx, 429) are retried up to 3
+    times with exponential backoff (250 → 500 → 1000 ms). 4xx is
+    deterministic and not retried.
+  - Retry is gated on HTTP-method idempotency: GET / PUT / PATCH /
+    DELETE retry; POST runs exactly once to avoid duplicate
+    resources on a retry after the server already accepted the
+    first request.
+"""
 
 load("@std//base64.axl", "base64")
 load("@std//time.axl", "time")
@@ -10,55 +26,19 @@ DEFAULT_GITHUB_API = "https://api.github.com"
 # Internal helpers
 
 def _is_retryable_http(success, status):
-    """Decide whether an HTTP call result is worth retrying.
-
-    Retry on:
-      - transport-level failures (status == 0 from our `.map_err(str)`
-        guard — DNS resolution, TLS handshake, connection refused,
-        connection reset, request timeout).
-      - 5xx server errors (502 / 503 / 504 in particular are routinely
-        emitted by GitHub's edge during regional incidents and tend to
-        clear on the next attempt).
-      - 429 (rate limited) — GitHub asks us to back off; the retry's
-        exponential backoff is the simplest honor of that.
-
-    Do NOT retry on other 4xx — those are deterministic client-side
-    errors (auth, bad request, not found). Retrying just delays the
-    inevitable error report.
-    """
+    """True for transient failures (transport, 5xx, 429). 4xx → False."""
     if success:
         return False
-    if status == 0:
-        return True
-    if status >= 500:
-        return True
-    if status == 429:
-        return True
-    return False
+    return status == 0 or status >= 500 or status == 429
 
-# Default retry knobs. Three attempts with exponential backoff so a
-# single network flake (the typical case) gets one or two free retries
-# before surfacing. Total worst-case wall time: ~1.6s (250ms + 500ms +
-# 1000ms) — well under the 120s `Http::new` timeout, so a deeply hung
-# peer still aborts within bounded time.
 _HTTP_MAX_ATTEMPTS = 3
 _HTTP_BACKOFF_BASE_MS = 250
 
 def _retry_http(fn):
-    """Run `fn()` with retry-on-transient-failure semantics.
-
-    `fn` is a zero-arg closure returning `(success, status, body)` —
-    the shape `_do_request` and `_github_twirp` already produce.
-    Retryable failures (transport / 5xx / 429) are retried up to
-    `_HTTP_MAX_ATTEMPTS` times with exponential backoff. The last
-    result is returned regardless — successful, deterministically
-    failed (4xx), or exhausted-retries (caller still gets the error
-    body and decides whether to log + continue or fail).
-    """
+    """Run `fn()` returning `(success, status, body)`, retrying transient
+    failures up to `_HTTP_MAX_ATTEMPTS` with exponential backoff."""
     result = fn()
     success, status, _ = result
-    # Accumulator for the exponential backoff — Starlark has no `**`
-    # operator, so we double each iteration.
     backoff_ms = _HTTP_BACKOFF_BASE_MS
     for _ in range(_HTTP_MAX_ATTEMPTS - 1):
         if not _is_retryable_http(success, status):
@@ -66,11 +46,12 @@ def _retry_http(fn):
         time.sleep(backoff_ms)
         result = fn()
         success, status, _ = result
+        # Starlark lacks `**`; double each iteration instead.
         backoff_ms = backoff_ms * 2
     return result
 
 def _do_request_once(ctx, method, url, token, payload = None):
-    """Single HTTP attempt — see `_do_request` for the retrying wrapper."""
+    """Single HTTP attempt. See file docstring for failure contract."""
     headers = {
         "Authorization": "Bearer " + token,
         "Accept": "application/vnd.github+json",
@@ -89,10 +70,6 @@ def _do_request_once(ctx, method, url, token, payload = None):
     else:
         return (False, 0, "unsupported method: " + method)
 
-    # Convert transport errors (DNS failure, TLS error, connection refused, …)
-    # to a string result. Without this, the underlying anyhow error would
-    # propagate up through any lifecycle hook calling into github.* and fail
-    # the parent task. Callers detect transport errors via type-check.
     response = fut.map_err(lambda e: str(e)).block()
     if type(response) == "string":
         return (False, 0, "transport error: " + response)
@@ -101,23 +78,12 @@ def _do_request_once(ctx, method, url, token, payload = None):
     if not body:
         return (success, response.status, body)
 
-    # 5xx responses (and any other server-side error) often come back as
-    # HTML or plain text from edge proxies / rate limiters between us
-    # and GitHub. Don't attempt to decode them — surface a transport-
-    # style error snippet so callers fall back to status-driven error
-    # paths.
+    # 5xx bodies are commonly HTML / plain text from edge proxies;
+    # don't try to JSON-decode them.
     if response.status >= 500:
         snippet = body[:200].replace("\n", " ")
         return (False, response.status, "upstream error (status %d): %s" % (response.status, snippet))
 
-    # 2xx success and documented 4xx error envelopes use JSON.
-    # `json.try_decode` returns a sentinel on parse failure (truncated
-    # bodies, empty strings, or anything else malformed) — without it,
-    # a malformed body would crash the parent task (no try/except in
-    # Starlark), including unrelated tasks that only touch GitHub via
-    # a lifecycle hook (e.g. `aspect test` updating a status check).
-    # The sentinel has to be distinguishable from a valid `null` parse,
-    # which would also produce None.
     _PARSE_FAILED = struct(_parse_failed = True)
     parsed = json.try_decode(body, _PARSE_FAILED)
     if parsed == _PARSE_FAILED:
@@ -125,29 +91,14 @@ def _do_request_once(ctx, method, url, token, payload = None):
         return (False, response.status, "non-JSON response (status %d): %s" % (response.status, snippet))
     return (success, response.status, parsed)
 
-# HTTP methods that are idempotent per RFC 7231 — safe to retry
-# because re-executing them produces the same server-side effect.
-# Retrying POST is unsafe: a transient transport failure AFTER the
-# server has processed the first request would create a duplicate
-# resource on retry (extra check-runs, duplicate PR comments,
-# multiple reviews, etc.). Callers that POST and want retry need to
-# implement their own idempotency strategy (server-side dedup key,
-# read-after-write check, etc.).
+# RFC 7231 idempotent methods — safe to retry. POST is excluded; a
+# retry after the server processed the first request would duplicate
+# the resource (extra check-runs, duplicate PR comments, etc.).
 _IDEMPOTENT_METHODS = ["GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
 
 def _do_request(ctx, method, url, token, payload = None):
-    """`_do_request_once` with retry gated on HTTP idempotency.
-
-    GET / PUT / PATCH / DELETE retry on transient failures (transport
-    errors, 5xx, 429) via `_retry_http`. POST runs once — retrying it
-    after the server may have already accepted the first request
-    risks duplicate resources, which is a strictly worse failure mode
-    than the original error. Callers that need retry on POST should
-    use server-side idempotency keys or check-then-write patterns.
-
-    All callers receive the same `(success, status, body)` tuple
-    shape as before.
-    """
+    """Single HTTP call, retried on transient failures for idempotent
+    methods. POST runs exactly once. Returns `(success, status, body)`."""
     if method in _IDEMPOTENT_METHODS:
         return _retry_http(lambda: _do_request_once(ctx, method, url, token, payload))
     return _do_request_once(ctx, method, url, token, payload)
@@ -1284,16 +1235,8 @@ To make it available, use one of the following options:
 """
 
 def _github_twirp_once(ctx, url, headers, payload):
-    """Single Twirp attempt — see `_github_twirp` for the retrying wrapper.
-
-    Returns `(success, status, body_or_err)`:
-      - On a 2xx with a JSON body: `(True, status, decoded_body)`.
-      - On a 2xx with an empty body: `(True, status, None)`.
-      - On a non-2xx: `(False, status, decoded_body_or_str_snippet)`.
-      - On a transport error: `(False, 0, "transport error: ...")` —
-        matches `_do_request_once`'s shape so `_is_retryable_http`
-        retries it the same way.
-    """
+    """Single Twirp attempt. Returns `(success, status, body_or_None)`
+    matching `_do_request_once` so `_is_retryable_http` applies."""
     response = ctx.http().post(
         url = url,
         headers = headers,
@@ -1309,36 +1252,18 @@ def _github_twirp_once(ctx, url, headers, payload):
         body = None if parsed == _PARSE_FAILED else parsed
     return (success, response.status, body)
 
-# Twirp methods that are safe to retry. Each entry is an
-# ArtifactService operation whose semantics make re-execution
-# idempotent:
-#   DeleteArtifact — DELETE-shaped; second call is a no-op or 4xx.
-# CreateArtifact and FinalizeArtifact are deliberately excluded
-# because each is non-idempotent (they create / transition server
-# state and a retry after a transient error would either duplicate
-# the resource or surface a confusing "already finalized" 4xx that
-# masks the original network flake).
+# Twirp methods semantically safe to retry. CreateArtifact /
+# FinalizeArtifact are excluded — they create or transition state
+# and a retry after partial success would duplicate / half-finalize.
 _TWIRP_IDEMPOTENT_METHODS = ["DeleteArtifact"]
 
 def _github_twirp(ctx, method, payload):
-    """Make a Twirp RPC call to the GitHub Actions artifact service.
-
-    Retries on transient failures (transport errors, 5xx, 429) ONLY
-    for idempotent operations listed in `_TWIRP_IDEMPOTENT_METHODS`.
-    Non-idempotent operations (`CreateArtifact`, `FinalizeArtifact`)
-    run once — a transient transport error after the server has
-    processed the first request would create a duplicate or
-    half-finalized artifact on retry, which is strictly worse than
-    the original error.
-
-    Returns `(ok, body_or_None, error_message_or_None)` — the shape
-    the existing `_upload_artifact` / `_delete_artifact` callers
-    already consume.
-    """
+    """Twirp RPC to the GitHub Actions ArtifactService. Retries
+    transient failures only for `_TWIRP_IDEMPOTENT_METHODS`. Returns
+    `(ok, body_or_None, error_message_or_None)`."""
     token = (ctx.std.env.var("ACTIONS_RUNTIME_TOKEN") or
              ctx.std.env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
-
-    # ACTIONS_RESULTS_URL is not injected by ScriptHandler; use the well-known default.
+    # ACTIONS_RESULTS_URL is not injected by ScriptHandler — fall back to the well-known default.
     results_url = (ctx.std.env.var("ACTIONS_RESULTS_URL") or
                    "https://results-receiver.actions.githubusercontent.com/")
     if not token:
@@ -1360,9 +1285,6 @@ def _github_twirp(ctx, method, payload):
         success, status, body_or_err = fn()
 
     if not success:
-        # `_retry_http` (or the single attempt) returns the final
-        # failed result unchanged. Surface as `err` text so callers
-        # see why instead of silently swallowing it.
         if status == 0:
             err = body_or_err if type(body_or_err) == "string" else "transport error"
         else:
@@ -1438,12 +1360,9 @@ def _upload_artifact(ctx, path, name, expires_at = ""):
         owns_zip = True
 
     zip_size = ctx.std.fs.metadata(zip_path).size
-    # Convert transport errors to a string result so a flaky PUT to
-    # the Azure Blob signed URL surfaces as a `success=False` return
-    # rather than propagating up as an exception that fails the
-    # parent task. No retry here — the PUT body is a `fs.open()`
-    # stream that can't be replayed safely, and a fresh
-    # CreateArtifact + signed-URL exchange is the proper retry path.
+    # No retry: body is a non-replayable `fs.open()` stream. Transport
+    # errors still convert to `success=False` so the upload fails
+    # softly rather than aborting the task.
     upload_resp = ctx.http().put(
         url = signed_url,
         headers = {


### PR DESCRIPTION
## Summary

A transient transport failure on a GitHub Actions Twirp
`DeleteArtifact` call propagated out of the GHSC publisher and
failed an in-flight `lint` task. Observability features must never
fail the underlying task.

`lib/github.axl` now applies one consistent HTTP failure-handling
contract to every helper:

- **Transport errors** (DNS / TLS / refused / reset / timeout) are
  caught via `.map_err(lambda e: str(e)).block()` and surfaced as
  `(False, 0, "transport error: ...")`. The exception that aborted
  the lint task can't happen.
- **Transient failures** (transport, 5xx, 429) are retried up to 3
  times with exponential backoff (250 → 500 → 1000 ms). 4xx is
  deterministic and not retried.
- **Retry is gated on idempotency**: GET / PUT / PATCH / DELETE
  retry, POST runs exactly once. Retrying POST after the server
  accepted the first request would duplicate check-runs / PR
  comments / reviews / review comments — strictly worse than the
  original error.
- For the GH Actions Twirp ArtifactService, retry is gated on a
  per-method allowlist (`_TWIRP_IDEMPOTENT_METHODS = ["DeleteArtifact"]`).
  `CreateArtifact` and `FinalizeArtifact` run once each.
- **Terminal failures emit a one-line `WARNING:`** with method, URL,
  attempts count (when retry applied), and status/transport-error
  detail. Before this change, the only signal was an opaque AXL
  parse trace pointing at the call site with no underlying cause.

Also fixed two adjacent paths surfaced while auditing every
`ctx.http()` call site that feeds into a feature handler:
`lib/circleci.axl::_request` (CircleCI runner API) and
`lib/artifacts.axl::_upload_file_gitlab` (GitLab generic-packages
PUT) — both now catch transport errors so a flaky CI API can't fail
a task that just happens to be uploading artifacts, and both emit
the same one-line WARNING on terminal failure.

`.map_err` is the pre-existing `StarlarkFuture` transform
(`axl-runtime/src/engine/async/future.rs:221`); no Rust changes.

### Builds on #1071

#1071 (already landed) put a hard upper bound on how long a single
HTTP call can hang. This PR layers retry + graceful-failure on top:
timeouts bound the worst case, retry covers the common case,
graceful failure means observability features never abort tasks.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (in-code only)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Transient GitHub / CI API failures no longer fail `aspect lint` /
  `aspect format` / `aspect gazelle` (or any other task using the
  GHSC / GHC / ArtifactUpload features). Idempotent calls (GET / PUT
  / PATCH / DELETE) retry up to 3 times with exponential backoff;
  POST runs once to avoid duplicate check-runs / comments / reviews.
  Terminal failures now log a `WARNING:` line with method, URL,
  attempts, and the underlying transport error or HTTP status.

### Test plan

- Covered by existing test cases: 727 AXL tests + 7 snapshot suites
  pass.
- Manual: ran `aspect lint` / `aspect format` / `aspect gazelle`
  locally; happy path unchanged. Retry behavior exercised whenever
  GitHub's edge flakes — visible in CI logs as `WARNING: GitHub API
  POST /repos/.../check-runs failed after 3 attempts: transport
  error: ...` followed by the next cycle's retry-and-recover.
