### PR TITLE
feat(cli): detect GitLab MR context from CI env vars (ENG-1649)

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -7,6 +7,7 @@ load("@aspect//lib/bazel_results_test.axl", "template_snapshot_tests")
 load("@aspect//lib/delivery_results_test.axl", "delivery_template_snapshot_tests")
 load("@aspect//lib/format_results_test.axl", "format_template_snapshot_tests")
 load("@aspect//lib/gazelle_results_test.axl", "gazelle_template_snapshot_tests")
+load("@aspect//lib/gitlab_detect_test.axl", "gitlab_detect_tests")
 load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
 load("@aspect//lib/lint_results_test.axl", "lint_template_snapshot_tests")
 load("@aspect//lint.axl", "LintTrait")
@@ -73,6 +74,10 @@ def config(ctx: ConfigContext):
     # validation on the network-touching surfaces.
     # Run with: aspect dev test-gitlab-client
     ctx.tasks.add(gitlab_client_tests)
+
+    # GitLab MR detection smoke — env-var detection across CI hosts.
+    # Run with: aspect dev test-gitlab-detect
+    ctx.tasks.add(gitlab_detect_tests)
 
     # Lint template snapshot tests — renders lint_results templates.
     # Run with: aspect dev test-lint-template-snapshots

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect.axl
@@ -1,0 +1,133 @@
+"""GitLab merge-request context detection from CI environment variables.
+
+Mirrors `lib/github.axl::detect_github_pr` for the GitLab side. Pure
+env-var inspection — no HTTP, no auth — so the gitlab feature path
+(ENG-1651) can wire this in early without dragging the HTTP client
+(ENG-1648) or auth (ENG-1650) along as load-time prerequisites.
+
+`detect_gitlab_mr(std)` is the single public entry point. It returns
+`(dict, "")` on success, or `(None, reason)` when no MR context can be
+determined.
+
+The dict shape:
+  {
+    "project_path":   str,   # "group/subgroup/project" — GitLab supports
+                             #   arbitrarily deep nested subgroups, so this
+                             #   is a single slash-separated path, not a
+                             #   (owner, repo) split like GitHub.
+    "project_id":     int?,  # GitLab numeric project ID when CI surfaces
+                             #   it (always present under native GitLab CI;
+                             #   may be None under the explicit override
+                             #   path). Either project_path or project_id
+                             #   can be used as `:id` in the REST API.
+    "mr_iid":         int,   # MR's per-project IID (the integer in the
+                             #   URL: gitlab.com/<path>/-/merge_requests/<iid>).
+    "sha":            str,   # Commit SHA the status surfaces should attach
+                             #   to. See `_resolve_sha` for why we prefer
+                             #   the source-branch HEAD over CI_COMMIT_SHA
+                             #   on MR-result pipelines.
+    "source_branch":  str,   # MR source branch (may be empty under the
+                             #   explicit override).
+    "target_branch":  str,   # MR target branch (may be empty under the
+                             #   explicit override).
+  }
+"""
+
+def _resolve_sha(env):
+    """Resolve the commit SHA to surface status against.
+
+    On GitLab's merged-result pipelines, `CI_COMMIT_SHA` is a synthetic
+    merge commit between the source branch and the target — not a real
+    commit in either branch's history. Status surfaces attached to that
+    SHA don't appear on the MR widget the way the per-pipeline status
+    does, and external tools that follow the SHA back to a branch get
+    nothing. `CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` is the real source
+    branch HEAD and is what users expect statuses to attach to.
+
+    Same shape as `lib/github.axl::detect_commit_sha`, which uses the
+    `pull_request.head.sha` payload to bypass the equivalent GitHub
+    Actions synthetic merge SHA.
+    """
+    return (
+        env.var("CI_MERGE_REQUEST_SOURCE_BRANCH_SHA") or
+        env.var("CI_COMMIT_SHA") or
+        ""
+    )
+
+def detect_gitlab_mr(std):
+    """Detect GitLab merge-request context from CI environment variables.
+
+    Detection order — first match wins:
+      1. ASPECT_GITLAB_MR_IID env var (explicit override). Pairs with
+         ASPECT_GITLAB_PROJECT_PATH and a SHA from either
+         ASPECT_GITLAB_SHA or CI_COMMIT_SHA. Escape hatch for setups
+         where no native GitLab CI var is set — e.g., Aspect-Workflows-
+         managed runners executing on a non-GitLab CI host that still
+         want to post status back to a GitLab MR.
+      2. Native GitLab CI: GITLAB_CI=true plus the standard
+         CI_MERGE_REQUEST_* variables that GitLab populates on every
+         MR pipeline (detached, merged-result, or merge-train).
+
+    Returns `(dict, "")` on success, or `(None, reason)` when no MR
+    context can be determined. The reason string is what the caller
+    surfaces under the Detect phase output, so it should be specific
+    enough that a misconfigured pipeline is debuggable from logs alone.
+    """
+    env = std.env
+
+    explicit = env.var("ASPECT_GITLAB_MR_IID") or ""
+    if explicit:
+        if not explicit.isdigit():
+            return None, "ASPECT_GITLAB_MR_IID must be numeric, got %r" % explicit
+        project_path = env.var("ASPECT_GITLAB_PROJECT_PATH") or env.var("CI_PROJECT_PATH") or ""
+        if not project_path:
+            return None, "ASPECT_GITLAB_MR_IID set but no project path could be determined (set ASPECT_GITLAB_PROJECT_PATH or CI_PROJECT_PATH)"
+        sha = env.var("ASPECT_GITLAB_SHA") or _resolve_sha(env)
+        if not sha:
+            return None, "ASPECT_GITLAB_MR_IID set but no commit SHA could be determined (set ASPECT_GITLAB_SHA, CI_MERGE_REQUEST_SOURCE_BRANCH_SHA, or CI_COMMIT_SHA)"
+        return {
+            "project_path": project_path,
+            "project_id": _parse_int_or_none(env.var("CI_MERGE_REQUEST_PROJECT_ID") or env.var("CI_PROJECT_ID")),
+            "mr_iid": int(explicit),
+            "sha": sha,
+            "source_branch": env.var("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME") or "",
+            "target_branch": env.var("CI_MERGE_REQUEST_TARGET_BRANCH_NAME") or "",
+        }, ""
+
+    if not env.var("GITLAB_CI"):
+        return None, "no GitLab MR context detected on this CI host"
+
+    iid = env.var("CI_MERGE_REQUEST_IID") or ""
+    if not iid:
+        # GitLab populates CI_MERGE_REQUEST_IID on every MR pipeline
+        # variant (detached, merged-result, merge-train). Its absence
+        # under GITLAB_CI means the current pipeline isn't running for
+        # an MR — branch pipelines, scheduled pipelines, tag pipelines,
+        # API-triggered pipelines all hit this path.
+        return None, "GitLab CI detected but CI_MERGE_REQUEST_IID is not set (not an MR pipeline)"
+    if not iid.isdigit():
+        return None, "CI_MERGE_REQUEST_IID is not numeric: %r" % iid
+
+    project_path = env.var("CI_MERGE_REQUEST_PROJECT_PATH") or env.var("CI_PROJECT_PATH") or ""
+    if not project_path:
+        return None, "no GitLab project path (CI_MERGE_REQUEST_PROJECT_PATH / CI_PROJECT_PATH unset)"
+
+    sha = _resolve_sha(env)
+    if not sha:
+        return None, "no commit SHA (CI_MERGE_REQUEST_SOURCE_BRANCH_SHA / CI_COMMIT_SHA unset)"
+
+    return {
+        "project_path": project_path,
+        "project_id": _parse_int_or_none(env.var("CI_MERGE_REQUEST_PROJECT_ID") or env.var("CI_PROJECT_ID")),
+        "mr_iid": int(iid),
+        "sha": sha,
+        "source_branch": env.var("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME") or "",
+        "target_branch": env.var("CI_MERGE_REQUEST_TARGET_BRANCH_NAME") or "",
+    }, ""
+
+def _parse_int_or_none(s):
+    if not s:
+        return None
+    if not s.isdigit():
+        return None
+    return int(s)

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect_test.axl
@@ -1,0 +1,202 @@
+"""Smoke tests for `lib/gitlab_detect.axl`.
+
+`detect_gitlab_mr` reads `std.env.var(name)`, so we stub `std` with a
+fake env backed by a dict. Each scenario asserts the detection branch
+that fires for a given set of env vars.
+
+Run with:
+  aspect dev test-gitlab-detect
+"""
+
+load("./gitlab_detect.axl", "detect_gitlab_mr")
+
+def _fake_std(vars):
+    """Stub std with an env that resolves `var(name)` against `vars`."""
+    return struct(
+        env = struct(
+            var = lambda name: vars.get(name, ""),
+        ),
+    )
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _expect_ok(label, vars, expected):
+    got, reason = detect_gitlab_mr(_fake_std(vars))
+    if got == None:
+        fail("%s: expected success but got None (%s)" % (label, reason))
+    for k, want in expected.items():
+        _eq(label + " / " + k, got.get(k), want)
+    if reason != "":
+        fail("%s: unexpected reason on success: %r" % (label, reason))
+
+def _expect_none(label, vars, reason_contains):
+    got, reason = detect_gitlab_mr(_fake_std(vars))
+    if got != None:
+        fail("%s: expected None but got %r" % (label, got))
+    if reason_contains not in reason:
+        fail("%s: reason %r missing substring %r" % (label, reason, reason_contains))
+
+def _test_impl(ctx):
+    # ── Native GitLab CI on a detached MR pipeline ──────────────────────
+    _expect_ok(
+        "native MR pipeline (detached)",
+        {
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_IID": "42",
+            "CI_MERGE_REQUEST_PROJECT_PATH": "aspect-build/example",
+            "CI_MERGE_REQUEST_PROJECT_ID": "12345",
+            "CI_MERGE_REQUEST_SOURCE_BRANCH_NAME": "feature/x",
+            "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": "main",
+            "CI_MERGE_REQUEST_SOURCE_BRANCH_SHA": "aaaaaaaaaaaaaaaa",
+            "CI_COMMIT_SHA": "bbbbbbbbbbbbbbbb",
+        },
+        {
+            "project_path": "aspect-build/example",
+            "project_id": 12345,
+            "mr_iid": 42,
+            # CI_MERGE_REQUEST_SOURCE_BRANCH_SHA wins over CI_COMMIT_SHA
+            # because CI_COMMIT_SHA on merged-result pipelines is a
+            # synthetic SHA the MR UI doesn't follow.
+            "sha": "aaaaaaaaaaaaaaaa",
+            "source_branch": "feature/x",
+            "target_branch": "main",
+        },
+    )
+
+    # ── CI_COMMIT_SHA fallback when source-branch SHA absent ────────────
+    _expect_ok(
+        "fallback to CI_COMMIT_SHA",
+        {
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_IID": "7",
+            "CI_MERGE_REQUEST_PROJECT_PATH": "g/p",
+            "CI_COMMIT_SHA": "cccccccccccccccc",
+        },
+        {"sha": "cccccccccccccccc", "mr_iid": 7},
+    )
+
+    # ── CI_PROJECT_PATH fallback when MR-specific var absent ────────────
+    _expect_ok(
+        "CI_PROJECT_PATH fallback",
+        {
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_IID": "9",
+            "CI_PROJECT_PATH": "fallback/group/project",
+            "CI_COMMIT_SHA": "ffffffffffffffff",
+        },
+        {"project_path": "fallback/group/project"},
+    )
+
+    # ── Nested subgroup path is preserved verbatim ──────────────────────
+    _expect_ok(
+        "nested subgroup",
+        {
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_IID": "1",
+            "CI_MERGE_REQUEST_PROJECT_PATH": "org/team/sub/svc",
+            "CI_COMMIT_SHA": "dddddddddddddddd",
+        },
+        {"project_path": "org/team/sub/svc"},
+    )
+
+    # ── Explicit override: ASPECT_GITLAB_MR_IID ─────────────────────────
+    _expect_ok(
+        "explicit override (no GITLAB_CI)",
+        {
+            "ASPECT_GITLAB_MR_IID": "100",
+            "ASPECT_GITLAB_PROJECT_PATH": "manual/repo",
+            "ASPECT_GITLAB_SHA": "eeeeeeeeeeeeeeee",
+        },
+        {
+            "project_path": "manual/repo",
+            "mr_iid": 100,
+            "sha": "eeeeeeeeeeeeeeee",
+            "source_branch": "",
+            "target_branch": "",
+            "project_id": None,
+        },
+    )
+
+    # Override falls back to CI_PROJECT_PATH / CI_COMMIT_SHA when its own
+    # ASPECT_GITLAB_* pair isn't set.
+    _expect_ok(
+        "override w/ CI_PROJECT_PATH + CI_COMMIT_SHA fallback",
+        {
+            "ASPECT_GITLAB_MR_IID": "55",
+            "CI_PROJECT_PATH": "fb/project",
+            "CI_COMMIT_SHA": "1234567890abcdef",
+        },
+        {"project_path": "fb/project", "mr_iid": 55, "sha": "1234567890abcdef"},
+    )
+
+    # ── Negative cases ──────────────────────────────────────────────────
+    _expect_none(
+        "no CI vars at all",
+        {},
+        "no GitLab MR context detected",
+    )
+    _expect_none(
+        "GitLab CI but not an MR pipeline (branch / tag / scheduled)",
+        {
+            "GITLAB_CI": "true",
+            "CI_PROJECT_PATH": "g/p",
+            "CI_COMMIT_SHA": "abc",
+        },
+        "not an MR pipeline",
+    )
+    _expect_none(
+        "MR pipeline but project path missing",
+        {
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_IID": "1",
+            "CI_COMMIT_SHA": "abc",
+        },
+        "no GitLab project path",
+    )
+    _expect_none(
+        "MR pipeline but SHA missing",
+        {
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_IID": "1",
+            "CI_MERGE_REQUEST_PROJECT_PATH": "g/p",
+        },
+        "no commit SHA",
+    )
+    _expect_none(
+        "explicit override but project path missing",
+        {"ASPECT_GITLAB_MR_IID": "1"},
+        "no project path",
+    )
+    _expect_none(
+        "explicit override but SHA missing",
+        {
+            "ASPECT_GITLAB_MR_IID": "1",
+            "ASPECT_GITLAB_PROJECT_PATH": "g/p",
+        },
+        "no commit SHA",
+    )
+    _expect_none(
+        "non-numeric IID",
+        {
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_IID": "not-a-number",
+        },
+        "not numeric",
+    )
+    _expect_none(
+        "non-numeric override IID",
+        {"ASPECT_GITLAB_MR_IID": "abc"},
+        "must be numeric",
+    )
+
+    print("gitlab_detect.axl smoke: OK (12 scenarios)")
+    return 0
+
+gitlab_detect_tests = task(
+    name = "test-gitlab-detect",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)


### PR DESCRIPTION
## Summary

Adds `detect_gitlab_mr(std)` in `lib/gitlab_detect.axl`. Mirrors the `detect_github_pr` shape but adapted for GitLab — single slash-separated `project_path` (GitLab supports nested subgroups, so no `(owner, repo)` split), MR `iid` instead of PR number, optional numeric `project_id`, plus source/target branch names. Step 2 of the [GitLab Marvin Implementation](https://linear.app/aspect-build/project/proposal-gitlab-marvin-implementation-e7b8f1306ba7) project.

## Detection order

1. **`ASPECT_GITLAB_MR_IID` override** — paired with `ASPECT_GITLAB_PROJECT_PATH` and `ASPECT_GITLAB_SHA`, or falling back to `CI_PROJECT_PATH` / `CI_COMMIT_SHA`. Escape hatch for Aspect-Workflows-managed runners executing on non-GitLab CI hosts that still want to post status back to a GitLab MR.
2. **Native GitLab CI** — `GITLAB_CI=true` plus the standard `CI_MERGE_REQUEST_*` variables that GitLab populates on every MR pipeline (detached, merged-result, merge-train).

## Why source-branch SHA wins over CI_COMMIT_SHA

On GitLab merged-result pipelines, `CI_COMMIT_SHA` is a synthetic merge commit that isn't part of either branch's history — statuses posted against it don't appear on the MR widget. `CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` is the real source HEAD. Same problem `detect_github_pr` solves by reading `pull_request.head.sha` instead of `GITHUB_SHA` on GitHub Actions `pull_request` events.

## Why a separate file (not folded into lib/gitlab.axl from ENG-1648)

This ticket should land independently of ENG-1648 (HTTP client). Keeping the env-var detection in its own file means this PR has zero load-time prerequisites on the GitLab API surface. ENG-1651 (features) can consolidate the public surface later if useful.

## Verification

Smoke task wired via `.aspect/config.axl`:

```
aspect dev test-gitlab-detect
```

12 scenarios:
- Native MR pipeline (detached) — source-branch SHA wins
- Fallback to `CI_COMMIT_SHA` when source-branch SHA absent
- `CI_PROJECT_PATH` fallback when MR-specific var absent
- Nested subgroup path preserved verbatim
- Explicit override (no `GITLAB_CI`)
- Override w/ CI_PROJECT_PATH + CI_COMMIT_SHA fallback
- Negative cases: no CI vars, branch/tag pipeline, missing path, missing SHA, override w/o path, override w/o SHA, non-numeric IIDs

## Test plan

- [x] `aspect dev test-gitlab-detect` passes locally (12 scenarios)
- [ ] CI build green

ENG-1649