### PR TITLE
fix(github): parse diff hunk header positionally

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -1686,6 +1686,14 @@ rename to new.txt
     tc = test_case(tc, len(files_rm) == 1 and files_rm[0]["file"] == "new.txt", "parse_local_diff: rename+modify → entry under new path")
     tc = test_case(tc, files_rm[0]["lines"] == [4], "parse_local_diff: rename+modify added line index")
 
+    # Hunk header with a section heading containing a bare `+` (e.g. when the
+    # function-context line found by git starts with `+`). Earlier versions
+    # scanned every space-split token and hit `int("")` on the bare `+`.
+    diff_sh = "--- a/h.md\n+++ b/h.md\n@@ -1,1 +1,1 @@ + heading\n-old\n+new"
+    files_sh = github.parse_local_diff(diff_sh)
+    tc = test_case(tc, len(files_sh) == 1 and files_sh[0]["file"] == "h.md", "parse_local_diff: section heading parsed")
+    tc = test_case(tc, files_sh[0]["lines"] == [0] and files_sh[0]["additions"] == 1, "parse_local_diff: section heading doesn't break range parse")
+
     _clear_pr_env(env)
     return tc
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -555,28 +555,34 @@ def _parse_local_diff_output(output):
                 files.pop()
                 current_file = None
         elif line.startswith("@@ ") and current_file != None:
+            # Parse positionally: the trailing section heading is free-form
+            # text that may itself contain `+`/`-` tokens, so iterating
+            # every space-split part would misparse `@@ -10,3 +10,3 @@ + heading`.
             parts = line.split(" ")
-            for part in parts:
-                if part.startswith("-"):
-                    minus = part.removeprefix("-")
-                    if "," in minus:
-                        old_count = int(minus.split(",")[1])
-                    else:
-                        old_count = 1
-                    current_file["deletions"] += old_count
-                elif part.startswith("+") and part != "+++":
-                    plus = part.removeprefix("+")
-                    if "," in plus:
-                        chunks = plus.split(",")
-                        start = int(chunks[0])
-                        count = int(chunks[1])
-                    else:
-                        start = int(plus)
-                        count = 1
-                    current_file["additions"] += count
-                    if count > 0:
-                        for i in range(count):
-                            current_file["lines"].append(start - 1 + i)
+            if len(parts) < 3:
+                continue
+            minus_part = parts[1]
+            plus_part = parts[2]
+            if minus_part.startswith("-") and minus_part != "-":
+                minus = minus_part.removeprefix("-")
+                if "," in minus:
+                    old_count = int(minus.split(",")[1])
+                else:
+                    old_count = 1
+                current_file["deletions"] += old_count
+            if plus_part.startswith("+") and plus_part not in ("+", "+++"):
+                plus = plus_part.removeprefix("+")
+                if "," in plus:
+                    chunks = plus.split(",")
+                    start = int(chunks[0])
+                    count = int(chunks[1])
+                else:
+                    start = int(plus)
+                    count = 1
+                current_file["additions"] += count
+                if count > 0:
+                    for i in range(count):
+                        current_file["lines"].append(start - 1 + i)
     return files
 
 def _parse_github_pr_patch(patch):


### PR DESCRIPTION
## Summary

`_parse_local_diff_output` (`lib/github.axl`) iterated every
space-separated token of an `@@ -X +Y @@ <section heading>` line.
The trailing section heading is free-form text and can itself
contain `+` / `-` tokens; hitting a bare `+` ran `int("")` and
aborted the calling task (lint / format / gazelle).

Parse `parts[1]` (old range) and `parts[2]` (new range)
positionally and skip the section heading entirely. Adds a
regression test case in `.aspect/axl.axl`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (in-code only)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Fix a crash in `aspect lint` / `aspect format` / `aspect gazelle`
  when a changed file's diff hunk header carries a section heading
  that begins with `+` or `-`.

### Test plan

- Covered by existing test cases: 729 AXL tests pass (16 existing
  `parse_local_diff` cases + 2 new ones).
- New test case added: section heading containing a bare `+` parses
  cleanly with the expected line index.