### PR TITLE
feat: allow stderr/out to be redirected to a file

### DIFF
--- a/.aspect/modules/dev/build.axl
+++ b/.aspect/modules/dev/build.axl
@@ -8,7 +8,8 @@ def _build_impl(ctx: TaskContext) -> int:
     build = ctx.bazel.build(
         build_events = True,
         flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))],
-        inherit_stderr = False,
+        stdout = None,
+        stderr = None,
         *ctx.args.targets
     )
     return tui(ctx, build)

--- a/.aspect/modules/dev/test.axl
+++ b/.aspect/modules/dev/test.axl
@@ -8,7 +8,8 @@ def _test_impl(ctx: TaskContext) -> int:
     test = ctx.bazel.test(
         build_events = True,
         flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))],
-        inherit_stderr = False,
+        stdout = None,
+        stderr = None,
         *ctx.args.targets
     )
     return tui(ctx, test)

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -412,8 +412,6 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     # TODO: Do not swallow errors here and surface them if we can not find the hashes for all the deliverable targets.
     ctx.bazel.build(
         flags = phase2_flags,
-        inherit_stdout = True,
-        inherit_stderr = True,
         *targets
     ).wait()
 
@@ -914,7 +912,7 @@ def _delivery_impl(ctx):
             "--build_runfile_links",
         ]
         _t_download = time.monotonic()
-        build = ctx.bazel.build(flags = phase3_flags, build_events = True, inherit_stderr = False, *delivery_targets)
+        build = ctx.bazel.build(flags = phase3_flags, build_events = True, stderr = None, *delivery_targets)
         for event in build.build_events():
             run_tracker.event(event)
         status = build.wait()

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -359,7 +359,6 @@ def run_bazel_task(ctx: TaskContext, command: str) -> TaskConclusion:
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
                 flags = flags,
-                inherit_stdout = True,
                 *ctx.args.targets
             )
         else:
@@ -367,7 +366,6 @@ def run_bazel_task(ctx: TaskContext, command: str) -> TaskConclusion:
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
                 flags = flags,
-                inherit_stdout = True,
                 *ctx.args.targets
             )
 

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -892,8 +892,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     build = ctx.bazel.build(
         flags = flags,
         build_events = build_events,
-        inherit_stderr = True,
-        inherit_stdout = True,
         *ctx.args.targets
     )
 

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -7,6 +7,7 @@ use std::process::Stdio;
 use std::thread::JoinHandle;
 
 use allocative::Allocative;
+use axl_types::stream::Writable;
 use derive_more::Display;
 use starlark::environment::Methods;
 use starlark::environment::MethodsBuilder;
@@ -38,6 +39,52 @@ use super::sink::tracing as tracing_sink;
 use super::stream::BuildEventStream;
 use super::stream::ExecLogStream;
 use super::stream::WorkspaceEventStream;
+
+/// Convert a Starlark `Writable` handle to a `std::process::Stdio` for use
+/// as a child's stdio slot.
+///
+/// Parent stdio handles (`Writable::Stdout`/`Stderr`/`ChildStdin`) get their
+/// underlying fd duplicated so cross-wiring (e.g. `stdout = ctx.std.io.stderr`)
+/// works and the original handle stays usable from Starlark. `Writable::File`
+/// is `try_clone`d for the same reason.
+pub fn writable_to_stdio(w: &Writable) -> io::Result<Stdio> {
+    let closed = || io::Error::other("writable stream is closed");
+    match w {
+        Writable::Stdout(arc) => {
+            let guard = arc.lock().unwrap();
+            let borrowed = guard.borrow();
+            let s = borrowed.as_ref().ok_or_else(closed)?;
+            dup_fd(s)
+        }
+        Writable::Stderr(arc) => {
+            let guard = arc.lock().unwrap();
+            let borrowed = guard.borrow();
+            let s = borrowed.as_ref().ok_or_else(closed)?;
+            dup_fd(s)
+        }
+        Writable::ChildStdin(arc) => {
+            let guard = arc.lock().unwrap();
+            let borrowed = guard.borrow();
+            let s = borrowed.as_ref().ok_or_else(closed)?;
+            dup_fd(s)
+        }
+        Writable::File(arc) => {
+            let guard = arc.lock().unwrap();
+            let file = guard.as_ref().ok_or_else(closed)?;
+            Ok(Stdio::from(file.try_clone()?))
+        }
+    }
+}
+
+#[cfg(unix)]
+fn dup_fd<H: std::os::fd::AsFd>(h: &H) -> io::Result<Stdio> {
+    Ok(Stdio::from(h.as_fd().try_clone_to_owned()?))
+}
+
+#[cfg(windows)]
+fn dup_fd<H: std::os::windows::io::AsHandle>(h: &H) -> io::Result<Stdio> {
+    Ok(Stdio::from(h.as_handle().try_clone_to_owned()?))
+}
 
 #[derive(Debug, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
 #[display("<bazel.build.BuildStatus>")]
@@ -182,8 +229,8 @@ impl Build {
         workspace_events: bool,
         flags: Vec<String>,
         startup_flags: Vec<String>,
-        inherit_stdout: bool,
-        inherit_stderr: bool,
+        stdout: Stdio,
+        stderr: Stdio,
         current_dir: Option<String>,
         rt: AsyncRuntime,
     ) -> Result<Build, std::io::Error> {
@@ -280,17 +327,8 @@ impl Build {
 
         crate::trace!("exec: {:?}", cmd.get_args());
 
-        // TODO: if not inheriting, we should pipe and make the streams available to AXL
-        cmd.stdout(if inherit_stdout {
-            Stdio::inherit()
-        } else {
-            Stdio::null()
-        });
-        cmd.stderr(if inherit_stderr {
-            Stdio::inherit()
-        } else {
-            Stdio::null()
-        });
+        cmd.stdout(stdout);
+        cmd.stderr(stderr);
         cmd.stdin(Stdio::null());
 
         let child = cmd
@@ -586,7 +624,7 @@ def _impl(ctx):
     build = ctx.bazel.build(
         flags = ["--scenario=success"],
         build_events = True,
-        inherit_stderr = False,
+        stderr = None,
     )
     started = 0
     finished = 0
@@ -634,7 +672,7 @@ def _impl(ctx):
     build = ctx.bazel.build(
         flags = ["--scenario=cache_evicted_no_retry"],
         build_events = True,
-        inherit_stderr = False,
+        stderr = None,
     )
     for _ in build.build_events():
         pass
@@ -768,7 +806,7 @@ def _impl(ctx):
     build = ctx.bazel.build(
         flags = ["--scenario=success"],
         build_events = [sink],
-        inherit_stderr = False,
+        stderr = None,
     )
     status = build.wait()
     if not status.success: return 1
@@ -805,7 +843,7 @@ def _impl(ctx):
     build = ctx.bazel.build(
         flags = ["--scenario=success"],
         build_events = [sink],
-        inherit_stderr = False,
+        stderr = None,
     )
     status = build.wait()
     if status.success: return 1
@@ -845,7 +883,7 @@ def _impl(ctx):
     build = ctx.bazel.build(
         flags = ["--scenario=signal_killed_sigkill"],
         build_events = [sink],
-        inherit_stderr = False,
+        stderr = None,
     )
     status = build.wait()
     if status.success: return 1
@@ -882,7 +920,7 @@ def _impl(ctx):
     build = ctx.bazel.build(
         flags = ["--scenario=nonzero_exit"],
         build_events = [sink],
-        inherit_stderr = False,
+        stderr = None,
     )
     status = build.wait()
     if status.success: return 1

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -27,8 +27,10 @@ use starlark::{
     values::starlark_value_as_type::StarlarkValueAsType,
 };
 
+use crate::engine::std::io::Stdio as StdStdio;
 use crate::engine::store::Env;
 use axl_proto;
+use axl_types::stream::Writable;
 
 mod build;
 mod cancel;
@@ -47,6 +49,36 @@ mod stream;
 /// it via `PATH`.
 pub(crate) fn bazel_binary() -> String {
     std::env::var("BAZEL_REAL").unwrap_or_else(|_| "bazel".to_string())
+}
+
+/// Resolve the `(stdout, stderr)` `Stdio` slots from the Starlark args.
+///
+/// Tri-state for each per-fd arg: not passed → inherit, Starlark `None` →
+/// `/dev/null`, `Writable` → fd-dup that handle into the child. The `stdio`
+/// shorthand sets both slots from a single `Stdio` bundle; combining it with
+/// per-fd `stdout`/`stderr` is an error so the resolution stays unambiguous.
+fn resolve_stdio(
+    stdio: NoneOr<StdStdio>,
+    stdout: Option<NoneOr<Writable>>,
+    stderr: Option<NoneOr<Writable>>,
+) -> anyhow::Result<(Stdio, Stdio)> {
+    if let NoneOr::Other(s) = stdio {
+        if stdout.is_some() || stderr.is_some() {
+            anyhow::bail!("stdio cannot be combined with stdout/stderr — pass one or the other");
+        }
+        return Ok((
+            build::writable_to_stdio(&s.stdout)?,
+            build::writable_to_stdio(&s.stderr)?,
+        ));
+    }
+    let to_stdio = |spec: Option<NoneOr<Writable>>| -> anyhow::Result<Stdio> {
+        match spec {
+            None => Ok(Stdio::inherit()),
+            Some(NoneOr::None) => Ok(Stdio::null()),
+            Some(NoneOr::Other(w)) => Ok(build::writable_to_stdio(&w)?),
+        }
+    };
+    Ok((to_stdio(stdout)?, to_stdio(stderr)?))
 }
 
 /// Resolve a mixed list of plain flags and conditional `(flag, constraint)` tuples into
@@ -178,8 +210,14 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///   or a list of `BuildEventSink` values to forward events to remote sinks.
     /// * `workspace_events` - Enable the workspace events stream.
     /// * `execution_logs` - Enable the execution logs stream.
-    /// * `inherit_stdout` - Inherit stdout from the parent process.
-    /// * `inherit_stderr` - Inherit stderr from the parent process. Defaults to `True`.
+    /// * `stdout` - Per-fd config for the child's stdout. Not passed →
+    ///   inherit the parent's stdout. `None` → discard (`/dev/null`). A
+    ///   `Writable` (e.g. `ctx.std.io.stderr`, `ctx.std.fs.create("out.log")`)
+    ///   → redirect the child's stdout into that handle (the fd is duplicated).
+    /// * `stderr` - Per-fd config for the child's stderr. Same shape as `stdout`.
+    /// * `stdio` - Shorthand: set both `stdout` and `stderr` from a single
+    ///   `Stdio` bundle (typically `ctx.std.io`). Cannot be combined with
+    ///   `stdout`/`stderr`.
     /// * `current_dir` - Working directory for the Bazel invocation.
     ///
     /// # Arguments
@@ -205,6 +243,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///         ("--notmp_sandbox", ">=8"),
     ///         ("--some_legacy_flag", "<7"),
     ///     ],
+    ///     stdout = None,                              # discard child stdout
+    ///     stderr = ctx.std.fs.create("bazel.err"),    # redirect stderr to a file
     /// )
     /// status = build.wait()
     /// ```
@@ -223,8 +263,9 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named, default = UnpackList::default())] flags: UnpackList<
             Either<values::StringValue<'v>, (values::StringValue<'v>, values::StringValue<'v>)>,
         >,
-        #[starlark(require = named, default = false)] inherit_stdout: bool,
-        #[starlark(require = named, default = true)] inherit_stderr: bool,
+        #[starlark(require = named)] stdout: Option<NoneOr<Writable>>,
+        #[starlark(require = named)] stderr: Option<NoneOr<Writable>>,
+        #[starlark(require = named, default = NoneOr::None)] stdio: NoneOr<StdStdio>,
         #[starlark(require = named, default = NoneOr::None)] current_dir: NoneOr<String>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<build::Build> {
@@ -247,6 +288,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         let resolved_flags = resolve_flags(&flags.items, bazel_version.as_ref())?;
         let resolved_startup_flags = read_startup_flags(this)?;
         let env = Env::from_eval(eval)?;
+        let (stdout, stderr) = resolve_stdio(stdio, stdout, stderr)?;
         let build = build::Build::spawn(
             "build",
             targets.items.iter().map(|f| f.as_str().to_string()),
@@ -255,8 +297,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             workspace_events,
             resolved_flags,
             resolved_startup_flags,
-            inherit_stdout,
-            inherit_stderr,
+            stdout,
+            stderr,
             current_dir.into_option(),
             env.rt.clone(),
         )?;
@@ -281,8 +323,14 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///   or a list of `BuildEventSink` values to forward events to remote sinks.
     /// * `workspace_events` - Enable the workspace events stream.
     /// * `execution_logs` - Enable the execution logs stream.
-    /// * `inherit_stdout` - Inherit stdout from the parent process.
-    /// * `inherit_stderr` - Inherit stderr from the parent process. Defaults to `True`.
+    /// * `stdout` - Per-fd config for the child's stdout. Not passed →
+    ///   inherit the parent's stdout. `None` → discard (`/dev/null`). A
+    ///   `Writable` (e.g. `ctx.std.io.stderr`, `ctx.std.fs.create("out.log")`)
+    ///   → redirect the child's stdout into that handle (the fd is duplicated).
+    /// * `stderr` - Per-fd config for the child's stderr. Same shape as `stdout`.
+    /// * `stdio` - Shorthand: set both `stdout` and `stderr` from a single
+    ///   `Stdio` bundle (typically `ctx.std.io`). Cannot be combined with
+    ///   `stdout`/`stderr`.
     /// * `current_dir` - Working directory for the Bazel invocation.
     ///
     /// # Arguments
@@ -326,8 +374,9 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named, default = UnpackList::default())] flags: UnpackList<
             Either<values::StringValue<'v>, (values::StringValue<'v>, values::StringValue<'v>)>,
         >,
-        #[starlark(require = named, default = false)] inherit_stdout: bool,
-        #[starlark(require = named, default = true)] inherit_stderr: bool,
+        #[starlark(require = named)] stdout: Option<NoneOr<Writable>>,
+        #[starlark(require = named)] stderr: Option<NoneOr<Writable>>,
+        #[starlark(require = named, default = NoneOr::None)] stdio: NoneOr<StdStdio>,
         #[starlark(require = named, default = NoneOr::None)] current_dir: NoneOr<String>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<build::Build> {
@@ -350,6 +399,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         let resolved_flags = resolve_flags(&flags.items, bazel_version.as_ref())?;
         let resolved_startup_flags = read_startup_flags(this)?;
         let env = Env::from_eval(eval)?;
+        let (stdout, stderr) = resolve_stdio(stdio, stdout, stderr)?;
         let test = build::Build::spawn(
             "test",
             targets.items.iter().map(|f| f.as_str().to_string()),
@@ -358,8 +408,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             workspace_events,
             resolved_flags,
             resolved_startup_flags,
-            inherit_stdout,
-            inherit_stderr,
+            stdout,
+            stderr,
             current_dir.into_option(),
             env.rt.clone(),
         )?;

--- a/crates/axl-runtime/src/engine/std/fs.rs
+++ b/crates/axl-runtime/src/engine/std/fs.rs
@@ -508,6 +508,18 @@ pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
         let file = fs::File::open(path.as_str())?;
         Ok(stream::Readable::File(Arc::new(Mutex::new(file))))
     }
+
+    /// Creates (or truncates) a file for writing and returns it as a writable stream.
+    ///
+    /// Mirrors `std::fs::File::create` — the file is opened write-only and
+    /// truncated to zero length, or created if it does not exist.
+    fn create<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        #[starlark(require = pos)] path: values::StringValue,
+    ) -> anyhow::Result<stream::Writable> {
+        let file = fs::File::create(path.as_str())?;
+        Ok(stream::Writable::from(file))
+    }
 }
 
 fn marshal_metadata<'v>(m: &fs::Metadata, heap: Heap<'v>) -> Metadata<'v> {

--- a/crates/axl-runtime/src/engine/std/io.rs
+++ b/crates/axl-runtime/src/engine/std/io.rs
@@ -12,17 +12,27 @@ use starlark::starlark_simple_value;
 use starlark::values;
 use starlark::values::NoSerialize;
 use starlark::values::ProvidesStaticType;
+use starlark::values::UnpackValue;
 use starlark::values::ValueLike;
 use starlark::values::starlark_value;
 
 use super::stream;
 
-#[derive(Debug, Display, ProvidesStaticType, NoSerialize, Allocative)]
+#[derive(Debug, Display, Clone, ProvidesStaticType, NoSerialize, Allocative)]
 #[display("<std.io.Stdio>")]
 pub struct Stdio {
-    stdout: stream::Writable,
-    stderr: stream::Writable,
-    stdin: stream::Readable,
+    pub stdout: stream::Writable,
+    pub stderr: stream::Writable,
+    pub stdin: stream::Readable,
+}
+
+impl<'v> UnpackValue<'v> for Stdio {
+    type Error = anyhow::Error;
+
+    fn unpack_value_impl(value: values::Value<'v>) -> Result<Option<Self>, Self::Error> {
+        let v = value.downcast_ref_err::<Stdio>().into_anyhow_result()?;
+        Ok(Some(v.clone()))
+    }
 }
 
 impl Stdio {

--- a/crates/axl-runtime/src/engine/std/mod.rs
+++ b/crates/axl-runtime/src/engine/std/mod.rs
@@ -18,7 +18,7 @@ use starlark::{
 
 mod env;
 mod fs;
-mod io;
+pub mod io;
 mod process;
 pub mod stream;
 

--- a/crates/axl-types/src/stream.rs
+++ b/crates/axl-types/src/stream.rs
@@ -26,6 +26,7 @@ use starlark::starlark_simple_value;
 use starlark::values;
 use starlark::values::NoSerialize;
 use starlark::values::ProvidesStaticType;
+use starlark::values::UnpackValue;
 use starlark::values::ValueLike;
 use starlark::values::none::NoneType;
 use starlark::values::starlark_value;
@@ -46,6 +47,7 @@ pub enum Writable {
     ChildStdin(#[allocative(skip)] Arc<Mutex<RefCell<Option<ChildStdin>>>>),
     Stdout(#[allocative(skip)] Arc<Mutex<RefCell<Option<Stdout>>>>),
     Stderr(#[allocative(skip)] Arc<Mutex<RefCell<Option<Stderr>>>>),
+    File(#[allocative(skip)] Arc<Mutex<Option<std::fs::File>>>),
 }
 
 impl Display for Readable {
@@ -65,6 +67,7 @@ impl Display for Writable {
             Self::ChildStdin(_) => write!(f, "stream<child_stdin>"),
             Self::Stderr(_) => write!(f, "stream<stderr>"),
             Self::Stdout(_) => write!(f, "stream<stdout>"),
+            Self::File(_) => write!(f, "stream<file>"),
         }
     }
 }
@@ -102,6 +105,30 @@ impl From<Stdout> for Writable {
 impl From<Stderr> for Writable {
     fn from(stderr: Stderr) -> Self {
         Self::Stderr(Arc::new(Mutex::new(RefCell::new(Some(stderr)))))
+    }
+}
+
+impl From<std::fs::File> for Writable {
+    fn from(file: std::fs::File) -> Self {
+        Self::File(Arc::new(Mutex::new(Some(file))))
+    }
+}
+
+impl<'v> UnpackValue<'v> for Writable {
+    type Error = anyhow::Error;
+
+    fn unpack_value_impl(value: values::Value<'v>) -> Result<Option<Self>, Self::Error> {
+        let v = value.downcast_ref_err::<Writable>().into_anyhow_result()?;
+        Ok(Some(v.dupe()))
+    }
+}
+
+impl<'v> UnpackValue<'v> for Readable {
+    type Error = anyhow::Error;
+
+    fn unpack_value_impl(value: values::Value<'v>) -> Result<Option<Self>, Self::Error> {
+        let v = value.downcast_ref_err::<Readable>().into_anyhow_result()?;
+        Ok(Some(v.dupe()))
     }
 }
 
@@ -281,6 +308,7 @@ fn writable_methods(registry: &mut MethodsBuilder) {
                 let borrowed = guard.borrow();
                 borrowed.as_ref().map(|s| s.is_terminal()).unwrap_or(false)
             }
+            Writable::File(_) => false,
         })
     }
 
@@ -333,6 +361,14 @@ fn writable_methods(registry: &mut MethodsBuilder) {
                     .map(|f| f as u32)
                     .map_err(|err| anyhow!(err))
             }
+            Writable::File(file) => {
+                let mut guard = file.lock().unwrap();
+                let inner = guard.as_mut().ok_or_else(|| anyhow!("stream is closed"))?;
+                inner
+                    .write(data)
+                    .map(|f| f as u32)
+                    .map_err(|err| anyhow!(err))
+            }
         }
     }
 
@@ -360,6 +396,11 @@ fn writable_methods(registry: &mut MethodsBuilder) {
                 let mut borrowed = guard.borrow_mut();
                 if let Some(inner) = borrowed.as_mut() {
                     inner.lock().flush()?;
+                }
+            }
+            Writable::File(file) => {
+                if let Some(inner) = file.lock().unwrap().as_mut() {
+                    inner.flush()?;
                 }
             }
         };
@@ -392,6 +433,12 @@ fn writable_methods(registry: &mut MethodsBuilder) {
                     .lock()
                     .unwrap()
                     .borrow_mut()
+                    .take()
+                    .ok_or_else(|| anyhow!("stream is already closed"))?;
+            }
+            Writable::File(file) => {
+                file.lock()
+                    .unwrap()
                     .take()
                     .ok_or_else(|| anyhow!("stream is already closed"))?;
             }

--- a/examples/large_bes/.aspect/remote_key.axl
+++ b/examples/large_bes/.aspect/remote_key.axl
@@ -19,7 +19,7 @@ def _idea_impl(ctx):
             "--nokeep_state_after_build",
             "--remote_grpc_log=bazel-log.bin",
         ],
-        inherit_stderr = False,
+        stderr = None,
     )
     r = build.wait()
 


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

`ctx.bazel.build`/`ctx.bazel.test` no longer accept `inherit_stdout` / `inherit_stderr` booleans — pass `stdout=` / `stderr=` with `None` (discard), a `Writable` handle from `ctx.std.io` / `ctx.std.fs.create()` (redirect), or omit for the new default of inheriting the parent.

### Test plan

- Covered by existing test cases
- New test cases added
