### PR TITLE
fix(github): merge-commit-first on shallow clones; HEAD-on-base diff

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -7,6 +7,7 @@ load("@aspect//lib/bazel_results_test.axl", "template_snapshot_tests")
 load("@aspect//lib/delivery_results_test.axl", "delivery_template_snapshot_tests")
 load("@aspect//lib/format_results_test.axl", "format_template_snapshot_tests")
 load("@aspect//lib/gazelle_results_test.axl", "gazelle_template_snapshot_tests")
+load("@aspect//lib/github_detect_test.axl", "github_detect_tests")
 load("@aspect//lib/gitlab_detect_test.axl", "gitlab_detect_tests")
 load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
 load("@aspect//lib/lint_results_test.axl", "lint_template_snapshot_tests")
@@ -78,6 +79,11 @@ def config(ctx: ConfigContext):
     # GitLab MR detection smoke — env-var detection across CI hosts.
     # Run with: aspect dev test-gitlab-detect
     ctx.tasks.add(gitlab_detect_tests)
+
+    # GitHub event detection smoke — pull_request / merge_group / push
+    # event shapes drive change-detection routing in detect_changed_files.
+    # Run with: aspect dev test-github-detect
+    ctx.tasks.add(github_detect_tests)
 
     # Lint template snapshot tests — renders lint_results templates.
     # Run with: aspect dev test-lint-template-snapshots

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ site
 .DS_Store
 
 .bazelrc.user
+
+.claude

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -286,7 +286,7 @@ def complete_check_run(ctx, token, owner, repo, check_run_id, conclusion, output
 
 # CI environment detection
 
-def _read_github_event(std):
+def read_github_event(std):
     """Read and parse the GitHub Actions event payload from
     `GITHUB_EVENT_PATH`. Returns the parsed dict, or `{}` when the
     env var isn't set, the file can't be read, or the JSON is
@@ -315,7 +315,7 @@ def detect_commit_sha(std):
     env = std.env
     event_name = env.var("GITHUB_EVENT_NAME") or ""
     if env.var("GITHUB_ACTIONS") and event_name in ("pull_request", "pull_request_target"):
-        head_sha = (_read_github_event(std).get("pull_request", {}) or {}).get("head", {}).get("sha", "")
+        head_sha = (read_github_event(std).get("pull_request", {}) or {}).get("head", {}).get("sha", "")
         if head_sha:
             return head_sha
     return (
@@ -326,7 +326,7 @@ def detect_commit_sha(std):
         ""
     )
 
-def _detect_merge_group_base_sha(std):
+def detect_merge_group_base_sha(std):
     """Return the merge-queue base SHA from the `merge_group` event
     payload, or `""` when not in a merge_group run.
 
@@ -343,7 +343,7 @@ def _detect_merge_group_base_sha(std):
         return ""
     if (env.var("GITHUB_EVENT_NAME") or "") != "merge_group":
         return ""
-    return (_read_github_event(std).get("merge_group", {}) or {}).get("base_sha", "") or ""
+    return (read_github_event(std).get("merge_group", {}) or {}).get("base_sha", "") or ""
 
 def detect_build_url(ctx):
     """Detect the CI build URL from common environment variables.
@@ -518,22 +518,60 @@ def _head_parents(ctx):
     """Return HEAD's parent SHAs as a list, or `[]` when HEAD is
     unresolvable. `len(result) >= 2` ⇒ HEAD is a merge commit.
 
+    Reads parents from the raw commit object via `git cat-file -p HEAD`
+    rather than `git log -1 --pretty=%P` or `git rev-list --parents`.
+    The latter two respect the `.git/shallow` overlay and return empty
+    on a shallow checkout (e.g. `actions/checkout` with `fetch-depth:
+    1`), even though the parent SHAs are still encoded in the commit
+    object itself. Reading the raw object bypasses the overlay so
+    merge-commit-first works on shallow PR checkouts too — the parent
+    SHAs become known, and a targeted `git fetch <sha> --depth=1`
+    (handled by `_try_local_git_diff_from_base_sha` /
+    `_ensure_local_sha`) can pull the parent object on demand.
+
     On a GitHub Actions `pull_request` / `pull_request_target` run,
     `actions/checkout` checks out the synthesized merge commit at
-    `refs/pull/<n>/merge` — HEAD^1 is the base branch SHA and HEAD^2
-    is the PR head. On a `merge_group` run, HEAD is the queue-
-    synthesized merge commit with the same shape. Both are local
-    (the parents are reachable from HEAD), so a local `git diff
-    HEAD^1..HEAD` produces the same change set as the PR Files API
-    at zero API cost.
+    `refs/pull/<n>/merge` — parents[0] is the base branch SHA and
+    parents[1] is the PR head. On a `merge_group` run, HEAD is the
+    queue-synthesized merge commit with the same shape.
     """
     process = ctx.std.process
     cwd = ctx.std.env.current_dir()
-    out = process.command("git").args(["log", "-1", "--pretty=%P"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
+    out = process.command("git").args(["cat-file", "-p", "HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
     if not out.status.success:
         return []
-    parents = out.stdout.strip().split()
-    return [p for p in parents if p]
+    parents = []
+    for line in out.stdout.split("\n"):
+        if line.startswith("parent "):
+            sha = line[len("parent "):].strip()
+            if sha:
+                parents.append(sha)
+        elif line == "":
+            # End of commit-object header block; commit message follows.
+            break
+    return parents
+
+def _ensure_local_sha(ctx, sha):
+    """Ensure `sha` is present in the local object store, fetching it
+    shallowly from `origin` on-demand. Returns True iff the object is
+    available after this call.
+
+    Companion to `_head_parents`: on shallow checkouts the cat-file-based
+    parent SHA is known but the parent commit OBJECT may not be local,
+    so a subsequent `git diff <sha>` would fail. This helper closes that
+    gap with a targeted depth-1 fetch by SHA (GitHub's git server
+    accepts arbitrary reachable SHAs via `uploadpack.allowAnySHA1InWant`).
+    """
+    process = ctx.std.process
+    cwd = ctx.std.env.current_dir()
+    have = process.command("git").args(["cat-file", "-e", sha]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
+    if have.status.success:
+        return True
+    fetched = process.command("git").args(["fetch", "--depth=1", "origin", sha]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
+    if not fetched.status.success:
+        return False
+    recheck = process.command("git").args(["cat-file", "-e", sha]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
+    return recheck.status.success
 
 def _resolve_merge_base(ctx, base_ref):
     """Resolve a diff base SHA for local-git change detection, with
@@ -541,23 +579,64 @@ def _resolve_merge_base(ctx, base_ref):
     or `("", reason)` when no candidate succeeds.
 
     Strategy, in order:
-      1. `git merge-base HEAD <base_ref>` — the canonical path.
-      2. `git rev-parse HEAD^1` when HEAD is a merge commit — works on
-         any merge commit (including a merge-queue HEAD) without
-         needing any ref to exist locally.
+      1. `git merge-base HEAD <base_ref>` — the canonical path. The
+         result determines what step 2 is allowed to do:
+           - Returns a SHA different from HEAD's: use it directly.
+           - Returns HEAD's own SHA (`mb == HEAD`): HEAD is already on
+             `base_ref` (push-to-base / squash-merge landing). Set
+             `head_on_base = True` and fall through; the HEAD^1 path
+             below will return the previous commit on the branch.
+           - Fails (`base_ref` ref not present, e.g. shallow checkout
+             without origin/main): unknown topology — DON'T use HEAD^1
+             for single-parent commits (would silently under-scope a
+             multi-commit feature branch to just its tip). Fall through
+             but skip the single-parent branch.
+      2. HEAD^1 — usable only in topology-confirmed cases:
+           a. HEAD is a merge commit (≥2 parents): parents[0] is the
+              base branch SHA (PR / merge-queue checkout). Safe
+              regardless of `head_on_base` — the merge commit's first
+              parent IS the base by construction.
+           b. HEAD is a single-parent commit AND `head_on_base` is
+              true: HEAD^1 is the previous commit on the branch
+              (push-to-base / squash-merge landing). NOT used when
+              merge-base failed — we'd be guessing the topology.
+         The parent OBJECT may not be local on shallow checkouts;
+         `_ensure_local_sha` fetches it on-demand before returning.
       3. `git fetch --depth=1 origin <base_ref>` then retry merge-base
-         — last-resort fetch in case the ref was just never fetched.
+         — last-resort fetch when the ref was never fetched. After a
+         successful retry, apply the same three-way result handling
+         as step 1: distinct SHA → use it; HEAD-equal → HEAD^1 path
+         (single-parent now safe because we've confirmed `head_on_base`).
     """
     process = ctx.std.process
     cwd = ctx.std.env.current_dir()
 
+    head_out = process.command("git").args(["rev-parse", "HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
+    head_sha = head_out.stdout.strip() if head_out.status.success else ""
+
+    head_on_base = False
     mb = process.command("git").args(["merge-base", "HEAD", base_ref]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
     if mb.status.success:
-        return mb.stdout.strip(), "git merge-base HEAD %s" % base_ref
+        mb_sha = mb.stdout.strip()
+        if mb_sha and mb_sha != head_sha:
+            return mb_sha, "git merge-base HEAD %s" % base_ref
+        if mb_sha == head_sha:
+            head_on_base = True
 
     parents = _head_parents(ctx)
-    if len(parents) >= 2:
-        return parents[0], "git rev-parse HEAD^1 (merge commit first parent)"
+
+    # Merge commit: parents[0] is the base by construction — safe even
+    # when we couldn't confirm `head_on_base`.
+    # Single-parent: only safe when merge-base CONFIRMED HEAD is on the
+    # base branch. Returning HEAD^1 for an arbitrary single-parent HEAD
+    # (e.g. multi-commit feature branch with origin/<base> not yet
+    # fetched) would under-scope the diff to just the tip commit.
+    if len(parents) >= 2 or (len(parents) >= 1 and head_on_base):
+        parent_sha = parents[0]
+        if _ensure_local_sha(ctx, parent_sha):
+            if len(parents) >= 2:
+                return parent_sha, "git rev-parse HEAD^1 (merge commit first parent)"
+            return parent_sha, "git rev-parse HEAD^1 (HEAD on %s)" % base_ref
 
     # `git fetch origin <ref>` wants the *remote* ref name. `base_ref`
     # is typically `origin/main` — a local remote-tracking ref. Strip
@@ -567,7 +646,16 @@ def _resolve_merge_base(ctx, base_ref):
     if fetch.status.success:
         retry = process.command("git").args(["merge-base", "HEAD", base_ref]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
         if retry.status.success:
-            return retry.stdout.strip(), "git merge-base HEAD %s (after `git fetch origin %s`)" % (base_ref, remote_ref)
+            mb_sha = retry.stdout.strip()
+            if mb_sha and mb_sha != head_sha:
+                return mb_sha, "git merge-base HEAD %s (after `git fetch origin %s`)" % (base_ref, remote_ref)
+
+            # mb_sha == head_sha now CONFIRMS HEAD is on base; the
+            # single-parent HEAD^1 branch is safe.
+            if mb_sha == head_sha and len(parents) >= 1:
+                parent_sha = parents[0]
+                if _ensure_local_sha(ctx, parent_sha):
+                    return parent_sha, "git rev-parse HEAD^1 (HEAD on %s, confirmed after `git fetch origin %s`)" % (base_ref, remote_ref)
 
     return "", "tried `git merge-base HEAD %s`, `git rev-parse HEAD^1`, and `git fetch --depth=1 origin %s`; none succeeded" % (base_ref, remote_ref)
 
@@ -586,17 +674,11 @@ def _try_local_git_diff_from_base_sha(ctx, line_level, base_sha):
     process = ctx.std.process
     cwd = ctx.std.env.current_dir()
 
-    # Ensure the base SHA is available locally. On shallow checkouts
-    # (e.g. `fetch-depth: 1`) the SHA may not be in the local repo
-    # and `git diff` would fail. Try a targeted fetch first.
-    have_sha = process.command("git").args(["cat-file", "-e", base_sha]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
-    if not have_sha.status.success:
-        fetched = process.command("git").args(["fetch", "origin", base_sha, "--depth=1"]).current_dir(cwd).stdout("null").stderr("piped").spawn().wait_with_output()
-        if not fetched.status.success:
-            return None
-        recheck = process.command("git").args(["cat-file", "-e", base_sha]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
-        if not recheck.status.success:
-            return None
+    # On shallow checkouts (e.g. `fetch-depth: 1`) the SHA may not be
+    # in the local object store and `git diff` would fail; do a
+    # targeted depth-1 fetch on-demand.
+    if not _ensure_local_sha(ctx, base_sha):
+        return None
 
     head_out = process.command("git").args(["rev-parse", "HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
     head_sha = head_out.stdout.strip() if head_out.status.success else ""
@@ -782,7 +864,7 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
 
     # (2) merge_group event
     if merge_base == None:
-        mg_base = _detect_merge_group_base_sha(ctx.std)
+        mg_base = detect_merge_group_base_sha(ctx.std)
         if mg_base:
             local = _try_local_git_diff_from_base_sha(ctx, line_level, mg_base)
             if local:
@@ -811,6 +893,14 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
         if not token:
             fallback_reason = "authentication failed: %s" % auth_reason.get("reason", "unknown")
         else:
+            # We've fallen past the merge-commit-first path (HEAD isn't
+            # a merge commit, or its first parent couldn't be fetched)
+            # so we have to consult the API. Surface this once so users
+            # can fix their checkout config and stop burning rate-limit
+            # budget on every run — the API call costs against the
+            # GitHub App's shared 5,000 req/hr quota, while the
+            # local-diff alternative is free.
+            warn(ctx.std, "Using GitHub PR Files API for change detection (consumes GitHub App API quota). To avoid this on future runs, keep the default `pull_request` merge-commit ref in `actions/checkout` (no `ref:` override) — aspect-cli derives the change set from a local `git diff HEAD^1..HEAD` at zero API cost. If you're already using the default ref, ensure `fetch-depth >= 1` (the default).")
             result = list_pull_request_files(ctx, token, pr["owner"], pr["repo"], pr["pr_number"])
             if result["success"]:
                 # `git rev-parse --show-prefix` strips the workspace prefix so

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -1,0 +1,292 @@
+"""Smoke tests for `lib/github.axl` CI-event detection helpers.
+
+Covers the three change-detection event shapes aspect-cli sees in
+GitHub Actions:
+
+  1. GitHub PR (`pull_request` / `pull_request_target`)
+     — `detect_github_pr` returns the PR context;
+       `detect_merge_group_base_sha` returns "".
+  2. Merge queue (`merge_group`)
+     — `detect_merge_group_base_sha` returns `merge_group.base_sha`
+       from the event payload;
+       `detect_github_pr` returns None (no PR ref).
+  3. Landed commit (`push`)
+     — both helpers return empty / None; downstream falls back to
+       local `git diff` against the base branch.
+
+These are env- and event-file-driven, so the tests stub `std` with a
+fake env (dict-backed) and a fake fs (path → content dict). No real
+filesystem, no real subprocesses.
+
+Run with:
+  aspect dev test-github-detect
+"""
+
+load(
+    "./github.axl",
+    "detect_commit_sha",
+    "detect_github_pr",
+    "detect_merge_group_base_sha",
+    "read_github_event",
+)
+
+def _fake_std(vars, files = {}):
+    """Stub std with env + fs:
+      env.var(name)           → vars.get(name, "")
+      fs.exists(path)          → path in files
+      fs.read_to_string(path)  → files[path]  (KeyError if missing)
+    """
+    return struct(
+        env = struct(
+            var = lambda name: vars.get(name, ""),
+        ),
+        fs = struct(
+            exists = lambda path: path in files,
+            read_to_string = lambda path: files[path],
+        ),
+    )
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+# ── detect_github_pr ────────────────────────────────────────────────
+
+def _expect_pr_ok(label, vars, files, expected):
+    pr, reason = detect_github_pr(_fake_std(vars, files))
+    if pr == None:
+        fail("%s: expected PR but got None (%s)" % (label, reason))
+    for k, want in expected.items():
+        _eq(label + " / " + k, pr.get(k), want)
+    if reason != "":
+        fail("%s: unexpected reason on success: %r" % (label, reason))
+
+def _expect_pr_none(label, vars, files, reason_contains):
+    pr, reason = detect_github_pr(_fake_std(vars, files))
+    if pr != None:
+        fail("%s: expected None but got %r" % (label, pr))
+    if reason_contains not in reason:
+        fail("%s: reason %r missing substring %r" % (label, reason, reason_contains))
+
+# ── detect_merge_group_base_sha ─────────────────────────────────────
+
+def _expect_mg_sha(label, vars, files, expected):
+    got = detect_merge_group_base_sha(_fake_std(vars, files))
+    _eq(label, got, expected)
+
+# ── detect_commit_sha ───────────────────────────────────────────────
+
+def _expect_commit_sha(label, vars, files, expected):
+    got = detect_commit_sha(_fake_std(vars, files))
+    _eq(label, got, expected)
+
+# ── read_github_event ───────────────────────────────────────────────
+
+def _expect_event(label, vars, files, expected):
+    got = read_github_event(_fake_std(vars, files))
+    _eq(label, got, expected)
+
+def _test_impl(ctx):
+    # ── (1) GitHub PR — pull_request event ──────────────────────────
+    # actions/checkout v6 default: synthesized merge commit at
+    # refs/pull/N/merge; pull_request.head.sha in event payload is the
+    # PR's real head (used for status checks / annotations).
+    pr_event_path = "/tmp/event-pr.json"
+    pr_event_json = """{
+        "pull_request": {
+            "head": {"sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+            "base": {"sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+        }
+    }"""
+    pr_vars = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_EVENT_NAME": "pull_request",
+        "GITHUB_REF": "refs/pull/42/merge",
+        "GITHUB_REPOSITORY": "aspect-build/aspect-cli",
+        "GITHUB_SHA": "ccccccccccccccccccccccccccccccccccccccccc",
+        "GITHUB_EVENT_PATH": pr_event_path,
+    }
+    pr_files = {pr_event_path: pr_event_json}
+
+    _expect_pr_ok(
+        "pull_request: detect_github_pr returns PR context",
+        pr_vars,
+        pr_files,
+        {
+            "owner": "aspect-build",
+            "repo": "aspect-cli",
+            "pr_number": 42,
+            # detect_commit_sha prefers pull_request.head.sha over the
+            # synthetic GITHUB_SHA (the latter points at the temp merge
+            # commit; check-runs anchored there are hidden in the UI).
+            "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+    )
+    _expect_mg_sha(
+        "pull_request: detect_merge_group_base_sha is empty",
+        pr_vars,
+        pr_files,
+        "",
+    )
+    _expect_commit_sha(
+        "pull_request: detect_commit_sha is pull_request.head.sha",
+        pr_vars,
+        pr_files,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+
+    # ── (2) Merge queue — merge_group event ─────────────────────────
+    # GitHub merges PRs through a queue branch
+    # (`gh-readonly-queue/<target>/<sha>`); the event payload exposes
+    # `merge_group.base_sha` directly so we don't have to resolve it
+    # via `git merge-base HEAD origin/<base>` on a shallow checkout.
+    mg_event_path = "/tmp/event-mg.json"
+    mg_event_json = """{
+        "merge_group": {
+            "base_sha": "1111111111111111111111111111111111111111",
+            "head_sha": "2222222222222222222222222222222222222222",
+            "base_ref": "refs/heads/main"
+        }
+    }"""
+    mg_vars = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_EVENT_NAME": "merge_group",
+        "GITHUB_REF": "refs/heads/gh-readonly-queue/main/pr-42-cafef00d",
+        "GITHUB_REPOSITORY": "aspect-build/aspect-cli",
+        "GITHUB_SHA": "2222222222222222222222222222222222222222",
+        "GITHUB_EVENT_PATH": mg_event_path,
+    }
+    mg_files = {mg_event_path: mg_event_json}
+
+    _expect_mg_sha(
+        "merge_group: detect_merge_group_base_sha returns base_sha",
+        mg_vars,
+        mg_files,
+        "1111111111111111111111111111111111111111",
+    )
+    _expect_pr_none(
+        "merge_group: detect_github_pr is None (no PR ref)",
+        mg_vars,
+        mg_files,
+        "GITHUB_REF is not a PR merge ref",
+    )
+
+    # ── (3) Landed commit — push to main ────────────────────────────
+    # No PR context, no merge_group payload. Downstream falls back to
+    # local `git diff` against `origin/main`.
+    push_event_path = "/tmp/event-push.json"
+    push_event_json = """{
+        "ref": "refs/heads/main",
+        "before": "1111111111111111111111111111111111111111",
+        "after": "3333333333333333333333333333333333333333"
+    }"""
+    push_vars = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_EVENT_NAME": "push",
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REPOSITORY": "aspect-build/aspect-cli",
+        "GITHUB_SHA": "3333333333333333333333333333333333333333",
+        "GITHUB_EVENT_PATH": push_event_path,
+    }
+    push_files = {push_event_path: push_event_json}
+
+    _expect_pr_none(
+        "push: detect_github_pr is None",
+        push_vars,
+        push_files,
+        "GITHUB_REF is not a PR merge ref",
+    )
+    _expect_mg_sha(
+        "push: detect_merge_group_base_sha is empty",
+        push_vars,
+        push_files,
+        "",
+    )
+    _expect_commit_sha(
+        "push: detect_commit_sha is GITHUB_SHA",
+        push_vars,
+        push_files,
+        "3333333333333333333333333333333333333333",
+    )
+
+    # ── read_github_event edge cases ────────────────────────────────
+    _expect_event(
+        "missing GITHUB_EVENT_PATH returns empty dict",
+        {},
+        {},
+        {},
+    )
+    _expect_event(
+        "GITHUB_EVENT_PATH set but file doesn't exist returns empty",
+        {"GITHUB_EVENT_PATH": "/does/not/exist"},
+        {},
+        {},
+    )
+    _expect_event(
+        "malformed JSON returns empty dict (json.try_decode)",
+        {"GITHUB_EVENT_PATH": "/tmp/bad.json"},
+        {"/tmp/bad.json": "not-valid-json {"},
+        {},
+    )
+
+    # ── detect_merge_group_base_sha guards ──────────────────────────
+    _expect_mg_sha(
+        "not on GitHub Actions returns empty",
+        {"GITHUB_EVENT_NAME": "merge_group"},
+        {},
+        "",
+    )
+    _expect_mg_sha(
+        "GitHub Actions but wrong event returns empty",
+        {"GITHUB_ACTIONS": "true", "GITHUB_EVENT_NAME": "pull_request"},
+        {},
+        "",
+    )
+    _expect_mg_sha(
+        "merge_group event with empty/missing event file returns empty",
+        {
+            "GITHUB_ACTIONS": "true",
+            "GITHUB_EVENT_NAME": "merge_group",
+            "GITHUB_EVENT_PATH": "/missing",
+        },
+        {},
+        "",
+    )
+
+    # ── ASPECT_GITHUB_PR_NUMBER explicit override (used on GitLab CI
+    # ── mirrors of GitHub repos) ─────────────────────────────────────
+    _expect_pr_ok(
+        "explicit override: ASPECT_GITHUB_PR_NUMBER",
+        {
+            "ASPECT_GITHUB_PR_NUMBER": "99",
+            "GITHUB_REPOSITORY": "aspect-build/aspect-cli",
+            "GITHUB_SHA": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        },
+        {},
+        {
+            "owner": "aspect-build",
+            "repo": "aspect-cli",
+            "pr_number": 99,
+            "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        },
+    )
+    _expect_pr_none(
+        "explicit override but non-numeric IID",
+        {
+            "ASPECT_GITHUB_PR_NUMBER": "not-a-number",
+            "GITHUB_REPOSITORY": "aspect-build/aspect-cli",
+            "GITHUB_SHA": "abc",
+        },
+        {},
+        "must be numeric",
+    )
+
+    print("github_detect.axl smoke: OK")
+    return 0
+
+github_detect_tests = task(
+    name = "test-github-detect",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)


### PR DESCRIPTION
Follow-up to #1086 fixing two bugs surfaced by live behavior on shallow CI checkouts.

**Bug 1 — PR runs hit the PR Files API despite merge-commit-first.** `_head_parents` was reading parents via `git log -1 --pretty=%P`, which honors the `.git/shallow` overlay and returns empty on every shallow checkout — even when HEAD is a merge commit. That silently disabled the merge-commit-first path on the common `actions/checkout` default (`fetch-depth: 1`). Switch to `git cat-file -p HEAD` and parse `^parent ` header lines: the raw commit object always carries the parent SHAs regardless of shallow state. To make the resulting HEAD^1 usable when the parent OBJECT also isn't local (shallow case), factor out `_ensure_local_sha` — `cat-file -e` then targeted `git fetch --depth=1 origin <sha>`.

**Bug 2 — `push` to base branch produced an empty diff.** `_resolve_merge_base` was accepting `git merge-base HEAD <base_ref>` results equal to HEAD's own SHA, which happens on push-to-base / squash-merge landings where HEAD IS the new tip of `origin/main`. `git diff HEAD..HEAD` is empty; lint/format saw zero changed files and quietly did nothing. Reject HEAD-equal merge-base results and fall through to HEAD^1, which works for both merge commits (PR/merge_queue) and single-parent commits on the base branch.

**WARN at the API fallback site.** When we still end up calling the PR Files API (e.g. user has a custom `ref:` override that makes HEAD a non-merge commit), surface a one-line WARN explaining the cost and recommending the default merge-commit ref.

**Helper rename.** `_read_github_event` → `read_github_event` and `_detect_merge_group_base_sha` → `detect_merge_group_base_sha` so the new test module can load them.

#### Suggested release notes

- `aspect lint` / `aspect format` / `aspect gazelle` now use a local `git diff HEAD^1..HEAD` on shallow PR checkouts (`actions/checkout` with `fetch-depth: 1`) instead of falling back to the GitHub PR Files API — reduces GitHub App rate-limit pressure on PR builds.
- `push` events to a base branch now correctly diff against `HEAD^1` instead of producing an empty change set when HEAD is the new tip of `origin/<base>` (previously silently skipped all files).
- New WARN when the PR Files API path is exercised, with guidance on the `actions/checkout` config that avoids it.

### Test plan

- New test cases added — `aspect dev test-github-detect` covers pull_request, merge_group, and push event shapes for `detect_github_pr`, `detect_merge_group_base_sha`, `detect_commit_sha`, and `read_github_event`, plus edge cases (missing event file, malformed JSON, `ASPECT_GITHUB_PR_NUMBER` override).
- Existing snapshot tests pass: `test-gitlab-detect`, `test-lint-template-snapshots`, `test-format-template-snapshots`.
- Manual: verified the cat-file approach on a real shallow clone (`git clone --depth=1 …`) — `git log --pretty=%P` returns empty while `git cat-file -p HEAD` shows the parent header; the bug-2 case reproduced on a depth-2 clone of the most recent push to `main` (`git merge-base HEAD origin/main` returned HEAD's own SHA, `git cat-file -p HEAD` revealed HEAD^1, and `git diff HEAD^1..HEAD` showed the expected landed change).
