### PR TITLE
feat(github): detect merge_base from CI env vars (Buildkite/GitLab/GHA)

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -21,10 +21,11 @@ load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "ArtifactsTrait", "artifact_name", "create_uploader")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
+load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/checkrun.axl", "GitHubCheckRunTrait")
 load("./lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
 load("./lib/format_results.axl", fmt_init_data = "init_data", format_conclusion = "conclusion")
-load("./lib/github.axl", "detect_changed_files", "print_changed_files_listing")
+load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_on_change", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
@@ -188,8 +189,9 @@ def _append_repro_command(ctx, data):
     ]
     if ctx.args.ignore_patterns:
         flags.append(("--ignore-pattern", list(ctx.args.ignore_patterns)))
-    if ctx.args.base_ref and ctx.args.base_ref != "origin/main":
-        flags.append(("--base-ref", ctx.args.base_ref))
+    surfaced_base_ref = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
+    if surfaced_base_ref:
+        flags.append(("--base-ref", surfaced_base_ref))
     if ctx.args.merge_base:
         flags.append(("--merge-base", ctx.args.merge_base))
     data["repro_commands"].append({
@@ -242,8 +244,9 @@ def _append_fix_commands(ctx, data):
     ]
     if ctx.args.ignore_patterns:
         detection_flags.append(("--ignore-pattern", list(ctx.args.ignore_patterns)))
-    if ctx.args.base_ref and ctx.args.base_ref != "origin/main":
-        detection_flags.append(("--base-ref", ctx.args.base_ref))
+    surfaced_base_ref = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
+    if surfaced_base_ref:
+        detection_flags.append(("--base-ref", surfaced_base_ref))
     if ctx.args.merge_base:
         detection_flags.append(("--merge-base", ctx.args.merge_base))
     data["fix_commands"].append({
@@ -723,8 +726,8 @@ format = task(
             description = "Upload the formatter's diff as a CI artifact (named `format.patch`) so reviewers can apply it locally without re-running the formatter. No-op when the working tree is clean post-format, or when not running on a recognized CI host (GitHub Actions, Buildkite, CircleCI, GitLab). The download URL (where the CI provider returns one) is surfaced via ArtifactsTrait.artifact_urls['format_diff']. Pass `--upload-format-diff=false` to disable.",
         ),
         "base_ref": args.string(
-            default = "origin/main",
-            description = "Base ref for the changed-file set when the local-git fallback runs (no PR context detected, or PR-API auth unavailable). Resolved to a merge-base via `git merge-base HEAD <base-ref>`. Ignored on the GitHub PR Files API path. Override --merge-base to skip the merge-base resolution and use a specific SHA directly.",
+            default = "",
+            description = "Base ref for the changed-file set, " + BASE_REF_DESCRIPTION_TAIL,
         ),
         "merge_base": args.string(
             description = "Explicit merge-base SHA for the local-git fallback's diff base. When set, skips the `git merge-base HEAD <base-ref>` resolution and uses this SHA directly. Ignored on the GitHub PR Files API path.",

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -188,10 +188,11 @@ load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "ArtifactsTrait", "artifact_name", "create_uploader")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
+load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/checkrun.axl", "GitHubCheckRunTrait")
 load("./lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
 load("./lib/gazelle_results.axl", "dedupe_subtrees", "dir_at_or_below", "extract_changed_dirs", gaz_init_data = "init_data", gazelle_conclusion = "conclusion")
-load("./lib/github.axl", "detect_changed_files", "print_changed_files_listing")
+load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_on_change", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
@@ -333,8 +334,9 @@ def _detection_flags(ctx, mode):
         ("--gazelle-target", ctx.args.gazelle_target),
     ]
     if ctx.args.scope == "changed":
-        if ctx.args.base_ref and ctx.args.base_ref != "origin/main":
-            flags.append(("--base-ref", ctx.args.base_ref))
+        surfaced_base_ref = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
+        if surfaced_base_ref:
+            flags.append(("--base-ref", surfaced_base_ref))
         if ctx.args.merge_base:
             flags.append(("--merge-base", ctx.args.merge_base))
         if ctx.args.scope_all_on_change:
@@ -934,8 +936,8 @@ gazelle = task(
             description = "Which directories gazelle should update BUILD files in. 'all' (default) considers every directory in the workspace. 'changed' restricts updates to directories that contain files changed against the base branch — the GitHub PR Files API in PR contexts when authenticated, otherwise local `git diff <merge-base>`. Useful for incremental gazelle in CI when you don't want to revisit BUILD files in unrelated subtrees. CAUTION: 'changed' (and the flags that shape its dir set — `--dirs`, `--scope-all-on-change`, `--changed-file-pattern`) narrows the work gazelle does; a misconfiguration can silently MISS BUILD-file updates a full `--scope=all` run would have produced. Use with caution; periodically run with `--scope=all` to catch drift. NOTE: 'changed' only saves the BUILD-regeneration step for non-listed dirs. By default gazelle still traverses the whole workspace, parses every BUILD, and re-determines target exports (often re-parsing source) before regeneration runs — on large repos those steps dominate wall time. Combine with `--gazelle-flag=-index=lazy` (plus `# gazelle:go_search` / `# gazelle:proto_search` directives in your BUILD files) to also narrow the traverse + parse + indexing work for the full incremental win. Optionally also pass `--gazelle-flag=-r=false` to skip recursion on top of that, but some gazelle language extensions are incompatible with non-recursive mode — test against your plugin set first. See https://github.com/bazel-contrib/bazel-gazelle#lazy-indexing-in-fix-and-update.",
         ),
         "base_ref": args.string(
-            default = "origin/main",
-            description = "Base ref for the changed-file set when --scope=changed and no PR context is detected (i.e., the local-git fallback runs). Resolved to a merge-base via `git merge-base HEAD <base-ref>`. Ignored on the GitHub PR Files API path. Override --merge-base to skip merge-base resolution.",
+            default = "",
+            description = "Base ref for the changed-file set under --scope=changed, " + BASE_REF_DESCRIPTION_TAIL,
         ),
         "merge_base": args.string(
             description = "Explicit merge-base SHA for the local-git fallback's diff base. When set, skips the `git merge-base HEAD <base-ref>` resolution.",

--- a/crates/aspect-cli/src/builtins/aspect/lib/change_detection.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/change_detection.axl
@@ -1,0 +1,15 @@
+"""Shared text constants for the change-detection surface.
+
+The implementation lives in `lib/github.axl::detect_changed_files`
+(named for the original GitHub-only path; now also covers Buildkite,
+CircleCI, and GitLab MR pipelines via the per-host detectors). The
+constants here are surfaced in user-facing `--help` text across every
+task that consumes `detect_changed_files` — lint, format, gazelle —
+so the auto-detect chain documentation stays consistent across CLIs.
+"""
+
+# Trailing clause for the `--base-ref` arg description on every task
+# that consumes `detect_changed_files`. Callers prepend their own
+# lead clause (e.g. "Base ref for the changed-file set, " or
+# "Base ref for the changed-file set under --scope=changed, ").
+BASE_REF_DESCRIPTION_TAIL = "resolved to a merge-base via `git merge-base HEAD <base-ref>`. When empty (default), auto-detected from the CI environment (`GITHUB_BASE_REF` on GitHub Actions PR builds, `BUILDKITE_PULL_REQUEST_BASE_BRANCH` on Buildkite, `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` on GitLab MR pipelines) — falling back to the remote's default branch (probed via `git symbolic-ref refs/remotes/origin/HEAD` or `git ls-remote --symref origin HEAD`), and finally `origin/main`. Any non-empty value is honored verbatim. Override --merge-base to skip merge-base resolution and pin to a specific SHA."

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -19,6 +19,7 @@ HTTP failure-handling contract (applies to every helper below):
 load("@std//base64.axl", "base64")
 load("@std//time.axl", "time")
 load("./environment.axl", "color_enabled", "warn")
+load("./gitlab_detect.axl", "detect_gitlab_mr_base_sha")
 load("./tar.axl", "zip_create")
 load("./text.axl", "pluralize")
 
@@ -345,6 +346,76 @@ def detect_merge_group_base_sha(std):
     if (env.var("GITHUB_EVENT_NAME") or "") != "merge_group":
         return ""
     return (read_github_event(std).get("merge_group", {}) or {}).get("base_sha", "") or ""
+
+_CI_BASE_BRANCH_PROBES = [
+    # (host_guard_env, target_branch_env). Probed in declaration order;
+    # first host whose guard env is truthy AND whose target-branch env
+    # is non-empty wins. CircleCI is absent — no standard env var
+    # surfaces the PR target branch there.
+    ("GITHUB_ACTIONS", "GITHUB_BASE_REF"),
+    ("BUILDKITE", "BUILDKITE_PULL_REQUEST_BASE_BRANCH"),
+    ("GITLAB_CI", "CI_MERGE_REQUEST_TARGET_BRANCH_NAME"),
+]
+
+def detect_ci_base_ref(std):
+    """Return `origin/<branch>` for the PR / MR target branch surfaced
+    by the running CI host, or `""` when none exposes one (CircleCI,
+    local dev, generic CI).
+
+    Used by `detect_changed_files` to pick a smarter default for the
+    `git merge-base HEAD <base_ref>` step when the caller didn't pass
+    an explicit `--base-ref`, and by lint / format / gazelle to surface
+    the detected ref in repro / fix commands so a developer copying the
+    command lands on the same scope as CI.
+    """
+    env = std.env
+    for host_var, branch_var in _CI_BASE_BRANCH_PROBES:
+        if not env.var(host_var):
+            continue
+        branch = env.var(branch_var) or ""
+        if branch:
+            return "origin/" + branch
+    return ""
+
+def detect_default_branch_ref(ctx):
+    """Best-effort detection of the remote's default branch, returning
+    `origin/<branch>` or `""` when undetectable.
+
+    Resolution order:
+      1. `git symbolic-ref refs/remotes/origin/HEAD` — set on clones
+         made via `git clone`; resolves offline. NOT set by
+         `actions/checkout`-style shallow checkouts on CI.
+      2. `git ls-remote --symref origin HEAD` — single network
+         round-trip to the remote; works whenever `origin` is
+         reachable, regardless of local state.
+
+    Used by `detect_changed_files` as the LAST fallback for the
+    merge-base ref, after caller-explicit `--base-ref` and
+    `detect_ci_base_ref` have both come up empty. Replaces the previous
+    hard-coded `origin/main` assumption so repos that still default to
+    `origin/master` (or `develop` / `trunk`) get the right base.
+    """
+    process = ctx.std.process
+    cwd = ctx.std.env.current_dir()
+
+    out = process.command("git").args(["symbolic-ref", "refs/remotes/origin/HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
+    if out.status.success:
+        ref = out.stdout.strip()
+        prefix = "refs/remotes/"
+        if ref.startswith(prefix) and len(ref) > len(prefix):
+            return ref[len(prefix):]  # "refs/remotes/origin/main" → "origin/main"
+
+    out = process.command("git").args(["ls-remote", "--symref", "origin", "HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
+    if out.status.success:
+        for line in out.stdout.split("\n"):
+            if line.startswith("ref: "):
+                ref = line[len("ref: "):].split("\t")[0].strip()
+                prefix = "refs/heads/"
+                if ref.startswith(prefix) and len(ref) > len(prefix):
+                    return "origin/" + ref[len(prefix):]
+                break  # malformed line; don't keep scanning
+
+    return ""
 
 def detect_build_url(ctx):
     """Detect the CI build URL from common environment variables.
@@ -822,27 +893,40 @@ def _local_diff_exhausted_prefix(diff_base_source):
     tried and why it didn't yield a diff."""
     return "Local `git diff` couldn't determine a base for change detection (%s)" % (diff_base_source or "no base candidate")
 
-def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge_base = None):
+def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = None):
     """Detect changed files for a build.
 
     Resolution order (first hit wins):
       1. Caller's explicit `merge_base` SHA → local `git diff`.
-      2. `merge_group` event → local diff against `merge_group.base_sha`
-         from the event payload (skips the PR Files API; the queue can
-         batch multiple PRs).
-      3. HEAD is a merge commit (≥2 parents) → local diff against
-         HEAD^1. Covers `actions/checkout`'s default `refs/pull/<n>/merge`
-         ref and merge-queue HEADs at zero API cost.
+      2. HEAD is a merge commit (≥2 parents) → local diff against
+         HEAD^1. Covers every synthesized-merge-commit checkout: GHA
+         `refs/pull/<n>/merge`, GHA merge_group, GitLab merged_result /
+         merge_train.
+      3. GitLab `detached` MR pipeline → local diff against
+         `CI_MERGE_REQUEST_DIFF_BASE_SHA`. Only fires when step 2
+         missed (HEAD is the source-branch head, not a merge commit).
       4. `_resolve_merge_base(ctx, base_ref)` → local diff against the
-         resolved merge-base. Engages on every CI host where local-git
-         can determine a base — including Buildkite / CircleCI PR
-         builds (which check out the PR head SHA directly, so HEAD
-         isn't a merge commit and step 3 doesn't apply) and GitHub
-         Actions configs that override the default `ref:`.
+         resolved merge-base. The fallback for everything not covered
+         above — Buildkite / CircleCI PR builds (PR head SHA checked
+         out directly), GitHub Actions configs that override the
+         default `ref:`, push-to-default-branch builds, local dev.
       5. PR Files API (fallback) — only when local-git couldn't
          determine a base in steps 1-4. Costs against the GitHub App's
-         shared rate-limit quota; we'd rather pay it only when no
-         cheaper path works.
+         shared rate-limit quota.
+
+    Why step 2 runs before step 3: on GitLab merged_result / merge_train
+    HEAD includes target-branch updates beyond
+    `CI_MERGE_REQUEST_DIFF_BASE_SHA`, so `DIFF_BASE_SHA..HEAD` over-
+    scopes by those updates. `HEAD^1..HEAD` correctly anchors on the
+    merge's first parent.
+
+    `base_ref` resolution for step 4:
+      - Non-empty `base_ref` → honored verbatim.
+      - Empty `base_ref` (the default sentinel) → `detect_ci_base_ref`
+        first (`GITHUB_BASE_REF`, `BUILDKITE_PULL_REQUEST_BASE_BRANCH`,
+        `CI_MERGE_REQUEST_TARGET_BRANCH_NAME`), then
+        `detect_default_branch_ref` (probes the remote's HEAD), then
+        falling back to `origin/main` when even that's undetectable.
 
     When every path fails (or the API returns malformed data), returns
     `{"files": None, "unscoped": True, "source": <reason>}` rather
@@ -876,7 +960,8 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
       line_level: True (default) → per-entry dict (lint usage).
                   False → per-entry filename string (format usage).
       base_ref:   merge-base argument for `_resolve_merge_base` (e.g.
-                  "origin/main"). Ignored when an earlier step succeeds.
+                  "origin/main"). Empty string is the sentinel that
+                  triggers CI-env / remote-default-branch auto-detection.
       merge_base: explicit merge-base SHA. Overrides every detection
                   path; routed through the local `git diff` helper.
     """
@@ -894,17 +979,7 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
             "unscoped": True,
         }
 
-    # (2) merge_group event base_sha
-    mg_base = detect_merge_group_base_sha(ctx.std)
-    if mg_base:
-        local = _try_local_git_diff_from_base_sha(ctx, line_level, mg_base)
-        if local:
-            local["source"] += " (merge_group event base_sha)"
-            return local
-
-    # (3) merge-commit-first — HEAD's first parent is the base by
-    # construction on `refs/pull/<n>/merge` and queue-synthesized merge
-    # commits.
+    # (2) merge-commit-first
     parents = _head_parents(ctx)
     if len(parents) >= 2:
         local = _try_local_git_diff_from_base_sha(ctx, line_level, parents[0])
@@ -912,9 +987,18 @@ def detect_changed_files(ctx, line_level = True, base_ref = "origin/main", merge
             local["source"] += " (HEAD is a merge commit)"
             return local
 
-    # (4) `_resolve_merge_base(base_ref)` — local-git's cascade against
-    # the base branch, covering every CI host where the base ref is
-    # locally fetchable (or can be fetched on-demand).
+    # (3) GitLab `detached` MR pipeline — HEAD isn't a merge commit, so
+    # step 2 skipped; CI_MERGE_REQUEST_DIFF_BASE_SHA is the correct base.
+    gitlab_base = detect_gitlab_mr_base_sha(ctx.std)
+    if gitlab_base:
+        local = _try_local_git_diff_from_base_sha(ctx, line_level, gitlab_base)
+        if local:
+            local["source"] += " (CI_MERGE_REQUEST_DIFF_BASE_SHA)"
+            return local
+
+    # (4) Resolve a base ref and run `_resolve_merge_base`.
+    if not base_ref:
+        base_ref = detect_ci_base_ref(ctx.std) or detect_default_branch_ref(ctx) or "origin/main"
     diff_base, diff_base_source = _resolve_merge_base(ctx, base_ref)
     if diff_base:
         local = _try_local_git_diff_from_base_sha(ctx, line_level, diff_base)

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -24,10 +24,15 @@ Run with:
 
 load(
     "./github.axl",
+    "detect_ci_base_ref",
     "detect_commit_sha",
     "detect_github_pr",
     "detect_merge_group_base_sha",
     "read_github_event",
+)
+load(
+    "./gitlab_detect.axl",
+    "detect_gitlab_mr_base_sha",
 )
 
 def _fake_std(vars, files = {}):
@@ -279,6 +284,78 @@ def _test_impl(ctx):
         },
         {},
         "must be numeric",
+    )
+
+    # ── CI-env base-ref detection ──────────────────────────────────────
+    # `detect_ci_base_ref` returns `origin/<branch>` from the first
+    # matching CI host (GHA → Buildkite → GitLab), or "" when none
+    # exposes the target branch. Callers compose this with their own
+    # `--base-ref` override and the default-branch probe to surface a
+    # base ref in repro commands and to seed merge-base resolution.
+
+    _eq(
+        "GHA PR: detect_ci_base_ref from GITHUB_BASE_REF",
+        detect_ci_base_ref(_fake_std({
+            "GITHUB_ACTIONS": "true",
+            "GITHUB_BASE_REF": "release/v2",
+        })),
+        "origin/release/v2",
+    )
+    _eq(
+        "Buildkite PR: detect_ci_base_ref from BUILDKITE_PULL_REQUEST_BASE_BRANCH",
+        detect_ci_base_ref(_fake_std({
+            "BUILDKITE": "true",
+            "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "master",
+        })),
+        "origin/master",
+    )
+    _eq(
+        "GitLab MR: detect_ci_base_ref from CI_MERGE_REQUEST_TARGET_BRANCH_NAME",
+        detect_ci_base_ref(_fake_std({
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": "develop",
+        })),
+        "origin/develop",
+    )
+    _eq(
+        "CircleCI: detect_ci_base_ref returns empty (no env var exposed)",
+        detect_ci_base_ref(_fake_std({"CIRCLECI": "true", "CIRCLE_PULL_REQUEST": "https://github.com/o/r/pull/5"})),
+        "",
+    )
+    _eq(
+        "no CI: detect_ci_base_ref empty",
+        detect_ci_base_ref(_fake_std({})),
+        "",
+    )
+    _eq(
+        "GHA precedence over GitLab in detect_ci_base_ref",
+        detect_ci_base_ref(_fake_std({
+            "GITHUB_ACTIONS": "true",
+            "GITHUB_BASE_REF": "main",
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_TARGET_BRANCH_NAME": "develop",
+        })),
+        "origin/main",
+    )
+    _eq(
+        "host guard: branch env var only honored when host var is truthy",
+        detect_ci_base_ref(_fake_std({"GITHUB_BASE_REF": "develop"})),
+        "",
+    )
+
+    # ── detect_gitlab_mr_base_sha ──────────────────────────────────────
+    _eq(
+        "GitLab MR: detect_gitlab_mr_base_sha",
+        detect_gitlab_mr_base_sha(_fake_std({
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_DIFF_BASE_SHA": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        })),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+    _eq(
+        "GitLab MR: detect_gitlab_mr_base_sha guard (no GITLAB_CI → empty)",
+        detect_gitlab_mr_base_sha(_fake_std({"CI_MERGE_REQUEST_DIFF_BASE_SHA": "x"})),
+        "",
     )
 
     print("github_detect.axl smoke: OK")

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect.axl
@@ -131,3 +131,29 @@ def _parse_int_or_none(s):
     if not s.isdigit():
         return None
     return int(s)
+
+def detect_gitlab_mr_base_sha(std):
+    """Return `CI_MERGE_REQUEST_DIFF_BASE_SHA` on a GitLab MR pipeline,
+    or `""` otherwise.
+
+    GitLab sets this variable to the merge-base from which the source
+    branch diverged from the target — the authoritative diff base for
+    the MR. Lets `detect_changed_files` skip `git merge-base HEAD
+    origin/<base>` resolution entirely on MR builds (which is how the
+    default `GIT_DEPTH=20` GitLab clone, missing `origin/<base>`,
+    used to slide into `--scope=all`).
+
+    Pipeline event-type interaction: on `merged_result` / `merge_train`
+    pipelines HEAD is a synthesized merge commit containing
+    target-branch updates beyond this SHA, so `DIFF_BASE_SHA..HEAD`
+    over-scopes by those updates. `detect_changed_files` handles this
+    by running the merge-commit-first path (HEAD^1) BEFORE consulting
+    this helper — on those pipelines HEAD has ≥2 parents and step 2
+    catches it. On `detached` pipelines (HEAD is the source-branch
+    head, no merge commit) the merge-commit-first path skips and this
+    helper supplies the correct diff base.
+    """
+    env = std.env
+    if not env.var("GITLAB_CI"):
+        return ""
+    return env.var("CI_MERGE_REQUEST_DIFF_BASE_SHA") or ""

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -22,9 +22,10 @@ load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "create_uploader")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
+load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/checkrun.axl", "GitHubCheckRunTrait")
 load("./lib/environment.axl", "color_enabled", "warn")
-load("./lib/github.axl", "detect_changed_files", "print_changed_files_listing")
+load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
 load("./lib/lint_results.axl", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
@@ -1155,8 +1156,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     repro_flags = [("--strategy", ctx.args.strategy)]
     if ctx.args.aspects:
         repro_flags.append(("--aspect", list(ctx.args.aspects)))
-    if ctx.args.base_ref and ctx.args.base_ref != "origin/main":
-        repro_flags.append(("--base-ref", ctx.args.base_ref))
+    surfaced_base_ref = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
+    if surfaced_base_ref:
+        repro_flags.append(("--base-ref", surfaced_base_ref))
     if ctx.args.merge_base:
         repro_flags.append(("--merge-base", ctx.args.merge_base))
     targets = list(ctx.args.targets)
@@ -1241,8 +1243,8 @@ lint = task(
             ),
         ),
         "base_ref": args.string(
-            default = "origin/main",
-            description = "Base ref for the changed-file set when the local-git fallback runs (no PR context detected, or PR-API auth unavailable). Resolved to a merge-base via `git merge-base HEAD <base-ref>`. Ignored on the GitHub PR Files API path. Override --merge-base to skip the merge-base resolution and use a specific SHA directly.",
+            default = "",
+            description = "Base ref for the changed-file set, " + BASE_REF_DESCRIPTION_TAIL,
         ),
         "merge_base": args.string(
             description = "Explicit merge-base SHA for the local-git fallback's diff base. When set, skips the `git merge-base HEAD <base-ref>` resolution and uses this SHA directly. Ignored on the GitHub PR Files API path.",


### PR DESCRIPTION
Follow-up to #1090 — detect the merge_base from CI environment variables on Buildkite, GitLab, and GitHub Actions PR builds, plus probe the remote's default branch as a final fallback, so `aspect lint` / `aspect format` / `aspect gazelle` stop silently mismatching `origin/main` on repos whose default branch isn't `main`. Also surface the detected ref in repro / fix commands so developers reproducing locally land on the same scope as CI.

## Survey: env vars per host

**Direct merge-base SHA** (lets us skip `git merge-base` resolution entirely):

| Host | Env var |
|---|---|
| GitHub Actions (merge_group) | `merge_group.base_sha` in event payload — already wired |
| **GitLab MR** | **`CI_MERGE_REQUEST_DIFF_BASE_SHA`** — new in this PR |
| Buildkite | — none |
| CircleCI | — none |

**Base-branch ref** (better default than hard-coded `origin/main` for the merge-base step):

| Host | Env var |
|---|---|
| GitHub Actions | `GITHUB_BASE_REF` |
| **Buildkite** | **`BUILDKITE_PULL_REQUEST_BASE_BRANCH`** |
| **GitLab** | **`CI_MERGE_REQUEST_TARGET_BRANCH_NAME`** |
| CircleCI | — none |

When no env var matches, **probe the remote** via `git symbolic-ref refs/remotes/origin/HEAD` (offline) → `git ls-remote --symref origin HEAD` (one network round-trip). Final fallback: `origin/main`.

## `detect_changed_files` resolution order

```
1. Explicit --merge-base SHA           → local diff
2. HEAD is a merge commit (≥2 parents) → local diff against HEAD^1
3. GitLab `detached` MR pipeline       → local diff against CI_MERGE_REQUEST_DIFF_BASE_SHA
4. _resolve_merge_base(base_ref)       → local diff
5. PR Files API                        → fallback
```

Why merge-commit-first runs before the GitLab DIFF_BASE_SHA path: on GitLab `merged_result` / `merge_train` pipelines HEAD is a synthesized merge commit containing target-branch updates BEYOND `CI_MERGE_REQUEST_DIFF_BASE_SHA`, so `DIFF_BASE_SHA..HEAD` over-scopes. `HEAD^1..HEAD` correctly anchors on the merge's first parent.

## `--base-ref` resolution

`--base-ref` default flips from `"origin/main"` to `""` in lint / format / gazelle args. The sentinel triggers this fallback chain inside `detect_changed_files`:

```
base_ref = "" 
  → detect_ci_base_ref(std)         (GHA / Buildkite / GitLab env vars)
  → detect_default_branch_ref(ctx)  (symbolic-ref → ls-remote)
  → "origin/main"
```

Any non-empty value is honored verbatim — explicit user override always wins.

Why the sentinel: with the previous `default = "origin/main"`, we couldn't tell "user didn't pass anything" apart from "user explicitly passed `--base-ref=origin/main`". An auto-detect that treated both the same would override the user's explicit `origin/main` on a Buildkite PR whose actual base is `develop`. The sentinel resolves that ambiguity.

### Behavior matrix

| Setup | `--base-ref` | effective `base_ref` | source |
|---|---|---|---|
| Local dev, `main` default, no flag | `""` | `origin/main` | symbolic-ref |
| Local dev, `master` default, no flag | `""` | `origin/master` | symbolic-ref |
| Local dev, `--base-ref=origin/develop` | `origin/develop` | `origin/develop` | explicit |
| GHA PR onto `develop`, no flag | `""` | `origin/develop` | `GITHUB_BASE_REF` |
| GHA PR onto `develop`, `--base-ref=origin/main` | `origin/main` | `origin/main` | explicit (user wins) |
| Buildkite PR onto `master`, no flag | `""` | `origin/master` | `BUILDKITE_PULL_REQUEST_BASE_BRANCH` |
| GitLab MR onto `trunk`, no flag | `""` | `origin/trunk` | `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` |
| CircleCI PR, `master` default, no flag | `""` | `origin/master` | ls-remote probe |
| Disconnected, `origin/HEAD` unset, no flag | `""` | `origin/main` | final fallback |

The only `--help` regression: the displayed default flips from `origin/main` to `""`. The description spells out the auto-detect chain.

## Repro / fix command surfacing

When the resolved `base_ref` came from a CI env var, that value is rendered into the lint / format / gazelle repro and fix commands as `--base-ref=...`. A developer copying the command to their local machine — where the CI env vars don't exist — lands on the same scope as CI.

The rule, at every call site:

```
surfaced = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
```

| Resolved from | Surfaced in repro |
|---|---|
| Explicit `--base-ref=...` | yes (user's value verbatim) |
| `detect_ci_base_ref` (GHA / Buildkite / GitLab) | yes (CI-detected value) |
| `detect_default_branch_ref` probe | no (developer's local probe yields the same value) |
| Hard-coded `origin/main` fallback | no (same on developer's side) |

Concretely: a GitHub Actions PR onto `release/v2` produces a repro command containing `--base-ref=origin/release/v2`. A PR onto `main` produces a clean command without a redundant `--base-ref`.

## GitLab impact

GitLab MR pipelines on `GIT_DEPTH=20` clones (the GitLab default) silently fell through to `--scope=all` because `origin/main` was never fetched. With this PR:

- **`detached` pipelines** (HEAD is the source-branch head) → step 3 catches it via `CI_MERGE_REQUEST_DIFF_BASE_SHA`, no API call.
- **`merged_result` / `merge_train` pipelines** (HEAD is a synthesized merge commit) → step 2 (merge-commit-first) catches it via `HEAD^1`, no API call.

If the base SHA isn't in the local object store (shallow clone), `_try_local_git_diff_from_base_sha` does a targeted depth-1 fetch.

## Suggested release notes

- `aspect lint` / `aspect format` / `aspect gazelle` now detect the merge-base from CI environment variables on Buildkite, GitLab, and GitHub Actions PR builds — `BUILDKITE_PULL_REQUEST_BASE_BRANCH` / `CI_MERGE_REQUEST_DIFF_BASE_SHA` / `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` / `GITHUB_BASE_REF`. Repos whose default branch is `develop` / `master` / `trunk` no longer need to pass `--base-ref` to get scoped change detection.
- When no CI env var matches, the remote's default branch is probed via `git symbolic-ref refs/remotes/origin/HEAD` then `git ls-remote --symref origin HEAD`, falling back to `origin/main` only when both fail.
- `--base-ref` default flips from `"origin/main"` to `""` — the sentinel for "auto-detect". Existing scripts passing `--base-ref=...` explicitly are unaffected.
- Repro and fix commands rendered on check-run output now pin the CI-detected base ref when it would otherwise differ from the developer's local default, so `aspect lint` reproductions land on the same scope as CI.

## Test plan

- New test cases in `aspect dev test-github-detect` covering `detect_ci_base_ref` across GHA / Buildkite / GitLab / CircleCI / no-CI / host-precedence / host-guard, plus `detect_gitlab_mr_base_sha` direct-SHA detection and its `GITLAB_CI` guard. `detect_default_branch_ref` requires `ctx` (shells out to `git`) so it's exercised via manual + CI runs rather than the std-stub test infrastructure.
- Existing snapshot suites all pass: `test-gitlab-detect`, `test-lint-template-snapshots`, `test-format-template-snapshots`, `test-gazelle-template-snapshots`.
