### PR TITLE
feat(github): prefer GITHUB_TOKEN / GH_TOKEN for non-attribution API calls

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -27,6 +27,7 @@ load("@aspect//lib/repro_commands.axl", "build_aspect_command", "dedup_and_attri
 load("@aspect//lib/result_text.axl", "severity_for_status")
 load("@aspect//lib/runnable.axl", "canonical_label", "runnable")
 load("@aspect//lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics", "sarif_to_review_comments")
+load("@aspect//lib/tips.axl", "TipsTrait")
 load("@aspect//lint.axl", "file_uri_to_path", "filter_all", "filter_changeset")
 load("@demo//answer.axl", "ANSWER")
 load("./lambda.axl", "lambda_with_global_bind")
@@ -3037,4 +3038,10 @@ axl = task(
     group = ["tests"],
     implementation = impl,
     args = {},
+    # TipsTrait must be in the trait list because several tested
+    # helpers (`detect_build_url`, `_preferred_token_pair`, …) emit
+    # tips on certain env-state branches and `add_tip` reads
+    # `ctx.traits[TipsTrait]`. The tip emit is dedup-by-id so the
+    # test run sees at most one fire per id.
+    traits = [TipsTrait],
 )

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -11,8 +11,8 @@ load("@aspect//lib/github_detect_test.axl", "github_detect_tests")
 load("@aspect//lib/gitlab_detect_test.axl", "gitlab_detect_tests")
 load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
 load("@aspect//lib/lint_results_test.axl", "lint_template_snapshot_tests")
-load("@aspect//lint.axl", "LintTrait")
-load("@aspect//traits.axl", "BazelTrait")
+load("@aspect//lib/tips_test.axl", "tips_tests")
+load("@aspect//traits.axl", "BazelTrait", "LintTrait", "TipsTrait")
 load("./lambda.axl", "lambda_with_global_bind")
 
 def _user_task_impl(ctx: TaskContext) -> int:
@@ -64,7 +64,10 @@ def config(ctx: ConfigContext):
     ctx.features[ArtifactUpload].args.upload_profile = True
     ctx.features[ArtifactUpload].args.upload_bep = True
 
-    # add a new task
+    # Silence tips
+    ctx.traits[TipsTrait].silenced_tips = []
+
+    # Add a new task
     ctx.tasks.add(_user_task)
 
     # Template snapshot tests — renders bazel_results templates across failure modes.
@@ -88,6 +91,12 @@ def config(ctx: ConfigContext):
     # Lint template snapshot tests — renders lint_results templates.
     # Run with: aspect dev test-lint-template-snapshots
     ctx.tasks.add(lint_template_snapshot_tests)
+
+    # Tips framework primitives — add_tip / emit_tip / collect_tips_sorted,
+    # severity helpers, blockquote_body, task_keys glob filtering,
+    # silenced_tips short-circuit, and built-in template shape.
+    # Run with: aspect dev test-tips
+    ctx.tasks.add(tips_tests)
 
     # Delivery template snapshot tests — renders delivery_results templates.
     # Run with: aspect dev test-delivery-template-snapshots
@@ -137,7 +146,7 @@ def config(ctx: ConfigContext):
         "--build_metadata=ASPECT_WORKFLOWS_LINKS=[Docs](https://docs.aspect.build),[Website](https://aspect.build/)",
     ])
 
-    # configure user_task's attrs by path (group/name).
+    # Configure user_task's attrs by path (group/name).
     t = ctx.tasks["user/nested/user-task"]
     t.args.message = "hello axl"
     t.args.run_count = 2

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -105,6 +105,28 @@ steps:
       $$LAUNCHER build --task-id not-a-uuid //... && echo "ERROR: --task-id should reject non-UUID" && exit 1 || true
       echo "--- :aspect: invalid task-key"
       $$LAUNCHER build --task-key "bad key!" //... && echo "ERROR: --task-key should reject invalid chars" && exit 1 || true
+      echo "--- :aspect: aspect dev test-template-snapshots"
+      $$LAUNCHER dev test-template-snapshots
+      echo "--- :aspect: aspect dev test-lint-template-snapshots"
+      $$LAUNCHER dev test-lint-template-snapshots
+      echo "--- :aspect: aspect dev test-format-template-snapshots"
+      $$LAUNCHER dev test-format-template-snapshots
+      echo "--- :aspect: aspect dev test-gazelle-template-snapshots"
+      $$LAUNCHER dev test-gazelle-template-snapshots
+      echo "--- :aspect: aspect dev test-delivery-template-snapshots"
+      $$LAUNCHER dev test-delivery-template-snapshots
+      echo "--- :aspect: aspect dev test-bk-annotation-snapshots"
+      $$LAUNCHER dev test-bk-annotation-snapshots
+      echo "--- :aspect: aspect dev test-pr-comment-snapshots"
+      $$LAUNCHER dev test-pr-comment-snapshots
+      echo "--- :aspect: aspect dev test-github-detect"
+      $$LAUNCHER dev test-github-detect
+      echo "--- :aspect: aspect dev test-gitlab-detect"
+      $$LAUNCHER dev test-gitlab-detect
+      echo "--- :aspect: aspect dev test-gitlab-client"
+      $$LAUNCHER dev test-gitlab-client
+      echo "--- :aspect: aspect dev test-tips"
+      $$LAUNCHER dev test-tips
       echo "--- :aspect: aspect tests axl"
       # Run AXL tests last — cancel tests may kill the Bazel server,
       # which invalidates bazel-out paths used by $$LAUNCHER above.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,20 +13,21 @@ on:
 
 permissions:
   id-token: write
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-# Workflow-level env. Per-job env: blocks add their own (e.g. ASPECT_API_TOKEN);
-# values defined here are inherited by every step in every job. The Dash0 OTLP
-# endpoint and bearer token feed `.aspect/config.axl`'s `ctx.telemetry.exporters.add(...)`
+# The Dash0 OTLP endpoint and bearer token feed `.aspect/config.axl`'s `ctx.telemetry.exporters.add(...)`
 # call, which dogfoods the trace.event/trace.log pipeline against a real backend.
 # Both are no-ops if a secret isn't configured (unset env var = empty string,
 # config.axl skips registration).
 env:
+  ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
   DASH0_ENDPOINT: ${{ secrets.DASH0_ENDPOINT }}
   DASH0_TOKEN: ${{ secrets.DASH0_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   pre-build:
@@ -43,8 +44,6 @@ jobs:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
     timeout-minutes: 10
-    env:
-      ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - name: Bootstrap
@@ -58,8 +57,6 @@ jobs:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
     timeout-minutes: 10
-    env:
-      ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - name: Bootstrap
@@ -73,8 +70,6 @@ jobs:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
     timeout-minutes: 10
-    env:
-      ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -99,8 +94,6 @@ jobs:
   buildifier-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
-    env:
-      ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -116,8 +109,6 @@ jobs:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
     timeout-minutes: 10
-    env:
-      ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -151,8 +142,6 @@ jobs:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
     timeout-minutes: 10
-    env:
-      ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -168,8 +157,6 @@ jobs:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
     timeout-minutes: 10
-    env:
-      ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -191,7 +178,6 @@ jobs:
     needs: [pre-build]
     timeout-minutes: 10
     env:
-      ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
       ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS: ${{ inputs.force_targets }}
     steps:
       - uses: actions/checkout@v6

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -9,6 +9,7 @@ load("./lib/bazel_runner.axl", "run_bazel_task")
 load("./lib/checkrun.axl", "GitHubCheckRunTrait")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "TaskLifecycleTrait")
+load("./lib/tips.axl", "TipsTrait")
 
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     return run_bazel_task(ctx, command = "build")
@@ -53,12 +54,13 @@ build = task(
         ),
     },
     traits = [
+        ArtifactsTrait,
         BazelTrait,
+        GitHubCheckRunTrait,
+        GitHubStatusChecksTrait,
         HealthCheckTrait,
         TaskLifecycleTrait,
-        GitHubStatusChecksTrait,
-        GitHubCheckRunTrait,
-        ArtifactsTrait,
+        TipsTrait,
     ],
     implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -142,6 +142,7 @@ load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrai
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "task_cli_path")
 load("@aspect//lib/runnable.axl", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
+load("@aspect//lib/tips.axl", "TipsTrait")
 load("@std//time.axl", "sleep_iter", "time")
 
 DeliveryTrait = trait(
@@ -1217,8 +1218,6 @@ delivery = task(
     description = """Build and deliver binary targets. Targets are built with stamping and delivered exactly once per commit unless forced; change detection skips targets whose outputs haven't changed since the last delivery.
 
 Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support for generic CI runners is planned. Contact Aspect support <support@aspect.build> for more info.""",
-    implementation = _delivery_impl,
-    traits = [BazelTrait, DeliveryTrait, HealthCheckTrait, TaskLifecycleTrait, GitHubCheckRunTrait],
     args = {
         "ci_host": args.string(
             default = "bk",
@@ -1285,4 +1284,13 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
             description = "Bazel target labels to deliver.",
         ),
     },
+    traits = [
+        BazelTrait,
+        DeliveryTrait,
+        GitHubCheckRunTrait,
+        HealthCheckTrait,
+        TaskLifecycleTrait,
+        TipsTrait,
+    ],
+    implementation = _delivery_impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
@@ -361,7 +361,7 @@ def _artifact_upload_impl(ctx: FeatureContext):
 
     def _on_build_end(ctx, exit_code):
         if not is_local:
-            reason = uploader.check(ctx.std.env)
+            reason = uploader.check(ctx)
             if reason:
                 info(ctx.std, "Artifact upload skipped: " + reason)
             else:

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -32,6 +32,7 @@ load(
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
 load("../lib/result_text.axl", "severity_for_status")
+load("../lib/tips.axl", "collect_tips_sorted")
 
 # ─── Style selection ──────────────────────────────────────────────────────────
 
@@ -277,7 +278,7 @@ def _buildkite_annotations(ctx: FeatureContext):
             ctx,
             initial_results,
             "running",
-            make_render_ctx(_state),
+            make_render_ctx(_state, tips = collect_tips_sorted(ctx)),
             _make_links(initial_results),
             None,
             None,
@@ -324,7 +325,7 @@ def _buildkite_annotations(ctx: FeatureContext):
             ctx,
             data,
             status,
-            make_render_ctx(_state),
+            make_render_ctx(_state, tips = collect_tips_sorted(ctx)),
             _make_links(data),
             None,
             None,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -52,6 +52,7 @@ load(
     lint_chunk_annotations = "chunk_annotations",
     lint_compute_annotations = "compute_annotations",
 )
+load("../lib/tips.axl", "collect_tips_sorted")
 load("../lint.axl", "LintTrait")
 
 # Configures the GitHub status check output templates for a task.
@@ -239,10 +240,15 @@ def _github_status_checks(ctx: FeatureContext):
         _state["_github_token"] = token
 
         # Upgrade the CI link from the run page to the specific job
-        # page; falls back to the run URL if the App lacks actions:read.
+        # page; falls back to the run URL if neither token has
+        # actions:read. Job URL lookup doesn't need App attribution,
+        # so spare App quota when a job-scoped GITHUB_TOKEN is
+        # exported. The check-run token is reused as the App fallback
+        # so `_resolve_current_job_url` can retry on 4xx-auth.
         if ctx.std.env.var("GITHUB_ACTIONS"):
             run_id = ctx.std.env.var("GITHUB_RUN_ID") or ""
-            job_url = github.resolve_current_job_url(ctx, token, owner, repo, run_id)
+            read_token, app_fallback = github.preferred_token_pair(ctx, owner = owner, repo = repo, roles = ["actions.read"], existing_app_token = token)
+            job_url = github.resolve_current_job_url(ctx, read_token, owner, repo, run_id, app_fallback_token = app_fallback)
             if job_url:
                 _ci_links_base["ci_url"] = job_url
         _state["_ci_links"] = _ci_links_base
@@ -255,7 +261,7 @@ def _github_status_checks(ctx: FeatureContext):
             ctx,
             initial_renderer.init(),
             "running",
-            make_render_ctx(_state, default_targets = "//..."),
+            make_render_ctx(_state, default_targets = "//...", tips = collect_tips_sorted(ctx)),
             dict(_ci_links_base),
             gh_trait.templates,
             gh_trait.metadata_keys,
@@ -495,7 +501,7 @@ def _github_status_checks(ctx: FeatureContext):
             ctx,
             data,
             status,
-            make_render_ctx(_state, default_targets = "//..."),
+            make_render_ctx(_state, default_targets = "//...", tips = collect_tips_sorted(ctx)),
             _make_links(data),
             gh_trait.templates,
             gh_trait.metadata_keys,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -46,6 +46,16 @@ load("../lib/lifecycle.axl", "TaskLifecycleTrait")
 load("../lib/repro_commands.axl", "dedup_and_attribute")
 load("../lib/result_text.axl", "severity_for_status")
 load("../lib/tar.axl", "bsdtar")
+load(
+    "../lib/tips.axl",
+    "TIP_CRITICAL",
+    "TIP_TEMPLATE_JINJA2",
+    "TIP_WARNING",
+    "collect_tips_sorted",
+    "decorate_tip",
+    "severity_rank",
+    "tip_to_payload",
+)
 
 _ARTIFACT_PREFIX = "aspect-ci-status-"
 _MARKER_FMT = "<!-- aspect-ci-status:pr-%d -->"
@@ -105,6 +115,18 @@ _No tasks have reported yet._
 {{ section("failing",     "❌", sections.failing) -}}
 {{ section("flagged",     "⚠️", sections.flagged) -}}
 {{ section("successful",  "✅", sections.successful) -}}
+{% if tip_rows %}
+## 💡 Tips
+{% for tip in tip_rows %}
+> {{ tip.severity_emoji }} **{{ tip.severity_label }}:** {{ tip.title }}
+>
+{{ tip.body_quoted }}
+>
+> <sub>_Surfaced by: {{ tip.task_keys|join(", ") }}_</sub>{% if tip.silence_hint %}
+>
+> {{ tip.silence_hint }}{% endif %}
+
+{% endfor %}{% endif -%}
 {% if repro_rows %}
 ## 🔁 Reproduce
 {% for r in repro_rows %}
@@ -493,6 +515,86 @@ def _collect_repro_fix_rows(sections):
     fix_rows = _gather(("running", "failed", "failing", "flagged", "successful"), "fix_commands")
     return (repro_rows, fix_rows)
 
+# Cap for non-critical / non-warning tips in the aggregated section.
+# Critical and warning always render in full; this cap applies to
+# suggestion + info combined so the comment can't get drowned by a
+# flood of low-urgency tips. See `_collect_tip_rows` for the contract.
+_MAX_SUBORDINATE_TIPS = 5
+
+def _is_must_show(severity):
+    """Tips at this severity always surface in the PR-comment Tips
+    section regardless of cap — critical signals key-feature breakage
+    and warning signals degraded behavior."""
+    return severity == TIP_CRITICAL or severity == TIP_WARNING
+
+def _collect_tip_rows(ctx, entries):
+    """Walk every entry's `tips` list, dedup by id, attribute by task
+    key, sort by severity, then apply the rendering caps.
+
+    Dedup is by `id`. Pre-rendered tips (RAW/FORMAT) take the first
+    seen `title` / `body`. JINJA2 tips union each accumulator's values
+    across tasks (preserving first-seen order) and re-render so the
+    comment surfaces the full cross-task picture (e.g. every scope +
+    endpoint contributed by every task that hit the path).
+
+    Render caps:
+      - `TIP_CRITICAL` and `TIP_WARNING` always surface.
+      - `TIP_SUGGESTION` + `TIP_INFO` are combined and capped at
+        `_MAX_SUBORDINATE_TIPS` total so a noisy task can't drown the
+        section.
+
+    Returns rows in `decorate_tip` shape plus `task_keys` (sorted) for
+    the attribution footer."""
+    by_id = {}
+    insertion_order = []
+    for e in entries:
+        task_key = e.get("key", "") or e.get("name", "")
+        for tip in e.get("tips", []) or []:
+            id_ = tip.get("id", "")
+            if not id_:
+                continue
+            if id_ not in by_id:
+                row = dict(tip)
+                row["accumulators"] = {
+                    name: list(values or [])
+                    for name, values in (tip.get("accumulators") or {}).items()
+                }
+                row["_task_keys"] = []
+                by_id[id_] = row
+                insertion_order.append(id_)
+            else:
+                row = by_id[id_]
+                for name, values in (tip.get("accumulators") or {}).items():
+                    current = row["accumulators"].get(name, [])
+                    for v in values or []:
+                        if v not in current:
+                            current = current + [v]
+                    row["accumulators"][name] = current
+            if task_key and task_key not in by_id[id_]["_task_keys"]:
+                by_id[id_]["_task_keys"].append(task_key)
+
+    for row in by_id.values():
+        if row.get("type") == TIP_TEMPLATE_JINJA2 and row["accumulators"]:
+            if row.get("title_template"):
+                row["title"] = ctx.template.jinja2(row["title_template"], data = row["accumulators"])
+            if row.get("body_template"):
+                row["body"] = ctx.template.jinja2(row["body_template"], data = row["accumulators"])
+
+    rows = sorted(
+        [by_id[id_] for id_ in insertion_order],
+        key = lambda r: severity_rank(r.get("severity")),
+    )
+    must_show, subordinate = [], []
+    for r in rows:
+        (must_show if _is_must_show(r.get("severity")) else subordinate).append(r)
+    selected = must_show + subordinate[:_MAX_SUBORDINATE_TIPS]
+    out = []
+    for r in selected:
+        decorated = decorate_tip(r)
+        decorated["task_keys"] = sorted(r["_task_keys"])
+        out.append(decorated)
+    return out
+
 def _render_body(ctx, marker, entries, started_at, body_template, status_badges, sections):
     """Render the comment body via the (possibly user-overridden) Jinja2 template.
 
@@ -518,8 +620,13 @@ def _render_body(ctx, marker, entries, started_at, body_template, status_badges,
     `_collect_repro_fix_rows`, with dedup-and-attribute applied so a
     command contributed by two tasks renders as one row with both
     task keys.
-    """
+
+    `tip_rows` is the deduped + attributed + severity-sorted output of
+    `_collect_tip_rows`, with the cap applied so suggestion / info
+    tips can't drown the section (critical + warning always pass
+    through in full)."""
     repro_rows, fix_rows = _collect_repro_fix_rows(sections)
+    tip_rows = _collect_tip_rows(ctx, entries)
     body = ctx.template.jinja2(body_template, data = {
         "marker": marker,
         "entries": entries,
@@ -528,6 +635,7 @@ def _render_body(ctx, marker, entries, started_at, body_template, status_badges,
         "sections": sections,
         "repro_rows": repro_rows,
         "fix_rows": fix_rows,
+        "tip_rows": tip_rows,
     })
     if not body.endswith("\n"):
         body = body + "\n"
@@ -596,10 +704,15 @@ def _github_status_comments(ctx: FeatureContext):
             "",  # failed_in_phase
         )
 
-    def _own_payload():
+    def _own_payload(ctx):
         """Build our own task entry dict — what _publish_self writes to disk and
         also what gets folded into the rendered comment without going through a
-        download round-trip."""
+        download round-trip.
+
+        `tips` carries this task's tips at upload time (filtered + sorted by
+        `collect_tips_sorted`); the comment aggregator dedups by id across
+        siblings and attributes by task key. Trimmed to render fields so the
+        upload payload doesn't carry filter glob lists or other internals."""
 
         # Prefer the per-job URL when we have it — drops the reviewer
         # straight on the failing job's logs.
@@ -611,6 +724,7 @@ def _github_status_comments(ctx: FeatureContext):
             "run_attempt": run_attempt,
             "status": _state.get("_status", "running"),
             "ci_run_url": link_url,
+            "tips": [tip_to_payload(t) for t in collect_tips_sorted(ctx)],
         }
         payload.update(_state.get("_results_subset") or _empty_results_subset())
 
@@ -627,7 +741,7 @@ def _github_status_comments(ctx: FeatureContext):
             _state["_workdir"] = ctx.std.fs.mkdtemp(prefix = "aspect-ci-status-")
         _state["_my_artifact_name"] = _ARTIFACT_PREFIX + job_name + "-" + _state["_task_key"] + "-" + run_attempt
 
-        payload = _own_payload()
+        payload = _own_payload(ctx)
         payload_str = json.encode(payload)
         if _state.get("_last_payload_str") == payload_str:
             return True
@@ -642,7 +756,7 @@ def _github_status_comments(ctx: FeatureContext):
         expires_at = _iso_in(ctx, artifact_expires_minutes)
         up = github.upload_artifact(ctx, payload_path, _state["_my_artifact_name"], expires_at = expires_at)
         if not up.get("success"):
-            _LOG.warn(ctx.std, "Upload failed: %s" % up.get("errors", []))
+            _LOG.warn(ctx.std, "Upload failed: %s" % "; ".join(up.get("errors", []) or []))
             return False
         _state["_last_payload_str"] = payload_str
         return True
@@ -674,7 +788,7 @@ def _github_status_comments(ctx: FeatureContext):
             # We have authoritative data for our own task in _state — skip the
             # download and use it directly. Avoids reading our own zip back.
             if aname == own_name:
-                seen[aname] = _own_payload()
+                seen[aname] = _own_payload(ctx)
                 continue
 
             cached = cache.get(aid)
@@ -804,14 +918,17 @@ def _github_status_comments(ctx: FeatureContext):
         _state["_github_token"] = token
 
         # Upgrade the GHA workflow-run URL to the per-job URL via the
-        # GitHub Actions API (`/repos/.../actions/runs/{id}/jobs`). The
-        # job URL drops a reviewer directly on the failing job's logs
-        # instead of the workflow-run summary. Same path
-        # `feature/github_status_checks.axl::_create_check_run` uses.
-        # Falls back silently to `_ci_run_url` if the resolution fails
-        # (e.g. the App lacks `actions:read`).
+        # GitHub Actions API. Same path as
+        # `feature/github_status_checks.axl::_create_check_run`. Routed
+        # through the GH_TOKEN-preferring resolver — the job URL
+        # lookup doesn't need App attribution, so spare the App
+        # quota when the workflow exposes a job-scoped token. The
+        # check-run feature's App token (already in scope) is passed
+        # as the 4xx-auth fallback. Falls back silently to
+        # `_ci_run_url` if neither token has `actions:read`.
         if run_id:
-            job_url = github.resolve_current_job_url(ctx, token, owner, repo, run_id)
+            read_token, app_fallback = github.preferred_token_pair(ctx, owner = owner, repo = repo, roles = ["actions.read"], existing_app_token = token)
+            job_url = github.resolve_current_job_url(ctx, read_token, owner, repo, run_id, app_fallback_token = app_fallback)
             if job_url:
                 _state["_ci_link_url"] = job_url
 
@@ -909,6 +1026,10 @@ def _github_status_comments(ctx: FeatureContext):
 def prepare_for_render(entries):
     """Public test hook; see `_prepare_for_render`."""
     return _prepare_for_render(entries)
+
+def collect_tip_rows(ctx, entries):
+    """Public test hook; see `_collect_tip_rows`."""
+    return _collect_tip_rows(ctx, entries)
 
 def bucket_entries(entries):
     """Public test hook; see `_bucket_entries`."""

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -16,6 +16,11 @@ Coverage:
   - Link availability variants (CI Run only, no Aspect, no Check, all)
   - Live phase + ProgressStyles round-trip via the artifact-shape dict
   - Failed-in-phase prefix
+  - Tips aggregation: single-task, multi-task dedup + attribution,
+    severity-sort with the `_MAX_SUBORDINATE_TIPS` cap on
+    suggestion / info; plus inline `_check_collect_tip_rows`
+    assertions on the aggregator's invariants (dedup,
+    attribution-key sort, severity order, cap, silence_hint).
 """
 
 load(
@@ -24,6 +29,7 @@ load(
     "DEFAULT_STATUS_BADGES",
     "MARKER_FMT",
     "bucket_entries",
+    "collect_tip_rows",
     "prepare_for_render",
     "render_body",
     "results_subset",
@@ -274,7 +280,8 @@ def _entry(
         current_phase_elapsed_ms = 0,
         progress = None,
         failed_in_phase = "",
-        start_time_ms = _DEFAULT_START_MS):
+        start_time_ms = _DEFAULT_START_MS,
+        tips = None):
     """Build an artifact-payload-shaped entry. Mirrors what
     `_publish_self` writes to task.json so the test exercises the same
     on-wire shape sibling jobs would read.
@@ -321,10 +328,119 @@ def _entry(
     payload["run_attempt"] = "1"
     payload["status"] = status
     payload["ci_run_url"] = ci_run_url
+    if tips != None:
+        payload["tips"] = tips
     return payload
+
+def _check_collect_tip_rows(ctx):
+    """Functional assertions for `_collect_tip_rows` — exercise the
+    dedup, attribution, severity-sort, `_MAX_SUBORDINATE_TIPS` cap,
+    and the multi-accumulator JINJA2 re-render logic without going
+    through the full snapshot pipeline."""
+
+    # Dedup + attribution: same id surfaced by two tasks merges into
+    # one row with both task keys in alphabetical order.
+    rows = collect_tip_rows(ctx, [
+        {"key": "lint-task", "tips": [
+            {"id": "x", "severity": "suggestion", "title": "T", "body": "B"},
+        ]},
+        {"key": "build-task", "tips": [
+            {"id": "x", "severity": "suggestion", "title": "T", "body": "B"},
+        ]},
+    ])
+    if len(rows) != 1:
+        fail("collect_tip_rows dedup: expected 1 row, got %d" % len(rows))
+    if rows[0]["task_keys"] != ["build-task", "lint-task"]:
+        fail("collect_tip_rows attribution: expected [build-task, lint-task], got %r" % rows[0]["task_keys"])
+
+    # Severity sort: critical first, then warning, then suggestion, then info.
+    rows = collect_tip_rows(ctx, [{"key": "t1", "tips": [
+        {"id": "i", "severity": "info", "title": "I", "body": ""},
+        {"id": "c", "severity": "critical", "title": "C", "body": ""},
+        {"id": "s", "severity": "suggestion", "title": "S", "body": ""},
+        {"id": "w", "severity": "warning", "title": "W", "body": ""},
+    ]}])
+    ids = [r["id"] for r in rows]
+    if ids != ["c", "w", "s", "i"]:
+        fail("collect_tip_rows severity sort: expected [c, w, s, i], got %r" % ids)
+
+    # Cap: suggestion + info combined capped at 5; critical + warning unbounded.
+    big = (
+        [{"id": "c%d" % i, "severity": "critical", "title": "C", "body": ""} for i in range(3)] +
+        [{"id": "w%d" % i, "severity": "warning", "title": "W", "body": ""} for i in range(4)] +
+        [{"id": "s%d" % i, "severity": "suggestion", "title": "S", "body": ""} for i in range(4)] +
+        [{"id": "i%d" % i, "severity": "info", "title": "I", "body": ""} for i in range(4)]
+    )
+    rows = collect_tip_rows(ctx, [{"key": "t1", "tips": big}])
+    critical_count = len([r for r in rows if r["severity_label"] == "Critical"])
+    warning_count = len([r for r in rows if r["severity_label"] == "Warning"])
+    subordinate_count = len([r for r in rows if r["severity_label"] in ("Tip", "Info")])
+    if critical_count != 3:
+        fail("collect_tip_rows cap: expected 3 critical, got %d" % critical_count)
+    if warning_count != 4:
+        fail("collect_tip_rows cap: expected 4 warning, got %d" % warning_count)
+    if subordinate_count != 5:
+        fail("collect_tip_rows cap: expected 5 subordinate (suggestion+info), got %d" % subordinate_count)
+
+    # silence_hint: empty for critical, non-empty for non-critical.
+    # The rendered tip carries this `<sub>...</sub>` line as its
+    # silence-hint footer; an empty value suppresses the footer.
+    rows = collect_tip_rows(ctx, [{"key": "t1", "tips": [
+        {"id": "c", "severity": "critical", "title": "C", "body": ""},
+        {"id": "s", "severity": "suggestion", "title": "S", "body": ""},
+    ]}])
+    by_id = {r["id"]: r for r in rows}
+    if by_id["c"]["silence_hint"] != "":
+        fail("collect_tip_rows: critical row must have empty silence_hint")
+    if "silenced_tips" not in by_id["s"]["silence_hint"]:
+        fail("collect_tip_rows: suggestion row must reference silenced_tips in silence_hint")
+
+    # Multi-accumulator cross-task merge: two tasks each emit the
+    # `add-github-token-scope` JINJA2 tip with distinct scopes and
+    # endpoints. The merged row carries the union of each
+    # accumulator (preserving first-seen order across tasks), and
+    # the title + body are re-rendered via Jinja2 so the surfaced
+    # text reflects the merged accumulator state (pluralized title,
+    # full endpoint list in the body).
+    title_tmpl = "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %}"
+    body_tmpl = "{{ endpoints|length }} calls fell back:\n{% for e in endpoints %}- {{ e }}\n{% endfor %}"
+    rows = collect_tip_rows(ctx, [
+        {"key": "build-task", "tips": [{
+            "id": "add-github-token-scope",
+            "severity": "warning",
+            "title": "Grant `actions: read`",
+            "body": "...",
+            "type": "jinja2",
+            "title_template": title_tmpl,
+            "body_template": body_tmpl,
+            "accumulators": {"scopes": ["actions: read"], "endpoints": ["/a/jobs"]},
+        }]},
+        {"key": "test-task", "tips": [{
+            "id": "add-github-token-scope",
+            "severity": "warning",
+            "title": "Grant `pull-requests: read`",
+            "body": "...",
+            "type": "jinja2",
+            "title_template": title_tmpl,
+            "body_template": body_tmpl,
+            "accumulators": {"scopes": ["pull-requests: read"], "endpoints": ["/b/files", "/c/files"]},
+        }]},
+    ])
+    if len(rows) != 1:
+        fail("multi-accumulator merge: expected 1 row, got %d" % len(rows))
+    if "2 scopes" not in rows[0]["title"]:
+        fail("multi-accumulator merge: title not re-rendered with plural form: %r" % rows[0]["title"])
+    if "/a/jobs" not in rows[0]["body_quoted"] or "/b/files" not in rows[0]["body_quoted"] or "/c/files" not in rows[0]["body_quoted"]:
+        fail("multi-accumulator merge: body missing an endpoint: %r" % rows[0]["body_quoted"])
+    if "3 calls" not in rows[0]["body_quoted"]:
+        fail("multi-accumulator merge: body not re-rendered with merged count: %r" % rows[0]["body_quoted"])
+    if rows[0]["task_keys"] != ["build-task", "test-task"]:
+        fail("multi-accumulator merge: task_keys merge wrong: %r" % rows[0]["task_keys"])
 
 def _test_impl(ctx):
     sep = "=" * 70
+
+    _check_collect_tip_rows(ctx)
 
     scenarios = [
         (
@@ -896,6 +1012,126 @@ def _test_impl(ctx):
                         fix = [("aspect lint --fix --strategy=hold-the-line -- //...", "")],
                     ),
                     16000,
+                ),
+            ],
+        ),
+        # ── Tips aggregation ─────────────────────────────────────────
+        # Each scenario below populates the new `tips` field on the
+        # per-task payload. The aggregator dedups by id, attributes
+        # by task key, severity-sorts, and applies the
+        # `_MAX_SUBORDINATE_TIPS` cap on suggestion / info tips.
+        (
+            "18. tips — single tip on one task",
+            [
+                _entry(
+                    "lint",
+                    "lint-task",
+                    "lint-task",
+                    "lint",
+                    "passed",
+                    make_lint_passed_clean(),
+                    16000,
+                    tips = [{
+                        "id": "add-github-token",
+                        "severity": "suggestion",
+                        "title": "Export `GITHUB_TOKEN` to free App quota",
+                        "body": "Setting `GITHUB_TOKEN` routes supporting calls through the job-scoped token.",
+                    }],
+                ),
+            ],
+        ),
+        (
+            "19. tips — same id surfaced by multiple tasks (dedup + attribution)",
+            [
+                _entry(
+                    "build",
+                    "build-task",
+                    "build-task",
+                    "build",
+                    "passed",
+                    make_build_passed(),
+                    8000,
+                    tips = [{
+                        "id": "add-github-token",
+                        "severity": "suggestion",
+                        "title": "Export `GITHUB_TOKEN` to free App quota",
+                        "body": "Setting `GITHUB_TOKEN` routes supporting calls through the job-scoped token.",
+                    }],
+                ),
+                _entry(
+                    "test",
+                    "test-task",
+                    "test-task",
+                    "test",
+                    "passed",
+                    make_test_passed_flaky_only(),
+                    12000,
+                    tips = [{
+                        "id": "add-github-token",
+                        "severity": "suggestion",
+                        "title": "Export `GITHUB_TOKEN` to free App quota",
+                        "body": "Setting `GITHUB_TOKEN` routes supporting calls through the job-scoped token.",
+                    }],
+                ),
+                _entry(
+                    "lint",
+                    "lint-task",
+                    "lint-task",
+                    "lint",
+                    "passed",
+                    make_lint_passed_clean(),
+                    4000,
+                    tips = [{
+                        "id": "add-github-token",
+                        "severity": "suggestion",
+                        "title": "Export `GITHUB_TOKEN` to free App quota",
+                        "body": "Setting `GITHUB_TOKEN` routes supporting calls through the job-scoped token.",
+                    }],
+                ),
+            ],
+        ),
+        (
+            "20. tips — critical + warning render in full; suggestion / info capped at 5",
+            [
+                _entry(
+                    "build",
+                    "build-task",
+                    "build-task",
+                    "build",
+                    "passed",
+                    make_build_passed(),
+                    8000,
+                    tips = [
+                        # 1 critical — always shown, no silence footer.
+                        {
+                            "id": "add-id-token-permission",
+                            "severity": "critical",
+                            "title": "Grant `id-token: write`",
+                            "body": "Required for artifact uploads.",
+                        },
+                        # 2 warnings — always shown.
+                        {
+                            "id": "warn-a",
+                            "severity": "warning",
+                            "title": "Warning A",
+                            "body": "Degraded behavior A.",
+                        },
+                        {
+                            "id": "warn-b",
+                            "severity": "warning",
+                            "title": "Warning B",
+                            "body": "Degraded behavior B.",
+                        },
+                        # 7 suggestion/info — but the section caps the
+                        # subordinate tier at 5, so two should be dropped.
+                        {"id": "sugg-1", "severity": "suggestion", "title": "Sugg 1", "body": "B1"},
+                        {"id": "sugg-2", "severity": "suggestion", "title": "Sugg 2", "body": "B2"},
+                        {"id": "sugg-3", "severity": "suggestion", "title": "Sugg 3", "body": "B3"},
+                        {"id": "info-1", "severity": "info", "title": "Info 1", "body": "I1"},
+                        {"id": "info-2", "severity": "info", "title": "Info 2", "body": "I2"},
+                        {"id": "info-3", "severity": "info", "title": "Info 3", "body": "I3"},
+                        {"id": "info-4", "severity": "info", "title": "Info 4", "body": "I4"},
+                    ],
                 ),
             ],
         ),

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -32,6 +32,7 @@ load("./lib/path_glob.axl", "match_any")
 load("./lib/repro_commands.axl", "build_aspect_command", "task_cli_path")
 load("./lib/runnable.axl", "runnable")
 load("./lib/text.axl", "pluralize")
+load("./lib/tips.axl", "TipsTrait")
 
 def _git_capture(ctx, *args):
     """Run `git <args>` and return (stdout, exit_code, stderr).
@@ -703,8 +704,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     return _emit_final(ctx, lifecycle, data, 0)
 
 format = task(
-    implementation = _impl,
-    traits = [BazelTrait, ArtifactsTrait, HealthCheckTrait, TaskLifecycleTrait, GitHubCheckRunTrait],
     args = {
         "scope": args.string(
             default = "changed",
@@ -764,4 +763,13 @@ format = task(
             minimum = 0,
         ),
     },
+    traits = [
+        ArtifactsTrait,
+        BazelTrait,
+        GitHubCheckRunTrait,
+        HealthCheckTrait,
+        TaskLifecycleTrait,
+        TipsTrait,
+    ],
+    implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -199,6 +199,7 @@ load("./lib/path_glob.axl", "match_any")
 load("./lib/repro_commands.axl", "build_aspect_command", "task_cli_path")
 load("./lib/runnable.axl", "runnable")
 load("./lib/text.axl", "pluralize")
+load("./lib/tips.axl", "TipsTrait")
 
 def _parse_diff_paths(diff_text):
     """Extract the set of affected paths from a unified diff.
@@ -915,8 +916,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     return _emit_final(ctx, lifecycle, data, 0)
 
 gazelle = task(
-    implementation = _impl,
-    traits = [ArtifactsTrait, BazelTrait, HealthCheckTrait, TaskLifecycleTrait, GitHubCheckRunTrait],
     args = {
         "on_change": args.string(
             default = "auto",
@@ -979,4 +978,13 @@ gazelle = task(
             description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
         ),
     },
+    traits = [
+        ArtifactsTrait,
+        BazelTrait,
+        GitHubCheckRunTrait,
+        HealthCheckTrait,
+        TaskLifecycleTrait,
+        TipsTrait,
+    ],
+    implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
@@ -347,10 +347,12 @@ def create_uploader(env):
     else:
         return None
 
-    def check(env):
-        """Return a warning message if the uploader is misconfigured, else None."""
+    def check(ctx):
+        """Return a warning message if the uploader is misconfigured,
+        else None. `check_token` may emit a tip on the missing-token
+        branch, so we forward `ctx` (not just `ctx.std.env`)."""
         if ci == "github":
-            return github.check_token(env)
+            return github.check_token(ctx)
         return None
 
     def upload_file(ctx, path, name):

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -55,6 +55,7 @@ load(
 load("./path_glob.axl", "match_path")
 load("./result_text.axl", "emoji_for_status")
 load("./text.axl", "format_int_comma", "pluralize")
+load("./tips.axl", "decorate_tip")
 
 # Max number of unique failed build target labels to track detail for. Entries
 # are small (label + deduped mnemonic list) so this can be generous.
@@ -2884,12 +2885,27 @@ def build_invocation_rows(ctx, data, render_ctx, status, links = None, run_date 
             rows.append(row)
     return rows
 
+# Shared `## 💡 Tips`-equivalent block for surface templates: one
+# Markdown blockquote per tip, header line is severity-emoji +
+# severity-label + title, body has `> ` line prefixes baked in by
+# `decorate_tip`, optional silence-hint footer (blank for critical
+# tips). Each surface template splices this in so lint / format /
+# gazelle / delivery / bazel-results stay consistent.
+TIPS_BLOCK = """{% if tips %}{% for tip in tips %}
+
+> {{ tip.severity_emoji }} **{{ tip.severity_label }}:** {{ tip.title }}
+>
+{{ tip.body_quoted }}{% if tip.silence_hint %}
+>
+> {{ tip.silence_hint }}{% endif %}
+{% endfor %}{% endif %}"""
+
 SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
 {% for item in row %}{{ item.icon }} {{ item.value }}{% if not loop.last %} · {% endif %}{% endfor %}{% if not loop.last %}  {% endif %}
 {%- endfor %}{% endif %}
 {% if config_items %}
 :gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}"""
+:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
 
 # `REPRO_COMMANDS_BLOCK` and `FIX_COMMANDS_BLOCK` are reusable
 # Jinja snippets each task's details template can splice in where
@@ -3381,6 +3397,7 @@ def build_summary_data(ctx, data, status, render_ctx, links, metadata_keys, run_
         "short_sha": sha[:7] if sha else "",
         "commit_msg": html_escape(commit_msg),
         "detail_rows": build_invocation_rows(ctx, data, render_ctx, status, links = links, run_date = run_date, extra_meta = extra_meta),
+        "tips": [decorate_tip(t) for t in (render_ctx.get("tips") if render_ctx else None) or []],
     }
 
 def build_kv_rows(kv):

--- a/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
@@ -117,7 +117,7 @@ def to_display_name(name):
     """
     return "".join([w[0].upper() + w[1:] for w in name.split("_") if w])
 
-def make_render_ctx(state, default_targets = ""):
+def make_render_ctx(state, default_targets = "", tips = None):
     """Build the render_ctx dict the per-kind renderers consume.
 
     Reads from `state` — the feature-private dict the caller maintains
@@ -129,6 +129,12 @@ def make_render_ctx(state, default_targets = ""):
     task_started). GitHubStatusChecks uses `"//..."` so the initial
     "running" check-run has *something* readable in the title;
     BuildkiteAnnotations leaves it empty.
+
+    `tips` is the caller-supplied list of tips (typically
+    `collect_tips_sorted(ctx)`); each entry is rendered as a
+    blockquote at the bottom of the check-run summary by the shared
+    `TIPS_BLOCK` template. Features pass it; direct-render call sites
+    that don't care leave it `None` and no tips render.
     """
     return {
         "triggered_by": state.get("_triggered_by", ""),
@@ -137,6 +143,7 @@ def make_render_ctx(state, default_targets = ""):
         "ended_ms": state.get("_ended_ms", 0),
         "progress": state.get("_progress", ""),
         "task_name": state.get("_task_name", ""),
+        "tips": tips or [],
     }
 
 def apply_artifact_links(links, artifacts_trait):

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
@@ -14,6 +14,7 @@ load(
     "FIX_COMMANDS_BLOCK",
     "REPRO_COMMANDS_BLOCK",
     "SHARED_DETAILS_BODY_TEMPLATE",
+    "TIPS_BLOCK",
     "active_phase_data",
     "build_details_data",
     "build_summary_data",
@@ -227,7 +228,7 @@ _SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
 {%- endfor %}{% endif %}
 {% if config_items %}
 :gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}"""
+:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
 
 _DETAILS_TEMPLATE = """{% if total == 0 %}### 🚀 No deliveries
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
@@ -19,6 +19,7 @@ load(
     "FIX_COMMANDS_BLOCK",
     "REPRO_COMMANDS_BLOCK",
     "SHARED_DETAILS_BODY_TEMPLATE",
+    "TIPS_BLOCK",
     "active_phase_data",
     "build_details_data",
     "build_summary_data",
@@ -166,7 +167,7 @@ _SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
 {%- endfor %}{% endif %}
 {% if config_items %}
 :gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}"""
+:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
 
 _DETAILS_TEMPLATE = """{% if is_running %}
 > 🔄 Format task in progress...

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
@@ -18,6 +18,7 @@ load(
     "FIX_COMMANDS_BLOCK",
     "REPRO_COMMANDS_BLOCK",
     "SHARED_DETAILS_BODY_TEMPLATE",
+    "TIPS_BLOCK",
     "active_phase_data",
     "build_details_data",
     "build_summary_data",
@@ -236,7 +237,7 @@ _SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
 {%- endfor %}{% endif %}
 {% if config_items %}
 :gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}"""
+:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
 
 _DETAILS_TEMPLATE = """{% if gazelle_error %}
 > ❌ Gazelle exited with code {{ gazelle_error_code }} without producing a diff. This usually indicates a configuration error — check the task log.

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -22,6 +22,13 @@ load("./environment.axl", "color_enabled", "warn")
 load("./gitlab_detect.axl", "detect_gitlab_mr_base_sha")
 load("./tar.axl", "zip_create")
 load("./text.axl", "pluralize")
+load(
+    "./tips.axl",
+    "TIP_ADD_GITHUB_TOKEN",
+    "TIP_ADD_GITHUB_TOKEN_SCOPE",
+    "TIP_ADD_ID_TOKEN_PERMISSION",
+    "emit_tip",
+)
 
 DEFAULT_GITHUB_API = "https://api.github.com"
 
@@ -122,15 +129,20 @@ def _do_request_once(ctx, method, url, token, payload = None):
 # the resource (extra check-runs, duplicate PR comments, etc.).
 _IDEMPOTENT_METHODS = ["GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
 
-def _do_request(ctx, method, url, token, payload = None):
+def _do_request(ctx, method, url, token, payload = None, quiet_4xx_auth = False):
     """Single HTTP call, retried on transient failures for idempotent
-    methods. POST runs exactly once. Returns `(success, status, body)`."""
+    methods. POST runs exactly once. Returns `(success, status, body)`.
+
+    `quiet_4xx_auth=True` suppresses the failure log on 4xx-auth
+    statuses (401 / 403 / 404). Use at call sites that have a token
+    fallback ready — the warn would describe a failure that's about
+    to be transparently retried with the App token."""
     if method in _IDEMPOTENT_METHODS:
         success, status, body, attempts = _retry_http(lambda: _do_request_once(ctx, method, url, token, payload))
     else:
         success, status, body = _do_request_once(ctx, method, url, token, payload)
         attempts = 1
-    if not success:
+    if not success and not (quiet_4xx_auth and _is_4xx_auth(status)):
         _warn_http_failure(ctx, "GitHub API %s %s" % (method, url), attempts, status, body)
     return (success, status, body)
 
@@ -162,6 +174,76 @@ def _missing_credentials_reason(ctx):
     else:
         msg = "not logged in — run `aspect auth login`"
     return msg + ". Setup guide: " + setup_url
+
+def _is_4xx_auth(status_code):
+    """True for HTTP statuses signaling "token lacks permission to call
+    this endpoint": 401 (unauthenticated), 403 (forbidden), 404
+    (some GitHub endpoints return 404 instead of 403 when the token
+    can't see the resource)."""
+    return status_code in (401, 403, 404)
+
+def _emit_gha_tip(ctx, template, **kwargs):
+    """Emit a tip that only makes sense on GitHub Actions (every
+    built-in tip in this module recommends GHA-specific workflow YAML).
+    Gated on `GITHUB_ACTIONS` env + `hasattr(ctx, "traits")` so test
+    stubs without the traits map don't crash. Dedup-by-id inside
+    `add_tip` keeps the tip to one fire per task across multiple call
+    sites."""
+    if not hasattr(ctx, "traits"):
+        return
+    if not ctx.std.env.var("GITHUB_ACTIONS"):
+        return
+    emit_tip(ctx, template, **kwargs)
+
+def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existing_app_token = None, _reason = None):
+    """Resolve `(primary_token, app_fallback_token)` for supporting
+    GitHub API calls, preferring the job-scoped `GITHUB_TOKEN` /
+    `GH_TOKEN` from env over the Aspect GitHub App's installation
+    token.
+
+    Use for API calls that don't need to attribute to the Aspect App
+    (job URL lookup, PR file diff, PR comment listing, artifact
+    downloads). Calls authenticated via the job-scoped env token
+    count against the *job's* token budget rather than the Aspect
+    App's shared installation-token quota (5,000 req/hr). The App
+    token comes back in the fallback slot so the caller can retry
+    on a 4xx-auth (workflow forgot to grant the scope).
+
+    Result shape:
+      - env exported: `(env_token, app_token)` — the API helper
+        retries with the App token on 4xx-auth and emits the
+        `add-github-token-scope` tip (accumulating the missing
+        scope and endpoint).
+      - env unset:    `(app_token, None)` — no fallback (and none
+        needed).
+      - auth failed:  `(None, None)` with `_reason` populated as for
+        `_authenticate`.
+
+    Pass `existing_app_token` when the caller already minted an App
+    token earlier in the same handler to avoid a redundant mint.
+
+    For calls that MUST attribute to the App (check-runs, PR / issue
+    comment create / update), call `_authenticate` directly.
+    """
+    env = ctx.std.env
+    env_token = env.var("GITHUB_TOKEN") or env.var("GH_TOKEN") or ""
+    app_token = existing_app_token if existing_app_token else _authenticate(
+        ctx,
+        owner = owner,
+        repo = repo,
+        profile = profile,
+        roles = roles,
+        _reason = _reason,
+    )
+    if env_token:
+        return env_token, app_token
+
+    # env unset — suggest setting it, but only when we have a viable App
+    # token to fall back to. Firing alongside an Aspect auth-failure warn
+    # would be misleading (the suggestion isn't what'd fix the auth error).
+    if app_token:
+        _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN)
+    return app_token, None
 
 def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None):
     """Resolve a GitHub token by exchanging Aspect credentials via the Aspect
@@ -440,9 +522,9 @@ def detect_build_url(ctx):
         run_url = server + "/" + repository + "/actions/runs/" + run_id
         owner, repo = detect_github_repo(ctx.std)
         if owner and repo:
-            token = _authenticate(ctx, owner = owner, repo = repo, roles = ["actions.read"])
+            token, app_fallback = _preferred_token_pair(ctx, owner, repo, roles = ["actions.read"])
             if token:
-                job_url = _resolve_current_job_url(ctx, token, owner, repo, run_id)
+                job_url = _resolve_current_job_url(ctx, token, owner, repo, run_id, app_fallback_token = app_fallback)
                 if job_url:
                     return job_url
         return run_url
@@ -747,6 +829,7 @@ def _try_local_git_diff_from_base_sha(ctx, line_level, base_sha):
     explicit `merge_base`, `merge_group` event, merge-commit-first, and
     the general `_resolve_merge_base` resolution against `base_ref`.
     """
+
     process = ctx.std.process
     cwd = ctx.std.env.current_dir()
 
@@ -1014,7 +1097,7 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
     pr, _ = detect_github_pr(ctx.std)
     if pr:
         auth_reason = {}
-        token = _authenticate(ctx, owner = pr["owner"], repo = pr["repo"], roles = ["prs.read"], _reason = auth_reason)
+        token, app_fallback = _preferred_token_pair(ctx, pr["owner"], pr["repo"], roles = ["prs.read"], _reason = auth_reason)
         if not token:
             warn(ctx.std, "%s and the GitHub PR Files API fallback can't authenticate (%s). Degrading to --scope=all." % (
                 _local_diff_exhausted_prefix(diff_base_source),
@@ -1025,7 +1108,7 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
                 _local_diff_exhausted_prefix(diff_base_source),
                 base_ref[len("origin/"):] if base_ref.startswith("origin/") else base_ref,
             ))
-            result = list_pull_request_files(ctx, token, pr["owner"], pr["repo"], pr["pr_number"])
+            result = list_pull_request_files(ctx, token, pr["owner"], pr["repo"], pr["pr_number"], app_fallback_token = app_fallback)
             if result["success"]:
                 # `git rev-parse --show-prefix` strips the workspace prefix so
                 # GitHub-API paths line up with local relative paths.
@@ -1498,34 +1581,14 @@ def _decode_backend_ids(ctx, token):
 
     return (None, None)
 
-_MISSING_TOKEN_MSG = """missing ACTIONS_RUNTIME_TOKEN
-
-GitHub Actions does not inject ACTIONS_RUNTIME_TOKEN into shell (run:) steps.
-To make it available, use one of the following options:
-
-  Option 1 — permissions: id-token: write  (zero config, recommended)
-    Add to your workflow job or at the top level:
-
-      permissions:
-        id-token: write
-
-    This makes ACTIONS_ID_TOKEN_REQUEST_TOKEN available in shell steps.
-    It is the same credential as ACTIONS_RUNTIME_TOKEN and is accepted
-    by the artifact API.
-
-  Option 2 — pass the token via env: on the step that calls aspect:
-
-      - run: aspect build //...
-        env:
-          ACTIONS_RUNTIME_TOKEN: ${{ secrets.ACTIONS_RUNTIME_TOKEN }}
-
-  Option 3 — set at the job level so all steps in the job receive it:
-
-      jobs:
-        build:
-          env:
-            ACTIONS_RUNTIME_TOKEN: ${{ secrets.ACTIONS_RUNTIME_TOKEN }}
-"""
+# Short error string returned from artifact-upload paths when neither
+# `ACTIONS_RUNTIME_TOKEN` nor `ACTIONS_ID_TOKEN_REQUEST_TOKEN` is
+# available. The full actionable guidance (workflow snippet, why this
+# happens, how to fix) lives in `TIP_ADD_ID_TOKEN_PERMISSION` so the
+# tip framework can surface it on the terminal + check-run summary +
+# PR comment — we don't need to repeat it inline on every failure
+# log line. The tip is auto-fired from the same use sites.
+_MISSING_TOKEN_MSG = "missing ACTIONS_RUNTIME_TOKEN (see the `add-id-token-permission` TIP)"
 
 def _github_twirp_once(ctx, url, headers, payload):
     """Single Twirp attempt. Returns `(success, status, body_or_None)`
@@ -1561,6 +1624,7 @@ def _github_twirp(ctx, method, payload):
     results_url = (ctx.std.env.var("ACTIONS_RESULTS_URL") or
                    "https://results-receiver.actions.githubusercontent.com/")
     if not token:
+        _emit_gha_tip(ctx, TIP_ADD_ID_TOKEN_PERMISSION)
         return (False, None, _MISSING_TOKEN_MSG)
 
     if results_url.endswith("/"):
@@ -1612,6 +1676,7 @@ def _upload_artifact(ctx, path, name, expires_at = ""):
     token = (ctx.std.env.var("ACTIONS_RUNTIME_TOKEN") or
              ctx.std.env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
     if not token:
+        _emit_gha_tip(ctx, TIP_ADD_ID_TOKEN_PERMISSION)
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": [_MISSING_TOKEN_MSG]}
 
     run_id, job_id = _decode_backend_ids(ctx, token)
@@ -1730,14 +1795,19 @@ def _delete_artifact(ctx, name):
     })
     return {"success": ok}
 
-def _check_token(env):
-    """Return an info message if the artifact token is unavailable, else None."""
+def _check_token(ctx):
+    """Return a short info message if the artifact token is unavailable,
+    else None. Fires `TIP_ADD_ID_TOKEN_PERMISSION` on the missing-token
+    branch — the tip carries the actionable workflow snippet, so the
+    return value just needs to identify the failure mode."""
+    env = ctx.std.env
     token = env.var("ACTIONS_RUNTIME_TOKEN") or env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
     if not token:
+        _emit_gha_tip(ctx, TIP_ADD_ID_TOKEN_PERMISSION)
         return _MISSING_TOKEN_MSG
     return None
 
-def _resolve_current_job_url(ctx, token, owner, repo, run_id, api_base = DEFAULT_GITHUB_API):
+def _resolve_current_job_url(ctx, token, owner, repo, run_id, app_fallback_token = None, api_base = DEFAULT_GITHUB_API):
     """Resolve the html_url of the currently running GitHub Actions job.
 
     Returns a URL of the form
@@ -1748,6 +1818,22 @@ def _resolve_current_job_url(ctx, token, owner, repo, run_id, api_base = DEFAULT
     by RUNNER_NAME + status=in_progress (most reliable: one job per runner).
     The caller must supply a token with actions:read scope (e.g. an Aspect App
     token obtained via `github.authenticate(..., roles=["actions.read"])`).
+
+    When `app_fallback_token` is supplied AND the primary `token` returns
+    a 4xx-auth status (401 / 403 / 404), retries with the App token and
+    accumulates `actions: read` into the `add-github-token-scope` tip.
+    Lets callers prefer a job-scoped `GITHUB_TOKEN` for the call while
+    still falling back to the App token if the workflow forgot to grant
+    `actions: read` in its `permissions:` block.
+
+    GitHub's docs list `actions: read` as required for the underlying
+    `GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs` endpoint, but
+    in practice GitHub grants `GITHUB_TOKEN` implicit access to its own
+    workflow run's metadata regardless of the `permissions:` block. So
+    the fallback + scope-tip path is dormant on a normally-configured
+    workflow — the wiring stays in place to handle the case where
+    GitHub tightens this implicit access, or where a caller queries a
+    workflow run other than the current one (no current call site does).
     """
     if not token or not owner or not repo or not run_id:
         return ""
@@ -1759,7 +1845,14 @@ def _resolve_current_job_url(ctx, token, owner, repo, run_id, api_base = DEFAULT
     url = api_base + "/repos/" + owner + "/" + repo + "/actions/runs/" + run_id + "/jobs?per_page=100"
     if attempt:
         url = url + "&attempt_number=" + attempt
-    success, _, body = _do_request(ctx, "GET", url, token)
+    has_fallback = app_fallback_token and app_fallback_token != token
+    success, status_code, body = _do_request(ctx, "GET", url, token, quiet_4xx_auth = has_fallback)
+    if (not success) and has_fallback and _is_4xx_auth(status_code):
+        _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN_SCOPE, accumulators = {
+            "scopes": "actions: read",
+            "endpoints": "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+        })
+        success, status_code, body = _do_request(ctx, "GET", url, app_fallback_token)
     if not success or type(body) != "dict":
         return ""
     jobs = body.get("jobs", []) or []
@@ -1781,21 +1874,46 @@ def _resolve_current_job_url(ctx, token, owner, repo, run_id, api_base = DEFAULT
 
 # Pull Request Reviews
 
-def list_pull_request_files(ctx, token, owner, repo, pull_number, api_base = DEFAULT_GITHUB_API):
+def list_pull_request_files(ctx, token, owner, repo, pull_number, app_fallback_token = None, api_base = DEFAULT_GITHUB_API):
     """List all files changed in a pull request, paginated.
 
     GitHub returns up to 100 files per page; PRs can carry up to 3000
     (the API caps there). We page through with `?per_page=100&page=N`
     and stop when a page returns fewer than 100 entries — no Link-header
     parsing needed. The 30-page safety cap matches GitHub's hard limit.
+
+    When `app_fallback_token` is supplied AND the primary `token` returns
+    a 4xx-auth status on the first page, retries with the App token and
+    accumulates `pull-requests: read` into the `add-github-token-scope`
+    tip. The fallback only triggers on page 1 — if pagination starts
+    succeeding and then 4xx-auths mid-stream the token is fine and
+    something else broke (timeout, rate limit, …).
+
+    GitHub's docs list `pull-requests: read` as required for the
+    underlying `GET /repos/{owner}/{repo}/pulls/{pull_number}/files`
+    endpoint, but in practice GitHub grants `GITHUB_TOKEN` implicit
+    access to the PR that triggered the workflow regardless of the
+    `permissions:` block. The fallback + scope-tip path is dormant for
+    own-PR queries; the wiring stays in place to handle cases where
+    GitHub tightens the implicit access (or where a caller queries a
+    PR other than the trigger PR — no current call site does).
     """
     base_url = api_base + "/repos/" + owner + "/" + repo + "/pulls/" + str(pull_number) + "/files"
     per_page = 100
     max_pages = 30
     all_files = []
+    active_token = token
     for page in range(1, max_pages + 1):
         url = base_url + "?per_page=" + str(per_page) + "&page=" + str(page)
-        success, status_code, body = _do_request(ctx, "GET", url, token)
+        has_fallback = page == 1 and app_fallback_token and app_fallback_token != token
+        success, status_code, body = _do_request(ctx, "GET", url, active_token, quiet_4xx_auth = has_fallback)
+        if (not success) and has_fallback and _is_4xx_auth(status_code):
+            _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN_SCOPE, accumulators = {
+                "scopes": "pull-requests: read",
+                "endpoints": "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
+            })
+            active_token = app_fallback_token
+            success, status_code, body = _do_request(ctx, "GET", url, active_token)
         if not success:
             return {"success": False, "error": "request failed (page %d): %s" % (page, str(status_code))}
         if type(body) != "list":
@@ -1885,6 +2003,7 @@ def delete_review_comment(ctx, token, owner, repo, comment_id, api_base = DEFAUL
 github = struct(
     VALID_ROLES = VALID_ROLES,
     authenticate = _authenticate,
+    preferred_token_pair = _preferred_token_pair,
     missing_credentials_reason = _missing_credentials_reason,
     validate_role = validate_role,
     check_token = _check_token,

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -28,12 +28,14 @@ load(
     "detect_commit_sha",
     "detect_github_pr",
     "detect_merge_group_base_sha",
+    "github",
     "read_github_event",
 )
 load(
     "./gitlab_detect.axl",
     "detect_gitlab_mr_base_sha",
 )
+load("./tips.axl", "TipsTrait")
 
 def _fake_std(vars, files = {}):
     """Stub std with env + fs:
@@ -358,12 +360,165 @@ def _test_impl(ctx):
         "",
     )
 
+    # ── github.preferred_token_pair: GITHUB_TOKEN / GH_TOKEN preference ─
+    # Resolves a `(primary, app_fallback)` pair for supporting
+    # GitHub API calls so the spend counts against the job's quota
+    # rather than the App's shared installation-token quota. The
+    # fallback is the App token, used to retry a 4xx-auth response.
+    # Fresh App-token mints via `_authenticate(...)` aren't covered
+    # here — they require `ctx.aspect.auth` stubbing; the
+    # `existing_app_token` parameter bypasses the mint for tests.
+
+    def _ctx_with_env(env_vars):
+        return struct(std = struct(env = struct(var = lambda name: env_vars.get(name, ""))))
+
+    _eq(
+        "preferred_token_pair: GITHUB_TOKEN wins; App token is fallback",
+        github.preferred_token_pair(_ctx_with_env({"GITHUB_TOKEN": "gh-actions-tok"}), "o", "r", existing_app_token = "app-tok"),
+        ("gh-actions-tok", "app-tok"),
+    )
+    _eq(
+        "preferred_token_pair: GH_TOKEN when GITHUB_TOKEN unset",
+        github.preferred_token_pair(_ctx_with_env({"GH_TOKEN": "gh-cli-tok"}), "o", "r", existing_app_token = "app-tok"),
+        ("gh-cli-tok", "app-tok"),
+    )
+    _eq(
+        "preferred_token_pair: GITHUB_TOKEN beats GH_TOKEN when both set",
+        github.preferred_token_pair(_ctx_with_env({"GITHUB_TOKEN": "gha", "GH_TOKEN": "gh"}), "o", "r", existing_app_token = "app-tok"),
+        ("gha", "app-tok"),
+    )
+    _eq(
+        "preferred_token_pair: env unset — App token is primary, no fallback",
+        github.preferred_token_pair(_ctx_with_env({}), "o", "r", existing_app_token = "app-tok"),
+        ("app-tok", None),
+    )
+
+    # Auth-failed branch — `_authenticate` short-circuits to `None`
+    # when owner / repo are missing, populating `_reason`. We exercise
+    # that path here (no `existing_app_token` to bypass the mint, no
+    # env token to take priority) and check both halves of the
+    # `(None, None)` return plus the `_reason` plumbing.
+    auth_reason = {}
+    _eq(
+        "preferred_token_pair: auth failed — returns (None, None)",
+        github.preferred_token_pair(_ctx_with_env({}), "", "", _reason = auth_reason),
+        (None, None),
+    )
+    if "reason" not in auth_reason:
+        fail("preferred_token_pair: expected _reason to be populated on auth failure, got %r" % auth_reason)
+
+    # ── list_pull_request_files 4xx-auth fallback ─────────────────────
+    # When the env token (primary) returns 401 / 403 / 404 on page 1,
+    # `list_pull_request_files` retries with the App-token fallback and
+    # accumulates the missing scope into the `add-github-token-scope`
+    # tip. This exercises the load-bearing call path that
+    # `_preferred_token_pair` enables for change-detection.
+    _test_pr_files_falls_back_to_app_token(ctx)
+
     print("github_detect.axl smoke: OK")
     return 0
+
+def _http_stub(responses):
+    """Stub `ctx.http()` returning canned responses in order. `responses`
+    is a list of `(status, body_str)` tuples; each `.get(...)` call
+    consumes one entry. Records every call's url + Authorization
+    header so tests can assert which token went out on which attempt."""
+    state = {"i": 0, "calls": []}
+
+    def _respond(url, headers):
+        i = state["i"]
+        if i >= len(responses):
+            fail("http stub exhausted at call %d (urls so far: %r)" % (i, [c["url"] for c in state["calls"]]))
+        state["i"] = i + 1
+        state["calls"].append({"url": url, "auth": headers.get("Authorization", "")})
+        status, body = responses[i]
+
+        # _do_request_once consumes `.map_err(...).block()` for transport-error
+        # normalization. The HTTP layer never errors here (we always return
+        # a status/body tuple) so `.map_err` is a passthrough.
+        return struct(
+            map_err = lambda _f: struct(
+                block = lambda: struct(status = status, body = body),
+            ),
+        )
+
+    return state, struct(get = _respond)
+
+def _stub_ctx(ctx, env_vars, http_client):
+    """Build a stub ctx for github.axl helpers that need `std.env`,
+    `ctx.http()`, `ctx.traits`, and `ctx.template`. Traits + template
+    pass through from the real ctx — the trait map carries the test
+    task's mutable `TipsTrait` and the template engine renders the
+    Jinja2 tip on emit, so assertions can read the merged tip back
+    out of `ctx.traits[TipsTrait].tips`."""
+    return struct(
+        std = struct(
+            env = struct(var = lambda name: env_vars.get(name, "")),
+            io = struct(stdout = struct(is_tty = False)),
+        ),
+        http = lambda: http_client,
+        traits = ctx.traits,
+        template = ctx.template,
+    )
+
+def _test_pr_files_falls_back_to_app_token(ctx):
+    # Reset the real TipsTrait so we can assert what this test emits.
+    trait = ctx.traits[TipsTrait]
+    trait.tips = []
+    trait.silenced_tips = []
+    trait.auto_print = False
+
+    # Stub: page-1 with env-token → 403, page-1 retry with app-token → 200
+    # with a single-file body that ends pagination.
+    state, http_client = _http_stub([
+        (403, '{"message":"Resource not accessible by integration"}'),
+        (200, '[{"filename":"src/foo.py","status":"modified","additions":1,"deletions":0}]'),
+    ])
+    stub = _stub_ctx(ctx, {"GITHUB_ACTIONS": "true"}, http_client)
+
+    result = github.pulls.list_files(stub, "env-tok", "o", "r", 42, app_fallback_token = "app-tok")
+
+    if not result["success"]:
+        fail("pr-files fallback: expected success=True after retry, got %r" % result)
+    _eq("pr-files fallback: file count", len(result["files"]), 1)
+    _eq("pr-files fallback: filename", result["files"][0]["filename"], "src/foo.py")
+
+    _eq("pr-files fallback: 2 http calls (env-tok primary + app-tok retry)", len(state["calls"]), 2)
+    _eq("pr-files fallback: 1st call used env token", state["calls"][0]["auth"], "Bearer env-tok")
+    _eq("pr-files fallback: 2nd call used App-token fallback", state["calls"][1]["auth"], "Bearer app-tok")
+
+    # Tip emitted with the missing scope + endpoint accumulated.
+    _eq("pr-files fallback: one tip surfaced", len(trait.tips), 1)
+    tip = trait.tips[0]
+    _eq("pr-files fallback: tip id", tip["id"], "add-github-token-scope")
+    _eq(
+        "pr-files fallback: scope accumulated",
+        tip["accumulators"]["scopes"],
+        ["pull-requests: read"],
+    )
+    _eq(
+        "pr-files fallback: endpoint accumulated",
+        tip["accumulators"]["endpoints"],
+        ["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"],
+    )
+
+    # No fallback supplied: same 403 surfaces as a hard failure
+    # (no silent --scope=all expansion path because the caller decides).
+    trait.tips = []
+    state2, http2 = _http_stub([
+        (403, '{"message":"Resource not accessible by integration"}'),
+    ])
+    stub2 = _stub_ctx(ctx, {"GITHUB_ACTIONS": "true"}, http2)
+    result2 = github.pulls.list_files(stub2, "env-tok", "o", "r", 42)
+    if result2["success"]:
+        fail("pr-files no-fallback: expected success=False on 403 with no fallback, got %r" % result2)
+    _eq("pr-files no-fallback: only the primary call ran", len(state2["calls"]), 1)
+    _eq("pr-files no-fallback: no tip emitted (fallback drives the tip)", len(trait.tips), 0)
 
 github_detect_tests = task(
     name = "test-github-detect",
     group = ["dev"],
     implementation = _test_impl,
     args = {},
+    traits = [TipsTrait],
 )

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
@@ -21,6 +21,7 @@ load(
     "RENDER_META_STANDARD_KEYS",
     "REPRO_COMMANDS_BLOCK",
     "SHARED_DETAILS_BODY_TEMPLATE",
+    "TIPS_BLOCK",
     "active_phase_data",
     "build_details_data",
     "build_summary_data",
@@ -254,7 +255,7 @@ _SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
 {%- endfor %}{% endif %}
 {% if config_items %}
 :gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}"""
+:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
 
 _DETAILS_TEMPLATE = """{% if lint_no_diagnostics_failure %}
 > ⚠️ Lint task was aborted: {{ lint_no_diagnostics_failure }}

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -1,0 +1,558 @@
+"""Surface-rendered tips: actionable suggestions for users.
+
+Tips are non-fatal recommendations that should be visible on the same
+surface the user is already looking at (check-run summary, PR comment)
+so the product is self-documenting — users shouldn't have to grep
+logs for WARNs or read docs to discover improvements.
+
+# Producer API
+
+`add_tip(ctx, id, severity, ...)` — adds a tip to the trait. Accepts
+either pre-rendered `title` + `body` (for `TIP_TEMPLATE_RAW` /
+`TIP_TEMPLATE_FORMAT` tips) or `title_template` + `body_template` +
+`accumulators` (for `TIP_TEMPLATE_JINJA2` tips, see below). Dedup
+by `id`: first add wins for pre-rendered tips; JINJA2 tips merge new
+accumulator values into the stored tip and re-render.
+
+`emit_tip(ctx, template, vars=None, accumulators=None, id_suffix="", task_keys=None)`
+— renders a tip template, then calls `add_tip`. Used by built-in
+producers (so their templates are overridable; see "Customization"
+below) and by user task code wanting parameterised tips.
+
+Tip templates are dicts of the shape:
+
+    {
+        "id":        str,         # stable dedup key; vars are NOT interpolated here
+        "severity":  str,         # TIP_CRITICAL / TIP_WARNING / TIP_SUGGESTION / TIP_INFO
+        "title":     str,         # short headline; interpolated per `type`
+        "body":      str,         # markdown body; interpolated per `type`
+        "type":      str,         # TIP_TEMPLATE_RAW / TIP_TEMPLATE_FORMAT (default) / TIP_TEMPLATE_JINJA2
+        "task_keys": list[str]?,  # optional glob list — see "Task-key scoping" below
+    }
+
+# Template types
+
+The `type` field selects the interpolation engine for `title` / `body`:
+
+  - `TIP_TEMPLATE_RAW`    — no interpolation; `vars` ignored.
+  - `TIP_TEMPLATE_FORMAT` — Starlark `str.format(**vars)` — `{name}`
+                            placeholders replaced from `vars`. Default.
+  - `TIP_TEMPLATE_JINJA2` — Jinja2 source rendered against the tip's
+                            `accumulators` dict (each name maps to a
+                            list). Re-rendered every time `accumulators`
+                            change so the surfaced strings always
+                            reflect the merged state.
+
+# Customization
+
+Built-in tip templates are exported as module-level constants
+(e.g. `TIP_ADD_GITHUB_TOKEN`). User task / config code can:
+
+  a) Add custom tips via `add_tip` or `emit_tip` with arbitrary
+     templates of their own.
+  b) Preempt a built-in tip by calling `add_tip` with that built-in
+     tip's id BEFORE the framework emits — dedup-by-id makes the
+     user's version win.
+  c) Silence any non-critical tip (built-in or custom) by adding its
+     id to `TipsTrait.silenced_tips`. `add_tip` short-circuits on a
+     match so the tip never enters the trait. Each rendered tip's
+     footer names its id and points users at this knob. Critical
+     tips (severity `TIP_CRITICAL`) ignore the silence list — they
+     signal a problem that breaks key features, so a `silenced_tips`
+     entry for a critical id is a no-op.
+
+`TipsTrait` is accessible from `.aspect/config.axl`, which doubles as
+the registry for tips that should seed every task's `TipsTrait` at
+setup. Combined with the `task_keys` glob filter (see below) this is
+how user-defined tips get scoped to specific tasks; the same trait
+is also where users silence noisy tips:
+
+    # In .aspect/config.axl
+    def config(ctx):
+        ctx.traits[TipsTrait].silenced_tips = [
+            "add-github-token",  # tip id from its footer
+        ]
+        ctx.traits[TipsTrait].tips = [
+            {
+                "id": "internal-docs-reminder",
+                "severity": TIP_INFO,
+                "title": "Internal docs link for lint failures",
+                "body": "See https://wiki.example/lint for triage notes.",
+                "task_keys": ["lint-*"],
+            },
+        ]
+
+# Surface rendering
+
+`collect_tips_sorted(ctx)` returns tips sorted by severity (most
+urgent first), stable within a bucket by insertion order. Renderers
+(check-run summary template, PR comment aggregator) call it and
+display the result.
+
+# Severity ordering (highest → lowest urgency)
+
+    TIP_CRITICAL    — action required; key features broken without it.
+                      Cannot be silenced (`silenced_tips` is ignored).
+                      Surface and terminal rendering omit the silence
+                      hint footer for critical tips.
+    TIP_WARNING     — degraded behavior; user should fix to restore full function.
+    TIP_SUGGESTION  — improvement opportunity; product works fine without it.
+    TIP_INFO        — FYI.
+
+# Task-key scoping
+
+Each tip optionally carries `task_keys` — a list of glob patterns matched
+against `ctx.task.key` at render time. When empty (the default), the tip
+shows on the task it was emitted into and no others. When non-empty,
+the tip shows only on tasks whose key matches one of the patterns.
+`["*"]` shows on every task, `["lint-*"]` on lint variants, etc.
+"""
+
+load("./environment.axl", "color_enabled")
+load("./path_glob.axl", "match_any")
+
+# ── Severity constants ───────────────────────────────────────────────
+
+TIP_CRITICAL = "critical"
+TIP_WARNING = "warning"
+TIP_SUGGESTION = "suggestion"
+TIP_INFO = "info"
+
+_SEVERITY_ORDER = {
+    TIP_CRITICAL: 0,
+    TIP_WARNING: 1,
+    TIP_SUGGESTION: 2,
+    TIP_INFO: 3,
+}
+
+_SEVERITY_EMOJI = {
+    TIP_CRITICAL: "🔥",
+    TIP_WARNING: "⚠️",
+    TIP_SUGGESTION: "💡",
+    TIP_INFO: "ℹ️",
+}
+
+# Human-readable label paired with the emoji on each tip's header line
+# (e.g. `💡 **Tip:** ...`, `🔥 **Critical:** ...`). The label is part of
+# the rendered tip — it makes the severity legible even where the emoji
+# may not render.
+_SEVERITY_LABEL = {
+    TIP_CRITICAL: "Critical",
+    TIP_WARNING: "Warning",
+    TIP_SUGGESTION: "Tip",
+    TIP_INFO: "Info",
+}
+
+# ── Template type enum ──────────────────────────────────────────────
+
+TIP_TEMPLATE_RAW = "raw"
+TIP_TEMPLATE_FORMAT = "format"
+TIP_TEMPLATE_JINJA2 = "jinja2"
+
+_VALID_TEMPLATE_TYPES = [TIP_TEMPLATE_RAW, TIP_TEMPLATE_FORMAT, TIP_TEMPLATE_JINJA2]
+
+# ── Trait ────────────────────────────────────────────────────────────
+
+TipsTrait = trait(
+    # Insertion-ordered list of stored tip dicts. Pre-rendered tips
+    # carry `{id, severity, title, body, type, task_keys}`; JINJA2
+    # tips additionally carry `title_template`, `body_template`, and
+    # `accumulators` (dict<name, list<value>>) so `add_tip` can
+    # re-render on each accumulation event. Dedup by `id`; tips in
+    # `silenced_tips` are dropped on `add_tip`.
+    tips = attr(list, default = []),
+    silenced_tips = attr(list, default = []),
+    # Gate on the `add_tip` terminal print. Tests flip to False so
+    # unit-test output stays clean while exercising storage / filter
+    # logic.
+    auto_print = attr(bool, default = True),
+)
+
+# ── Built-in tip templates ───────────────────────────────────────────
+#
+# Each constant is a tip-template dict consumed by `emit_tip`. The
+# YAML constants below are shared snippets the bodies splice in;
+# both are rendered at workflow-top-level indentation so users can
+# paste them verbatim above `jobs:` or re-indent under a specific
+# `jobs.<name>:` for per-job scoping.
+
+GITHUB_TOKEN_ENV_YAML = """env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+"""
+
+ID_TOKEN_PERMISSIONS_YAML = """permissions:
+  id-token: write    # artifact uploads + PR summary comment aggregation
+"""
+
+TIP_ADD_GITHUB_TOKEN = {
+    "id": "add-github-token",
+    "severity": TIP_SUGGESTION,
+    "title": "Export `GITHUB_TOKEN` to route supporting API calls through the job-scoped quota",
+    "body": "When `GITHUB_TOKEN` is set, aspect-cli sends supporting API calls (job URL lookup, PR file diff, etc.) using the job-scoped token rather than the Aspect Workflows GitHub App. The job-scoped token has [a higher rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#primary-rate-limit-for-github_token-in-github-actions) — up to 60,000 req/hr per repository — than [the App's quota](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#primary-rate-limit-for-github-app-installations) (5,000 req/hr, or 15,000 req/hr on GitHub Enterprise Cloud), and they're separate buckets. Routing supporting calls through the job-scoped token reduces App quota usage and prevents live job updates to GitHub Status Checks and Status Comments from being throttled on busy repos.\n\nGitHub Actions grants `GITHUB_TOKEN` implicit read access to the workflow's own run metadata and the PR that triggered it, so no extra `permissions:` block scopes are required for the supporting calls aspect-cli makes today. Add at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that need it:\n\n```yaml\n" + GITHUB_TOKEN_ENV_YAML + "```",
+    "type": TIP_TEMPLATE_RAW,
+}
+
+# One tip per task accumulating both the missing scopes and the API
+# endpoints that fell back. Pluralization + per-scope snippet lines
+# are driven by Jinja2 on the merged accumulator state.
+TIP_ADD_GITHUB_TOKEN_SCOPE = {
+    "id": "add-github-token-scope",
+    "severity": TIP_WARNING,
+    "title": "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %} to the job-scoped `GITHUB_TOKEN`",
+    "body": """aspect-cli made {{ endpoints|length }} supporting API {{ "call" if endpoints|length == 1 else "calls" }} that needed {{ "a scope" if scopes|length == 1 else "scopes" }} the job-scoped `GITHUB_TOKEN` lacks; {{ "the call" if endpoints|length == 1 else "the calls" }} fell back to the Aspect Workflows GitHub App token. Granting {{ "this scope" if scopes|length == 1 else "these scopes" }} keeps the {{ "call" if endpoints|length == 1 else "calls" }} on the job-scoped token and reduces App quota usage.
+
+Add at the top level of the workflow (so every job inherits) or scope to the specific job(s) that need it:
+
+```yaml
+permissions:
+{% for s in scopes %}  {{ s }}
+{% endfor %}```
+
+API {{ "endpoint" if endpoints|length == 1 else "endpoints" }} that fell back ({{ endpoints|length }}):
+{% for e in endpoints %}- `{{ e }}`
+{% endfor %}""",
+    "type": TIP_TEMPLATE_JINJA2,
+}
+
+# Severity is CRITICAL because key features depend on this permission:
+# artifact uploads (status payloads, BEP files, test logs, profiles)
+# fail outright, and PR summary comment aggregation breaks because
+# per-task payloads ride on the same artifact upload path. Critical
+# tips can't be silenced.
+TIP_ADD_ID_TOKEN_PERMISSION = {
+    "id": "add-id-token-permission",
+    "severity": TIP_CRITICAL,
+    "title": "Grant `id-token: write` to enable GitHub Actions artifact uploads",
+    "body": "aspect-cli is trying to upload an artifact via GitHub Actions' ArtifactService but the API needs an OIDC token (`ACTIONS_ID_TOKEN_REQUEST_TOKEN`) that GitHub only exposes to the job when `id-token: write` is granted. Without it, the artifact upload fails.\n\nWhich features depend on this varies by configuration. When enabled, the PR summary comment aggregator and test-log / BEP / profile artifact uploads all ride on the ArtifactService — any of those features will be affected until the permission is granted. The task itself completes regardless.\n\nAdd at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that upload artifacts:\n\n```yaml\n" + ID_TOKEN_PERMISSIONS_YAML + "```",
+    "type": TIP_TEMPLATE_RAW,
+}
+
+# ── API ──────────────────────────────────────────────────────────────
+
+def _merge_accumulators(existing, incoming):
+    """Merge `incoming` (dict<name, value>) into `existing`
+    (dict<name, list<value>>). Returns `(merged, changed)`. `changed`
+    is True when at least one new value landed — callers re-render
+    and re-print only on `changed`."""
+    merged = {name: list(values) for name, values in (existing or {}).items()}
+    changed = False
+    for name, value in (incoming or {}).items():
+        if value == None or value == "":
+            continue
+        current = merged.get(name, [])
+        if value in current:
+            continue
+        merged[name] = current + [value]
+        changed = True
+    return merged, changed
+
+def add_tip(
+        ctx,
+        id,
+        severity,
+        task_keys = None,
+        title = "",
+        body = "",
+        type_ = TIP_TEMPLATE_RAW,
+        title_template = "",
+        body_template = "",
+        accumulators = None):
+    """Add a tip to the task's `TipsTrait` and print a `TIP:` block
+    to the terminal.
+
+    No-op if `id` is listed in `TipsTrait.silenced_tips` AND
+    `severity != TIP_CRITICAL` (critical tips can't be silenced —
+    see "Severity ordering" in the module docstring).
+
+    Two storage shapes:
+
+      - Pre-rendered tips (`type_ == TIP_TEMPLATE_RAW` / `_FORMAT`):
+        `title` and `body` are the final strings to surface. No
+        accumulators. Dedup-by-id is silent (first add wins).
+
+      - Jinja2 tips (`type_ == TIP_TEMPLATE_JINJA2`):
+        `title_template` and `body_template` are stored as Jinja2
+        source. `accumulators` is a dict<name, value> for the
+        initial emit. The framework converts each value to a
+        single-entry list and re-renders title + body with the
+        accumulators as `dict<name, list<value>>`. On every
+        subsequent emit with the same id, the new accumulator
+        values get unioned into the stored lists (skipping
+        duplicates), the title and body are re-rendered, and the
+        terminal re-prints so each accumulation event surfaces in
+        the log. Plain dedups (no accumulator change) stay silent.
+
+    `task_keys` is an optional list of glob patterns; when set, the
+    renderer only shows the tip on tasks whose key matches one of the
+    patterns. When unset / empty, the tip shows on the task it was
+    emitted into (natural for framework tips emitted during a
+    specific task's run). The terminal print fires regardless of
+    `task_keys`.
+    """
+    if severity not in _SEVERITY_ORDER:
+        fail("unknown tip severity %r; valid: %s" % (severity, ", ".join(_SEVERITY_ORDER.keys())))
+    trait = ctx.traits[TipsTrait]
+    if severity != TIP_CRITICAL and id in trait.silenced_tips:
+        return
+
+    is_jinja2 = type_ == TIP_TEMPLATE_JINJA2
+    if is_jinja2 and not [v for v in (accumulators or {}).values() if v]:
+        fail("TIP_TEMPLATE_JINJA2 tip %r requires at least one non-empty accumulator value" % id)
+
+    for i, existing in enumerate(trait.tips):
+        if existing.get("id") != id:
+            continue
+        if not is_jinja2:
+            return
+        merged, changed = _merge_accumulators(existing.get("accumulators", {}), accumulators)
+        if not changed:
+            return
+        stored_severity = existing.get("severity", severity)
+        rendered_title = ctx.template.jinja2(existing["title_template"], data = merged)
+        rendered_body = ctx.template.jinja2(existing["body_template"], data = merged)
+        updated = dict(existing)
+        updated["title"] = rendered_title
+        updated["body"] = rendered_body
+        updated["accumulators"] = merged
+        trait.tips = trait.tips[:i] + [updated] + trait.tips[i + 1:]
+        if trait.auto_print:
+            _print_tip(ctx.std, id, stored_severity, rendered_title, rendered_body)
+        return
+
+    if is_jinja2:
+        seeded = {name: [value] for name, value in accumulators.items() if value}
+        new_tip = {
+            "id": id,
+            "severity": severity,
+            "title": ctx.template.jinja2(title_template, data = seeded),
+            "body": ctx.template.jinja2(body_template, data = seeded),
+            "task_keys": list(task_keys) if task_keys else [],
+            "type": TIP_TEMPLATE_JINJA2,
+            "title_template": title_template,
+            "body_template": body_template,
+            "accumulators": seeded,
+        }
+    else:
+        new_tip = {
+            "id": id,
+            "severity": severity,
+            "title": title,
+            "body": body,
+            "task_keys": list(task_keys) if task_keys else [],
+            "type": type_,
+        }
+    trait.tips = list(trait.tips) + [new_tip]
+    if trait.auto_print:
+        _print_tip(ctx.std, id, severity, new_tip["title"], new_tip["body"])
+
+def emit_tip(ctx, template, vars = None, accumulators = None, id_suffix = "", task_keys = None):
+    """Render a tip template and add it via `add_tip`.
+
+    Args:
+      template:      dict — see module docstring for shape.
+      vars:          dict — `{name: value}` interpolated into title /
+                     body when `template.type == TIP_TEMPLATE_FORMAT`.
+                     Ignored for `TIP_TEMPLATE_RAW` and
+                     `TIP_TEMPLATE_JINJA2` (the latter takes its
+                     data from `accumulators` instead).
+      accumulators:  dict — `{name: value}` for
+                     `TIP_TEMPLATE_JINJA2` tips. Each value becomes
+                     the first entry of a per-name accumulator list
+                     on first emit; subsequent emits union new
+                     values into the existing lists. The body /
+                     title templates see each accumulator as a list
+                     and can iterate / pluralize on it.
+      id_suffix:     optional kebab-case suffix appended to
+                     `template.id`.
+      task_keys:     optional list of glob patterns overriding the
+                     template's `task_keys` (or supplying it if
+                     absent).
+    """
+    type_ = template.get("type", TIP_TEMPLATE_FORMAT)
+    if type_ not in _VALID_TEMPLATE_TYPES:
+        fail("unknown tip template type %r; valid: %s" % (type_, ", ".join(_VALID_TEMPLATE_TYPES)))
+    id = template["id"]
+    if id_suffix:
+        id = id + "-" + id_suffix
+    resolved_task_keys = task_keys if task_keys != None else template.get("task_keys")
+    if type_ == TIP_TEMPLATE_JINJA2:
+        add_tip(
+            ctx,
+            id = id,
+            severity = template["severity"],
+            task_keys = resolved_task_keys,
+            type_ = TIP_TEMPLATE_JINJA2,
+            title_template = template["title"],
+            body_template = template["body"],
+            accumulators = accumulators or {},
+        )
+        return
+    title = template["title"]
+    body = template["body"]
+    if type_ == TIP_TEMPLATE_FORMAT and vars:
+        title = title.format(**vars)
+        body = body.format(**vars)
+    add_tip(
+        ctx,
+        id = id,
+        severity = template["severity"],
+        task_keys = resolved_task_keys,
+        title = title,
+        body = body,
+        type_ = type_,
+    )
+
+def collect_tips_sorted(ctx, limit = None):
+    """Return the current tips list filtered by `task_keys` (when set)
+    against `ctx.task.key`, then sorted by severity (highest urgency
+    first); the sort is stable, so insertion order is preserved
+    within a severity bucket.
+
+    Tips without `task_keys` pass through unconditionally — they're
+    scoped to the task they were emitted into. Tips with `task_keys`
+    apply only on tasks whose key matches one of the glob patterns
+    (e.g. `["lint-*"]`, `["*"]`).
+
+    Pass `limit` to cap the result for space-constrained surfaces
+    (e.g. PR comment summary).
+    """
+    trait = ctx.traits[TipsTrait]
+    task_key = ctx.task.key
+    filtered = []
+    for t in trait.tips:
+        patterns = t.get("task_keys") or []
+        if patterns and not match_any(patterns, task_key):
+            continue
+        filtered.append(t)
+    out = sorted(filtered, key = lambda t: severity_rank(t.get("severity")))
+    if limit != None and limit >= 0:
+        out = out[:limit]
+    return out
+
+def severity_emoji(severity):
+    """Emoji prefix for a tip's severity. Used by renderers."""
+    return _SEVERITY_EMOJI.get(severity, "ℹ️")
+
+def severity_label(severity):
+    """Human-readable label for a tip's severity (e.g. "Tip",
+    "Warning", "Critical"). Paired with `severity_emoji` to introduce
+    each rendered tip — readable even where the emoji may not."""
+    return _SEVERITY_LABEL.get(severity, "Info")
+
+def severity_rank(severity):
+    """Sort rank for a tip's severity — lower = more urgent. Use for
+    cross-task aggregators (e.g. PR-comment tip dedup) that need to
+    order tips without taking a dependency on the underlying constant
+    dict. Unknown severities sort after `TIP_INFO`."""
+    return _SEVERITY_ORDER.get(severity, 999)
+
+def silence_hint_line(id, severity):
+    """Standard Markdown `<sub>` silence-hint line for a tip — the
+    fine-print footer naming the tip's id and the knob to silence
+    it via `.aspect/config.axl`.
+
+    Returns `""` for critical tips (which can't be silenced) and for
+    blank ids. Used by the check-run summary's `TIPS_BLOCK` and by
+    the PR-comment tip section so the two surfaces stay aligned on
+    the silence affordance."""
+    if not id or severity == TIP_CRITICAL:
+        return ""
+    return '<sub>_Silence by adding `"%s"` to `ctx.traits[TipsTrait].silenced_tips` in `.aspect/config.axl`._</sub>' % id
+
+def tip_to_payload(t):
+    """Project a stored tip dict into the render-only field subset
+    that crosses the per-task artifact boundary (PR-comment
+    aggregation pipeline). JINJA2 fields are preserved so the
+    cross-task merge in `_collect_tip_rows` can re-render against
+    the unioned accumulator state."""
+    return {
+        "id": t.get("id", ""),
+        "severity": t.get("severity", ""),
+        "title": t.get("title", ""),
+        "body": t.get("body", ""),
+        "type": t.get("type", ""),
+        "title_template": t.get("title_template", ""),
+        "body_template": t.get("body_template", ""),
+        "accumulators": t.get("accumulators", {}) or {},
+    }
+
+def decorate_tip(t):
+    """Project a stored tip dict into the render-shape consumed by the
+    surface templates (`TIPS_BLOCK` in `bazel_results.axl`, the
+    `## 💡 Tips` section in `feature/github_status_comments.axl`).
+    Single source of truth so both surfaces stay aligned by
+    construction. The PR-comment aggregator additionally injects a
+    `task_keys` list on top of this shape for its "Surfaced by:"
+    attribution footer."""
+    severity = t.get("severity")
+    return {
+        "id": t.get("id", ""),
+        "severity": severity,
+        "severity_emoji": severity_emoji(severity),
+        "severity_label": severity_label(severity),
+        "title": t.get("title", ""),
+        "body_quoted": blockquote_body(t.get("body", "")),
+        "silence_hint": silence_hint_line(t.get("id", ""), severity),
+    }
+
+def strip_code_fences(body):
+    """Drop Markdown code-fence delimiter lines (``` or ```lang) so a
+    tip body renders cleanly on the terminal. Inner content of the
+    fenced block is preserved — only the delimiter lines disappear.
+    Surface (Markdown) rendering uses the unmodified body."""
+    if not body:
+        return body
+    kept = []
+    for line in body.split("\n"):
+        if not line.strip().startswith("```"):
+            kept.append(line)
+    return "\n".join(kept)
+
+_TERMINAL_TIP_COLOR = {
+    TIP_CRITICAL: "1;31",  # bold red — required action, key features broken without it
+    TIP_WARNING: "0;33",  # yellow — degraded behavior
+    TIP_SUGGESTION: "1;35",  # bold magenta — improvement opportunity
+    TIP_INFO: "1;36",  # bold cyan — informational
+}
+
+def _print_tip(std, id, severity, title, body):
+    """Print a `TIP:` block to the terminal — called from `add_tip` on
+    each first add and (for `TIP_TEMPLATE_JINJA2` tips) on each
+    accumulator change. The format mirrors `warn` / `info` from
+    `environment.axl` so users recognize it as the same family of
+    framework messages. Prefix color scales with severity (red for
+    critical, yellow for warning, magenta for suggestion, cyan for
+    info). Code-fence delimiter lines are stripped from the body so
+    the inline YAML reads naturally on the terminal. The silence
+    footer is omitted for critical tips (they can't be silenced)."""
+    if color_enabled(std):
+        code = _TERMINAL_TIP_COLOR.get(severity, "1;35")
+        prefix = "\x1b[" + code + "mTIP\x1b[0m: "
+    else:
+        prefix = "TIP: "
+    print(prefix + title)
+    cleaned = strip_code_fences(body)
+    if cleaned:
+        print("")
+        print(cleaned)
+    if severity != TIP_CRITICAL:
+        print("")
+        print('(Silence this tip by adding "%s" to `ctx.traits[TipsTrait].silenced_tips` in `.aspect/config.axl`.)' % id)
+
+def blockquote_body(body):
+    """Prefix every line of a tip body with `> ` (or `>` for empty
+    lines) so the body renders inside a Markdown blockquote — the
+    closest "box" affordance available on both GitHub check-run
+    summaries and Buildkite annotations. Code fences inside the body
+    are preserved because GFM and Buildkite both nest code blocks
+    inside blockquotes correctly."""
+    if not body:
+        return ""
+    lines = body.split("\n")
+    out = []
+    for line in lines:
+        if line == "":
+            out.append(">")
+        else:
+            out.append("> " + line)
+    return "\n".join(out)

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -1,0 +1,614 @@
+"""Tests for `lib/tips.axl`.
+
+Covers the tip framework primitives directly:
+  - `add_tip` — fully-rendered emission + dedup-by-id + severity guard
+                + `silenced_tips` short-circuit.
+  - `emit_tip` — template render + vars interpolation + id_suffix +
+                 type validation + task_keys propagation + silence.
+  - `collect_tips_sorted` — severity ordering, insertion-order stability,
+                            task_keys glob filter, limit.
+  - `severity_emoji`, `severity_label`.
+  - `blockquote_body` — the line-prefix transform applied to tip bodies
+                        so they render as Markdown blockquotes.
+  - `strip_code_fences` — fence-line strip used by the terminal
+                            `TIP:` printer.
+  - `TipsTrait.auto_print` — `add_tip` reads this to gate its terminal
+                              print; tests pin it `False`.
+
+These tests need a real `ctx` (the trait map lives on it). The test
+task registers `TipsTrait` so `ctx.traits[TipsTrait]` resolves.
+
+Run with:
+  aspect dev test-tips
+"""
+
+load(
+    "./tips.axl",
+    "TIP_ADD_GITHUB_TOKEN",
+    "TIP_ADD_GITHUB_TOKEN_SCOPE",
+    "TIP_ADD_ID_TOKEN_PERMISSION",
+    "TIP_CRITICAL",
+    "TIP_INFO",
+    "TIP_SUGGESTION",
+    "TIP_TEMPLATE_FORMAT",
+    "TIP_TEMPLATE_JINJA2",
+    "TIP_TEMPLATE_RAW",
+    "TIP_WARNING",
+    "TipsTrait",
+    "add_tip",
+    "blockquote_body",
+    "collect_tips_sorted",
+    "decorate_tip",
+    "emit_tip",
+    "severity_emoji",
+    "severity_label",
+    "severity_rank",
+    "silence_hint_line",
+    "strip_code_fences",
+    "tip_to_payload",
+)
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _reset(ctx):
+    """Clear the TipsTrait between subtests so each section runs from
+    a known-empty state. The trait persists across the whole `_test_impl`
+    invocation otherwise. Also pin `auto_print = False` so the
+    `add_tip` terminal print doesn't drown out the test-runner output."""
+    ctx.traits[TipsTrait].tips = []
+    ctx.traits[TipsTrait].silenced_tips = []
+    ctx.traits[TipsTrait].auto_print = False
+
+def _ids(tips):
+    """Project to id strings — most assertions only care about which
+    tips made it through, in what order."""
+    return [t.get("id") for t in tips]
+
+def _test_add_tip_basic(ctx):
+    _reset(ctx)
+    add_tip(ctx, id = "a", severity = TIP_INFO, title = "T", body = "B")
+    add_tip(ctx, id = "b", severity = TIP_WARNING, title = "T", body = "B")
+    _eq("add_tip basic — count", len(ctx.traits[TipsTrait].tips), 2)
+    _eq("add_tip basic — ids in insertion order", _ids(ctx.traits[TipsTrait].tips), ["a", "b"])
+
+def _test_add_tip_dedup(ctx):
+    _reset(ctx)
+    add_tip(ctx, id = "a", severity = TIP_INFO, title = "first", body = "first body")
+    add_tip(ctx, id = "a", severity = TIP_WARNING, title = "second", body = "second body")
+    tips = ctx.traits[TipsTrait].tips
+    _eq("dedup — count is 1", len(tips), 1)
+    _eq("dedup — first add wins (title)", tips[0]["title"], "first")
+    _eq("dedup — first add wins (severity)", tips[0]["severity"], TIP_INFO)
+
+def _test_silenced_tips_short_circuits_add_tip(ctx):
+    _reset(ctx)
+    ctx.traits[TipsTrait].silenced_tips = ["noisy", "also-noisy"]
+    add_tip(ctx, id = "noisy", severity = TIP_INFO, title = "T", body = "B")
+    add_tip(ctx, id = "also-noisy", severity = TIP_WARNING, title = "T", body = "B")
+    add_tip(ctx, id = "keep-me", severity = TIP_INFO, title = "T", body = "B")
+    _eq(
+        "silenced — only non-silenced ids survive",
+        _ids(ctx.traits[TipsTrait].tips),
+        ["keep-me"],
+    )
+
+def _test_silenced_tips_blocks_emit_tip(ctx):
+    _reset(ctx)
+    ctx.traits[TipsTrait].silenced_tips = ["add-github-token"]
+    emit_tip(ctx, TIP_ADD_GITHUB_TOKEN)
+    _eq(
+        "silenced — emit_tip respects silence list",
+        ctx.traits[TipsTrait].tips,
+        [],
+    )
+
+def _test_critical_tips_cannot_be_silenced(ctx):
+    """Critical tips ignore `silenced_tips` — they signal a key-feature
+    breakage and must always reach the user. Verified both via direct
+    `add_tip` and via `emit_tip` against a built-in critical template."""
+    _reset(ctx)
+    ctx.traits[TipsTrait].silenced_tips = ["unsuppressable", "add-id-token-permission"]
+    add_tip(ctx, id = "unsuppressable", severity = TIP_CRITICAL, title = "T", body = "B")
+    emit_tip(ctx, TIP_ADD_ID_TOKEN_PERMISSION)
+    _eq(
+        "critical — silence list ignored",
+        _ids(ctx.traits[TipsTrait].tips),
+        ["unsuppressable", "add-id-token-permission"],
+    )
+
+def _test_add_tip_task_keys_stored(ctx):
+    _reset(ctx)
+    add_tip(ctx, id = "a", severity = TIP_INFO, title = "T", body = "B", task_keys = ["lint-*", "format-*"])
+    add_tip(ctx, id = "b", severity = TIP_INFO, title = "T", body = "B")
+    tips = ctx.traits[TipsTrait].tips
+    _eq("task_keys stored", tips[0]["task_keys"], ["lint-*", "format-*"])
+    _eq("task_keys default — empty list when None", tips[1]["task_keys"], [])
+
+def _test_emit_tip_format(ctx):
+    _reset(ctx)
+    template = {
+        "id": "scope-missing",
+        "severity": TIP_WARNING,
+        "title": "Token lacks `{scope}` scope",
+        "body": "Endpoint {endpoint} returned 403.",
+        "type": TIP_TEMPLATE_FORMAT,
+    }
+    emit_tip(ctx, template, vars = {"scope": "actions: read", "endpoint": "/runs/jobs"})
+    tip = ctx.traits[TipsTrait].tips[0]
+    _eq("format — title interpolated", tip["title"], "Token lacks `actions: read` scope")
+    _eq("format — body interpolated", tip["body"], "Endpoint /runs/jobs returned 403.")
+
+def _test_emit_tip_raw_skips_interpolation(ctx):
+    _reset(ctx)
+    template = {
+        "id": "raw-tip",
+        "severity": TIP_INFO,
+        "title": "Title with {literal} braces",
+        "body": "Body with {curly} braces",
+        "type": TIP_TEMPLATE_RAW,
+    }
+    emit_tip(ctx, template, vars = {"literal": "shouldn't be touched"})
+    tip = ctx.traits[TipsTrait].tips[0]
+    _eq("raw — title untouched", tip["title"], "Title with {literal} braces")
+    _eq("raw — body untouched", tip["body"], "Body with {curly} braces")
+
+def _test_emit_tip_default_type_is_format(ctx):
+    _reset(ctx)
+    template = {
+        "id": "default-type",
+        "severity": TIP_INFO,
+        "title": "Hello {name}",
+        "body": "B",
+        # no `type` field — should default to TIP_TEMPLATE_FORMAT.
+    }
+    emit_tip(ctx, template, vars = {"name": "world"})
+    _eq("default type — interpolated as FORMAT", ctx.traits[TipsTrait].tips[0]["title"], "Hello world")
+
+def _test_emit_tip_id_suffix(ctx):
+    _reset(ctx)
+    template = {
+        "id": "base",
+        "severity": TIP_INFO,
+        "title": "T",
+        "body": "B",
+        "type": TIP_TEMPLATE_RAW,
+    }
+    emit_tip(ctx, template)
+    emit_tip(ctx, template, id_suffix = "variant-a")
+    emit_tip(ctx, template, id_suffix = "variant-b")
+    _eq("id_suffix — distinct ids", _ids(ctx.traits[TipsTrait].tips), ["base", "base-variant-a", "base-variant-b"])
+
+def _test_emit_tip_task_keys_override(ctx):
+    _reset(ctx)
+    template = {
+        "id": "tmpl-1",
+        "severity": TIP_INFO,
+        "title": "T",
+        "body": "B",
+        "type": TIP_TEMPLATE_RAW,
+        "task_keys": ["lint-*"],
+    }
+    emit_tip(ctx, template)
+    emit_tip(ctx, template, id_suffix = "override", task_keys = ["format-*", "gazelle-*"])
+    tips = ctx.traits[TipsTrait].tips
+    _eq("emit_tip — template task_keys honored", tips[0]["task_keys"], ["lint-*"])
+    _eq("emit_tip — explicit task_keys override template", tips[1]["task_keys"], ["format-*", "gazelle-*"])
+
+_JINJA2_TEMPLATE = {
+    "id": "scope-fail",
+    "severity": TIP_WARNING,
+    "title": "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %}",
+    "body": "{{ endpoints|length }} {{ \"call\" if endpoints|length == 1 else \"calls\" }} fell back:\n{% for e in endpoints %}- {{ e }}\n{% endfor %}",
+    "type": TIP_TEMPLATE_JINJA2,
+}
+
+def _test_jinja2_first_emit_seeds_accumulators(ctx):
+    """First emit of a JINJA2 tip seeds each accumulator with the
+    initial value as a single-entry list, renders title + body, and
+    stores both the templates and the dict<name, list> for later
+    re-render on merge."""
+    _reset(ctx)
+    emit_tip(
+        ctx,
+        _JINJA2_TEMPLATE,
+        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
+    )
+    tips = ctx.traits[TipsTrait].tips
+    _eq("jinja2 first-emit — single tip", len(tips), 1)
+    _eq("jinja2 first-emit — type recorded", tips[0]["type"], TIP_TEMPLATE_JINJA2)
+    _eq(
+        "jinja2 first-emit — accumulators seeded as lists",
+        tips[0]["accumulators"],
+        {"scopes": ["actions: read"], "endpoints": ["/jobs"]},
+    )
+    if "actions: read" not in tips[0]["title"]:
+        fail("jinja2 first-emit — title missing scope: %r" % tips[0]["title"])
+    if "/jobs" not in tips[0]["body"]:
+        fail("jinja2 first-emit — body missing endpoint: %r" % tips[0]["body"])
+
+    # Templates retained for later re-render on accumulator merge.
+    if not tips[0].get("title_template"):
+        fail("jinja2 first-emit — title_template not retained")
+    if not tips[0].get("body_template"):
+        fail("jinja2 first-emit — body_template not retained")
+
+def _test_jinja2_dedup_merges_new_values(ctx):
+    """Second emit with new accumulator values: dedup on id, union
+    each accumulator (preserving insertion order), re-render title +
+    body so the merged state is what's stored."""
+    _reset(ctx)
+    emit_tip(
+        ctx,
+        _JINJA2_TEMPLATE,
+        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
+    )
+    emit_tip(
+        ctx,
+        _JINJA2_TEMPLATE,
+        accumulators = {"scopes": "pull-requests: read", "endpoints": "/files"},
+    )
+    tips = ctx.traits[TipsTrait].tips
+    _eq("jinja2 dedup — still single tip", len(tips), 1)
+    _eq(
+        "jinja2 dedup — scopes unioned in order",
+        tips[0]["accumulators"]["scopes"],
+        ["actions: read", "pull-requests: read"],
+    )
+    _eq(
+        "jinja2 dedup — endpoints unioned in order",
+        tips[0]["accumulators"]["endpoints"],
+        ["/jobs", "/files"],
+    )
+
+    # Title plural form now applies (2 scopes).
+    if "2 scopes" not in tips[0]["title"]:
+        fail("jinja2 dedup — title not re-rendered with plural form: %r" % tips[0]["title"])
+
+    # Body lists both endpoints with plural noun.
+    if "/jobs" not in tips[0]["body"] or "/files" not in tips[0]["body"]:
+        fail("jinja2 dedup — body missing one endpoint: %r" % tips[0]["body"])
+    if "2 calls" not in tips[0]["body"]:
+        fail("jinja2 dedup — body not re-rendered with plural form: %r" % tips[0]["body"])
+
+def _test_jinja2_dedup_skips_duplicate_values(ctx):
+    """Re-emitting the same accumulator values is a no-op — no
+    duplicate list entries, no re-render."""
+    _reset(ctx)
+    emit_tip(
+        ctx,
+        _JINJA2_TEMPLATE,
+        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
+    )
+    emit_tip(
+        ctx,
+        _JINJA2_TEMPLATE,
+        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
+    )
+    tip = ctx.traits[TipsTrait].tips[0]
+    _eq(
+        "jinja2 dedup — duplicate scope skipped",
+        tip["accumulators"]["scopes"],
+        ["actions: read"],
+    )
+    _eq(
+        "jinja2 dedup — duplicate endpoint skipped",
+        tip["accumulators"]["endpoints"],
+        ["/jobs"],
+    )
+
+def _test_jinja2_partial_overlap_appends_only_new(ctx):
+    """Second emit sharing one accumulator value with the first only
+    appends the new value to the differing accumulator. Confirms the
+    per-name union is independent (scopes can dedup while endpoints
+    accumulate)."""
+    _reset(ctx)
+    emit_tip(
+        ctx,
+        _JINJA2_TEMPLATE,
+        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
+    )
+    emit_tip(
+        ctx,
+        _JINJA2_TEMPLATE,
+        accumulators = {"scopes": "actions: read", "endpoints": "/runs"},
+    )
+    tip = ctx.traits[TipsTrait].tips[0]
+    _eq(
+        "jinja2 partial overlap — scopes deduped",
+        tip["accumulators"]["scopes"],
+        ["actions: read"],
+    )
+    _eq(
+        "jinja2 partial overlap — endpoints both retained",
+        tip["accumulators"]["endpoints"],
+        ["/jobs", "/runs"],
+    )
+
+def _test_collect_sorted_by_severity(ctx):
+    _reset(ctx)
+    add_tip(ctx, id = "info-1", severity = TIP_INFO, title = "T", body = "B")
+    add_tip(ctx, id = "critical-1", severity = TIP_CRITICAL, title = "T", body = "B")
+    add_tip(ctx, id = "warning-1", severity = TIP_WARNING, title = "T", body = "B")
+    add_tip(ctx, id = "suggestion-1", severity = TIP_SUGGESTION, title = "T", body = "B")
+    add_tip(ctx, id = "critical-2", severity = TIP_CRITICAL, title = "T", body = "B")
+    sorted_ids = _ids(collect_tips_sorted(ctx))
+    _eq(
+        "sorted — critical → warning → suggestion → info; stable within bucket",
+        sorted_ids,
+        ["critical-1", "critical-2", "warning-1", "suggestion-1", "info-1"],
+    )
+
+def _test_collect_task_keys_filter(ctx):
+    # Task keys are auto-generated at task instantiation
+    # (`ctx.task.key` looks like a `truthful-ice`-style word pair). The
+    # test can't hardcode the value, so we exercise the filter with
+    # patterns that are deterministic regardless: empty list (current
+    # task), `["*"]` (match all), `["never-match-*"]` (no match), and
+    # one synthesized from the actual `ctx.task.key`.
+    _reset(ctx)
+    add_tip(ctx, id = "empty-keys", severity = TIP_INFO, title = "T", body = "B")
+    add_tip(ctx, id = "match-all", severity = TIP_INFO, title = "T", body = "B", task_keys = ["*"])
+    add_tip(ctx, id = "match-exact", severity = TIP_INFO, title = "T", body = "B", task_keys = [ctx.task.key])
+    add_tip(ctx, id = "never-match", severity = TIP_INFO, title = "T", body = "B", task_keys = ["zzzz-never-match-*"])
+    _eq(
+        "filter — empty + `*` + exact-key pass; mismatched glob skipped",
+        _ids(collect_tips_sorted(ctx)),
+        ["empty-keys", "match-all", "match-exact"],
+    )
+
+def _test_collect_limit(ctx):
+    _reset(ctx)
+    for i in range(5):
+        add_tip(ctx, id = "tip-" + str(i), severity = TIP_WARNING, title = "T", body = "B")
+    _eq("limit — caps at requested count", len(collect_tips_sorted(ctx, limit = 3)), 3)
+    _eq("limit — None returns all", len(collect_tips_sorted(ctx, limit = None)), 5)
+    _eq("limit — 0 returns empty", len(collect_tips_sorted(ctx, limit = 0)), 0)
+
+def _test_severity_emoji(ctx):
+    _eq("emoji — critical", severity_emoji(TIP_CRITICAL), "🔥")
+    _eq("emoji — warning", severity_emoji(TIP_WARNING), "⚠️")
+    _eq("emoji — suggestion", severity_emoji(TIP_SUGGESTION), "💡")
+    _eq("emoji — info", severity_emoji(TIP_INFO), "ℹ️")
+    _eq("emoji — unknown defaults to info", severity_emoji("bogus"), "ℹ️")
+
+def _test_severity_label(ctx):
+    _eq("label — critical", severity_label(TIP_CRITICAL), "Critical")
+    _eq("label — warning", severity_label(TIP_WARNING), "Warning")
+    _eq("label — suggestion", severity_label(TIP_SUGGESTION), "Tip")
+    _eq("label — info", severity_label(TIP_INFO), "Info")
+    _eq("label — unknown defaults to info", severity_label("bogus"), "Info")
+
+def _test_blockquote_body(ctx):
+    _eq("blockquote — empty body", blockquote_body(""), "")
+    _eq("blockquote — single line", blockquote_body("hello"), "> hello")
+    _eq("blockquote — two lines", blockquote_body("a\nb"), "> a\n> b")
+    _eq(
+        "blockquote — blank line between paragraphs uses bare `>`",
+        blockquote_body("para1\n\npara2"),
+        "> para1\n>\n> para2",
+    )
+    _eq(
+        "blockquote — preserves code-fence lines",
+        blockquote_body("intro\n\n```yaml\nkey: value\n```"),
+        "> intro\n>\n> ```yaml\n> key: value\n> ```",
+    )
+
+def _test_builtin_templates_shape(ctx):
+    """Smoke-test the built-in templates have the required keys so a
+    rename or restructure trips the test before users see a broken tip."""
+    for name, tmpl in [
+        ("TIP_ADD_GITHUB_TOKEN", TIP_ADD_GITHUB_TOKEN),
+        ("TIP_ADD_GITHUB_TOKEN_SCOPE", TIP_ADD_GITHUB_TOKEN_SCOPE),
+        ("TIP_ADD_ID_TOKEN_PERMISSION", TIP_ADD_ID_TOKEN_PERMISSION),
+    ]:
+        for key in ("id", "severity", "title", "body", "type"):
+            if key not in tmpl:
+                fail("%s missing required key %r" % (name, key))
+
+def _test_builtin_insufficient_scope_renders(ctx):
+    """`TIP_ADD_GITHUB_TOKEN_SCOPE` is the canonical multi-accumulator
+    JINJA2 template — both `scopes` and `endpoints` accumulate, the
+    title pluralizes on `scopes`, and the body pluralizes on
+    `endpoints` and renders one bullet per endpoint. One tip per task;
+    distinct scopes union into the same tip's `scopes` accumulator."""
+    _reset(ctx)
+    emit_tip(
+        ctx,
+        TIP_ADD_GITHUB_TOKEN_SCOPE,
+        accumulators = {
+            "scopes": "pull-requests: read",
+            "endpoints": "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
+        },
+    )
+    tip = ctx.traits[TipsTrait].tips[0]
+    _eq("scope tip — id is the canonical id (no suffix)", tip["id"], "add-github-token-scope")
+    _eq("scope tip — severity is WARNING", tip["severity"], TIP_WARNING)
+    _eq("scope tip — type is JINJA2", tip["type"], TIP_TEMPLATE_JINJA2)
+    if "pull-requests: read" not in tip["title"]:
+        fail("scope tip — title missing scope: %r" % tip["title"])
+    if "GET /repos/{owner}/{repo}/pulls/{pull_number}/files" not in tip["body"]:
+        fail("scope tip — body missing endpoint: %r" % tip["body"])
+    _eq("scope tip — scopes accumulated", tip["accumulators"]["scopes"], ["pull-requests: read"])
+    _eq(
+        "scope tip — endpoints accumulated",
+        tip["accumulators"]["endpoints"],
+        ["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"],
+    )
+
+    # Second emit with a different scope + endpoint: merge.
+    emit_tip(
+        ctx,
+        TIP_ADD_GITHUB_TOKEN_SCOPE,
+        accumulators = {
+            "scopes": "actions: read",
+            "endpoints": "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+        },
+    )
+    _eq("scope tip — still single tip after merge", len(ctx.traits[TipsTrait].tips), 1)
+    merged = ctx.traits[TipsTrait].tips[0]
+    _eq(
+        "scope tip — both scopes unioned",
+        merged["accumulators"]["scopes"],
+        ["pull-requests: read", "actions: read"],
+    )
+    _eq(
+        "scope tip — both endpoints unioned",
+        merged["accumulators"]["endpoints"],
+        [
+            "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
+            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+        ],
+    )
+    if "2 scopes" not in merged["title"]:
+        fail("scope tip — merged title not pluralized: %r" % merged["title"])
+
+def _test_silence_hint_line(ctx):
+    _eq("silence_hint — empty id", silence_hint_line("", TIP_INFO), "")
+    _eq(
+        "silence_hint — critical returns empty",
+        silence_hint_line("anything", TIP_CRITICAL),
+        "",
+    )
+    for sev in (TIP_WARNING, TIP_SUGGESTION, TIP_INFO):
+        line = silence_hint_line("add-github-token", sev)
+        if "add-github-token" not in line:
+            fail("silence_hint %s: missing tip id: %r" % (sev, line))
+        if "silenced_tips" not in line:
+            fail("silence_hint %s: missing silenced_tips ref: %r" % (sev, line))
+        if not line.startswith("<sub>"):
+            fail("silence_hint %s: must wrap in <sub>: %r" % (sev, line))
+
+def _test_severity_rank(ctx):
+    _eq("rank — critical most urgent", severity_rank(TIP_CRITICAL), 0)
+    _eq("rank — warning", severity_rank(TIP_WARNING), 1)
+    _eq("rank — suggestion", severity_rank(TIP_SUGGESTION), 2)
+    _eq("rank — info least urgent", severity_rank(TIP_INFO), 3)
+    if severity_rank("bogus") <= severity_rank(TIP_INFO):
+        fail("rank — unknown severity must sort after info")
+
+def _test_tip_to_payload(ctx):
+    """`tip_to_payload` projects a stored tip into the artifact-boundary
+    shape consumed by the PR-comment aggregator. Test pins the field
+    set so a future drop (e.g. of `title_template`) trips here rather
+    than at the downstream JINJA2 re-render."""
+    stored = {
+        "id": "x",
+        "severity": TIP_WARNING,
+        "title": "Title",
+        "body": "Body",
+        "type": TIP_TEMPLATE_JINJA2,
+        "title_template": "T",
+        "body_template": "B",
+        "accumulators": {"scopes": ["actions: read"]},
+        "task_keys": ["lint-*"],  # producer-side filter; payload omits this
+    }
+    payload = tip_to_payload(stored)
+    _eq("tip_to_payload — id", payload["id"], "x")
+    _eq("tip_to_payload — severity", payload["severity"], TIP_WARNING)
+    _eq("tip_to_payload — title", payload["title"], "Title")
+    _eq("tip_to_payload — body", payload["body"], "Body")
+    _eq("tip_to_payload — type", payload["type"], TIP_TEMPLATE_JINJA2)
+    _eq("tip_to_payload — title_template", payload["title_template"], "T")
+    _eq("tip_to_payload — body_template", payload["body_template"], "B")
+    _eq("tip_to_payload — accumulators", payload["accumulators"], {"scopes": ["actions: read"]})
+    if "task_keys" in payload:
+        fail("tip_to_payload — task_keys (producer-side filter) must NOT cross the artifact boundary")
+
+    # Empty accumulators normalize to {} rather than None.
+    minimal = tip_to_payload({"id": "y", "severity": TIP_INFO, "title": "T", "body": "B"})
+    _eq("tip_to_payload — missing accumulators → empty dict", minimal["accumulators"], {})
+
+def _test_decorate_tip(ctx):
+    """`decorate_tip` projects a stored tip into the render shape both
+    surfaces consume (TIPS_BLOCK + PR-comment Tips section). Test
+    keeps the two surfaces aligned by construction."""
+    decorated = decorate_tip({
+        "id": "x",
+        "severity": TIP_WARNING,
+        "title": "T",
+        "body": "line1\nline2",
+    })
+    _eq("decorate_tip — id", decorated["id"], "x")
+    _eq("decorate_tip — severity_emoji", decorated["severity_emoji"], "⚠️")
+    _eq("decorate_tip — severity_label", decorated["severity_label"], "Warning")
+    _eq("decorate_tip — title", decorated["title"], "T")
+    _eq("decorate_tip — body_quoted prefixes each line", decorated["body_quoted"], "> line1\n> line2")
+    if "silenced_tips" not in decorated["silence_hint"]:
+        fail("decorate_tip — non-critical row missing silence_hint: %r" % decorated["silence_hint"])
+
+    # Critical: silence_hint should be blank.
+    crit = decorate_tip({"id": "c", "severity": TIP_CRITICAL, "title": "C", "body": ""})
+    _eq("decorate_tip — critical silence_hint blank", crit["silence_hint"], "")
+
+def _test_strip_code_fences(ctx):
+    _eq("fences — empty body", strip_code_fences(""), "")
+    _eq("fences — no fences passes through", strip_code_fences("hello\nworld"), "hello\nworld")
+    _eq(
+        "fences — bare ``` lines dropped, content kept",
+        strip_code_fences("intro\n```\nx: y\n```"),
+        "intro\nx: y",
+    )
+    _eq(
+        "fences — language tag dropped (```yaml)",
+        strip_code_fences("intro\n```yaml\nkey: value\n```"),
+        "intro\nkey: value",
+    )
+    _eq(
+        "fences — indented ``` still treated as fence (matches Markdown laxness)",
+        strip_code_fences("intro\n   ```\nbody\n   ```"),
+        "intro\nbody",
+    )
+
+def _test_auto_print_flag(ctx):
+    """`add_tip` reads `TipsTrait.auto_print` to gate the terminal
+    print. Tests run with `auto_print = False` (set by `_reset`) — so
+    we just verify the storage still works in that mode, which
+    indirectly proves the `auto_print = False` branch doesn't crash
+    or interfere with the dedup / silence paths."""
+    _reset(ctx)
+    _eq("auto_print — pinned False in test reset", ctx.traits[TipsTrait].auto_print, False)
+    add_tip(ctx, id = "x", severity = TIP_INFO, title = "T", body = "B")
+    _eq("auto_print False — tip still recorded", _ids(ctx.traits[TipsTrait].tips), ["x"])
+
+def _test_impl(ctx):
+    _test_add_tip_basic(ctx)
+    _test_add_tip_dedup(ctx)
+    _test_silenced_tips_short_circuits_add_tip(ctx)
+    _test_silenced_tips_blocks_emit_tip(ctx)
+    _test_critical_tips_cannot_be_silenced(ctx)
+    _test_add_tip_task_keys_stored(ctx)
+    _test_emit_tip_format(ctx)
+    _test_emit_tip_raw_skips_interpolation(ctx)
+    _test_emit_tip_default_type_is_format(ctx)
+    _test_emit_tip_id_suffix(ctx)
+    _test_emit_tip_task_keys_override(ctx)
+    _test_jinja2_first_emit_seeds_accumulators(ctx)
+    _test_jinja2_dedup_merges_new_values(ctx)
+    _test_jinja2_dedup_skips_duplicate_values(ctx)
+    _test_jinja2_partial_overlap_appends_only_new(ctx)
+    _test_collect_sorted_by_severity(ctx)
+    _test_collect_task_keys_filter(ctx)
+    _test_collect_limit(ctx)
+    _test_severity_emoji(ctx)
+    _test_severity_label(ctx)
+    _test_severity_rank(ctx)
+    _test_blockquote_body(ctx)
+    _test_builtin_templates_shape(ctx)
+    _test_builtin_insufficient_scope_renders(ctx)
+    _test_silence_hint_line(ctx)
+    _test_decorate_tip(ctx)
+    _test_tip_to_payload(ctx)
+    _test_strip_code_fences(ctx)
+    _test_auto_print_flag(ctx)
+    print("tips.axl: OK (28 sections)")
+    return 0
+
+tips_tests = task(
+    name = "test-tips",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+    traits = [TipsTrait],
+)

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -33,6 +33,7 @@ load("./lib/repro_commands.axl", "build_aspect_command", "task_cli_path")
 load("./lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics")
 load("./lib/tar.axl", "tar_create")
 load("./lib/text.axl", "pluralize")
+load("./lib/tips.axl", "TipsTrait")
 
 # bb_clientd FUSE mount root for resolving bytestream:// URIs on Aspect Workflows runners.
 _BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
@@ -1204,8 +1205,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     )
 
 lint = task(
-    implementation = _impl,
-    traits = [LintTrait, BazelTrait, HealthCheckTrait, TaskLifecycleTrait, GitHubCheckRunTrait],
     args = {
         "aspects": args.string_list(
             long = "aspect",
@@ -1256,4 +1255,13 @@ lint = task(
             description = "Bazel target patterns to lint. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory. Pass multiple patterns to combine includes and excludes; when any pattern is hyphen-led, separate them from flags with `--` (e.g. `aspect lint -- //... -//experimental/...`).",
         ),
     },
+    traits = [
+        BazelTrait,
+        GitHubCheckRunTrait,
+        HealthCheckTrait,
+        LintTrait,
+        TaskLifecycleTrait,
+        TipsTrait,
+    ],
+    implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -9,20 +9,12 @@ load("./lib/bazel_runner.axl", "run_bazel_task")
 load("./lib/checkrun.axl", "GitHubCheckRunTrait")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "TaskLifecycleTrait")
+load("./lib/tips.axl", "TipsTrait")
 
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     return run_bazel_task(ctx, command = "test")
 
 test = task(
-    implementation = _impl,
-    traits = [
-        BazelTrait,
-        HealthCheckTrait,
-        TaskLifecycleTrait,
-        GitHubStatusChecksTrait,
-        GitHubCheckRunTrait,
-        ArtifactsTrait,
-    ],
     args = {
         # TODO: Support a long --pattern_file like bazel does (@./targets)
         # TODO: Support - (list from stdin)
@@ -61,4 +53,14 @@ test = task(
             description = "Bazel output base path. Use to target a specific Bazel server instance — distinct paths run independent JVMs and cache contents.",
         ),
     },
+    traits = [
+        ArtifactsTrait,
+        BazelTrait,
+        GitHubCheckRunTrait,
+        GitHubStatusChecksTrait,
+        HealthCheckTrait,
+        TaskLifecycleTrait,
+        TipsTrait,
+    ],
+    implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/traits.axl
+++ b/crates/aspect-cli/src/builtins/aspect/traits.axl
@@ -28,12 +28,16 @@ load(
     _TaskLifecycleTrait = "TaskLifecycleTrait",
     _TaskUpdate = "TaskUpdate",
 )
+load("./lib/tips.axl", _TipsTrait = "TipsTrait")
+load("./lint.axl", _LintTrait = "LintTrait")
 
-TaskUpdate = _TaskUpdate
-TaskLifecycleTrait = _TaskLifecycleTrait
-BazelTrait = _BazelTrait
-HealthCheckTrait = _HealthCheckTrait
 ArtifactsTrait = _ArtifactsTrait
-GitHubCheckRunTrait = _GitHubCheckRunTrait
+BazelTrait = _BazelTrait
 DeliveryTrait = _DeliveryTrait
+GitHubCheckRunTrait = _GitHubCheckRunTrait
 GitHubStatusChecksTrait = _GitHubStatusChecksTrait
+HealthCheckTrait = _HealthCheckTrait
+LintTrait = _LintTrait
+TaskLifecycleTrait = _TaskLifecycleTrait
+TaskUpdate = _TaskUpdate
+TipsTrait = _TipsTrait


### PR DESCRIPTION
aspect-cli currently mints a fresh Aspect GitHub App installation token for every GitHub API call, charging the App's 5,000 req/hr quota even when the call doesn't need to be authored by the Aspect bot identity. On busy monorepos with many concurrent PR builds, that quota becomes the bottleneck.

This PR prefers the job-scoped `GITHUB_TOKEN` / `GH_TOKEN` from env for supporting GitHub API calls (PR file diff, job URL lookup, etc.) — those count against the job's per-repository budget (up to 60,000 req/hr) instead of the App quota. Calls that must be authored by the Aspect App (check-run create/update, PR / issue comments) keep minting the App token directly. A new `TipsTrait` framework surfaces actionable suggestions on the same surfaces the user is already looking at (terminal, check-run summary, Buildkite annotation, PR summary comment) and is used to walk users through the GitHub Actions configuration that unblocks the quota path.

## Token preference

`github.preferred_token_pair(ctx, owner, repo, ...)` returns `(primary_token, app_fallback_token)`:

- `primary` is `GITHUB_TOKEN` then `GH_TOKEN` from env when exported, else the App token.
- `app_fallback` is the App token when env is primary, else `None`. Used to retry on 4xx-auth when the workflow forgot to grant the scope.
- `existing_app_token` lets a caller pass through an App token it already minted, avoiding a redundant mint.

Wired into the four supporting call sites:

| Call site | Role | Why it doesn't need attribution |
|---|---|---|
| `lib/github.axl::detect_build_url` | `actions.read` | Job metadata for the run-page link |
| `lib/github.axl::detect_changed_files` | `prs.read` | PR Files API for the diff |
| `feature/github_status_checks.axl` | `actions.read` | Job URL upgrade post check-run creation |
| `feature/github_status_comments.axl` | `actions.read` | Job URL upgrade post comment publish |

### 4xx-auth fallback to the App token

Modern GitHub Actions defaults restrict `GITHUB_TOKEN` to `contents: read` + `metadata: read` only. Workflows that don't grant `pull-requests: read` / `actions: read` in their `permissions:` block return 4xx-auth on those endpoints.

`_resolve_current_job_url` and `list_pull_request_files` accept an `app_fallback_token`. When the primary token returns 401 / 403 / 404 they transparently retry with the App token and accumulate the missing scope + endpoint into the `add-github-token-scope` tip (one tip per task across all 4xx-auth call sites; see below). The 4xx warning is suppressed on the first attempt when a fallback is available so the log doesn't flag the transparent retry as a failure.

## TipsTrait — surface-rendered tips

`TipsTrait` + `add_tip` / `emit_tip` in `lib/tips.axl`. Producers add tips; the framework auto-prints each one to the terminal (severity-colored `TIP:` prefix) and surfaces them on the check-run summary, Buildkite annotation, and PR summary comment.

**Severity** (highest → lowest urgency): `TIP_CRITICAL` (🔥) → `TIP_WARNING` (⚠️) → `TIP_SUGGESTION` (💡) → `TIP_INFO` (ℹ️). Critical tips signal a key-feature breakage and can't be silenced; the silence-hint footer is omitted for them on both terminal and surface.

**Template types**: `TIP_TEMPLATE_RAW` (no interpolation), `TIP_TEMPLATE_FORMAT` (`title.format(**vars)`, default), and `TIP_TEMPLATE_JINJA2` (Jinja2 source rendered against a `dict<name, list>` accumulator dict). JINJA2 tips re-render on every accumulation event so the surfaced text always reflects merged state.

**`task_keys` glob filter**: each tip optionally carries `task_keys` — a list of glob patterns matched against `ctx.task.key` at render time. Tips without `task_keys` show only on the task they were emitted into; `["*"]` shows on every task, `["lint-*"]` on lint variants.

**User customization** (documented in `lib/tips.axl`):

- Add custom tips via `add_tip` / `emit_tip` from task code.
- Preempt a built-in tip by calling `add_tip` with the same id earlier (dedup-by-id; first add wins for pre-rendered tips).
- Silence any non-critical tip via `ctx.traits[TipsTrait].silenced_tips = ["<tip-id>", ...]` in `.aspect/config.axl`. Each rendered tip's footer surfaces its id and points users at this knob.
- Seed tips from `.aspect/config.axl`: `ctx.traits[TipsTrait].tips = [{...}, ...]`.

**Rendering**: Each tip renders as a Markdown blockquote with `<emoji> **<Label>:** <title>` header, body indented inside the blockquote, then a fine-print `<sub>` footer with the silence knob (omitted for critical). The shared `TIPS_BLOCK` Jinja2 snippet (in `lib/bazel_results.axl`) splices into every task surface; `decorate_tip()` in `lib/tips.axl` is the single source of truth for the row shape so all surfaces stay aligned by construction. The terminal `TIP:` prefix color scales with severity.

### Built-in tips

- `TIP_ADD_ID_TOKEN_PERMISSION` (critical) — fires on GitHub Actions when neither `ACTIONS_ID_TOKEN_REQUEST_TOKEN` nor `ACTIONS_RUNTIME_TOKEN` is exposed. Artifact uploads (status payloads, BEP files, test logs, profiles) fail outright and PR summary comment aggregation breaks until `id-token: write` is granted.
- `TIP_ADD_GITHUB_TOKEN` (suggestion) — fires from `_preferred_token_pair` when a supporting call is made without a job-scoped env token. Routing supporting calls through `GITHUB_TOKEN` reduces App quota usage.
- `TIP_ADD_GITHUB_TOKEN_SCOPE` (warning) — fires on the 4xx-auth fallback. JINJA2 template with two accumulators: `scopes` (every missing scope across the task) and `endpoints` (every API endpoint that fell back). The rendered title and body pluralize naturally, list every accumulated scope in one `permissions:` snippet, and list every endpoint that fell back.

All three tips are gated on `GITHUB_ACTIONS` env (their recommendations are GHA-specific) and use first-use emission — no lifecycle-phase hook.

### PR-comment aggregation

The PR summary comment aggregates tips across every task in the workflow. `_collect_tip_rows`:

- Dedups by tip id; merges every contributing task's key into the row's attribution footer.
- For JINJA2 tips, unions each accumulator's values across tasks (preserving first-seen order) and re-renders title + body so the comment surfaces the full cross-task picture.
- Sorts by severity (critical → warning → suggestion → info), insertion-order tiebreak.
- Always surfaces all critical + warning tips; caps suggestion + info combined at `_MAX_SUBORDINATE_TIPS = 5` so a noisy task can't drown the section.

Renders as a `## 💡 Tips` section between the per-task list and the Reproduce / Fix sections, with each tip carrying a `Surfaced by: <tasks>` attribution footer and (for non-critical tips) the silence-hint footer.

## CI

`.buildkite/pipeline.yaml` axl-tests job now runs every `aspect dev test-*` task explicitly (template snapshots, github-detect, gitlab-detect / -client, tips, pr-comment-snapshots) so regressions trip the BK build instead of waiting for someone to run them locally.

## Changes are visible to end-users

- Yes (`TIP:` blocks on stdout; rendered tips in check-run summary, Buildkite annotations, and the PR summary comment).

## Suggested release notes

- `aspect-cli` now prefers the job-scoped `GITHUB_TOKEN` / `GH_TOKEN` for supporting GitHub API calls (PR file diff, job URL lookup) so the calls count against the job's per-repository budget (up to 60,000 req/hr) instead of the Aspect App's installation-token quota (5,000 req/hr; 15,000 req/hr on GHEC). Workflows that restrict `GITHUB_TOKEN` permissions transparently fall back to the Aspect App token and surface a tip naming every missing scope and the endpoints that fell back.
- New `TipsTrait` framework lets `aspect-cli` surface actionable suggestions on the same surfaces the user is already looking at (terminal `TIP:` prefix, check-run summary, Buildkite annotation, PR summary comment). Critical tips can't be silenced; all others can be opted out via `ctx.traits[TipsTrait].silenced_tips` in `.aspect/config.axl`.
- Two built-in setup tips walk users through the GitHub Actions configuration that unblocks artifact uploads / PR-comment aggregation (`id-token: write`) and reduces App-quota pressure (`GITHUB_TOKEN` env).

## Test plan

- `aspect dev test-tips` — 28 sections covering `add_tip` / `emit_tip` / `collect_tips_sorted` / `severity_*` / `decorate_tip` / `tip_to_payload` / `blockquote_body` / `strip_code_fences` / `silence_hint_line`, `silenced_tips` short-circuit (both `add_tip` and `emit_tip`), critical-can't-be-silenced, template type validation, id_suffix, task_keys glob filter, severity sort, dedup-by-id for pre-rendered tips, JINJA2 multi-accumulator seed + merge + re-render + partial-overlap, `auto_print` flag, and built-in template shape.
- `aspect dev test-github-detect` — `preferred_token_pair` precedence + `(None, None)` auth-failed branch, plus an HTTP-stubbed `list_pull_request_files` test that pins the 4xx-auth fallback retry path (env token → 403 → silent retry with App token, scope + endpoint accumulated into the `add-github-token-scope` tip) and verifies that omitting the fallback surfaces the 403 as a regular failure with no tip and no silent scope expansion.
- `aspect dev test-pr-comment-snapshots` — 20 PR-comment scenarios including three for tip aggregation (single-task, multi-task dedup + attribution, severity-ordered cap) plus inline assertions on `_collect_tip_rows` invariants (dedup, attribution-key sort, severity order, cap, multi-accumulator cross-task merge + re-render).
- All snapshot suites pass: `test-template-snapshots`, `test-lint-template-snapshots`, `test-format-template-snapshots`, `test-gazelle-template-snapshots`, `test-delivery-template-snapshots`, `test-bk-annotation-snapshots`, `test-pr-comment-snapshots`, `test-gitlab-detect`, `test-gitlab-client`.
- All listed tasks wired into `.buildkite/pipeline.yaml`'s `axl-tests` job.
- Local smoke verified: critical id-token tip fires when neither `ACTIONS_ID_TOKEN_REQUEST_TOKEN` nor `ACTIONS_RUNTIME_TOKEN` is set; suggestion GITHUB_TOKEN tip fires when id-token is granted but env token isn't; scope tip fires + accumulates on the 4xx-auth fallback path when the local-diff fast paths are bypassed (validated end-to-end on a CI run that forced the PR Files API path); neither fires outside GitHub Actions. With local-diff in its normal place, change-detection takes the fast path and the scope-tip path stays dormant — `_resolve_current_job_url` and `list_pull_request_files` carry docstring notes explaining that `GITHUB_TOKEN` has implicit access to the workflow's own run + trigger PR regardless of the `permissions:` block.
