### PR TITLE
fix(github): PR comment dedups tasks across run-attempt + same-name artifact duplicates

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -60,6 +60,9 @@ load(
 _ARTIFACT_PREFIX = "aspect-ci-status-"
 _MARKER_FMT = "<!-- aspect-ci-status:pr-%d -->"
 
+# Used by `_should_quiet_delete_log` — see that helper's docstring.
+_EVENTUAL_CONSISTENCY_WINDOW_S = 15
+
 # Status badges keyed by the precomputed `_badge_key` on each entry,
 # *not* the raw lifecycle status. `_badge_key` is one of:
 #   "failed"  — terminal `failed` or live `failing` (severity error)
@@ -299,6 +302,65 @@ def _prepare_for_render(entries):
         e.get("name", ""),
         e.get("key", ""),
     ))
+
+def _run_attempt_int(entry):
+    """Parse `entry.run_attempt` as int. Missing / non-numeric → 1."""
+    raw = entry.get("run_attempt", "1") or "1"
+    if type(raw) == "int":
+        return raw
+    if type(raw) != "string" or not raw.isdigit():
+        return 1
+    return int(raw)
+
+def _dedup_by_run_attempt(entries):
+    """Collapse entries that share a `(name, key, job)` identity to the
+    one with the highest `run_attempt`.
+
+    The artifacts API (`GET /actions/runs/{run_id}/artifacts`) doesn't
+    accept an `attempt_number` filter, so a re-run workflow's listing
+    returns artifacts from every prior attempt alongside the live
+    attempt's. Without this dedup, a task that uploaded a "Starting..."
+    payload on attempt 1 and then a terminal payload on attempt 2
+    surfaces in BOTH `running` and the relevant terminal section of
+    the rendered comment.
+
+    Same-task / different-job rows (e.g. matrix jobs) are NOT collapsed
+    because they're legitimately distinct entries — `job` is part of
+    the dedup key.
+
+    Tiebreak on equal `run_attempt`: the first entry to land in
+    `by_logical` wins. Callers feeding entries newest-first (e.g.
+    `_collect_sibling_entries`'s newest-id-first artifact sort) get
+    the newest-by-upstream-ordering as the tiebreaker — sufficient
+    for the only realistic tie scenario (two same-name artifacts on
+    the same attempt left over from a delete-race)."""
+    by_logical = {}
+    for e in entries:
+        key = (e.get("name", ""), e.get("key", ""), e.get("job", ""))
+        existing = by_logical.get(key)
+        if existing == None or _run_attempt_int(e) > _run_attempt_int(existing):
+            by_logical[key] = e
+    return list(by_logical.values())
+
+def _should_quiet_delete_log(last_upload_at, now):
+    """Decide whether a `DeleteArtifact` failure on a pre-upload cleanup
+    should log at INFO (`True`) or WARN (`False`).
+
+    Two benign cases:
+
+      - `last_upload_at == None` → first cycle, nothing was ever
+        uploaded for this artifact name. The Twirp `DeleteArtifact`
+        will return 404; that's expected.
+      - `(now - last_upload_at) <= _EVENTUAL_CONSISTENCY_WINDOW_S` →
+        the Azure-backed read replica handling the delete may not yet
+        see the freshly-uploaded artifact. The next cycle's delete
+        typically catches up once the consistency window closes.
+
+    Past the window, a continued failure is no longer attributable to
+    eventual consistency and stays at WARN."""
+    if last_upload_at == None:
+        return True
+    return (now - last_upload_at) <= _EVENTUAL_CONSISTENCY_WINDOW_S
 
 def _bucket_entries(entries):
     """Split entries into status sections for the rendered comment.
@@ -735,8 +797,12 @@ def _github_status_comments(ctx: FeatureContext):
         return payload
 
     def _publish_self(ctx, token):
-        """Skip the upload when nothing in our payload has changed since the
-        last successful upload — saves ~half the API calls on quiet builds."""
+        """Upload this task's status payload, replacing the prior
+        cycle's artifact in place. Skips the API round-trip when the
+        payload hasn't changed since the last successful upload —
+        saves ~half the API calls on quiet builds. The pre-upload
+        `delete_artifact` call uses `quiet_failure_log` gated on
+        `_should_quiet_delete_log` so benign 404s don't spam WARN."""
         if "_workdir" not in _state:
             _state["_workdir"] = ctx.std.fs.mkdtemp(prefix = "aspect-ci-status-")
         _state["_my_artifact_name"] = _ARTIFACT_PREFIX + job_name + "-" + _state["_task_key"] + "-" + run_attempt
@@ -749,7 +815,8 @@ def _github_status_comments(ctx: FeatureContext):
         payload_path = _state["_workdir"] + "/task.json"
         ctx.std.fs.write(payload_path, payload_str)
 
-        github.delete_artifact(ctx, _state["_my_artifact_name"])
+        quiet = _should_quiet_delete_log(_state.get("_last_upload_at"), monotonic())
+        github.delete_artifact(ctx, _state["_my_artifact_name"], quiet_failure_log = quiet)
 
         # Server-side TTL — fresh per-cycle so a still-polling task
         # keeps its artifact alive while inactive ones expire on their own.
@@ -759,15 +826,44 @@ def _github_status_comments(ctx: FeatureContext):
             _LOG.warn(ctx.std, "Upload failed: %s" % "; ".join(up.get("errors", []) or []))
             return False
         _state["_last_payload_str"] = payload_str
+        _state["_last_upload_at"] = monotonic()
         return True
 
     def _collect_sibling_entries(ctx, token):
-        """List sibling artifacts; reuse cached entries by artifact id and only
-        download artifacts whose id is new. Returns a sorted list of entry dicts,
-        or None on transport failure.
+        """List sibling artifacts and return one entry dict per logical task.
 
-        The artifact id changes on every replacement (we delete+upload), so a
-        stable id means the producer hasn't pushed a new payload since last poll.
+        Per-artifact downloads are cached by artifact id; only new ids
+        cost a download. The artifact id changes on every replacement
+        (delete + upload), so a stable id means the producer hasn't
+        pushed a new payload since the last poll.
+
+        Two duplicate-handling paths converge here:
+
+          - **Same artifact name appears multiple times.** GitHub's
+            artifact API is backed by Azure storage with eventual-
+            consistency reads, so a listing can briefly include a
+            previously-deleted artifact alongside the freshly-uploaded
+            one. We sort newest-first (by artifact id; ids are
+            monotonically increasing per repo) and skip names already
+            in `seen`, so the newest payload always wins.
+
+          - **Same logical `(name, key, job)` across run attempts.**
+            The artifacts endpoint doesn't accept an `attempt_number`
+            filter, so a re-run workflow's listing returns every prior
+            attempt's artifacts alongside the live attempt's.
+            `_dedup_by_run_attempt` collapses them to the latest
+            attempt before returning.
+
+        Eager same-cycle re-cleanup of duplicates was considered and
+        rejected: the same eventual-consistency window means a
+        delete-after-upload may not see the just-uploaded artifact,
+        leaving a fresh ghost AND a stale one. The natural per-cycle
+        `delete_artifact + upload_artifact` in `_publish_self`
+        converges over 1-2 cycles once the consistency window closes;
+        the two dedup paths above ensure correct rendering in the
+        meantime.
+
+        Returns `None` on transport failure listing artifacts.
         """
         listed = github.actions.list_run_artifacts(ctx, token, owner, repo, run_id, name_prefix = _ARTIFACT_PREFIX)
         if not listed.get("success"):
@@ -780,10 +876,14 @@ def _github_status_comments(ctx: FeatureContext):
         seen = {}  # artifact name -> entry
         current_ids = {}  # current ids in this listing → bool, used to GC cache
 
-        for a in listed["artifacts"]:
+        sorted_artifacts = sorted(listed["artifacts"], key = lambda a: -(a.get("id") or 0))
+        for a in sorted_artifacts:
             aname = a.get("name", "")
             aid = str(a["id"])
             current_ids[aid] = True
+
+            if aname in seen:
+                continue
 
             # We have authoritative data for our own task in _state — skip the
             # download and use it directly. Avoids reading our own zip back.
@@ -818,8 +918,7 @@ def _github_status_comments(ctx: FeatureContext):
             if aid not in current_ids:
                 cache.pop(aid)
 
-        # `_prepare_for_render` decorates and sorts; just return raw.
-        return list(seen.values())
+        return _dedup_by_run_attempt(list(seen.values()))
 
     def _upsert_comment(ctx, token, body):
         """PATCH the existing comment if known/findable, else POST and dedupe duplicates."""
@@ -1034,6 +1133,14 @@ def collect_tip_rows(ctx, entries):
 def bucket_entries(entries):
     """Public test hook; see `_bucket_entries`."""
     return _bucket_entries(entries)
+
+def dedup_by_run_attempt(entries):
+    """Public test hook; see `_dedup_by_run_attempt`."""
+    return _dedup_by_run_attempt(entries)
+
+def should_quiet_delete_log(last_upload_at, now):
+    """Public test hook; see `_should_quiet_delete_log`."""
+    return _should_quiet_delete_log(last_upload_at, now)
 
 def render_body(ctx, marker, entries, started_at, body_template, status_badges, sections):
     """Public test hook; see `_render_body`."""

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -30,9 +30,11 @@ load(
     "MARKER_FMT",
     "bucket_entries",
     "collect_tip_rows",
+    "dedup_by_run_attempt",
     "prepare_for_render",
     "render_body",
     "results_subset",
+    "should_quiet_delete_log",
 )
 load(
     "./test_fixtures.axl",
@@ -56,6 +58,11 @@ load(
     "make_test_running_flaky_only",
 )
 load("../lib/bazel_results.axl", "compute_reproducer_command")
+load("../lib/github.axl", "github")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
 
 _DEFAULT_RUN_URL = "https://github.com/aspect-build/aspect-cli/actions/runs/25615893249"
 _DEFAULT_ASPECT_URL = "https://app.aspect.build/build/sink-uuid-1234-5678-9abc"
@@ -437,10 +444,126 @@ def _check_collect_tip_rows(ctx):
     if rows[0]["task_keys"] != ["build-task", "test-task"]:
         fail("multi-accumulator merge: task_keys merge wrong: %r" % rows[0]["task_keys"])
 
+def _check_dedup_by_run_attempt():
+    """Functional assertions for `_dedup_by_run_attempt` — collapse
+    `(name, key, job)` duplicates from a re-run workflow's artifact
+    listing to the entry from the latest attempt."""
+
+    # Re-run scenario: attempt 1 left a stale "running" entry; attempt
+    # 2 is the terminal "passed". One entry per (name, key, job)
+    # survives, with the higher run_attempt's payload.
+    out = dedup_by_run_attempt([
+        {"name": "format", "key": "format-gha", "job": "format-task", "run_attempt": "1", "status": "running"},
+        {"name": "format", "key": "format-gha", "job": "format-task", "run_attempt": "2", "status": "passed"},
+    ])
+    if len(out) != 1:
+        fail("dedup_by_run_attempt rerun: expected 1 entry, got %d: %r" % (len(out), out))
+    if out[0]["status"] != "passed" or out[0]["run_attempt"] != "2":
+        fail("dedup_by_run_attempt rerun: expected attempt-2 payload to win, got %r" % out[0])
+
+    # Different `job` → NOT collapsed (matrix-style: same task surfaced
+    # by two distinct yaml jobs is two legitimate rows).
+    out = dedup_by_run_attempt([
+        {"name": "test", "key": "test-gha", "job": "cpu-test", "run_attempt": "1", "status": "passed"},
+        {"name": "test", "key": "test-gha", "job": "gpu-test", "run_attempt": "1", "status": "passed"},
+    ])
+    if len(out) != 2:
+        fail("dedup_by_run_attempt matrix: expected 2 distinct rows, got %d: %r" % (len(out), out))
+
+    # Numeric ordering, not lexicographic: "10" > "9".
+    out = dedup_by_run_attempt([
+        {"name": "x", "key": "x", "job": "j", "run_attempt": "9", "status": "running"},
+        {"name": "x", "key": "x", "job": "j", "run_attempt": "10", "status": "passed"},
+    ])
+    if out[0]["run_attempt"] != "10":
+        fail("dedup_by_run_attempt numeric: expected '10' to win over '9', got %r" % out[0])
+
+    # Missing / non-numeric run_attempt defaults to 1.
+    out = dedup_by_run_attempt([
+        {"name": "y", "key": "y", "job": "j", "status": "running"},
+        {"name": "y", "key": "y", "job": "j", "run_attempt": "2", "status": "passed"},
+    ])
+    if out[0].get("run_attempt") != "2":
+        fail("dedup_by_run_attempt missing-attempt: expected attempt-2 to win, got %r" % out[0])
+
+def _check_should_quiet_delete_log():
+    """Functional assertions for `_should_quiet_delete_log` — gate for
+    the WARN→INFO downgrade on a pre-upload `DeleteArtifact` failure."""
+
+    # First cycle: no prior upload → benign (delete will 404 because
+    # nothing was ever uploaded). Quiet.
+    if not should_quiet_delete_log(None, 1000.0):
+        fail("should_quiet_delete_log: first cycle (None last_upload_at) must be quiet")
+
+    # Recent upload (within the 15s window): eventual-consistency miss
+    # is the most likely cause of a failure. Quiet.
+    if not should_quiet_delete_log(990.0, 1000.0):
+        fail("should_quiet_delete_log: 10s after upload must be quiet")
+    if not should_quiet_delete_log(985.0, 1000.0):
+        fail("should_quiet_delete_log: exactly 15s after upload must be quiet")
+    if not should_quiet_delete_log(1000.0, 1000.0):
+        fail("should_quiet_delete_log: 0s after upload must be quiet")
+
+    # Past the window: WARN-worthy.
+    if should_quiet_delete_log(984.0, 1000.0):
+        fail("should_quiet_delete_log: 16s after upload must NOT be quiet")
+    if should_quiet_delete_log(0.0, 1000.0):
+        fail("should_quiet_delete_log: 1000s after upload must NOT be quiet")
+
+def _check_format_http_failure_detail():
+    """Functional assertions for `github.format_http_failure_detail` —
+    one-line failure-detail formatting shared by the WARN and INFO
+    failure-log paths."""
+    detail = github.format_http_failure_detail
+
+    # status=0 → transport-error path uses the error string or a default.
+    _eq(
+        "format_http_failure_detail status=0 with error",
+        detail(0, "DNS resolution failed"),
+        "DNS resolution failed",
+    )
+    _eq(
+        "format_http_failure_detail status=0 empty error → default",
+        detail(0, ""),
+        "transport error",
+    )
+
+    # status != 0 + no error → bare `HTTP N`.
+    _eq(
+        "format_http_failure_detail HTTP only",
+        detail(404, ""),
+        "HTTP 404",
+    )
+
+    # status != 0 + error → `HTTP N: <snippet>`.
+    _eq(
+        "format_http_failure_detail HTTP + body snippet",
+        detail(500, "internal server error"),
+        "HTTP 500: internal server error",
+    )
+
+    # Newline collapse: multi-line body renders as a single line.
+    _eq(
+        "format_http_failure_detail newline collapse",
+        detail(503, "line1\nline2\nline3"),
+        "HTTP 503: line1 line2 line3",
+    )
+
+    # Truncation at 200 chars + "...".
+    long_body = "x" * 250
+    truncated = detail(500, long_body)
+    if len(truncated) != len("HTTP 500: ") + 200 + 3:
+        fail("format_http_failure_detail truncation: expected cap at 200 + '...', got %d chars" % len(truncated))
+    if not truncated.endswith("..."):
+        fail("format_http_failure_detail truncation: expected '...' suffix, got %r" % truncated[-10:])
+
 def _test_impl(ctx):
     sep = "=" * 70
 
     _check_collect_tip_rows(ctx)
+    _check_dedup_by_run_attempt()
+    _check_should_quiet_delete_log()
+    _check_format_http_failure_detail()
 
     scenarios = [
         (

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -18,7 +18,7 @@ HTTP failure-handling contract (applies to every helper below):
 
 load("@std//base64.axl", "base64")
 load("@std//time.axl", "time")
-load("./environment.axl", "color_enabled", "warn")
+load("./environment.axl", "color_enabled", "info", "warn")
 load("./gitlab_detect.axl", "detect_gitlab_mr_base_sha")
 load("./tar.axl", "zip_create")
 load("./text.axl", "pluralize")
@@ -63,25 +63,38 @@ def _retry_http(fn):
         backoff_ms = backoff_ms * 2
     return (result[0], result[1], result[2], attempts)
 
+def _format_http_failure_detail(status, error):
+    """Format the trailing `<status>: <body-snippet>` portion of an HTTP
+    failure message. Shared by `_warn_http_failure` and the
+    quiet-failure-log path so the two surfaces show the same detail."""
+    if status == 0:
+        return error if error else "transport error"
+    detail = "HTTP %d" % status
+    if error:
+        extra = error if type(error) == "string" else str(error)
+
+        # Keep one-line: collapse newlines, cap to 200 chars.
+        extra = extra.replace("\n", " ")
+        if len(extra) > 200:
+            extra = extra[:200] + "..."
+        detail = detail + ": " + extra
+    return detail
+
 def _warn_http_failure(ctx, label, attempts, status, error):
     """Emit a single WARNING line summarizing a terminal HTTP failure.
 
     `label` is a short identifier (e.g. `"GitHub API POST /repos/.../check-runs"`).
     `error` is the body or transport-error string from the response triple."""
-    if status == 0:
-        detail = error if error else "transport error"
-    else:
-        detail = "HTTP %d" % status
-        if error:
-            extra = error if type(error) == "string" else str(error)
-
-            # Keep one-line: collapse newlines, cap to 200 chars.
-            extra = extra.replace("\n", " ")
-            if len(extra) > 200:
-                extra = extra[:200] + "..."
-            detail = detail + ": " + extra
     suffix = " after %d attempts" % attempts if attempts > 1 else ""
-    warn(ctx.std, "%s failed%s: %s" % (label, suffix, detail))
+    warn(ctx.std, "%s failed%s: %s" % (label, suffix, _format_http_failure_detail(status, error)))
+
+def _info_http_failure(ctx, label, attempts, status, error):
+    """INFO-level sibling of `_warn_http_failure` for benign failures —
+    e.g. a `DeleteArtifact` that 404s on the eventual-consistency
+    window after a known prior upload. Same one-line shape so log
+    grep matches both."""
+    suffix = " after %d attempts" % attempts if attempts > 1 else ""
+    info(ctx.std, "%s failed%s (benign): %s" % (label, suffix, _format_http_failure_detail(status, error)))
 
 def _do_request_once(ctx, method, url, token, payload = None):
     """Single HTTP attempt. See file docstring for failure contract."""
@@ -1613,10 +1626,15 @@ def _github_twirp_once(ctx, url, headers, payload):
 # and a retry after partial success would duplicate / half-finalize.
 _TWIRP_IDEMPOTENT_METHODS = ["DeleteArtifact"]
 
-def _github_twirp(ctx, method, payload):
+def _github_twirp(ctx, method, payload, quiet_failure_log = False):
     """Twirp RPC to the GitHub Actions ArtifactService. Retries
     transient failures only for `_TWIRP_IDEMPOTENT_METHODS`. Returns
-    `(ok, body_or_None, error_message_or_None)`."""
+    `(ok, body_or_None, error_message_or_None)`.
+
+    `quiet_failure_log=True` downgrades the failure log from WARN to
+    INFO. Use at call sites where a failure is an expected/benign
+    outcome — e.g. `DeleteArtifact` 404'ing because the artifact
+    isn't there yet (eventual-consistency window) or never was."""
     token = (ctx.std.env.var("ACTIONS_RUNTIME_TOKEN") or
              ctx.std.env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
 
@@ -1644,7 +1662,10 @@ def _github_twirp(ctx, method, payload):
         attempts = 1
 
     if not success:
-        _warn_http_failure(ctx, "GitHub Actions Twirp %s" % method, attempts, status, body_or_err)
+        if quiet_failure_log:
+            _info_http_failure(ctx, "GitHub Actions Twirp %s" % method, attempts, status, body_or_err)
+        else:
+            _warn_http_failure(ctx, "GitHub Actions Twirp %s" % method, attempts, status, body_or_err)
         if status == 0:
             err = body_or_err if type(body_or_err) == "string" else "transport error"
         else:
@@ -1777,8 +1798,14 @@ def _upload_artifact(ctx, path, name, expires_at = ""):
 
     return {"success": True, "artifact_ref": name, "download_url": download_url, "errors": []}
 
-def _delete_artifact(ctx, name):
-    """Delete an artifact from GitHub Actions using the Twirp API."""
+def _delete_artifact(ctx, name, quiet_failure_log = False):
+    """Delete an artifact from GitHub Actions using the Twirp API.
+
+    `quiet_failure_log=True` forwards to `_github_twirp` so the failure
+    log lands at INFO instead of WARN. Use when a delete failure is
+    expected to be benign — e.g. pre-upload cleanup where 404 is the
+    common "nothing to delete" outcome, or eventual-consistency miss
+    on a known prior upload."""
     token = (ctx.std.env.var("ACTIONS_RUNTIME_TOKEN") or
              ctx.std.env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
     if not token:
@@ -1792,7 +1819,7 @@ def _delete_artifact(ctx, name):
         "workflowRunBackendId": run_id,
         "workflowJobRunBackendId": job_id,
         "name": name,
-    })
+    }, quiet_failure_log = quiet_failure_log)
     return {"success": ok}
 
 def _check_token(ctx):
@@ -2045,4 +2072,5 @@ github = struct(
     parse_pr_patch = _parse_github_pr_patch,
     parse_local_diff = _parse_local_diff_output,
     extract_owner_repo = _extract_github_owner_repo_from_url,
+    format_http_failure_detail = _format_http_failure_detail,
 )


### PR DESCRIPTION
A bug report surfaced a task appearing in BOTH "In Progress" and "Successful" sections of the same PR summary comment — which should be impossible since a task has one current status at any moment. Root cause turned out to be two independent bugs in `feature/github_status_comments.axl`'s artifact aggregation, each capable of producing the symptom on its own.

## Bug #1 — re-run attempts surface stale prior-attempt payloads

`GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts` returns artifacts from EVERY prior attempt of a re-run workflow alongside the live attempt's — the endpoint doesn't accept an `attempt_number` filter the way the Jobs API does. Our per-task artifact name encodes `run_attempt` as a suffix (`aspect-ci-status-{job}-{key}-{attempt}`), so attempt 1 and attempt 2 produce distinct artifact names; both get listed, both get downloaded, both surface in the comment as separate entries with the same `(name, key, job)`. Attempt 1's frozen "Starting..." entry lands in `running`; attempt 2's terminal entry lands in `passed`.

Fix: new `_dedup_by_run_attempt(entries)` collapses entries that share `(name, key, job)` to the one with the highest `run_attempt` (numeric, so `"10" > "9"`; missing / non-numeric defaults to `1`). Different-`job` rows are preserved so matrix-style legitimate duplicates aren't lost.

## Bug #2 — same-name artifact duplicates from eventual consistency

`_publish_self` calls `github.delete_artifact(name)` then `github.upload_artifact(..., name)` in non-atomic sequence. The underlying Twirp ArtifactService allows multiple artifacts with the same name in a run (only `actions/upload-artifact@v4`'s client code enforces uniqueness, which we bypass), so when the Azure-backed read replica briefly shows a previously-deleted artifact alongside the freshly-uploaded one — or when a transient delete failure leaves a duplicate behind — the listing transiently exposes two artifacts with the same name, different ids, different payloads.

The old loop did `seen[aname] = entry` unconditionally so "whichever artifact GitHub returned last" won. GitHub's default sort order for that endpoint isn't documented, so the stale payload could surface.

Fix: walk the listing newest-first (sort by artifact id descending — ids are monotonically increasing per repo) and skip names already populated in `seen`. The newest payload always wins, even through the eventual-consistency window.

Eager same-cycle re-cleanup of duplicates was considered and rejected: the same eventual-consistency window means a delete-after-upload may not see the just-uploaded artifact, so the re-run could leave a fresh ghost AND create a new duplicate. The natural per-cycle `delete_artifact + upload_artifact` in `_publish_self` self-heals over 1-2 cycles once the consistency window closes; the newest-first iteration above plus `_dedup_by_run_attempt` ensure correct rendering in the meantime.

## `DeleteArtifact` 404 inside the eventual-consistency window logs INFO

The "GitHub Actions Twirp DeleteArtifact failed: HTTP 404: artifact not found" WARN is alarming but expected in two benign cases:

- First cycle of any task — nothing was ever uploaded for this artifact name.
- Within ~15s of a successful upload — the Azure-backed read replica handling the delete may not yet see the freshly-uploaded artifact.

Past that window a continued failure is no longer attributable to eventual consistency and stays at WARN.

Implementation:

- `_should_quiet_delete_log(last_upload_at, now)` — pure helper, returns True for the two benign cases. Gated on `_EVENTUAL_CONSISTENCY_WINDOW_S = 15`.
- `_publish_self` records `_state["_last_upload_at"] = monotonic()` on each successful upload and passes `quiet_failure_log = _should_quiet_delete_log(...)` to `github.delete_artifact`.
- Plumbed `quiet_failure_log` kwarg through `_delete_artifact` → `_github_twirp` so the failure log lands at INFO with a `(benign)` suffix instead of WARN.
- Extracted `_format_http_failure_detail(status, error)` from `_warn_http_failure` so the WARN and INFO paths produce identical `<status>: <body-snippet>` detail.

## Test plan

- `aspect dev test-pr-comment-snapshots` — new inline `_check_*` blocks cover:
  - `_dedup_by_run_attempt`: re-run collapse, matrix-rows preservation, numeric vs lexicographic ordering, missing / non-numeric `run_attempt`.
  - `_should_quiet_delete_log`: first cycle (None) → quiet; within 15s of upload (0s, 10s, exactly 15s) → quiet; past 15s → loud.
  - `github.format_http_failure_detail`: transport-error path, HTTP-only, HTTP + body, newline collapse, 200-char truncation with `...` suffix.
- All existing snapshot suites still pass: `test-tips`, `test-github-detect`, `test-template-snapshots`, `test-bk-annotation-snapshots`, `test-lint-template-snapshots`, `test-format-template-snapshots`, `test-gazelle-template-snapshots`, `test-delivery-template-snapshots`.

## Changes are visible to end-users

- Yes — fixes a visible bug where re-run attempts or transient artifact-API state caused the same task to appear in two sections of the PR summary comment. Also reduces log noise (benign `DeleteArtifact` 404s no longer surface as WARN).

## Suggested release notes

- `aspect-cli` fixes a PR summary comment rendering bug where a task could appear in both "In Progress" and "Successful" sections simultaneously. The aggregator now collapses re-run-attempt duplicates (different `run_attempt`, same `(name, key, job)`) to the latest attempt's payload, and disambiguates same-name artifact duplicates (eventual-consistency window) by preferring the newest artifact id.
- Benign `DeleteArtifact` 404s — on the first cycle of a task and within the eventual-consistency window of a recent upload — now log at INFO instead of WARN, reducing log noise on healthy runs.
