### PR TITLE
feat(github): prefer Aspect App token over GITHUB_TOKEN for supporting calls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   id-token: write
-  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -48,7 +48,7 @@ load("../lib/result_text.axl", "severity_for_status")
 load("../lib/tar.axl", "bsdtar")
 load(
     "../lib/tips.axl",
-    "TIP_CRITICAL",
+    "TIP_IMPORTANT",
     "TIP_TEMPLATE_JINJA2",
     "TIP_WARNING",
     "collect_tips_sorted",
@@ -121,7 +121,7 @@ _No tasks have reported yet._
 {% if tip_rows %}
 ## 💡 Tips
 {% for tip in tip_rows %}
-> {{ tip.severity_emoji }} **{{ tip.severity_label }}:** {{ tip.title }}
+> {{ tip.severity_emoji }} **{{ tip.severity_label|upper }}: {{ tip.title }}**
 >
 {{ tip.body_quoted }}
 >
@@ -577,17 +577,17 @@ def _collect_repro_fix_rows(sections):
     fix_rows = _gather(("running", "failed", "failing", "flagged", "successful"), "fix_commands")
     return (repro_rows, fix_rows)
 
-# Cap for non-critical / non-warning tips in the aggregated section.
-# Critical and warning always render in full; this cap applies to
+# Cap for non-important / non-warning tips in the aggregated section.
+# Important and warning always render in full; this cap applies to
 # suggestion + info combined so the comment can't get drowned by a
 # flood of low-urgency tips. See `_collect_tip_rows` for the contract.
 _MAX_SUBORDINATE_TIPS = 5
 
 def _is_must_show(severity):
     """Tips at this severity always surface in the PR-comment Tips
-    section regardless of cap — critical signals key-feature breakage
+    section regardless of cap — important signals key-feature breakage
     and warning signals degraded behavior."""
-    return severity == TIP_CRITICAL or severity == TIP_WARNING
+    return severity == TIP_IMPORTANT or severity == TIP_WARNING
 
 def _collect_tip_rows(ctx, entries):
     """Walk every entry's `tips` list, dedup by id, attribute by task
@@ -600,7 +600,7 @@ def _collect_tip_rows(ctx, entries):
     endpoint contributed by every task that hit the path).
 
     Render caps:
-      - `TIP_CRITICAL` and `TIP_WARNING` always surface.
+      - `TIP_IMPORTANT` and `TIP_WARNING` always surface.
       - `TIP_SUGGESTION` + `TIP_INFO` are combined and capped at
         `_MAX_SUBORDINATE_TIPS` total so a noisy task can't drown the
         section.
@@ -685,7 +685,7 @@ def _render_body(ctx, marker, entries, started_at, body_template, status_badges,
 
     `tip_rows` is the deduped + attributed + severity-sorted output of
     `_collect_tip_rows`, with the cap applied so suggestion / info
-    tips can't drown the section (critical + warning always pass
+    tips can't drown the section (important + warning always pass
     through in full)."""
     repro_rows, fix_rows = _collect_repro_fix_rows(sections)
     tip_rows = _collect_tip_rows(ctx, entries)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -360,10 +360,10 @@ def _check_collect_tip_rows(ctx):
     if rows[0]["task_keys"] != ["build-task", "lint-task"]:
         fail("collect_tip_rows attribution: expected [build-task, lint-task], got %r" % rows[0]["task_keys"])
 
-    # Severity sort: critical first, then warning, then suggestion, then info.
+    # Severity sort: important first, then warning, then suggestion, then info.
     rows = collect_tip_rows(ctx, [{"key": "t1", "tips": [
         {"id": "i", "severity": "info", "title": "I", "body": ""},
-        {"id": "c", "severity": "critical", "title": "C", "body": ""},
+        {"id": "c", "severity": "important", "title": "C", "body": ""},
         {"id": "s", "severity": "suggestion", "title": "S", "body": ""},
         {"id": "w", "severity": "warning", "title": "W", "body": ""},
     ]}])
@@ -371,34 +371,34 @@ def _check_collect_tip_rows(ctx):
     if ids != ["c", "w", "s", "i"]:
         fail("collect_tip_rows severity sort: expected [c, w, s, i], got %r" % ids)
 
-    # Cap: suggestion + info combined capped at 5; critical + warning unbounded.
+    # Cap: suggestion + info combined capped at 5; important + warning unbounded.
     big = (
-        [{"id": "c%d" % i, "severity": "critical", "title": "C", "body": ""} for i in range(3)] +
+        [{"id": "c%d" % i, "severity": "important", "title": "C", "body": ""} for i in range(3)] +
         [{"id": "w%d" % i, "severity": "warning", "title": "W", "body": ""} for i in range(4)] +
         [{"id": "s%d" % i, "severity": "suggestion", "title": "S", "body": ""} for i in range(4)] +
         [{"id": "i%d" % i, "severity": "info", "title": "I", "body": ""} for i in range(4)]
     )
     rows = collect_tip_rows(ctx, [{"key": "t1", "tips": big}])
-    critical_count = len([r for r in rows if r["severity_label"] == "Critical"])
+    important_count = len([r for r in rows if r["severity_label"] == "Important"])
     warning_count = len([r for r in rows if r["severity_label"] == "Warning"])
     subordinate_count = len([r for r in rows if r["severity_label"] in ("Tip", "Info")])
-    if critical_count != 3:
-        fail("collect_tip_rows cap: expected 3 critical, got %d" % critical_count)
+    if important_count != 3:
+        fail("collect_tip_rows cap: expected 3 important, got %d" % important_count)
     if warning_count != 4:
         fail("collect_tip_rows cap: expected 4 warning, got %d" % warning_count)
     if subordinate_count != 5:
         fail("collect_tip_rows cap: expected 5 subordinate (suggestion+info), got %d" % subordinate_count)
 
-    # silence_hint: empty for critical, non-empty for non-critical.
+    # silence_hint: empty for important, non-empty for non-important.
     # The rendered tip carries this `<sub>...</sub>` line as its
     # silence-hint footer; an empty value suppresses the footer.
     rows = collect_tip_rows(ctx, [{"key": "t1", "tips": [
-        {"id": "c", "severity": "critical", "title": "C", "body": ""},
+        {"id": "c", "severity": "important", "title": "C", "body": ""},
         {"id": "s", "severity": "suggestion", "title": "S", "body": ""},
     ]}])
     by_id = {r["id"]: r for r in rows}
     if by_id["c"]["silence_hint"] != "":
-        fail("collect_tip_rows: critical row must have empty silence_hint")
+        fail("collect_tip_rows: important row must have empty silence_hint")
     if "silenced_tips" not in by_id["s"]["silence_hint"]:
         fail("collect_tip_rows: suggestion row must reference silenced_tips in silence_hint")
 
@@ -1214,7 +1214,7 @@ def _test_impl(ctx):
             ],
         ),
         (
-            "20. tips — critical + warning render in full; suggestion / info capped at 5",
+            "20. tips — important + warning render in full; suggestion / info capped at 5",
             [
                 _entry(
                     "build",
@@ -1225,10 +1225,10 @@ def _test_impl(ctx):
                     make_build_passed(),
                     8000,
                     tips = [
-                        # 1 critical — always shown, no silence footer.
+                        # 1 important — always shown, no silence footer.
                         {
                             "id": "add-id-token-permission",
-                            "severity": "critical",
+                            "severity": "important",
                             "title": "Grant `id-token: write`",
                             "body": "Required for artifact uploads.",
                         },

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -2888,12 +2888,20 @@ def build_invocation_rows(ctx, data, render_ctx, status, links = None, run_date 
 # Shared `## 💡 Tips`-equivalent block for surface templates: one
 # Markdown blockquote per tip, header line is severity-emoji +
 # severity-label + title, body has `> ` line prefixes baked in by
-# `decorate_tip`, optional silence-hint footer (blank for critical
+# `decorate_tip`, optional silence-hint footer (blank for important
 # tips). Each surface template splices this in so lint / format /
 # gazelle / delivery / bazel-results stay consistent.
+#
+# Each tip is preceded by `<div class="border-top my3"></div>` (the
+# same delimiter used between the BK annotation's summary and details
+# sections) so the boundary is visibly drawn on both GitHub and
+# Buildkite — including BK's dark mode where a Markdown horizontal
+# rule reads as a faint line that's easy to miss.
 TIPS_BLOCK = """{% if tips %}{% for tip in tips %}
 
-> {{ tip.severity_emoji }} **{{ tip.severity_label }}:** {{ tip.title }}
+<div class="border-top my3"></div>
+
+> {{ tip.severity_emoji }} **{{ tip.severity_label|upper }}: {{ tip.title }}**
 >
 {{ tip.body_quoted }}{% if tip.silence_hint %}
 >

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -24,6 +24,9 @@ load("./tar.axl", "zip_create")
 load("./text.axl", "pluralize")
 load(
     "./tips.axl",
+    "TIP_ADD_ASPECT_API_TOKEN_BUILDKITE",
+    "TIP_ADD_ASPECT_API_TOKEN_CIRCLECI",
+    "TIP_ADD_ASPECT_API_TOKEN_GHA",
     "TIP_ADD_GITHUB_TOKEN",
     "TIP_ADD_GITHUB_TOKEN_SCOPE",
     "TIP_ADD_ID_TOKEN_PERMISSION",
@@ -176,17 +179,49 @@ def validate_role(role):
     """Validate that a role is in the known set."""
     return role in VALID_ROLES
 
-def _missing_credentials_reason(ctx):
-    """Human-readable explanation for `ctx.aspect.auth.credentials()` returning
-    None, tailored to the environment the CLI is running in."""
+# Stable identifiers populated into `_reason["kind"]` by `_authenticate`.
+# Downstream code (tip gates, error handlers) discriminates on these
+# rather than the human-readable `_reason["reason"]` string, which is
+# subject to change.
+_AUTH_KIND_NO_OWNER_REPO = "no-owner-repo"
+_AUTH_KIND_NO_CREDENTIALS = "no-credentials"  # CI without ASPECT_API_TOKEN
+_AUTH_KIND_NOT_LOGGED_IN = "not-logged-in"  # local without `aspect auth login`
+_AUTH_KIND_TRANSPORT_ERROR = "aspect-api-transport-error"
+_AUTH_KIND_BAD_RESPONSE = "aspect-api-bad-response"
+_AUTH_KIND_EXPIRED = "credentials-expired"
+_AUTH_KIND_DENIED = "access-denied"
+_AUTH_KIND_APP_NOT_INSTALLED = "app-not-installed"
+_AUTH_KIND_API_ERROR = "aspect-api-error"
+
+def _set_auth_reason(_reason, kind, msg):
+    """Populate `_reason` with both the structured `kind` and the
+    human-readable `reason`. No-op when the caller didn't pass a dict."""
+    if _reason != None:
+        _reason["kind"] = kind
+        _reason["reason"] = msg
+
+def _classify_missing_credentials(ctx):
+    """Return `(kind, msg)` for `ctx.aspect.auth.credentials()` returning
+    None. The kind discriminates the CI case (where setting
+    `ASPECT_API_TOKEN` is the fix) from the local case (`aspect auth login`).
+    """
     setup_url = "https://docs.aspect.build/cli/authentication"
     if ctx.std.env.var("BUILDKITE_AGENT_ACCESS_TOKEN"):
         msg = "no Aspect credentials — set ASPECT_API_TOKEN in the job env or provision it as a Buildkite secret (https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets)"
+        kind = _AUTH_KIND_NO_CREDENTIALS
     elif ctx.std.env.var("CI"):
         msg = "no Aspect credentials — set ASPECT_API_TOKEN (client_id:secret) in the job env"
+        kind = _AUTH_KIND_NO_CREDENTIALS
     else:
         msg = "not logged in — run `aspect auth login`"
-    return msg + ". Setup guide: " + setup_url
+        kind = _AUTH_KIND_NOT_LOGGED_IN
+    return kind, msg + ". Setup guide: " + setup_url
+
+def _missing_credentials_reason(ctx):
+    """Human-readable explanation for `ctx.aspect.auth.credentials()` returning
+    None, tailored to the environment the CLI is running in."""
+    _, msg = _classify_missing_credentials(ctx)
+    return msg
 
 def _is_4xx_auth(status_code):
     """True for HTTP statuses signaling "token lacks permission to call
@@ -195,42 +230,78 @@ def _is_4xx_auth(status_code):
     can't see the resource)."""
     return status_code in (401, 403, 404)
 
-def _emit_gha_tip(ctx, template, **kwargs):
-    """Emit a tip that only makes sense on GitHub Actions (every
-    built-in tip in this module recommends GHA-specific workflow YAML).
-    Gated on `GITHUB_ACTIONS` env + `hasattr(ctx, "traits")` so test
-    stubs without the traits map don't crash. Dedup-by-id inside
-    `add_tip` keeps the tip to one fire per task across multiple call
-    sites."""
+def _emit_tip_if_ready(ctx, template, **kwargs):
+    """Emit a tip when `ctx.traits` is available. Defensive against
+    test stubs that don't carry a traits map. Use for tips whose
+    recommendation applies on every CI host."""
     if not hasattr(ctx, "traits"):
-        return
-    if not ctx.std.env.var("GITHUB_ACTIONS"):
         return
     emit_tip(ctx, template, **kwargs)
 
+def _emit_gha_tip(ctx, template, **kwargs):
+    """Emit a tip whose recommendation is GitHub-Actions-specific
+    (workflow YAML, `permissions:` block, `${{ secrets.* }}`). Wraps
+    `_emit_tip_if_ready` with an additional `GITHUB_ACTIONS` env gate
+    so the tip never surfaces on Buildkite / CircleCI / GitLab where
+    its example syntax would be wrong."""
+    if not ctx.std.env.var("GITHUB_ACTIONS"):
+        return
+    _emit_tip_if_ready(ctx, template, **kwargs)
+
+def _emit_aspect_api_token_tip(ctx):
+    """Emit the host-specific `add-aspect-api-token-<host>` tip on CI
+    hosts where `ASPECT_API_TOKEN` is a documented Aspect integration
+    (GitHub Actions, Buildkite, CircleCI). Skip on GitLab and other
+    CIs where there's no documented use case yet."""
+    env = ctx.std.env
+    if env.var("GITHUB_ACTIONS"):
+        template = TIP_ADD_ASPECT_API_TOKEN_GHA
+    elif env.var("BUILDKITE"):
+        template = TIP_ADD_ASPECT_API_TOKEN_BUILDKITE
+    elif env.var("CIRCLECI"):
+        template = TIP_ADD_ASPECT_API_TOKEN_CIRCLECI
+    else:
+        return
+    _emit_tip_if_ready(ctx, template)
+
 def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existing_app_token = None, _reason = None):
-    """Resolve `(primary_token, app_fallback_token)` for supporting
-    GitHub API calls, preferring the job-scoped `GITHUB_TOKEN` /
-    `GH_TOKEN` from env over the Aspect GitHub App's installation
-    token.
+    """Resolve `(primary_token, fallback_token)` for supporting GitHub
+    API calls, preferring the Aspect GitHub App's installation token
+    over the job-scoped `GITHUB_TOKEN` / `GH_TOKEN` from env.
 
     Use for API calls that don't need to attribute to the Aspect App
     (job URL lookup, PR file diff, PR comment listing, artifact
-    downloads). Calls authenticated via the job-scoped env token
-    count against the *job's* token budget rather than the Aspect
-    App's shared installation-token quota (5,000 req/hr). The App
-    token comes back in the fallback slot so the caller can retry
-    on a 4xx-auth (workflow forgot to grant the scope).
+    downloads). The App token is preferred because:
+
+      - The job-scoped `GITHUB_TOKEN` shares a single per-repository
+        bucket with every other workflow step in the repo. Routing
+        aspect-cli's supporting calls through it competes with the
+        user's own workflow logic for that budget.
+      - The Aspect App's installation token has its own bucket,
+        consumed only by aspect-cli, so calls made through it don't
+        contend with anything else the user is running.
+
+    See GitHub's rate-limit docs for the per-bucket numbers and how
+    they vary by plan: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
 
     Result shape:
-      - env exported: `(env_token, app_token)` — the API helper
-        retries with the App token on 4xx-auth and emits the
-        `add-github-token-scope` tip (accumulating the missing
-        scope and endpoint).
-      - env unset:    `(app_token, None)` — no fallback (and none
-        needed).
-      - auth failed:  `(None, None)` with `_reason` populated as for
-        `_authenticate`.
+      - App auth succeeded:           `(app_token, env_token_or_None)`.
+                                      App is primary; env token (when
+                                      exported) sits in the fallback
+                                      slot for the 4xx-auth retry path.
+      - App auth failed, env present: `(env_token, None)` — env token
+                                      becomes the last-resort primary.
+      - App auth failed, env unset:   `(None, None)`.
+
+    On any auth failure, `_reason` (when supplied) is populated with
+    both a structured `kind` and a human-readable `reason` from
+    `_authenticate`.
+
+    `_authenticate` emits `TIP_ADD_ASPECT_API_TOKEN` (kind + host gated)
+    on the missing-credentials path. `_preferred_token_pair` additionally
+    emits `TIP_ADD_GITHUB_TOKEN` on GitHub Actions when neither App nor
+    env produces a token, since exporting `GITHUB_TOKEN` is the
+    GHA-specific path to an immediate fallback.
 
     Pass `existing_app_token` when the caller already minted an App
     token earlier in the same handler to avoid a redundant mint.
@@ -240,40 +311,56 @@ def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existi
     """
     env = ctx.std.env
     env_token = env.var("GITHUB_TOKEN") or env.var("GH_TOKEN") or ""
+    local_reason = {}
     app_token = existing_app_token if existing_app_token else _authenticate(
         ctx,
         owner = owner,
         repo = repo,
         profile = profile,
         roles = roles,
-        _reason = _reason,
+        _reason = local_reason,
     )
-    if env_token:
-        return env_token, app_token
 
-    # env unset — suggest setting it, but only when we have a viable App
-    # token to fall back to. Firing alongside an Aspect auth-failure warn
-    # would be misleading (the suggestion isn't what'd fix the auth error).
     if app_token:
-        _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN)
-    return app_token, None
+        return app_token, (env_token or None)
+
+    if _reason != None:
+        _reason["kind"] = local_reason.get("kind", "")
+        _reason["reason"] = local_reason.get("reason", "")
+
+    if env_token:
+        return env_token, None
+
+    _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN)
+    return None, None
 
 def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None):
     """Resolve a GitHub token by exchanging Aspect credentials via the Aspect
     GitHub App (requires owner and repo to be provided).
 
     Returns the token string, or None if authentication is not possible.
-    If _reason is a dict, it will be populated with a "reason" key describing why auth failed.
+    If `_reason` is a dict, it is populated on failure with both a stable
+    `kind` (one of the `_AUTH_KIND_*` identifiers) and a human-readable
+    `reason` describing why auth failed.
+
+    Side-effect: when the failure kind is `_AUTH_KIND_NO_CREDENTIALS`,
+    emits the host-specific `add-aspect-api-token-<host>` tip via
+    `_emit_aspect_api_token_tip`. Emitted at this layer (not at
+    higher-level callers) so every App-using path — direct
+    `authenticate` calls from features, plus the supporting-call path
+    through `_preferred_token_pair` — surfaces the same actionable
+    suggestion alongside the per-feature WARNING.
     """
     if not owner or not repo:
-        if _reason != None:
-            _reason["reason"] = "owner/repo not provided"
+        _set_auth_reason(_reason, _AUTH_KIND_NO_OWNER_REPO, "owner/repo not provided")
         return None
 
     creds = ctx.aspect.auth.credentials(profile = profile)
     if not creds:
-        if _reason != None:
-            _reason["reason"] = _missing_credentials_reason(ctx)
+        kind, msg = _classify_missing_credentials(ctx)
+        _set_auth_reason(_reason, kind, msg)
+        if kind == _AUTH_KIND_NO_CREDENTIALS:
+            _emit_aspect_api_token_tip(ctx)
         return None
 
     if roles:
@@ -299,32 +386,41 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
     ).map_err(lambda e: str(e)).block()
 
     if type(resp) == "string":
-        if _reason != None:
-            _reason["reason"] = "Aspect API request failed (transport error): %s" % resp
+        _set_auth_reason(
+            _reason,
+            _AUTH_KIND_TRANSPORT_ERROR,
+            "Aspect API request failed (transport error): %s" % resp,
+        )
         return None
 
     if resp.status >= 200 and resp.status < 300:
-        # Aspect's auth endpoint returns JSON on success. Use try_decode
-        # so a malformed/empty 2xx body (rare, but possible during partial
+        # Aspect's auth endpoint returns JSON on success. try_decode so a
+        # malformed/empty 2xx body (rare, but possible during partial
         # outages) doesn't crash the parent task — falls through to the
-        # _reason error path instead.
+        # `_reason` error path instead.
         parsed = json.try_decode(resp.body, None)
         if parsed != None and "token" in parsed:
             return parsed["token"]
-        if _reason != None:
-            snippet = (resp.body or "")[:200].replace("\n", " ")
-            _reason["reason"] = "Aspect API returned 2xx but body was unusable: %s" % snippet
+        snippet = (resp.body or "")[:200].replace("\n", " ")
+        _set_auth_reason(
+            _reason,
+            _AUTH_KIND_BAD_RESPONSE,
+            "Aspect API returned 2xx but body was unusable: %s" % snippet,
+        )
         return None
 
-    if _reason != None:
-        if resp.status == 401:
-            _reason["reason"] = "credentials expired (run `aspect auth login`)"
-        elif resp.status == 403:
-            _reason["reason"] = "access denied: %s" % resp.body
-        elif resp.status == 404:
-            _reason["reason"] = "GitHub App not installed (see https://docs.aspect.build/cli/authentication)"
-        else:
-            _reason["reason"] = "API request failed (HTTP %d): %s" % (resp.status, resp.body)
+    if resp.status == 401:
+        _set_auth_reason(_reason, _AUTH_KIND_EXPIRED, "credentials expired (run `aspect auth login`)")
+    elif resp.status == 403:
+        _set_auth_reason(_reason, _AUTH_KIND_DENIED, "access denied: %s" % resp.body)
+    elif resp.status == 404:
+        _set_auth_reason(
+            _reason,
+            _AUTH_KIND_APP_NOT_INSTALLED,
+            "GitHub App not installed (see https://docs.aspect.build/cli/authentication)",
+        )
+    else:
+        _set_auth_reason(_reason, _AUTH_KIND_API_ERROR, "API request failed (HTTP %d): %s" % (resp.status, resp.body))
     return None
 
 # Check Runs

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -372,20 +372,22 @@ def _test_impl(ctx):
     def _ctx_with_env(env_vars):
         return struct(std = struct(env = struct(var = lambda name: env_vars.get(name, ""))))
 
+    # App token is primary; env token (when exported) is the fallback
+    # for the 4xx-auth retry path.
     _eq(
-        "preferred_token_pair: GITHUB_TOKEN wins; App token is fallback",
+        "preferred_token_pair: App token primary; GITHUB_TOKEN is fallback",
         github.preferred_token_pair(_ctx_with_env({"GITHUB_TOKEN": "gh-actions-tok"}), "o", "r", existing_app_token = "app-tok"),
-        ("gh-actions-tok", "app-tok"),
+        ("app-tok", "gh-actions-tok"),
     )
     _eq(
-        "preferred_token_pair: GH_TOKEN when GITHUB_TOKEN unset",
+        "preferred_token_pair: App primary; GH_TOKEN fallback when GITHUB_TOKEN unset",
         github.preferred_token_pair(_ctx_with_env({"GH_TOKEN": "gh-cli-tok"}), "o", "r", existing_app_token = "app-tok"),
-        ("gh-cli-tok", "app-tok"),
+        ("app-tok", "gh-cli-tok"),
     )
     _eq(
-        "preferred_token_pair: GITHUB_TOKEN beats GH_TOKEN when both set",
+        "preferred_token_pair: GITHUB_TOKEN preferred over GH_TOKEN in fallback slot when both set",
         github.preferred_token_pair(_ctx_with_env({"GITHUB_TOKEN": "gha", "GH_TOKEN": "gh"}), "o", "r", existing_app_token = "app-tok"),
-        ("gha", "app-tok"),
+        ("app-tok", "gha"),
     )
     _eq(
         "preferred_token_pair: env unset — App token is primary, no fallback",
@@ -394,26 +396,42 @@ def _test_impl(ctx):
     )
 
     # Auth-failed branch — `_authenticate` short-circuits to `None`
-    # when owner / repo are missing, populating `_reason`. We exercise
-    # that path here (no `existing_app_token` to bypass the mint, no
-    # env token to take priority) and check both halves of the
-    # `(None, None)` return plus the `_reason` plumbing.
+    # when owner / repo are missing, populating `_reason` with both a
+    # structured `kind` and a human-readable `reason`. Without an env
+    # token callers get `(None, None)`; with env exported, env becomes
+    # the last-resort primary so the call can still proceed.
     auth_reason = {}
     _eq(
-        "preferred_token_pair: auth failed — returns (None, None)",
+        "preferred_token_pair: App auth failed + env unset → (None, None)",
         github.preferred_token_pair(_ctx_with_env({}), "", "", _reason = auth_reason),
         (None, None),
     )
-    if "reason" not in auth_reason:
-        fail("preferred_token_pair: expected _reason to be populated on auth failure, got %r" % auth_reason)
+    _eq("preferred_token_pair: _reason.kind populated", auth_reason.get("kind"), "no-owner-repo")
+    if not auth_reason.get("reason"):
+        fail("preferred_token_pair: expected _reason['reason'] to be set, got %r" % auth_reason)
+    _eq(
+        "preferred_token_pair: App auth failed + env set → env as last-resort primary",
+        github.preferred_token_pair(_ctx_with_env({"GITHUB_TOKEN": "gha-fallback"}), "", "", _reason = {}),
+        ("gha-fallback", None),
+    )
+
+    # ── Failure-kind gate for TIP_ADD_ASPECT_API_TOKEN ────────────────
+    # `_authenticate` classifies failures via a stable `kind` field;
+    # `_preferred_token_pair` keys the missing-credentials tip off
+    # that field (not the human-readable message) and further restricts
+    # emission to CI hosts where `ASPECT_API_TOKEN` is a documented
+    # Aspect integration.
+    _test_aspect_api_token_tip_gate(ctx)
 
     # ── list_pull_request_files 4xx-auth fallback ─────────────────────
-    # When the env token (primary) returns 401 / 403 / 404 on page 1,
-    # `list_pull_request_files` retries with the App-token fallback and
+    # When the primary token returns 401 / 403 / 404 on page 1,
+    # `list_pull_request_files` retries with the fallback token and
     # accumulates the missing scope into the `add-github-token-scope`
-    # tip. This exercises the load-bearing call path that
-    # `_preferred_token_pair` enables for change-detection.
-    _test_pr_files_falls_back_to_app_token(ctx)
+    # tip. With App-primary, env-fallback the fallback is reached only
+    # when the App's installation token unexpectedly 4xx's on a
+    # supporting-call endpoint (rare; typically only when the App
+    # installation is mid-rotation or scope-pruned).
+    _test_pr_files_4xx_auth_fallback(ctx)
 
     print("github_detect.axl smoke: OK")
     return 0
@@ -461,31 +479,165 @@ def _stub_ctx(ctx, env_vars, http_client):
         template = ctx.template,
     )
 
-def _test_pr_files_falls_back_to_app_token(ctx):
+def _test_aspect_api_token_tip_gate(ctx):
+    """Verify `_authenticate` populates `_reason["kind"]` with the right
+    discriminator and emits `TIP_ADD_ASPECT_API_TOKEN` only when (1) the
+    kind is `no-credentials` AND (2) the CI host is in the
+    documented-Aspect-integration set (GHA / Buildkite / CircleCI).
+    Covers both call paths: features calling `authenticate` directly
+    (status-checks / status-comments / lint-comments) and the
+    supporting-call path through `preferred_token_pair`.
+    """
+    trait = ctx.traits[TipsTrait]
+
+    def _ctx_no_creds(env_vars):
+        # Stub ctx where `aspect.auth.credentials(...)` returns None so
+        # `_authenticate` short-circuits before any HTTP call.
+        return struct(
+            std = struct(env = struct(var = lambda name: env_vars.get(name, ""))),
+            aspect = struct(auth = struct(credentials = lambda profile = None: None)),
+            traits = ctx.traits,
+        )
+
+    def _reset_tips():
+        trait.tips = []
+        trait.silenced_tips = []
+        trait.auto_print = False
+
+    # GHA + missing Aspect creds + env token set → kind="no-credentials",
+    # tip fires (GHA is a supported host), env returns as last-resort
+    # primary so the only fired tip is the API-token one.
+    _reset_tips()
+    reason = {}
+    result = github.preferred_token_pair(
+        _ctx_no_creds({"CI": "true", "GITHUB_ACTIONS": "true", "GITHUB_TOKEN": "env-tok"}),
+        "o",
+        "r",
+        _reason = reason,
+    )
+    _eq("kind-gate GHA: kind populated", reason.get("kind"), "no-credentials")
+    _eq("kind-gate GHA: env-token returned as primary", result, ("env-tok", None))
+    _eq("kind-gate GHA: one tip fired", len(trait.tips), 1)
+    _eq("kind-gate GHA: tip id (GHA-specific)", trait.tips[0]["id"], "add-aspect-api-token-github-actions")
+    _eq("kind-gate GHA: tip is important", trait.tips[0]["severity"], "important")
+
+    # Buildkite + missing creds → kind via the BK branch of
+    # `_classify_missing_credentials`; tip fires because BUILDKITE is
+    # in the host gate.
+    _reset_tips()
+    github.preferred_token_pair(
+        _ctx_no_creds({
+            "BUILDKITE": "true",
+            "BUILDKITE_AGENT_ACCESS_TOKEN": "bk-tok",
+            "GITHUB_TOKEN": "env-tok",
+        }),
+        "o",
+        "r",
+    )
+    _eq("kind-gate Buildkite: tip fires", len(trait.tips), 1)
+    _eq("kind-gate Buildkite: tip id (BK-specific)", trait.tips[0]["id"], "add-aspect-api-token-buildkite")
+
+    # CircleCI + missing creds → kind via the generic-CI branch (no
+    # BK token); tip fires because CIRCLECI is in the host gate.
+    _reset_tips()
+    github.preferred_token_pair(
+        _ctx_no_creds({"CI": "true", "CIRCLECI": "true", "GITHUB_TOKEN": "env-tok"}),
+        "o",
+        "r",
+    )
+    _eq("kind-gate CircleCI: tip fires", len(trait.tips), 1)
+    _eq("kind-gate CircleCI: tip id (CircleCI-specific)", trait.tips[0]["id"], "add-aspect-api-token-circleci")
+
+    # GitLab + missing creds → kind="no-credentials" BUT the host gate
+    # in `_emit_aspect_api_token_tip` skips emission (no GHA / BK /
+    # CircleCI env var set). The tip is not relevant on GitLab since
+    # `ASPECT_API_TOKEN` isn't a documented integration there yet.
+    _reset_tips()
+    reason = {}
+    github.preferred_token_pair(
+        _ctx_no_creds({"CI": "true", "GITLAB_CI": "true", "GITHUB_TOKEN": "env-tok"}),
+        "o",
+        "r",
+        _reason = reason,
+    )
+    _eq("host-gate GitLab: kind", reason.get("kind"), "no-credentials")
+    _eq("host-gate GitLab: tip skipped (host not supported)", len(trait.tips), 0)
+
+    # Local (no CI env vars) + missing creds → kind="not-logged-in",
+    # tip skipped by the kind gate. The fix path here is `aspect auth
+    # login`, not `ASPECT_API_TOKEN`; the caller surfaces
+    # `_reason["reason"]` as a human-readable message.
+    _reset_tips()
+    reason = {}
+    github.preferred_token_pair(
+        _ctx_no_creds({"GITHUB_TOKEN": "env-tok"}),
+        "o",
+        "r",
+        _reason = reason,
+    )
+    _eq("kind-gate local: kind", reason.get("kind"), "not-logged-in")
+    _eq("kind-gate local: tip skipped (wrong fix path)", len(trait.tips), 0)
+
+    # Direct `github.authenticate` call path — exercises the same gate
+    # without going through `preferred_token_pair`. Features doing
+    # App-attribution-required calls (status-checks, status-comments,
+    # lint-comments) hit this path; the tip should still fire so they
+    # surface an actionable suggestion alongside the per-feature
+    # WARNING.
+    _reset_tips()
+    reason = {}
+    token = github.authenticate(
+        _ctx_no_creds({"CI": "true", "GITHUB_ACTIONS": "true"}),
+        owner = "o",
+        repo = "r",
+        _reason = reason,
+    )
+    _eq("direct authenticate: returns None on no-creds", token, None)
+    _eq("direct authenticate: kind populated", reason.get("kind"), "no-credentials")
+    _eq("direct authenticate: tip fires", len(trait.tips), 1)
+    _eq("direct authenticate: tip id (GHA-specific)", trait.tips[0]["id"], "add-aspect-api-token-github-actions")
+
+    # Direct `github.authenticate` on a host that's outside the
+    # supported-CI set — same kind, but host gate skips emission.
+    _reset_tips()
+    reason = {}
+    github.authenticate(
+        _ctx_no_creds({"CI": "true", "GITLAB_CI": "true"}),
+        owner = "o",
+        repo = "r",
+        _reason = reason,
+    )
+    _eq("direct authenticate (GitLab): kind", reason.get("kind"), "no-credentials")
+    _eq("direct authenticate (GitLab): tip skipped", len(trait.tips), 0)
+
+def _test_pr_files_4xx_auth_fallback(ctx):
     # Reset the real TipsTrait so we can assert what this test emits.
     trait = ctx.traits[TipsTrait]
     trait.tips = []
     trait.silenced_tips = []
     trait.auto_print = False
 
-    # Stub: page-1 with env-token → 403, page-1 retry with app-token → 200
-    # with a single-file body that ends pagination.
+    # Stub: page-1 with App token (primary) → 403, page-1 retry with
+    # env token (fallback) → 200 with a single-file body that ends
+    # pagination. The 4xx-auth fallback mechanism in
+    # `list_pull_request_files` is bucket-agnostic; only the strings
+    # change post-flip.
     state, http_client = _http_stub([
         (403, '{"message":"Resource not accessible by integration"}'),
         (200, '[{"filename":"src/foo.py","status":"modified","additions":1,"deletions":0}]'),
     ])
     stub = _stub_ctx(ctx, {"GITHUB_ACTIONS": "true"}, http_client)
 
-    result = github.pulls.list_files(stub, "env-tok", "o", "r", 42, app_fallback_token = "app-tok")
+    result = github.pulls.list_files(stub, "app-tok", "o", "r", 42, app_fallback_token = "env-tok")
 
     if not result["success"]:
         fail("pr-files fallback: expected success=True after retry, got %r" % result)
     _eq("pr-files fallback: file count", len(result["files"]), 1)
     _eq("pr-files fallback: filename", result["files"][0]["filename"], "src/foo.py")
 
-    _eq("pr-files fallback: 2 http calls (env-tok primary + app-tok retry)", len(state["calls"]), 2)
-    _eq("pr-files fallback: 1st call used env token", state["calls"][0]["auth"], "Bearer env-tok")
-    _eq("pr-files fallback: 2nd call used App-token fallback", state["calls"][1]["auth"], "Bearer app-tok")
+    _eq("pr-files fallback: 2 http calls (App primary + env fallback retry)", len(state["calls"]), 2)
+    _eq("pr-files fallback: 1st call used App token", state["calls"][0]["auth"], "Bearer app-tok")
+    _eq("pr-files fallback: 2nd call used env-token fallback", state["calls"][1]["auth"], "Bearer env-tok")
 
     # Tip emitted with the missing scope + endpoint accumulated.
     _eq("pr-files fallback: one tip surfaced", len(trait.tips), 1)
@@ -509,7 +661,7 @@ def _test_pr_files_falls_back_to_app_token(ctx):
         (403, '{"message":"Resource not accessible by integration"}'),
     ])
     stub2 = _stub_ctx(ctx, {"GITHUB_ACTIONS": "true"}, http2)
-    result2 = github.pulls.list_files(stub2, "env-tok", "o", "r", 42)
+    result2 = github.pulls.list_files(stub2, "app-tok", "o", "r", 42)
     if result2["success"]:
         fail("pr-files no-fallback: expected success=False on 403 with no fallback, got %r" % result2)
     _eq("pr-files no-fallback: only the primary call ran", len(state2["calls"]), 1)

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -23,7 +23,7 @@ Tip templates are dicts of the shape:
 
     {
         "id":        str,         # stable dedup key; vars are NOT interpolated here
-        "severity":  str,         # TIP_CRITICAL / TIP_WARNING / TIP_SUGGESTION / TIP_INFO
+        "severity":  str,         # TIP_IMPORTANT / TIP_WARNING / TIP_SUGGESTION / TIP_INFO
         "title":     str,         # short headline; interpolated per `type`
         "body":      str,         # markdown body; interpolated per `type`
         "type":      str,         # TIP_TEMPLATE_RAW / TIP_TEMPLATE_FORMAT (default) / TIP_TEMPLATE_JINJA2
@@ -53,13 +53,13 @@ Built-in tip templates are exported as module-level constants
   b) Preempt a built-in tip by calling `add_tip` with that built-in
      tip's id BEFORE the framework emits — dedup-by-id makes the
      user's version win.
-  c) Silence any non-critical tip (built-in or custom) by adding its
+  c) Silence any non-important tip (built-in or custom) by adding its
      id to `TipsTrait.silenced_tips`. `add_tip` short-circuits on a
      match so the tip never enters the trait. Each rendered tip's
-     footer names its id and points users at this knob. Critical
-     tips (severity `TIP_CRITICAL`) ignore the silence list — they
+     footer names its id and points users at this knob. Important
+     tips (severity `TIP_IMPORTANT`) ignore the silence list — they
      signal a problem that breaks key features, so a `silenced_tips`
-     entry for a critical id is a no-op.
+     entry for an important id is a no-op.
 
 `TipsTrait` is accessible from `.aspect/config.axl`, which doubles as
 the registry for tips that should seed every task's `TipsTrait` at
@@ -91,10 +91,10 @@ display the result.
 
 # Severity ordering (highest → lowest urgency)
 
-    TIP_CRITICAL    — action required; key features broken without it.
+    TIP_IMPORTANT   — action required; key features broken without it.
                       Cannot be silenced (`silenced_tips` is ignored).
                       Surface and terminal rendering omit the silence
-                      hint footer for critical tips.
+                      hint footer for important tips.
     TIP_WARNING     — degraded behavior; user should fix to restore full function.
     TIP_SUGGESTION  — improvement opportunity; product works fine without it.
     TIP_INFO        — FYI.
@@ -113,31 +113,31 @@ load("./path_glob.axl", "match_any")
 
 # ── Severity constants ───────────────────────────────────────────────
 
-TIP_CRITICAL = "critical"
+TIP_IMPORTANT = "important"
 TIP_WARNING = "warning"
 TIP_SUGGESTION = "suggestion"
 TIP_INFO = "info"
 
 _SEVERITY_ORDER = {
-    TIP_CRITICAL: 0,
+    TIP_IMPORTANT: 0,
     TIP_WARNING: 1,
     TIP_SUGGESTION: 2,
     TIP_INFO: 3,
 }
 
 _SEVERITY_EMOJI = {
-    TIP_CRITICAL: "🔥",
+    TIP_IMPORTANT: "🔥",
     TIP_WARNING: "⚠️",
     TIP_SUGGESTION: "💡",
     TIP_INFO: "ℹ️",
 }
 
 # Human-readable label paired with the emoji on each tip's header line
-# (e.g. `💡 **Tip:** ...`, `🔥 **Critical:** ...`). The label is part of
+# (e.g. `💡 **Tip:** ...`, `🔥 **Important:** ...`). The label is part of
 # the rendered tip — it makes the severity legible even where the emoji
 # may not render.
 _SEVERITY_LABEL = {
-    TIP_CRITICAL: "Critical",
+    TIP_IMPORTANT: "Important",
     TIP_WARNING: "Warning",
     TIP_SUGGESTION: "Tip",
     TIP_INFO: "Info",
@@ -187,10 +187,61 @@ ID_TOKEN_PERMISSIONS_YAML = """permissions:
 TIP_ADD_GITHUB_TOKEN = {
     "id": "add-github-token",
     "severity": TIP_SUGGESTION,
-    "title": "Export `GITHUB_TOKEN` to route supporting API calls through the job-scoped quota",
-    "body": "When `GITHUB_TOKEN` is set, aspect-cli sends supporting API calls (job URL lookup, PR file diff, etc.) using the job-scoped token rather than the Aspect Workflows GitHub App. The job-scoped token has [a higher rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#primary-rate-limit-for-github_token-in-github-actions) — up to 60,000 req/hr per repository — than [the App's quota](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#primary-rate-limit-for-github-app-installations) (5,000 req/hr, or 15,000 req/hr on GitHub Enterprise Cloud), and they're separate buckets. Routing supporting calls through the job-scoped token reduces App quota usage and prevents live job updates to GitHub Status Checks and Status Comments from being throttled on busy repos.\n\nGitHub Actions grants `GITHUB_TOKEN` implicit read access to the workflow's own run metadata and the PR that triggered it, so no extra `permissions:` block scopes are required for the supporting calls aspect-cli makes today. Add at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that need it:\n\n```yaml\n" + GITHUB_TOKEN_ENV_YAML + "```",
+    "title": "Export `GITHUB_TOKEN` as a fallback for supporting API calls",
+    "body": "aspect-cli authenticates supporting GitHub API calls (job URL lookup, PR file diff, etc.) via the Aspect Workflows GitHub App. When the App can't authenticate — typically because `ASPECT_API_TOKEN` is missing or invalid — there's currently no fallback, and supporting calls fail.\n\nExporting `GITHUB_TOKEN` to the job env gives aspect-cli a last-resort token to fall back to. `GITHUB_TOKEN` is shared across every workflow step in the repo and has [a low default rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api), so it's not a permanent solution — fix the Aspect App authentication path when possible.\n\nGitHub Actions grants `GITHUB_TOKEN` implicit read access to the workflow's own run metadata and the PR that triggered it, so no extra `permissions:` block scopes are required for the supporting calls aspect-cli makes today. Add at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that need it:\n\n```yaml\n" + GITHUB_TOKEN_ENV_YAML + "```",
     "type": TIP_TEMPLATE_RAW,
 }
+
+# IMPORTANT because every aspect-cli feature that calls the GitHub API
+# as the Aspect Workflows GitHub App depends on `ASPECT_API_TOKEN`:
+# without it those surfaces silently degrade.
+#
+# Three per-CI variants because both the wire-up *and* the list of
+# features that degrade differ per host (PR-summary-comment aggregation
+# is GHA-only today). The emit helper in `lib/github.axl` picks one
+# based on detected env. Each carries a host-suffixed id so users who
+# run multiple CI hosts off the same repo can silence them independently.
+
+def _aspect_api_token_tip(host_id, degraded_features, host_advice):
+    return {
+        "id": "add-aspect-api-token-" + host_id,
+        "severity": TIP_IMPORTANT,
+        "title": "Set ASPECT_API_TOKEN to authenticate the Aspect Workflows GitHub App",
+        "body": (
+            "aspect-cli authenticates GitHub API calls via the Aspect Workflows " +
+            "GitHub App, which needs `ASPECT_API_TOKEN` (a `client_id:client_secret` " +
+            "pair from your Aspect organization) provided to the CI job.\n\n" +
+            "Without it, " + degraded_features + " degrade. The task itself " +
+            "completes regardless — only the GitHub-side surfaces are affected.\n\n" +
+            "Issue an `ASPECT_API_TOKEN` from the Aspect Web UI " +
+            "(see https://docs.aspect.build/cli/authentication). " +
+            host_advice
+        ),
+        "type": TIP_TEMPLATE_RAW,
+    }
+
+TIP_ADD_ASPECT_API_TOKEN_GHA = _aspect_api_token_tip(
+    "github-actions",
+    "PR check-run creation and updates, and PR summary comment aggregation",
+    "On GitHub Actions, expose the secret to your workflow:\n\n" +
+    "```yaml\nenv:\n  ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}\n```",
+)
+
+TIP_ADD_ASPECT_API_TOKEN_BUILDKITE = _aspect_api_token_tip(
+    "buildkite",
+    "PR check-run creation and updates",
+    "On Buildkite, provision `ASPECT_API_TOKEN` using any of the approaches in " +
+    "[Buildkite's secrets docs](https://buildkite.com/docs/pipelines/security/secrets) " +
+    "— aspect-cli reads it from the agent's secret store automatically.",
+)
+
+TIP_ADD_ASPECT_API_TOKEN_CIRCLECI = _aspect_api_token_tip(
+    "circleci",
+    "PR check-run creation and updates",
+    "On CircleCI, add `ASPECT_API_TOKEN` as a project environment variable or via a " +
+    "[context](https://circleci.com/docs/contexts/); aspect-cli picks it up from the " +
+    "job env.",
+)
 
 # One tip per task accumulating both the missing scopes and the API
 # endpoints that fell back. Pluralization + per-scope snippet lines
@@ -214,14 +265,14 @@ API {{ "endpoint" if endpoints|length == 1 else "endpoints" }} that fell back ({
     "type": TIP_TEMPLATE_JINJA2,
 }
 
-# Severity is CRITICAL because key features depend on this permission:
+# Severity is IMPORTANT because key features depend on this permission:
 # artifact uploads (status payloads, BEP files, test logs, profiles)
 # fail outright, and PR summary comment aggregation breaks because
-# per-task payloads ride on the same artifact upload path. Critical
+# per-task payloads ride on the same artifact upload path. Important
 # tips can't be silenced.
 TIP_ADD_ID_TOKEN_PERMISSION = {
     "id": "add-id-token-permission",
-    "severity": TIP_CRITICAL,
+    "severity": TIP_IMPORTANT,
     "title": "Grant `id-token: write` to enable GitHub Actions artifact uploads",
     "body": "aspect-cli is trying to upload an artifact via GitHub Actions' ArtifactService but the API needs an OIDC token (`ACTIONS_ID_TOKEN_REQUEST_TOKEN`) that GitHub only exposes to the job when `id-token: write` is granted. Without it, the artifact upload fails.\n\nWhich features depend on this varies by configuration. When enabled, the PR summary comment aggregator and test-log / BEP / profile artifact uploads all ride on the ArtifactService — any of those features will be affected until the permission is granted. The task itself completes regardless.\n\nAdd at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that upload artifacts:\n\n```yaml\n" + ID_TOKEN_PERMISSIONS_YAML + "```",
     "type": TIP_TEMPLATE_RAW,
@@ -261,7 +312,7 @@ def add_tip(
     to the terminal.
 
     No-op if `id` is listed in `TipsTrait.silenced_tips` AND
-    `severity != TIP_CRITICAL` (critical tips can't be silenced —
+    `severity != TIP_IMPORTANT` (important tips can't be silenced —
     see "Severity ordering" in the module docstring).
 
     Two storage shapes:
@@ -292,7 +343,7 @@ def add_tip(
     if severity not in _SEVERITY_ORDER:
         fail("unknown tip severity %r; valid: %s" % (severity, ", ".join(_SEVERITY_ORDER.keys())))
     trait = ctx.traits[TipsTrait]
-    if severity != TIP_CRITICAL and id in trait.silenced_tips:
+    if severity != TIP_IMPORTANT and id in trait.silenced_tips:
         return
 
     is_jinja2 = type_ == TIP_TEMPLATE_JINJA2
@@ -435,7 +486,7 @@ def severity_emoji(severity):
 
 def severity_label(severity):
     """Human-readable label for a tip's severity (e.g. "Tip",
-    "Warning", "Critical"). Paired with `severity_emoji` to introduce
+    "Warning", "Important"). Paired with `severity_emoji` to introduce
     each rendered tip — readable even where the emoji may not."""
     return _SEVERITY_LABEL.get(severity, "Info")
 
@@ -451,11 +502,11 @@ def silence_hint_line(id, severity):
     fine-print footer naming the tip's id and the knob to silence
     it via `.aspect/config.axl`.
 
-    Returns `""` for critical tips (which can't be silenced) and for
+    Returns `""` for important tips (which can't be silenced) and for
     blank ids. Used by the check-run summary's `TIPS_BLOCK` and by
     the PR-comment tip section so the two surfaces stay aligned on
     the silence affordance."""
-    if not id or severity == TIP_CRITICAL:
+    if not id or severity == TIP_IMPORTANT:
         return ""
     return '<sub>_Silence by adding `"%s"` to `ctx.traits[TipsTrait].silenced_tips` in `.aspect/config.axl`._</sub>' % id
 
@@ -509,35 +560,53 @@ def strip_code_fences(body):
     return "\n".join(kept)
 
 _TERMINAL_TIP_COLOR = {
-    TIP_CRITICAL: "1;31",  # bold red — required action, key features broken without it
-    TIP_WARNING: "0;33",  # yellow — degraded behavior
-    TIP_SUGGESTION: "1;35",  # bold magenta — improvement opportunity
-    TIP_INFO: "1;36",  # bold cyan — informational
+    TIP_IMPORTANT: "1;31",  # bold red — required action, key features broken without it
+    TIP_WARNING: "0;33",  # yellow — matches `warn()` in environment.axl
+    TIP_SUGGESTION: "1;32",  # bold green — helpful suggestion, distinct from INFO's cyan
+    TIP_INFO: "1;36",  # bold cyan — matches `info()` in environment.axl
 }
 
 def _print_tip(std, id, severity, title, body):
-    """Print a `TIP:` block to the terminal — called from `add_tip` on
-    each first add and (for `TIP_TEMPLATE_JINJA2` tips) on each
-    accumulator change. The format mirrors `warn` / `info` from
-    `environment.axl` so users recognize it as the same family of
-    framework messages. Prefix color scales with severity (red for
-    critical, yellow for warning, magenta for suggestion, cyan for
-    info). Code-fence delimiter lines are stripped from the body so
-    the inline YAML reads naturally on the terminal. The silence
-    footer is omitted for critical tips (they can't be silenced)."""
-    if color_enabled(std):
-        code = _TERMINAL_TIP_COLOR.get(severity, "1;35")
-        prefix = "\x1b[" + code + "mTIP\x1b[0m: "
-    else:
-        prefix = "TIP: "
-    print(prefix + title)
+    """Print a tip block to the terminal — called from `add_tip` on each
+    first add and (for `TIP_TEMPLATE_JINJA2` tips) on each accumulator
+    change.
+
+    Header line is `<emoji> <LABEL>: <title>`, rendered bold throughout.
+    The `<emoji> <LABEL>:` segment is colored by severity (red / yellow
+    / green / cyan; see `_TERMINAL_TIP_COLOR`); the title follows in
+    bold-default-color so the urgency reads loud at a glance without
+    the title blending into the colored prefix. Matches the
+    surface-template rendering on the GHSC check-run summary, BK
+    annotation, and PR summary comment, which bold the entire header.
+
+    Body and silence footer are prefixed with a colored vertical bar
+    (`│ `) so the tip boundary is visually drawn down the left edge of
+    the terminal — readers can see exactly where the tip starts and
+    ends in a stream of WARNINGs and INFO lines.
+
+    Code-fence delimiter lines are stripped from the body so the inline
+    YAML reads naturally on the terminal. The silence footer is
+    omitted for important tips (they can't be silenced)."""
+    code = _TERMINAL_TIP_COLOR.get(severity, "1;36")  # default to INFO's cyan for unknown severities
+    color_on = color_enabled(std)
+
+    prefix = "%s %s:" % (severity_emoji(severity), severity_label(severity).upper())
+    if color_on:
+        prefix = "\x1b[" + code + "m" + prefix + "\x1b[0m"
+
+        # Bold the title too (without color) so the whole header reads
+        # as a single emphasized line, matching the rendered surfaces.
+        title = "\x1b[1m" + title + "\x1b[0m"
+    print(prefix + " " + title)
+
+    bar = "\x1b[" + code + "m│\x1b[0m" if color_on else "│"
     cleaned = strip_code_fences(body)
     if cleaned:
-        print("")
-        print(cleaned)
-    if severity != TIP_CRITICAL:
-        print("")
-        print('(Silence this tip by adding "%s" to `ctx.traits[TipsTrait].silenced_tips` in `.aspect/config.axl`.)' % id)
+        for line in cleaned.split("\n"):
+            print(bar if line == "" else bar + " " + line)
+    if severity != TIP_IMPORTANT:
+        print(bar)
+        print(bar + ' (Silence this tip by adding "%s" to `ctx.traits[TipsTrait].silenced_tips` in `.aspect/config.axl`.)' % id)
 
 def blockquote_body(body):
     """Prefix every line of a tip body with `> ` (or `>` for empty

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -24,10 +24,13 @@ Run with:
 
 load(
     "./tips.axl",
+    "TIP_ADD_ASPECT_API_TOKEN_BUILDKITE",
+    "TIP_ADD_ASPECT_API_TOKEN_CIRCLECI",
+    "TIP_ADD_ASPECT_API_TOKEN_GHA",
     "TIP_ADD_GITHUB_TOKEN",
     "TIP_ADD_GITHUB_TOKEN_SCOPE",
     "TIP_ADD_ID_TOKEN_PERMISSION",
-    "TIP_CRITICAL",
+    "TIP_IMPORTANT",
     "TIP_INFO",
     "TIP_SUGGESTION",
     "TIP_TEMPLATE_FORMAT",
@@ -104,16 +107,16 @@ def _test_silenced_tips_blocks_emit_tip(ctx):
         [],
     )
 
-def _test_critical_tips_cannot_be_silenced(ctx):
-    """Critical tips ignore `silenced_tips` — they signal a key-feature
+def _test_important_tips_cannot_be_silenced(ctx):
+    """Important tips ignore `silenced_tips` — they signal a key-feature
     breakage and must always reach the user. Verified both via direct
-    `add_tip` and via `emit_tip` against a built-in critical template."""
+    `add_tip` and via `emit_tip` against a built-in important template."""
     _reset(ctx)
     ctx.traits[TipsTrait].silenced_tips = ["unsuppressable", "add-id-token-permission"]
-    add_tip(ctx, id = "unsuppressable", severity = TIP_CRITICAL, title = "T", body = "B")
+    add_tip(ctx, id = "unsuppressable", severity = TIP_IMPORTANT, title = "T", body = "B")
     emit_tip(ctx, TIP_ADD_ID_TOKEN_PERMISSION)
     _eq(
-        "critical — silence list ignored",
+        "important — silence list ignored",
         _ids(ctx.traits[TipsTrait].tips),
         ["unsuppressable", "add-id-token-permission"],
     )
@@ -329,15 +332,15 @@ def _test_jinja2_partial_overlap_appends_only_new(ctx):
 def _test_collect_sorted_by_severity(ctx):
     _reset(ctx)
     add_tip(ctx, id = "info-1", severity = TIP_INFO, title = "T", body = "B")
-    add_tip(ctx, id = "critical-1", severity = TIP_CRITICAL, title = "T", body = "B")
+    add_tip(ctx, id = "important-1", severity = TIP_IMPORTANT, title = "T", body = "B")
     add_tip(ctx, id = "warning-1", severity = TIP_WARNING, title = "T", body = "B")
     add_tip(ctx, id = "suggestion-1", severity = TIP_SUGGESTION, title = "T", body = "B")
-    add_tip(ctx, id = "critical-2", severity = TIP_CRITICAL, title = "T", body = "B")
+    add_tip(ctx, id = "important-2", severity = TIP_IMPORTANT, title = "T", body = "B")
     sorted_ids = _ids(collect_tips_sorted(ctx))
     _eq(
-        "sorted — critical → warning → suggestion → info; stable within bucket",
+        "sorted — important → warning → suggestion → info; stable within bucket",
         sorted_ids,
-        ["critical-1", "critical-2", "warning-1", "suggestion-1", "info-1"],
+        ["important-1", "important-2", "warning-1", "suggestion-1", "info-1"],
     )
 
 def _test_collect_task_keys_filter(ctx):
@@ -367,14 +370,14 @@ def _test_collect_limit(ctx):
     _eq("limit — 0 returns empty", len(collect_tips_sorted(ctx, limit = 0)), 0)
 
 def _test_severity_emoji(ctx):
-    _eq("emoji — critical", severity_emoji(TIP_CRITICAL), "🔥")
+    _eq("emoji — important", severity_emoji(TIP_IMPORTANT), "🔥")
     _eq("emoji — warning", severity_emoji(TIP_WARNING), "⚠️")
     _eq("emoji — suggestion", severity_emoji(TIP_SUGGESTION), "💡")
     _eq("emoji — info", severity_emoji(TIP_INFO), "ℹ️")
     _eq("emoji — unknown defaults to info", severity_emoji("bogus"), "ℹ️")
 
 def _test_severity_label(ctx):
-    _eq("label — critical", severity_label(TIP_CRITICAL), "Critical")
+    _eq("label — important", severity_label(TIP_IMPORTANT), "Important")
     _eq("label — warning", severity_label(TIP_WARNING), "Warning")
     _eq("label — suggestion", severity_label(TIP_SUGGESTION), "Tip")
     _eq("label — info", severity_label(TIP_INFO), "Info")
@@ -397,15 +400,60 @@ def _test_blockquote_body(ctx):
 
 def _test_builtin_templates_shape(ctx):
     """Smoke-test the built-in templates have the required keys so a
-    rename or restructure trips the test before users see a broken tip."""
-    for name, tmpl in [
+    rename or restructure trips the test before users see a broken tip.
+    Also pins severity + per-host id stability — distinct ids per CI host
+    let users silence one variant without silencing the others."""
+    aspect_token_variants = [
+        ("TIP_ADD_ASPECT_API_TOKEN_GHA", TIP_ADD_ASPECT_API_TOKEN_GHA, "add-aspect-api-token-github-actions"),
+        ("TIP_ADD_ASPECT_API_TOKEN_BUILDKITE", TIP_ADD_ASPECT_API_TOKEN_BUILDKITE, "add-aspect-api-token-buildkite"),
+        ("TIP_ADD_ASPECT_API_TOKEN_CIRCLECI", TIP_ADD_ASPECT_API_TOKEN_CIRCLECI, "add-aspect-api-token-circleci"),
+    ]
+    other_templates = [
         ("TIP_ADD_GITHUB_TOKEN", TIP_ADD_GITHUB_TOKEN),
         ("TIP_ADD_GITHUB_TOKEN_SCOPE", TIP_ADD_GITHUB_TOKEN_SCOPE),
         ("TIP_ADD_ID_TOKEN_PERMISSION", TIP_ADD_ID_TOKEN_PERMISSION),
-    ]:
+    ]
+    for name, tmpl, expected_id in aspect_token_variants:
         for key in ("id", "severity", "title", "body", "type"):
             if key not in tmpl:
                 fail("%s missing required key %r" % (name, key))
+        _eq("%s id" % name, tmpl["id"], expected_id)
+        _eq("%s severity is IMPORTANT" % name, tmpl["severity"], TIP_IMPORTANT)
+    for name, tmpl in other_templates:
+        for key in ("id", "severity", "title", "body", "type"):
+            if key not in tmpl:
+                fail("%s missing required key %r" % (name, key))
+    _eq(
+        "TIP_ADD_GITHUB_TOKEN severity is SUGGESTION (fallback hint, not failure)",
+        TIP_ADD_GITHUB_TOKEN["severity"],
+        TIP_SUGGESTION,
+    )
+
+    # Body specialization sanity-check — wire-up advice differs per host.
+    if "workflow" not in TIP_ADD_ASPECT_API_TOKEN_GHA["body"]:
+        fail("GHA tip body missing GHA-specific advice")
+    if "Buildkite's secrets docs" not in TIP_ADD_ASPECT_API_TOKEN_BUILDKITE["body"]:
+        fail("Buildkite tip body missing Buildkite-specific advice")
+    if "context" not in TIP_ADD_ASPECT_API_TOKEN_CIRCLECI["body"]:
+        fail("CircleCI tip body missing CircleCI-specific advice")
+
+    # PR-summary-comment aggregation is GHA-only today, so only the GHA
+    # tip should mention it. BK / CircleCI tips listing a feature that
+    # doesn't work there would mislead users into thinking the App
+    # unlocks it.
+    if "PR summary comment" not in TIP_ADD_ASPECT_API_TOKEN_GHA["body"]:
+        fail("GHA tip should mention PR summary comment aggregation (GHA-only feature)")
+    if "PR summary comment" in TIP_ADD_ASPECT_API_TOKEN_BUILDKITE["body"]:
+        fail("BK tip should not mention PR summary comment aggregation (not yet supported)")
+    if "PR summary comment" in TIP_ADD_ASPECT_API_TOKEN_CIRCLECI["body"]:
+        fail("CircleCI tip should not mention PR summary comment aggregation (not yet supported)")
+
+    # `--scope=changed` falls back to local git diff when the App is
+    # unavailable, so listing it as a "degraded" feature would be
+    # misleading — none of the variants should mention it.
+    for name, tmpl, _ in aspect_token_variants:
+        if "scope=changed" in tmpl["body"]:
+            fail("%s should not mention --scope=changed (App is only a fallback there)" % name)
 
 def _test_builtin_insufficient_scope_renders(ctx):
     """`TIP_ADD_GITHUB_TOKEN_SCOPE` is the canonical multi-accumulator
@@ -467,8 +515,8 @@ def _test_builtin_insufficient_scope_renders(ctx):
 def _test_silence_hint_line(ctx):
     _eq("silence_hint — empty id", silence_hint_line("", TIP_INFO), "")
     _eq(
-        "silence_hint — critical returns empty",
-        silence_hint_line("anything", TIP_CRITICAL),
+        "silence_hint — important returns empty",
+        silence_hint_line("anything", TIP_IMPORTANT),
         "",
     )
     for sev in (TIP_WARNING, TIP_SUGGESTION, TIP_INFO):
@@ -481,7 +529,7 @@ def _test_silence_hint_line(ctx):
             fail("silence_hint %s: must wrap in <sub>: %r" % (sev, line))
 
 def _test_severity_rank(ctx):
-    _eq("rank — critical most urgent", severity_rank(TIP_CRITICAL), 0)
+    _eq("rank — important most urgent", severity_rank(TIP_IMPORTANT), 0)
     _eq("rank — warning", severity_rank(TIP_WARNING), 1)
     _eq("rank — suggestion", severity_rank(TIP_SUGGESTION), 2)
     _eq("rank — info least urgent", severity_rank(TIP_INFO), 3)
@@ -536,11 +584,11 @@ def _test_decorate_tip(ctx):
     _eq("decorate_tip — title", decorated["title"], "T")
     _eq("decorate_tip — body_quoted prefixes each line", decorated["body_quoted"], "> line1\n> line2")
     if "silenced_tips" not in decorated["silence_hint"]:
-        fail("decorate_tip — non-critical row missing silence_hint: %r" % decorated["silence_hint"])
+        fail("decorate_tip — non-important row missing silence_hint: %r" % decorated["silence_hint"])
 
-    # Critical: silence_hint should be blank.
-    crit = decorate_tip({"id": "c", "severity": TIP_CRITICAL, "title": "C", "body": ""})
-    _eq("decorate_tip — critical silence_hint blank", crit["silence_hint"], "")
+    # Important: silence_hint should be blank.
+    crit = decorate_tip({"id": "c", "severity": TIP_IMPORTANT, "title": "C", "body": ""})
+    _eq("decorate_tip — important silence_hint blank", crit["silence_hint"], "")
 
 def _test_strip_code_fences(ctx):
     _eq("fences — empty body", strip_code_fences(""), "")
@@ -577,7 +625,7 @@ def _test_impl(ctx):
     _test_add_tip_dedup(ctx)
     _test_silenced_tips_short_circuits_add_tip(ctx)
     _test_silenced_tips_blocks_emit_tip(ctx)
-    _test_critical_tips_cannot_be_silenced(ctx)
+    _test_important_tips_cannot_be_silenced(ctx)
     _test_add_tip_task_keys_stored(ctx)
     _test_emit_tip_format(ctx)
     _test_emit_tip_raw_skips_interpolation(ctx)

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -121,6 +121,13 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
 
             let dispatch = cmd.dispatch(matches)?;
 
+            // Print the "Running <task>" header before feature
+            // implementations run so any diagnostic output from feature
+            // initialization (auth WARNINGs, tip blocks, etc.) is
+            // framed by the header.
+            mpe.print_running_task_header(dispatch.task_id, &dispatch.task_key)
+                .map_err(anyhow::Error::from)?;
+
             // Phase 3: run enabled feature impls.
             mpe.execute_features_with_args(|f, h| dispatch.feature_args(f, h))
                 .map_err(anyhow::Error::from)?;

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -45,6 +45,37 @@ const SGR_RESET: &str = "\x1b[0m";
 const DEFAULT_HIGHLIGHT_COLOR: &str = "1;36";
 const HIGHLIGHT_COLOR_ENV: &str = "ASPECT_CLI_HIGHLIGHT_COLOR";
 
+/// True on any recognized CI host (Buildkite / GitHub Actions / CircleCI /
+/// GitLab CI / generic `CI=...`). Used to gate task-key suffix on the
+/// running-task header and to force-enable color when stderr is piped to
+/// a CI log viewer that renders ANSI.
+fn on_recognized_ci() -> bool {
+    std::env::var_os("BUILDKITE").is_some()
+        || std::env::var_os("CI").is_some()
+        || std::env::var_os("GITHUB_ACTIONS").is_some()
+        || std::env::var_os("CIRCLECI").is_some()
+        || std::env::var_os("GITLAB_CI").is_some()
+}
+
+/// Return `(verb_color_prefix, reset)` for the "Running" verb on the
+/// task-starting line. `verb_color_prefix` is empty when color is
+/// disabled or `ASPECT_CLI_HIGHLIGHT_COLOR=""`; `reset` is empty when
+/// color is disabled. Color is enabled when stderr is a TTY or we're on
+/// a recognized CI host.
+fn running_verb_color() -> (String, &'static str) {
+    let color = std::io::stderr().is_terminal() || on_recognized_ci();
+    let highlight = std::env::var(HIGHLIGHT_COLOR_ENV)
+        .ok()
+        .unwrap_or_else(|| DEFAULT_HIGHLIGHT_COLOR.to_string());
+    let verb_seq = if color && !highlight.is_empty() {
+        format!("\x1b[{}m", highlight)
+    } else {
+        String::new()
+    };
+    let reset = if color { SGR_RESET } else { "" };
+    (verb_seq, reset)
+}
+
 /// Wrapper around a live Starlark Module heap.
 ///
 /// All three evaluation phases share this heap so `Value<'v>` references
@@ -325,6 +356,53 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         Ok(())
     }
 
+    /// Print the universal "task starting" announcement — the `→ 🎬 Running …`
+    /// line, or `--- :aspect: Running …` BK section header — for the task at
+    /// `task_index` in `self.tasks()`.
+    ///
+    /// Called from the CLI before `execute_features_with_args` so that any
+    /// diagnostic output emitted during feature initialization (auth WARNINGs,
+    /// tip blocks, etc.) is framed by the task header. Without this, the header
+    /// would only appear after features finish — and feature-init output would
+    /// look like it preceded any task running.
+    pub fn print_running_task_header(
+        &self,
+        task_index: usize,
+        task_key: &str,
+    ) -> Result<(), EvalError> {
+        let task = *self.tasks().get(task_index).ok_or_else(|| {
+            EvalError::UnknownError(anyhow!("task index {} out of range", task_index))
+        })?;
+        let (verb_seq, reset) = running_verb_color();
+        let key_suffix = if on_recognized_ci() {
+            format!(" [{}]", task_key)
+        } else {
+            String::new()
+        };
+        if std::env::var_os("BUILDKITE").is_some() {
+            // The BK section header replaces the `→` line on BK (avoids
+            // duplicating the same text in the BK log viewer).
+            eprintln!(
+                "--- :aspect: {}Running{} `{}` task{}",
+                verb_seq,
+                reset,
+                task.name(),
+                key_suffix
+            );
+        } else {
+            // 🎬 (clapper board) pairs with the closing ✅ / ⚠️ / ❌ as
+            // the task's bookend.
+            eprintln!(
+                "→ 🎬 {}Running{} `{}` task{}",
+                verb_seq,
+                reset,
+                task.name(),
+                key_suffix
+            );
+        }
+        Ok(())
+    }
+
     /// Phase 3: run enabled feature implementations.
     ///
     /// Must be called after `eval_config` so that config files have had the opportunity
@@ -415,57 +493,15 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         let task_name = task.name();
         let task_info = TaskInfo::new(task.name(), task.group().clone(), task_key, task_id);
 
-        // Universal "task starting" announcement. Fires for every task —
-        // built-in or custom — so users can see in CI logs which task is
-        // running and what key/id it was invoked under, without each
-        // task's AXL impl having to remember to print this itself. Phase
-        // boundaries inside the task body are still announced from AXL
-        // via `lib/lifecycle.axl::announce`; this line just frames each
-        // task invocation.
-        //
-        // Diagnostic output → stderr. stdout is reserved for the primary
-        // task output (anything a downstream consumer might want to
-        // capture or pipe).
-        //
-        // On Buildkite, a `--- :aspect: Running …` section header
-        // opens a collapsible section that groups the task's output
-        // under one header — this REPLACES the `→ Running …` line on
-        // BK (avoids printing the same text twice on the BK log
-        // viewer). Off BK, the `→ Running …` line is the only marker.
-        // Bracket form `[key]` matches BazelDefaults' "Running bazel
-        // <cmd> [<key>] <targets>" so the two adjacent log lines read
-        // as a pair.
-        //
-        // The `[<key>]` bracket is only included on CI. Locally most
-        // invocations don't pass `--task-key`, so the auto-generated
-        // name (e.g. `taboo-rub`) just clutters every task line. CI
-        // shows it because that's where users correlate task-key with
-        // the GHSC check-run / BK annotation context. Detected via
-        // any of the major CI env markers.
-        let on_buildkite = std::env::var_os("BUILDKITE").is_some();
-        let on_ci = on_buildkite
-            || std::env::var_os("CI").is_some()
-            || std::env::var_os("GITHUB_ACTIONS").is_some()
-            || std::env::var_os("CIRCLECI").is_some()
-            || std::env::var_os("GITLAB_CI").is_some();
-        let key_suffix = if on_ci {
-            format!(" [{}]", task_info.task_key)
-        } else {
-            String::new()
-        };
-        // Color when stderr is a TTY or we're on a known CI host (CI
-        // log viewers render ANSI even when stderr is piped).
-        // `HIGHLIGHT_COLOR_ENV` overrides the highlight color used for
-        // the opening "Running" verb; defaults to `DEFAULT_HIGHLIGHT_COLOR`.
-        let color = std::io::stderr().is_terminal() || on_ci;
-        let highlight_color = std::env::var(HIGHLIGHT_COLOR_ENV)
-            .ok()
-            .unwrap_or_else(|| DEFAULT_HIGHLIGHT_COLOR.to_string());
-        let verb_seq = if color && !highlight_color.is_empty() {
-            format!("\x1b[{}m", highlight_color)
-        } else {
-            String::new()
-        };
+        // The opening `→ 🎬 Running …` (or BK `--- :aspect: Running …`)
+        // header is printed by `print_running_task_header` BEFORE phase
+        // 3 (feature impls) so that any diagnostic output emitted during
+        // feature initialization is framed by the header. Only the
+        // closing announcement is built here; phase boundaries inside
+        // the task body are still announced from AXL via
+        // `lib/lifecycle.axl::announce`. Color setup mirrors the helper
+        // so the verdict glyph and labels match.
+        let color = std::io::stderr().is_terminal() || on_recognized_ci();
         let sgr = |params: &str| {
             if color {
                 format!("\x1b[{}m", params)
@@ -477,21 +513,6 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         let bold_yellow = sgr(SGR_BOLD_YELLOW);
         let bold_red = sgr(SGR_BOLD_RED);
         let reset = if color { SGR_RESET } else { "" };
-        if on_buildkite {
-            // The BK section header carries the same text the `→` line
-            // would; skip the duplicate `→` print on BK.
-            eprintln!(
-                "--- :aspect: {}Running{} `{}` task{}",
-                verb_seq, reset, task_info.name, key_suffix
-            );
-        } else {
-            // 🎬 (clapper board) pairs with the closing ✅ / ⚠️ / ❌
-            // as the task's bookend.
-            eprintln!(
-                "→ 🎬 {}Running{} `{}` task{}",
-                verb_seq, reset, task_info.name, key_suffix
-            );
-        }
 
         let task_trait_map = match self.trait_map_value {
             Some(tmap_val) => {


### PR DESCRIPTION
Routes supporting GitHub API calls (job URL lookup, PR file diff, PR comment listing, artifact downloads) through the Aspect Workflows GitHub App's installation token instead of the job-scoped `GITHUB_TOKEN`. The App's bucket is consumed only by aspect-cli, so its budget doesn't contend with the rest of the user's workflow steps. `GITHUB_TOKEN` is retained as a last-resort fallback when Aspect-side auth is unavailable. See [GitHub's rate-limit docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api) for the per-bucket numbers.

## `_preferred_token_pair` result shape

`_preferred_token_pair(ctx, owner, repo, ...)` returns `(primary, fallback)`:

| App auth | env exported | Result | Tip emitted |
| --- | --- | --- | --- |
| ✓ | ✓ | `(app_token, env_token)` — App primary, env fallback | — |
| ✓ | — | `(app_token, None)` — App primary, no fallback | — |
| ✗ | ✓ | `(env_token, None)` — env as last-resort primary | `add-aspect-api-token-<host>` (when applicable) |
| ✗ | — | `(None, None)` | `add-aspect-api-token-<host>` (when applicable) + `add-github-token` (GHA-only) |

The 4xx-auth fallback mechanism in `_resolve_current_job_url` and `list_pull_request_files` is unchanged — primary tries first; on 401 / 403 / 404 the helper retries with whatever's in the fallback slot. Only the bucket assignments flip.

## Structured auth-failure classification

`_authenticate` populates `_reason` with a stable `kind` and a human-readable `reason`. Downstream gates discriminate on `kind` rather than prefix-matching the message:

| `_reason["kind"]` | Trigger |
| --- | --- |
| `no-owner-repo` | owner / repo not provided (non-GitHub VCS caller) |
| `no-credentials` | `ASPECT_API_TOKEN` missing on CI |
| `not-logged-in` | local dev without `aspect auth login` |
| `aspect-api-transport-error` | network error reaching the Aspect API |
| `aspect-api-bad-response` | 2xx but body is unparseable |
| `credentials-expired` / `access-denied` / `app-not-installed` / `aspect-api-error` | 401 / 403 / 404 / other from the exchange |

## Tip emissions

**`TIP_ADD_GITHUB_TOKEN`** (suggestion) — reframed as a fallback hint rather than a quota-saver. Body links to GitHub's rate-limit docs. Fires only when both App and env paths are unavailable on GitHub Actions.

**`TIP_ADD_ASPECT_API_TOKEN_{GHA,BUILDKITE,CIRCLECI}`** (important) — three per-CI variants. Both the wire-up advice (workflow YAML / Buildkite secrets docs / CircleCI project env + contexts) *and* the list of degraded features differ per host (PR summary comment aggregation is GHA-only today, so only the GHA variant mentions it). Each carries a host-suffixed id (`add-aspect-api-token-github-actions` / `-buildkite` / `-circleci`) so users running multiple CI hosts off the same repo can silence them independently. Emitted from `_authenticate` itself (not from `_preferred_token_pair`) so every App-using path — direct `authenticate` calls from `github_status_checks` / `github_status_comments` / `github_lint_comments`, plus the supporting-call path — surfaces the same actionable suggestion alongside the per-feature WARNING.

Emit helpers in `lib/github.axl`:

- `_emit_tip_if_ready` — emits when `ctx.traits` is available; defensive against test stubs.
- `_emit_gha_tip` — adds a `GITHUB_ACTIONS` env gate (for tips whose example syntax is GHA-specific).
- `_emit_aspect_api_token_tip` — adds a `GITHUB_ACTIONS | BUILDKITE | CIRCLECI` host gate, picks the matching variant.

## Severity vocabulary

Renamed the highest urgency level end-to-end: `TIP_CRITICAL` → `TIP_IMPORTANT`, value `"critical"` → `"important"`, label `"Critical"` → `"Important"`. "Important" reads better when paired with the other labels (`Important` / `Warning` / `Tip` / `Info`) and matches GitHub's own callout vocabulary.

## Tip rendering

Headers render the full `<emoji> <LABEL>: <title>` line **bold** with the **label uppercased** on every surface:

- **Terminal `_print_tip`** — colored severity prefix (`🔥 IMPORTANT:` / `⚠️ WARNING:` / `💡 TIP:` / `ℹ️ INFO:`) followed by the title in bold-default-color; body + silence footer prefixed with a colored `│ ` bar so the tip boundary is drawn down the left edge. `TIP_SUGGESTION` is bold green (was bold magenta); `INFO` stays bold cyan to match `info()` in `environment.axl`.
- **GHSC check-run summary, Buildkite annotation, PR summary comment** — `TIPS_BLOCK` in `bazel_results.axl` and the `## 💡 Tips` section in `feature/github_status_comments.axl` both use `**{{ severity_label|upper }}: {{ title }}**` so the whole header line bolds. Each tip is preceded by `<div class="border-top my3"></div>` (the separator BK already uses between an annotation's summary and details sections) so the boundary is visibly drawn — including BK dark mode where a Markdown `---` reads as a hair-thin line that's easy to miss.

## Runtime: print "Running" before features

Feature implementations run in phase 3 of `MultiPhaseEval`, before phase 4 starts the task body. Diagnostic output from feature init — auth WARNINGs, the `add-aspect-api-token-<host>` tip block — therefore appeared on stderr *before* the `→ 🎬 Running <task>` opening bookend, making it look like that output preceded any task running.

Extracted the header-printing logic into `MultiPhaseEval::print_running_task_header` and call it from the CLI dispatch before `execute_features_with_args`. Phase 4 drops the now-duplicated header print; the closing `→ ✅ Passed <task>` bookend stays in place. Two helpers — `on_recognized_ci` and `running_verb_color` — share the CI-detection and color-decision logic across open and close.

## Test plan

- `aspect dev test-github-detect` — `preferred_token_pair` cases updated for the new ordering; new `_test_aspect_api_token_tip_gate` exercises each kind / host-gate cell (GHA, Buildkite, CircleCI, GitLab, local) plus the direct-`authenticate` path with a stubbed `aspect.auth.credentials` returning None.
- `aspect dev test-tips` — `_test_builtin_templates_shape` extended for all three host-specific tip variants: pins severity, host-suffixed id, body specialization (wire-up advice per host, PR-summary-comment mention only on GHA, no `--scope=changed` mention on any variant).
- Snapshot suites all pass: `test-pr-comment-snapshots`, `test-template-snapshots`, `test-bk-annotation-snapshots`, `test-lint-template-snapshots`, `test-format-template-snapshots`, `test-gazelle-template-snapshots`, `test-delivery-template-snapshots`.

## Changes are visible to end-users

Yes. Workflows that exported `GITHUB_TOKEN` to "save App quota" will see supporting calls routed through the App instead. No action required — the user-facing surface (PR comment / check-run summary) is unchanged in structure (only tip rendering changed). Workflows missing `ASPECT_API_TOKEN` on a supported CI host will see a new important tip explaining the missing-auth state.

## Suggested release notes

- `aspect-cli` now prefers the Aspect Workflows GitHub App token over the job-scoped `GITHUB_TOKEN` for supporting GitHub API calls. The App's installation-token bucket is consumed only by aspect-cli, and the user's `GITHUB_TOKEN` budget is preserved for their own workflow steps. `GITHUB_TOKEN` is retained as a last-resort fallback when Aspect-side authentication is unavailable.
- The `add-github-token` tip is now a fallback hint rather than a save-quota suggestion; it fires only when both the App and env paths are unavailable on GitHub Actions.
- New `add-aspect-api-token-{github-actions,buildkite,circleci}` (important) tips fire when `ASPECT_API_TOKEN` is missing on a supported CI host and the Aspect App can't authenticate. Each variant carries host-specific wire-up advice, a host-specific degraded-feature list, and an independent silence id.
- Tip headers render the full line bold with an uppercased severity label (`🔥 IMPORTANT:`, `⚠️ WARNING:`, `💡 TIP:`, `ℹ️ INFO:`) across all four surfaces. Terminal tip blocks gain a colored `│` gutter; check-run / annotation / PR-comment tip blocks gain a visible top border.
- The runtime `→ 🎬 Running <task>` header now prints before feature implementations run, so any feature-init WARNINGs / tip blocks appear under the header instead of preceding it.
- The most urgent tip severity is renamed `Critical` → `Important` end-to-end (constant, discriminator value, and rendered label).
