### PR TITLE
fix(format,gazelle): tighten is_running + add aborted body branch

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
@@ -281,32 +281,22 @@ def _build_details_data(data, status):
         "file_list": "\n".join(shown),
         "overflow": str(overflow) if overflow > 0 else "",
         "ignored_count": str(ignored),
-        # Boolean flags used in Jinja2 conditions.
-        # `is_running` short-circuits the rest so the body shows a
-        # "Format task in progress…" placeholder while bazel is still
-        # building the formatter. Match `status == "running"` exactly:
-        # `warning` (terminal drift with --on-change=warn) and `failing`
-        # (mid-stream drift with --on-change=fail) both carry
+        # Boolean flags for Jinja2 conditions. `total == 0` guards
+        # ensure the files-list `else` branch wins whenever the
+        # formatter produced affected_files, even on non-passing
+        # statuses. `running` only — `warning` and `failing` carry
         # affected_files and must render the files-list body, not the
         # placeholder.
         "is_running": status == "running",
-        # `is_clean` is only true on a real passing run — `failed` with
-        # no recorded affected_files happens on early-bail paths and
-        # would otherwise misleadingly claim "All files are properly
-        # formatted."
         "is_clean": status == "passed" and total == 0,
-        # Reserved for early-bail terminal failures — `status="failed"`
-        # with no affected files and no specific failure mode flag.
-        # When `affected_files` IS populated the formatter ran and the
-        # template's normal "N files need formatting" branch should win.
+        # Early-bail terminal failure: `failed` with no affected_files
+        # and no specific failure mode (formatter_error / no_git /
+        # no_files_to_format).
         "is_failed": status == "failed" and
                      total == 0 and
                      not data["format"].get("formatter_error") and
                      not data["format"].get("no_git") and
                      not data["format"].get("no_files_to_format"),
-        # Aborted before producing a verdict — bazel terminated
-        # mid-build, so `affected_files` is empty and the `else` branch
-        # would misleadingly say "❌ 0 files need formatting".
         "is_aborted": status == "aborted" and total == 0,
         "applied": bool(data.get("applied")),
         # Optional count threaded into the "✅ All N files in scope are

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
@@ -175,6 +175,9 @@ _DETAILS_TEMPLATE = """{% if is_running %}
 {% elif formatter_error %}
 > ❌ The formatter binary exited with code {{ formatter_error_code }}. Check the task log for details.
 
+{% elif is_aborted %}
+> ⚠️ Format task was aborted before producing a verdict. Check the task log for details.
+
 {% elif is_failed %}
 > ❌ Format task failed before the formatter could run. Check the task log for details.
 
@@ -281,11 +284,12 @@ def _build_details_data(data, status):
         # Boolean flags used in Jinja2 conditions.
         # `is_running` short-circuits the rest so the body shows a
         # "Format task in progress…" placeholder while bazel is still
-        # building the formatter — without it, an empty `affected_files`
-        # list during the running phase falls through to `is_clean` and
-        # the body misleadingly says "✅ All files are properly
-        # formatted." before the formatter has even run.
-        "is_running": status not in ("passed", "failed", "aborted"),
+        # building the formatter. Match `status == "running"` exactly:
+        # `warning` (terminal drift with --on-change=warn) and `failing`
+        # (mid-stream drift with --on-change=fail) both carry
+        # affected_files and must render the files-list body, not the
+        # placeholder.
+        "is_running": status == "running",
         # `is_clean` is only true on a real passing run — `failed` with
         # no recorded affected_files happens on early-bail paths and
         # would otherwise misleadingly claim "All files are properly
@@ -300,6 +304,10 @@ def _build_details_data(data, status):
                      not data["format"].get("formatter_error") and
                      not data["format"].get("no_git") and
                      not data["format"].get("no_files_to_format"),
+        # Aborted before producing a verdict — bazel terminated
+        # mid-build, so `affected_files` is empty and the `else` branch
+        # would misleadingly say "❌ 0 files need formatting".
+        "is_aborted": status == "aborted" and total == 0,
         "applied": bool(data.get("applied")),
         # Optional count threaded into the "✅ All N files in scope are
         # properly formatted." body when scope=changed recorded an input

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
@@ -185,15 +185,11 @@ def _make_large():
     return r
 
 def _make_aborted():
-    """Bazel aborted mid-build — no recorded affected files. Body must NOT
-    fall through to the `else` branch and render "❌ 0 files need
-    formatting"."""
+    """Aborted-mid-build data: empty affected_files (paired with status=aborted)."""
     return _make_base()
 
 def _make_failing_with_drift():
-    """`--on-change=fail` + drift detected mid-stream (pre-terminal):
-    `pick_task_status` returns "failing". Body must show the files-list,
-    NOT the in-progress placeholder."""
+    """`--on-change=fail` with mid-stream drift; `pick_task_status` returns "failing"."""
     r = _make_base()
     r["format"]["on_change_resolved"] = "fail"
     r["format"]["affected_files"] = [
@@ -256,11 +252,10 @@ def _test_impl(ctx):
         # entrypoint resolution failed). Title and body must say "Failed",
         # NOT "Passed" / "All files are properly formatted."
         ("14. early-fail · GH", _make_early_fail(), "failed", "github", None),
-        # Bazel aborted mid-build — body must render the "aborted" notice,
-        # NOT "❌ 0 files need formatting".
+        # Aborted-mid-build and drift-detected non-running statuses must
+        # NOT fall through to "0 files need formatting" or the in-progress
+        # placeholder.
         ("15. aborted · GH", _make_aborted(), "aborted", "github", None),
-        # Drift-detected non-running status: body must render the files-list,
-        # NOT the "Format task in progress…" placeholder.
         ("16. failing-with-drift · GH", _make_failing_with_drift(), "failing", "github", None),
     ]
 
@@ -283,15 +278,13 @@ def _test_impl(ctx):
         print(out["text"][:4000])
         print("")
 
-        # Invariant: the "Format task in progress…" placeholder renders
-        # IFF status == "running". Catches regressions where a broader
-        # `is_running` tuple collapses `warning` / `failing` into the
-        # placeholder branch even though affected_files is populated.
+        # Invariant: "Format task in progress…" placeholder renders IFF
+        # status == "running".
         has_placeholder = "Format task in progress" in out["text"]
         if status == "running" and not has_placeholder:
             errors.append("%s: status=running but body has no in-progress placeholder" % label)
         if status != "running" and has_placeholder:
-            errors.append("%s: status=%s rendered the in-progress placeholder (must show terminal body)" % (label, status))
+            errors.append("%s: status=%s rendered the in-progress placeholder" % (label, status))
 
     if errors:
         for e in errors:

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
@@ -7,13 +7,24 @@ Scenarios:
   1. clean-passed        — no files need formatting
   2. files-need-format   — 3 files need formatting (scope=changed)
   3. scope-all-many      — 15 files need formatting (scope=all)
-  4. on-change-warn      — files need formatting, --on-change=warn; exits 0
+  4. on-change-warn      — status=warning + drift; body must show files list
   5. formatter-error     — formatter binary crashed
   6. no-git              — no initial commit / not in git repo
   7. no-files-to-format  — scope=changed, no changed files found
   8. with-patch-url      — patch artifact uploaded; check run shows download link
   9. non-default-target  — custom formatter target label in repro command
  10. large               — 250 files to exercise the trim cascade
+ 11. in-progress         — status=running with affected_files (placeholder body)
+ 12. metadata-all        — GitHubStatusChecksTrait.metadata_keys = ["*"]
+ 13. applied             — formatter rewrote files (--on-change=silent path)
+ 14. early-fail          — status=failed, no specific failure mode (body says "Failed")
+ 15. aborted             — bazel aborted mid-build, no recorded affected files
+ 16. failing-with-drift  — status=failing (mid-stream --on-change=fail): drift
+                           detected, body must show files list (not placeholder)
+
+Body-content invariant (asserted in the loop): the "Format task in progress…"
+placeholder renders IFF status == "running". A regression where `warning` or
+`failing` short-circuits to the placeholder fails the suite.
 """
 
 load("./format_results.axl", "init_data", "render_check_output")
@@ -173,6 +184,24 @@ def _make_large():
     r["format"]["affected_files"] = files
     return r
 
+def _make_aborted():
+    """Bazel aborted mid-build — no recorded affected files. Body must NOT
+    fall through to the `else` branch and render "❌ 0 files need
+    formatting"."""
+    return _make_base()
+
+def _make_failing_with_drift():
+    """`--on-change=fail` + drift detected mid-stream (pre-terminal):
+    `pick_task_status` returns "failing". Body must show the files-list,
+    NOT the in-progress placeholder."""
+    r = _make_base()
+    r["format"]["on_change_resolved"] = "fail"
+    r["format"]["affected_files"] = [
+        "apps/web/src/auth/login.ts",
+        "apps/api/handler.go",
+    ]
+    return r
+
 # ─── Test harness ─────────────────────────────────────────────────────────────
 
 def _render_ctx(task_name = "format"):
@@ -227,9 +256,16 @@ def _test_impl(ctx):
         # entrypoint resolution failed). Title and body must say "Failed",
         # NOT "Passed" / "All files are properly formatted."
         ("14. early-fail · GH", _make_early_fail(), "failed", "github", None),
+        # Bazel aborted mid-build — body must render the "aborted" notice,
+        # NOT "❌ 0 files need formatting".
+        ("15. aborted · GH", _make_aborted(), "aborted", "github", None),
+        # Drift-detected non-running status: body must render the files-list,
+        # NOT the "Format task in progress…" placeholder.
+        ("16. failing-with-drift · GH", _make_failing_with_drift(), "failing", "github", None),
     ]
 
     sep = "=" * 70
+    errors = []
 
     for (label, data, status, ci, metadata_keys) in scenarios:
         rc = _render_ctx()
@@ -246,6 +282,21 @@ def _test_impl(ctx):
         print("DETAILS (first 4000 chars):")
         print(out["text"][:4000])
         print("")
+
+        # Invariant: the "Format task in progress…" placeholder renders
+        # IFF status == "running". Catches regressions where a broader
+        # `is_running` tuple collapses `warning` / `failing` into the
+        # placeholder branch even though affected_files is populated.
+        has_placeholder = "Format task in progress" in out["text"]
+        if status == "running" and not has_placeholder:
+            errors.append("%s: status=running but body has no in-progress placeholder" % label)
+        if status != "running" and has_placeholder:
+            errors.append("%s: status=%s rendered the in-progress placeholder (must show terminal body)" % (label, status))
+
+    if errors:
+        for e in errors:
+            print("FAIL: " + e)
+        fail("Body-content invariant violations: %d" % len(errors))
 
     print(sep)
     print("All " + str(len(scenarios)) + " format scenarios rendered without error.")

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
@@ -239,7 +239,10 @@ _SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
 :gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
 :speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
 
-_DETAILS_TEMPLATE = """{% if gazelle_error %}
+_DETAILS_TEMPLATE = """{% if is_running %}
+> 🔄 Gazelle task in progress...
+
+{% elif gazelle_error %}
 > ❌ Gazelle exited with code {{ gazelle_error_code }} without producing a diff. This usually indicates a configuration error — check the task log.
 
 {% elif apply_error %}
@@ -247,6 +250,9 @@ _DETAILS_TEMPLATE = """{% if gazelle_error %}
 {% if apply_error_msg %}
 > Error: {{ apply_error_msg }}
 {% endif %}
+
+{% elif is_aborted %}
+> ⚠️ Gazelle task was aborted before producing a verdict. Check the task log for details.
 
 {% elif is_failed %}
 > ❌ Gazelle task failed before gazelle could run. Check the task log for details.
@@ -341,6 +347,14 @@ def _build_details_data(data, status):
         "file_list": "\n".join(shown),
         "overflow": str(overflow) if overflow > 0 else "",
         # Boolean flags for Jinja2 conditions.
+        # `is_running` short-circuits the rest so the body shows a
+        # "Gazelle task in progress..." placeholder before the diff
+        # phase records affected_files. Match `status == "running"`
+        # exactly: `warning` (terminal drift with --on-change=warn) and
+        # `failing` (mid-stream drift with --on-change=fail) both carry
+        # affected_files and must render the files-list body, not the
+        # placeholder. Mirrors format_results' `is_running` handling.
+        "is_running": status == "running",
         # `is_clean` is only true on a real passing run — `failed` with
         # no recorded affected_files happens on early-bail paths and
         # would otherwise misleadingly claim "All BUILD files are up to
@@ -354,6 +368,12 @@ def _build_details_data(data, status):
                      total == 0 and
                      not data["gazelle"].get("gazelle_error") and
                      not data["gazelle"].get("apply_error"),
+        # Aborted before producing a verdict — bazel terminated mid-build,
+        # so `affected_files` is empty and we don't have anything to
+        # render. Without this branch the template would fall through to
+        # the `else` and misleadingly emit "❌ 0 BUILD files are out of
+        # date".
+        "is_aborted": status == "aborted" and total == 0,
         "has_overflow": overflow > 0,
         # `check_only` mirrors the resolved `--check-only` bool — the
         # template uses it to surface "tree not modified" guidance.

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
@@ -346,33 +346,19 @@ def _build_details_data(data, status):
         "verb": "is" if total == 1 else "are",
         "file_list": "\n".join(shown),
         "overflow": str(overflow) if overflow > 0 else "",
-        # Boolean flags for Jinja2 conditions.
-        # `is_running` short-circuits the rest so the body shows a
-        # "Gazelle task in progress..." placeholder before the diff
-        # phase records affected_files. Match `status == "running"`
-        # exactly: `warning` (terminal drift with --on-change=warn) and
-        # `failing` (mid-stream drift with --on-change=fail) both carry
-        # affected_files and must render the files-list body, not the
-        # placeholder. Mirrors format_results' `is_running` handling.
+        # Boolean flags for Jinja2 conditions. `total == 0` guards
+        # ensure the files-list `else` branch wins whenever gazelle
+        # produced affected_files, even on non-passing statuses.
+        # `running` only — `warning` and `failing` carry affected_files
+        # and must render the files-list body. Mirrors format_results.
         "is_running": status == "running",
-        # `is_clean` is only true on a real passing run — `failed` with
-        # no recorded affected_files happens on early-bail paths and
-        # would otherwise misleadingly claim "All BUILD files are up to
-        # date."
         "is_clean": status == "passed" and total == 0,
-        # Reserved for early-bail terminal failures — `status="failed"`
-        # with no affected files and no specific failure mode flag.
-        # When `affected_files` IS populated gazelle ran and the
-        # template's "N BUILD files out of date" branch should win.
+        # Early-bail terminal failure: `failed` with no affected_files
+        # and no specific failure mode (gazelle_error / apply_error).
         "is_failed": status == "failed" and
                      total == 0 and
                      not data["gazelle"].get("gazelle_error") and
                      not data["gazelle"].get("apply_error"),
-        # Aborted before producing a verdict — bazel terminated mid-build,
-        # so `affected_files` is empty and we don't have anything to
-        # render. Without this branch the template would fall through to
-        # the `else` and misleadingly emit "❌ 0 BUILD files are out of
-        # date".
         "is_aborted": status == "aborted" and total == 0,
         "has_overflow": overflow > 0,
         # `check_only` mirrors the resolved `--check-only` bool — the

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
@@ -19,6 +19,16 @@ Scenarios:
  13. scope=changed       — Configuration row with Scope + default escalation list
  14. scope=changed full  — all four Config rows fire (Scope, On-change, escalate, pattern)
  15. scope=changed empty — no-op short-circuit, dirs=[]
+ 16. in-progress empty   — status=running with no affected files yet (must not
+                           render "0 BUILD files are out of date")
+ 17. aborted             — bazel aborted mid-build, no recorded affected files
+ 18. warning-with-drift  — status=warning (terminal --on-change=warn): drift
+                           detected, body must show files list (not placeholder)
+ 19. failing-with-drift  — status=failing (mid-stream --on-change=fail): same
+
+Body-content invariant (asserted in the loop): the "Gazelle task in progress…"
+placeholder renders IFF status == "running". A regression where `warning` or
+`failing` short-circuits to the placeholder fails the suite.
 """
 
 load("./gazelle_results.axl", "init_data", "render_check_output")
@@ -183,6 +193,30 @@ def _make_large():
     ]
     return r
 
+def _make_aborted():
+    """Bazel aborted mid-build — no recorded affected files. Body must NOT
+    fall through to the `else` branch and render "❌ 0 BUILD files are out
+    of date"."""
+    return _make_base()
+
+def _make_warning_with_drift():
+    """`--on-change=warn` + drift detected: `pick_task_status` returns
+    "warning" once `affected_files` is populated. Body must show the
+    files-list / patch guidance, NOT the in-progress placeholder."""
+    r = _make_base()
+    r["gazelle"]["on_change_resolved"] = "warn"
+    r["gazelle"]["affected_files"] = _OUT_OF_DATE_FILES
+    return r
+
+def _make_failing_with_drift():
+    """`--on-change=fail` + drift detected mid-stream (pre-terminal):
+    `pick_task_status` returns "failing". Body must show the files-list,
+    NOT the in-progress placeholder."""
+    r = _make_base()
+    r["gazelle"]["on_change_resolved"] = "fail"
+    r["gazelle"]["affected_files"] = _OUT_OF_DATE_FILES
+    return r
+
 # ─── Test harness ─────────────────────────────────────────────────────────────
 
 def _render_ctx(task_name = "gazelle"):
@@ -236,9 +270,21 @@ def _test_impl(ctx):
         ("13. scope=changed default · GH", _make_scope_changed(), "failed", "github", None),
         ("14. scope=changed full config · GH", _make_scope_changed_with_filter(), "failed", "github", None),
         ("15. scope=changed empty no-op · GH", _make_scope_changed_empty(), "passed", "github", None),
+        # Transient running state before the diff phase: affected_files is
+        # empty. Body must render the in-progress placeholder, NOT "❌ 0
+        # BUILD files are out of date" (the bug `is_running` guards
+        # against).
+        ("16. in-progress empty · GH", _make_clean(), "running", "github", None),
+        # Bazel aborted mid-build — same guard, different terminal status.
+        ("17. aborted · GH", _make_aborted(), "aborted", "github", None),
+        # Drift-detected non-running statuses: body must render the
+        # files-list, NOT the "Gazelle task in progress…" placeholder.
+        ("18. warning-with-drift · GH", _make_warning_with_drift(), "warning", "github", None),
+        ("19. failing-with-drift · GH", _make_failing_with_drift(), "failing", "github", None),
     ]
 
     sep = "=" * 70
+    errors = []
 
     for (label, data, status, ci, metadata_keys) in scenarios:
         rc = _render_ctx()
@@ -255,6 +301,21 @@ def _test_impl(ctx):
         print("DETAILS (first 4000 chars):")
         print(out["text"][:4000])
         print("")
+
+        # Invariant: the "Gazelle task in progress…" placeholder renders
+        # IFF status == "running". Catches regressions where a broader
+        # `is_running` tuple collapses `warning` / `failing` into the
+        # placeholder branch even though affected_files is populated.
+        has_placeholder = "Gazelle task in progress" in out["text"]
+        if status == "running" and not has_placeholder:
+            errors.append("%s: status=running but body has no in-progress placeholder" % label)
+        if status != "running" and has_placeholder:
+            errors.append("%s: status=%s rendered the in-progress placeholder (must show terminal body)" % (label, status))
+
+    if errors:
+        for e in errors:
+            print("FAIL: " + e)
+        fail("Body-content invariant violations: %d" % len(errors))
 
     print(sep)
     print("All " + str(len(scenarios)) + " gazelle scenarios rendered without error.")

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
@@ -194,24 +194,18 @@ def _make_large():
     return r
 
 def _make_aborted():
-    """Bazel aborted mid-build — no recorded affected files. Body must NOT
-    fall through to the `else` branch and render "❌ 0 BUILD files are out
-    of date"."""
+    """Aborted-mid-build data: empty affected_files (paired with status=aborted)."""
     return _make_base()
 
 def _make_warning_with_drift():
-    """`--on-change=warn` + drift detected: `pick_task_status` returns
-    "warning" once `affected_files` is populated. Body must show the
-    files-list / patch guidance, NOT the in-progress placeholder."""
+    """`--on-change=warn` with drift; `pick_task_status` returns "warning"."""
     r = _make_base()
     r["gazelle"]["on_change_resolved"] = "warn"
     r["gazelle"]["affected_files"] = _OUT_OF_DATE_FILES
     return r
 
 def _make_failing_with_drift():
-    """`--on-change=fail` + drift detected mid-stream (pre-terminal):
-    `pick_task_status` returns "failing". Body must show the files-list,
-    NOT the in-progress placeholder."""
+    """`--on-change=fail` with mid-stream drift; `pick_task_status` returns "failing"."""
     r = _make_base()
     r["gazelle"]["on_change_resolved"] = "fail"
     r["gazelle"]["affected_files"] = _OUT_OF_DATE_FILES
@@ -270,15 +264,12 @@ def _test_impl(ctx):
         ("13. scope=changed default · GH", _make_scope_changed(), "failed", "github", None),
         ("14. scope=changed full config · GH", _make_scope_changed_with_filter(), "failed", "github", None),
         ("15. scope=changed empty no-op · GH", _make_scope_changed_empty(), "passed", "github", None),
-        # Transient running state before the diff phase: affected_files is
-        # empty. Body must render the in-progress placeholder, NOT "❌ 0
-        # BUILD files are out of date" (the bug `is_running` guards
-        # against).
+        # Non-passing statuses with empty affected_files must NOT render
+        # the "0 BUILD files are out of date" fall-through.
         ("16. in-progress empty · GH", _make_clean(), "running", "github", None),
-        # Bazel aborted mid-build — same guard, different terminal status.
         ("17. aborted · GH", _make_aborted(), "aborted", "github", None),
-        # Drift-detected non-running statuses: body must render the
-        # files-list, NOT the "Gazelle task in progress…" placeholder.
+        # Drift-detected non-running statuses must render the files-list
+        # body, NOT the in-progress placeholder.
         ("18. warning-with-drift · GH", _make_warning_with_drift(), "warning", "github", None),
         ("19. failing-with-drift · GH", _make_failing_with_drift(), "failing", "github", None),
     ]
@@ -302,15 +293,13 @@ def _test_impl(ctx):
         print(out["text"][:4000])
         print("")
 
-        # Invariant: the "Gazelle task in progress…" placeholder renders
-        # IFF status == "running". Catches regressions where a broader
-        # `is_running` tuple collapses `warning` / `failing` into the
-        # placeholder branch even though affected_files is populated.
+        # Invariant: "Gazelle task in progress…" placeholder renders IFF
+        # status == "running".
         has_placeholder = "Gazelle task in progress" in out["text"]
         if status == "running" and not has_placeholder:
             errors.append("%s: status=running but body has no in-progress placeholder" % label)
         if status != "running" and has_placeholder:
-            errors.append("%s: status=%s rendered the in-progress placeholder (must show terminal body)" % (label, status))
+            errors.append("%s: status=%s rendered the in-progress placeholder" % (label, status))
 
     if errors:
         for e in errors:


### PR DESCRIPTION
## Summary

Two bugs in the `format` and `gazelle` details-template renderers, fixed together to keep the surfaces aligned.

**1. Zero-count fall-through on non-passing statuses.** Under
`status == "running"` (no diff data yet) or `status == "aborted"` (bazel
terminated mid-build), the empty `affected_files` list fell through to
the `{% else %}` body and rendered `❌ 0 BUILD files are out of date`.
Adds `is_running` + `is_aborted` template branches in both files.

**2. `is_running` swallowed `warning` and `failing`.** Both renderers had
`is_running = status not in ("passed", "failed", "aborted")`. But
[`pick_task_status`](crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl)
also returns `"warning"` (terminal `--on-change=warn` with drift) and
`"failing"` (mid-stream `--on-change=fail` with drift) — both carry
populated `affected_files` and must render the files-list body, not the
in-progress placeholder. Tightens to `status == "running"`.

### Test coverage

Adds a body-content invariant to both snapshot suites: the in-progress
placeholder must render IFF `status == "running"`. Suite `fail()`s on
regression. New scenarios:

- `gazelle_results_test.axl` — `18. warning-with-drift`, `19. failing-with-drift`
- `format_results_test.axl`  — `15. aborted`, `16. failing-with-drift`

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fix `format` / `gazelle` status check details: no more "❌ 0 BUILD files are out of date" placeholder during running / aborted states, and `--on-change=warn` / `--on-change=fail` runs now correctly show the affected-files body instead of the "task in progress…" placeholder.

### Test plan

- `aspect dev test-gazelle-template-snapshots` (19 scenarios)
- `aspect dev test-format-template-snapshots` (16 scenarios)
- `aspect dev test-bk-annotation-snapshots` (21 scenarios, unchanged)
