### PR TITLE
fix(timings): give synthetic init phase a 🌱 emoji

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -2520,8 +2520,8 @@ def format_elapsed_with_phases(ctx, status):
       Phases, running:                   "4m13s · 🔨 Build 4m11s | ⚙ Setup 1.7s · 🔍 Detect 1.2s"
       Phases, failing:                   "4m13s · 🔨 Build (failing 4m11s) | ⚙ Setup 1.7s · 🔍 Detect 1.2s"
       Phases, passed (terminal):         "46.8s — ⚙ Setup 1.7s · 🔍 Detect 1.2s · 🔨 Build 45.3s"
-      Phases, failed-during-phase:       "1m 15s · 🔨 Build (failed after 1m 12s) | Init 2.3s"
-      Phases, failed-after-phase-bound:  "1m 15s — Init 2.3s · 🔨 Build 1m 12s"
+      Phases, failed-during-phase:       "1m 15s · 🔨 Build (failed after 1m 12s) | 🌱 Init 2.3s"
+      Phases, failed-after-phase-bound:  "1m 15s — 🌱 Init 2.3s · 🔨 Build 1m 12s"
 
     Each phase name leads with a small unicode icon supplied by the
     task at phase-transition time (`Phase(name="build", emoji="🔨")`);

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -547,9 +547,9 @@ def setup_phase(ctx, lifecycle):
 
     Without an explicit phase mark, that 600ms-2.3s gets swallowed into
     the synthetic `init` phase — the breakdown line shows
-    `Init 1.5s · Pre-flight 245ms` and users wonder where the
+    `🌱 Init 1.5s · ✈ Pre-flight 245ms` and users wonder where the
     1.5s went. Opening a `setup` phase here makes it explicit:
-    `Setup 1.5s — Authenticating and creating CI status checks · Pre-flight 245ms`.
+    `⚙ Setup 1.5s — Authenticating and creating CI status checks · ✈ Pre-flight 245ms`.
 
     Locally those handlers are no-ops (no GitHub App auth, no
     `buildkite-agent`), so the time is negligible (~10ms) and the

--- a/crates/axl-runtime/src/engine/task_info.rs
+++ b/crates/axl-runtime/src/engine/task_info.rs
@@ -408,15 +408,15 @@ fn task_info_methods(registry: &mut MethodsBuilder) {
         if current.is_none() && phases.is_empty() {
             // Synthetic "init" phase covers task spawn to now —
             // Aspect runtime startup, AXL eval, trait construction,
-            // and any pre-first-phase task code in `_impl`. No emoji
-            // and no display-name override — renderers titlecase
-            // `init` to `Init`.
+            // and any pre-first-phase task code in `_impl`. 🌱 is the
+            // "sprout / first moment" cue; no display-name override —
+            // renderers titlecase `init` to `Init`.
             phases.push(PhaseRecord {
                 name: "init".to_string(),
                 description: "Aspect runtime startup".to_string(),
                 duration: now.duration_since(this.started_at),
                 interrupted: false,
-                emoji: String::new(),
+                emoji: "🌱".to_string(),
                 display_name: String::new(),
             });
         } else if let Some(prev) = current.as_ref() {

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -734,7 +734,7 @@ pub enum TimingMode {
     /// `→ ✅ Passed `lint` task in 46.8s`
     Total,
     /// Total + inline phase breakdown.
-    /// `→ ✅ Passed `lint` task in 46.8s — Init 0.2s · Detect 1.2s · ...`
+    /// `→ ✅ Passed `lint` task in 46.8s — 🌱 Init 0.2s · 🔍 Detect 1.2s · ...`
     Summary,
     /// Total + multi-line breakdown with descriptions. Default.
     Detailed,


### PR DESCRIPTION
Every phase in the timings strip leads with an emoji (`🔨 Build`, `⚙ Setup`, `✈ Pre-flight`, `🎯 Resolve`, `🔍 Detect`) because callers set one on `Phase(emoji=...)`. The synthetic `init` phase the runtime opens on the first `ctx.task.phase()` call had an empty emoji, so it rendered as bare `Init` next to its labelled neighbours:

Before:
```
⏱ 2m 49s · 🔨 Build 2m 37s | Init 628ms · ⚙ Setup 10.1s · ✈ Pre-flight 1.1s · 🎯 Resolve 604ms
```

After:
```
⏱ 2m 49s · 🔨 Build 2m 37s | 🌱 Init 628ms · ⚙ Setup 10.1s · ✈ Pre-flight 1.1s · 🎯 Resolve 604ms
```

🌱 ("sprout / first moment") is set at the synthesis site in `TaskInfo::phase`, matching how every other phase emoji enters the system (producer-supplied at the boundary). Surface renderers (timings strip, CLI breakdown line, GHSC/BK templates) already read `p.emoji` off the phase snapshot — no renderer changes needed.

Docstring examples that showed bare `Init …` in `bazel_results.axl`, `lifecycle.axl`, and the `TimingMode::Summary` Rust doc were updated to match.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- The synthetic `Init` phase in the task timings strip now leads with a 🌱 emoji, matching every other phase entry.

### Test plan

- Covered by existing test cases (`aspect dev test-template-snapshots` still passes)
- Manual: run any task that calls `ctx.task.phase(...)` (e.g. `aspect lint`, `aspect build`) and confirm the timings strip on its status surface renders `🌱 Init <duration>` instead of `Init <duration>`.
