### PR TITLE
fix(bazel): show "Failed to build" instead of "Successful build" on failed runs with no BES failure data

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -3,7 +3,7 @@ load("@aspect//feature/buildkite_annotations.axl", "BuildkiteAnnotations")
 load("@aspect//feature/buildkite_annotations_test.axl", "bk_annotation_snapshot_tests")
 load("@aspect//feature/github_status_checks.axl", "GithubStatusChecks")
 load("@aspect//feature/github_status_comments_test.axl", "pr_comment_snapshot_tests")
-load("@aspect//lib/bazel_results_test.axl", "bazel_results_skipped_tests", "template_snapshot_tests")
+load("@aspect//lib/bazel_results_test.axl", "bazel_results_unit_tests", "template_snapshot_tests")
 load("@aspect//lib/delivery_results_test.axl", "delivery_template_snapshot_tests")
 load("@aspect//lib/format_results_test.axl", "format_template_snapshot_tests")
 load("@aspect//lib/gazelle_results_test.axl", "gazelle_template_snapshot_tests")
@@ -76,10 +76,10 @@ def config(ctx: ConfigContext):
     # Run with: aspect test-template-snapshots
     ctx.tasks.add(template_snapshot_tests)
 
-    # Skipped-bucket plumbing — exercises _compute_bucket_counts +
-    # compute_invocation_state for the SKIPPED target path.
-    # Run with: aspect dev test-bazel-results-skipped
-    ctx.tasks.add(bazel_results_skipped_tests)
+    # Bazel results unit tests — compute_invocation_state, conclusion,
+    # and skipped-bucket plumbing.
+    # Run with: aspect dev test-bazel-results
+    ctx.tasks.add(bazel_results_unit_tests)
 
     # GitLab HTTP client smoke tests — pure-fn URL helpers + input
     # validation on the network-touching surfaces.

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -174,7 +174,7 @@ _No tasks have reported yet._
 ---
 
 {% if last_updated_at or api_usage %}<sub>{% if last_updated_at %}⏱ Last updated {{ last_updated_at }}{% endif %}{% if last_updated_at and api_usage %} · {% endif %}{% if api_usage %}{{ api_usage }}{% endif %}</sub><br>
-{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) | [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
+{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
 """
 
 # ─── Status → badge ───────────────────────────────────────────────────────────

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -1936,6 +1936,14 @@ def _compute_bucket_counts(data):
     counts[_BUCKET_SUCCESSFUL_BUILD] = non_test_built
     return counts
 
+# Buckets eligible to label a failed invocation, walked in priority order.
+# ABORTED is short-circuited above; FLAKY doesn't fail the build.
+_FAILURE_BUCKETS = [
+    _BUCKET_FAILED_TO_BUILD,
+    _BUCKET_TEST_FAILED,
+    _BUCKET_TEST_TIMEOUT,
+]
+
 def compute_invocation_state(data, status):
     """Return the invocation-state label for the title.
 
@@ -1945,6 +1953,11 @@ def compute_invocation_state(data, status):
 
     Returns "Running..." while the build is in progress — that overrides
     bucket state since partial data aren't yet authoritative.
+
+    When `status == "failed"`, restricts the search to `_FAILURE_BUCKETS` and
+    falls back to "Failed to build" when none has a count — otherwise an
+    analysis-phase failure (Bazel exits non-zero but emits no failed_action
+    / failed_target) would fall through to "Successful build".
     """
 
     # Aborted build: label is fixed, no matter what else ran.
@@ -1955,6 +1968,13 @@ def compute_invocation_state(data, status):
     if status in ("running", "failing"):
         return _BUCKET_INVOCATION_LABELS[_BUCKET_PENDING]
     counts = _compute_bucket_counts(data)
+
+    if status == "failed":
+        for bucket in _FAILURE_BUCKETS:
+            if counts.get(bucket, 0) > 0:
+                return _BUCKET_INVOCATION_LABELS[bucket]
+        return _BUCKET_INVOCATION_LABELS[_BUCKET_FAILED_TO_BUILD]
+
     for group in _BUCKET_PRIORITY_GROUPS:
         for bucket in group:
             if counts.get(bucket, 0) > 0:
@@ -3331,7 +3351,7 @@ SHARED_DETAILS_BODY_TEMPLATE = """{% if artifacts_browse_url or artifact_links %
 ---
 
 {% if last_updated_at or api_usage %}<sub>{% if last_updated_at %}⏱ Last updated {{ last_updated_at }}{% endif %}{% if last_updated_at and api_usage %} · {% endif %}{% if api_usage %}{{ api_usage }}{% endif %}</sub><br>
-{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) | [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
+{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
 """
 
 # Build/test detail template: bazel-aborted prelude, the hoisted

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -1,21 +1,14 @@
-"""Snapshot tests for bazel_results template rendering.
+"""Tests for the bazel_results template rendering + invocation-state logic.
 
-Run with:
-  ASPECT_CLI_TESTING=template_snapshots aspect test-template-snapshots
-
-Each scenario prints TITLE, SUMMARY, and the first 3000 chars of DETAILS.
-Inspect the output to verify rendering is correct across failure modes.
-
-Scenarios covered:
-  1. all-passed  — fully cached test run, all green
-  2. failed      — build action failure + multiple test failures
-  3. flaky       — flaky tests with Bazel exiting 0
-  4. failing     — live "mid-build" state with some failures already seen
-  5. aborted     — build aborted mid-stream
-  6. large       — many targets/tests (exercises the trim cascade)
+Two task implementations live here:
+  * `template_snapshot_tests` (`aspect test-template-snapshots`) — renders
+    each scenario's TITLE, SUMMARY, and the first 3000 chars of DETAILS for
+    eyeball verification across failure modes.
+  * `bazel_results_unit_tests` (`aspect dev test-bazel-results`) — exercises
+    `compute_invocation_state`, `conclusion`, and skipped-bucket plumbing.
 """
 
-load("./bazel_results.axl", "build_details_data", "compute_invocation_state", "init_data", "render_check_output")
+load("./bazel_results.axl", "build_details_data", "compute_invocation_state", "conclusion", "init_data", "render_check_output")
 
 # ---------------------------------------------------------------------------
 # Fake data builders
@@ -647,11 +640,35 @@ template_snapshot_tests = task(
     args = {},
 )
 
-# ─── Unit tests — skipped target plumbing ────────────────────────────────────
+# ─── Unit tests — compute_invocation_state / conclusion ──────────────────────
 
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
+
+def _make_unaffected_targets_built():
+    """BES streamed 145 successful targets, no failure event recorded —
+    e.g. Bazel exited non-zero from a loading / analysis failure."""
+    r = init_data()
+    r["bazel"]["build_command"] = "build"
+    r["bazel"]["targets_total"] = 145
+    return r
+
+def _make_explicit_action_failure():
+    """One failed action produces a failed_target."""
+    r = init_data()
+    r["bazel"]["build_command"] = "build"
+    r["bazel"]["targets_total"] = 10
+    r["bazel"]["failed_actions_total"] = 1
+    r["bazel"]["failed_actions"] = [{"label": "//pkg:broken", "mnemonics": ["CppCompile"]}]
+    r["bazel"]["failed_action_labels"] = ["//pkg:broken"]
+    r["bazel"]["failed_targets"] = [{"label": "//pkg:broken"}]
+    return r
+
+def _make_aborted_data():
+    r = init_data()
+    r["bazel"]["aborted"] = True
+    return r
 
 def _make_skipped_only():
     """4 targets, all skipped — no built, no failed, no tests."""
@@ -696,21 +713,66 @@ def _make_skipped_with_failure():
     return r
 
 def _make_skipped_over_cap():
-    """5000 skipped targets — exceeds MAX_BUILT_TARGETS so the list IS capped
-    in production. Simulate the post-accumulation shape: capped list +
-    accurate total. Bucket count must come from the total (not list len),
-    and the body should render the overflow line."""
+    """5000 skipped targets — exceeds MAX_BUILT_TARGETS so the list is capped
+    in production. Bucket count must come from `skipped_targets_total` (not
+    list len) and the body must render the overflow line."""
     r = init_data()
     total = 5000
     r["bazel"]["targets_total"] = total
-
-    # Mimic what process_event leaves on disk after the cap fires.
     r["bazel"]["skipped_targets"] = [
         {"label": "//pkg/lib_%d:lib" % i, "kind": "py_library", "reason": "skipped"}
         for i in range(250)
     ]
     r["bazel"]["skipped_targets_total"] = total
     return r
+
+def _test_failed_status_without_failure_bucket(ctx):
+    data = _make_unaffected_targets_built()
+    _eq(
+        "compute_invocation_state — failed verdict without failure bucket",
+        compute_invocation_state(data, "failed"),
+        "Failed to build",
+    )
+    _eq(
+        "conclusion — failed verdict without failure bucket",
+        conclusion("failed", data),
+        "Failed to build",
+    )
+
+def _test_failed_status_with_explicit_action_failure(ctx):
+    _eq(
+        "compute_invocation_state — failed with failed_action",
+        compute_invocation_state(_make_explicit_action_failure(), "failed"),
+        "Failed to build",
+    )
+
+def _test_passed_status_returns_successful_build(ctx):
+    _eq(
+        "compute_invocation_state — passed verdict surfaces success",
+        compute_invocation_state(_make_unaffected_targets_built(), "passed"),
+        "Successful build",
+    )
+
+def _test_aborted_short_circuits(ctx):
+    """`bazel.aborted` overrides everything else."""
+    _eq(
+        "compute_invocation_state — aborted overrides status",
+        compute_invocation_state(_make_aborted_data(), "failed"),
+        "Invocation disconnected",
+    )
+
+def _test_running_returns_pending(ctx):
+    data = _make_unaffected_targets_built()
+    _eq(
+        "compute_invocation_state — running",
+        compute_invocation_state(data, "running"),
+        "Running...",
+    )
+    _eq(
+        "conclusion — running returns empty",
+        conclusion("running", data),
+        "",
+    )
 
 def _test_skipped_only_surfaces_invocation_skipped(ctx):
     _eq(
@@ -720,8 +782,6 @@ def _test_skipped_only_surfaces_invocation_skipped(ctx):
     )
 
 def _test_skipped_with_success_prefers_successful_build(ctx):
-    """A mixed run with both skipped and built targets surfaces the
-    successful-build label — skipped is lowest priority."""
     _eq(
         "compute_invocation_state — skipped + success",
         compute_invocation_state(_make_skipped_with_success(), "passed"),
@@ -729,7 +789,6 @@ def _test_skipped_with_success_prefers_successful_build(ctx):
     )
 
 def _test_skipped_with_failure_prefers_failure(ctx):
-    """Failed targets dominate skipped in the priority walk."""
     _eq(
         "compute_invocation_state — skipped + failure",
         compute_invocation_state(_make_skipped_with_failure(), "failed"),
@@ -758,16 +817,26 @@ def _test_skipped_over_cap_keeps_accurate_count(ctx):
         "4750",
     )
 
+_UNIT_TESTS = [
+    _test_failed_status_without_failure_bucket,
+    _test_failed_status_with_explicit_action_failure,
+    _test_passed_status_returns_successful_build,
+    _test_aborted_short_circuits,
+    _test_running_returns_pending,
+    _test_skipped_only_surfaces_invocation_skipped,
+    _test_skipped_with_success_prefers_successful_build,
+    _test_skipped_with_failure_prefers_failure,
+    _test_skipped_over_cap_keeps_accurate_count,
+]
+
 def _unit_test_impl(ctx):
-    _test_skipped_only_surfaces_invocation_skipped(ctx)
-    _test_skipped_with_success_prefers_successful_build(ctx)
-    _test_skipped_with_failure_prefers_failure(ctx)
-    _test_skipped_over_cap_keeps_accurate_count(ctx)
-    print("bazel_results.axl skipped-bucket: OK (4 sections)")
+    for t in _UNIT_TESTS:
+        t(ctx)
+    print("bazel_results.axl: OK (%d sections)" % len(_UNIT_TESTS))
     return 0
 
-bazel_results_skipped_tests = task(
-    name = "test-bazel-results-skipped",
+bazel_results_unit_tests = task(
+    name = "test-bazel-results",
     group = ["dev"],
     implementation = _unit_test_impl,
     args = {},


### PR DESCRIPTION
## Summary

When Bazel exits non-zero from a loading or analysis failure (e.g. an external-repo fetch timeout), it emits no `failed_action`, `failed_target`, or `Aborted` BES event. `compute_invocation_state` walked the bucket priority groups regardless of `status`, so the label fell through to `SUCCESSFUL_BUILD` and rendered "Successful build" on a check-run whose `conclusion` was correctly set to `failure` — bookend and title contradicted the verdict.

Reproduction in the field:
- https://github.com/aspect-build/aspect-cli/pull/1092/checks?check_run_id=76612702281 — `conclusion=failure`, title `❌ build //... · Successful build`
- https://github.com/aspect-build/aspect-cli/pull/1095/checks?check_run_id=76637717606 — same pattern

Fix: when `status == "failed"`, restrict the bucket walk to `_FAILURE_BUCKETS` (`FAILED_TO_BUILD`, `TEST_FAILED`, `TEST_TIMEOUT`) and fall back to "Failed to build" when none has data. Both surfaces (GitHub check-run title via `summary_title`, terminal bookend via `conclusion`) inherit the fix because both delegate to `compute_invocation_state`. Passing, warning, and aborted paths are unchanged.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Suggested release notes:

- **Bug fix:** build and test task surfaces no longer render "Successful build" in the check-run title or terminal bookend when Bazel exits non-zero with no BES failure data (e.g. external-repo fetch timeout). They now render "Failed to build" — consistent with the failure conclusion the surface already reported.

### Test plan

- `lib/bazel_results_test.axl` `bazel_results_unit_tests` (`aspect dev test-bazel-results`, 9 sections) covers the analysis-failure regression, explicit-failure, passing, aborted short-circuit, running, and the skipped-bucket priority cases.
- `aspect dev test-template-snapshots` renders all 18 scenarios without error.
