### PR TITLE
feat(workflows): append AXL tasks to runner_job_history file

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -13,6 +13,7 @@ load(
     "version_gte",
     "version_tuple",
 )
+load("@aspect//lib/ci.axl", "detect_build_url")
 load("@aspect//lib/deliveryd.axl", deliveryd_parse_endpoint = "parse_endpoint")
 load("@aspect//lib/environment.axl", "color_enabled", "detect_ci", "parse_git_url_name", "sanitize_filename")
 load(
@@ -21,7 +22,7 @@ load(
     "dir_at_or_below",
     "extract_changed_dirs",
 )
-load("@aspect//lib/github.axl", "detect_build_url", "detect_commit_sha", "github")
+load("@aspect//lib/github.axl", "detect_commit_sha", "github")
 load("@aspect//lib/path_glob.axl", "match_any", "match_path")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "dedup_and_attribute", "patch_download_cmd", "task_cli_path")
 load("@aspect//lib/result_text.axl", "severity_for_status")
@@ -1396,6 +1397,8 @@ _GH_PR_ENVS = [
     "BUILDKITE_COMMIT",
     "BUILDKITE_REPO",
     "BUILDKITE_BUILD_URL",
+    "BUILDKITE_JOB_ID",
+    "ASPECT_JOB_URL_CACHE",
     "CIRCLECI",
     "CIRCLE_PULL_REQUEST",
     "CIRCLE_SHA1",
@@ -2148,13 +2151,20 @@ def test_detect_build_url(ctx: TaskContext, tc: int) -> int:
     # No CI env → empty.
     tc = test_case(tc, detect_build_url(ctx) == "", "detect_build_url: no env → \"\"")
 
-    # Buildkite
+    # Buildkite — bare build URL when no job id is set.
     _clear_pr_env(env)
     env.set_var("BUILDKITE", "true")
     env.set_var("BUILDKITE_BUILD_URL", "https://buildkite.com/acme/widgets/builds/42")
-    tc = test_case(tc, detect_build_url(ctx) == "https://buildkite.com/acme/widgets/builds/42", "detect_build_url: Buildkite")
+    tc = test_case(tc, detect_build_url(ctx) == "https://buildkite.com/acme/widgets/builds/42", "detect_build_url: Buildkite (no job id)")
+
+    # Buildkite — job-anchored URL when BUILDKITE_JOB_ID is also set.
+    # Clear the URL cache so the prior bare-URL resolve isn't reused.
+    env.remove_var("ASPECT_JOB_URL_CACHE")
+    env.set_var("BUILDKITE_JOB_ID", "abc-123")
+    tc = test_case(tc, detect_build_url(ctx) == "https://buildkite.com/acme/widgets/builds/42#abc-123", "detect_build_url: Buildkite (with job id)")
 
     # Buildkite without BUILDKITE_BUILD_URL set.
+    env.remove_var("ASPECT_JOB_URL_CACHE")
     env.remove_var("BUILDKITE_BUILD_URL")
     tc = test_case(tc, detect_build_url(ctx) == "", "detect_build_url: Buildkite without URL → \"\"")
 
@@ -2185,8 +2195,21 @@ def test_detect_build_url(ctx: TaskContext, tc: int) -> int:
     tc = test_case(tc, got == expected, "detect_build_url: GHA falls back to run URL when auth unavailable (got %r)" % got)
 
     # GHA without GITHUB_REPOSITORY → empty.
+    env.remove_var("ASPECT_JOB_URL_CACHE")
     env.remove_var("GITHUB_REPOSITORY")
     tc = test_case(tc, detect_build_url(ctx) == "", "detect_build_url: GHA without GITHUB_REPOSITORY → \"\"")
+
+    # GHA cache hit: a previously-resolved job URL is reused as-is without
+    # touching the GitHub API.
+    _clear_pr_env(env)
+    env.set_var("GITHUB_ACTIONS", "true")
+    env.set_var("GITHUB_SERVER_URL", "https://github.com")
+    env.set_var("GITHUB_REPOSITORY", "fake-owner-axl-test/fake-repo-axl-test")
+    env.set_var("GITHUB_RUN_ID", "12345")
+    cached_job_url = "https://github.com/fake-owner-axl-test/fake-repo-axl-test/actions/runs/12345/job/99"
+    env.set_var("ASPECT_JOB_URL_CACHE", cached_job_url)
+    tc = test_case(tc, detect_build_url(ctx) == cached_job_url, "detect_build_url: GHA cache hit returns cached job URL")
+    env.remove_var("ASPECT_JOB_URL_CACHE")
 
     _clear_pr_env(env)
     return tc

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -12,6 +12,7 @@ load("@aspect//lib/gitlab_detect_test.axl", "gitlab_detect_tests")
 load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
 load("@aspect//lib/lint_results_test.axl", "lint_annotation_plan_tests", "lint_template_snapshot_tests")
 load("@aspect//lib/rate_limit_test.axl", "rate_limit_tests")
+load("@aspect//lib/runner_job_history_test.axl", "runner_job_history_tests")
 load("@aspect//lib/tips_test.axl", "tips_tests")
 load("@aspect//traits.axl", "BazelTrait", "LintTrait", "TipsTrait")
 load("./lambda.axl", "lambda_with_global_bind")
@@ -105,6 +106,12 @@ def config(ctx: ConfigContext):
     # `seed_from_rate_limit_body` + watermark badge rendering.
     # Run with: aspect dev test-rate-limit
     ctx.tasks.add(rate_limit_tests)
+
+    # Runner job history — exercises the silent-no-op + dedup behavior
+    # of `append_runner_job_history`. Scenario list lives in the test
+    # file's module docstring.
+    # Run with: aspect dev test-runner-job-history
+    ctx.tasks.add(runner_job_history_tests)
 
     # Delivery template snapshot tests — renders delivery_results templates.
     # Run with: aspect dev test-delivery-template-snapshots

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -131,6 +131,8 @@ steps:
       $$LAUNCHER dev test-tips
       echo "--- :aspect: aspect dev test-rate-limit"
       $$LAUNCHER dev test-rate-limit
+      echo "--- :aspect: aspect dev test-runner-job-history"
+      $$LAUNCHER dev test-runner-job-history
       echo "--- :aspect: aspect tests axl"
       # Run AXL tests last — cancel tests may kill the Bazel server,
       # which invalidates bazel-out paths used by $$LAUNCHER above.

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -127,6 +127,7 @@ User-facing migration guide: https://docs.aspect.build/cli/migration/delivery
 load("@aspect//bazel.axl", "BazelTrait")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("@aspect//lib/checkrun.axl", "GitHubCheckRunTrait")
+load("@aspect//lib/ci.axl", "detect_build_url")
 load("@aspect//lib/delivery_results.axl", delivery_add_result = "add_result", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
 load(
     "@aspect//lib/deliveryd.axl",
@@ -136,7 +137,7 @@ load(
     deliveryd_record = "record",
 )
 load("@aspect//lib/environment.axl", "color_enabled", "error", "info", "warn")
-load("@aspect//lib/github.axl", "detect_build_url", "detect_commit_sha")
+load("@aspect//lib/github.axl", "detect_commit_sha")
 load("@aspect//lib/health_check.axl", "HealthCheckTrait")
 load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
 load("@aspect//lib/rate_limit.axl", "GitHubApiRateLimitTrait")

--- a/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/artifacts.axl
@@ -60,6 +60,7 @@ features like GithubStatusChecks can surface download links:
 
 load("../bazel.axl", "BazelTrait")
 load("../lib/artifacts.axl", "ArtifactsTrait", "artifact_name", "create_uploader")
+load("../lib/ci.axl", "detect_artifacts_browse_url")
 load("../lib/environment.axl", "detect_ci", "info", "warn")
 
 def _record_artifact_url(artifacts_trait, kind, url):
@@ -74,7 +75,7 @@ def _record_artifact_url(artifacts_trait, kind, url):
     urls[kind] = url
     artifacts_trait.artifact_urls = urls
 
-def _update_testlogs_trait(artifacts_trait, state, env, ci):
+def _update_testlogs_trait(artifacts_trait, state, ctx):
     """Sync testlogs-related fields from upload state to the trait.
 
     - artifacts_browse_url → CI artifacts page/tab (always a browse URL)
@@ -84,7 +85,7 @@ def _update_testlogs_trait(artifacts_trait, state, env, ci):
     group = state.get("_artifact_upload", {}).get("testlogs", {})
 
     # Browse URL is the CI artifacts page/tab — always the "Artifacts" link in the check run.
-    browse = _make_artifacts_browse_url(env, ci)
+    browse = detect_artifacts_browse_url(ctx)
     if browse:
         artifacts_trait.artifacts_browse_url = browse
 
@@ -224,69 +225,6 @@ def _init_upload_state(state):
             "testlogs": {"last_count": 0, "version": 0, "prev_ref": None, "download_url": "", "label_urls": {}},
         }
 
-def _circleci_vcs(env):
-    """Infer CircleCI's VCS path segment from CIRCLE_REPOSITORY_URL.
-
-    The modern app.circleci.com URL contains a VCS segment:
-        .../pipelines/{github|bitbucket|circleci}/...
-    CircleCI doesn't expose it directly, but CIRCLE_REPOSITORY_URL (SSH or HTTPS
-    form) contains the host. Defaults to `github` for unrecognized hosts since
-    that's the overwhelmingly common case.
-    """
-    url = env.var("CIRCLE_REPOSITORY_URL") or ""
-    if "bitbucket.org" in url:
-        return "bitbucket"
-    return "github"
-
-def _make_artifacts_browse_url(env, ci):
-    """Construct the CI artifacts browse URL for the current job.
-
-    This URL goes to the page/tab where a user can see all artifacts uploaded
-    during the job — it's the "Artifacts" link in status checks.
-
-      GitHub:    {server}/{repo}/actions/runs/{run_id}                               (run page, artifacts section)
-      Buildkite: {BUILDKITE_BUILD_URL}/steps/canvas?sid={step}&tab=artifacts         (step artifacts tab)
-      CircleCI:  app.circleci.com/pipelines/{vcs}/{org}/{repo}/{pipeline_num}/
-                 workflows/{workflow_id}/jobs/{job_num}/artifacts                    (modern UI artifacts tab)
-      GitLab:    "" — GitLab's {job}/artifacts/browse only works for artifacts
-                 uploaded via the standard `artifacts:` config. We upload via
-                 the Generic Packages API (see `_upload_file_gitlab` in
-                 lib/artifacts.axl), which lands files in the project's Package
-                 Registry with no clean per-job page. Users see per-file
-                 download URLs via artifact_urls/testlogs_label_urls instead.
-
-    Returns "" if the necessary env vars are missing, or if the CI host has no
-    usable browse URL for this upload strategy.
-    """
-    if ci == "github":
-        server = env.var("GITHUB_SERVER_URL") or "https://github.com"
-        repo = env.var("GITHUB_REPOSITORY") or ""
-        run_id = env.var("GITHUB_RUN_ID") or ""
-        if repo and run_id:
-            return server + "/" + repo + "/actions/runs/" + run_id
-    elif ci == "buildkite":
-        build_url = env.var("BUILDKITE_BUILD_URL") or ""
-        step_id = env.var("BUILDKITE_STEP_ID") or ""
-        if build_url and step_id:
-            return build_url + "/steps/canvas?sid=" + step_id + "&tab=artifacts"
-        return build_url
-    elif ci == "circleci":
-        # Build the modern app.circleci.com URL. The legacy circleci.com hash
-        # anchors (#artifacts, /artifacts) don't route reliably anymore.
-        org = env.var("CIRCLE_PROJECT_USERNAME") or ""
-        repo = env.var("CIRCLE_PROJECT_REPONAME") or ""
-        pipeline_num = env.var("CIRCLE_PIPELINE_NUMBER") or ""
-        workflow_id = env.var("CIRCLE_WORKFLOW_ID") or ""
-        job_num = env.var("CIRCLE_BUILD_NUM") or ""
-        if org and repo and pipeline_num and workflow_id and job_num:
-            vcs = _circleci_vcs(env)
-            return ("https://app.circleci.com/pipelines/" + vcs + "/" + org + "/" + repo +
-                    "/" + pipeline_num + "/workflows/" + workflow_id + "/jobs/" + job_num + "/artifacts")
-
-        # Fall back to the legacy build URL if the pipeline env vars aren't set.
-        return env.var("CIRCLE_BUILD_URL") or ""
-    return ""
-
 def _artifact_upload_impl(ctx: FeatureContext):
     """Wire interval-based artifact upload into BazelTrait lifecycle hooks.
 
@@ -357,7 +295,7 @@ def _artifact_upload_impl(ctx: FeatureContext):
             # Surface URLs as soon as the first batch lands so
             # GithubStatusChecks can add download links quickly.
             if success:
-                _update_testlogs_trait(artifacts_trait, state, ctx.std.env, ci)
+                _update_testlogs_trait(artifacts_trait, state, ctx)
 
     def _on_build_end(ctx, exit_code):
         if not is_local:
@@ -384,7 +322,7 @@ def _artifact_upload_impl(ctx: FeatureContext):
 
                     # Refresh after final so URLs reflect the complete set.
                     if success:
-                        _update_testlogs_trait(artifacts_trait, state, ctx.std.env, ci)
+                        _update_testlogs_trait(artifacts_trait, state, ctx)
 
                 # Upload profile/bep/execlog (opt-in each). Buildkite
                 # returns empty download_urls so artifact_urls stays
@@ -416,7 +354,7 @@ def _artifact_upload_impl(ctx: FeatureContext):
                 # Buildkite artifact_urls is empty because download_urls
                 # are short-lived, so we can't rely on it alone.
                 if uploaded_any and not artifacts_trait.artifacts_browse_url:
-                    browse = _make_artifacts_browse_url(ctx.std.env, ci)
+                    browse = detect_artifacts_browse_url(ctx)
                     if browse:
                         artifacts_trait.artifacts_browse_url = browse
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -29,6 +29,7 @@ load(
     "renderer_for_kind",
     "should_emit_update",
 )
+load("../lib/ci.axl", "detect_build_url")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
 load("../lib/rate_limit.axl", "usage_footer")
@@ -238,16 +239,11 @@ def _buildkite_annotations(ctx: FeatureContext):
     _state = {}
 
     def _make_links(data):
-        # Minimal BK env scrape — the annotation IS on the BK job page,
-        # so we only need enough for the rendered summary's CI link.
-        build_url = ctx.std.env.var("BUILDKITE_BUILD_URL") or ""
-        step_id = ctx.std.env.var("BUILDKITE_STEP_ID") or ""
-        ci_url = build_url
-        if build_url and step_id:
-            ci_url = build_url + "/steps/canvas?sid=" + step_id
+        # The annotation IS on the BK job page, so we only need enough for
+        # the rendered summary's CI link.
         links = {
             "ci_label": "Buildkite",
-            "ci_url": ci_url,
+            "ci_url": detect_build_url(ctx),
             "aspect_url": "",
             "bes_url": "",
             "results_base_url": workflows_results_url(ctx.std),

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -44,6 +44,7 @@ load(
     "should_emit_update",
 )
 load("../lib/checkrun.axl", "GitHubCheckRunTrait")
+load("../lib/ci.axl", "detect_build_url", "detect_ci_host")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/github.axl", "detect_commit_sha", "detect_github_repo", "github")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
@@ -115,36 +116,12 @@ def _detect_triggered_by(env):
         return env.var("GITLAB_USER_LOGIN") or "GitLab CI"
     return ""
 
-def _collect_ci_links(env, results_base_url):
-    """Collect CI job URL and optional Aspect Web UI URL from the environment."""
-    ci_label = ""
-    ci_url = ""
-
-    if env.var("GITHUB_ACTIONS"):
-        ci_label = "GitHub Actions"
-        server = env.var("GITHUB_SERVER_URL") or "https://github.com"
-        repository = env.var("GITHUB_REPOSITORY") or ""
-        run_id = env.var("GITHUB_RUN_ID") or ""
-        if repository and run_id:
-            ci_url = server + "/" + repository + "/actions/runs/" + run_id
-    elif env.var("BUILDKITE"):
-        ci_label = "Buildkite"
-        build_url = env.var("BUILDKITE_BUILD_URL") or ""
-        step_id = env.var("BUILDKITE_STEP_ID") or ""
-        if build_url and step_id:
-            ci_url = build_url + "/steps/canvas?sid=" + step_id
-        else:
-            ci_url = build_url
-    elif env.var("CIRCLECI"):
-        ci_label = "CircleCI"
-        ci_url = env.var("CIRCLE_BUILD_URL") or ""
-    elif env.var("GITLAB_CI"):
-        ci_label = "GitLab CI"
-        ci_url = env.var("CI_JOB_URL") or ""
-
+def _collect_ci_links(ctx, results_base_url):
+    """Collect CI job URL and label, plus placeholders for sibling-feature URLs."""
+    host = detect_ci_host(ctx.std.env)
     return {
-        "ci_label": ci_label,
-        "ci_url": ci_url,
+        "ci_label": host["label"] if host else "",
+        "ci_url": detect_build_url(ctx),
         "aspect_url": "",
         "bes_url": "",
         "results_base_url": results_base_url,
@@ -181,7 +158,7 @@ def _github_status_checks(ctx: FeatureContext):
     if not sha or not owner or not repo:
         return
 
-    _ci_links_base = _collect_ci_links(ctx.std.env, workflows_results_url(ctx.std))
+    _ci_links_base = _collect_ci_links(ctx, workflows_results_url(ctx.std))
 
     # Sub-1-second cadences would burn API quota and rarely surface as
     # something a reviewer can react to in time — clamp to 1s floor.
@@ -251,18 +228,10 @@ def _github_status_checks(ctx: FeatureContext):
             return
         _state["_github_token"] = token
 
-        # Upgrade the CI link from the run page to the specific job
-        # page; falls back to the run URL if neither token has
-        # actions:read. Job URL lookup doesn't need App attribution,
-        # so spare App quota when a job-scoped GITHUB_TOKEN is
-        # exported. The check-run token is reused as the App fallback
-        # so `_resolve_current_job_url` can retry on 4xx-auth.
-        if ctx.std.env.var("GITHUB_ACTIONS"):
-            run_id = ctx.std.env.var("GITHUB_RUN_ID") or ""
-            read_token, read_fallback, read_class = github.preferred_token_pair(ctx, owner = owner, repo = repo, roles = ["actions.read"], existing_app_token = token)
-            job_url = github.resolve_current_job_url(ctx, read_token, owner, repo, run_id, fallback_token = read_fallback, token_class = read_class)
-            if job_url:
-                _ci_links_base["ci_url"] = job_url
+        # Re-resolve with the just-minted App token: upgrades the GHA
+        # run URL to the per-job URL if `_collect_ci_links` couldn't
+        # auth at feature setup. Hits the cache on the typical path.
+        _ci_links_base["ci_url"] = detect_build_url(ctx, existing_app_token = token) or _ci_links_base["ci_url"]
         _state["_ci_links"] = _ci_links_base
 
         # No `task_update.kind` yet — pick by task name, falling

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -41,6 +41,7 @@ load(
     "resolve_aspect_url",
 )
 load("../lib/checkrun.axl", "GitHubCheckRunTrait")
+load("../lib/ci.axl", "detect_build_url")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/github.axl", "github")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait")
@@ -1201,20 +1202,11 @@ def _github_status_comments(ctx: FeatureContext):
             return
         _state["_github_token"] = token
 
-        # Upgrade the GHA workflow-run URL to the per-job URL via the
-        # GitHub Actions API. Same path as
-        # `feature/github_status_checks.axl::_create_check_run`. Routed
-        # through the GH_TOKEN-preferring resolver — the job URL
-        # lookup doesn't need App attribution, so spare the App
-        # quota when the workflow exposes a job-scoped token. The
-        # check-run feature's App token (already in scope) is passed
-        # as the 4xx-auth fallback. Falls back silently to
-        # `_ci_run_url` if neither token has `actions:read`.
-        if run_id:
-            read_token, read_fallback, read_class = github.preferred_token_pair(ctx, owner = owner, repo = repo, roles = ["actions.read"], existing_app_token = token)
-            job_url = github.resolve_current_job_url(ctx, read_token, owner, repo, run_id, fallback_token = read_fallback, token_class = read_class)
-            if job_url:
-                _state["_ci_link_url"] = job_url
+        # Re-resolve with the just-minted App token; cache-hits if a
+        # sibling feature already resolved.
+        upgraded = detect_build_url(ctx, existing_app_token = token)
+        if upgraded:
+            _state["_ci_link_url"] = upgraded
 
         _publish(ctx)
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -46,6 +46,7 @@ isn't worth it for a check run display. We show the failing target label plus
 the list of failing action mnemonics; users follow the CI link for the raw log.
 """
 
+load("./ci.axl", "detect_build_url", "detect_ci_host")
 load(
     "./environment.axl",
     "build_aspect_runner_rows",
@@ -2441,40 +2442,18 @@ STATUS_LABELS = {
 def ci_link_item(ctx, links):
     """Build the CI-host link item for the final summary row.
 
-    Prefers a pre-resolved ci_url from the feature (e.g. a job-level deep link
-    resolved against the GitHub API); falls back to deriving from env vars so
-    the link works even when the feature doesn't pass one through.
+    Prefers the feature-supplied `links["ci_url"]` (which may be a
+    job-scoped deep link resolved against the GitHub API); falls back to
+    `detect_build_url` so the link works even when the feature doesn't
+    pass one through.
     """
-    env = ctx.std.env
-    override_url = (links or {}).get("ci_url", "") or ""
-    if env.var("GITHUB_ACTIONS"):
-        url = override_url
-        if not url:
-            server = env.var("GITHUB_SERVER_URL") or "https://github.com"
-            repo = env.var("GITHUB_REPOSITORY") or ""
-            run_id = env.var("GITHUB_RUN_ID") or ""
-            if repo and run_id:
-                url = server + "/" + repo + "/actions/runs/" + run_id
-        if url:
-            return {"icon": "🐙", "value": "[GitHub Actions](" + url + ")"}
-    elif env.var("BUILDKITE"):
-        url = override_url
-        if not url:
-            build_url = env.var("BUILDKITE_BUILD_URL") or ""
-            step_id = env.var("BUILDKITE_STEP_ID") or ""
-            if build_url:
-                url = build_url + "/steps/canvas?sid=" + step_id if step_id else build_url
-        if url:
-            return {"icon": "🏗", "value": "[Buildkite](" + url + ")"}
-    elif env.var("CIRCLECI"):
-        url = override_url or env.var("CIRCLE_BUILD_URL") or ""
-        if url:
-            return {"icon": "⭕", "value": "[CircleCI](" + url + ")"}
-    elif env.var("GITLAB_CI"):
-        url = override_url or env.var("CI_JOB_URL") or ""
-        if url:
-            return {"icon": "🦊", "value": "[GitLab CI](" + url + ")"}
-    return None
+    host = detect_ci_host(ctx.std.env)
+    if not host:
+        return None
+    url = (links or {}).get("ci_url", "") or detect_build_url(ctx)
+    if not url:
+        return None
+    return {"icon": host["icon"], "value": "[%s](%s)" % (host["label"], url)}
 
 def _titlecase(s):
     """Title-case the first character and convert underscores to spaces.

--- a/crates/aspect-cli/src/builtins/aspect/lib/build_metadata.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/build_metadata.axl
@@ -12,6 +12,8 @@ kilgore/app/layout/header/ExecutionContext.tsx). Canonical values are
 uppercase enum-style strings (VCS=GITHUB, CI_HOST=BUILDKITE, …).
 """
 
+load("./ci.axl", "detect_buildkite_build_url")
+
 _VCS_HOST_TO_ENUM = {
     "github.com": "GITHUB",
     "gitlab.com": "GITLAB",
@@ -322,15 +324,10 @@ def _collect_buildkite(env, meta):
     else:
         meta["RUN_TYPE"] = "BRANCH_PUSH"
 
-    # BUILD_URL should match exactly what the status-check CI link points at
-    # — the per-step "Buildkite" link in summary row 6. Without the step-id
-    # query suffix the link lands on the build page, not on this specific
-    # step's job page, which is often not what the user wants.
-    build_url = env.var("BUILDKITE_BUILD_URL") or ""
-    step_id = env.var("BUILDKITE_STEP_ID") or ""
-    if build_url and step_id:
-        meta["BUILD_URL"] = build_url + "/steps/canvas?sid=" + step_id
-    elif build_url:
+    # BUILD_URL — the job-anchored form so the link lands on the specific
+    # job execution rather than the build root.
+    build_url = detect_buildkite_build_url(env)
+    if build_url:
         meta["BUILD_URL"] = build_url
 
 # ---------------------------------------------------------------------------

--- a/crates/aspect-cli/src/builtins/aspect/lib/ci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/ci.axl
@@ -1,0 +1,159 @@
+"""Cross-CI URL helpers.
+
+`detect_build_url` and `detect_artifacts_browse_url` centralize the
+URL shapes status surfaces, build metadata, and the runner job history
+all need. Each CI host yields a job-scoped URL when one is available
+so links land on the specific execution, not the build root.
+
+Shapes by host:
+
+  - GitHub Actions
+      build URL       — `<server>/<repo>/actions/runs/<run_id>` upgraded
+                        to `.../job/<job_id>` when the Aspect Workflows
+                        GitHub App is authenticated (`actions:read`).
+      artifacts URL   — the run page (the artifacts section lives there).
+  - Buildkite
+      build URL       — `<BUILDKITE_BUILD_URL>#<BUILDKITE_JOB_ID>`; the
+                        fragment anchor scrolls to the specific job.
+      artifacts URL   — `<BUILDKITE_BUILD_URL>/steps/canvas?sid=<step>&tab=artifacts`
+                        opens the step's artifacts tab.
+  - CircleCI
+      build URL       — `CIRCLE_BUILD_URL` (job-scoped already).
+      artifacts URL   — modern `app.circleci.com/.../artifacts` URL.
+  - GitLab
+      build URL       — `CI_JOB_URL` (job-scoped already).
+      artifacts URL   — `""`; our artifact upload uses the Generic
+                        Packages API, which has no clean per-job page.
+"""
+
+load("./github.axl", "detect_github_actions_build_url")
+
+# Per-process env var holding the once-resolved build URL. Populated by
+# the first `detect_build_url` caller in the task; subsequent callers
+# (sibling features, per-render lookups) short-circuit to this value.
+_JOB_URL_CACHE_ENV = "ASPECT_JOB_URL_CACHE"
+
+# Per-CI-host metadata. Order is the detection precedence: `detect_ci_host`
+# returns the first entry whose `marker` env var is set.
+_CI_HOSTS = [
+    {"marker": "GITHUB_ACTIONS", "label": "GitHub Actions", "icon": "🐙"},
+    {"marker": "BUILDKITE", "label": "Buildkite", "icon": "🏗"},
+    {"marker": "CIRCLECI", "label": "CircleCI", "icon": "⭕"},
+    {"marker": "GITLAB_CI", "label": "GitLab CI", "icon": "🦊"},
+]
+
+def detect_ci_host(env):
+    """Return the matching `_CI_HOSTS` entry for the current env, or `None`.
+
+    Entry shape: `{"marker": str, "label": str, "icon": str}`. Used by
+    status surfaces that need a human-readable CI label and/or icon
+    alongside the URL `detect_build_url` returns.
+    """
+    for host in _CI_HOSTS:
+        if env.var(host["marker"]):
+            return host
+    return None
+
+def detect_buildkite_build_url(env):
+    """Buildkite job-anchored build URL.
+
+    Returns `BUILDKITE_BUILD_URL#BUILDKITE_JOB_ID` when both env vars are
+    set; the bare build URL when only `BUILDKITE_BUILD_URL` is present;
+    or "" otherwise. Exposed as an `env`-only helper for callers that
+    don't have a full `ctx` in scope (e.g. the `_collect_*` metadata
+    functions in `lib/build_metadata.axl`).
+    """
+    build_url = env.var("BUILDKITE_BUILD_URL") or ""
+    job_id = env.var("BUILDKITE_JOB_ID") or ""
+    if build_url and job_id:
+        return build_url + "#" + job_id
+    return build_url
+
+def detect_build_url(ctx, existing_app_token = None):
+    """Detect the job-scoped CI build URL from the environment.
+
+    Returns the URL of the running CI build (the page a developer would
+    visit to see logs/status), or "" if no recognized CI host is detected
+    or the env vars aren't populated. See the module docstring for the
+    per-host shape.
+
+    Caches the resolved URL in `ASPECT_JOB_URL_CACHE` so sibling callers
+    in the same task share the result without re-resolving. Only GHA's
+    job URL requires an API call; the cache makes subsequent renders /
+    sibling features free.
+
+    `existing_app_token` is forwarded to the GHA upgrade path so a caller
+    with a freshly-minted App token in hand can skip a redundant mint.
+    """
+    env = ctx.std.env
+    cached = env.var(_JOB_URL_CACHE_ENV) or ""
+    if cached:
+        return cached
+    if env.var("GITHUB_ACTIONS"):
+        url = detect_github_actions_build_url(ctx, existing_app_token = existing_app_token)
+    elif env.var("BUILDKITE"):
+        url = detect_buildkite_build_url(env)
+    elif env.var("CIRCLECI"):
+        url = env.var("CIRCLE_BUILD_URL") or ""
+    elif env.var("GITLAB_CI"):
+        url = env.var("CI_JOB_URL") or ""
+    else:
+        return ""
+    if url:
+        env.set_var(_JOB_URL_CACHE_ENV, url)
+    return url
+
+def _circleci_vcs(env):
+    """Infer CircleCI's VCS path segment from CIRCLE_REPOSITORY_URL.
+
+    The modern app.circleci.com URL contains a VCS segment:
+        .../pipelines/{github|bitbucket|circleci}/...
+    CircleCI doesn't expose it directly, but CIRCLE_REPOSITORY_URL (SSH or
+    HTTPS form) contains the host. Defaults to `github` for unrecognized
+    hosts since that's the overwhelmingly common case.
+    """
+    url = env.var("CIRCLE_REPOSITORY_URL") or ""
+    if "bitbucket.org" in url:
+        return "bitbucket"
+    return "github"
+
+def detect_artifacts_browse_url(ctx):
+    """Detect the CI artifacts browse URL for the current job.
+
+    This URL goes to the page/tab where a user can see all artifacts
+    uploaded during the job — it's the "Artifacts" link in status checks.
+    See the module docstring for the per-host shape.
+    """
+    env = ctx.std.env
+    if env.var("GITHUB_ACTIONS"):
+        server = env.var("GITHUB_SERVER_URL") or "https://github.com"
+        repo = env.var("GITHUB_REPOSITORY") or ""
+        run_id = env.var("GITHUB_RUN_ID") or ""
+        if repo and run_id:
+            return server + "/" + repo + "/actions/runs/" + run_id
+    elif env.var("BUILDKITE"):
+        build_url = env.var("BUILDKITE_BUILD_URL") or ""
+        step_id = env.var("BUILDKITE_STEP_ID") or ""
+        if build_url and step_id:
+            return build_url + "/steps/canvas?sid=" + step_id + "&tab=artifacts"
+        return build_url
+    elif env.var("CIRCLECI"):
+        # Modern app.circleci.com URL — the legacy circleci.com hash
+        # anchors (#artifacts, /artifacts) don't route reliably anymore.
+        org = env.var("CIRCLE_PROJECT_USERNAME") or ""
+        repo = env.var("CIRCLE_PROJECT_REPONAME") or ""
+        pipeline_num = env.var("CIRCLE_PIPELINE_NUMBER") or ""
+        workflow_id = env.var("CIRCLE_WORKFLOW_ID") or ""
+        job_num = env.var("CIRCLE_BUILD_NUM") or ""
+        if org and repo and pipeline_num and workflow_id and job_num:
+            vcs = _circleci_vcs(env)
+            return ("https://app.circleci.com/pipelines/" + vcs + "/" + org + "/" + repo +
+                    "/" + pipeline_num + "/workflows/" + workflow_id + "/jobs/" + job_num + "/artifacts")
+
+        # Fall back to the legacy build URL if the pipeline env vars aren't set.
+        return env.var("CIRCLE_BUILD_URL") or ""
+
+    # GitLab: artifact upload uses the Generic Packages API (see
+    # `_upload_file_gitlab` in lib/artifacts.axl), which lands files
+    # in the project's Package Registry with no clean per-job page.
+    return ""

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -642,42 +642,41 @@ def detect_default_branch_ref(ctx):
 
     return ""
 
-def detect_build_url(ctx):
-    """Detect the CI build URL from common environment variables.
+def detect_github_actions_build_url(ctx, existing_app_token = None):
+    """GitHub Actions build URL — job-scoped when the App is authenticated.
 
-    Returns the URL of the running CI build (the page a developer would visit
-    to see logs/status), or "" if no recognized CI host is detected.
+    Returns the run URL `/actions/runs/<run_id>` and transparently upgrades
+    to the per-job URL `/actions/runs/<run_id>/job/<job_id>` when the Aspect
+    Workflows GitHub App is authenticated with `actions:read`. Silently
+    falls back to the run URL on any failure. Returns "" off-GHA or when
+    the required env vars are missing.
 
-    On GitHub Actions, transparently upgrades the run URL
-    (`/actions/runs/<run_id>`) to the specific job URL
-    (`/actions/runs/<run_id>/job/<job_id>`) when the Aspect Workflows GitHub
-    App is installed and the active ASPECT_API_TOKEN has the `actions:read`
-    scope. Silently falls back to the run URL on any failure (no app,
-    missing scope, API error).
+    Exposed here (rather than in `lib/ci.axl`) so the multi-CI wrapper can
+    delegate without needing access to the module-private token helpers.
+
+    `existing_app_token` lets a caller that already minted an App token in
+    the same handler skip a redundant mint.
+
+    The caller (`lib/ci.axl::detect_build_url`) is responsible for caching
+    so the `_resolve_current_job_url` HTTP call only happens once per task.
     """
     env = ctx.std.env
-    if env.var("GITHUB_ACTIONS"):
-        server = env.var("GITHUB_SERVER_URL") or "https://github.com"
-        repository = env.var("GITHUB_REPOSITORY") or ""
-        run_id = env.var("GITHUB_RUN_ID") or ""
-        if not (repository and run_id):
-            return ""
-        run_url = server + "/" + repository + "/actions/runs/" + run_id
-        owner, repo = detect_github_repo(ctx.std)
-        if owner and repo:
-            token, fallback, token_class = _preferred_token_pair(ctx, owner, repo, roles = ["actions.read"])
-            if token:
-                job_url = _resolve_current_job_url(ctx, token, owner, repo, run_id, fallback_token = fallback, token_class = token_class)
-                if job_url:
-                    return job_url
-        return run_url
-    if env.var("BUILDKITE"):
-        return env.var("BUILDKITE_BUILD_URL") or ""
-    if env.var("CIRCLECI"):
-        return env.var("CIRCLE_BUILD_URL") or ""
-    if env.var("GITLAB_CI"):
-        return env.var("CI_JOB_URL") or ""
-    return ""
+    if not env.var("GITHUB_ACTIONS"):
+        return ""
+    server = env.var("GITHUB_SERVER_URL") or "https://github.com"
+    repository = env.var("GITHUB_REPOSITORY") or ""
+    run_id = env.var("GITHUB_RUN_ID") or ""
+    if not (repository and run_id):
+        return ""
+    run_url = server + "/" + repository + "/actions/runs/" + run_id
+    owner, repo = detect_github_repo(ctx.std)
+    if owner and repo:
+        token, fallback, token_class = _preferred_token_pair(ctx, owner, repo, roles = ["actions.read"], existing_app_token = existing_app_token)
+        if token:
+            job_url = _resolve_current_job_url(ctx, token, owner, repo, run_id, fallback_token = fallback, token_class = token_class)
+            if job_url:
+                return job_url
+    return run_url
 
 def detect_github_pr(std):
     """Detect GitHub pull-request context from common CI environment variables.

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -56,6 +56,7 @@ the verdict.
 
 load("./environment.axl", "color_enabled", "detect_ci")
 load("./github.axl", "detect_github_repo", "github")
+load("./runner_job_history.axl", "append_runner_job_history")
 
 # Structured update passed to task_update hooks.
 #
@@ -559,7 +560,12 @@ def setup_phase(ctx, lifecycle):
     `lifecycle.task_started` handlers. No-op when:
       - the trait has no started handlers, or
       - we're not running on a recognized CI host.
+
+    `append_runner_job_history` fires up top — it self-gates on
+    `ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE`, so every task on a
+    Workflows runner records an entry independent of CI detection.
     """
+    append_runner_job_history(ctx)
     if not lifecycle.task_started:
         return
     if not _on_ci(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history.axl
@@ -1,0 +1,146 @@
+"""Runner job history — append-once-per-task to the Workflows
+`runner_job_history` file so Vigor's "Number of builds on this runner"
+status check renders an entry for every aspect-cli task, matching the
+historical Rosetta behavior.
+
+File format (line-per-task, opaque to the consumer):
+
+    [<human-readable date>] <task-URL> <task-path> <task-key>\\n
+
+Vigor reads the file, counts non-empty lines, and prints the latest 10
+verbatim. The date is rendered for humans (no parsing on the read
+side); we still match Rosetta's `new Date().toString()` shape closely
+so a single status check can mix Rosetta-era and AXL-era entries
+without visual jank. The trailing `<task-path>` (colon-separated
+group + name, e.g. `dev:test-runner-job-history`) and `<task-key>`
+fields are AXL-era additions — Rosetta wrote only `[<date>] <URL>`,
+and its reader regex strips the bracket prefix and treats the rest as
+the dedup key, so the extra trailing fields are forwards-compatible
+on both sides.
+
+Plumbing:
+
+  - `ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE` — path to write. Unset
+    off-runner; we silently skip. Default on Workflows runners is
+    `/etc/aspect/workflows/platform/runner_job_history`.
+  - `append_runner_job_history(ctx)` — single entry-point, designed to
+    be called once per task from the lifecycle's `setup_phase`.
+
+Hard invariant: a failure to write the history file must NEVER fail
+the task. Every error path here is a silent no-op — missing env var,
+missing parent dir, permission denied, unwritable file, unreadable
+file, no URL to record. The user-visible task surface stays unchanged
+whether or not the runner history file write succeeds.
+
+Dedup: skip the append when the post-`] ` portion already appears as
+a line tail in the file. The dedup key is the full
+`<URL> <task-path> <task-key>` triple, so the same (job, task, key)
+tuple appearing across multiple aspect-cli invocations on a warm
+runner won't bloat the file. Different tasks on the same job land as
+distinct rows — an improvement over Rosetta's URL-only dedup, which
+collapsed all tasks in one job to a single entry.
+"""
+
+load("./ci.axl", "detect_build_url")
+
+# Env var the agent populates with the path. Mirrors
+# `PlatformConfigurationFiles.RUNNER_JOB_HISTORY()` on the Rosetta /
+# Vigor side — the agent points both writers and the readers at the
+# same file.
+_HISTORY_PATH_ENV = "ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE"
+
+def _task_path(ctx):
+    """Colon-separated invocation path: `<group>:<name>`, or just `<name>`
+    when the task has no group. Mirrors the `aspect <group> <name>` CLI
+    shape (`aspect build` → `build`, `aspect dev test-foo` → `dev:test-foo`).
+    """
+    groups = ctx.task.group
+    if not groups:
+        return ctx.task.name
+    return ":".join(groups + [ctx.task.name])
+
+def _format_date(ctx):
+    """Human-readable timestamp for the `[<date>]` prefix.
+
+    Rosetta uses JS `Date.toString()` which produces
+    `Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)`.
+    We match the leading shape — `%a %b %d %Y %H:%M:%S GMT%z` — close
+    enough that a Rosetta-era line and an aspect-cli-era line render
+    consistently in Vigor's "Most recently" list. The trailing
+    `(Coordinated Universal Time)` annotation is JS-specific and not
+    parsed by anything; we drop it.
+
+    Falls back to an empty string on `date` failure; the caller treats
+    that as "skip the write" since a bare `[]` prefix is uglier than
+    no entry at all.
+    """
+    result = ctx.std.process.command("date").args(["+%a %b %d %Y %H:%M:%S GMT%z"]).stdout("piped").stderr("null").spawn().wait_with_output()
+    if result.status.code != 0:
+        return ""
+    return result.stdout.strip()
+
+def _existing_dedup_keys(ctx, path):
+    """Parse the post-prefix dedup payload out of each history line.
+
+    Each line has the shape `[<date>] <dedup-key>` (where dedup-key is
+    `<url> <path> <key>` for AXL-era entries or just `<url>` for
+    Rosetta-era entries). We split on `] ` and take the trimmed
+    remainder as the dedup key. Lines that don't match the prefix
+    shape are ignored — a malformed entry (hand-edit, partial write
+    from a crashed process) must not corrupt the dedup set.
+
+    Returns an empty set on any read failure (missing file, perms,
+    non-UTF-8 content). `try_read_to_string` swallows I/O errors so
+    the lifecycle hook never raises on a misconfigured runner. The
+    caller treats an empty set as "no dedup", which falls through to
+    a fresh append.
+    """
+    text = ctx.std.fs.try_read_to_string(path)
+    keys = {}
+    for line in text.split("\n"):
+        if not line:
+            continue
+        idx = line.find("] ")
+        if idx < 0:
+            continue
+        key = line[idx + 2:].strip()
+        if key:
+            keys[key] = True
+    return keys
+
+def append_runner_job_history(ctx):
+    """Append a `[<date>] <url> <path> <key>` line to the runner history file.
+
+    Silent no-op when:
+      - `ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE` is unset (off-runner).
+      - No task URL can be derived (off-CI, missing env signals).
+      - The same `<url> <path> <key>` triple is already in the file (dedup).
+        Dedup tolerates an unreadable file via `try_read_to_string`,
+        which degrades to "no dedup".
+      - The `date` shell-out fails (rare; a bare `[]` prefix is uglier
+        than no entry).
+      - The append itself fails — permissions, missing parent dir,
+        target is a directory, disk full. The hard invariant is that
+        history-file plumbing never fails the task; every error path
+        is swallowed.
+
+    Returns `True` when a line was appended, `False` otherwise. The
+    return is for tests — production callers ignore it.
+    """
+    path = ctx.std.env.var(_HISTORY_PATH_ENV)
+    if not path:
+        return False
+
+    task_url = detect_build_url(ctx)
+    if not task_url:
+        return False
+
+    dedup_key = "%s %s %s" % (task_url, _task_path(ctx), ctx.task.key)
+    if dedup_key in _existing_dedup_keys(ctx, path):
+        return False
+
+    date_str = _format_date(ctx)
+    if not date_str:
+        return False
+
+    return ctx.std.fs.try_append(path, "[%s] %s\n" % (date_str, dedup_key))

--- a/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history_test.axl
@@ -1,0 +1,347 @@
+"""Tests for `lib/runner_job_history.axl`.
+
+Covers:
+  - Round-trip: setting `ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE`
+    + a recognized CI env var, calling `append_runner_job_history`,
+    reading the file back, and asserting one well-formed line.
+  - Env-var-unset: no file is created, no failure.
+  - Empty / no-CI: no task URL → no file is created, no failure.
+  - Dedup: a second call with the same task URL doesn't append.
+  - Distinct URLs: a different `BUILDKITE_JOB_ID` lands a second line.
+  - Unreadable existing file: dedup-read failure (chmod 000) silently
+    falls back to "no dedup" instead of raising — exercises the
+    never-fail invariant on a misconfigured / locked-down history
+    file.
+  - Unwritable path: writing to a path under a non-existent directory
+    silently no-ops (the file write returns False, the task is
+    unaffected).
+  - Concurrent-write safety: many short appends round-trip with
+    every record landing intact (POSIX `O_APPEND` covers writes
+    ≤ `PIPE_BUF`, which the `[<date>] <url> <path> <key>` line
+    easily fits in).
+
+The test exercises real fs / env / process — there's no mocking
+layer in AXL, and the production module already isolates I/O behind
+silent-no-op helpers so error paths are exercised directly.
+
+Run with:
+  aspect dev test-runner-job-history
+"""
+
+load("./runner_job_history.axl", "append_runner_job_history")
+
+# Env vars we set/restore around each subtest so the runner CI
+# environment doesn't leak into other test cases (or vice versa).
+# Buildkite is the simplest CI host to fake — two env vars produce a
+# fully-formed task URL `<build_url>#<job_id>`.
+_ENV_KEYS = [
+    "ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE",
+    "ASPECT_JOB_URL_CACHE",
+    "BUILDKITE",
+    "BUILDKITE_BUILD_URL",
+    "BUILDKITE_JOB_ID",
+    "GITHUB_ACTIONS",
+    "CIRCLECI",
+    "GITLAB_CI",
+]
+
+def _snapshot_env(ctx):
+    """Capture the current values of every env var this test touches.
+
+    Returned as a dict keyed by env name; `None` means "was unset".
+    `_restore_env` reverses it so every subtest starts and ends from
+    the same baseline regardless of which CI host the test harness
+    happens to be running on.
+    """
+    return {k: ctx.std.env.var(k) for k in _ENV_KEYS}
+
+def _restore_env(ctx, snapshot):
+    for k, v in snapshot.items():
+        if v == None:
+            ctx.std.env.remove_var(k)
+        else:
+            ctx.std.env.set_var(k, v)
+
+def _clear_ci_env(ctx):
+    """Drop every CI-host marker so `detect_build_url` returns "" on
+    the catch-all path. Used by subtests that want to assert the
+    "no task URL" no-op branch independently of whatever CI host
+    happens to be active."""
+    for k in _ENV_KEYS:
+        ctx.std.env.remove_var(k)
+
+def _set_bk_env(ctx, history_path, build_url = "https://buildkite.com/aspect-build/aspect-cli/builds/42", job_id = "job-1"):
+    """Configure a fake Buildkite runner: history file + the two env
+    vars `_task_url` reads. Returns the expected task URL so callers
+    don't reconstruct the format in two places."""
+    _clear_ci_env(ctx)
+    ctx.std.env.set_var("ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE", history_path)
+    ctx.std.env.set_var("BUILDKITE", "true")
+    ctx.std.env.set_var("BUILDKITE_BUILD_URL", build_url)
+    ctx.std.env.set_var("BUILDKITE_JOB_ID", job_id)
+    return build_url + "#" + job_id
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _assert(label, cond):
+    if not cond:
+        fail("%s: condition false" % label)
+
+def _read_lines(ctx, path):
+    """Read the history file and return its non-empty lines. Returns
+    [] when the file doesn't exist — every "should not have written"
+    assertion treats both states identically."""
+    if not ctx.std.fs.exists(path):
+        return []
+    text = ctx.std.fs.read_to_string(path)
+    return [line for line in text.split("\n") if line]
+
+def _tmpdir(ctx):
+    """Create + return a fresh temp directory for an isolated test run.
+
+    Each subtest gets its own root so a leftover file from one case
+    can't interfere with assertions in another, and the test harness
+    can be re-run any number of times without manual cleanup.
+    """
+    return ctx.std.fs.mkdtemp(prefix = "axl-runner-job-history-test-")
+
+def _cleanup(ctx, tmpdir):
+    """Best-effort cleanup. AXL has no try/except, so we just remove
+    the directory tree if it's still there — every test directory is
+    freshly minted by `mkdtemp` so removal should succeed in the
+    happy path. Any leftover dirs from a crash get GC'd by the
+    system temp cleanup on the next reboot."""
+    if ctx.std.fs.exists(tmpdir):
+        ctx.std.fs.remove_dir_all(tmpdir)
+
+def _test_no_env_no_write(ctx):
+    """`ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE` unset → silent no-op.
+
+    The function returns False and writes nothing. Critical because
+    every aspect-cli invocation outside a Workflows runner hits this
+    branch — must not error, must not create stray files.
+    """
+    snapshot = _snapshot_env(ctx)
+    _clear_ci_env(ctx)
+
+    # No history-file env → no-op even with full CI env populated.
+    ctx.std.env.set_var("BUILDKITE", "true")
+    ctx.std.env.set_var("BUILDKITE_BUILD_URL", "https://example/build/1")
+    ctx.std.env.set_var("BUILDKITE_JOB_ID", "job-1")
+    result = append_runner_job_history(ctx)
+    _eq("no-env — append returns False", result, False)
+
+    _restore_env(ctx, snapshot)
+
+def _test_no_task_url_no_write(ctx):
+    """History env set but no CI markers → no task URL → no-op.
+
+    Production case: a misconfigured runner that exports the history
+    path but the actual CI host hasn't populated its build-URL env
+    yet. Must not write an empty `[<date>] ` line — that would render
+    as a useless row in Vigor's "Most recently" list.
+    """
+    snapshot = _snapshot_env(ctx)
+    tmpdir = _tmpdir(ctx)
+    history_path = tmpdir + "/history"
+
+    _clear_ci_env(ctx)
+    ctx.std.env.set_var("ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE", history_path)
+
+    result = append_runner_job_history(ctx)
+    _eq("no-url — append returns False", result, False)
+    _eq("no-url — no file created", ctx.std.fs.exists(history_path), False)
+
+    _cleanup(ctx, tmpdir)
+    _restore_env(ctx, snapshot)
+
+def _test_round_trip(ctx):
+    """Happy path: env set + CI markers populated → exactly one line
+    is appended with the `[<date>] <url> <path> <key>` shape.
+
+    The date string is dynamic so we slice on `] ` and assert the
+    post-prefix tokens directly.
+    """
+    snapshot = _snapshot_env(ctx)
+    tmpdir = _tmpdir(ctx)
+    history_path = tmpdir + "/history"
+
+    expected_url = _set_bk_env(ctx, history_path, job_id = "round-trip-job")
+
+    result = append_runner_job_history(ctx)
+    _eq("round-trip — append returns True", result, True)
+
+    lines = _read_lines(ctx, history_path)
+    _eq("round-trip — one line written", len(lines), 1)
+    _assert("round-trip — line starts with `[`", lines[0].startswith("["))
+
+    # Strip `[<date>] ` and parse the remaining three space-separated tokens.
+    idx = lines[0].find("] ")
+    _assert("round-trip — line has a `] ` delimiter", idx >= 0)
+    tail = lines[0][idx + 2:]
+    tokens = tail.split(" ")
+    _eq("round-trip — tail has <url> <path> <key>", len(tokens), 3)
+    _eq("round-trip — token[0] == url", tokens[0], expected_url)
+
+    # The test harness invokes this as a `dev` task, so path is `dev:test-runner-job-history`.
+    _eq("round-trip — token[1] == task path", tokens[1], "dev:test-runner-job-history")
+    _assert("round-trip — token[2] is a non-empty task key", len(tokens[2]) > 0)
+
+    _cleanup(ctx, tmpdir)
+    _restore_env(ctx, snapshot)
+
+def _test_dedup(ctx):
+    """Two calls with the same `<url> <path> <key>` triple write one entry.
+
+    A warm runner that re-invokes the same task with the same key
+    shouldn't bloat the history file with duplicate rows.
+    """
+    snapshot = _snapshot_env(ctx)
+    tmpdir = _tmpdir(ctx)
+    history_path = tmpdir + "/history"
+
+    _set_bk_env(ctx, history_path, job_id = "dedup-job")
+
+    _eq("dedup — first append writes", append_runner_job_history(ctx), True)
+    _eq("dedup — second append skips", append_runner_job_history(ctx), False)
+    _eq("dedup — file still has 1 line", len(_read_lines(ctx, history_path)), 1)
+
+    _cleanup(ctx, tmpdir)
+    _restore_env(ctx, snapshot)
+
+def _test_distinct_urls_both_landed(ctx):
+    """Two different task URLs both land as separate lines.
+
+    Catches a regression where the dedup set incorrectly matches
+    different URLs (e.g. substring rather than equality).
+    """
+    snapshot = _snapshot_env(ctx)
+    tmpdir = _tmpdir(ctx)
+    history_path = tmpdir + "/history"
+
+    _set_bk_env(ctx, history_path, job_id = "first-job")
+    _eq("distinct — first URL written", append_runner_job_history(ctx), True)
+
+    _set_bk_env(ctx, history_path, job_id = "second-job")
+    _eq("distinct — second URL written", append_runner_job_history(ctx), True)
+
+    lines = _read_lines(ctx, history_path)
+    _eq("distinct — both lines retained", len(lines), 2)
+    _assert("distinct — first job present", any(["#first-job " in line for line in lines]))
+    _assert("distinct — second job present", any(["#second-job " in line for line in lines]))
+
+    _cleanup(ctx, tmpdir)
+    _restore_env(ctx, snapshot)
+
+def _test_unreadable_existing_file_silent(ctx):
+    """An existing history file we can't read silently no-ops the dedup
+    pass — `try_read_to_string` swallows I/O errors, the dedup set
+    falls back to empty, and the subsequent append still tries (and
+    here also fails, since chmod 000 disables write too).
+
+    The critical assertion: `append_runner_job_history` returns
+    cleanly. Before `try_read_to_string`, the read raised and crashed
+    the lifecycle hook.
+    """
+    snapshot = _snapshot_env(ctx)
+    tmpdir = _tmpdir(ctx)
+    history_path = tmpdir + "/history"
+
+    # Seed an entry, then chmod the file unreadable.
+    _set_bk_env(ctx, history_path, job_id = "seed-job")
+    _eq("unreadable — seed entry lands", append_runner_job_history(ctx), True)
+    ctx.std.process.command("chmod").args(["000", history_path]).spawn().wait()
+
+    # A subsequent append with a different job-id must not crash. The
+    # read fails (chmod 000) and the write also fails — the function
+    # returns False either way, and the task is unaffected.
+    _set_bk_env(ctx, history_path, job_id = "follow-up-job")
+    result = append_runner_job_history(ctx)
+    _eq("unreadable — follow-up returns False (no crash)", result, False)
+
+    # Restore perms so `_cleanup` can remove the file.
+    ctx.std.process.command("chmod").args(["600", history_path]).spawn().wait()
+    _cleanup(ctx, tmpdir)
+    _restore_env(ctx, snapshot)
+
+def _test_unwritable_path_silent(ctx):
+    """A write to a path under a non-existent parent dir silently no-ops.
+
+    Validates the hard invariant: a runner with a misconfigured /
+    permission-restricted history-file path must not crash aspect-cli
+    tasks. `fs.try_append` swallows the io::Error and returns False;
+    `append_runner_job_history` propagates the False return without
+    raising.
+    """
+    snapshot = _snapshot_env(ctx)
+    tmpdir = _tmpdir(ctx)
+
+    # Parent dir is the temp dir but the next level down doesn't exist.
+    # `try_append` with `OpenOptions::create(true)` still requires the
+    # parent to exist, so this fails to open the file — exercising the
+    # error path.
+    bad_path = tmpdir + "/no-such-parent/history"
+
+    _set_bk_env(ctx, bad_path, job_id = "unwritable-job")
+    result = append_runner_job_history(ctx)
+    _eq("unwritable — append returns False (no crash)", result, False)
+    _eq("unwritable — bad path was not created", ctx.std.fs.exists(bad_path), False)
+
+    _cleanup(ctx, tmpdir)
+    _restore_env(ctx, snapshot)
+
+def _test_concurrent_writes_round_trip(ctx):
+    """Many sequential appends with distinct URLs all land, in order.
+
+    POSIX `O_APPEND` is atomic for writes ≤ `PIPE_BUF` (4096 bytes on
+    Linux, typically 512 on macOS — both well above our short record
+    length). This subtest covers the happy-path interleaving by
+    issuing N writes back-to-back and verifying every record landed
+    intact. True concurrency would require subprocess spawning, which
+    AXL's process API supports but is overkill: the sequential test
+    exercises the same code path and the kernel `O_APPEND` guarantee
+    is what gives us multi-writer safety on real runners.
+    """
+    snapshot = _snapshot_env(ctx)
+    tmpdir = _tmpdir(ctx)
+    history_path = tmpdir + "/history"
+
+    n = 25
+    for i in range(n):
+        _set_bk_env(ctx, history_path, job_id = "burst-%d" % i)
+        _eq("concurrent[%d] — append succeeds" % i, append_runner_job_history(ctx), True)
+
+    lines = _read_lines(ctx, history_path)
+    _eq("concurrent — all %d lines landed" % n, len(lines), n)
+
+    # Each line has shape `[<date>] <url>#<job-id> <path> <key>`. Pull
+    # the job-id out by splitting on `#` (the fragment marker we added
+    # to the URL) and taking the prefix of the next space-delimited
+    # token.
+    job_ids = sorted([line.split("#")[-1].split(" ")[0] for line in lines])
+    expected = sorted(["burst-%d" % i for i in range(n)])
+    _eq("concurrent — every job-id present exactly once", job_ids, expected)
+
+    _cleanup(ctx, tmpdir)
+    _restore_env(ctx, snapshot)
+
+def _test_impl(ctx):
+    _test_no_env_no_write(ctx)
+    _test_no_task_url_no_write(ctx)
+    _test_round_trip(ctx)
+    _test_dedup(ctx)
+    _test_distinct_urls_both_landed(ctx)
+    _test_unreadable_existing_file_silent(ctx)
+    _test_unwritable_path_silent(ctx)
+    _test_concurrent_writes_round_trip(ctx)
+    print("runner_job_history.axl: OK (8 sections)")
+    return 0
+
+runner_job_history_tests = task(
+    name = "test-runner-job-history",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/axl-runtime/src/engine/std/fs.rs
+++ b/crates/axl-runtime/src/engine/std/fs.rs
@@ -7,6 +7,7 @@ use starlark::values::ValueOfUnchecked;
 use starlark::values::list::UnpackList;
 use starlark::values::none::NoneType;
 use std::fs;
+use std::io::Write;
 use std::sync::{Arc, Mutex};
 use std::time::UNIX_EPOCH;
 
@@ -494,6 +495,48 @@ pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
     ) -> anyhow::Result<NoneType> {
         fs::write(path.as_str(), content.as_str())?;
         Ok(NoneType)
+    }
+
+    /// Appends a string to the end of a file, creating it if it does not exist.
+    ///
+    /// Opens the file with `OpenOptions::append(true)` so concurrent writers
+    /// see their bytes interleaved at record boundaries rather than racing.
+    /// POSIX `O_APPEND` is atomic for writes ≤ `PIPE_BUF`, which covers the
+    /// short single-line records this is designed for (the
+    /// `runner_job_history` lines fit comfortably). The parent directory
+    /// must exist; this function will not create intermediate directories.
+    ///
+    /// Returns `True` on success and `False` on any I/O error (parent
+    /// directory missing, permissions denied, target is a directory, etc.).
+    /// Errors are swallowed because the primary caller is the runner job
+    /// history hook, where a write failure must never fail the task.
+    fn try_append<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        #[starlark(require = pos)] path: values::StringValue,
+        #[starlark(require = pos)] content: values::StringValue,
+    ) -> anyhow::Result<bool> {
+        let result = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path.as_str())
+            .and_then(|mut f| f.write_all(content.as_str().as_bytes()));
+        Ok(result.is_ok())
+    }
+
+    /// Reads the entire contents of a file into a string, or returns `""`
+    /// on any I/O error (missing file, permission denied, non-UTF-8 content,
+    /// transient read failure). Companion to `try_append`: the silent
+    /// fall-through lets callers handle never-fail invariants without
+    /// try/except — e.g. the runner job history dedup read, where a
+    /// failed read must degrade to "assume empty file" rather than fail
+    /// the task.
+    fn try_read_to_string<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        #[starlark(require = pos)] path: values::StringValue,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<values::StringValue<'v>> {
+        let s = fs::read_to_string(path.as_str()).unwrap_or_default();
+        Ok(heap.alloc_str(s.as_str()))
     }
 
     /// Opens a file for reading and returns it as a readable stream.


### PR DESCRIPTION
## Summary

AXL tasks didn't write to the Workflows `runner_job_history` file, so Vigor's "Number of builds on this runner" / "Most recently" status check rendered nothing for aspect-cli tasks. Rosetta-era tasks still did, leaving a confusing per-runner blank section after migration. This adds the write back, and along the way centralizes the CI URL helpers that the write (and the sibling status surfaces) all need.

Each AXL task fires `append_runner_job_history(ctx)` from `lifecycle.setup_phase`. The function reads `ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE`, dedups against existing entries, then appends one line in the format:

    [<date>] <task-URL> <task-path> <task-key>\n

`<task-path>` is the colon-separated `<group>:<name>` (e.g. `dev:test-foo`) or just `<name>` for top-level tasks like `build` / `lint`. `<task-key>` is the per-invocation human-readable key (auto-generated or set via `--task-key`). The trailing two fields are AXL-era extensions: Rosetta writes only `[<date>] <URL>` and its reader regex strips the bracket prefix and treats the rest as the dedup key, so the extra fields are forwards-compatible on both sides. Aspect-cli's dedup key is the full `<url> <path> <key>` triple, so distinct tasks within the same job land as distinct rows (Rosetta's URL-only dedup collapsed them).

Every error path is a silent no-op — missing env var, no derivable task URL, unreadable file (dedup read), unwritable file (append) — so a misconfigured runner can never fail a task.

### New `lib/ci.axl`

Centralizes the CI URL helpers that previously lived in `lib/github.axl` (despite handling every CI host) and were duplicated inline across the status surfaces:

- `detect_build_url(ctx) → str` — job-scoped build URL across GHA / Buildkite / CircleCI / GitLab. For Buildkite, returns `<BUILDKITE_BUILD_URL>#<BUILDKITE_JOB_ID>` (the canonical link to a specific job, matching what `web_url` returns in the Builds API). For GHA, transparently upgrades the run URL to the per-job URL when the Aspect Workflows GitHub App is authenticated (delegates to `lib/github.axl::detect_github_actions_build_url`, the wrapper around the existing private token helpers).
- `detect_buildkite_build_url(env) → str` — env-only Buildkite helper for callers without a full `ctx` (`build_metadata._collect_buildkite`, `github_status_checks._collect_ci_links`).
- `detect_artifacts_browse_url(ctx) → str` — promoted from `feature/artifacts.axl::_make_artifacts_browse_url`. Returns the canvas `?tab=artifacts` URL on Buildkite (the artifacts tab needs the canvas form, not the job anchor) and the per-host equivalents for the other CI hosts.

Refactors 4 inline canvas-URL sites to use `detect_build_url` / `detect_buildkite_build_url`. The fifth canvas-URL site (`feature/artifacts.axl`) needed the `?tab=artifacts` form and now calls `detect_artifacts_browse_url`. `lib/bazel_results.axl::ci_link_item` collapses to a single table-driven dispatch.

### Job-URL resolve: once per task, then reused

Token priority is **App primary, `GITHUB_TOKEN` fallback** via `_preferred_token_pair` (unchanged). `detect_build_url` reads/writes `ASPECT_JOB_URL_CACHE` so sibling callers in the same task share the resolved URL — only the first call burns a `_resolve_current_job_url` HTTP call. `existing_app_token` is forwarded to the GHA path so callers with a freshly-minted App token in hand skip a redundant auth.

`lib/ci.axl` also exposes `detect_ci_host(env) → {marker, label, icon}`, used by `bazel_results.ci_link_item` and `github_status_checks._collect_ci_links` to replace parallel per-host if/elif chains with a single table lookup.

### Rust primitives

Two small `fs` methods back the AXL helper, mirroring each other:

- `fs.try_append(path, content) → bool` — opens with `O_APPEND` (POSIX-atomic for the short record length, covering multi-task concurrency on a warm runner) and returns False on any I/O error instead of raising.
- `fs.try_read_to_string(path) → str` — returns `""` on any I/O error (missing file, perms, non-UTF-8 content). Used by the dedup read so a locked-down history file degrades to "no dedup" instead of crashing the task.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

```
* Aspect Workflows status checks now render the "Most recently" list for runners executing AXL tasks, with each row showing the task path and invocation key. Previously only Rosetta-era tasks contributed entries (URL-only).
* Buildkite links on aspect-cli status surfaces now point at the specific job (`<build_url>#<job-id>`) rather than the build root.
```

### Test plan

- New test cases added (`aspect dev test-runner-job-history`) — covers round-trip (asserts the `[<date>] <url> <path> <key>` shape), env-var-unset silent skip, no-task-URL silent skip, dedup, distinct-URL append, unreadable existing file silent skip, unwritable path silent skip, and burst-append safety.
- New `detect_build_url` AXL test cases for `BUILDKITE_BUILD_URL` + `BUILDKITE_JOB_ID` → `#<job-id>` shape and `ASPECT_GHA_JOB_URL_CACHE` reuse; existing AXL suite (`aspect tests axl`, 765 tests) all pass.
- Snapshot suites still render cleanly: `test-bk-annotation-snapshots` (21), `test-pr-comment-snapshots` (20), `test-template-snapshots` (16), `test-delivery-template-snapshots` (13).
- Manual smoke: `ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE=/tmp/foo GITHUB_ACTIONS=true GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=aspect-build/aspect-cli GITHUB_RUN_ID=9999 aspect build //...` writes `[<date>] <run-url> build <key>` to `/tmp/foo`; re-running with the same `GITHUB_RUN_ID` + same `--task-key` dedups (no duplicate line); re-running with a different `GITHUB_RUN_ID` or `--task-key` appends a second line. Running without the env var doesn't create the file and doesn't error.
