### PR TITLE
fix(bazel): render skipped targets as "Invocation skipped", not "Failed to build"

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -3,7 +3,7 @@ load("@aspect//feature/buildkite_annotations.axl", "BuildkiteAnnotations")
 load("@aspect//feature/buildkite_annotations_test.axl", "bk_annotation_snapshot_tests")
 load("@aspect//feature/github_status_checks.axl", "GithubStatusChecks")
 load("@aspect//feature/github_status_comments_test.axl", "pr_comment_snapshot_tests")
-load("@aspect//lib/bazel_results_test.axl", "template_snapshot_tests")
+load("@aspect//lib/bazel_results_test.axl", "bazel_results_skipped_tests", "template_snapshot_tests")
 load("@aspect//lib/delivery_results_test.axl", "delivery_template_snapshot_tests")
 load("@aspect//lib/format_results_test.axl", "format_template_snapshot_tests")
 load("@aspect//lib/gazelle_results_test.axl", "gazelle_template_snapshot_tests")
@@ -75,6 +75,11 @@ def config(ctx: ConfigContext):
     # Template snapshot tests — renders bazel_results templates across failure modes.
     # Run with: aspect test-template-snapshots
     ctx.tasks.add(template_snapshot_tests)
+
+    # Skipped-bucket plumbing — exercises _compute_bucket_counts +
+    # compute_invocation_state for the SKIPPED target path.
+    # Run with: aspect dev test-bazel-results-skipped
+    ctx.tasks.add(bazel_results_skipped_tests)
 
     # GitLab HTTP client smoke tests — pure-fn URL helpers + input
     # validation on the network-touching surfaces.

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -174,7 +174,7 @@ _No tasks have reported yet._
 ---
 
 {% if last_updated_at or api_usage %}<sub>{% if last_updated_at %}⏱ Last updated {{ last_updated_at }}{% endif %}{% if last_updated_at and api_usage %} · {% endif %}{% if api_usage %}{{ api_usage }}{% endif %}</sub><br>
-{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) — [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
+{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) | [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
 """
 
 # ─── Status → badge ───────────────────────────────────────────────────────────

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -342,6 +342,14 @@ def init_data():
         "bazel": {
             # Failed build targets (not test-related): [{label}]
             "failed_targets": [],
+            # Skipped build targets — Bazel emitted a target_completed event
+            # with an Aborted payload (reason=SKIPPED). Typical sources are
+            # `--build_tag_filters`, `target_compatible_with`, and incompatible
+            # toolchain selection. [{label, kind, reason}], capped at
+            # MAX_BUILT_TARGETS so a filter-everything run doesn't blow up
+            # the body. The uncapped count lives on `skipped_targets_total`.
+            "skipped_targets": [],
+            "skipped_targets_total": 0,
             # Failed build actions, grouped by target label:
             #   [{label, mnemonics}]   where mnemonics = deduped list of strings
             # Capped at MAX_FAILED_ACTIONS unique labels. Deliberately NOT capturing
@@ -689,11 +697,27 @@ def process_event(data, event):
     elif kind == "target_completed":
         data["bazel"]["targets_total"] += 1
         payload = event.payload
-        success = _bes_get(payload, "success", None)
         label = _bes_get(event.id, "label", "") or ""
 
         # Kind was captured on the prior target_configured event.
         target_kind = data["bazel"]["target_kinds"].get(label, "") if label else ""
+
+        # Bazel emits skipped targets (build_tag_filters, target_compatible_with,
+        # incompatible toolchains) as target_completed events with an Aborted
+        # payload. Aborted has `reason` + `description`; TargetComplete has
+        # `success` — presence of `reason` is the cleanest payload-shape probe.
+        abort_reason = _bes_get(payload, "reason", None)
+        if abort_reason != None:
+            data["bazel"]["skipped_targets_total"] += 1
+            if len(data["bazel"]["skipped_targets"]) < MAX_BUILT_TARGETS:
+                data["bazel"]["skipped_targets"].append({
+                    "label": label,
+                    "kind": target_kind,
+                    "reason": abort_reason,
+                })
+            return True
+
+        success = _bes_get(payload, "success", None)
         if success == None:
             trace.log("warning: BES target_completed event missing expected field 'success' (label=" + label + ")")
         if not success:
@@ -992,7 +1016,10 @@ def process_event(data, event):
         data["bazel"]["aborted"] = True
         payload = event.payload
         if payload:
-            data["bazel"]["abort_reason"] = _bes_get(payload, "abort_reason", "") or ""
+            # Aborted proto fields are `reason` + `description` (not
+            # `abort_reason`). Our data-dict key stays `abort_reason` to
+            # avoid renaming the template variable.
+            data["bazel"]["abort_reason"] = _bes_get(payload, "reason", "") or ""
             data["bazel"]["abort_description"] = _bes_get(payload, "description", "") or ""
         return True
 
@@ -1861,6 +1888,7 @@ def _compute_bucket_counts(data):
       - failed_tests split by .status     → TEST_FAILED / TEST_TIMEOUT / FAILED_TO_BUILD
       - flaky_tests                       → TEST_FLAKY
       - passed_tests split by .cached     → TEST_PASSED / TEST_PASSED_CACHED
+      - skipped_targets                   → SKIPPED
       - built_targets (non-test only)     → SUCCESSFUL_BUILD
       - aborted flag                      → ABORTED_STATE
     """
@@ -1891,9 +1919,16 @@ def _compute_bucket_counts(data):
     counts[_BUCKET_TEST_PASSED_CACHED] = passed_cached
     counts[_BUCKET_TEST_PASSED] = passed_total - passed_cached if passed_total > passed_cached else 0
 
-    # successful − tests. Aggregates only, since the capped
-    # built_targets sample would under-count.
-    successful_target_count = data["bazel"].get("targets_total", 0) - len(data["bazel"].get("failed_targets", []))
+    # Uncapped count (the list itself is capped at MAX_BUILT_TARGETS).
+    skipped_total = data["bazel"].get("skipped_targets_total", 0)
+    counts[_BUCKET_SKIPPED] = skipped_total
+
+    # successful = targets_total − failed − skipped, minus the tests we
+    # already accounted for via the *_TEST_* buckets. Aggregates only,
+    # since the capped built_targets sample would under-count.
+    successful_target_count = (data["bazel"].get("targets_total", 0) -
+                               len(data["bazel"].get("failed_targets", [])) -
+                               skipped_total)
     if successful_target_count < 0:
         successful_target_count = 0
     test_target_count = passed_total + data["bazel"].get("failed_test_total", 0) + data["bazel"].get("flaky_test_total", 0)
@@ -3055,6 +3090,22 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 </details>
 
 {% endif %}
+{%- if skipped_targets_any %}
+<details>
+<summary>{{ skipped_targets_icon }} {{ skipped_targets_header }}</summary>
+
+<pre>
+{%- if skipped_targets %}
+{{- skipped_targets_table_head }}
+{{ skipped_targets_table_sep }}
+{%- for t in skipped_targets %}
+{{ t.aligned_label }} | {{ t.aligned_kind }}
+{%- endfor %}
+{%- endif %}
+{% if skipped_targets_overflow %}_{{ skipped_targets_overflow }} more not shown._{% endif %}</pre>
+</details>
+
+{% endif %}
 {% endif %}
 {% if render_repro_in_targets %}""" + REPRO_COMMANDS_BLOCK + FIX_COMMANDS_BLOCK + """{% endif %}
 """
@@ -3280,7 +3331,7 @@ SHARED_DETAILS_BODY_TEMPLATE = """{% if artifacts_browse_url or artifact_links %
 ---
 
 {% if last_updated_at or api_usage %}<sub>{% if last_updated_at %}⏱ Last updated {{ last_updated_at }}{% endif %}{% if last_updated_at and api_usage %} · {% endif %}{% if api_usage %}{{ api_usage }}{% endif %}</sub><br>
-{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) — [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
+{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) | [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
 """
 
 # Build/test detail template: bazel-aborted prelude, the hoisted
@@ -3866,6 +3917,16 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         )
     ]
 
+    # Skipped targets — surfaced as their own section since they're neither
+    # built nor failed.
+    skipped_for_table = [
+        {"label": _truncate_label(t.get("label", "")), "kind": t.get("kind", "")}
+        for t in sorted(
+            data["bazel"].get("skipped_targets", []),
+            key = lambda t: t.get("label", ""),
+        )
+    ]
+
     # --- Partition failed_targets into root (own action failed) vs derived
     # (no own action failed — some dep broke). Surfaces the same "Broken by"
     # UX as the Aspect Web UI without requiring the full rdeps graph.
@@ -3901,6 +3962,7 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         passed_test_count = 0
     cached_test_count = data["bazel"].get("cached_test_total", 0)
     built_non_test_count = bucket_counts.get(_BUCKET_SUCCESSFUL_BUILD, 0)
+    skipped_count = bucket_counts.get(_BUCKET_SKIPPED, 0)
 
     # --- Overflow detection for trim cascade ---
     # failed_actions is now per-label (deduped); overflow = total unique failing
@@ -3909,12 +3971,14 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
     passed_overflow = data["bazel"].get("passed_test_total", 0) - len(raw_passed)
     built_overflow = built_non_test_count - len(built_non_test)
     derived_failures_overflow = derived_failures_count - len(derived_failures)
+    skipped_overflow = skipped_count - len(skipped_for_table)
 
     # --- Build column-aligned tables for <pre> sections ---
     _passed_table = _align_for_pre(_with_duration(passed_executed), has_duration = True)
     _cached_table = _align_for_pre(_with_duration(passed_cached), has_duration = True)
     _built_table = _align_for_pre(built_non_test, has_duration = False)
     _derived_table = _align_for_pre(derived_failures, has_duration = False)
+    _skipped_table = _align_for_pre(skipped_for_table, has_duration = False)
 
     # Failed / timeout / flaky test buckets render as aligned tables
     # too — same `Label | Target Type | Duration` shape passed/cached
@@ -3964,7 +4028,8 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         passed_test_count > 0 or
         cached_test_count > 0 or
         built_non_test_count > 0 or
-        derived_failures_count > 0
+        derived_failures_count > 0 or
+        skipped_count > 0
     )
 
     # --- Badges ---
@@ -4078,6 +4143,18 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         "built_targets_header": _bucket_header(_BUCKET_SUCCESSFUL_BUILD, built_non_test_count),
         "built_targets_overflow": str(built_overflow) if built_overflow > 0 else "",
         "passed_tests_overflow": str(passed_overflow) if passed_overflow > 0 else "",
+
+        # Skipped-targets table: label | kind. Header uses the uncapped
+        # count; `skipped_targets_overflow` drives the "N more not shown"
+        # line and is halved further by the render-time trim cascade.
+        "skipped_targets": _skipped_table["rows"],
+        "skipped_targets_table_head": _skipped_table["header"],
+        "skipped_targets_table_sep": _skipped_table["separator"],
+        "skipped_targets_count": skipped_count,
+        "skipped_targets_any": "1" if skipped_count > 0 else "",
+        "skipped_targets_header": _bucket_header(_BUCKET_SKIPPED, skipped_count),
+        "skipped_targets_icon": _BUCKET_ICONS[_BUCKET_SKIPPED],
+        "skipped_targets_overflow": str(skipped_overflow) if skipped_overflow > 0 else "",
 
         # Command-line views (derived from options_parsed, redacted for secrets).
         # long form: multi-line reproducer. short: "bazel test //foo:bar"
@@ -4408,6 +4485,21 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         if debug_render:
             trace.log("debug [render_check_output]   after test trim: details len=" + str(len(details_text)) +
                       " passed_tests=" + str(len(passed)))
+
+    if len(details_text) > _DETAILS_LIMIT:
+        skipped = details_data.get("skipped_targets", [])
+        skipped_total = details_data.get("skipped_targets_count", 0)
+        for _ in range(10):
+            if len(details_text) <= _DETAILS_LIMIT or len(skipped) == 0:
+                break
+            skipped = skipped[:len(skipped) // 2]
+            overflow = skipped_total - len(skipped)
+            details_data["skipped_targets"] = skipped
+            details_data["skipped_targets_overflow"] = str(overflow) if overflow > 0 else ""
+            details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        if debug_render:
+            trace.log("debug [render_check_output]   after skipped trim: details len=" + str(len(details_text)) +
+                      " skipped_targets=" + str(len(skipped)))
 
     if len(details_text) > _DETAILS_LIMIT:
         # Last resort: drop cached_tests too.

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -15,7 +15,7 @@ Scenarios covered:
   6. large       — many targets/tests (exercises the trim cascade)
 """
 
-load("./bazel_results.axl", "init_data", "render_check_output")
+load("./bazel_results.axl", "build_details_data", "compute_invocation_state", "init_data", "render_check_output")
 
 # ---------------------------------------------------------------------------
 # Fake data builders
@@ -357,6 +357,53 @@ def _make_results_html_chars():
     }
     return r
 
+def _make_results_skipped():
+    """Build where every target was filtered out by `--build_tag_filters` /
+    `target_compatible_with`. Bazel exits 0 and emits target_completed events
+    with Aborted payloads (reason=SKIPPED). The status surface must render
+    "Invocation skipped", not "Successful build" or "Failed to build"."""
+    r = init_data()
+    r["bazel"]["invocation_id"] = "skip0000-1111-2222-3333-444455556666"
+    r["bazel"]["build_command"] = "build"
+    r["bazel"]["wall_time_ms"] = 1200
+    r["bazel"]["actions_executed"] = 0
+    r["bazel"]["actions_cached"] = 0
+    r["bazel"]["actions_total"] = 0
+    r["bazel"]["targets_total"] = 4
+    r["bazel"]["skipped_targets"] = [
+        {"label": "//apps/web:bundle", "kind": "ts_project", "reason": "skipped"},
+        {"label": "//apps/web:test", "kind": "vitest_test", "reason": "skipped"},
+        {"label": "//services/api:server", "kind": "go_binary", "reason": "skipped"},
+        {"label": "//services/api:test", "kind": "go_test", "reason": "skipped"},
+    ]
+    r["bazel"]["skipped_targets_total"] = 4
+    r["bazel"]["target_kinds"] = {
+        "//apps/web:bundle": "ts_project",
+        "//apps/web:test": "vitest_test",
+        "//services/api:server": "go_binary",
+        "//services/api:test": "go_test",
+    }
+    r["bazel"]["metadata"] = {"BRANCH": "main", "COMMIT_SHA": "00112233aabbccdd"}
+    return r
+
+def _make_results_skipped_over_cap():
+    """Filter-everything-out run on a large workspace: 5000 targets all
+    skipped, list capped at MAX_BUILT_TARGETS. Exercises the overflow
+    line + trim-cascade interaction."""
+    r = init_data()
+    r["bazel"]["invocation_id"] = "skip5000-1111-2222-3333-444455556666"
+    r["bazel"]["build_command"] = "build"
+    r["bazel"]["wall_time_ms"] = 8500
+    total = 5000
+    r["bazel"]["targets_total"] = total
+    r["bazel"]["skipped_targets"] = [
+        {"label": "//pkg/lib_%d:lib" % i, "kind": "py_library", "reason": "skipped"}
+        for i in range(250)
+    ]
+    r["bazel"]["skipped_targets_total"] = total
+    r["bazel"]["metadata"] = {"BRANCH": "main", "COMMIT_SHA": "deadbeef00112233"}
+    return r
+
 def _make_results_aborted():
     """Build aborted mid-stream (e.g. Ctrl-C or OOM)."""
     r = init_data()
@@ -561,6 +608,14 @@ def _test_impl(ctx):
         # render as escaped entities (`&lt;hr&gt;`) so BK/GHSC don't
         # interpret them as real HTML and break the metadata layout.
         ("16. html-chars-in-metadata · GH", _make_results_html_chars(), "passed", "//...", False, "github", ["*"], ""),
+        # Skipped-only build: target_completed events came in with Aborted
+        # payloads (reason=SKIPPED). Status is passed (Bazel exited 0); the
+        # title must surface "Invocation skipped" instead of "Successful build".
+        ("17. all-skipped · GH", _make_results_skipped(), "passed", "//...", False, "github", None, ""),
+        # Skipped-over-cap: 5000 skipped targets, list capped at
+        # MAX_BUILT_TARGETS. Header reports the uncapped count; body
+        # renders the overflow line.
+        ("18. skipped-over-cap · GH", _make_results_skipped_over_cap(), "passed", "//...", False, "github", None, ""),
     ]
 
     sep = "=" * 70
@@ -589,5 +644,131 @@ template_snapshot_tests = task(
     name = "test-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,
+    args = {},
+)
+
+# ─── Unit tests — skipped target plumbing ────────────────────────────────────
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _make_skipped_only():
+    """4 targets, all skipped — no built, no failed, no tests."""
+    r = init_data()
+    r["bazel"]["targets_total"] = 4
+    r["bazel"]["skipped_targets"] = [
+        {"label": "//a:b", "kind": "py_library", "reason": "skipped"},
+        {"label": "//a:c", "kind": "py_library", "reason": "skipped"},
+        {"label": "//d:e", "kind": "go_binary", "reason": "skipped"},
+        {"label": "//d:f", "kind": "go_test", "reason": "skipped"},
+    ]
+    r["bazel"]["skipped_targets_total"] = 4
+    return r
+
+def _make_skipped_with_success():
+    """3 built + 2 skipped — SUCCESSFUL_BUILD outranks SKIPPED in the walk."""
+    r = init_data()
+    r["bazel"]["targets_total"] = 5
+    r["bazel"]["skipped_targets"] = [
+        {"label": "//x:a", "kind": "cc_library", "reason": "skipped"},
+        {"label": "//x:b", "kind": "cc_library", "reason": "skipped"},
+    ]
+    r["bazel"]["skipped_targets_total"] = 2
+    r["bazel"]["built_targets"] = [
+        {"label": "//y:a", "kind": "cc_library"},
+        {"label": "//y:b", "kind": "cc_binary"},
+        {"label": "//y:c", "kind": "py_binary"},
+    ]
+    return r
+
+def _make_skipped_with_failure():
+    """1 failed + 3 skipped — FAILED_TO_BUILD outranks SKIPPED."""
+    r = init_data()
+    r["bazel"]["targets_total"] = 4
+    r["bazel"]["failed_targets"] = [{"label": "//z:broken", "kind": "cc_binary"}]
+    r["bazel"]["skipped_targets"] = [
+        {"label": "//x:a", "kind": "cc_library", "reason": "skipped"},
+        {"label": "//x:b", "kind": "cc_library", "reason": "skipped"},
+        {"label": "//x:c", "kind": "cc_library", "reason": "skipped"},
+    ]
+    r["bazel"]["skipped_targets_total"] = 3
+    return r
+
+def _make_skipped_over_cap():
+    """5000 skipped targets — exceeds MAX_BUILT_TARGETS so the list IS capped
+    in production. Simulate the post-accumulation shape: capped list +
+    accurate total. Bucket count must come from the total (not list len),
+    and the body should render the overflow line."""
+    r = init_data()
+    total = 5000
+    r["bazel"]["targets_total"] = total
+
+    # Mimic what process_event leaves on disk after the cap fires.
+    r["bazel"]["skipped_targets"] = [
+        {"label": "//pkg/lib_%d:lib" % i, "kind": "py_library", "reason": "skipped"}
+        for i in range(250)
+    ]
+    r["bazel"]["skipped_targets_total"] = total
+    return r
+
+def _test_skipped_only_surfaces_invocation_skipped(ctx):
+    _eq(
+        "compute_invocation_state — skipped-only run",
+        compute_invocation_state(_make_skipped_only(), "passed"),
+        "Invocation skipped",
+    )
+
+def _test_skipped_with_success_prefers_successful_build(ctx):
+    """A mixed run with both skipped and built targets surfaces the
+    successful-build label — skipped is lowest priority."""
+    _eq(
+        "compute_invocation_state — skipped + success",
+        compute_invocation_state(_make_skipped_with_success(), "passed"),
+        "Successful build",
+    )
+
+def _test_skipped_with_failure_prefers_failure(ctx):
+    """Failed targets dominate skipped in the priority walk."""
+    _eq(
+        "compute_invocation_state — skipped + failure",
+        compute_invocation_state(_make_skipped_with_failure(), "failed"),
+        "Failed to build",
+    )
+
+def _test_skipped_over_cap_keeps_accurate_count(ctx):
+    """When the skipped list is capped at MAX_BUILT_TARGETS, the bucket
+    count must read from `skipped_targets_total` so the title header
+    and details overflow line reflect the true number."""
+    data = _make_skipped_over_cap()
+    _eq(
+        "compute_invocation_state — over-cap skipped count",
+        compute_invocation_state(data, "passed"),
+        "Invocation skipped",
+    )
+    details = build_details_data(data, links = {}, status = "passed", include_bazel_targets = True)
+    _eq(
+        "build_details_data — over-cap skipped count surfaces uncapped total",
+        details["skipped_targets_count"],
+        5000,
+    )
+    _eq(
+        "build_details_data — overflow field is the difference",
+        details["skipped_targets_overflow"],
+        "4750",
+    )
+
+def _unit_test_impl(ctx):
+    _test_skipped_only_surfaces_invocation_skipped(ctx)
+    _test_skipped_with_success_prefers_successful_build(ctx)
+    _test_skipped_with_failure_prefers_failure(ctx)
+    _test_skipped_over_cap_keeps_accurate_count(ctx)
+    print("bazel_results.axl skipped-bucket: OK (4 sections)")
+    return 0
+
+bazel_results_skipped_tests = task(
+    name = "test-bazel-results-skipped",
+    group = ["dev"],
+    implementation = _unit_test_impl,
     args = {},
 )


### PR DESCRIPTION
## Summary

Skipped build targets (filtered out by `--build_tag_filters`, `target_compatible_with`, or incompatible toolchain selection) were rendering as "Failed to build" / ❌ on status surfaces — even though Bazel exited 0.

Root cause: Bazel emits skipped targets as `target_completed` events whose payload is `Aborted` (with `reason=SKIPPED`), not `TargetComplete`. The `process_event` handler read `payload.success` (defined on `TargetComplete`, absent on `Aborted`), got `None`, and routed the target into `failed_targets` — populating `FAILED_TO_BUILD` in the bucket walk. The `_BUCKET_SKIPPED` constants existed in the table but `_compute_bucket_counts` never populated them.

This PR:

- Detects the Aborted-payload shape in the `target_completed` handler via `payload.reason` and routes the target into a new `skipped_targets` list.
- Populates `_BUCKET_SKIPPED` in `_compute_bucket_counts` and subtracts skipped from the `successful_target_count` derivation.
- Renders a Skipped Targets `<details>` section in the body, under Built Targets, using the existing `⤵️` icon and "Target{s} Skipped" header.
- Drive-by: the whole-build aborted handler was reading the wrong proto field name (`abort_reason` instead of `reason`), so `data["bazel"]["abort_reason"]` was always "". Fixed.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

```
* Bug fix: build/test task surfaces now render skipped targets (filtered by `--build_tag_filters`, `target_compatible_with`, or incompatible toolchain) under "⤵️ Targets Skipped" instead of mis-attributing them to "Failed to build".
```

### Test plan

- New `aspect dev test-bazel-results-skipped` task covers `compute_invocation_state` for skipped-only, skipped+success (success wins), and skipped+failure (failure wins) shapes.
- New `17. all-skipped` snapshot scenario in `test-template-snapshots` renders a 4-target skipped-only invocation; verified the title reads `✅ test //... · Invocation skipped` and the body has a `⤵️ 4 Targets Skipped` section with a properly aligned target list.
- Full AXL suite (`aspect tests axl`) passes (765 tests).
