### PR TITLE
fix(format): refresh index before `git stash create` to avoid silent exit-1 flake

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -84,6 +84,19 @@ def _snapshot_tracked_state(ctx):
     if head_code != 0:
         return None
 
+    # Refresh the index before `git stash create` to avoid a known git
+    # race: when the index's cached stat info disagrees with the working
+    # tree (common after a CI workspace restore via tar — content matches
+    # HEAD but mtimes don't), `git stash create`'s entry-point dirty
+    # check sees "changes", then its internal refresh clears the
+    # stat-mismatch, then the post-refresh check sees "no changes" and
+    # exits 1 silently with no stderr. Refreshing first makes the entry
+    # check observe the same state the internal refresh will produce.
+    # Exit code is intentionally ignored: --refresh exits 1 when any
+    # entry has a real content difference, which is fine — we want the
+    # stat-info sync, not a verdict.
+    _git_capture(ctx, "update-index", "--refresh", "-q")
+
     out, code, err = _git_capture(ctx, "stash", "create")
     if code != 0:
         msg = "`git stash create` failed (exit %d).\nstderr: %s\nThe formatter task uses this to snapshot pre-format state for diff detection. Ensure the workspace is a git repo." % (code, err.strip())


### PR DESCRIPTION
## Summary

A CircleCI user reported `aspect format` failing intermittently with an empty-stderr error from `git stash create`:

```
error: fail: `git stash create` failed (exit 1).
stderr:
The formatter task uses this to snapshot pre-format state for diff detection.
```

Root cause is a race inside `git stash create` itself:

1. Entry-point `check_changes_tracked_files` compares the index's cached stat info to the working tree. CircleCI's `attach_workspace` extracts files via tar, which rewrites mtimes without changing content, so this sees stat-mismatch and reports "tree is dirty".
2. Enters `do_create_stash`, which calls `refresh_and_write_cache` — re-stats each file, finds the content matches HEAD, and clears the in-memory stat-mismatch.
3. Post-refresh `check_changes` now reports "no changes" → sets `ret = 1` and jumps to `done`. No error path = no stderr written.
4. Exits 1 silently. The first call's refresh persists, so a retry succeeds — hence the flake character.

Reproducer (any git version):

```sh
cd "$(mktemp -d)" && git init -q && echo hello > a && git add a && git commit -q -m init
touch -d "2020-01-01 00:00:00" a   # forces stat-mismatch, content unchanged
git stash create; echo exit=$?     # → exit=1, no stderr
git stash create; echo exit=$?     # → exit=0 (refreshed on the prior call)
```

Fix: run `git update-index --refresh -q` before `git stash create` so the entry-point dirty check sees the post-refresh state directly. The refresh's own exit code is intentionally ignored — `--refresh` exits 1 on any actual content difference, which is exactly the state we want `git stash create` to handle.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

```
* Bug fix: `aspect format` no longer fails intermittently with `git stash create` exit 1 (no stderr) when the workspace's index has stat-mismatched entries — common after a CI workspace restore via tar (e.g. CircleCI `attach_workspace`).
```

### Test plan

- Manual: the reproducer above produces exit=1 on the first call without the fix; with the fix in place (or with the `git update-index --refresh -q` prepended), both calls return exit=0.
- Existing `aspect tests axl` (765 tests) passes — no regression.
