### PR TITLE
fix(format,gazelle): place --remote_download_outputs=toplevel after user/trait flags

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -908,12 +908,26 @@ def _delivery_impl(ctx):
             data = dr,
             phase = Phase(name = "download", description = "Download runfiles", emoji = "📥"),
         )
+
+        # Required flags — appended LAST so they win over any --config=X
+        # expansion in expanded_flags. We set these explicitly even when
+        # Bazel's default agrees, since user rc / trait flags can flip
+        # the effective value otherwise.
+        #   * upload strategy `local`: keep BES artifact references as
+        #     local paths. We're about to spawn the delivery target
+        #     locally, so re-uploading via BES is wasted bandwidth and
+        #     can stall when the remote cache is slow.
+        #   * noremote_upload_local_results: don't push this build's
+        #     outputs to the remote cache — the delivery target was
+        #     built for local execution, no other consumer benefits.
+        #   * remote_download_outputs `toplevel`: ensure the delivery
+        #     target lands on local disk so we can spawn it.
+        #   * build_runfile_links: materialize the runfiles tree so the
+        #     binary's wrappers / data deps resolve at runtime.
         phase3_flags = list(expanded_flags) + [
             "--experimental_build_event_upload_strategy=local",
             "--noremote_upload_local_results",
-            # Download the targets that needs delivery
             "--remote_download_outputs=toplevel",
-            # Build the runfiles tree before running the target
             "--build_runfile_links",
         ]
         _t_download = time.monotonic()

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -327,11 +327,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # BK section markers.
     preflight_phase(ctx, lifecycle, hc_trait)
 
-    flags = [
-        "--remote_download_outputs=toplevel",
-        "--build_runfile_links",
-        "--experimental_build_event_upload_strategy=local",
-    ]
+    flags = []
     flags.extend(ctx.args.bazel_flags)
     flags.extend(bazel_trait.extra_flags)
 
@@ -343,6 +339,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         flags.extend(hook(ctx))
     if bazel_trait.flags:
         flags = bazel_trait.flags(flags)
+
+    # Overrides — must come LAST so they win over any --config=X expansion
+    # introduced by user / trait flags. A customer .bazelrc with
+    # `common:workflows-ci --remote_download_outputs=minimal --nobuild_runfile_links`
+    # would otherwise leave the formatter binary undownloaded and spawn would
+    # ENOENT. See delivery.axl phase 3 for the same pattern.
+    flags.append("--experimental_build_event_upload_strategy=local")
+    flags.append("--remote_download_outputs=toplevel")
+    flags.append("--build_runfile_links")
 
     startup_flags = list(ctx.args.bazel_startup_flags)
     startup_flags.extend(bazel_trait.extra_startup_flags)

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -340,11 +340,22 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if bazel_trait.flags:
         flags = bazel_trait.flags(flags)
 
-    # Overrides — must come LAST so they win over any --config=X expansion
-    # introduced by user / trait flags. A customer .bazelrc with
-    # `common:workflows-ci --remote_download_outputs=minimal --nobuild_runfile_links`
-    # would otherwise leave the formatter binary undownloaded and spawn would
-    # ENOENT. See delivery.axl phase 3 for the same pattern.
+    # Required flags — appended LAST so they win over any --config=X
+    # expansion introduced by user / trait flags (e.g. a customer .bazelrc
+    # with `common:workflows-ci --remote_download_outputs=minimal
+    # --nobuild_runfile_links` would otherwise shadow our settings and
+    # spawn would ENOENT on the formatter binary). We set these explicitly
+    # even when Bazel's default agrees, since user rc / trait flags can
+    # flip the effective value otherwise. See delivery.axl phase 3 for the
+    # same pattern.
+    #   * upload strategy `local`: keep BES artifact references as local
+    #     paths. We're about to spawn the formatter binary locally, so
+    #     re-uploading it via BES is wasted bandwidth and can stall when
+    #     the remote cache is slow.
+    #   * remote_download_outputs `toplevel`: ensure the formatter binary
+    #     lands on local disk so we can spawn it.
+    #   * build_runfile_links: materialize the runfiles tree so the
+    #     binary's wrappers / data deps resolve at runtime.
     flags.append("--experimental_build_event_upload_strategy=local")
     flags.append("--remote_download_outputs=toplevel")
     flags.append("--build_runfile_links")

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -616,11 +616,22 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if bazel_trait.flags:
         flags = bazel_trait.flags(flags)
 
-    # Overrides — must come LAST so they win over any --config=X expansion
-    # introduced by user / trait flags. A customer .bazelrc with
-    # `common:workflows-ci --remote_download_outputs=minimal --nobuild_runfile_links`
-    # would otherwise leave the gazelle binary undownloaded and spawn would
-    # ENOENT. See delivery.axl phase 3 for the same pattern.
+    # Required flags — appended LAST so they win over any --config=X
+    # expansion introduced by user / trait flags (e.g. a customer .bazelrc
+    # with `common:workflows-ci --remote_download_outputs=minimal
+    # --nobuild_runfile_links` would otherwise shadow our settings and
+    # spawn would ENOENT on the gazelle binary). We set these explicitly
+    # even when Bazel's default agrees, since user rc / trait flags can
+    # flip the effective value otherwise. See delivery.axl phase 3 for the
+    # same pattern.
+    #   * upload strategy `local`: keep BES artifact references as local
+    #     paths. We're about to spawn the gazelle binary locally, so
+    #     re-uploading it via BES is wasted bandwidth and can stall when
+    #     the remote cache is slow.
+    #   * remote_download_outputs `toplevel`: ensure the gazelle binary
+    #     lands on local disk so we can spawn it.
+    #   * build_runfile_links: materialize the runfiles tree so the
+    #     binary's wrappers / data deps resolve at runtime.
     flags.append("--experimental_build_event_upload_strategy=local")
     flags.append("--remote_download_outputs=toplevel")
     flags.append("--build_runfile_links")

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -605,11 +605,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # BK section markers.
     preflight_phase(ctx, lifecycle, hc_trait)
 
-    flags = [
-        "--remote_download_outputs=toplevel",
-        "--build_runfile_links",
-        "--experimental_build_event_upload_strategy=local",
-    ]
+    flags = []
     flags.extend(ctx.args.bazel_flag)
     flags.extend(bazel_trait.extra_flags)
 
@@ -619,6 +615,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         flags.extend(hook(ctx))
     if bazel_trait.flags:
         flags = bazel_trait.flags(flags)
+
+    # Overrides — must come LAST so they win over any --config=X expansion
+    # introduced by user / trait flags. A customer .bazelrc with
+    # `common:workflows-ci --remote_download_outputs=minimal --nobuild_runfile_links`
+    # would otherwise leave the gazelle binary undownloaded and spawn would
+    # ENOENT. See delivery.axl phase 3 for the same pattern.
+    flags.append("--experimental_build_event_upload_strategy=local")
+    flags.append("--remote_download_outputs=toplevel")
+    flags.append("--build_runfile_links")
 
     startup_flags = list(ctx.args.bazel_startup_flag)
     startup_flags.extend(bazel_trait.extra_startup_flags)


### PR DESCRIPTION
## Summary

Seen live across Buildkite, CircleCI, and GitLab CI for `bazel-examples` — `aspect format` and `aspect gazelle` failing with ENOENT after the formatter / gazelle build "succeeded":

```
error: failed to spawn command
    /mnt/ephemeral/.../execroot/_main/bazel-out/k8-fastbuild/bin/tools/format/format-starlark.bash
    ".aspect/config.axl" ".bazelrc" ... : No such file or directory (os error 2)
```

Reproductions:
- https://buildkite.com/aspect-build/bazel-examples/builds/1454
- https://gitlab.com/aspect-build/bazel-examples/-/jobs/14472838173
- https://gitlab.com/aspect-build/bazel-examples/-/jobs/14472838172

Root cause: flag ordering. `format.axl` and `gazelle.axl` placed their explicit `--remote_download_outputs=toplevel` and `--build_runfile_links` at the **head** of the flags list, then appended user / trait flags afterward. The customer's `.bazelrc` has:

```
common:workflows-ci --remote_download_outputs=minimal
common:workflows-ci --nobuild_runfile_links
```

When `--config=workflows-ci` rides in through `ctx.args.bazel_flags` or `bazel_trait.extra_flags`, Bazel expands the config block **inline at the position of `--config=`**. Since `--config=` lands after our overrides on the resulting command line, last-wins picks `minimal` / `nobuild_runfile_links` — the tool binary stays in the remote cache, never reaches disk, and `spawn()` ENOENTs.

Fix: move the override flags to the **end** of the list, after user and trait flags. This matches the pattern `delivery.axl` phase 3 already uses ([line 911](crates/aspect-cli/src/builtins/aspect/delivery.axl#L911)) for the same reason.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

```
* Bug fix: `aspect format` and `aspect gazelle` no longer fail with `spawn ENOENT` when the workspace's `.bazelrc` sets `--remote_download_outputs=minimal` / `--nobuild_runfile_links` under a `--config=X` block (e.g. `:workflows-ci`). The output-download and runfile-link overrides are now placed after user / trait flags so they win over inline config-block expansion.
```

### Test plan

- CI green
- `aspect tests axl` (765 tests) passes