### PR TITLE
feat(bazel): make bazel retry attempts configurable, default to 3

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/bazel.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazel.axl
@@ -28,6 +28,14 @@ exit_codes = struct(
     EXTERNAL_DEPS_ERROR = 48,
 )
 
+# Default attempt budget for the build/test/delivery retry loops. Tasks
+# that wire up `--bazel-retry-attempts` use this as their `args.int`
+# default; the `bazel_runner.axl` / `delivery.axl` retry loops also fall
+# back to it when a task doesn't define the arg at all, so adding a new
+# bazel-driving task doesn't silently inherit `range(0)` or fail at load
+# time.
+DEFAULT_BAZEL_RETRY_ATTEMPTS = 3
+
 # https://bazel.build/run/scripts#exit-codes
 def default_retry(code: int) -> bool:
     """Returns True if the given exit code is retryable.

--- a/crates/aspect-cli/src/builtins/aspect/bazel.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazel.axl
@@ -36,6 +36,16 @@ exit_codes = struct(
 # time.
 DEFAULT_BAZEL_RETRY_ATTEMPTS = 3
 
+# Canonical help text for the `--bazel-retry-attempts` flag. Centralized so
+# `build`, `test`, `delivery` (and any future bazel-driving task) can share
+# one description and not drift over time.
+BAZEL_RETRY_ATTEMPTS_DESCRIPTION = (
+    "Maximum number of Bazel invocation attempts (including the first attempt) before giving up. " +
+    "Only retried for exit codes the build_retry trait predicate accepts " +
+    "(BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). " +
+    "Set to 1 to disable retries."
+)
+
 # https://bazel.build/run/scripts#exit-codes
 def default_retry(code: int) -> bool:
     """Returns True if the given exit code is retryable.

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -2,7 +2,7 @@
 A default 'build' task that wraps a 'bazel build' command.
 """
 
-load("./bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
+load("./bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("./feature/github_status_checks.axl", "GitHubStatusChecksTrait")
 load("./lib/artifacts.axl", "ArtifactsTrait")
 load("./lib/bazel_runner.axl", "run_bazel_task")
@@ -39,7 +39,7 @@ build = task(
         ),
         "bazel_retry_attempts": args.int(
             default = DEFAULT_BAZEL_RETRY_ATTEMPTS,
-            description = "Maximum number of Bazel invocation attempts (including the first attempt) before giving up. Only retried for exit codes the build_retry trait predicate accepts (BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). Set to 1 to disable retries.",
+            description = BAZEL_RETRY_ATTEMPTS_DESCRIPTION,
         ),
         "bes_backends": args.string_list(
             description = "Build Event Service backend(s) to stream BEP events to. Repeat the flag to pass multiple. Translated to --bes_backend=<value> on the Bazel command.",

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -37,6 +37,10 @@ build = task(
             description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
             long = "bazel-startup-flag",
         ),
+        "bazel_retry_attempts": args.int(
+            default = 3,
+            description = "Maximum number of Bazel invocation attempts (including the first attempt) before giving up. Only retried for exit codes the build_retry trait predicate accepts (BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). Set to 1 to disable retries.",
+        ),
         "bes_backends": args.string_list(
             description = "Build Event Service backend(s) to stream BEP events to. Repeat the flag to pass multiple. Translated to --bes_backend=<value> on the Bazel command.",
             long = "bes-backend",

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -2,7 +2,7 @@
 A default 'build' task that wraps a 'bazel build' command.
 """
 
-load("./bazel.axl", "BazelTrait")
+load("./bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("./feature/github_status_checks.axl", "GitHubStatusChecksTrait")
 load("./lib/artifacts.axl", "ArtifactsTrait")
 load("./lib/bazel_runner.axl", "run_bazel_task")
@@ -38,7 +38,7 @@ build = task(
             long = "bazel-startup-flag",
         ),
         "bazel_retry_attempts": args.int(
-            default = 3,
+            default = DEFAULT_BAZEL_RETRY_ATTEMPTS,
             description = "Maximum number of Bazel invocation attempts (including the first attempt) before giving up. Only retried for exit codes the build_retry trait predicate accepts (BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). Set to 1 to disable retries.",
         ),
         "bes_backends": args.string_list(

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -124,7 +124,7 @@ selective runs).
 User-facing migration guide: https://docs.aspect.build/cli/migration/delivery
 """
 
-load("@aspect//bazel.axl", "BazelTrait")
+load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("@aspect//lib/checkrun.axl", "GitHubCheckRunTrait")
 load("@aspect//lib/ci.axl", "detect_build_url")
@@ -279,9 +279,12 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     # stays valid across retries.
     pre_loop_state = dict(data)
 
-    # `max(1, ...)` so a 0 or negative `--bazel-retry-attempts` still runs
-    # bazel once instead of being a silent no-op.
-    max_attempts = max(1, ctx.args.bazel_retry_attempts)
+    # `hasattr` guard so a future caller of `_get_output_shas` without
+    # `--bazel-retry-attempts` wired up still works; `max(1, ...)` so a 0
+    # or negative value still runs bazel once instead of being a silent
+    # no-op.
+    requested = ctx.args.bazel_retry_attempts if hasattr(ctx.args, "bazel_retry_attempts") else DEFAULT_BAZEL_RETRY_ATTEMPTS
+    max_attempts = max(1, requested)
     for attempt in range(max_attempts):
         if attempt > 0:
             # Archive the just-completed (now-failed) attempt before
@@ -1281,7 +1284,7 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
             description = "Additional Bazel startup flags.",
         ),
         "bazel_retry_attempts": args.int(
-            default = 3,
+            default = DEFAULT_BAZEL_RETRY_ATTEMPTS,
             description = "Maximum number of Bazel invocation attempts (including the first attempt) per delivery build phase before giving up. Only retried for exit codes the build_retry trait predicate accepts (BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). Set to 1 to disable retries.",
         ),
         "salt": args.string(

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -124,7 +124,7 @@ selective runs).
 User-facing migration guide: https://docs.aspect.build/cli/migration/delivery
 """
 
-load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
+load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("@aspect//lib/checkrun.axl", "GitHubCheckRunTrait")
 load("@aspect//lib/ci.axl", "detect_build_url")
@@ -1285,7 +1285,7 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         ),
         "bazel_retry_attempts": args.int(
             default = DEFAULT_BAZEL_RETRY_ATTEMPTS,
-            description = "Maximum number of Bazel invocation attempts (including the first attempt) per delivery build phase before giving up. Only retried for exit codes the build_retry trait predicate accepts (BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). Set to 1 to disable retries.",
+            description = BAZEL_RETRY_ATTEMPTS_DESCRIPTION,
         ),
         "salt": args.string(
             default = "",

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -278,7 +278,11 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     # in place via .clear()+.update() so the caller's `dr` reference
     # stays valid across retries.
     pre_loop_state = dict(data)
-    for attempt in range(10):
+
+    # `max(1, ...)` so a 0 or negative `--bazel-retry-attempts` still runs
+    # bazel once instead of being a silent no-op.
+    max_attempts = max(1, ctx.args.bazel_retry_attempts)
+    for attempt in range(max_attempts):
         if attempt > 0:
             # Archive the just-completed (now-failed) attempt before
             # resetting; the 0-indexed loop var matches the 1-indexed
@@ -1275,6 +1279,10 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
             long = "bazel-startup-flag",
             default = [],
             description = "Additional Bazel startup flags.",
+        ),
+        "bazel_retry_attempts": args.int(
+            default = 3,
+            description = "Maximum number of Bazel invocation attempts (including the first attempt) per delivery build phase before giving up. Only retried for exit codes the build_retry trait predicate accepts (BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). Set to 1 to disable retries.",
         ),
         "salt": args.string(
             default = "",

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -19,7 +19,7 @@ load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
 load("./repro_commands.axl", "build_aspect_command", "task_cli_path")
 load("./text.axl", "pluralize")
-load("../bazel.axl", "BazelTrait")
+load("../bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 
 # ─── Lifecycle status + Result-cell text ──────────────────────────────────────
 #
@@ -301,9 +301,12 @@ def run_bazel_task(ctx: TaskContext, command: str) -> TaskConclusion:
 
     base_desc = "Run bazel tests" if command == "test" else "Build bazel targets"
 
-    # `max(1, ...)` so a 0 or negative `--bazel-retry-attempts` still runs
-    # bazel once instead of being a silent no-op.
-    max_attempts = max(1, ctx.args.bazel_retry_attempts)
+    # `hasattr` guard so a future task that calls `run_bazel_task` without
+    # wiring up `--bazel-retry-attempts` still works; `max(1, ...)` so a 0
+    # or negative value still runs bazel once instead of being a silent
+    # no-op.
+    requested = ctx.args.bazel_retry_attempts if hasattr(ctx.args, "bazel_retry_attempts") else DEFAULT_BAZEL_RETRY_ATTEMPTS
+    max_attempts = max(1, requested)
     for attempt in range(max_attempts):
         # Distinct phase id per attempt so each retry surfaces as its
         # own row in the Task timing table — retries are exceptional

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -210,10 +210,11 @@ def run_bazel_task(ctx: TaskContext, command: str) -> TaskConclusion:
 
     Args:
         ctx:     TaskContext with the standard build/test args (targets,
-                 bazel_flags, bazel_startup_flags, bes_backends, bes_headers,
-                 cancel, output_base). Task-specific args (e.g. build's
-                 remote_executor) are not touched here — tasks can still read
-                 them from `ctx.args` before/after calling this function.
+                 bazel_flags, bazel_startup_flags, bazel_retry_attempts,
+                 bes_backends, bes_headers, cancel, output_base). Task-specific
+                 args (e.g. build's remote_executor) are not touched here —
+                 tasks can still read them from `ctx.args` before/after calling
+                 this function.
         command: "build" or "test" — selects which Bazel subcommand to invoke
                  and which rc section to expand. The shape of the BES event
                  stream (including the presence of test_summary events for
@@ -299,7 +300,11 @@ def run_bazel_task(ctx: TaskContext, command: str) -> TaskConclusion:
         trace.log(rc.announce(command = command, ansi = False))
 
     base_desc = "Run bazel tests" if command == "test" else "Build bazel targets"
-    for attempt in range(10):
+
+    # `max(1, ...)` so a 0 or negative `--bazel-retry-attempts` still runs
+    # bazel once instead of being a silent no-op.
+    max_attempts = max(1, ctx.args.bazel_retry_attempts)
+    for attempt in range(max_attempts):
         # Distinct phase id per attempt so each retry surfaces as its
         # own row in the Task timing table — retries are exceptional
         # and should stand out, not hide inside a cumulative `Build`.

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -37,6 +37,10 @@ test = task(
             long = "bazel-startup-flag",
             description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
         ),
+        "bazel_retry_attempts": args.int(
+            default = 3,
+            description = "Maximum number of Bazel invocation attempts (including the first attempt) before giving up. Only retried for exit codes the build_retry trait predicate accepts (BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). Set to 1 to disable retries.",
+        ),
         "bes_backends": args.string_list(
             long = "bes-backend",
             description = "Build Event Service backend(s) to stream BEP events to. Repeat the flag to pass multiple. Translated to --bes_backend=<value> on the Bazel command.",

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -2,7 +2,7 @@
 A default 'test' task that wraps a 'bazel test' command.
 """
 
-load("./bazel.axl", "BazelTrait")
+load("./bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("./feature/github_status_checks.axl", "GitHubStatusChecksTrait")
 load("./lib/artifacts.axl", "ArtifactsTrait")
 load("./lib/bazel_runner.axl", "run_bazel_task")
@@ -38,7 +38,7 @@ test = task(
             description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
         ),
         "bazel_retry_attempts": args.int(
-            default = 3,
+            default = DEFAULT_BAZEL_RETRY_ATTEMPTS,
             description = "Maximum number of Bazel invocation attempts (including the first attempt) before giving up. Only retried for exit codes the build_retry trait predicate accepts (BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). Set to 1 to disable retries.",
         ),
         "bes_backends": args.string_list(

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -2,7 +2,7 @@
 A default 'test' task that wraps a 'bazel test' command.
 """
 
-load("./bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
+load("./bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("./feature/github_status_checks.axl", "GitHubStatusChecksTrait")
 load("./lib/artifacts.axl", "ArtifactsTrait")
 load("./lib/bazel_runner.axl", "run_bazel_task")
@@ -39,7 +39,7 @@ test = task(
         ),
         "bazel_retry_attempts": args.int(
             default = DEFAULT_BAZEL_RETRY_ATTEMPTS,
-            description = "Maximum number of Bazel invocation attempts (including the first attempt) before giving up. Only retried for exit codes the build_retry trait predicate accepts (BLAZE_INTERNAL_ERROR (37) and LOCAL_ENVIRONMENTAL_ERROR (36) by default). Set to 1 to disable retries.",
+            description = BAZEL_RETRY_ATTEMPTS_DESCRIPTION,
         ),
         "bes_backends": args.string_list(
             long = "bes-backend",


### PR DESCRIPTION
The bazel retry loop in [`bazel_runner.axl`](crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl) (used by `build`/`test`) and the equivalent loop in [`delivery.axl`](crates/aspect-cli/src/builtins/aspect/delivery.axl) were both hard-coded to 10 attempts. With the post-cancellation sandbox-corruption mode tracked in [bazelbuild/bazel#23880](https://github.com/bazelbuild/bazel/issues/23880), a stuck server gets hammered 10× before we give up — same underlying bug, but unnecessarily loud in the failure trace.

Exposes `--bazel-retry-attempts` on the three tasks that retry today: `build`, `test`, and `delivery`. (`format`/`lint`/`gazelle` invoke bazel exactly once and have no retry loop, so they don't get the flag.) Default is **3**.

The default lives in `DEFAULT_BAZEL_RETRY_ATTEMPTS` in [bazel.axl](crates/aspect-cli/src/builtins/aspect/bazel.axl) so the per-task `args.int` defaults and the runner-side fallback share one source of truth. The runner-side reads are `hasattr`-guarded, so a future task that drives bazel without wiring up the CLI flag picks up the default instead of failing at load. `max(1, …)` ensures `--bazel-retry-attempts=0` doesn't turn into a silent no-op where bazel is never invoked.

The retry predicate (`bazel_trait.build_retry`) is unchanged — *which* exit codes are retryable is still controlled by the trait; this flag only bounds the attempt count.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (no user-facing docs reference the retry count)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- `aspect build`, `aspect test`, and `aspect delivery` now accept `--bazel-retry-attempts=N` to bound the number of bazel invocation attempts. Default is **3** (previously hard-coded to 10). Set to `1` to disable retries.

### Test plan

- Manual testing:
  - `aspect build //…` with no flag → 3 attempts max on a stuck server (was 10).
  - `aspect build --bazel-retry-attempts=1 //…` → no retries.
  - `aspect build --bazel-retry-attempts=5 //…` → up to 5 attempts.
  - `aspect build --bazel-retry-attempts=0 //…` → clamped to 1, bazel runs once.
  - Same matrix for `aspect test` and `aspect delivery`.
