### PR TITLE
feat(surfaces): show aspect-cli version in footer

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -174,7 +174,7 @@ _No tasks have reported yet._
 ---
 
 {% if last_updated_at or api_usage %}<sub>{% if last_updated_at %}⏱ Last updated {{ last_updated_at }}{% endif %}{% if last_updated_at and api_usage %} · {% endif %}{% if api_usage %}{{ api_usage }}{% endif %}</sub><br>
-{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli){% if cli_version %} v{{ cli_version }}{% endif %} &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
+{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli){% if cli_version %} (v{{ cli_version }}){% endif %} &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
 """
 
 # ─── Status → badge ───────────────────────────────────────────────────────────

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -174,7 +174,7 @@ _No tasks have reported yet._
 ---
 
 {% if last_updated_at or api_usage %}<sub>{% if last_updated_at %}⏱ Last updated {{ last_updated_at }}{% endif %}{% if last_updated_at and api_usage %} · {% endif %}{% if api_usage %}{{ api_usage }}{% endif %}</sub><br>
-{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
+{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli){% if cli_version %} v{{ cli_version }}{% endif %} &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
 """
 
 # ─── Status → badge ───────────────────────────────────────────────────────────
@@ -762,6 +762,7 @@ def _render_body(ctx, marker, entries, started_at, body_template, status_badges,
         "tip_rows": tip_rows,
         "api_usage": api_usage,
         "last_updated_at": last_updated_at,
+        "cli_version": ctx.std.env.aspect_cli_version(),
     })
     if not body.endswith("\n"):
         body = body + "\n"

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -3351,7 +3351,7 @@ SHARED_DETAILS_BODY_TEMPLATE = """{% if artifacts_browse_url or artifact_links %
 ---
 
 {% if last_updated_at or api_usage %}<sub>{% if last_updated_at %}⏱ Last updated {{ last_updated_at }}{% endif %}{% if last_updated_at and api_usage %} · {% endif %}{% if api_usage %}{{ api_usage }}{% endif %}</sub><br>
-{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli){% if cli_version %} v{{ cli_version }}{% endif %} &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
+{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli){% if cli_version %} (v{{ cli_version }}){% endif %} &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
 """
 
 # Build/test detail template: bazel-aborted prelude, the hoisted

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -3351,7 +3351,7 @@ SHARED_DETAILS_BODY_TEMPLATE = """{% if artifacts_browse_url or artifact_links %
 ---
 
 {% if last_updated_at or api_usage %}<sub>{% if last_updated_at %}⏱ Last updated {{ last_updated_at }}{% endif %}{% if last_updated_at and api_usage %} · {% endif %}{% if api_usage %}{{ api_usage }}{% endif %}</sub><br>
-{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
+{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli){% if cli_version %} v{{ cli_version }}{% endif %} &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)</sub>
 """
 
 # Build/test detail template: bazel-aborted prelude, the hoisted
@@ -4235,6 +4235,11 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         # direct-render sites) — the template gates and skips.
         "api_usage": (render_ctx.get("api_usage") if render_ctx else "") or "",
         "last_updated_at": (render_ctx.get("last_updated_at") if render_ctx else "") or "",
+
+        # Rendered next to the `Powered by Aspect CLI` footer link.
+        # Empty in direct-render sites that don't pass `std` (snapshot
+        # tests) — the template gates and skips the version suffix.
+        "cli_version": std.env.aspect_cli_version() if std else "",
     }
 
 def active_phase_data(ctx):


### PR DESCRIPTION
Appends `v<aspect-cli-version>` to the `🚀 Powered by Aspect CLI` footer on the status-check details template and the PR-comment body template.

Renders as:

> 🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli) (v2026.11.11) &nbsp;|&nbsp; [Aspect Build](https://aspect.build/) · [X](https://twitter.com/aspect_build) · [LinkedIn](https://www.linkedin.com/company/aspect-dev/) · [YouTube](http://www.youtube.com/@aspectbuild)

The version suffix is gated on `cli_version` being non-empty, so direct-render call sites that don't pass `std` (snapshot tests, etc.) continue to render the footer without it.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Status-check and PR-comment surfaces now include the aspect-cli version in the `Powered by` footer.

### Test plan

- `aspect dev test-template-snapshots` — verified the new `v<version>` segment renders on every scenario.
- `aspect dev test-pr-comment-snapshots` — same.