### PR TITLE
feat(task): add task.alias() for first-class task aliases

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -3,6 +3,7 @@ load("@aspect//feature/buildkite_annotations.axl", "BuildkiteAnnotations")
 load("@aspect//feature/buildkite_annotations_test.axl", "bk_annotation_snapshot_tests")
 load("@aspect//feature/github_status_checks.axl", "GithubStatusChecks")
 load("@aspect//feature/github_status_comments_test.axl", "pr_comment_snapshot_tests")
+load("@aspect//format.axl", "format")
 load("@aspect//lib/bazel_results_test.axl", "bazel_results_unit_tests", "template_snapshot_tests")
 load("@aspect//lib/delivery_results_test.axl", "delivery_template_snapshot_tests")
 load("@aspect//lib/format_results_test.axl", "format_template_snapshot_tests")
@@ -26,6 +27,16 @@ _user_task = task(
     group = ["user"],
     implementation = _user_task_impl,
     args = {},
+)
+
+# `aspect buildifier` — alias of `aspect format` preset to the Starlark-only
+# formatter target. CI runs `aspect buildifier` instead of repeating the
+# `--formatter-target` flag in each pipeline.
+buildifier = format.alias(
+    defaults = {
+        "formatter_target": "//tools/format:format-starlark",
+    },
+    summary = "Format Starlark files using buildifier.",
 )
 
 def _customize_message(s: str, a: str) -> str:
@@ -73,6 +84,9 @@ def config(ctx: ConfigContext):
 
     # Add a new task
     ctx.tasks.add(_user_task)
+
+    # Register the buildifier alias as a real CLI command.
+    ctx.tasks.add(buildifier)
 
     # Template snapshot tests — renders bazel_results templates across failure modes.
     # Run with: aspect test-template-snapshots

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -194,8 +194,8 @@ steps:
         - exit_status: 78 # unhealthy signal from .buildkite/hooks/pre-command
           limit: 1
     command: |
-      ASPECT_DEBUG=1 aspect format --task-key buildifier-bk-debug --formatter-target=//tools/format:format-starlark
-      aspect format --task-key buildifier-bk --formatter-target=//tools/format:format-starlark
+      ASPECT_DEBUG=1 aspect buildifier --task-key buildifier-bk-debug
+      aspect buildifier --task-key buildifier-bk
 
   - key: format-task
     label: ":aspect: Format Task"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,10 +112,10 @@ jobs:
           command: .aspect/bootstrap.sh
       - run:
           name: Buildifier Task (ASPECT_DEBUG=1)
-          command: ASPECT_DEBUG=1 aspect format --task-key buildifier-cci-debug --formatter-target=//tools/format:format-starlark
+          command: ASPECT_DEBUG=1 aspect buildifier --task-key buildifier-cci-debug
       - run:
           name: Buildifier Task
-          command: aspect format --task-key buildifier-cci --formatter-target=//tools/format:format-starlark
+          command: aspect buildifier --task-key buildifier-cci
 
   format-task:
     machine: true

--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 2
       - uses: ./.github/actions/install-prebuilt-aspect-cli
       - name: Buildifier Task
-        run: aspect format --task-key buildifier-gha-ephemeral --formatter-target=//tools/format:format-starlark
+        run: aspect buildifier --task-key buildifier-gha-ephemeral
 
   format-task:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -102,9 +102,9 @@ jobs:
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Buildifier Task (ASPECT_DEBUG=1)
-        run: ASPECT_DEBUG=1 aspect format --task-key buildifier-gha-debug --formatter-target=//tools/format:format-starlark
+        run: ASPECT_DEBUG=1 aspect buildifier --task-key buildifier-gha-debug
       - name: Buildifier Task
-        run: aspect format --task-key buildifier-gha --formatter-target=//tools/format:format-starlark
+        run: aspect buildifier --task-key buildifier-gha
 
   format-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]

--- a/crates/axl-runtime/src/engine/arg.rs
+++ b/crates/axl-runtime/src/engine/arg.rs
@@ -9,6 +9,7 @@ use starlark::eval::Evaluator;
 use starlark::starlark_module;
 use starlark::starlark_simple_value;
 use starlark::values::FrozenValue;
+use starlark::values::Heap;
 use starlark::values::NoSerialize;
 use starlark::values::ProvidesStaticType;
 use starlark::values::StarlarkValue;
@@ -19,6 +20,7 @@ use starlark::values::list::UnpackList;
 use starlark::values::none::NoneOr;
 use starlark::values::starlark_value;
 use starlark::values::starlark_value_as_type::StarlarkValueAsType;
+use starlark::values::typing::TypeCompiled;
 
 #[derive(Clone, Debug, ProvidesStaticType, NoSerialize, Allocative)]
 pub enum Arg {
@@ -148,6 +150,125 @@ impl Arg {
             Self::Positional { .. } | Self::TrailingVarArgs { .. } | Self::Custom { .. } => None,
         }
     }
+
+    /// Return a clone of `self` with this variant's `default` replaced by `value`.
+    ///
+    /// Used by `task.alias(defaults = {...})` to overlay new defaults on a base
+    /// task's arg schema. `value`'s Starlark type must match the variant — a
+    /// mismatch produces an error mentioning `arg_name`. The schema constraints
+    /// declared on the original arg are re-enforced: `args.string(values =
+    /// [...])` membership and `args.custom(type, ...)` type predicates.
+    ///
+    /// `TrailingVarArgs` carries no schema-level default and rejects override
+    /// attempts. `Custom` defaults that cannot be frozen (live containers,
+    /// inline lambdas) drop to `None` — the same limitation `args.custom(...)`
+    /// has at definition time.
+    pub fn with_default<'v>(
+        &self,
+        arg_name: &str,
+        value: Value<'v>,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<Arg> {
+        let mut next = self.clone();
+        match &mut next {
+            Self::String {
+                default, values, ..
+            } => {
+                *default = unpack_typed::<String>(arg_name, "string", value)?;
+                if let Some(allowed) = values
+                    && !allowed.iter().any(|v| v == default)
+                {
+                    return Err(anyhow::anyhow!(
+                        "arg {:?}: value {:?} is not one of the allowed values {:?}",
+                        arg_name,
+                        default,
+                        allowed,
+                    ));
+                }
+            }
+            Self::Boolean { default, .. } => {
+                *default = unpack_typed::<bool>(arg_name, "boolean", value)?;
+            }
+            Self::Int { default, .. } => {
+                *default = unpack_typed::<i32>(arg_name, "int", value)?;
+            }
+            Self::UInt { default, .. } => {
+                *default = unpack_typed::<u32>(arg_name, "uint", value)?;
+            }
+            Self::Positional { default, .. } => {
+                *default = Some(unpack_list_items::<String>(arg_name, "positional", value)?);
+            }
+            Self::StringList { default, .. } => {
+                *default = unpack_list_items::<String>(arg_name, "string_list", value)?;
+            }
+            Self::BooleanList { default, .. } => {
+                *default = unpack_list_items::<bool>(arg_name, "boolean_list", value)?;
+            }
+            Self::IntList { default, .. } => {
+                *default = unpack_list_items::<i32>(arg_name, "int_list", value)?;
+            }
+            Self::UIntList { default, .. } => {
+                *default = unpack_list_items::<u32>(arg_name, "uint_list", value)?;
+            }
+            Self::Custom {
+                typ_value, default, ..
+            } => {
+                if let Some(typ) = typ_value {
+                    let compiled = TypeCompiled::new(typ.to_value(), heap)
+                        .map_err(|e| anyhow::anyhow!("{:?}", e))?;
+                    if !compiled.matches(value) {
+                        return Err(anyhow::anyhow!(
+                            "arg {:?}: value `{}` does not match arg type `{}`",
+                            arg_name,
+                            value,
+                            compiled,
+                        ));
+                    }
+                }
+                *default = value.unpack_frozen();
+            }
+            Self::TrailingVarArgs { .. } => {
+                return Err(anyhow::anyhow!(
+                    "arg {:?}: cannot override a trailing_var_args default — \
+                     the schema does not carry one",
+                    arg_name,
+                ));
+            }
+        }
+        Ok(next)
+    }
+}
+
+fn type_error(arg_name: &str, expected: &str, got: Value<'_>) -> anyhow::Error {
+    anyhow::anyhow!(
+        "arg {:?}: expected {}, got '{}'",
+        arg_name,
+        expected,
+        got.get_type(),
+    )
+}
+
+fn unpack_typed<'v, T: UnpackValue<'v>>(
+    arg_name: &str,
+    expected: &str,
+    value: Value<'v>,
+) -> anyhow::Result<T> {
+    T::unpack_value(value)
+        .ok()
+        .flatten()
+        .ok_or_else(|| type_error(arg_name, expected, value))
+}
+
+fn unpack_list_items<'v, T: UnpackValue<'v>>(
+    arg_name: &str,
+    expected: &str,
+    value: Value<'v>,
+) -> anyhow::Result<Vec<T>> {
+    UnpackList::<T>::unpack_value(value)
+        .ok()
+        .flatten()
+        .map(|l| l.items)
+        .ok_or_else(|| type_error(arg_name, expected, value))
 }
 
 impl Display for Arg {

--- a/crates/axl-runtime/src/engine/task.rs
+++ b/crates/axl-runtime/src/engine/task.rs
@@ -5,6 +5,9 @@ use allocative::Allocative;
 use derive_more::Display;
 use starlark::collections::SmallMap;
 use starlark::environment::GlobalsBuilder;
+use starlark::environment::Methods;
+use starlark::environment::MethodsBuilder;
+use starlark::environment::MethodsStatic;
 use starlark::starlark_module;
 use starlark::starlark_simple_value;
 use starlark::typing::ParamIsRequired;
@@ -18,6 +21,7 @@ use starlark::values::StarlarkValue;
 use starlark::values::Trace;
 use starlark::values::Value;
 use starlark::values::ValueLike;
+use starlark::values::dict::UnpackDictEntries;
 use starlark::values::list::UnpackList;
 use starlark::values::none::NoneType;
 use starlark::values::starlark_value;
@@ -50,8 +54,18 @@ pub trait TaskLike<'v> {
     fn overrides(&self) -> Value<'v>;
     /// Implementation function lifted to the live heap via `to_value()`.
     fn implementation(&self) -> Value<'v>;
+    /// Trait values this task opts into, lifted to the live heap via
+    /// `to_value()`. The returned `Vec` is suitable for storing on a fresh
+    /// `Task<'v>` (e.g. when building an alias).
+    fn trait_values(&self) -> Vec<Value<'v>>;
+
     /// Trait type ids this task opts into (via the `traits = [...]` kwarg).
-    fn trait_type_ids(&self) -> Vec<u64>;
+    fn trait_type_ids(&self) -> Vec<u64> {
+        self.trait_values()
+            .into_iter()
+            .filter_map(extract_trait_type_id)
+            .collect()
+    }
 
     /// Returns only the CLI-exposed args (non-Custom entries), as (name, &Arg) pairs.
     fn cli_args(&self) -> Vec<(&str, &Arg)> {
@@ -67,7 +81,9 @@ pub trait TaskLike<'v> {
 ///
 /// Implemented for `Task` / `FrozenTask` (trivial upcast) and for `Value<'v>`
 /// (downcasts to whichever variant the value holds). Lets callers iterate
-/// `TaskMap` entries without caring whether they are live or frozen.
+/// `TaskMap` entries without caring whether they are live or frozen. The
+/// `Value<'v>` impl panics on type mismatch — use `try_as_task` when the
+/// value's type is not statically guaranteed.
 pub trait AsTaskLike<'v> {
     fn as_task(&self) -> &dyn TaskLike<'v>;
 }
@@ -86,14 +102,22 @@ impl<'v> AsTaskLike<'v> for FrozenTask {
 
 impl<'v> AsTaskLike<'v> for Value<'v> {
     fn as_task(&self) -> &dyn TaskLike<'v> {
-        if let Some(t) = self.downcast_ref::<Task<'v>>() {
-            return t;
-        }
-        if let Some(t) = self.downcast_ref::<FrozenTask>() {
-            return t;
-        }
-        panic!("expected a task value, got '{}'", self.get_type());
+        try_as_task(*self).unwrap_or_else(|| {
+            panic!("expected a task value, got '{}'", self.get_type());
+        })
     }
+}
+
+/// Non-panicking variant of `AsTaskLike::as_task`. Returns `None` when the
+/// value is neither a `Task` nor a `FrozenTask`.
+pub fn try_as_task<'v>(value: Value<'v>) -> Option<&'v dyn TaskLike<'v>> {
+    if let Some(t) = value.downcast_ref::<Task<'v>>() {
+        return Some(t);
+    }
+    if let Some(t) = value.downcast_ref::<FrozenTask>() {
+        return Some(t);
+    }
+    None
 }
 
 #[derive(Debug, Clone, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
@@ -206,11 +230,8 @@ impl<'v> TaskLike<'v> for Task<'v> {
     fn implementation(&self) -> Value<'v> {
         self.r#impl
     }
-    fn trait_type_ids(&self) -> Vec<u64> {
-        self.traits
-            .iter()
-            .filter_map(|v| extract_trait_type_id(*v))
-            .collect()
+    fn trait_values(&self) -> Vec<Value<'v>> {
+        self.traits.clone()
     }
     fn overrides(&self) -> Value<'v> {
         self.overrides
@@ -254,6 +275,11 @@ impl<'v> StarlarkValue<'v> for Task<'v> {
 
     fn dir_attr(&self) -> Vec<String> {
         vec!["args".to_owned()]
+    }
+
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(task_methods)
     }
 }
 
@@ -305,6 +331,11 @@ starlark_simple_value!(FrozenTask);
 #[starlark_value(type = "Task")]
 impl<'v> StarlarkValue<'v> for FrozenTask {
     type Canonical = Task<'v>;
+
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(task_methods)
+    }
 }
 
 impl FrozenTask {
@@ -357,11 +388,8 @@ impl<'v> TaskLike<'v> for FrozenTask {
     fn implementation(&self) -> Value<'v> {
         self.r#impl.to_value()
     }
-    fn trait_type_ids(&self) -> Vec<u64> {
-        self.traits
-            .iter()
-            .filter_map(|f| extract_trait_type_id(f.to_value()))
-            .collect()
+    fn trait_values(&self) -> Vec<Value<'v>> {
+        self.traits.iter().map(|f| f.to_value()).collect()
     }
     fn overrides(&self) -> Value<'v> {
         self.overrides.to_value()
@@ -380,6 +408,176 @@ impl StarlarkCallableParamSpec for TaskImpl {
             None,
         )
         .unwrap()
+    }
+}
+
+/// Validate `name`/`group` and resolve `display_name` per the rules shared by
+/// `task()` and `task.alias(...)`.
+///
+/// - `group` length is capped at `MAX_TASK_GROUPS`.
+/// - `name`, when non-empty, must match `[a-z][a-z0-9-]*`. An empty `name`
+///   defers naming to `export_as` (which fills from the variable name).
+/// - Each `group` element must match the same pattern as `name`.
+/// - The returned `display_name` is `display_name` verbatim if non-empty,
+///   then a Title-Case derivation of `name` if `name` is non-empty, else
+///   empty (deferred until `export_as` populates `name`).
+///
+/// `context` is the user-facing identifier used in error messages — typically
+/// `"task"` or `"task.alias"`.
+fn resolve_task_metadata(
+    context: &str,
+    name: &str,
+    group: &[String],
+    display_name: String,
+) -> anyhow::Result<String> {
+    if group.len() > MAX_TASK_GROUPS {
+        return Err(anyhow::anyhow!(
+            "{} cannot have more than {} group levels",
+            context,
+            MAX_TASK_GROUPS,
+        ));
+    }
+    if !name.is_empty() {
+        validate_command_name(name, context).map_err(|e| anyhow::anyhow!(e))?;
+    }
+    for g in group {
+        validate_command_name(g, "group").map_err(|e| anyhow::anyhow!(e))?;
+    }
+    Ok(if !display_name.is_empty() {
+        display_name
+    } else if !name.is_empty() {
+        to_display_name(name)
+    } else {
+        String::new()
+    })
+}
+
+/// Build a fresh `Task<'v>` that aliases `base`. The alias shares the base's
+/// `implementation` callable and `traits` vector and inherits nothing else —
+/// `name`, `group`, `summary`, `description`, and `display_name` come from
+/// the alias's own kwargs. An empty `name` defers naming to `export_as`.
+///
+/// `defaults` may overlay new defaults onto any arg present on `base`; see
+/// `Arg::with_default` for the per-variant validation rules.
+fn build_alias<'v>(
+    base: &dyn TaskLike<'v>,
+    defaults: UnpackDictEntries<String, Value<'v>>,
+    summary: String,
+    description: String,
+    display_name: String,
+    group: Vec<String>,
+    name: String,
+    eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
+) -> anyhow::Result<Task<'v>> {
+    let display_name = resolve_task_metadata("task.alias", &name, &group, display_name)?;
+
+    let mut overlaid = base.args().clone();
+    for (k, v) in defaults.entries {
+        let Some(existing) = overlaid.get(&k) else {
+            return Err(anyhow::anyhow!(
+                "task.alias defaults[{:?}]: no such arg on aliased task `{}`",
+                k,
+                base.name(),
+            ));
+        };
+        let next = existing.with_default(&k, v, eval.heap())?;
+        overlaid.insert(k, next);
+    }
+
+    // `(alias of `<base>`)` is appended to `description` so it shows up in
+    // `<task> --help`. The compact `aspect --help` task list still reads from
+    // `summary` and stays uncluttered. When the user supplied a `summary` but
+    // no `description`, seed the description from the summary so the user's
+    // text isn't displaced by the hint in the per-task help view.
+    let alias_hint = format!("(alias of `{}`)", base.name());
+    let description = match (description.is_empty(), summary.is_empty()) {
+        (true, true) => alias_hint,
+        (true, false) => format!("{}\n\n{}", summary, alias_hint),
+        (false, _) => format!("{}\n\n{}", description, alias_hint),
+    };
+
+    Ok(Task {
+        args: overlaid,
+        r#impl: base.implementation(),
+        summary,
+        description,
+        display_name: RefCell::new(display_name),
+        group,
+        name: RefCell::new(name),
+        traits: base.trait_values(),
+        path: Env::current_script_path(eval)?,
+        overrides: eval.heap().alloc(Arguments::new()),
+    })
+}
+
+#[starlark_module]
+fn task_methods(builder: &mut MethodsBuilder) {
+    /// Define an alias of this task with overridden arg defaults.
+    ///
+    /// The alias is a new top-level CLI command that shares this task's
+    /// `implementation` and `traits`, but exposes overridden defaults for one
+    /// or more of its args. The base task is undisturbed — both commands
+    /// coexist, and a CLI flag still wins over the alias's default (so
+    /// `aspect buildifier --formatter-target=X` overrides the alias default).
+    ///
+    /// ## Naming
+    ///
+    /// Assign the result to a **snake_case** variable; the CLI command name is
+    /// derived from the variable. The base task's name is never inherited.
+    /// Use `name = "explicit-name"` to override.
+    ///
+    /// ## Constraints
+    ///
+    /// - `defaults` keys must already exist on the base task.
+    /// - The value type must match the base arg's variant (`args.string` →
+    ///   `str`, `args.int` → `int`, `args.string_list` → `list[str]`, etc.).
+    ///   `args.string(values = [...])` re-checks membership on the new default.
+    /// - `args.trailing_var_args` carries no default in the schema and cannot
+    ///   be overridden via `defaults`.
+    /// - Aliases cannot add args beyond the base. Use `task()` if you need to.
+    ///
+    /// ## Example
+    ///
+    /// ```starlark
+    /// load("@aspect//format.axl", "format")
+    ///
+    /// buildifier = format.alias(
+    ///     defaults = {
+    ///         "formatter_target": "//tools/format:format-starlark",
+    ///     },
+    ///     summary = "Format Starlark files with buildifier.",
+    /// )
+    ///
+    /// def config(ctx: ConfigContext):
+    ///     ctx.tasks.add(buildifier)
+    /// ```
+    fn alias<'v>(
+        this: Value<'v>,
+        #[starlark(require = named, default = UnpackDictEntries::default())]
+        defaults: UnpackDictEntries<String, Value<'v>>,
+        #[starlark(require = named, default = String::new())] summary: String,
+        #[starlark(require = named, default = String::new())] description: String,
+        #[starlark(require = named, default = String::new())] display_name: String,
+        #[starlark(require = named, default = UnpackList::default())] group: UnpackList<String>,
+        #[starlark(require = named, default = String::new())] name: String,
+        eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<Task<'v>> {
+        let base = try_as_task(this).ok_or_else(|| {
+            anyhow::anyhow!(
+                "task.alias: expected a Task value, got '{}'",
+                this.get_type(),
+            )
+        })?;
+        build_alias(
+            base,
+            defaults,
+            summary,
+            description,
+            display_name,
+            group.items,
+            name,
+            eval,
+        )
     }
 }
 
@@ -412,6 +610,12 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
     /// - `summary` — one-liner shown in the task list; falls back to `"<name> task defined in <file>"`.
     /// - `description` — extended prose shown in `--help` (replaces summary in that view).
     /// - `display_name` — Title Case name for help section headings; auto-derived from command name.
+    ///
+    /// ## Aliases
+    ///
+    /// Call `<task>.alias(defaults = {...})` to declare a new top-level command
+    /// that shares this task's implementation but exposes overridden defaults
+    /// for one or more args. See the `task.alias` docstring for details.
     ///
     /// ## Example
     ///
@@ -446,32 +650,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         #[starlark(require = named, default = UnpackList::default())] traits: UnpackList<Value<'v>>,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<Task<'v>> {
-        let path = Env::current_script_path(eval)?;
-        let overrides = eval.heap().alloc(Arguments::new());
-        if group.items.len() > MAX_TASK_GROUPS {
-            return Err(anyhow::anyhow!(
-                "task cannot have more than {} group levels",
-                MAX_TASK_GROUPS
-            )
-            .into());
-        }
-        // Validate name if explicitly set (empty means "derive from variable name via to_command_name").
-        if !name.is_empty() {
-            validate_command_name(&name, "task").map_err(|e| anyhow::anyhow!(e))?;
-        }
-
-        // Validate group elements.
-        for g in &group.items {
-            validate_command_name(g, "group").map_err(|e| anyhow::anyhow!(e))?;
-        }
-
-        let display_name = if !display_name.is_empty() {
-            display_name
-        } else if !name.is_empty() {
-            to_display_name(&name)
-        } else {
-            String::new()
-        };
+        let display_name = resolve_task_metadata("task", &name, &group.items, display_name)?;
 
         // Parse and validate args.
         let mut args_ = SmallMap::new();
@@ -484,19 +663,19 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                     value.get_type()
                 )
             })?.clone();
-            if let Some(lo) = cli_arg.long_override() {
-                if lo.contains(':') {
-                    return Err(anyhow::anyhow!(
-                        "task arg {:?}: `long` override may not contain ':'; \
-                         namespaced overrides (e.g. \"feature:flag\") are only valid for feature args",
-                        arg_name
-                    ).into());
-                }
+            if let Some(lo) = cli_arg.long_override()
+                && lo.contains(':')
+            {
+                return Err(anyhow::anyhow!(
+                    "task arg {:?}: `long` override may not contain ':'; \
+                     namespaced overrides (e.g. \"feature:flag\") are only valid for feature args",
+                    arg_name,
+                ));
             }
             args_.insert(arg_name, cli_arg);
         }
 
-        // Validate each element is a TraitType or FrozenTraitType.
+        // Trait list elements must be TraitType / FrozenTraitType values.
         let all_traits = traits.items;
         for t in &all_traits {
             if t.downcast_ref::<TraitType>().is_none()
@@ -505,8 +684,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 return Err(anyhow::anyhow!(
                     "traits list must contain trait types, got '{}'",
                     t.get_type()
-                )
-                .into());
+                ));
             }
         }
 
@@ -519,8 +697,219 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             group: group.items,
             name: RefCell::new(name),
             traits: all_traits,
-            path,
-            overrides,
+            path: Env::current_script_path(eval)?,
+            overrides: eval.heap().alloc(Arguments::new()),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for `task.alias(...)` and the shared `resolve_task_metadata`
+    //! helper. Behavior pinned here: the alias's impl runs (inheritance),
+    //! arg-default overlays succeed across all variants, schema constraints
+    //! on the base survive the overlay, and validation errors surface
+    //! useful messages.
+
+    /// Boilerplate every alias test reuses: a no-op `_impl` plus a `base`
+    /// task that the test extends or aliases.
+    const BASE_PRELUDE: &str = r#"
+def _impl(ctx):
+    return 0
+"#;
+
+    fn eval_snippet(extra: &str) -> crate::test::EvalBuilder {
+        crate::test::eval(&format!("{BASE_PRELUDE}{extra}"))
+    }
+
+    fn assert_eval_err_contains(extra: &str, needle: &str) {
+        let err = eval_snippet(extra).check().expect_err("expected error");
+        let msg = err.to_string();
+        assert!(msg.contains(needle), "expected {needle:?} in {msg:?}");
+    }
+
+    #[test]
+    fn alias_inherits_implementation() {
+        let exit = eval_snippet(
+            r#"
+base = task(implementation = _impl)
+aliased = base.alias()
+"#,
+        )
+        .run_task(1)
+        .expect("run_task");
+        assert_eq!(exit, Some(0));
+    }
+
+    #[test]
+    fn alias_of_alias_runs() {
+        let exit = eval_snippet(
+            r#"
+base = task(implementation = _impl)
+first = base.alias()
+second = first.alias()
+"#,
+        )
+        .run_task(2)
+        .expect("run_task");
+        assert_eq!(exit, Some(0));
+    }
+
+    #[test]
+    fn alias_unknown_default_key_errors() {
+        assert_eval_err_contains(
+            r#"
+base = task(
+    implementation = _impl,
+    args = {"mode": args.string(default = "auto")},
+)
+buildifier = base.alias(defaults = {"nope": "x"})
+"#,
+            "no such arg",
+        );
+    }
+
+    #[test]
+    fn alias_scalar_defaults_overlaid() {
+        eval_snippet(
+            r#"
+base = task(
+    implementation = _impl,
+    args = {
+        "name":    args.string(default = ""),
+        "verbose": args.boolean(default = False),
+        "retries": args.int(default = 0),
+        "port":    args.uint(default = 0),
+    },
+)
+aliased = base.alias(defaults = {
+    "name":    "preset",
+    "verbose": True,
+    "retries": 3,
+    "port":    8080,
+})
+"#,
+        )
+        .check()
+        .expect("alias with scalar defaults should evaluate");
+    }
+
+    #[test]
+    fn alias_list_defaults_overlaid() {
+        eval_snippet(
+            r#"
+base = task(
+    implementation = _impl,
+    args = {
+        "tags":     args.string_list(default = []),
+        "depths":   args.int_list(default = []),
+        "ports":    args.uint_list(default = []),
+        "flags":    args.boolean_list(default = []),
+        "files":    args.positional(default = []),
+    },
+)
+aliased = base.alias(defaults = {
+    "tags":   ["a", "b"],
+    "depths": [1, 2, 3],
+    "ports":  [80, 443],
+    "flags":  [True, False],
+    "files":  ["x.txt", "y.txt"],
+})
+"#,
+        )
+        .check()
+        .expect("alias with list defaults should evaluate");
+    }
+
+    #[test]
+    fn alias_type_mismatch_errors() {
+        assert_eval_err_contains(
+            r#"
+base = task(
+    implementation = _impl,
+    args = {"mode": args.string(default = "auto")},
+)
+buildifier = base.alias(defaults = {"mode": 42})
+"#,
+            "expected string",
+        );
+    }
+
+    #[test]
+    fn alias_list_element_type_mismatch_errors() {
+        assert_eval_err_contains(
+            r#"
+base = task(
+    implementation = _impl,
+    args = {"tags": args.string_list(default = [])},
+)
+buildifier = base.alias(defaults = {"tags": [1, 2, 3]})
+"#,
+            "expected string_list",
+        );
+    }
+
+    #[test]
+    fn alias_string_values_constraint_enforced() {
+        assert_eval_err_contains(
+            r#"
+base = task(
+    implementation = _impl,
+    args = {"mode": args.string(default = "auto", values = ["auto", "fail"])},
+)
+buildifier = base.alias(defaults = {"mode": "nope"})
+"#,
+            "not one of the allowed values",
+        );
+    }
+
+    #[test]
+    fn alias_trailing_var_args_default_rejected() {
+        assert_eval_err_contains(
+            r#"
+base = task(
+    implementation = _impl,
+    args = {"tail": args.trailing_var_args()},
+)
+buildifier = base.alias(defaults = {"tail": []})
+"#,
+            "trailing_var_args",
+        );
+    }
+
+    #[test]
+    fn alias_custom_default_type_validated() {
+        assert_eval_err_contains(
+            r#"
+base = task(
+    implementation = _impl,
+    args = {"opt": args.custom(str, default = "x")},
+)
+buildifier = base.alias(defaults = {"opt": 42})
+"#,
+            "does not match arg type",
+        );
+    }
+
+    #[test]
+    fn alias_invalid_name_rejected() {
+        assert_eval_err_contains(
+            r#"
+base = task(implementation = _impl)
+aliased = base.alias(name = "Bad-Name")
+"#,
+            "task.alias",
+        );
+    }
+
+    #[test]
+    fn alias_too_many_group_levels_rejected() {
+        assert_eval_err_contains(
+            r#"
+base = task(implementation = _impl)
+aliased = base.alias(group = ["a", "b", "c", "d", "e", "f"])
+"#,
+            "group levels",
+        );
     }
 }


### PR DESCRIPTION
Adds a `<task>.alias(defaults = {...})` method on Task values that returns a new top-level CLI command sharing the base task's `implementation` and `traits` with overridden arg defaults. The base is undisturbed — both commands coexist, and a CLI flag still wins over the alias's default.

```python
load("@aspect//format.axl", "format")

buildifier = format.alias(
    defaults = {"formatter_target": "//tools/format:format-starlark"},
    summary = "Format Starlark files using buildifier.",
)

def config(ctx: ConfigContext):
    ctx.tasks.add(buildifier)
```

Per-variant overlay validation lives on a new `Arg::with_default` helper: type-checks the value, re-enforces `args.string(values = [...])` and `args.custom(type, ...)` constraints, rejects overrides on `args.trailing_var_args` (no schema default). The shared `resolve_task_metadata` helper now backs both `task()` and `task.alias`. `--help` on the alias renders the user's summary followed by an `(alias of \`<base>\`)` hint.

Dogfoods the new API: registers `buildifier` in [.aspect/config.axl](.aspect/config.axl) and switches GHA / Buildkite / CircleCI pipelines from `aspect format --formatter-target=//tools/format:format-starlark` to `aspect buildifier`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- New `<task>.alias(defaults = {...})` method declares a CLI command that aliases an existing task with overridden arg defaults.

### Test plan

- New test cases added: 12 eval tests in [task.rs](crates/axl-runtime/src/engine/task.rs) covering inheritance, alias-of-alias, unknown-key / type-mismatch / list-element-type / values-constraint / trailing-var-args / custom-type / invalid-name / too-many-groups errors, and scalar + list default overlays.
- Manual testing:
  - `aspect buildifier --help` shows `--formatter-target [default: //tools/format:format-starlark]` and `(alias of \`format\`)`.
  - `aspect format --help` still shows `[default: //tools/format]` (base undisturbed).
  - `aspect buildifier` runs the format pipeline against `//tools/format:format-starlark`.
  - `aspect buildifier --formatter-target=//tools/format` overrides the alias default (CLI precedence preserved).
