### PR TITLE
fix(tar): soft-fail bsdtar download so transient GitHub CDN errors don't abort the task

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -14,6 +14,7 @@ load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
 load("@aspect//lib/lint_results_test.axl", "lint_annotation_plan_tests", "lint_template_snapshot_tests")
 load("@aspect//lib/rate_limit_test.axl", "rate_limit_tests")
 load("@aspect//lib/runner_job_history_test.axl", "runner_job_history_tests")
+load("@aspect//lib/tar_test.axl", "tar_tests")
 load("@aspect//lib/tips_test.axl", "tips_tests")
 load("@aspect//traits.axl", "BazelTrait", "LintTrait")
 load("./lambda.axl", "lambda_with_global_bind")
@@ -120,6 +121,11 @@ def config(ctx: ConfigContext):
     # silenced_tips short-circuit, and built-in template shape.
     # Run with: aspect dev test-tips
     ctx.tasks.add(tips_tests)
+
+    # bsdtar platform-key mapping — supported (darwin/linux × amd64/arm64)
+    # and unsupported host inputs.
+    # Run with: aspect dev test-tar
+    ctx.tasks.add(tar_tests)
 
     # Adaptive rate-limit throttling — observations / burn-rate
     # inference / threshold ladder / tip firing / two-bucket

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -451,8 +451,17 @@ def _bucket_entries(entries):
     }
 
 def _extract_zip(ctx, zip_path, dest_dir):
-    """Extract a zip into dest_dir using bsdtar (already cached for zip_create)."""
+    """Extract a zip into dest_dir using bsdtar (already cached for zip_create).
+
+    Returns False (with a warning) if the bsdtar binary is unavailable —
+    sibling-artifact discovery is best-effort and must not abort the task
+    when github.com's release CDN has a hiccup. The root-cause warning is
+    emitted by `bsdtar` itself; this one surfaces what was skipped.
+    """
     bin_path = bsdtar(ctx)
+    if not bin_path:
+        _LOG.warn(ctx.std, "Sibling-artifact extraction skipped: bsdtar unavailable")
+        return False
     child = ctx.std.process.command(bin_path).args(["xf", zip_path, "-C", dest_dir]).stdout("piped").stderr("piped").spawn()
     return child.wait().code == 0
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/tar.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tar.axl
@@ -1,7 +1,14 @@
 """Prebuilt bsdtar binary download and execution helper.
 
 Downloads a platform-appropriate bsdtar binary from
-https://github.com/aspect-build/bsdtar-prebuilt and caches it locally.
+https://github.com/aspect-build/bsdtar-prebuilt and caches it locally,
+then exposes thin wrappers (`tar_create`, `tar_create_from_dir`,
+`zip_create`) for the archive shapes our callers need.
+
+All acquisition failures degrade to `None` with a warning rather than
+raising, because the binary only powers best-effort artifact archiving.
+A CDN hiccup on github.com must not abort the task that triggered the
+archive.
 """
 
 load("@std//hash.axl", "sha256")
@@ -20,9 +27,15 @@ _SHA256 = {
 _ARCH_MAP = {"x86_64": "amd64", "aarch64": "arm64"}
 _OS_MAP = {"macos": "darwin", "linux": "linux"}
 
-def _platform_key(ctx):
-    os = _OS_MAP.get(ctx.std.env.os())
-    arch = _ARCH_MAP.get(ctx.std.env.arch())
+def platform_key(os_name, arch_name):
+    """Map a host (os, arch) pair to the bsdtar release naming convention.
+
+    Returns `(os, arch)` for supported platforms (darwin/linux × amd64/arm64),
+    or `(None, None)` when either input is unrecognized. Pure function — kept
+    separate from `bsdtar` so it can be exercised without a TaskContext.
+    """
+    os = _OS_MAP.get(os_name)
+    arch = _ARCH_MAP.get(arch_name)
     if not os or not arch:
         return None, None
     return os, arch
@@ -39,51 +52,49 @@ def _file_sha256(ctx, path):
         h.update(chunk)
     return h.hexdigest()
 
+def _warn_skip(ctx, reason):
+    """Warn that bsdtar is unavailable for `reason` and archive operations
+    will be skipped. Centralized so the wording stays consistent across
+    every acquisition failure mode."""
+    warn(ctx.std, "bsdtar: %s; archive operations will be skipped" % reason)
+
 def bsdtar(ctx):
     """Return the path to a cached bsdtar binary, downloading if necessary.
 
-    All failure modes (unknown platform, no $HOME, transient HTTP error on
-    download, post-download rename failure) degrade to `None` + a warning
-    rather than raising. The binary is downloaded only to power best-effort
-    artifact archiving, so a download blip on github.com must not take down
-    the user-facing task that triggered it. Callers (`tar_create`,
-    `zip_create`, `tar_create_from_dir`, `_extract_zip`) treat `None` as a
-    skip signal and return `False`.
+    Returns `None` (with a warning) on any acquisition failure: unsupported
+    platform, missing `$HOME`, or a transient HTTP error from the release
+    CDN. Callers (`tar_create`, `zip_create`, `tar_create_from_dir`,
+    `_extract_zip`) treat `None` as a skip signal and return `False`.
 
-    Downloads to a unique staging path and atomically rename into place. Two
-    benefits fall out of this pattern:
+    Downloads to a unique staging path and atomically renames into place:
 
-    1. Cancellation resilience: if the download is interrupted (SIGINT, crash,
-       killed process), the partial file is stranded in the staging dir rather
-       than at `bin_path`. The next run finds `bin_path` either absent or still
-       valid, and re-downloads into a fresh staging dir — we never exec a
-       half-downloaded binary.
+    1. Cancellation resilience: an interrupted download (SIGINT, crash) is
+       stranded in the staging dir rather than at `bin_path`. The next run
+       finds `bin_path` either absent or still valid, never half-written.
 
-    2. Avoids `ETXTBSY` (`Text file busy`, Linux errno 26) on exec. We've
-       observed this even with a single task running, when downloading straight
-       to `bin_path` and exec'ing it shortly after. The exact mechanism is
-       unclear, but the atomic-rename pattern sidesteps the whole class: the
-       final inode at `bin_path` has never had a write fd against it, so exec
-       always sees a clean file. On Linux/macOS `execve()` resolves through
-       the inode, so renaming under an in-flight exec is also safe.
+    2. Avoids `ETXTBSY` (`Text file busy`, Linux errno 26) on exec —
+       observed even with a single task running when downloading straight
+       to `bin_path` and exec'ing it shortly after. The atomic-rename
+       pattern sidesteps the whole class: the final inode at `bin_path`
+       has never had a write fd against it. On Linux/macOS `execve()`
+       resolves through the inode, so renaming under an in-flight exec is
+       also safe.
 
-    Windows note: this module only runs on darwin/linux today (see `_OS_MAP`
-    and `_SHA256`), so we rely on POSIX rename semantics. If/when Windows
-    support is added, re-evaluate: `rename` on Windows does overwrite via
-    `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` in modern Rust, but Windows
-    locks running executable images — a concurrent exec of `bin_path` could
-    block the rename. A Windows port of this function will likely need a
-    different strategy (e.g. delete-then-rename or MoveFileEx with delay-
-    until-reboot fallback).
+    Windows note: this module only runs on darwin/linux today (see
+    `_OS_MAP` / `_SHA256`), so we rely on POSIX rename semantics. A
+    Windows port would need a different strategy — modern Rust's `rename`
+    uses `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`, but Windows locks
+    running executable images, so a concurrent exec of `bin_path` could
+    block the rename.
     """
     cache = _cache_dir(ctx)
     if not cache:
-        warn(ctx.std, "bsdtar: cannot determine home directory for cache; archive operations will be skipped")
+        _warn_skip(ctx, "cannot determine home directory for cache")
         return None
 
-    os, arch = _platform_key(ctx)
+    os, arch = platform_key(ctx.std.env.os(), ctx.std.env.arch())
     if not os or not arch:
-        warn(ctx.std, "bsdtar: unsupported platform %s/%s; archive operations will be skipped" % (ctx.std.env.os(), ctx.std.env.arch()))
+        _warn_skip(ctx, "unsupported platform: %s/%s" % (ctx.std.env.os(), ctx.std.env.arch()))
         return None
 
     bin_path = cache + "/tar"
@@ -98,12 +109,10 @@ def bsdtar(ctx):
         # the old file in place. Removing first creates a window where exec()
         # would hit a missing file or a partial download.
 
-    asset = "tar_" + os + "_" + arch
-    url = _BASE_URL + "/" + asset
+    url = _BASE_URL + "/tar_" + os + "_" + arch
 
     ctx.std.fs.create_dir_all(cache)
 
-    # Staging dir → download target → rename to final. See docstring for why.
     # Staging lives under `cache` (not a per-job tmpdir) so the final rename
     # stays on the same filesystem — rename(2) fails with EXDEV across
     # filesystems, and on Aspect Workflows runners ~/.cache and the job
@@ -111,9 +120,6 @@ def bsdtar(ctx):
     staging = ctx.std.fs.mkdtemp(prefix = "bsdtar-dl-", parent = cache)
     tmp_path = staging + "/tar"
 
-    # Soft-fail on HTTP errors (502s, DNS hiccups, etc.). The github.com
-    # release CDN occasionally serves 5xx; we never want that to abort the
-    # task that owned this archive request.
     download_result = ctx.http().download(
         url = url,
         output = tmp_path,
@@ -121,29 +127,49 @@ def bsdtar(ctx):
         sha256 = expected,
     ).map_err(lambda e: str(e)).block()
     if type(download_result) == "string":
-        warn(ctx.std, "bsdtar: download from %s failed (%s); archive operations will be skipped" % (url, download_result))
+        _warn_skip(ctx, "download from %s failed (%s)" % (url, download_result))
         return None
 
     ctx.std.fs.rename(tmp_path, bin_path)
-    # Intentionally no cleanup of `staging` here. After the rename it's an empty
-    # directory named `bsdtar-dl-<random>` inside the cache; leaving it behind
-    # costs nothing. AXL has no try/except, so any remove_dir_all error (permission
-    # drift, transient fs issue, networked $HOME hiccup) would turn a successful
-    # download into a user-facing failure even though `bin_path` is already valid.
+    # `staging` is intentionally left behind. After the rename it's an empty
+    # `bsdtar-dl-<random>/` inside the cache; leaving it costs nothing, and
+    # AXL has no try/except — any remove_dir_all error would turn a successful
+    # download into a user-facing failure.
 
     return bin_path
+
+def _create_archive(ctx, archive_path, mtree_spec, format_args):
+    """Build an archive at `archive_path` from an mtree spec.
+
+    `format_args` are the bsdtar flags that precede the archive path
+    (e.g. `["czf"]` for tar.gz, `["--format=zip", "-cf"]` for zip). The
+    mtree spec is written to a sidecar file and removed after spawn.
+
+    Returns False if the bsdtar binary is unavailable or bsdtar exits
+    non-zero. Shared by `tar_create` and `zip_create`.
+    """
+    bin_path = bsdtar(ctx)
+    if not bin_path:
+        return False
+
+    mtree_path = archive_path + ".mtree"
+    ctx.std.fs.write(mtree_path, mtree_spec)
+
+    child = ctx.std.process.command(bin_path) \
+        .args(format_args + [archive_path, "@" + mtree_path]) \
+        .stdout("inherit").stderr("inherit").spawn()
+    status = child.wait()
+
+    if ctx.std.fs.exists(mtree_path):
+        ctx.std.fs.remove_file(mtree_path)
+
+    return status.code == 0
 
 def tar_create_from_dir(ctx, archive_path, dir_path):
     """Create a tar.gz archive of a directory's contents.
 
-    Args:
-        ctx: TaskContext
-        archive_path: str - output .tar.gz path
-        dir_path: str - directory to archive
-
-    Returns:
-        bool - True on success; False if the bsdtar binary is unavailable
-        or the archive command exited non-zero.
+    Returns False if the bsdtar binary is unavailable or the archive
+    command exited non-zero.
     """
     bin_path = bsdtar(ctx)
     if not bin_path:
@@ -155,73 +181,26 @@ def tar_create_from_dir(ctx, archive_path, dir_path):
         dir_path,
         ".",
     ]).stdout("inherit").stderr("inherit").spawn()
-    status = child.wait()
-    return status.code == 0
+    return child.wait().code == 0
 
 def tar_create(ctx, archive_path, mtree_spec):
     """Create a tar.gz archive from an mtree spec string.
 
-    Args:
-        ctx: TaskContext
-        archive_path: str - output .tar.gz path
-        mtree_spec: str - mtree spec content mapping archive paths to source files
-
-    Returns:
-        bool - True on success; False if the bsdtar binary is unavailable
-        or the archive command exited non-zero.
+    Returns False if the bsdtar binary is unavailable or the archive
+    command exited non-zero.
     """
-    bin_path = bsdtar(ctx)
-    if not bin_path:
-        return False
-    mtree_path = archive_path + ".mtree"
-
-    ctx.std.fs.write(mtree_path, mtree_spec)
-
-    child = ctx.std.process.command(bin_path).args([
-        "czf",
-        archive_path,
-        "@" + mtree_path,
-    ]).stdout("inherit").stderr("inherit").spawn()
-    status = child.wait()
-
-    if ctx.std.fs.exists(mtree_path):
-        ctx.std.fs.remove_file(mtree_path)
-
-    return status.code == 0
+    return _create_archive(ctx, archive_path, mtree_spec, ["czf"])
 
 def zip_create(ctx, archive_path, mtree_spec):
     """Create a .zip archive from an mtree spec string.
 
-    Mirrors `tar_create` but asks bsdtar for `--format=zip`. Motivating use
-    case: GitHub's v2 artifact API (`CreateArtifact` / `FinalizeArtifact`)
-    requires ZIP-formatted uploads — raw uploads land as a `{name}.zip`
-    download that fails `unzip` because the bytes aren't a valid archive.
+    Mirrors `tar_create` but asks bsdtar for `--format=zip`. Motivating
+    use case: GitHub's v2 artifact API (`CreateArtifact` /
+    `FinalizeArtifact`) requires ZIP-formatted uploads — raw uploads land
+    as a `{name}.zip` download that fails `unzip` because the bytes
+    aren't a valid archive.
 
-    Args:
-        ctx: TaskContext
-        archive_path: str - output .zip path
-        mtree_spec: str - mtree spec content mapping archive paths to source files
-
-    Returns:
-        bool - True on success; False if the bsdtar binary is unavailable
-        or the archive command exited non-zero.
+    Returns False if the bsdtar binary is unavailable or the archive
+    command exited non-zero.
     """
-    bin_path = bsdtar(ctx)
-    if not bin_path:
-        return False
-    mtree_path = archive_path + ".mtree"
-
-    ctx.std.fs.write(mtree_path, mtree_spec)
-
-    child = ctx.std.process.command(bin_path).args([
-        "--format=zip",
-        "-cf",
-        archive_path,
-        "@" + mtree_path,
-    ]).stdout("inherit").stderr("inherit").spawn()
-    status = child.wait()
-
-    if ctx.std.fs.exists(mtree_path):
-        ctx.std.fs.remove_file(mtree_path)
-
-    return status.code == 0
+    return _create_archive(ctx, archive_path, mtree_spec, ["--format=zip", "-cf"])

--- a/crates/aspect-cli/src/builtins/aspect/lib/tar.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tar.axl
@@ -24,8 +24,7 @@ def _platform_key(ctx):
     os = _OS_MAP.get(ctx.std.env.os())
     arch = _ARCH_MAP.get(ctx.std.env.arch())
     if not os or not arch:
-        msg = "unsupported platform: " + ctx.std.env.os() + "/" + ctx.std.env.arch()
-        fail(msg)
+        return None, None
     return os, arch
 
 def _cache_dir(ctx):
@@ -42,6 +41,14 @@ def _file_sha256(ctx, path):
 
 def bsdtar(ctx):
     """Return the path to a cached bsdtar binary, downloading if necessary.
+
+    All failure modes (unknown platform, no $HOME, transient HTTP error on
+    download, post-download rename failure) degrade to `None` + a warning
+    rather than raising. The binary is downloaded only to power best-effort
+    artifact archiving, so a download blip on github.com must not take down
+    the user-facing task that triggered it. Callers (`tar_create`,
+    `zip_create`, `tar_create_from_dir`, `_extract_zip`) treat `None` as a
+    skip signal and return `False`.
 
     Downloads to a unique staging path and atomically rename into place. Two
     benefits fall out of this pattern:
@@ -71,9 +78,14 @@ def bsdtar(ctx):
     """
     cache = _cache_dir(ctx)
     if not cache:
-        fail("cannot determine home directory for bsdtar cache")
+        warn(ctx.std, "bsdtar: cannot determine home directory for cache; archive operations will be skipped")
+        return None
 
     os, arch = _platform_key(ctx)
+    if not os or not arch:
+        warn(ctx.std, "bsdtar: unsupported platform %s/%s; archive operations will be skipped" % (ctx.std.env.os(), ctx.std.env.arch()))
+        return None
+
     bin_path = cache + "/tar"
     expected = _SHA256.get(os + "-" + arch)
 
@@ -98,7 +110,20 @@ def bsdtar(ctx):
     # tmpdir are typically on different mounts.
     staging = ctx.std.fs.mkdtemp(prefix = "bsdtar-dl-", parent = cache)
     tmp_path = staging + "/tar"
-    ctx.http().download(url = url, output = tmp_path, mode = 0o755, sha256 = expected).block()
+
+    # Soft-fail on HTTP errors (502s, DNS hiccups, etc.). The github.com
+    # release CDN occasionally serves 5xx; we never want that to abort the
+    # task that owned this archive request.
+    download_result = ctx.http().download(
+        url = url,
+        output = tmp_path,
+        mode = 0o755,
+        sha256 = expected,
+    ).map_err(lambda e: str(e)).block()
+    if type(download_result) == "string":
+        warn(ctx.std, "bsdtar: download from %s failed (%s); archive operations will be skipped" % (url, download_result))
+        return None
+
     ctx.std.fs.rename(tmp_path, bin_path)
     # Intentionally no cleanup of `staging` here. After the rename it's an empty
     # directory named `bsdtar-dl-<random>` inside the cache; leaving it behind
@@ -117,9 +142,12 @@ def tar_create_from_dir(ctx, archive_path, dir_path):
         dir_path: str - directory to archive
 
     Returns:
-        bool - True on success
+        bool - True on success; False if the bsdtar binary is unavailable
+        or the archive command exited non-zero.
     """
     bin_path = bsdtar(ctx)
+    if not bin_path:
+        return False
     child = ctx.std.process.command(bin_path).args([
         "czf",
         archive_path,
@@ -139,9 +167,12 @@ def tar_create(ctx, archive_path, mtree_spec):
         mtree_spec: str - mtree spec content mapping archive paths to source files
 
     Returns:
-        bool - True on success
+        bool - True on success; False if the bsdtar binary is unavailable
+        or the archive command exited non-zero.
     """
     bin_path = bsdtar(ctx)
+    if not bin_path:
+        return False
     mtree_path = archive_path + ".mtree"
 
     ctx.std.fs.write(mtree_path, mtree_spec)
@@ -172,9 +203,12 @@ def zip_create(ctx, archive_path, mtree_spec):
         mtree_spec: str - mtree spec content mapping archive paths to source files
 
     Returns:
-        bool - True on success
+        bool - True on success; False if the bsdtar binary is unavailable
+        or the archive command exited non-zero.
     """
     bin_path = bsdtar(ctx)
+    if not bin_path:
+        return False
     mtree_path = archive_path + ".mtree"
 
     ctx.std.fs.write(mtree_path, mtree_spec)

--- a/crates/aspect-cli/src/builtins/aspect/lib/tar_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tar_test.axl
@@ -1,0 +1,52 @@
+"""Unit tests for `lib/tar.axl`.
+
+Exercises the pure `platform_key` host-mapping function. The `bsdtar`
+download path and the archive creators are I/O-heavy and validated by
+the live artifact-upload paths in CI; no AXL-level mocking surface
+exists for them today.
+"""
+
+load("./tar.axl", "platform_key")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _test_supported_platforms_round_trip(ctx):
+    """Every (os, arch) combo we ship a prebuilt for maps to the release
+    asset's naming convention."""
+    _eq("macos × x86_64", platform_key("macos", "x86_64"), ("darwin", "amd64"))
+    _eq("macos × aarch64", platform_key("macos", "aarch64"), ("darwin", "arm64"))
+    _eq("linux × x86_64", platform_key("linux", "x86_64"), ("linux", "amd64"))
+    _eq("linux × aarch64", platform_key("linux", "aarch64"), ("linux", "arm64"))
+
+def _test_unsupported_os_returns_none(ctx):
+    _eq("windows host", platform_key("windows", "x86_64"), (None, None))
+    _eq("empty os", platform_key("", "x86_64"), (None, None))
+
+def _test_unsupported_arch_returns_none(ctx):
+    _eq("riscv64 arch", platform_key("linux", "riscv64"), (None, None))
+    _eq("empty arch", platform_key("linux", ""), (None, None))
+
+def _test_both_unsupported_returns_none(ctx):
+    _eq("both unknown", platform_key("plan9", "ppc64"), (None, None))
+
+_UNIT_TESTS = [
+    _test_supported_platforms_round_trip,
+    _test_unsupported_os_returns_none,
+    _test_unsupported_arch_returns_none,
+    _test_both_unsupported_returns_none,
+]
+
+def _test_impl(ctx):
+    for t in _UNIT_TESTS:
+        t(ctx)
+    print("tar.axl: OK (%d sections)" % len(_UNIT_TESTS))
+    return 0
+
+tar_tests = task(
+    name = "test-tar",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)


### PR DESCRIPTION
A transient 502 from `https://github.com/aspect-build/bsdtar-prebuilt/releases` was bubbling through `bsdtar()` → `zip_create` → `github.upload_artifact` → `_publish_self` → the task's `_task_started` hook → `run_bazel_task`, killing the test invocation:

```
error: HTTP status server error (502 Bad Gateway or Proxy Error) for url
       (https://github.com/aspect-build/bsdtar-prebuilt/releases/download/v3.8.1-fix.1/tar_linux_amd64)
   --> aspect/lib/tar.axl:101:5
```

Artifact archiving is best-effort sidecar work; a CDN hiccup must not abort the task that triggered it. `bsdtar()` now returns `None` (with a warning naming the URL and the transport error) on any acquisition failure — download, unsupported platform (warning preserves `<os>/<arch>`), or no `$HOME`. `tar_create` / `tar_create_from_dir` / `zip_create` / `_extract_zip` all early-return `False` when the binary is unavailable. Every site that used to get the hard fail still warns at its own layer.

Other cleanups bundled in:
- `tar_create` and `zip_create` consolidate behind a shared `_create_archive(format_args)` helper.
- `platform_key(os_name, arch_name)` extracted as a pure public function (was the inline `_platform_key(ctx)`) so it can be tested directly.
- "archive operations will be skipped" wording centralized in `_warn_skip`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- Fix: a transient 5xx from the bsdtar prebuilt release CDN no longer aborts the running task. Artifact archiving is skipped with a warning instead.

### Test plan

- New unit tests in [tar_test.axl](crates/aspect-cli/src/builtins/aspect/lib/tar_test.axl) cover `platform_key` for every supported `(os, arch)` pair plus unsupported OS / arch / both. Wired in as `aspect dev test-tar`.
- `aspect dev test-bazel-results`, `test-template-snapshots`, `test-format-template-snapshots` still pass.
- `aspect format --on-change=silent --scope=changed --upload-format-diff=false` exercises the `_create_archive` happy path end-to-end.
