### PR TITLE
feat(repro): narrow repro command to root-cause / common-root targets

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -1104,6 +1104,110 @@ def failed_labels(data):
 
     return labels
 
+# Test-failure repro: above this count, collapse to a common-root pattern (when
+# one exists) rather than listing every failing label. Tuned so the rendered
+# command stays comfortably under `build_aspect_command`'s soft wrap of ~100
+# chars when targets are short (e.g. `//pkg:test`).
+_REPRO_INLINE_MAX = 10
+
+def common_label_root(labels):
+    """Return a Bazel target pattern that covers every label in `labels`.
+
+    - All labels in the same package -> `//<pkg>:all`
+    - Labels sharing a package-path prefix -> `//<prefix>/...`
+    - No useful prefix (root-package labels, mixed-repo labels, etc.) -> ``""``
+
+    Skips external-repo labels (`@foo//...`) — collapsing them into a
+    workspace-relative pattern would be wrong. Pure function.
+    """
+    if not labels:
+        return ""
+
+    packages = []
+    for lbl in labels:
+        if not lbl.startswith("//"):
+            # External repo (`@foo//...`), `@@`, or some other non-workspace form.
+            # No safe single-pattern collapse, so bail.
+            return ""
+        pkg = lbl[2:]
+        if ":" in pkg:
+            pkg, _, _ = pkg.partition(":")
+        packages.append(pkg)
+
+    distinct = {pkg: True for pkg in packages}
+    if len(distinct) == 1:
+        pkg = packages[0]
+        return "//" + pkg + ":all" if pkg else ""
+
+    split = [pkg.split("/") for pkg in packages]
+    min_depth = min([len(s) for s in split])
+    shared = []
+    for i in range(min_depth):
+        head = split[0][i]
+        if all([s[i] == head for s in split]):
+            shared.append(head)
+        else:
+            break
+    if not shared or shared == [""]:
+        return ""
+    return "//" + "/".join(shared) + "/..."
+
+def _is_explicit_label(target):
+    """True when `target` names a single rule (no wildcard).
+
+    Used to detect user-named labels that must survive a `//pkg/...` or
+    `//pkg:all` collapse: Bazel's wildcard test patterns skip
+    `tags = ["manual"]` rules, so an explicitly-named manual test could
+    otherwise disappear from the repro once we collapse to a pattern.
+    """
+    if "..." in target:
+        return False
+    if not (target.startswith("//") or target.startswith("@")):
+        # Negation (`-//foo:bar`) or other non-label form.
+        return False
+    _, sep, name = target.partition(":")
+    if not sep or not name:
+        return False  # package-shorthand like `//pkg` with no `:name`
+    if name in ("all", "*", "all-targets"):
+        return False
+    return True
+
+def repro_targets(data, original_targets):
+    """Pick the target list to render in the repro command for a failing
+    build/test task.
+
+    Small failure sets (≤ `_REPRO_INLINE_MAX`) pass through verbatim.
+    Larger sets collapse to a common-root pattern (`//pkg/...` or
+    `//pkg:all`) when one exists. Failed labels that the user named
+    explicitly in the original command are kept alongside the collapse —
+    Bazel's wildcard test patterns skip manual-tagged rules, and we
+    don't want to silently lose explicit failures to that. No usable
+    collapse → fall back to `original_targets`.
+
+    Builds and tests run through the same logic: `failed_labels(data)`
+    merges action failures, target-level failures (analysis / link /
+    derived), and failed test labels. We don't try to subtract derived
+    consumers — we can't reliably distinguish them from analysis-only
+    failures, and rebuilding a derived target is harmless once the
+    root is fixed.
+
+    `original_targets` is the user-supplied positional list (e.g.
+    `ctx.args.targets`). Returns a list[str] suitable for
+    `build_aspect_command`'s `targets` arg.
+    """
+    failed = failed_labels(data)
+    if not failed:
+        return list(original_targets)
+    if len(failed) <= _REPRO_INLINE_MAX:
+        return failed
+    root = common_label_root(failed)
+    if not root:
+        return list(original_targets)
+
+    explicit_in_original = {t: True for t in original_targets if _is_explicit_label(t)}
+    explicit_failed = [l for l in failed if l in explicit_in_original]
+    return explicit_failed + [root]
+
 def compute_reproducer_command(data, task_name, max_chars = MAX_REPRO_CHARS):
     """Legacy helper preserved for test fixtures. New code should append
     `{"command", "description"}` entries to `data["repro_commands"]`

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -8,7 +8,7 @@ Two task implementations live here:
     `compute_invocation_state`, `conclusion`, and skipped-bucket plumbing.
 """
 
-load("./bazel_results.axl", "MAX_TEST_TARGETS", "bes_get", "build_details_data", "compute_invocation_state", "conclusion", "init_data", "process_event", "render_check_output")
+load("./bazel_results.axl", "MAX_TEST_TARGETS", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "init_data", "process_event", "render_check_output", "repro_targets")
 
 # ---------------------------------------------------------------------------
 # Fake data builders
@@ -895,6 +895,149 @@ def _test_flaky_test_survives_passed_bucket_cap(ctx):
     _eq("flaky test recorded despite full passed bucket", flaky, ["//pkg/flake:test"])
     _eq("flaky_test_total reflects the flake", data["bazel"]["flaky_test_total"], 1)
 
+# ─── common_label_root / repro_targets ──────────────────────────────────────
+
+def _test_common_label_root_same_package_returns_all_pattern(ctx):
+    _eq(
+        "single package",
+        common_label_root(["//pkg/foo:t1", "//pkg/foo:t2", "//pkg/foo:t3"]),
+        "//pkg/foo:all",
+    )
+
+def _test_common_label_root_returns_shared_prefix(ctx):
+    _eq(
+        "shared prefix",
+        common_label_root(["//app/foo:t1", "//app/foo:t2", "//app/bar:t1"]),
+        "//app/...",
+    )
+
+def _test_common_label_root_no_prefix_returns_empty(ctx):
+    """Labels in disjoint top-level packages have no useful collapse —
+    `//...` is no narrower than the original `aspect <build|test>`."""
+    _eq(
+        "disjoint packages",
+        common_label_root(["//app:t1", "//other:t2"]),
+        "",
+    )
+
+def _test_common_label_root_external_repo_returns_empty(ctx):
+    """External-repo labels (`@foo//pkg:t`) can't be collapsed into a
+    workspace-relative pattern without lying about scope."""
+    _eq(
+        "external repo present",
+        common_label_root(["//app/foo:t1", "@third_party//lib:bar"]),
+        "",
+    )
+
+def _test_common_label_root_empty_input(ctx):
+    _eq("empty list", common_label_root([]), "")
+
+def _test_common_label_root_single_label(ctx):
+    _eq("single target", common_label_root(["//pkg/foo:test"]), "//pkg/foo:all")
+
+def _test_repro_targets_small_set_passes_through(ctx):
+    """A handful of failures render verbatim — small enough to fit."""
+    data = init_data()
+    data["bazel"]["failed_tests"] = [
+        {"label": "//pkg/a:test", "status": "failed"},
+        {"label": "//pkg/b:test", "status": "timeout"},
+        {"label": "//pkg/c:test", "status": "failed"},
+    ]
+    _eq(
+        "small set passes through",
+        repro_targets(data, ["//..."]),
+        ["//pkg/a:test", "//pkg/b:test", "//pkg/c:test"],
+    )
+
+def _test_repro_targets_large_set_collapses_to_root(ctx):
+    """Above the inline cap, collapse to the common-root pattern."""
+    data = init_data()
+    data["bazel"]["failed_tests"] = [
+        {"label": "//app/feature/foo:test_%d" % i, "status": "failed"}
+        for i in range(15)
+    ]
+    _eq(
+        "large set → //app/feature/foo:all",
+        repro_targets(data, ["//..."]),
+        ["//app/feature/foo:all"],
+    )
+
+def _test_repro_targets_large_set_falls_back_when_no_common_root(ctx):
+    """No useful collapse → original command."""
+    data = init_data()
+    data["bazel"]["failed_tests"] = [
+        {"label": "//app%d:test_%d" % (i, i), "status": "failed"}
+        for i in range(15)
+    ]
+    _eq(
+        "large set, no shared root → fallback",
+        repro_targets(data, ["//..."]),
+        ["//..."],
+    )
+
+def _test_repro_targets_no_failures_falls_back(ctx):
+    """Empty failure set (warning-level invocation) → original command."""
+    data = init_data()
+    _eq(
+        "no failures → fallback",
+        repro_targets(data, ["//app/..."]),
+        ["//app/..."],
+    )
+
+def _test_repro_targets_includes_target_failures(ctx):
+    """Build failures land in `failed_targets` (with action-level entries
+    when present, plus any failed_targets without a matching action —
+    analysis / loading / link failures, derived consumers). Both feed
+    the repro: the action label is the most informative, and including
+    target-only entries means a mixed-failure run doesn't drop targets
+    that broke during analysis."""
+    data = init_data()
+    data["bazel"]["failed_action_labels"] = ["//pkg/broken:lib"]
+    data["bazel"]["failed_actions"] = [{"label": "//pkg/broken:lib", "mnemonics": ["CppCompile"]}]
+    data["bazel"]["failed_targets"] = [
+        {"label": "//pkg/broken:lib"},  # root with an action failure
+        {"label": "//pkg/analysis:bad"},  # analysis-only failure
+        {"label": "//pkg/consumer:bin"},  # derived consumer
+    ]
+    _eq(
+        "build — action + target failures both surface",
+        repro_targets(data, ["//..."]),
+        ["//pkg/broken:lib", "//pkg/analysis:bad", "//pkg/consumer:bin"],
+    )
+
+def _test_repro_targets_preserves_explicit_label_through_collapse(ctx):
+    """A failed label that the user named directly in the original
+    command stays as an explicit entry alongside the collapse pattern —
+    `bazel test //pkg:all` (and `//pkg/...`) skip `tags = ["manual"]`
+    rules, so a wildcard repro could silently lose a manual test the
+    user invoked by label."""
+    data = init_data()
+    data["bazel"]["failed_tests"] = [
+        {"label": "//app/foo:test_%d" % i, "status": "failed"}
+        for i in range(12)
+    ] + [
+        {"label": "//app/foo:manual_test", "status": "failed"},
+    ]
+    _eq(
+        "collapse keeps the explicit manual label",
+        repro_targets(data, ["//app/...", "//app/foo:manual_test"]),
+        ["//app/foo:manual_test", "//app/foo:all"],
+    )
+
+def _test_repro_targets_collapse_with_only_wildcard_originals(ctx):
+    """When the original command has no explicit labels, the collapse
+    stands alone — no extra entries to preserve."""
+    data = init_data()
+    data["bazel"]["failed_tests"] = [
+        {"label": "//app/foo:test_%d" % i, "status": "failed"}
+        for i in range(15)
+    ]
+    _eq(
+        "wildcard-only original → collapse only",
+        repro_targets(data, ["//app/...", "-//app/legacy/..."]),
+        ["//app/foo:all"],
+    )
+
 _UNIT_TESTS = [
     _test_failed_status_without_failure_bucket,
     _test_failed_status_with_explicit_action_failure,
@@ -910,6 +1053,19 @@ _UNIT_TESTS = [
     _test_bes_get_handles_none,
     _test_failed_test_survives_passed_bucket_cap,
     _test_flaky_test_survives_passed_bucket_cap,
+    _test_common_label_root_same_package_returns_all_pattern,
+    _test_common_label_root_returns_shared_prefix,
+    _test_common_label_root_no_prefix_returns_empty,
+    _test_common_label_root_external_repo_returns_empty,
+    _test_common_label_root_empty_input,
+    _test_common_label_root_single_label,
+    _test_repro_targets_small_set_passes_through,
+    _test_repro_targets_large_set_collapses_to_root,
+    _test_repro_targets_large_set_falls_back_when_no_common_root,
+    _test_repro_targets_no_failures_falls_back,
+    _test_repro_targets_includes_target_failures,
+    _test_repro_targets_preserves_explicit_label_through_collapse,
+    _test_repro_targets_collapse_with_only_wildcard_originals,
 ]
 
 def _unit_test_impl(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -13,7 +13,7 @@ applies uniformly to both tasks.
 """
 
 load("@std//time.axl", "sleep_iter")
-load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "failed_labels", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
+load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "init_data", "now_ms", "process_event", "repro_targets", bazel_conclusion = "conclusion")
 load("./environment.axl", "color_enabled")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
@@ -465,10 +465,11 @@ def run_bazel_task(ctx: TaskContext, command: str) -> TaskConclusion:
     if data.get("bazel_attempts"):
         archive_bazel_attempt(data, attempt + 1, invocation_status.code)
 
-    # Narrow the repro to failed labels when present; else fall back to the task's target pattern.
-    _failed = failed_labels(data)
-    _repro_targets = _failed if _failed else list(ctx.args.targets)
-    _repro_cmd = build_aspect_command(task_cli_path(ctx.task), [], _repro_targets)
+    _repro_cmd = build_aspect_command(
+        task_cli_path(ctx.task),
+        [],
+        repro_targets(data, ctx.args.targets),
+    )
     if _repro_cmd:
         data["repro_commands"].append({"command": _repro_cmd, "description": ""})
 


### PR DESCRIPTION
When a build/test task fails, the repro command now zooms in on what actually broke instead of listing every failed label:

- **build**: just the action-failure labels (root causes with stderr). Transitive consumers refail on their own once the roots rebuild, so listing them adds noise. Falls back to the original target pattern when no root labels are known (loading/analysis failures, aborts).
- **test**: small failure sets (≤10) pass through verbatim. Larger sets collapse to a common-root pattern (`//pkg/foo:all` when every failure is in one package, `//app/...` when they share a package-path prefix); otherwise fall back to the original target pattern.

New helpers in [bazel_results.axl](crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl):

- `common_label_root(labels)` — returns `//<pkg>:all`, `//<prefix>/...`, or `""` for "no useful collapse". External-repo labels (`@foo//...`) and disjoint top-level packages bail to `""`.
- `repro_targets(command, data, original_targets)` — orchestrates per-command behavior described above.

`bazel_runner.axl` calls `repro_targets` instead of the prior inline `failed_labels(data) or ctx.args.targets`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- Build/test repro commands now narrow to root-cause action failures (build) or a small failure set / common-root pattern (test) instead of listing every failed label.

### Test plan

- 12 new unit tests in [bazel_results_test.axl](crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl) cover `common_label_root` (single package, shared prefix, disjoint packages, external repo, empty, single) and `repro_targets` (build root-cause + fallback, test small-set passthrough, test large-set collapse, test large-set fallback when no common root, no-failures fallback).
- `aspect dev test-bazel-results` — 24 sections pass (was 12).
- All snapshot suites (`test-template-snapshots`, `test-format-template-snapshots`, `test-gazelle-template-snapshots`, `test-delivery-template-snapshots`, `test-lint-template-snapshots`, `test-bk-annotation-snapshots`, `test-pr-comment-snapshots`) still pass.
- `aspect build //crates/aspect-cli:aspect-cli` happy path completes — no regression on success.
