### PR TITLE
fix(bazel-results): cap test buckets independently so failures survive a full passed bucket

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -770,13 +770,13 @@ def process_event(data, event):
             if duration_ms:
                 data["bazel"]["executed_duration_ms"] += duration_ms
 
-        total_tracked = (len(data["bazel"]["failed_tests"]) +
-                         len(data["bazel"]["flaky_tests"]) +
-                         len(data["bazel"]["passed_tests"]))
-
+        # Each bucket is capped independently so failures aren't crowded out
+        # by the (much larger) passed-test set on big invocations. A shared
+        # cap left `failed_tests` empty whenever `passed_tests` filled first,
+        # silently breaking repro narrowing and the rendered failure list.
         if status in _FAILED_STATUSES:
             data["bazel"]["failed_test_total"] += 1
-            if total_tracked < MAX_TEST_TARGETS:
+            if len(data["bazel"]["failed_tests"]) < MAX_TEST_TARGETS:
                 data["bazel"]["failed_tests"].append({
                     "label": label,
                     "cached": cached,
@@ -790,7 +790,7 @@ def process_event(data, event):
             return True
         elif status == _TEST_STATUS_FLAKY:
             data["bazel"]["flaky_test_total"] += 1
-            if total_tracked < MAX_TEST_TARGETS:
+            if len(data["bazel"]["flaky_tests"]) < MAX_TEST_TARGETS:
                 data["bazel"]["flaky_tests"].append({
                     "label": label,
                     "cached": cached,
@@ -807,7 +807,7 @@ def process_event(data, event):
             data["bazel"]["passed_test_total"] += 1
             if cached:
                 data["bazel"]["cached_test_total"] += 1
-            if label and total_tracked < MAX_TEST_TARGETS:
+            if label and len(data["bazel"]["passed_tests"]) < MAX_TEST_TARGETS:
                 data["bazel"]["passed_tests"].append({
                     "label": label,
                     "cached": cached,

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -8,7 +8,7 @@ Two task implementations live here:
     `compute_invocation_state`, `conclusion`, and skipped-bucket plumbing.
 """
 
-load("./bazel_results.axl", "bes_get", "build_details_data", "compute_invocation_state", "conclusion", "init_data", "render_check_output")
+load("./bazel_results.axl", "MAX_TEST_TARGETS", "bes_get", "build_details_data", "compute_invocation_state", "conclusion", "init_data", "process_event", "render_check_output")
 
 # ---------------------------------------------------------------------------
 # Fake data builders
@@ -839,6 +839,62 @@ def _test_bes_get_handles_none(ctx):
     _eq("bes_get(None) → default", bes_get(None, "status", ""), "")
     _eq("bes_get(None) → None default", bes_get(None, "anything"), None)
 
+def _make_test_summary(label, status, cached = False, duration_ms = 0):
+    """Synthesize a minimal `test_summary` BES event for `process_event`."""
+    return struct(
+        kind = "test_summary",
+        id = struct(label = label),
+        payload = struct(
+            overall_status = status,
+            total_num_cached = 1 if cached else 0,
+            total_run_duration_millis = duration_ms,
+        ),
+    )
+
+def _test_failed_test_survives_passed_bucket_cap(ctx):
+    """Regression: a failed test arriving after `passed_tests` hits
+    `MAX_TEST_TARGETS` must still land in `failed_tests`. A previous
+    shared-cap implementation left `failed_tests` empty in this case,
+    which silently broke repro narrowing and the rendered failure list.
+
+    BES status strings are snake_case (see `_FAILED_STATUSES`)."""
+    data = init_data()
+
+    # Drive `passed_tests` past the cap.
+    for i in range(MAX_TEST_TARGETS + 50):
+        process_event(data, _make_test_summary("//pkg/p:test_%d" % i, "passed"))
+
+    _eq(
+        "passed bucket capped at MAX_TEST_TARGETS",
+        len(data["bazel"]["passed_tests"]),
+        MAX_TEST_TARGETS,
+    )
+    _eq(
+        "passed_test_total counts every passed test",
+        data["bazel"]["passed_test_total"],
+        MAX_TEST_TARGETS + 50,
+    )
+
+    # The failure arrives after the cap was hit. With per-bucket caps it lands.
+    process_event(data, _make_test_summary("//pkg/broken:test", "failed", duration_ms = 1000))
+
+    failed = [t["label"] for t in data["bazel"]["failed_tests"]]
+    _eq("failed test recorded despite full passed bucket", failed, ["//pkg/broken:test"])
+    _eq("failed_test_total reflects the failure", data["bazel"]["failed_test_total"], 1)
+
+def _test_flaky_test_survives_passed_bucket_cap(ctx):
+    """Same reasoning as failed-tests: flakies are diagnostic and must
+    survive a full passed bucket."""
+    data = init_data()
+    for i in range(MAX_TEST_TARGETS + 5):
+        process_event(data, _make_test_summary("//pkg/p:test_%d" % i, "passed"))
+
+    process_event(data, _make_test_summary("//pkg/flake:test", "flaky"))
+
+    flaky = [t["label"] for t in data["bazel"]["flaky_tests"]]
+    _eq("flaky test recorded despite full passed bucket", flaky, ["//pkg/flake:test"])
+    _eq("flaky_test_total reflects the flake", data["bazel"]["flaky_test_total"], 1)
+
 _UNIT_TESTS = [
     _test_failed_status_without_failure_bucket,
     _test_failed_status_with_explicit_action_failure,
@@ -852,6 +908,8 @@ _UNIT_TESTS = [
     _test_bes_get_returns_default_for_missing_field,
     _test_bes_get_returns_value_for_present_field,
     _test_bes_get_handles_none,
+    _test_failed_test_survives_passed_bucket_cap,
+    _test_flaky_test_survives_passed_bucket_cap,
 ]
 
 def _unit_test_impl(ctx):


### PR DESCRIPTION
`test_summary` events were gated by a shared `total_tracked < MAX_TEST_TARGETS` check across the failed / flaky / passed buckets. On large invocations `passed_tests` fills to 100 quickly, after which every subsequent `test_summary` — failed, flaky, or passed — was dropped from its bucket while the `*_total` counter still ticked.

**Effect for users:** a 1000-test run with a single failure left `failed_tests` empty whenever the passing tests reported in first. The PR comment's "Reproduce" block fell back to the original task target pattern (the full `//... -//excluded/...` list) instead of the one failing label, and the rendered failure list was blank.

**Fix:** each bucket caps on its own length. Worst-case memory grows from 1× to 3× `MAX_TEST_TARGETS` (~300 entries), which is fine for status-check rendering. Failures always make it in (up to 100), which is the diagnostic signal that matters.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- Fix: failed and flaky test labels are no longer dropped on large invocations when the passing-test bucket reaches its cap. The PR comment's failure list and the repro command now reflect the actual failures.

### Test plan

- Two new regression unit tests in [bazel_results_test.axl](crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl) drive `passed_tests` past `MAX_TEST_TARGETS` via synthesized `test_summary` events, then feed a failed / flaky summary and assert the label lands in its bucket. Fails on `main`; passes with the fix.
- `aspect dev test-bazel-results` — 14 sections pass (was 12).
- All template-snapshot suites still pass (`test-template-snapshots`, `test-format-template-snapshots`, `test-gazelle-template-snapshots`, `test-delivery-template-snapshots`, `test-lint-template-snapshots`, `test-bk-annotation-snapshots`, `test-pr-comment-snapshots`).
