### PR TITLE
fix(repro): dedup target list so duplicates from `original_targets` don't render

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -1172,6 +1172,16 @@ def _is_explicit_label(target):
         return False
     return True
 
+def _dedup_preserve_order(items):
+    """Order-preserving dedup of a list of strings."""
+    seen = {}
+    out = []
+    for x in items:
+        if x not in seen:
+            seen[x] = True
+            out.append(x)
+    return out
+
 def repro_targets(data, original_targets):
     """Pick the target list to render in the repro command for a failing
     build/test task.
@@ -1192,17 +1202,19 @@ def repro_targets(data, original_targets):
     root is fixed.
 
     `original_targets` is the user-supplied positional list (e.g.
-    `ctx.args.targets`). Returns a list[str] suitable for
-    `build_aspect_command`'s `targets` arg.
+    `ctx.args.targets`). The returned list is always order-preserving
+    deduped so the rendered repro never carries duplicate labels — the
+    fallback path passes through whatever the user typed, which is the
+    one place a duplicate can sneak in.
     """
     failed = failed_labels(data)
     if not failed:
-        return list(original_targets)
+        return _dedup_preserve_order(original_targets)
     if len(failed) <= _REPRO_INLINE_MAX:
         return failed
     root = common_label_root(failed)
     if not root:
-        return list(original_targets)
+        return _dedup_preserve_order(original_targets)
 
     explicit_in_original = {t: True for t in original_targets if _is_explicit_label(t)}
     explicit_failed = [l for l in failed if l in explicit_in_original]

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -1038,6 +1038,22 @@ def _test_repro_targets_collapse_with_only_wildcard_originals(ctx):
         ["//app/foo:all"],
     )
 
+def _test_repro_targets_dedups_fallback_input(ctx):
+    """Fallback to `original_targets` passes through whatever the user
+    typed; if they listed the same label twice, the rendered repro must
+    not echo the duplicate."""
+    data = init_data()  # no failures → fallback
+    _eq(
+        "duplicate explicit labels collapsed",
+        repro_targets(data, ["//pkg:a", "//pkg:b", "//pkg:a"]),
+        ["//pkg:a", "//pkg:b"],
+    )
+    _eq(
+        "duplicate wildcards collapsed",
+        repro_targets(data, ["//pkg/...", "//pkg/..."]),
+        ["//pkg/..."],
+    )
+
 _UNIT_TESTS = [
     _test_failed_status_without_failure_bucket,
     _test_failed_status_with_explicit_action_failure,
@@ -1066,6 +1082,7 @@ _UNIT_TESTS = [
     _test_repro_targets_includes_target_failures,
     _test_repro_targets_preserves_explicit_label_through_collapse,
     _test_repro_targets_collapse_with_only_wildcard_originals,
+    _test_repro_targets_dedups_fallback_input,
 ]
 
 def _unit_test_impl(ctx):


### PR DESCRIPTION
Bug report on top of #1124: the rendered repro command sometimes carried duplicate `//target:name` entries.

**Audit:**
- `failed_labels(data)` already dedups across `failed_actions` / `failed_targets` / `failed_tests`.
- The collapse path returns `explicit_failed + [root]`; explicit labels are a deduped subset of `failed`, and the root is a wildcard pattern that can't match an explicit label as an exact string.
- The fallback paths (`if not failed: return list(original_targets)` and `if not root: return list(original_targets)`) pass `ctx.args.targets` through verbatim. If the user typed the same label twice — or upstream tooling synthesized duplicates — we relayed them.

**Fix:** order-preserving dedup at the two fallback return sites. Output is now guaranteed unique regardless of source. User's original ordering is preserved.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- Fix: duplicate `//target:name` entries no longer appear in the rendered repro command for failing build/test tasks.

### Test plan

- New `_test_repro_targets_dedups_fallback_input` regression test in [bazel_results_test.axl](crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl) covers the explicit-label and wildcard duplicate cases. Fails on `main`; passes with the fix.
- `aspect dev test-bazel-results` — 28 sections pass (was 27).
