### PR TITLE
fix(rate-limit): protect quota under multi-task swarms

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
@@ -131,17 +131,28 @@ _RESET_JUMP_S = 600
 _TERMINAL_ONLY_FACTOR = 999999.0
 
 # Fractions of `limit` at which the LOW and IMPORTANT WARN lines
-# fire. The threshold ladder reuses these so the WARN boundary and
-# the throttle-factor step align by construction.
+# fire. Independent from the threshold ladder below — these are the
+# "user-visible" boundaries; the ladder is finer-grained.
 _THRESHOLD_LOW_FRACTION = 0.20
 _THRESHOLD_IMPORTANT_FRACTION = 0.05
 
-# Threshold table for the `<2 observations` fallback factor. Order
-# matters: first row whose pct ≥ remaining/limit wins.
+# Throttle-factor table used when burn-rate inference is unavailable
+# (`< 2 observations` in the merged buffer). Order matters: first row
+# whose threshold the bucket fraction exceeds wins.
+#
+# Pinned for swarms: the 20-50% band is sliced so the at-risk 20-30%
+# slice steps to 5× (was 2× under the old single 20-50% tier), the
+# 10-20% band sits at 20×, and the 5-10% band lifts to 50× — at that
+# pressure the only API calls worth making are initial spawn-label
+# flips and terminal verdicts (both of which bypass the throttle in
+# their callers), so the 50× factor stretches every heartbeat past
+# any realistic task lifetime.
 _THRESHOLD_LADDER = [
     (0.50, 1.0),
-    (_THRESHOLD_LOW_FRACTION, 2.0),
-    (_THRESHOLD_IMPORTANT_FRACTION, 5.0),
+    (0.30, 2.0),
+    (_THRESHOLD_LOW_FRACTION, 5.0),
+    (0.10, 20.0),
+    (_THRESHOLD_IMPORTANT_FRACTION, 50.0),
     (0.00, _TERMINAL_ONLY_FACTOR),
 ]
 
@@ -151,11 +162,13 @@ _TIME_TO_RESET_FLOOR_S = 60
 
 # Fraction of `limit` to reserve as untouchable headroom for terminal
 # / must-succeed calls (final task verdicts, attribution-required
-# check-run conclusions). The burn-rate path
-# sizes itself so steady-state usage stops at `1 - _RESERVE_FRACTION`
-# of the limit — i.e., we aim to use at most 80% of the bucket before
-# yielding to terminal-only cadence.
-_RESERVE_FRACTION = 0.20
+# check-run conclusions). The burn-rate path sizes itself so
+# steady-state usage stops at `1 - _RESERVE_FRACTION` of the limit —
+# i.e., we aim to use at most 70% of the bucket before yielding to
+# terminal-only cadence. The cushion is wide enough to absorb the
+# overshoot a swarm of concurrent tasks generates while burn-rate
+# inference converges on the per-task interval.
+_RESERVE_FRACTION = 0.30
 
 # ── Per-task state (file pattern) ───────────────────────────────────
 #
@@ -485,7 +498,17 @@ def throttle_factor(ctx, bucket, now_epoch_s = None):
 def _throttle_factor_from_state(state, bucket, now_epoch_s, std):
     """Pure version of `throttle_factor` that operates on already-loaded
     state. `effective_throttle_factor` uses this so it doesn't load the
-    state file twice in one call."""
+    state file twice in one call.
+
+    Burn-rate inference is preferred because the merged buffer
+    already encodes swarm pressure (own + sibling observations →
+    swarm-wide burn). When that path can't fire (`< 2 observations`),
+    the threshold-ladder fallback is multiplied by the visible swarm
+    size for the App bucket — without that scaling, a fresh task in a
+    busy swarm reads the same ladder factor as a solo task and emits
+    at the same cadence, undercutting the swarm's collective throttle.
+    The Env bucket is per-job, so siblings are not competing for it
+    and the factor stays unscaled."""
     obs = _merged_observations_from_state(state, bucket)
     if len(obs) >= 2:
         clock = now_epoch_s if now_epoch_s != None else epoch_now_s(std)
@@ -494,8 +517,22 @@ def _throttle_factor_from_state(state, bucket, now_epoch_s, std):
             return factor
     if obs:
         latest = obs[-1]
-        return _threshold_factor(latest[1], latest[2])
+        swarm = _competing_swarm_size(state, bucket)
+        return _threshold_factor(latest[1], latest[2]) * float(swarm)
     return 1.0
+
+def _competing_swarm_size(state, bucket):
+    """Count tasks competing for `bucket`'s quota. Shared App-bucket:
+    self + every sibling that's posted an App-bucket observation.
+    Per-job Env bucket: always 1 (each task has its own quota)."""
+    if bucket != BUCKET_APP:
+        return 1
+    siblings = state.get("sibling_observations") or {}
+    count = 1  # self
+    for sibling_obs in siblings.values():
+        if sibling_obs.get(bucket, []):
+            count += 1
+    return count
 
 # Cap on the merged-view buffer size. Slightly larger than `_RING_SIZE`
 # because we're unioning own + sibling rings; pulling the latest 32 by
@@ -743,17 +780,22 @@ def effective_throttle_factor(ctx, bucket, elapsed_s, min_interval_s):
 
 # Step boundaries — keep in sync with `_THRESHOLD_LADDER` so the
 # transition log lines up with the points where the quota path
-# changes behavior.
-_FACTOR_STEP_TERMINAL = 100.0
+# changes behavior. The TERMINAL step is the sentinel itself so
+# swarm-scaled factors of (say) 50 × 28 = 1400 still display as a
+# real multiplier rather than masquerading as "terminal-only".
+_FACTOR_STEP_TERMINAL = _TERMINAL_ONLY_FACTOR
+_FACTOR_STEP_AGGRESSIVE = 50.0
 _FACTOR_STEP_HIGH = 5.0
 _FACTOR_STEP_MEDIUM = 2.0
 
 def _factor_step(factor):
     """Categorize a continuous throttle factor into a coarse step for
-    transition logging. The step labels (1 / 2 / 5 / 999999) match
+    transition logging. The step labels (1 / 2 / 5 / 50 / 999999) match
     the rows of `_THRESHOLD_LADDER`."""
     if factor >= _FACTOR_STEP_TERMINAL:
         return 999999
+    if factor >= _FACTOR_STEP_AGGRESSIVE:
+        return 50
     if factor >= _FACTOR_STEP_HIGH:
         return 5
     if factor >= _FACTOR_STEP_MEDIUM:

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
@@ -140,9 +140,9 @@ def _test_reset_crossing_rebaselines_watermark(ctx):
     # post-reset observations now, so it computes a meaningful rate.
     record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 5000, reset_epoch = 4600, epoch_s = 110.0)
 
-    # 100 calls in 10s = 10/s. safe_remaining = 4900 - 0.20*5000 = 3900.
-    # time_to_reset = max(60, 4600-0) = 4600. safe_burn = 3900/4600 ≈ 0.85/s.
-    # factor ≈ 10/0.85 ≈ 11.8.
+    # 100 calls in 10s = 10/s. safe_remaining = 4900 - 0.30*5000 = 3400.
+    # time_to_reset = max(60, 4600-0) = 4600. safe_burn = 3400/4600 ≈ 0.74/s.
+    # factor ≈ 10/0.74 ≈ 13.5.
     factor = throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0)
     _assert("post-reset — burn-rate sees only fresh-window data", factor > 5.0)
 
@@ -239,19 +239,28 @@ def _test_two_bucket_independence(ctx):
 
 def _test_threshold_factor_ladder(ctx):
     """With a single observation, the factor falls through the
-    threshold ladder. Verifies the boundaries: 95% → 1×, 30% → 2×,
-    10% → 5×, 3% → terminal-only."""
+    threshold ladder. Solo task (no visible siblings) means the
+    swarm-size multiplier is 1, so the factor reads back as the raw
+    ladder row. Verifies every boundary."""
     _reset(ctx)
     record_observation(ctx, BUCKET_APP, remaining = 4800, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
     _eq("threshold — 96% → 1×", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 1.0)
 
     _reset(ctx)
-    record_observation(ctx, BUCKET_APP, remaining = 1500, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
-    _eq("threshold — 30% → 2×", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 2.0)
+    record_observation(ctx, BUCKET_APP, remaining = 2000, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq("threshold — 40% → 2×", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 2.0)
 
     _reset(ctx)
-    record_observation(ctx, BUCKET_APP, remaining = 500, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
-    _eq("threshold — 10% → 5×", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 5.0)
+    record_observation(ctx, BUCKET_APP, remaining = 1250, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq("threshold — 25% → 5×", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 5.0)
+
+    _reset(ctx)
+    record_observation(ctx, BUCKET_APP, remaining = 600, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq("threshold — 12% → 20×", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 20.0)
+
+    _reset(ctx)
+    record_observation(ctx, BUCKET_APP, remaining = 400, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq("threshold — 8% → 50×", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 50.0)
 
     _reset(ctx)
     record_observation(ctx, BUCKET_APP, remaining = 150, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
@@ -273,8 +282,9 @@ def _test_throttle_factor_burn_rate_inference(ctx):
     _reset(ctx)
 
     # Reset 1 hour out (now_epoch_s = 0). Bucket has burned 100/sec
-    # over 10s = effectively 100 calls/sec. safe_burn = 4900/3600 ≈ 1.36/sec.
-    # factor ≈ 100/1.36 ≈ 73.5×.
+    # over 10s = effectively 100 calls/sec. safe_remaining = 4900 -
+    # 0.30*6000 = 3100. safe_burn = 3100/3600 ≈ 0.86/sec. factor ≈
+    # 100/0.86 ≈ 116×.
     reset_epoch = 3600
     record_observation(ctx, BUCKET_APP, remaining = 5900, limit = 6000, reset_epoch = reset_epoch, epoch_s = 100.0)
     record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 6000, reset_epoch = reset_epoch, epoch_s = 110.0)
@@ -383,13 +393,13 @@ def _test_effective_throttle_factor_picks_larger(ctx):
         6.0,
     )
 
-    # Drop the quota into the threshold ladder's 5% step (factor 5.0).
+    # Drop the quota into the threshold ladder's 5-10% step (factor 50.0).
     # Time at 0 elapsed → 1.0. Quota factor wins.
-    record_observation(ctx, BUCKET_APP, remaining = 500, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    record_observation(ctx, BUCKET_APP, remaining = 400, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
     _eq(
         "effective — quota pressure dominates time at task start",
         effective_throttle_factor(ctx, BUCKET_APP, elapsed_s = 0, min_interval_s = 10),
-        5.0,
+        50.0,
     )
 
 def _test_seed_from_rate_limit_body(ctx):
@@ -524,11 +534,11 @@ def _test_burn_rate_falls_back_on_degenerate_inputs(ctx):
     # Missing reset_epoch — burn-rate calc can't compute time_to_reset
     # without it, so falls back to the threshold ladder.
     _reset(ctx)
-    record_observation(ctx, BUCKET_APP, remaining = 600, limit = 5000, reset_epoch = 0, epoch_s = 1.0)
-    record_observation(ctx, BUCKET_APP, remaining = 500, limit = 5000, reset_epoch = 0, epoch_s = 2.0)
+    record_observation(ctx, BUCKET_APP, remaining = 700, limit = 5000, reset_epoch = 0, epoch_s = 1.0)
+    record_observation(ctx, BUCKET_APP, remaining = 600, limit = 5000, reset_epoch = 0, epoch_s = 2.0)
 
-    # 10% remaining on the threshold ladder → 5×.
-    _eq("no reset_epoch — falls back to threshold (10% → 5×)", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 5.0)
+    # 12% remaining on the threshold ladder → 20×.
+    _eq("no reset_epoch — falls back to threshold (12% → 20×)", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 20.0)
 
 def _test_seed_from_rate_limit_body_edge_cases(ctx):
     """`seed_from_rate_limit_body` ignores partially-missing bodies
@@ -707,8 +717,8 @@ def _test_merged_view_drives_throttle_factor(ctx):
     _reset(ctx)
 
     # Reset 1 hour out (now_epoch_s = 0). Sibling A burned 100 calls
-    # in 10s = ~10/s. safe_burn ≈ (4700 - 0.20*5000) / 3600 = 1.0/s.
-    # factor ≈ 10× — well above threshold-ladder (96% remaining → 1×).
+    # in 10s = ~10/s. safe_burn ≈ (4700 - 0.30*5000) / 3600 ≈ 0.89/s.
+    # factor ≈ 11× — well above threshold-ladder (96% remaining → 1×).
     reset_epoch = 3600
 
     # Only our own first observation: 4700/5000 → threshold ladder hits the 96% row → 1×.
@@ -754,6 +764,62 @@ def _test_merged_view_handles_flat_burn(ctx):
         1.0,
     )
 
+def _test_threshold_factor_scales_with_visible_swarm(ctx):
+    """A cold-started task with one App-bucket observation reads the
+    threshold ladder. When siblings are visible *for the same shared
+    bucket*, the factor is multiplied by the swarm size (self +
+    siblings) so the per-task interval stretches by enough to keep
+    the swarm's collective burn under safe. Burn-rate inference
+    covers the steady-state case; this multiplier covers the
+    cold-start window before burn-rate observations stabilize.
+
+    The test reaches the threshold-path branch by giving siblings
+    the same `epoch_s` as the own observation — `delta_t == 0` makes
+    `_burn_rate_factor` return None, so the fallback path runs."""
+    _reset(ctx)
+
+    # Solo task at 25% App-bucket remaining — ladder picks the 5× row.
+    record_observation(ctx, BUCKET_APP, remaining = 1250, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq("swarm — solo task at 25% → 5×", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 5.0)
+
+    # Three siblings, each with one App-bucket observation at the same
+    # `epoch_s` as the own observation. Merged buffer has 4 samples
+    # but `delta_t == 0`, so burn-rate inference returns None and the
+    # threshold-path branch runs with `swarm = 4`.
+    for i in range(3):
+        ingest_sibling_observations(ctx, "sibling-%d" % i, {
+            BUCKET_APP: [
+                {"epoch_s": 1.0, "remaining": 1250, "limit": 5000, "reset_epoch": _FAR_FUTURE},
+            ],
+        })
+    _eq(
+        "swarm — 1 + 3 siblings at 25% → 5× × 4 = 20×",
+        throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0),
+        20.0,
+    )
+
+def _test_threshold_factor_swarm_scaling_skips_env_bucket(ctx):
+    """The Env bucket is the per-job `GITHUB_TOKEN` — siblings don't
+    compete for it because each has its own quota. The swarm-size
+    multiplier must stay 1 for Env even when many siblings are
+    visible."""
+    _reset(ctx)
+    record_observation(ctx, BUCKET_ENV, remaining = 250, limit = 1000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq("env — solo at 25% → 5×", throttle_factor(ctx, BUCKET_ENV, now_epoch_s = 0), 5.0)
+
+    # Three siblings, each with App-bucket activity (irrelevant to env quota).
+    for i in range(3):
+        ingest_sibling_observations(ctx, "sibling-%d" % i, {
+            BUCKET_APP: [
+                {"epoch_s": 0.5, "remaining": 4000, "limit": 5000, "reset_epoch": _FAR_FUTURE},
+            ],
+        })
+    _eq(
+        "env — siblings active on App bucket don't compete for Env → 5× unchanged",
+        throttle_factor(ctx, BUCKET_ENV, now_epoch_s = 0),
+        5.0,
+    )
+
 def _test_impl(ctx):
     _test_record_basic(ctx)
     _test_record_buffer_truncation(ctx)
@@ -785,7 +851,9 @@ def _test_impl(ctx):
     _test_ingest_sibling_observations(ctx)
     _test_merged_view_drives_throttle_factor(ctx)
     _test_merged_view_handles_flat_burn(ctx)
-    print("rate_limit.axl: OK (30 sections)")
+    _test_threshold_factor_scales_with_visible_swarm(ctx)
+    _test_threshold_factor_swarm_scaling_skips_env_bucket(ctx)
+    print("rate_limit.axl: OK (32 sections)")
     return 0
 
 rate_limit_tests = task(


### PR DESCRIPTION
A large swarm of concurrent tasks can burn through the shared GitHub App quota before the reactive throttle has time to converge. Each task's burn-rate inference eventually settles on a safe per-task interval, but during the cold-start window — and in the bands where the threshold-ladder fallback is loose — the swarm can consume most of the budget before any throttling visibly kicks in.

Four tighter knobs close the gap:

- **`_RESERVE_FRACTION` 0.20 → 0.30.** Burn-rate path keeps a bigger untouched cushion for terminal/must-succeed calls; the factor escalates sooner.
- **Threshold ladder split + lifted.** The old 20-50% tier is now 30-50% → 2× and 20-30% → 5×. The 5-20% band splits into 10-20% → 20× and **5-10% → 50×** (very aggressive — at that pressure only spawn-label flips and terminal verdicts are worth making, and both bypass the throttle in their callers).
- **Threshold-path factor scaled by visible competing swarm size** for the shared App bucket. Env bucket (per-job `GITHUB_TOKEN`) stays unscaled because siblings aren't competing for it.
- **`_FACTOR_STEP_TERMINAL` raised to the actual sentinel value** so swarm-scaled factors (e.g. 50 × 28 = 1400) render in the throttle-transition log as "1400×" instead of masquerading as "terminal-only".

Burn-rate inference is untouched — the merged observation buffer already encodes swarm pressure.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- Tighter GitHub API rate-limit throttling for multi-task runs: bigger reserve, more aggressive threshold ladder (new 5-10% tier at 50×), and per-task interval scaled by the visible competing swarm size for the shared App bucket.

### Test plan

- Two new tests in [rate_limit_test.axl](crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl):
  - `_test_threshold_factor_scales_with_visible_swarm` — solo task at 25% remaining → 5×; same task + 3 visible App-bucket siblings → 20× (= 5× × 4).
  - `_test_threshold_factor_swarm_scaling_skips_env_bucket` — Env factor stays 5× regardless of siblings.
- Existing `_test_threshold_factor_ladder` updated for every new boundary (40% → 2×, 25% → 5×, 12% → 20×, 8% → 50×, 3% → terminal-only).
- `_test_burn_rate_falls_back_on_degenerate_inputs` updated (12% remaining → 20×).
- `_test_effective_throttle_factor_picks_larger` updated (quota at 8% → 50×).
- `aspect dev test-rate-limit` — 32 sections pass (was 30).
- `test-bazel-results`, `test-template-snapshots`, `test-pr-comment-snapshots`, `test-bk-annotation-snapshots` still pass.
