### PR TITLE
fix(launcher): split aspect root from bazel root for bazelrc lookup

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -76,11 +76,17 @@ def test_env(ctx: TaskContext, tc: int, temp_dir: str) -> int:
         tc = test_case(tc, type(var[0]) == "string" and type(var[1]) == "string", "Var entries should be string pairs")
         break
 
-    # Test root_dir
-    root_dir = ctx.std.env.root_dir()
-    tc = test_case(tc, root_dir != None and root_dir != "", "root_dir should return a non-empty value")
-    tc = test_case(tc, type(root_dir) == "string", "root_dir should be a string")
-    tc = test_case(tc, ctx.std.fs.is_dir(root_dir), "root_dir should be a directory")
+    # Test aspect_root_dir
+    aspect_root_dir = ctx.std.env.aspect_root_dir()
+    tc = test_case(tc, aspect_root_dir != None and aspect_root_dir != "", "aspect_root_dir should return a non-empty value")
+    tc = test_case(tc, type(aspect_root_dir) == "string", "aspect_root_dir should be a string")
+    tc = test_case(tc, ctx.std.fs.is_dir(aspect_root_dir), "aspect_root_dir should be a directory")
+
+    # Test bazel_root_dir
+    bazel_root_dir = ctx.std.env.bazel_root_dir()
+    tc = test_case(tc, bazel_root_dir != None and bazel_root_dir != "", "bazel_root_dir should return a non-empty value")
+    tc = test_case(tc, type(bazel_root_dir) == "string", "bazel_root_dir should be a string")
+    tc = test_case(tc, ctx.std.fs.is_dir(bazel_root_dir), "bazel_root_dir should be a directory")
 
     # Test set_var: set a new variable and read it back
     ctx.std.env.set_var("AXL_TEST_SET_VAR", "hello")
@@ -385,9 +391,9 @@ def test_bazel_info(ctx: TaskContext, tc: int) -> int:
     # output_base should be an absolute path
     tc = test_case(tc, info["output_base"].startswith("/"), "output_base should be an absolute path")
 
-    # workspace should match root_dir
-    root_dir = ctx.std.env.root_dir()
-    tc = test_case(tc, info["workspace"] == root_dir, "bazel.info()['workspace'] should match ctx.std.env.root_dir()")
+    # workspace should match aspect_root_dir
+    aspect_root_dir = ctx.std.env.aspect_root_dir()
+    tc = test_case(tc, info["workspace"] == aspect_root_dir, "bazel.info()['workspace'] should match ctx.std.env.aspect_root_dir()")
 
     # calling info() again should return the same output_base
     info2 = ctx.bazel.info()

--- a/.aspect/bootstrap.sh
+++ b/.aspect/bootstrap.sh
@@ -250,7 +250,7 @@ if [ -n "${ASPECT_WORKFLOWS_RUNNER:-}" ]; then
   fi
 
   # Derive workspace subdir from the checkout path.
-  # Mirrors the root_dir derivation in get_bazelrc_flags in environment.axl.
+  # Mirrors the aspect_root_dir derivation in get_bazelrc_flags in environment.axl.
   WORKSPACE_DIR="${BUILDKITE_BUILD_CHECKOUT_PATH:-${GITHUB_WORKSPACE:-${CIRCLE_WORKING_DIRECTORY:-${CI_PROJECT_DIR:-$(pwd)}}}}"
   SUBDIR=$(basename "${WORKSPACE_DIR}" | sed 's|[^a-zA-Z0-9._-]|_|g')
 

--- a/crates/aspect-cli/src/builtins/aspect/axl_add.axl
+++ b/crates/aspect-cli/src/builtins/aspect/axl_add.axl
@@ -235,7 +235,7 @@ def generate_axl_archive_dep(name: str, url: str, integrity: str, strip_prefix: 
 
 def read_module_aspect(ctx: TaskContext) -> str:
     """Read the current MODULE.aspect file content."""
-    module_path = ctx.std.env.root_dir() + "/MODULE.aspect"
+    module_path = ctx.std.env.aspect_root_dir() + "/MODULE.aspect"
 
     if ctx.std.fs.exists(module_path):
         return ctx.std.fs.read_to_string(module_path)
@@ -244,7 +244,7 @@ def read_module_aspect(ctx: TaskContext) -> str:
 
 def write_module_aspect(ctx: TaskContext, content: str):
     """Write content to MODULE.aspect file."""
-    module_path = ctx.std.env.root_dir() + "/MODULE.aspect"
+    module_path = ctx.std.env.aspect_root_dir() + "/MODULE.aspect"
     ctx.std.fs.write(module_path, content)
 
 def check_existing_dep(content: str, name: str) -> bool:

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -694,9 +694,8 @@ def _delivery_impl(ctx):
     for handler in bazel_trait.build_start:
         handler(ctx)
 
-    # Expand .bazelrc so remote cache config flows in automatically
+    # Expand .bazelrc so remote cache config flows in automatically.
     rc = ctx.bazel.parse_rc(
-        root = ctx.std.env.root_dir(),
         flags = flags,
         startup_flags = startup_flags,
     )

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
@@ -873,7 +873,7 @@ def _github_lint_impl(ctx: FeatureContext):
         # Workspace prefix relative to the git root (e.g. "subdir/") —
         # _post_individually prepends it when posting because SARIF paths are
         # workspace-relative but GitHub expects repo-relative paths.
-        git_out = ctx.std.process.command("git").arg("rev-parse").arg("--show-prefix").current_dir(ctx.std.env.root_dir()).stdout("piped").stderr("null").spawn().wait_with_output()
+        git_out = ctx.std.process.command("git").arg("rev-parse").arg("--show-prefix").current_dir(ctx.std.env.aspect_root_dir()).stdout("piped").stderr("null").spawn().wait_with_output()
         if git_out.status.success:
             gh["prefix"] = git_out.stdout.strip()
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -50,7 +50,7 @@ def _workflows_impl(ctx: FeatureContext):
         # Flags to optimize build & test
         (startup_flags, build_flags) = get_bazelrc_flags(
             environment = environment,
-            root_dir = ctx.std.env.root_dir(),
+            aspect_root_dir = ctx.std.env.aspect_root_dir(),
         )
 
         bazel_trait.extra_startup_flags.extend(startup_flags)

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -833,7 +833,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         patch_path = tmp + "/gazelle-" + ctx.task.key + ".patch"
         ctx.std.fs.write(patch_path, diff_stdout)
         apply_result = ctx.std.process.command("git").args(["apply", "-p0", patch_path]) \
-            .current_dir(ctx.std.env.root_dir()) \
+            .current_dir(ctx.std.env.aspect_root_dir()) \
             .stdout("piped").stderr("piped").spawn().wait_with_output()
         ctx.std.fs.remove_file(patch_path)
         if not apply_result.status.success:

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -283,7 +283,6 @@ def run_bazel_task(ctx: TaskContext, command: str) -> TaskConclusion:
         cancellation.wait()
 
     rc = ctx.bazel.parse_rc(
-        root = ctx.std.env.root_dir(),
         startup_flags = startup_flags,
         flags = flags,
     )

--- a/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
@@ -469,7 +469,7 @@ def sanitize_filename(name: str) -> str:
             result += "_"
     return result
 
-def get_bazelrc_flags(environment: WorkflowsEnvironment, root_dir: str) -> (list, list):
+def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str) -> (list, list):
     """
     Generate bazelrc flags from platform configuration.
 
@@ -478,7 +478,7 @@ def get_bazelrc_flags(environment: WorkflowsEnvironment, root_dir: str) -> (list
                      Caller is expected to have already verified
                      `environment.runner != None` since the output_base
                      / output_user_root paths come from the runner.
-        root_dir: absolute path to the workspace root directory
+        aspect_root_dir: absolute path to the Aspect project root.
 
     Returns:
         (startup_flags, build_flags): two lists of flag strings
@@ -488,7 +488,7 @@ def get_bazelrc_flags(environment: WorkflowsEnvironment, root_dir: str) -> (list
         fail("get_bazelrc_flags called without a Workflows runner — gate on environment.runner != None")
 
     repo_name = environment.ci.scm_repo_name if environment.ci else ""
-    subdir = sanitize_filename(root_dir.rstrip("/").split("/")[-1]) if root_dir else "__main__"
+    subdir = sanitize_filename(aspect_root_dir.rstrip("/").split("/")[-1]) if aspect_root_dir else "__main__"
 
     build_flags = []
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -1254,7 +1254,7 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
             if result["success"]:
                 # `git rev-parse --show-prefix` strips the workspace prefix so
                 # GitHub-API paths line up with local relative paths.
-                git_out = ctx.std.process.command("git").arg("rev-parse").arg("--show-prefix").current_dir(ctx.std.env.root_dir()).stdout("piped").stderr("null").spawn().wait_with_output()
+                git_out = ctx.std.process.command("git").arg("rev-parse").arg("--show-prefix").current_dir(ctx.std.env.aspect_root_dir()).stdout("piped").stderr("null").spawn().wait_with_output()
                 prefix = git_out.stdout.strip() if git_out.status.success else ""
                 files = []
                 skipped = []

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -90,7 +90,7 @@ def _spawn(ctx: TaskContext, state: struct, entrypoint: str, args: list[str], ca
         .env("RUNFILES_DIR", runfiles) \
         .env("JAVA_RUNFILES", runfiles) \
         .env("RUNFILES_MANIFEST_FILE", runfiles + "_manifest") \
-        .env("BUILD_WORKSPACE_DIRECTORY", ctx.std.env.root_dir()) \
+        .env("BUILD_WORKSPACE_DIRECTORY", ctx.std.env.aspect_root_dir()) \
         .env("BUILD_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
         .args(args)
     if capture:

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -842,9 +842,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for hook in bazel_trait.build_start:
         hook(ctx)
 
-    # 5. Parse bazelrc and hand startup flags to the Bazel server
+    # 5. Parse bazelrc and hand startup flags to the Bazel server.
     rc = ctx.bazel.parse_rc(
-        root = ctx.std.env.root_dir(),
         startup_flags = startup_flags,
         flags = flags,
     )

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -48,7 +48,7 @@ pub enum CmdError {
 pub struct Cmd<'a, 'v> {
     pub tasks: Vec<&'v dyn TaskLike<'v>>,
     pub features: Vec<&'v dyn FeatureLike<'v>>,
-    pub repo_root: &'a Path,
+    pub aspect_root: &'a Path,
     pub modules: &'a [Mod],
 }
 
@@ -67,12 +67,12 @@ impl<'a, 'v> Cmd<'a, 'v> {
         let feature_blocks: Vec<FeatureBlock> = self
             .features
             .iter()
-            .filter_map(|f| feature_block(*f, self.repo_root, self.modules))
+            .filter_map(|f| feature_block(*f, self.aspect_root, self.modules))
             .collect();
 
         let mut tree = Tree::default();
         for (idx, task) in self.tasks.iter().enumerate() {
-            let label = defined_in_label(task.path(), self.repo_root, self.modules);
+            let label = defined_in_label(task.path(), self.aspect_root, self.modules);
             let task_cmd = task_command(idx, *task, &label, &feature_blocks);
             tree.insert(*task, &label, task_cmd)?;
         }
@@ -565,7 +565,7 @@ struct FeatureBlock {
 
 fn feature_block(
     feat: &dyn FeatureLike<'_>,
-    repo_root: &Path,
+    aspect_root: &Path,
     modules: &[Mod],
 ) -> Option<FeatureBlock> {
     let mut args: Vec<(String, Arg)> = feat
@@ -602,7 +602,7 @@ fn feature_block(
     }
 
     let identifier = feat.export_name().unwrap_or_default();
-    let label = defined_in_label(feat.path(), repo_root, modules);
+    let label = defined_in_label(feat.path(), aspect_root, modules);
     let heading = format!("{} Options", feat.display_name());
     let context = format!(
         "\x1b[3m{}\x1b[0m feature defined in \x1b[3m{}\x1b[0m",
@@ -836,7 +836,7 @@ fn group_section(group_names: &[String]) -> String {
 
 // ── Misc helpers ───────────────────────────────────────────────────────────
 
-fn defined_in_label(path: &Path, repo_root: &Path, modules: &[Mod]) -> String {
+fn defined_in_label(path: &Path, aspect_root: &Path, modules: &[Mod]) -> String {
     for r#mod in modules {
         if r#mod.is_root() || !path.starts_with(&r#mod.root) {
             continue;
@@ -844,7 +844,7 @@ fn defined_in_label(path: &Path, repo_root: &Path, modules: &[Mod]) -> String {
         let rel = path.strip_prefix(&r#mod.root).unwrap_or(path);
         return format!("@{}//{}", r#mod.name, rel.display());
     }
-    let rel = path.strip_prefix(repo_root).unwrap_or(path);
+    let rel = path.strip_prefix(aspect_root).unwrap_or(path);
     format!("{}", rel.display())
 }
 
@@ -988,7 +988,7 @@ mod tests {
         let cmd = Cmd {
             tasks: vec![&t as &dyn TaskLike],
             features: vec![],
-            repo_root: Path::new("/repo"),
+            aspect_root: Path::new("/repo"),
             modules: &[],
         };
         let root = cmd.build("0.0.0").expect("build ok");
@@ -1002,7 +1002,7 @@ mod tests {
         let cmd = Cmd {
             tasks: vec![&t1, &t2],
             features: vec![],
-            repo_root: Path::new("/repo"),
+            aspect_root: Path::new("/repo"),
             modules: &[],
         };
         let root = cmd.build("0.0.0").expect("build ok");
@@ -1018,7 +1018,7 @@ mod tests {
         let cmd = Cmd {
             tasks: vec![&t1, &t2],
             features: vec![],
-            repo_root: Path::new("/repo"),
+            aspect_root: Path::new("/repo"),
             modules: &[],
         };
         match cmd.build("0.0.0") {
@@ -1035,7 +1035,7 @@ mod tests {
         let cmd = Cmd {
             tasks: vec![&t],
             features: vec![],
-            repo_root: Path::new("/repo"),
+            aspect_root: Path::new("/repo"),
             modules: &[],
         };
         let root = cmd.build("0.0.0").expect("build ok");
@@ -1054,7 +1054,7 @@ mod tests {
         let cmd = Cmd {
             tasks: vec![&t],
             features: vec![],
-            repo_root: Path::new("/repo"),
+            aspect_root: Path::new("/repo"),
             modules: &[],
         };
         let root = cmd.build("0.0.0").expect("build ok");
@@ -1075,7 +1075,7 @@ mod tests {
         let cmd = Cmd {
             tasks: vec![&t],
             features: vec![],
-            repo_root: Path::new("/repo"),
+            aspect_root: Path::new("/repo"),
             modules: &[],
         };
         let root = cmd.build("0.0.0").expect("build ok");

--- a/crates/aspect-cli/src/helpers.rs
+++ b/crates/aspect-cli/src/helpers.rs
@@ -6,19 +6,14 @@ use axl_runtime::module::{
 use tokio::fs;
 use tracing::instrument;
 
-// Constants for special directory names used in module resolution.
-// These define the structure for local modules (e.g., .aspect/axl/module_name).
+/// Conventional name of the `.aspect` directory under an Aspect project root.
 pub const DOT_ASPECT_FOLDER: &str = ".aspect";
 
-/// Boundary files identifying an Aspect project root. Probed before the Bazel
-/// markers so a nested Aspect workspace inside a Bazel monorepo (e.g.
-/// `/mono/proj/.aspect/version.axl` under `/mono/MODULE.bazel`) resolves to
-/// the Aspect workspace, not the outer Bazel one.
+/// Markers identifying an Aspect project root.
 const ASPECT_BOUNDARY_FILES: &[&str] = &[AXL_MODULE_FILE, ".aspect/version.axl"];
 
-/// Bazel repository boundary marker files (see
-/// https://bazel.build/external/overview#repository), probed only when no
-/// Aspect boundary file is found.
+/// Markers identifying a Bazel workspace root (see
+/// https://bazel.build/external/overview#repository).
 const BAZEL_BOUNDARY_FILES: &[&str] = &[
     "MODULE.bazel",
     "MODULE.bazel.lock",
@@ -27,25 +22,54 @@ const BAZEL_BOUNDARY_FILES: &[&str] = &[
     "WORKSPACE.bazel",
 ];
 
-/// Asynchronously finds the project root directory starting from `current_work_dir`.
+/// Aspect project root for axl / config loading.
 ///
-/// Two-pass walk over the ancestors of `current_work_dir`, deepest to shallowest:
-/// 1. Returns the first ancestor containing any [`ASPECT_BOUNDARY_FILES`] entry.
-/// 2. If none found, returns the first ancestor containing any [`BAZEL_BOUNDARY_FILES`] entry.
-/// 3. If still none found, returns `current_work_dir`.
-///
-/// The Aspect-first ordering lets a nested Aspect workspace inside a Bazel
-/// monorepo opt out of the surrounding Bazel root by dropping a `.aspect/`
-/// directory or a `MODULE.aspect` file at its boundary.
+/// Deepest ancestor of `current_work_dir` containing `.aspect/version.axl`
+/// or `MODULE.aspect`. Falls back to the deepest Bazel workspace marker so
+/// a pure-Bazel monorepo still resolves to a sane project anchor. Returns
+/// `None` only when neither marker exists anywhere in the ancestry.
 #[instrument]
-pub async fn find_repo_root(current_work_dir: &PathBuf) -> Result<PathBuf, ()> {
-    if let Some(root) = find_ancestor_with_any(current_work_dir, ASPECT_BOUNDARY_FILES).await {
-        return Ok(root);
+pub async fn find_aspect_root(current_work_dir: &Path) -> Option<PathBuf> {
+    find_root_with_fallback(
+        current_work_dir,
+        ASPECT_BOUNDARY_FILES,
+        BAZEL_BOUNDARY_FILES,
+    )
+    .await
+}
+
+/// Bazel workspace root for bazelrc discovery, `bazel info workspace`, and
+/// BES output paths.
+///
+/// Deepest ancestor of `current_work_dir` containing a Bazel marker. Falls
+/// back to the deepest Aspect marker so a pure-Aspect workspace still
+/// resolves. Returns `None` only when neither marker exists.
+///
+/// Diverges from [`find_aspect_root`] when both markers exist in the
+/// ancestry: with `/proj/.aspect/version.axl` and `/proj/e2e/MODULE.bazel`,
+/// invoking from `/proj/e2e/sub/` puts the Aspect root at `/proj` and the
+/// Bazel root at `/proj/e2e`.
+#[instrument]
+pub async fn find_bazel_root(current_work_dir: &Path) -> Option<PathBuf> {
+    find_root_with_fallback(
+        current_work_dir,
+        BAZEL_BOUNDARY_FILES,
+        ASPECT_BOUNDARY_FILES,
+    )
+    .await
+}
+
+/// Walk ancestors of `start` looking for `primary` markers; on miss, walk
+/// again looking for `fallback`. Returns `None` if neither set is found.
+async fn find_root_with_fallback(
+    start: &Path,
+    primary: &[&str],
+    fallback: &[&str],
+) -> Option<PathBuf> {
+    if let Some(root) = find_ancestor_with_any(start, primary).await {
+        return Some(root);
     }
-    if let Some(root) = find_ancestor_with_any(current_work_dir, BAZEL_BOUNDARY_FILES).await {
-        return Ok(root);
-    }
-    Ok(current_work_dir.clone())
+    find_ancestor_with_any(start, fallback).await
 }
 
 /// Walk ancestors of `start` and return the deepest one containing any of `markers`.
@@ -60,18 +84,19 @@ async fn find_ancestor_with_any(start: &Path, markers: &[&str]) -> Option<PathBu
     None
 }
 
-/// Returns a list of axl search paths by constructing paths from the `root_dir` up to the `current_dir`,
-/// appending ".aspect" to each path. If the relative path from `root_dir` to `current_dir` includes
-/// a ".aspect" component, the search stops at the parent directory of that ".aspect", excluding
-/// ".aspect" and any subdirectories from the results.
+/// Returns a list of axl search paths by constructing paths from the
+/// `aspect_root_dir` up to `current_work_dir`, appending `.aspect` to each.
+/// If the relative path from `aspect_root_dir` to `current_work_dir` includes
+/// a `.aspect` component, the search stops at the parent directory of that
+/// `.aspect`, excluding `.aspect` and any subdirectories from the results.
 #[instrument]
 pub fn get_default_axl_search_paths(
     current_work_dir: &PathBuf,
-    root_dir: &PathBuf,
+    aspect_root_dir: &PathBuf,
 ) -> Vec<PathBuf> {
-    if let Ok(rel_path) = current_work_dir.strip_prefix(root_dir) {
-        let mut paths = vec![root_dir.join(DOT_ASPECT_FOLDER)];
-        let mut current = root_dir.clone();
+    if let Ok(rel_path) = current_work_dir.strip_prefix(aspect_root_dir) {
+        let mut paths = vec![aspect_root_dir.join(DOT_ASPECT_FOLDER)];
+        let mut current = aspect_root_dir.clone();
         for component in rel_path.components() {
             if component.as_os_str() == DOT_ASPECT_FOLDER {
                 break;
@@ -122,4 +147,96 @@ pub async fn search_sources(
     }
 
     Ok((found, configs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::{TempDir, tempdir};
+    use tokio::fs as tokio_fs;
+
+    /// Set up a temp directory with the given markers. Each entry is a
+    /// path relative to the temp root; empty content is written. Returns
+    /// the temp handle (kept alive for the test) and the root path.
+    async fn setup(layout: &[&str]) -> (TempDir, PathBuf) {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        for rel in layout {
+            let p = root.join(rel);
+            if let Some(parent) = p.parent() {
+                tokio_fs::create_dir_all(parent).await.unwrap();
+            }
+            tokio_fs::write(&p, "").await.unwrap();
+        }
+        (tmp, root)
+    }
+
+    /// Aspect marker outside, Bazel marker in a sub-workspace: the two
+    /// roots diverge at exactly the boundary their consumers care about.
+    #[tokio::test]
+    async fn aspect_and_bazel_roots_diverge_in_sub_workspace() {
+        let (_tmp, root) = setup(&[".aspect/version.axl", "e2e/MODULE.bazel"]).await;
+        let cwd = root.join("e2e/sub");
+        tokio_fs::create_dir_all(&cwd).await.unwrap();
+
+        assert_eq!(find_aspect_root(&cwd).await, Some(root.clone()));
+        assert_eq!(find_bazel_root(&cwd).await, Some(root.join("e2e")));
+    }
+
+    /// Pure-Aspect workspace → both roots resolve to the Aspect marker.
+    #[tokio::test]
+    async fn bazel_root_falls_back_to_aspect_marker() {
+        let (_tmp, root) = setup(&[".aspect/version.axl"]).await;
+        let cwd = root.join("sub");
+        tokio_fs::create_dir_all(&cwd).await.unwrap();
+
+        assert_eq!(find_aspect_root(&cwd).await, Some(root.clone()));
+        assert_eq!(find_bazel_root(&cwd).await, Some(root));
+    }
+
+    /// Pure-Bazel monorepo → both roots resolve to the Bazel marker.
+    #[tokio::test]
+    async fn aspect_root_falls_back_to_bazel_marker() {
+        let (_tmp, root) = setup(&["MODULE.bazel"]).await;
+        let cwd = root.join("sub");
+        tokio_fs::create_dir_all(&cwd).await.unwrap();
+
+        assert_eq!(find_aspect_root(&cwd).await, Some(root.clone()));
+        assert_eq!(find_bazel_root(&cwd).await, Some(root));
+    }
+
+    /// No markers anywhere → both roots are `None`; callers supply their
+    /// own fallback (typically cwd).
+    #[tokio::test]
+    async fn both_roots_are_none_when_no_markers() {
+        let (_tmp, root) = setup(&[]).await;
+        let cwd = root.join("sub");
+        tokio_fs::create_dir_all(&cwd).await.unwrap();
+
+        assert_eq!(find_aspect_root(&cwd).await, None);
+        assert_eq!(find_bazel_root(&cwd).await, None);
+    }
+
+    /// `MODULE.aspect` is recognized as an Aspect marker.
+    #[tokio::test]
+    async fn aspect_root_recognizes_module_aspect() {
+        let (_tmp, root) = setup(&["MODULE.aspect"]).await;
+        let cwd = root.join("sub");
+        tokio_fs::create_dir_all(&cwd).await.unwrap();
+
+        assert_eq!(find_aspect_root(&cwd).await, Some(root.clone()));
+        assert_eq!(find_bazel_root(&cwd).await, Some(root));
+    }
+
+    /// Every documented Bazel marker is recognized — guards against
+    /// silent drift in `BAZEL_BOUNDARY_FILES`.
+    #[tokio::test]
+    async fn bazel_root_recognizes_every_marker() {
+        for marker in BAZEL_BOUNDARY_FILES {
+            let (_tmp, root) = setup(&[marker]).await;
+            let cwd = root.join("sub");
+            tokio_fs::create_dir_all(&cwd).await.unwrap();
+            assert_eq!(find_bazel_root(&cwd).await, Some(root), "marker: {marker}");
+        }
+    }
 }

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -17,7 +17,9 @@ use tokio::task::spawn_blocking;
 use tracing::info_span;
 
 use crate::cmd::Cmd;
-use crate::helpers::{find_repo_root, get_default_axl_search_paths, search_sources};
+use crate::helpers::{
+    find_aspect_root, find_bazel_root, get_default_axl_search_paths, search_sources,
+};
 
 // Must use a multi thread runtime with at least 3 threads for following reasons;
 //
@@ -73,15 +75,20 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
     .entered();
 
     let current_work_dir = std::env::current_dir()?;
-    let repo_root = find_repo_root(&current_work_dir)
+    // `Env` requires both roots; cwd is the last-resort fallback when no
+    // marker file exists anywhere up the tree.
+    let aspect_root = find_aspect_root(&current_work_dir)
         .await
-        .map_err(|_| anyhow::anyhow!("could not find root directory"))?;
+        .unwrap_or_else(|| current_work_dir.clone());
+    let bazel_root = find_bazel_root(&current_work_dir)
+        .await
+        .unwrap_or_else(|| current_work_dir.clone());
 
-    let disk_store = DiskStore::new(repo_root.clone());
-    let mode = ModEvaluator::new(repo_root.clone());
+    let disk_store = DiskStore::new(aspect_root.clone());
+    let mode = ModEvaluator::new(aspect_root.clone());
 
-    let root_mod = mode.evaluate(AXL_ROOT_MODULE_NAME.to_string(), repo_root.clone())?;
-    let builtins = builtins::expand_builtins(repo_root.clone(), disk_store.builtins_path())?;
+    let root_mod = mode.evaluate(AXL_ROOT_MODULE_NAME.to_string(), aspect_root.clone())?;
+    let builtins = builtins::expand_builtins(aspect_root.clone(), disk_store.builtins_path())?;
     let module_roots = disk_store.expand_store(&root_mod, builtins).await?;
 
     let mut modules: Vec<Mod> = vec![];
@@ -91,7 +98,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
         modules.push(r#mod)
     }
 
-    let search_paths = get_default_axl_search_paths(&current_work_dir, &repo_root);
+    let search_paths = get_default_axl_search_paths(&current_work_dir, &aspect_root);
     let (scripts, configs) = search_sources(&search_paths).await?;
 
     // `_root` is entered on this thread; spawn_blocking moves work to a
@@ -103,7 +110,12 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
         let cli_version = cargo_pkg_short_version();
 
         ModuleEnv::with(|env| -> Result<ExitCode, anyhow::Error> {
-            let loader = Loader::new(cli_version.clone(), repo_root.clone(), &modules);
+            let loader = Loader::new(
+                cli_version.clone(),
+                aspect_root.clone(),
+                bazel_root.clone(),
+                &modules,
+            );
             let mut mpe = MultiPhaseEval::new(env, &loader);
 
             // Phase 1: discover tasks and features.
@@ -118,7 +130,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
             let cmd = Cmd {
                 tasks: mpe.tasks(),
                 features: mpe.features(),
-                repo_root: &repo_root,
+                aspect_root: &aspect_root,
                 modules: &modules,
             };
             let mut root_cmd = cmd.build(&cli_version)?;

--- a/crates/axl-runtime/src/docs.rs
+++ b/crates/axl-runtime/src/docs.rs
@@ -34,7 +34,7 @@ pub fn documentation() -> anyhow::Result<Documentation> {
     // short-circuit before any caller-context lookups in `FileLoader::load`),
     // so no seeding is required.
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
-    let loader = Loader::new("docgen".to_string(), cwd, &[]);
+    let loader = Loader::new("docgen".to_string(), cwd.clone(), cwd, &[]);
 
     let mut builtins = Vec::new();
     for filename in list_std_files() {

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -530,16 +530,15 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         Ok(health_check::run(&startup_flags))
     }
 
-    /// Cancel whatever invocation is currently running on the Bazel server.
-    ///
-    /// Finds the bazel client process holding the server lock and sends it
-    /// SIGINT (graceful cancellation, like Ctrl+C). The client then forwards
-    /// a CancelRequest RPC to the server.
-    /// Returns an `Cancellation` with status and control methods.
     /// Parse `.bazelrc` files rooted at `root` and return a `BazelRC` object.
     ///
     /// # Arguments
-    /// * `root` - Workspace root directory. Defaults to the workspace root from `ctx`.
+    /// * `root` - Bazel workspace root directory. Defaults to
+    ///   `env.bazel_root_dir` — the deepest `MODULE.bazel` / `WORKSPACE`
+    ///   ancestor of `cwd`. Pass an explicit `root` only to read a
+    ///   bazelrc outside the surrounding workspace; passing the Aspect
+    ///   root here in a sub-workspace layout would read the outer
+    ///   `.bazelrc` and leak the parent project's flags.
     /// * `startup_flags` - Startup flags (e.g. `["--bazelrc=/path/to/extra.bazelrc"]`).
     /// * `flags` - Command-line flags to inject as synthetic `always` options
     ///   (e.g. `["--config=opt"]`).
@@ -591,7 +590,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         let root = root
             .into_option()
             .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| env.root_dir.clone());
+            .unwrap_or_else(|| env.bazel_root_dir.clone());
         let startup_flags_vec: Vec<&str> = startup_flags
             .items
             .iter()
@@ -617,6 +616,14 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         })
     }
 
+    /// Cancel whatever invocation is currently running on the Bazel server.
+    ///
+    /// Finds the bazel client process holding the server lock and sends it
+    /// SIGINT (graceful cancellation, like Ctrl+C). The client then forwards
+    /// a CancelRequest RPC to the server. Returns a `Cancellation` with
+    /// status and control methods.
+    ///
+    /// # Arguments
     /// * `force_kill_after_ms` - If the build is still running after this many
     ///   milliseconds, `wait()` will automatically escalate by sending the 2nd
     ///   and 3rd SIGINT to the Bazel client (the 3rd triggers Bazel's built-in

--- a/crates/axl-runtime/src/engine/std/env.rs
+++ b/crates/axl-runtime/src/engine/std/env.rs
@@ -235,24 +235,53 @@ pub(crate) fn env_methods(registry: &mut MethodsBuilder) {
         ))
     }
 
-    /// Returns the project root directory.
+    /// Returns the Aspect project root directory — the anchor for axl /
+    /// config loading.
     ///
-    /// This project root directory is found starting at current working directory and searching upwards
-    /// through its ancestors for repository boundary marker files (such as `MODULE.aspect`, `MODULE.bazel`,
-    /// `MODULE.bazel.lock`, `REPO.bazel`, `WORKSPACE`, or `WORKSPACE.bazel`). The first ancestor directory
-    /// containing any of these files is considered the project root. If no such directory is found, the
-    /// current directory is used as the project root.
-    fn root_dir<'v>(
+    /// Found by walking upwards from the current working directory looking
+    /// for an `.aspect/version.axl` or `MODULE.aspect` marker. Falls back
+    /// to the deepest Bazel workspace marker (`MODULE.bazel`, `WORKSPACE`,
+    /// etc.) so a pure-Bazel monorepo still resolves to a sane project
+    /// anchor, and finally to the current working directory if no marker
+    /// exists anywhere.
+    ///
+    /// Distinct from the Bazel workspace root — bazelrc discovery and
+    /// `bazel info workspace` use the deepest Bazel marker, which can
+    /// differ when a Bazel sub-workspace sits under an Aspect root.
+    fn aspect_root_dir<'v>(
         #[allow(unused)] this: values::Value<'v>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<values::StringValue<'v>> {
         let env = RuntimeEnv::from_eval(eval)?;
-        Ok(eval.heap().alloc_str(
-            &env.root_dir
-                .to_str()
-                // to_str() returns None() if string is not UTF-8 (https://doc.rust-lang.org/std/path/struct.Path.html#method.to_str)
-                .ok_or(anyhow::anyhow!("root dir is non utf-8"))?,
-        ))
+        let s = env
+            .aspect_root_dir
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("aspect root dir is non utf-8"))?;
+        Ok(eval.heap().alloc_str(s))
+    }
+
+    /// Returns the Bazel workspace root directory — the anchor for bazelrc
+    /// discovery, `bazel info workspace`, and BES output paths.
+    ///
+    /// Found by walking upwards from the current working directory looking
+    /// for a `MODULE.bazel` / `WORKSPACE` marker. Falls back to the deepest
+    /// `.aspect/version.axl` or `MODULE.aspect` marker so a pure-Aspect
+    /// workspace still resolves, and finally to the current working
+    /// directory if no marker exists anywhere.
+    ///
+    /// Distinct from the Aspect project root — axl / config loading uses
+    /// the deepest `.aspect/` marker, which can differ when a Bazel
+    /// sub-workspace sits under an Aspect root.
+    fn bazel_root_dir<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<values::StringValue<'v>> {
+        let env = RuntimeEnv::from_eval(eval)?;
+        let s = env
+            .bazel_root_dir
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("bazel root dir is non utf-8"))?;
+        Ok(eval.heap().alloc_str(s))
     }
 
     /// Returns the operating system name.

--- a/crates/axl-runtime/src/engine/store.rs
+++ b/crates/axl-runtime/src/engine/store.rs
@@ -11,15 +11,22 @@ use super::r#async::rt::AsyncRuntime;
 #[derive(Debug, ProvidesStaticType, Clone)]
 pub struct Env {
     pub cli_version: String,
-    pub root_dir: PathBuf,
+    /// Aspect project root — anchor for axl / config loading.
+    pub aspect_root_dir: PathBuf,
+    /// Bazel workspace root — anchor for bazelrc discovery,
+    /// `bazel info workspace`, and BES output paths. Distinct from
+    /// `aspect_root_dir` when a Bazel sub-workspace sits under an
+    /// Aspect root.
+    pub bazel_root_dir: PathBuf,
     pub rt: AsyncRuntime,
 }
 
 impl Env {
-    pub fn new(cli_version: String, root_dir: PathBuf) -> Self {
+    pub fn new(cli_version: String, aspect_root_dir: PathBuf, bazel_root_dir: PathBuf) -> Self {
         Self {
             cli_version,
-            root_dir,
+            aspect_root_dir,
+            bazel_root_dir,
             rt: AsyncRuntime::new(),
         }
     }

--- a/crates/axl-runtime/src/eval/load.rs
+++ b/crates/axl-runtime/src/eval/load.rs
@@ -53,9 +53,14 @@ pub struct AxlLoader<'m> {
 }
 
 impl<'m> AxlLoader<'m> {
-    pub fn new(cli_version: String, repo_root: PathBuf, modules: &'m [Mod]) -> Self {
+    pub fn new(
+        cli_version: String,
+        aspect_root: PathBuf,
+        bazel_root: PathBuf,
+        modules: &'m [Mod],
+    ) -> Self {
         Self {
-            env: Env::new(cli_version, repo_root),
+            env: Env::new(cli_version, aspect_root, bazel_root),
             dialect: api::dialect(),
             globals: api::get_globals().build(),
             modules,

--- a/crates/axl-runtime/src/test.rs
+++ b/crates/axl-runtime/src/test.rs
@@ -68,7 +68,7 @@ impl EvalBuilder {
         let globals = get_globals().build();
         let rt = Runtime::new().map_err(|e| anyhow!("failed to create runtime: {}", e))?;
         let _g = rt.enter();
-        let env_store = Env::new("test".to_string(), PathBuf::from("/"));
+        let env_store = Env::new("test".to_string(), PathBuf::from("/"), PathBuf::from("/"));
         ModuleEnv::with(|env| {
             let mut eval = Evaluator::new(&env.0);
             eval.extra = Some(&env_store);
@@ -81,7 +81,7 @@ impl EvalBuilder {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let rt = Runtime::new()?;
         let _g = rt.enter();
-        let loader = Loader::new("test".to_string(), manifest_dir, &[]);
+        let loader = Loader::new("test".to_string(), manifest_dir.clone(), manifest_dir, &[]);
         let ast = AstModule::parse("test", self.code, &dialect()).map_err(|e| anyhow!("{}", e))?;
         Module::with_temp_heap(|module| {
             let mut eval = Evaluator::new(&module);
@@ -104,7 +104,7 @@ impl EvalBuilder {
         let globals = get_globals().build();
         let rt = Runtime::new().expect("failed to create runtime");
         let _g = rt.enter();
-        let env_store = Env::new("test".to_string(), PathBuf::from("/"));
+        let env_store = Env::new("test".to_string(), PathBuf::from("/"), PathBuf::from("/"));
         Module::with_temp_heap(|module| {
             let mut eval = Evaluator::new(&module);
             eval.extra = Some(&env_store);
@@ -142,7 +142,12 @@ impl EvalBuilder {
                 "_root".to_string(),
                 tmp.path().to_path_buf(),
             );
-            let loader = Loader::new("test".to_string(), tmp.path().to_path_buf(), &modules);
+            let loader = Loader::new(
+                "test".to_string(),
+                tmp.path().to_path_buf(),
+                tmp.path().to_path_buf(),
+                &modules,
+            );
             let mut mpe = MultiPhaseEval::new(env, &loader);
             let scripts = vec![script_path];
             mpe.eval(&scripts, &root_mod, &modules)

--- a/examples/large_bes/.aspect/remote_config.axl
+++ b/examples/large_bes/.aspect/remote_config.axl
@@ -8,7 +8,7 @@ def remote_config(ctx, path = None):
     Returns:
         struct with fields: uri, headers, instance_name
     """
-    workspace_dir = ctx.std.env.root_dir()
+    workspace_dir = ctx.std.env.aspect_root_dir()
     if not path:
         path = workspace_dir + "/.bazelrc"
     flags = bazelrc(ctx, "build", config = "", path = path, workspace_dir = workspace_dir)


### PR DESCRIPTION
Splits the project anchor used by aspect-cli into two distinct concepts so axl/config loading and bazelrc discovery each pick the right one.

## Two roots

- **Aspect root** — deepest `.aspect/version.axl` or `MODULE.aspect` ancestor of cwd. Anchors axl module / config loading.
- **Bazel root** — deepest `MODULE.bazel` / `WORKSPACE` ancestor of cwd. Anchors bazelrc discovery, `bazel info workspace`, and BES output paths.

Each falls back to the other when its primary marker is absent, so a pure-Aspect workspace and a pure-Bazel monorepo resolve identically under both names. They diverge when a Bazel sub-workspace sits under an Aspect root — for example `/proj/.aspect/` with `/proj/e2e/MODULE.bazel` and cwd `/proj/e2e/sub/`: Aspect root resolves to `/proj/`, Bazel root to `/proj/e2e/`.

## What changes

- `crates/aspect-cli/src/helpers.rs` — `find_aspect_root` and `find_bazel_root` are the public API; both delegate to a `find_root_with_fallback` helper that walks a primary marker set first then a fallback set. Six tests cover the diverging-roots case, both single-marker fallbacks, the no-markers case, `MODULE.aspect` recognition, and every Bazel marker.
- `crates/axl-runtime/src/engine/store.rs` — `Env` carries `root_dir` (Aspect) and `bazel_root_dir` (Bazel), both required.
- `crates/axl-runtime/src/engine/bazel/mod.rs` — `parse_rc` defaults to `env.bazel_root_dir`; the docstring spells out "Bazel workspace root" and warns that passing the Aspect root in a sub-workspace layout would read the outer `.bazelrc`.
- `crates/axl-runtime/src/engine/std/env.rs` — `ctx.std.env.root_dir()` docstring clarifies it returns the Aspect root (with the documented fallback).
- `crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl`, `lint.axl`, `delivery.axl` — drop the explicit `root = ctx.std.env.root_dir()` argument so the new default kicks in.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Fixed: a Bazel sub-workspace under an Aspect root (e.g. `proj/e2e/MODULE.bazel` under `proj/.aspect/`) now reads its own `.bazelrc` instead of inheriting the outer one.

### Test plan

- New unit tests in `crates/aspect-cli/src/helpers.rs::tests`.
- Exercised against rules_py's Bazel-9 sub-workspace builds (`e2e/` and `examples/uv_pip_compile/`).
