### PR TITLE
feat(repro): print Reproduce / Fix commands to the CLI on failure

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -28,7 +28,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_on_change", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
-load("./lib/repro_commands.axl", "build_aspect_command", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "task_cli_path")
 load("./lib/runnable.axl", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
@@ -252,6 +252,7 @@ def _emit_final(ctx, lifecycle, data, exit_code):
                 body = _body_text(status, data),
             ),
         ))
+    print_repro_and_fix(ctx.std, data, status)
     for handler in lifecycle.task_complete:
         handler(ctx, exit_code)
 
@@ -679,11 +680,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Verdict from --on-change (resolved at entry).
     data["applied"] = True
     if on_change_resolved == "fail":
-        error(ctx.std, "Formatting required. Run `aspect format` locally and commit the result.")
+        error(ctx.std, "Formatting required.")
         return _emit_final(ctx, lifecycle, data, 1)
     if on_change_resolved == "warn":
-        info(ctx.std, "Formatter modified %d file(s). --on-change=warn → exiting 0 with a warning signal. " % len(affected) +
-                      "Run `aspect format` locally and commit the result, or set --on-change=fail to gate.")
+        info(ctx.std, "Formatter modified %d file(s). --on-change=warn → exiting 0 with a warning signal." % len(affected))
     else:
         print("Formatted %d file(s). Review and commit the changes." % len(affected))
     return _emit_final(ctx, lifecycle, data, 0)

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -195,7 +195,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_on_change", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
-load("./lib/repro_commands.axl", "build_aspect_command", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "task_cli_path")
 load("./lib/runnable.axl", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
@@ -514,6 +514,7 @@ def _emit_final(ctx, lifecycle, data, exit_code):
                 body = _body_text(status, data),
             ),
         ))
+    print_repro_and_fix(ctx.std, data, status)
     for handler in lifecycle.task_complete:
         handler(ctx, exit_code)
 
@@ -871,11 +872,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # Verdict from --on-change (resolved at entry).
     if on_change_resolved == "fail":
-        error(ctx.std, "BUILD files are out of date. Run `aspect gazelle` locally and commit the result.")
+        error(ctx.std, "BUILD files are out of date.")
         return _emit_final(ctx, lifecycle, data, 1)
     if on_change_resolved == "warn":
-        info(ctx.std, "BUILD files are out of date. --on-change=warn → exiting 0 with a warning signal. " +
-                      "Run `aspect gazelle` locally and commit the result, or set --on-change=fail to gate.")
+        info(ctx.std, "BUILD files are out of date. --on-change=warn → exiting 0 with a warning signal.")
     elif not check_only:
         # Local apply, silent: we just updated the tree; don't tell the
         # user to run what they just ran.

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -17,7 +17,7 @@ load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "a
 load("./environment.axl", "color_enabled")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
-load("./repro_commands.axl", "build_aspect_command", "task_cli_path")
+load("./repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "task_cli_path")
 load("./text.axl", "pluralize")
 load("../bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 
@@ -196,6 +196,7 @@ def _emit_terminal(ctx, lifecycle, command, data, exit_code):
             data = data,
             progress = _live_progress(data, command, final_status),
         ))
+    print_repro_and_fix(ctx.std, data, final_status)
     for handler in lifecycle.task_complete:
         handler(ctx, exit_code)
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -28,8 +28,14 @@ the per-task lists into a single rolled-up view across tasks: two
 contributions of the same `(command, description)` collapse into one
 row that lists every contributing task_key.
 
-Both helpers are pure — no I/O, no ctx access.
+`print_repro_and_fix(std, data, status)` prints the same blocks to
+the CLI so a developer reading the raw CI log sees the actionable
+commands without opening the status surface.
+
+`build_aspect_command` and `dedup_and_attribute` are pure (no I/O).
 """
+
+load("./environment.axl", "color_enabled")
 
 # Soft cap on a composed command's length; targets past it collapse to
 # ` … +N more` so the output stays copy-paste-able.
@@ -255,3 +261,54 @@ def patch_download_cmd(patch_url, strip = 1):
                     "  && unzip -p /tmp/aspect-patch.zip \\\n" +
                     "  | %s") % (owner, repo, artifact_id, apply_cmd)
     return ""
+
+# ── CLI rendering ─────────────────────────────────────────────────────
+
+def print_repro_and_fix(std, data, status):
+    """Print the `data["repro_commands"]` and `data["fix_commands"]`
+    blocks to the CLI as a plain-text counterpart to the
+    `### 🔁 Reproduce` / `### 🛠️ Fix` Markdown sections that render on
+    status surfaces. Mirrors the same content so a developer reading
+    the raw CI log can copy the actionable command without opening
+    the status surface.
+
+    No-op when `status == "passed"` (no need to nag a clean run) or
+    when both lists are empty. Caller passes `ctx.std` for color
+    detection and the terminal-state `data` dict; safe to call from
+    any task's terminal-emit path."""
+    if status == "passed":
+        return
+    repros = data.get("repro_commands", []) or []
+    fixes = data.get("fix_commands", []) or []
+    if not repros and not fixes:
+        return
+
+    ansi = color_enabled(std)
+    if repros:
+        print("")
+        print(_repro_header(ansi, "🔁 Reproduce:"))
+        for entry in repros:
+            _print_repro_entry(ansi, entry)
+    if fixes:
+        print("")
+        print(_repro_header(ansi, "🛠️ Fix:"))
+        for entry in fixes:
+            _print_repro_entry(ansi, entry)
+    print("")
+
+def _repro_header(ansi, label):
+    return "\x1b[1m" + label + "\x1b[0m" if ansi else label
+
+def _print_repro_entry(ansi, entry):
+    """Print one `{command, description}` entry, indenting every
+    command line two spaces so multi-line composed commands (the
+    backslash-continuation form `build_aspect_command` produces for
+    long flag/target lists) keep their visual grouping."""
+    command = entry.get("command", "") or ""
+    description = entry.get("description", "") or ""
+    if not command:
+        return
+    for line in command.split("\n"):
+        print("  " + line)
+    if description:
+        print(("  \x1b[2m" + description + "\x1b[0m") if ansi else ("  " + description))

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -28,7 +28,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
 load("./lib/lint_results.axl", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
-load("./lib/repro_commands.axl", "build_aspect_command", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "task_cli_path")
 load("./lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics")
 load("./lib/tar.axl", "tar_create")
 load("./lib/text.axl", "pluralize")
@@ -1170,6 +1170,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 body = _body_text(final_status, data),
             ),
         ))
+    print_repro_and_fix(ctx.std, data, final_status)
     for handler in lifecycle.task_complete:
         handler(ctx, exit_code)
 


### PR DESCRIPTION
A CI log like:

```
ERROR: BUILD files are out of date. Run `aspect gazelle` locally and commit the result.

→ ❌ Failed `gazelle` task (exit code 1) in 53.8s · 7 BUILD files out of date
```

leaves the developer to open the GitHub check-run / PR comment to find the actionable repro command. The same content was already being assembled into `data["repro_commands"]` / `data["fix_commands"]` on every task — it just wasn't being printed to the CLI.

New `print_repro_and_fix(std, data, status)` in [lib/repro_commands.axl](crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl) renders the same content as a plain-text block to stdout. Wired into the terminal-emit path of `build`, `test`, `format`, `gazelle`, and `lint` tasks. No-op on `status == "passed"` so clean runs stay quiet.

Also trims the now-redundant `Run \`aspect <task>\` locally and commit the result` tail from `format` and `gazelle`'s on-change ERROR/INFO lines — that bare instruction is worse than the resolved repro the Fix block carries (it omits the scope / base-ref / etc. the user needs to reproduce CI's exact invocation).

After:

```
ERROR: BUILD files are out of date.

🔁 Reproduce:
  aspect gazelle --on-change=fail --check-only=true --scope=changed --gazelle-target=//:gazelle

🛠️ Fix:
  aspect gazelle --on-change=silent --check-only=false ...

→ ❌ Failed `gazelle` task (exit code 1) in 53.8s · 7 BUILD files out of date
```

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- Failing build / test / format / gazelle / lint tasks now print their Reproduce / Fix commands to the CLI in addition to the status surfaces.

### Test plan

- Manual smoke: triggered a build failure (`genrule(cmd = "exit 1")` in a scratch workspace) and observed the `🔁 Reproduce:` block render between Bazel's failure output and the runtime footer.
- Manual smoke: ran `aspect build //crates/nonexistent:target` for the parse-error path; same block renders.
- All template-snapshot suites still pass: `test-bazel-results`, `test-template-snapshots`, `test-format-template-snapshots`, `test-gazelle-template-snapshots`, `test-lint-template-snapshots`, `test-delivery-template-snapshots`, `test-pr-comment-snapshots`, `test-bk-annotation-snapshots`.
