### PR TITLE
feat(repro): skip default-value flags from repro / fix commands

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -13,6 +13,7 @@ load("@aspect//lib/gitlab_detect_test.axl", "gitlab_detect_tests")
 load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
 load("@aspect//lib/lint_results_test.axl", "lint_annotation_plan_tests", "lint_template_snapshot_tests")
 load("@aspect//lib/rate_limit_test.axl", "rate_limit_tests")
+load("@aspect//lib/repro_commands_test.axl", "repro_commands_tests")
 load("@aspect//lib/runner_job_history_test.axl", "runner_job_history_tests")
 load("@aspect//lib/tar_test.axl", "tar_tests")
 load("@aspect//lib/tips_test.axl", "tips_tests")
@@ -126,6 +127,12 @@ def config(ctx: ConfigContext):
     # and unsupported host inputs.
     # Run with: aspect dev test-tar
     ctx.tasks.add(tar_tests)
+
+    # Repro-command filtering — `explicit_flags` skips flags whose
+    # values match the task's default (including alias-overridden
+    # defaults and config.axl overrides).
+    # Run with: aspect dev test-repro-commands
+    ctx.tasks.add(repro_commands_tests)
 
     # Adaptive rate-limit throttling — observations / burn-rate
     # inference / threshold ladder / tip firing / two-bucket

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -28,7 +28,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_on_change", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
-load("./lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "task_cli_path")
 load("./lib/runnable.axl", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
@@ -150,24 +150,33 @@ def _body_text(status, data):
 # fallback that uses the detection flags.
 _FIX_FILES_LIMIT = 20
 
+# Plain-default flags echoed iff the user explicitly passed them on
+# the CLI. Auto / env-resolved flags (`--on-change`, `--base-ref`) are
+# pinned by the repro / fix callers themselves — the local default
+# typically differs from CI's resolution, so the repro must encode
+# CI's behavior to be faithful.
+_DETECTION_PAIRS = [
+    ("scope", "--scope"),
+    ("formatter_target", "--formatter-target"),
+    ("ignore_patterns", "--ignore-pattern"),
+    ("merge_base", "--merge-base"),
+]
+
+def _surfaced_base_ref_flag(ctx):
+    """`--base-ref` carrying CI's resolved base ref (env var if unset).
+    Returned as a one-element list for `+`-concatenation, empty when
+    no base ref is known."""
+    surfaced = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
+    return [("--base-ref", surfaced)] if surfaced else []
+
 def _append_repro_command(ctx, data):
     """Append the always-rendered "Reproduce" command. Re-runs the
-    same `aspect format --on-change=fail ...` invocation CI ran, with
-    the same scope / formatter / ignore-pattern flags, so the user
-    gets the same diagnose-then-fail behavior locally.
-    """
-    flags = [
-        ("--on-change", "fail"),
-        ("--scope", ctx.args.scope),
-        ("--formatter-target", ctx.args.formatter_target),
-    ]
-    if ctx.args.ignore_patterns:
-        flags.append(("--ignore-pattern", list(ctx.args.ignore_patterns)))
-    surfaced_base_ref = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
-    if surfaced_base_ref:
-        flags.append(("--base-ref", surfaced_base_ref))
-    if ctx.args.merge_base:
-        flags.append(("--merge-base", ctx.args.merge_base))
+    same `aspect format ...` invocation CI ran so the user gets the
+    same diagnose-then-fail behavior locally. `--on-change=fail` is
+    pinned — the repro intent is "make me see the failure"."""
+    flags = ([("--on-change", "fail")] +
+             explicit_flags(ctx, _DETECTION_PAIRS) +
+             _surfaced_base_ref_flag(ctx))
     data["repro_commands"].append({
         "command": build_aspect_command(task_cli_path(ctx.task), flags, []),
         "description": "",
@@ -187,15 +196,14 @@ def _append_fix_commands(ctx, data):
         return
     task_path = task_cli_path(ctx.task)
 
-    # Positionals bypass --scope / --base-ref / --merge-base /
-    # --ignore-pattern, so the explicit-file fix command omits them.
-    explicit_flags = [
-        ("--on-change", "silent"),
-        ("--formatter-target", ctx.args.formatter_target),
-    ]
+    # Positional file list bypasses --scope / --base-ref / --merge-base /
+    # --ignore-pattern, so the explicit-file fix command omits them
+    # and only preserves the user-explicit `--formatter-target`.
+    positional_flags = ([("--on-change", "silent")] +
+                        explicit_flags(ctx, [("formatter_target", "--formatter-target")]))
     if len(affected) <= _FIX_FILES_LIMIT:
         data["fix_commands"].append({
-            "command": build_aspect_command(task_path, explicit_flags, affected, max_chars = 4096),
+            "command": build_aspect_command(task_path, positional_flags, affected, max_chars = 4096),
             "description": "",
         })
         return
@@ -203,7 +211,7 @@ def _append_fix_commands(ctx, data):
     shown = affected[:_FIX_FILES_LIMIT]
     remaining = len(affected) - _FIX_FILES_LIMIT
     data["fix_commands"].append({
-        "command": build_aspect_command(task_path, explicit_flags, shown, max_chars = 4096),
+        "command": build_aspect_command(task_path, positional_flags, shown, max_chars = 4096),
         "description": "First %d of %d affected files (plus %d other%s)" % (
             _FIX_FILES_LIMIT,
             len(affected),
@@ -212,19 +220,11 @@ def _append_fix_commands(ctx, data):
         ),
     })
 
-    detection_flags = [
-        ("--scope", ctx.args.scope),
-        ("--formatter-target", ctx.args.formatter_target),
-    ]
-    if ctx.args.ignore_patterns:
-        detection_flags.append(("--ignore-pattern", list(ctx.args.ignore_patterns)))
-    surfaced_base_ref = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
-    if surfaced_base_ref:
-        detection_flags.append(("--base-ref", surfaced_base_ref))
-    if ctx.args.merge_base:
-        detection_flags.append(("--merge-base", ctx.args.merge_base))
+    detection = ([("--on-change", "silent")] +
+                 explicit_flags(ctx, _DETECTION_PAIRS) +
+                 _surfaced_base_ref_flag(ctx))
     data["fix_commands"].append({
-        "command": build_aspect_command(task_path, [("--on-change", "silent")] + detection_flags, []),
+        "command": build_aspect_command(task_path, detection, []),
         "description": "Or re-discover and format all %d affected files" % len(affected),
     })
 

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -195,7 +195,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_on_change", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
-load("./lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "task_cli_path")
 load("./lib/runnable.axl", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
@@ -267,55 +267,54 @@ def _body_text(status, data):
 # fallback that uses the detection flags.
 _FIX_DIRS_LIMIT = 20
 
-# Per-task forwarded flags that aren't scope/check related — included
-# in every emitted repro / fix command so local re-runs use the same
-# gazelle target and subcommand CI used.
-def _forwarded_flags(ctx):
-    flags = []
-    if ctx.args.gazelle_command:
-        flags.append(("--gazelle-command", ctx.args.gazelle_command))
-    if ctx.args.gazelle_flags:
-        flags.append(("--gazelle-flag", list(ctx.args.gazelle_flags)))
-    return flags
+# Per-task forwarded flags that aren't scope/check related — echoed
+# in every emitted repro / fix command iff the user passed them.
+_FORWARDED_PAIRS = [
+    ("gazelle_command", "--gazelle-command"),
+    ("gazelle_flags", "--gazelle-flag"),
+]
+
+# Plain-default scope / change-detection flags echoed iff the user
+# explicitly passed them. Auto / env-resolved flags (`--on-change`,
+# `--check-only`, `--base-ref`) are pinned by the callers below.
+_SCOPE_PAIRS = [
+    ("scope", "--scope"),
+    ("gazelle_target", "--gazelle-target"),
+]
+_CHANGED_SCOPE_PAIRS = [
+    ("merge_base", "--merge-base"),
+    ("scope_all_on_change", "--scope-all-on-change"),
+    ("changed_file_patterns", "--changed-file-pattern"),
+]
+
+def _mode_prefix(mode):
+    """Pin the auto-style `--on-change` and `--check-only` flags to the
+    explicit values needed to reproduce CI's behavior locally:
+    `mode="check"` → diagnose-then-fail, `mode="apply"` → apply-locally."""
+    if mode == "check":
+        return [("--on-change", "fail"), ("--check-only", "true")]
+    return [("--on-change", "silent"), ("--check-only", "false")]
 
 def _detection_flags(ctx, mode):
     """Flag set that recreates the original change-detection invocation.
-    Used by both the repro command and the fix-command's re-discovery
-    fallback. Omits `--base-ref` when it's the default so the rendered
-    command stays short. The repro/fix renderers pass `mode="check"` to
-    reproduce CI's check-only run, or `mode="apply"` to apply locally;
-    that maps to `--on-change=fail --check-only=true` and
-    `--on-change=silent --check-only=false` respectively."""
-    if mode == "check":
-        flags = [("--on-change", "fail"), ("--check-only", "true")]
-    else:
-        flags = [("--on-change", "silent"), ("--check-only", "false")]
-    flags = flags + [
-        ("--scope", ctx.args.scope),
-        ("--gazelle-target", ctx.args.gazelle_target),
-    ]
+    Used by the repro command and by the fix-command's re-discovery
+    fallback. `--base-ref` is surfaced from `detect_ci_base_ref` so
+    the repro encodes CI's resolved base ref even when CI itself ran
+    without `--base-ref`."""
+    flags = _mode_prefix(mode) + explicit_flags(ctx, _SCOPE_PAIRS)
     if ctx.args.scope == "changed":
         surfaced_base_ref = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
         if surfaced_base_ref:
             flags.append(("--base-ref", surfaced_base_ref))
-        if ctx.args.merge_base:
-            flags.append(("--merge-base", ctx.args.merge_base))
-        if ctx.args.scope_all_on_change:
-            flags.append(("--scope-all-on-change", list(ctx.args.scope_all_on_change)))
-        if ctx.args.changed_file_patterns:
-            flags.append(("--changed-file-pattern", list(ctx.args.changed_file_patterns)))
-    return flags + _forwarded_flags(ctx)
+        flags += explicit_flags(ctx, _CHANGED_SCOPE_PAIRS)
+    return flags + explicit_flags(ctx, _FORWARDED_PAIRS)
 
 def _explicit_dirs_flags(ctx, mode):
     """Flag set for invocations that scope via explicit positional dirs
     and bypass change detection. Smaller subset of `_detection_flags`."""
-    if mode == "check":
-        flags = [("--on-change", "fail"), ("--check-only", "true")]
-    else:
-        flags = [("--on-change", "silent"), ("--check-only", "false")]
-    return flags + [
-        ("--gazelle-target", ctx.args.gazelle_target),
-    ] + _forwarded_flags(ctx)
+    return (_mode_prefix(mode) +
+            explicit_flags(ctx, [("gazelle_target", "--gazelle-target")]) +
+            explicit_flags(ctx, _FORWARDED_PAIRS))
 
 def _append_repro_command(ctx, data):
     """Append the always-rendered Reproduce command. Re-runs the same

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -72,6 +72,29 @@ def task_cli_path(task):
     """
     return " ".join(list(task.group) + [task.name])
 
+def explicit_flags(ctx, pairs):
+    """Convert `[(arg_name, flag_name), ...]` into the subset of
+    `(flag_name, ctx.args.<arg_name>)` tuples the user actually passed
+    on the CLI for the current invocation.
+
+    Use to compose the `flags` list handed to `build_aspect_command`
+    when building repro / fix commands. Skips flags whose values
+    would just re-emit the task's default — including alias-overridden
+    defaults and `config.axl` overrides. The developer copying the
+    rendered command gets back exactly what they (or CI) typed.
+
+    Auto / env-resolved args (`--on-change`, `--check-only`,
+    `--base-ref`, ...) are NOT served by this helper; their callers
+    pin the resolved value explicitly because the local default
+    typically differs from CI's resolution and the repro must encode
+    CI's behavior to be faithful.
+    """
+    out = []
+    for arg_name, flag_name in pairs:
+        if ctx.args.is_explicit(arg_name):
+            out.append((flag_name, getattr(ctx.args, arg_name)))
+    return out
+
 def build_aspect_command(subcommand, flags, targets, max_chars = _DEFAULT_MAX_CHARS, wrap_at = _DEFAULT_WRAP_AT):
     """Compose `aspect <subcommand> <flags...> [-- <targets>]`.
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -1,0 +1,103 @@
+"""Unit tests for `lib/repro_commands.axl::explicit_flags`.
+
+A struct-based fake `ctx` substitutes for a real `TaskContext` so the
+test can run without the CLI / merge plumbing. Wiring of `ctx.args.
+is_explicit` through clap's `ValueSource::CommandLine` is covered by
+the Rust unit tests on `Arguments`.
+"""
+
+load("./repro_commands.axl", "explicit_flags")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _explicit_in(names):
+    """Build an `is_explicit` predicate that returns True iff its
+    argument is in `names`."""
+    lookup = {n: True for n in names}
+    return lambda name: name in lookup
+
+def _test_returns_empty_when_no_explicit(ctx):
+    fake = struct(args = struct(
+        is_explicit = _explicit_in([]),
+        scope = "changed",
+        formatter_target = "//tools/format",
+    ))
+    _eq(
+        "no explicit args → empty list",
+        explicit_flags(fake, [("scope", "--scope"), ("formatter_target", "--formatter-target")]),
+        [],
+    )
+
+def _test_includes_only_explicit_pairs(ctx):
+    fake = struct(args = struct(
+        is_explicit = _explicit_in(["scope"]),
+        scope = "all",
+        formatter_target = "//tools/format",
+    ))
+    _eq(
+        "only scope is explicit → only --scope returned",
+        explicit_flags(fake, [("scope", "--scope"), ("formatter_target", "--formatter-target")]),
+        [("--scope", "all")],
+    )
+
+def _test_preserves_input_pair_order(ctx):
+    """The output order tracks the `pairs` argument, not the order in
+    which keys were marked explicit."""
+    fake = struct(args = struct(
+        is_explicit = _explicit_in(["formatter_target", "scope", "merge_base"]),
+        scope = "all",
+        formatter_target = "//x",
+        merge_base = "abc",
+    ))
+    _eq(
+        "order follows input pairs",
+        explicit_flags(fake, [
+            ("scope", "--scope"),
+            ("formatter_target", "--formatter-target"),
+            ("merge_base", "--merge-base"),
+        ]),
+        [("--scope", "all"), ("--formatter-target", "//x"), ("--merge-base", "abc")],
+    )
+
+def _test_handles_list_valued_args(ctx):
+    """List-valued args round-trip without conversion — the rendered
+    command emits `--name=a --name=b` via `build_aspect_command`."""
+    fake = struct(args = struct(
+        is_explicit = _explicit_in(["ignore_patterns"]),
+        ignore_patterns = ["*.txt", "vendor/*"],
+    ))
+    _eq(
+        "list-valued args round-trip",
+        explicit_flags(fake, [("ignore_patterns", "--ignore-pattern")]),
+        [("--ignore-pattern", ["*.txt", "vendor/*"])],
+    )
+
+def _test_empty_pairs_list_returns_empty(ctx):
+    fake = struct(args = struct(
+        is_explicit = _explicit_in(["scope"]),
+        scope = "all",
+    ))
+    _eq("empty pairs → empty list", explicit_flags(fake, []), [])
+
+_UNIT_TESTS = [
+    _test_returns_empty_when_no_explicit,
+    _test_includes_only_explicit_pairs,
+    _test_preserves_input_pair_order,
+    _test_handles_list_valued_args,
+    _test_empty_pairs_list_returns_empty,
+]
+
+def _test_impl(ctx):
+    for t in _UNIT_TESTS:
+        t(ctx)
+    print("repro_commands.axl: OK (%d sections)" % len(_UNIT_TESTS))
+    return 0
+
+repro_commands_tests = task(
+    name = "test-repro-commands",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -28,7 +28,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
 load("./lib/lint_results.axl", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
-load("./lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "task_cli_path")
 load("./lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics")
 load("./lib/tar.axl", "tar_create")
 load("./lib/text.axl", "pluralize")
@@ -1133,14 +1133,14 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # then excluded (e.g. `hold-the-line` on a file outside the diff),
     # and offering a fix command for nothing-to-fix-in-scope reads as
     # noise.
-    repro_flags = [("--strategy", ctx.args.strategy)]
-    if ctx.args.aspects:
-        repro_flags.append(("--aspect", list(ctx.args.aspects)))
+    repro_flags = explicit_flags(ctx, [
+        ("strategy", "--strategy"),
+        ("aspects", "--aspect"),
+        ("merge_base", "--merge-base"),
+    ])
     surfaced_base_ref = ctx.args.base_ref or detect_ci_base_ref(ctx.std)
     if surfaced_base_ref:
         repro_flags.append(("--base-ref", surfaced_base_ref))
-    if ctx.args.merge_base:
-        repro_flags.append(("--merge-base", ctx.args.merge_base))
     targets = list(ctx.args.targets)
     task_path = task_cli_path(ctx.task)
     data["repro_commands"].append({

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -445,6 +445,11 @@ fn merge_args<'v>(
                 if let Some(val) = clap_to_value(cli, &key, matches, heap) {
                     args.insert(name.clone(), val);
                 }
+                // Track CLI-explicit keys so `ctx.args.is_explicit(name)`
+                // can tell defaults from user-typed values downstream.
+                if matches.value_source(&key) == Some(ValueSource::CommandLine) {
+                    args.mark_explicit(name.clone());
+                }
             }
         }
     }

--- a/crates/axl-runtime/src/engine/arguments.rs
+++ b/crates/axl-runtime/src/engine/arguments.rs
@@ -3,6 +3,10 @@ use std::cell::RefCell;
 use allocative::Allocative;
 use derive_more::Display;
 use starlark::collections::SmallMap;
+use starlark::environment::Methods;
+use starlark::environment::MethodsBuilder;
+use starlark::environment::MethodsStatic;
+use starlark::starlark_module;
 use starlark::starlark_simple_value;
 use starlark::values;
 use starlark::values::Heap;
@@ -12,6 +16,7 @@ use starlark::values::StarlarkValue;
 use starlark::values::Trace;
 use starlark::values::Tracer;
 use starlark::values::Value;
+use starlark::values::ValueLike;
 use starlark::values::list::AllocList;
 use starlark::values::starlark_value;
 
@@ -24,17 +29,28 @@ use starlark::values::starlark_value;
 /// - **Config-time override store** — `ctx.tasks["k"].args` and `ctx.features[X].args`
 ///   in `config.axl`. Mutable via `set_attr`; presence of a key marks it as
 ///   "explicitly set in config.axl" for runtime precedence (CLI > config > default).
+///
+/// `explicit_cli_keys` is a side-set tracking which keys came from clap's
+/// `ValueSource::CommandLine` during the runtime-args merge. Exposed via
+/// the `is_explicit(name)` Starlark method so repro/fix command builders
+/// can skip echoing flags that match the task's default (including
+/// alias-overridden defaults and config.axl overrides). Empty for the
+/// config-time override store role — nothing is "explicit on the CLI"
+/// there.
 #[derive(Debug, Clone, ProvidesStaticType, Display, NoSerialize, Allocative)]
 #[display("<Arguments>")]
 pub struct Arguments<'v> {
     #[allocative(skip)]
     args: RefCell<SmallMap<String, Value<'v>>>,
+    #[allocative(skip)]
+    explicit_cli_keys: RefCell<SmallMap<String, ()>>,
 }
 
 impl<'v> Arguments<'v> {
     pub fn new() -> Self {
         Self {
             args: RefCell::new(SmallMap::new()),
+            explicit_cli_keys: RefCell::new(SmallMap::new()),
         }
     }
 
@@ -57,6 +73,18 @@ impl<'v> Arguments<'v> {
             .iter()
             .map(|(k, v)| (k.clone(), *v))
             .collect()
+    }
+
+    /// Mark `key` as having been supplied on the CLI for the current
+    /// invocation. Idempotent. See `is_explicit_key`.
+    pub fn mark_explicit(&self, key: String) {
+        self.explicit_cli_keys.borrow_mut().insert(key, ());
+    }
+
+    /// Return `true` iff `key` was marked explicit during the runtime
+    /// merge (i.e. clap saw it as `ValueSource::CommandLine`).
+    pub fn is_explicit_key(&self, key: &str) -> bool {
+        self.explicit_cli_keys.borrow().contains_key(key)
     }
 
     pub fn alloc_list<L>(items: L) -> AllocList<L> {
@@ -82,6 +110,11 @@ impl<'v> StarlarkValue<'v> for Arguments<'v> {
         self.args.borrow_mut().insert(attribute.to_owned(), value);
         Ok(())
     }
+
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(arguments_methods)
+    }
 }
 
 impl<'v> values::AllocValue<'v> for Arguments<'v> {
@@ -98,7 +131,10 @@ impl<'v> values::Freeze for Arguments<'v> {
         for (k, v) in inner.into_iter() {
             frozen.insert(k, v.freeze(freezer)?);
         }
-        Ok(FrozenArguments { args: frozen })
+        Ok(FrozenArguments {
+            args: frozen,
+            explicit_cli_keys: self.explicit_cli_keys.into_inner(),
+        })
     }
 }
 
@@ -107,6 +143,8 @@ impl<'v> values::Freeze for Arguments<'v> {
 pub struct FrozenArguments {
     #[allocative(skip)]
     args: SmallMap<String, values::FrozenValue>,
+    #[allocative(skip)]
+    explicit_cli_keys: SmallMap<String, ()>,
 }
 
 starlark_simple_value!(FrozenArguments);
@@ -119,6 +157,10 @@ impl FrozenArguments {
     pub fn contains_key(&self, key: &str) -> bool {
         self.args.contains_key(key)
     }
+
+    pub fn is_explicit_key(&self, key: &str) -> bool {
+        self.explicit_cli_keys.contains_key(key)
+    }
 }
 
 #[starlark_value(type = "Arguments")]
@@ -127,5 +169,70 @@ impl<'v> StarlarkValue<'v> for FrozenArguments {
 
     fn get_attr(&self, key: &str, _heap: Heap<'v>) -> Option<Value<'v>> {
         self.args.get(key).map(|v| v.to_value())
+    }
+
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(arguments_methods)
+    }
+}
+
+#[starlark_module]
+fn arguments_methods(builder: &mut MethodsBuilder) {
+    /// Return `True` iff the user passed `--<name>=...` (or its short
+    /// form) on the CLI for the current invocation.
+    ///
+    /// Returns `False` for args that were resolved from the task's
+    /// default, an alias's overridden default, or a `config.axl`
+    /// override — anything that wasn't typed at the command line.
+    ///
+    /// Used by repro / fix command builders to skip echoing flags
+    /// whose values would just reproduce the task's default. The
+    /// developer copying the rendered repro gets back exactly what
+    /// they (or CI) typed.
+    fn is_explicit<'v>(
+        this: Value<'v>,
+        #[starlark(require = pos)] name: &str,
+    ) -> anyhow::Result<bool> {
+        if let Some(a) = this.downcast_ref::<Arguments>() {
+            return Ok(a.is_explicit_key(name));
+        }
+        if let Some(a) = this.downcast_ref::<FrozenArguments>() {
+            return Ok(a.is_explicit_key(name));
+        }
+        Err(anyhow::anyhow!(
+            "is_explicit: expected an Arguments value, got '{}'",
+            this.get_type(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_keys_default_to_unset() {
+        let args = Arguments::new();
+        assert!(!args.is_explicit_key("anything"));
+        assert!(!args.is_explicit_key(""));
+    }
+
+    #[test]
+    fn marked_keys_report_explicit() {
+        let args = Arguments::new();
+        args.mark_explicit("scope".to_string());
+        args.mark_explicit("formatter_target".to_string());
+        assert!(args.is_explicit_key("scope"));
+        assert!(args.is_explicit_key("formatter_target"));
+        assert!(!args.is_explicit_key("ignore_patterns"));
+    }
+
+    #[test]
+    fn mark_explicit_is_idempotent() {
+        let args = Arguments::new();
+        args.mark_explicit("scope".to_string());
+        args.mark_explicit("scope".to_string());
+        assert!(args.is_explicit_key("scope"));
     }
 }


### PR DESCRIPTION
The repro / fix command builders for `format`, `gazelle`, and `lint` echoed every `ctx.args.<name>` verbatim into the rendered command — including flags whose values matched the task's default. For an alias like

```python
buildifier = format.alias(
    defaults = {"formatter_target": "//tools/format:format-starlark"},
)
```

the repro carried `--formatter-target=//tools/format:format-starlark` even though it's the alias's default and the user never typed it.

**Before:**
```
🔁 Reproduce:
  aspect buildifier --on-change=fail --scope=changed --formatter-target=//tools/format:format-starlark
```

**After (user ran `aspect buildifier --scope=all`):**
```
🔁 Reproduce:
  aspect buildifier --on-change=fail --scope=all
```

The `--formatter-target` flag is filtered because the user didn't type it on the CLI; `--scope=all` is preserved because they did. If the user instead ran `aspect buildifier --formatter-target=X --scope=all`, both flags would appear.

### Mechanism

- `Arguments` carries an `explicit_cli_keys` side-set of names that came from clap's `ValueSource::CommandLine` during the runtime merge. Exposed to AXL via `ctx.args.is_explicit("name") -> bool`.
- New `explicit_flags(ctx, pairs)` helper in [lib/repro_commands.axl](crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl) takes `[(arg_name, flag_name), ...]` and returns the subset the user actually typed, ready to splice into a `build_aspect_command` flags list.
- `format.axl`, `gazelle.axl`, `lint.axl` repro / fix builders use it for plain-default args.
- Auto / env-resolved args (`--on-change`, `--check-only`, `--base-ref`) stay manually resolved by their callers — the local default typically differs from CI's resolution, and the repro must encode CI's behavior to be faithful. `--on-change=fail` is pinned in the repro; `--base-ref` is surfaced from `detect_ci_base_ref(ctx.std)` so the repro encodes CI's resolved base ref even when CI itself ran without `--base-ref`.

### Naming

`ctx.args.is_explicit("scope")` — boolean predicate, matches the existing `is_tty` style.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- Repro / fix commands rendered by `format`, `gazelle`, and `lint` now omit flags that match the task's default (including alias-overridden defaults). The rendered command echoes back what the user (or CI) actually typed.

### Test plan

- Rust unit tests on `Arguments::mark_explicit` / `is_explicit_key` (3 cases).
- AXL unit tests for `explicit_flags` (5 cases: empty input, no-explicit, partial-explicit, list-valued args, output ordering) in [lib/repro_commands_test.axl](crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl), wired as `aspect dev test-repro-commands`.
- Manual smoke: in a scratch workspace with `buildifier = format.alias(defaults = {"formatter_target": "//tools/format:format-starlark"})`, `aspect buildifier --scope=all` omits `--formatter-target` from the repro; `aspect buildifier --formatter-target=X --scope=all` includes it.
- All template-snapshot suites still pass (`test-bazel-results`, `test-template-snapshots`, `test-format-template-snapshots`, `test-gazelle-template-snapshots`, `test-lint-template-snapshots`, `test-pr-comment-snapshots`, `test-bk-annotation-snapshots`, `test-delivery-template-snapshots`, `test-tar`, `test-rate-limit`).
