### PR TITLE
feat(lint): accept --bazel-flag and --bazel-startup-flag

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1264,6 +1264,8 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
             default = 1,
             description = "Maximum number of delivery targets to run concurrently. When greater than 1, stdout/stderr is captured and printed atomically after each target finishes.",
         ),
+        # TODO: Support a long --pattern_file like bazel does (@./targets)
+        # TODO: Support - (list from stdin)
         "targets": args.positional(
             maximum = 1000000000,
             description = "Bazel target labels to deliver.",

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -820,6 +820,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if lint_trait.lint_report:
         flags.append("--output_groups=rules_lint_machine")
 
+    flags.extend(ctx.args.bazel_flags)
     flags.extend(bazel_trait.extra_flags)
 
     # Task-time flag contributors — features register hooks that need
@@ -831,7 +832,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if bazel_trait.flags:
         flags = bazel_trait.flags(flags)
 
-    startup_flags = list(bazel_trait.extra_startup_flags)
+    startup_flags = list(ctx.args.bazel_startup_flags)
+    startup_flags.extend(bazel_trait.extra_startup_flags)
     if bazel_trait.startup_flags:
         startup_flags = bazel_trait.startup_flags(startup_flags)
 
@@ -1195,6 +1197,14 @@ lint = task(
             default = False,
             description = "Print the resolved Bazel `.bazelrc` flags before running the lint build. Useful when debugging which config sections fired or what the final flag set looks like.",
         ),
+        "bazel_flags": args.string_list(
+            description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
+            long = "bazel-flag",
+        ),
+        "bazel_startup_flags": args.string_list(
+            description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
+            long = "bazel-startup-flag",
+        ),
         "fix": args.boolean(
             description = (
                 "Apply auto-fixes from rules_lint to the working tree. " +
@@ -1228,6 +1238,8 @@ lint = task(
         "merge_base": args.string(
             description = "Explicit merge-base SHA for the local-git fallback's diff base. When set, skips the `git merge-base HEAD <base-ref>` resolution and uses this SHA directly. Ignored on the GitHub PR Files API path.",
         ),
+        # TODO: Support a long --pattern_file like bazel does (@./targets)
+        # TODO: Support - (list from stdin)
         "targets": args.positional(
             minimum = 0,
             maximum = 512,


### PR DESCRIPTION
The lint task didn't expose `--bazel-flag` / `--bazel-startup-flag`,
so users who wanted to load a bazelrc section like `--config=lint`
(to pick the aspects) had no way to do it from the `aspect lint`
command line. This adds the same pair of args that `build`, `test`,
and `format` already accept, and wires them into the flag /
startup-flag lists the lint task hands to Bazel.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`aspect lint` now accepts `--bazel-flag` and `--bazel-startup-flag`, matching `build` / `test` / `format`. Repeat each flag to pass multiple, e.g. `aspect lint --bazel-flag=--config=lint`.

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  - `aspect lint --bazel-flag=--config=lint -- //...` — the `lint` config section in `.bazelrc` is loaded for the build that runs the lint aspects.
  - `aspect lint --bazel-startup-flag=--host_jvm_args=-Xmx2g -- //...` — the JVM heap flag is passed as a Bazel startup flag.