### PR TITLE
fix(rate-limit): cold-start floor + phase-change debounce for swarms

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -56,7 +56,7 @@ load(
     lint_chunk_annotations = "chunk_annotations",
     lint_compute_annotations = "compute_annotations",
 )
-load("../lib/rate_limit.axl", "BUCKET_APP", "effective_throttle_factor", "usage_footer")
+load("../lib/rate_limit.axl", "BUCKET_APP", "cold_start_phase_change_gate_seconds", "effective_throttle_factor", "usage_footer")
 load("../lib/tips.axl", "collect_tips_sorted")
 load("../lint.axl", "LintTrait")
 
@@ -447,9 +447,36 @@ def _github_status_checks(ctx: FeatureContext):
         if not (is_conclusion_transition or is_initial):
             now = now_ms(ctx)
             elapsed_s = float(now - _state.get("_started_ms", now)) / 1000.0
-            factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, min_update_interval_s)
-            if not should_emit_update(_state, now, int(min_update_interval_ms * factor), final):
-                return
+
+            # Cold-start phase-change debounce. During the swarm
+            # cold-start window the heartbeat factor floors at 10×
+            # (50s at the 5s base, 200s at the 20s GHSC default) —
+            # which collapses fast early phase transitions into
+            # invisible silence on tasks that finish quickly. Phase
+            # boundaries get a separate 5s debounce so the swarm-
+            # defensive floor stays in effect for heartbeats while
+            # phase emits remain visible. Once burn-rate inference
+            # stabilizes (≥ 3 obs spanning ≥ 30s) the gate returns
+            # 0 and phase emits fall back to the normal heartbeat
+            # throttle below.
+            phase_gate_s = 0
+            if update.phase_change:
+                phase_gate_s = cold_start_phase_change_gate_seconds(ctx, BUCKET_APP)
+            if phase_gate_s > 0:
+                last_pc = _state.get("_last_phase_change_ms", 0)
+                if now - last_pc < phase_gate_s * 1000:
+                    return
+                _state["_last_phase_change_ms"] = now
+
+                # Stamp `_last_update_ms` too so a heartbeat
+                # immediately after this phase emit honors the 10×
+                # factor relative to *this* emit, not the one before
+                # the phase boundary.
+                _state["_last_update_ms"] = now
+            else:
+                factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, min_update_interval_s)
+                if not should_emit_update(_state, now, int(min_update_interval_ms * factor), final):
+                    return
         elif final:
             # The terminal render needs _ended_ms for duration.
             _state["_ended_ms"] = now_ms(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -56,7 +56,15 @@ load(
     lint_chunk_annotations = "chunk_annotations",
     lint_compute_annotations = "compute_annotations",
 )
-load("../lib/rate_limit.axl", "BUCKET_APP", "cold_start_phase_change_gate_seconds", "effective_throttle_factor", "usage_footer")
+load(
+    "../lib/rate_limit.axl",
+    "BUCKET_APP",
+    "PHASE_FALL_THROUGH",
+    "PHASE_SUPPRESS",
+    "effective_throttle_factor",
+    "should_emit_phase_change",
+    "usage_footer",
+)
 load("../lib/tips.axl", "collect_tips_sorted")
 load("../lint.axl", "LintTrait")
 
@@ -446,34 +454,19 @@ def _github_status_checks(ctx: FeatureContext):
             _state["_saw_priority"] = True
         if not (is_conclusion_transition or is_initial):
             now = now_ms(ctx)
-            elapsed_s = float(now - _state.get("_started_ms", now)) / 1000.0
-
-            # Cold-start phase-change debounce. During the swarm
-            # cold-start window the heartbeat factor floors at 10×
-            # (50s at the 5s base, 200s at the 20s GHSC default) —
-            # which collapses fast early phase transitions into
-            # invisible silence on tasks that finish quickly. Phase
-            # boundaries get a separate 5s debounce so the swarm-
-            # defensive floor stays in effect for heartbeats while
-            # phase emits remain visible. Once burn-rate inference
-            # stabilizes (≥ 3 obs spanning ≥ 30s) the gate returns
-            # 0 and phase emits fall back to the normal heartbeat
-            # throttle below.
-            phase_gate_s = 0
-            if update.phase_change:
-                phase_gate_s = cold_start_phase_change_gate_seconds(ctx, BUCKET_APP)
-            if phase_gate_s > 0:
-                last_pc = _state.get("_last_phase_change_ms", 0)
-                if now - last_pc < phase_gate_s * 1000:
-                    return
-                _state["_last_phase_change_ms"] = now
-
-                # Stamp `_last_update_ms` too so a heartbeat
-                # immediately after this phase emit honors the 10×
-                # factor relative to *this* emit, not the one before
-                # the phase boundary.
-                _state["_last_update_ms"] = now
-            else:
+            phase_result = should_emit_phase_change(
+                ctx,
+                BUCKET_APP,
+                update,
+                _state,
+                now,
+                "_last_phase_change_ms",
+                "_last_update_ms",
+            )
+            if phase_result == PHASE_SUPPRESS:
+                return
+            if phase_result == PHASE_FALL_THROUGH:
+                elapsed_s = float(now - _state.get("_started_ms", now)) / 1000.0
                 factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, min_update_interval_s)
                 if not should_emit_update(_state, now, int(min_update_interval_ms * factor), final):
                     return

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -51,11 +51,13 @@ load("../lib/lifecycle.axl", "TaskLifecycleTrait")
 load(
     "../lib/rate_limit.axl",
     "BUCKET_APP",
-    "cold_start_phase_change_gate_seconds",
+    "PHASE_FALL_THROUGH",
+    "PHASE_SUPPRESS",
     "effective_throttle_factor",
     "epoch_now_s",
     "export_observations",
     "ingest_sibling_observations",
+    "should_emit_phase_change",
     "usage_footer",
 )
 load("../lib/repro_commands.axl", "dedup_and_attribute")
@@ -1585,28 +1587,20 @@ def _github_status_comments(ctx: FeatureContext):
             # lease in `_publish` is what actually gates the
             # App-bucket-burning REST PATCH.
             now = monotonic()
-            elapsed_s = now - _state.get("_task_started_at", now)
-
-            # Cold-start phase-change debounce — see the matching
-            # comment in `feature/github_status_checks.axl::_task_update`.
-            # During the swarm cold-start window phase boundaries
-            # bypass the 10× heartbeat factor and gate on a 5s
-            # debounce instead, so fast early phases stay visible
-            # without spending quota in lockstep with heartbeats.
-            phase_gate_s = 0
-            if update.phase_change:
-                phase_gate_s = cold_start_phase_change_gate_seconds(ctx, BUCKET_APP)
-            if phase_gate_s > 0:
-                last_pc = _state.get("_last_phase_change_s", 0.0)
-                if now - last_pc < float(phase_gate_s):
-                    return
-                _state["_last_phase_change_s"] = now
-
-                # Stamp the heartbeat clock too so a heartbeat after
-                # this phase emit honors the 10× factor relative to
-                # *this* emit, not the prior one.
-                _state["_last_publish_s"] = now
-            else:
+            phase_result = should_emit_phase_change(
+                ctx,
+                BUCKET_APP,
+                update,
+                _state,
+                now,
+                "_last_phase_change_s",
+                "_last_publish_s",
+                scale = 1,
+            )
+            if phase_result == PHASE_SUPPRESS:
+                return
+            if phase_result == PHASE_FALL_THROUGH:
+                elapsed_s = now - _state.get("_task_started_at", now)
                 factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, min_poll_interval_seconds)
                 if now - _state.get("_last_publish_s", 0.0) < min_poll_interval_seconds * factor:
                     return

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -51,6 +51,7 @@ load("../lib/lifecycle.axl", "TaskLifecycleTrait")
 load(
     "../lib/rate_limit.axl",
     "BUCKET_APP",
+    "cold_start_phase_change_gate_seconds",
     "effective_throttle_factor",
     "epoch_now_s",
     "export_observations",
@@ -1585,10 +1586,31 @@ def _github_status_comments(ctx: FeatureContext):
             # App-bucket-burning REST PATCH.
             now = monotonic()
             elapsed_s = now - _state.get("_task_started_at", now)
-            factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, min_poll_interval_seconds)
-            if now - _state.get("_last_publish_s", 0.0) < min_poll_interval_seconds * factor:
-                return
-            _state["_last_publish_s"] = now
+
+            # Cold-start phase-change debounce — see the matching
+            # comment in `feature/github_status_checks.axl::_task_update`.
+            # During the swarm cold-start window phase boundaries
+            # bypass the 10× heartbeat factor and gate on a 5s
+            # debounce instead, so fast early phases stay visible
+            # without spending quota in lockstep with heartbeats.
+            phase_gate_s = 0
+            if update.phase_change:
+                phase_gate_s = cold_start_phase_change_gate_seconds(ctx, BUCKET_APP)
+            if phase_gate_s > 0:
+                last_pc = _state.get("_last_phase_change_s", 0.0)
+                if now - last_pc < float(phase_gate_s):
+                    return
+                _state["_last_phase_change_s"] = now
+
+                # Stamp the heartbeat clock too so a heartbeat after
+                # this phase emit honors the 10× factor relative to
+                # *this* emit, not the prior one.
+                _state["_last_publish_s"] = now
+            else:
+                factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, min_poll_interval_seconds)
+                if now - _state.get("_last_publish_s", 0.0) < min_poll_interval_seconds * factor:
+                    return
+                _state["_last_publish_s"] = now
         _publish(ctx, final = update.final)
 
     lifecycle.task_started.append(_task_started)

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -121,15 +121,11 @@ TaskUpdate = record(
     kind = field(str, default = ""),
     priority = field(bool, default = False),
     # True iff this update crossed a phase boundary — set by
-    # `task_update(...)` when `phase != None` and `phase.name` differs
-    # from the previous `ctx.task.current_phase().name`. Surfaces that
-    # apply a cold-start swarm-throttle (GithubStatusChecks,
-    # GithubStatusComments) read this to gate phase emits on a separate
-    # short debounce so fast early phases stay visible during the
-    # rate-limit cold-start window without burning quota at the 10×
-    # heartbeat floor. Same condition that triggers the BK section
-    # header emit upstream, plumbed through so downstream features can
-    # branch on it without re-computing the boundary.
+    # `task_update(...)` when `phase.name` differs from the previous
+    # `ctx.task.current_phase().name`. Surfaces with a cold-start
+    # swarm throttle (GithubStatusChecks, GithubStatusComments) read
+    # it to gate phase emits on a debounce separate from the heartbeat
+    # throttle. Same condition that triggers the BK section header.
     phase_change = field(bool, default = False),
     # True iff this is the final TaskUpdate the producer will emit before
     # `task_complete` fires. Used by surfaces that distinguish live from
@@ -416,11 +412,7 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
     # surfaces, where the `→` print is the only phase marker.
     bk_section_emitted = False
 
-    # True iff this emit crossed a phase boundary — same condition as
-    # the BK section header. Plumbed onto `TaskUpdate.phase_change`
-    # below so cold-start-aware features (GithubStatusChecks,
-    # GithubStatusComments) can gate phase emits on a debounce
-    # separate from the heartbeat throttle.
+    # Plumbed onto `TaskUpdate.phase_change` below — see field comment.
     phase_change = False
 
     if phase != None:

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -120,6 +120,17 @@ TaskUpdate = record(
     status = field(str, default = "running"),
     kind = field(str, default = ""),
     priority = field(bool, default = False),
+    # True iff this update crossed a phase boundary — set by
+    # `task_update(...)` when `phase != None` and `phase.name` differs
+    # from the previous `ctx.task.current_phase().name`. Surfaces that
+    # apply a cold-start swarm-throttle (GithubStatusChecks,
+    # GithubStatusComments) read this to gate phase emits on a separate
+    # short debounce so fast early phases stay visible during the
+    # rate-limit cold-start window without burning quota at the 10×
+    # heartbeat floor. Same condition that triggers the BK section
+    # header emit upstream, plumbed through so downstream features can
+    # branch on it without re-computing the boundary.
+    phase_change = field(bool, default = False),
     # True iff this is the final TaskUpdate the producer will emit before
     # `task_complete` fires. Used by surfaces that distinguish live from
     # terminal renders even when status alone wouldn't (e.g. `warning`
@@ -405,6 +416,13 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
     # surfaces, where the `→` print is the only phase marker.
     bk_section_emitted = False
 
+    # True iff this emit crossed a phase boundary — same condition as
+    # the BK section header. Plumbed onto `TaskUpdate.phase_change`
+    # below so cold-start-aware features (GithubStatusChecks,
+    # GithubStatusComments) can gate phase emits on a debounce
+    # separate from the heartbeat throttle.
+    phase_change = False
+
     if phase != None:
         # `ctx.task.phase()` no-ops on same-name; capture the prior
         # phase name so we only auto-emit a BK section header on real
@@ -420,6 +438,7 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
         if phase.name != prev_phase:
             _emit_bk_phase_section(ctx, phase, progress_styles)
             bk_section_emitted = bool(ctx.std.env.var("BUILDKITE"))
+            phase_change = True
 
     cli_text = progress_styles.stream
     if cli_text:
@@ -457,6 +476,7 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
         status = status,
         progress = progress_styles,
         priority = priority,
+        phase_change = phase_change,
         final = final,
         conclusion = conclusion,
         data = data if data != None else {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
@@ -114,7 +114,7 @@ absent trait or empty buffer returns `1.0`. The probe at `setup_phase`
 catches all errors and returns silently. There are no `fail()` calls.
 """
 
-load("./environment.axl", "info", "warn")
+load("./environment.axl", "detect_ci", "info", "warn")
 
 # ── Public bucket keys ───────────────────────────────────────────────
 
@@ -191,50 +191,17 @@ _RESERVE_FRACTION = 0.30
 
 # ── Cold-start window ────────────────────────────────────────────────
 #
-# When a swarm of matrix-axis tasks all start at once (e.g. rules_js
-# with ~100 jobs in a single workflow), every task initially has only
-# the setup-phase `/rate_limit` probe in its merged buffer. Burn-rate
-# inference needs ≥ 2 observations across a non-zero Δt, so the
-# `< 2 observations` branch runs — which at 100% remaining returns the
-# `> 50%` threshold-ladder row (1×, no throttle). Siblings haven't
-# yet propagated their observations through the artifact-share cycle,
-# so the swarm-size multiplier is 1. Result: every task in the swarm
-# runs at full cadence for ~30–60s before burn-rate stabilizes, and
-# the shared App-bucket quota can be largely spent in that window.
-#
-# The cold-start window adds a defensive floor for that gap: while
-# the merged buffer has fewer than `_COLD_START_MIN_OBS` observations
-# OR spans less than `_COLD_START_MIN_SPAN_S` of wall-clock time AND
-# we're running on a recognized CI host (where a matrix swarm is
-# likely), the heartbeat throttle floors at `_COLD_START_HEARTBEAT_FACTOR`
-# regardless of remaining quota. Once both conditions are satisfied,
-# burn-rate inference takes over and the cold-start floor is dropped.
-#
-# Fast early phases (preflight → detect → build, often firing within
-# a few seconds) shouldn't disappear behind the 10× heartbeat factor
-# — that's UX-hostile on tasks that finish quickly. They get a
-# separate debounce gate (`_COLD_START_PHASE_CHANGE_GATE_S` seconds)
-# exposed via `cold_start_phase_change_gate_seconds`; callers track
-# a per-task `_last_phase_change_ms` independently of their main
-# heartbeat clock so phase transitions remain visible during the
-# cold-start window without burning quota in lockstep with heartbeats.
+# See the module docstring section "Cold-start window" for the design
+# rationale. Numbers below tune the window's boundaries.
 _COLD_START_MIN_OBS = 3
 _COLD_START_MIN_SPAN_S = 30
 _COLD_START_HEARTBEAT_FACTOR = 10.0
 _COLD_START_PHASE_CHANGE_GATE_S = 5
 
-# Env-var override (test seam). Tests set `ASPECT_RATE_LIMIT_COLD_START`
-# to "1" / "0" to force cold-start CI detection on or off without
-# touching the host CI markers. Unset (the default) falls through to
-# the real CI markers via `lifecycle._on_ci`. Kept private — production
-# callers never set it.
+# Test seam — `"1"` forces `_is_ci` True, `"0"` forces False. Unset
+# (the default) falls through to `detect_ci`. Production callers
+# never set this.
 _COLD_START_OVERRIDE_VAR = "ASPECT_RATE_LIMIT_COLD_START"
-
-# CI markers consulted by `_is_ci`. Mirrors `lifecycle._on_ci` rather
-# than reaching across modules, so this file stays self-contained for
-# test isolation (the lifecycle module pulls in trait machinery the
-# rate-limit tests don't want to depend on).
-_CI_ENV_MARKERS = ("CI", "BUILDKITE", "GITHUB_ACTIONS", "CIRCLECI", "GITLAB_CI")
 
 # ── Per-task state (file pattern) ───────────────────────────────────
 #
@@ -818,62 +785,81 @@ def time_throttle_factor(elapsed_s, min_interval_s):
     return 1.0 + (target_factor - 1.0) * progress
 
 def _is_ci(std):
-    """True iff one of `_CI_ENV_MARKERS` is set, or the
-    `_COLD_START_OVERRIDE_VAR` env var explicitly forces the answer
-    (test seam — `"1"` forces True, `"0"` forces False)."""
+    """True iff the process is running on a recognized CI host.
+    Reads `_COLD_START_OVERRIDE_VAR` first as a test seam; otherwise
+    delegates to `detect_ci`."""
     override = std.env.var(_COLD_START_OVERRIDE_VAR)
     if override == "1":
         return True
     if override == "0":
         return False
-    for marker in _CI_ENV_MARKERS:
-        if std.env.var(marker):
-            return True
-    return False
+    return detect_ci(std.env) != None
 
 def _in_cold_start(merged_obs):
     """True iff the merged observation buffer is too sparse for
-    burn-rate inference to be stable. The cold-start floor applies
-    until BOTH `_COLD_START_MIN_OBS` observations have accumulated
-    AND the buffer spans at least `_COLD_START_MIN_SPAN_S` seconds.
-    Pure — operates on the buffer alone; callers gate on `_is_ci`
-    separately."""
+    burn-rate inference to be stable. Pure — operates on the buffer
+    alone; callers gate on `_is_ci` separately."""
     if len(merged_obs) < _COLD_START_MIN_OBS:
         return True
-    span_s = merged_obs[-1][0] - merged_obs[0][0]
-    return span_s < _COLD_START_MIN_SPAN_S
+    return merged_obs[-1][0] - merged_obs[0][0] < _COLD_START_MIN_SPAN_S
 
 def cold_start_phase_change_gate_seconds(ctx, bucket):
-    """Return the cold-start phase-change debounce gate in seconds.
+    """Return the cold-start phase-change debounce gate in seconds, or
+    0 when the gate is inactive.
 
-    Returns `_COLD_START_PHASE_CHANGE_GATE_S` (5s) when the task is
-    on a CI host AND `_in_cold_start` is true for `bucket`. Returns 0
-    once burn-rate inference is stable so callers fall back to their
-    normal heartbeat throttle for subsequent phase emits.
+    Returns `_COLD_START_PHASE_CHANGE_GATE_S` (5s) when on a CI host
+    AND the merged buffer is still in cold start for `bucket`. Returns
+    0 on an unknown bucket so callers don't have to validate.
 
-    Callers track a separate `_last_phase_change_ms` from their main
-    heartbeat clock and gate phase-change emits on this debounce
-    (when > 0) instead of the 10× heartbeat factor — that keeps fast
-    early phases (preflight → detect → build inside a few seconds)
-    visible during the cold-start window without spending quota in
-    lockstep with the heartbeat floor.
-
-    Best-effort: returns 0 on an unknown bucket so callers don't have
-    to validate."""
+    Most callers should use `should_emit_phase_change` instead — it
+    encapsulates the gate-evaluation + state-stamping pattern."""
     if bucket not in _VALID_BUCKETS:
         return 0
     if not _is_ci(ctx.std):
         return 0
-    state = _load(ctx)
-    obs = _merged_observations_from_state(state, bucket)
-    if _in_cold_start(obs):
+    if _in_cold_start(_merged_observations_from_state(_load(ctx), bucket)):
         return _COLD_START_PHASE_CHANGE_GATE_S
     return 0
 
+# Tri-state return values for `should_emit_phase_change`. String values
+# are arbitrary; callers compare by name.
+PHASE_EMIT = "emit"
+PHASE_SUPPRESS = "suppress"
+PHASE_FALL_THROUGH = "fall_through"
+
+def should_emit_phase_change(ctx, bucket, update, state, now, last_phase_key, last_emit_key, scale = 1000):
+    """Apply the cold-start phase-change debounce for one emit.
+
+    Returns one of:
+      PHASE_EMIT         — phase change passes; render + push. `state[last_phase_key]`
+                           and `state[last_emit_key]` are stamped to `now`.
+      PHASE_SUPPRESS     — phase change is within the debounce window; drop the emit.
+      PHASE_FALL_THROUGH — not a cold-start phase change. Use the heartbeat throttle.
+
+    The first phase emit while the gate is active always passes —
+    `state[last_phase_key]` defaults to 0 (never stamped) and the
+    debounce only applies between successive stamped emits. Without
+    this carve-out a fast task whose first phase advance happens
+    before any prior emit ever stamped the key would lose visibility.
+
+    `scale` converts seconds to the caller's clock unit: 1000 for
+    millisecond clocks (`now_ms`), 1 for second clocks (`monotonic`)."""
+    if not update.phase_change:
+        return PHASE_FALL_THROUGH
+    gate_s = cold_start_phase_change_gate_seconds(ctx, bucket)
+    if gate_s <= 0:
+        return PHASE_FALL_THROUGH
+    last_pc = state.get(last_phase_key, 0)
+    if last_pc > 0 and now - last_pc < gate_s * scale:
+        return PHASE_SUPPRESS
+    state[last_phase_key] = now
+    state[last_emit_key] = now
+    return PHASE_EMIT
+
 def effective_throttle_factor(ctx, bucket, elapsed_s, min_interval_s):
-    """Combine the quota-pressure and time-based throttles into a
-    single multiplier ≥ 1.0. Callers multiply this into their native
-    heartbeat interval (ms or s).
+    """Combine the quota-pressure, time-based, and cold-start throttles
+    into a single multiplier ≥ 1.0. Callers multiply this into their
+    native heartbeat interval (ms or s).
 
     Side-effects:
       - Records the resulting factor on
@@ -885,28 +871,16 @@ def effective_throttle_factor(ctx, bucket, elapsed_s, min_interval_s):
         terminal-only). Step-bucketed so the linear ramp inside
         `time_throttle_factor` doesn't spam a log line per heartbeat.
 
-    Cold-start floor: when the merged observation buffer is too
-    sparse for burn-rate inference to be stable (see `_in_cold_start`)
-    AND the task is running on a recognized CI host (where a matrix
-    swarm is likely), the heartbeat factor floors at
-    `_COLD_START_HEARTBEAT_FACTOR`. That covers the gap between task
-    start and burn-rate stabilization where, today, every task in a
-    fresh swarm sees only its own setup-phase probe (100% remaining,
-    no siblings yet propagated through the artifact-share cycle) and
-    returns 1× from the threshold ladder. Phase-change emits use a
-    separate debounce gate via `cold_start_phase_change_gate_seconds`
-    so they don't disappear behind the 10× floor.
-
-    Centralizes the composition every heartbeat call site uses so
-    new throttle dimensions (or weight changes between the two
-    existing ones) land in one place."""
+    Centralizes composition so new throttle dimensions land in one
+    place. See the module docstring "Cold-start window" for the
+    swarm-defensive floor applied during the cold-start window."""
     state = _load(ctx)
-    quota_factor = _throttle_factor_from_state(state, bucket, None, ctx.std)
-    factor = max(quota_factor, time_throttle_factor(elapsed_s, min_interval_s))
-    if _is_ci(ctx.std):
-        obs = _merged_observations_from_state(state, bucket)
-        if _in_cold_start(obs):
-            factor = max(factor, _COLD_START_HEARTBEAT_FACTOR)
+    factor = max(
+        _throttle_factor_from_state(state, bucket, None, ctx.std),
+        time_throttle_factor(elapsed_s, min_interval_s),
+    )
+    if _is_ci(ctx.std) and _in_cold_start(_merged_observations_from_state(state, bucket)):
+        factor = max(factor, _COLD_START_HEARTBEAT_FACTOR)
     _record_effective_factor_in_state(ctx, state, bucket, factor, elapsed_s)
     _save(ctx, state)
     return factor

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
@@ -201,7 +201,7 @@ _COLD_START_PHASE_CHANGE_GATE_S = 5
 # Test seam — `"1"` forces `_is_ci` True, `"0"` forces False. Unset
 # (the default) falls through to `detect_ci`. Production callers
 # never set this.
-_COLD_START_OVERRIDE_VAR = "ASPECT_RATE_LIMIT_COLD_START"
+_COLD_START_OVERRIDE_VAR = "ASPECT_WORKFLOWS_GITHUB_API_RATE_LIMIT_COLD_START"
 
 # ── Per-task state (file pattern) ───────────────────────────────────
 #

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
@@ -69,6 +69,25 @@ minutes, ramping to a 60s effective interval at 30 minutes).
 combines both via `max(...)` so whichever pressure is greater drives
 the cadence.
 
+# Cold-start window (swarm defensive floor)
+
+When a matrix swarm of tasks all start at once (rules_js' ~100-job
+matrix is the motivating case), each task's merged buffer initially
+holds only the setup-phase probe — burn-rate inference can't fire,
+the threshold ladder reads 100% remaining and returns 1×, and the
+swarm-size multiplier is 1 because no sibling has propagated an
+observation through the artifact-share cycle yet. Every task runs
+at full cadence for ~30–60s and the shared App-bucket can be largely
+spent in that window.
+
+`effective_throttle_factor` floors the heartbeat factor at
+`_COLD_START_HEARTBEAT_FACTOR` (10×) when on a CI host AND the
+merged buffer is too sparse for burn-rate inference (see
+`_in_cold_start`). Phase-change emits use a separate debounce gate
+returned by `cold_start_phase_change_gate_seconds` (5s during the
+window, 0 once burn-rate stabilizes) so fast early phases remain
+visible without spending quota in lockstep with the heartbeat floor.
+
 # Reset crossings
 
 When a fresh observation's `reset_epoch` jumps forward by more than
@@ -169,6 +188,53 @@ _TIME_TO_RESET_FLOOR_S = 60
 # overshoot a swarm of concurrent tasks generates while burn-rate
 # inference converges on the per-task interval.
 _RESERVE_FRACTION = 0.30
+
+# ── Cold-start window ────────────────────────────────────────────────
+#
+# When a swarm of matrix-axis tasks all start at once (e.g. rules_js
+# with ~100 jobs in a single workflow), every task initially has only
+# the setup-phase `/rate_limit` probe in its merged buffer. Burn-rate
+# inference needs ≥ 2 observations across a non-zero Δt, so the
+# `< 2 observations` branch runs — which at 100% remaining returns the
+# `> 50%` threshold-ladder row (1×, no throttle). Siblings haven't
+# yet propagated their observations through the artifact-share cycle,
+# so the swarm-size multiplier is 1. Result: every task in the swarm
+# runs at full cadence for ~30–60s before burn-rate stabilizes, and
+# the shared App-bucket quota can be largely spent in that window.
+#
+# The cold-start window adds a defensive floor for that gap: while
+# the merged buffer has fewer than `_COLD_START_MIN_OBS` observations
+# OR spans less than `_COLD_START_MIN_SPAN_S` of wall-clock time AND
+# we're running on a recognized CI host (where a matrix swarm is
+# likely), the heartbeat throttle floors at `_COLD_START_HEARTBEAT_FACTOR`
+# regardless of remaining quota. Once both conditions are satisfied,
+# burn-rate inference takes over and the cold-start floor is dropped.
+#
+# Fast early phases (preflight → detect → build, often firing within
+# a few seconds) shouldn't disappear behind the 10× heartbeat factor
+# — that's UX-hostile on tasks that finish quickly. They get a
+# separate debounce gate (`_COLD_START_PHASE_CHANGE_GATE_S` seconds)
+# exposed via `cold_start_phase_change_gate_seconds`; callers track
+# a per-task `_last_phase_change_ms` independently of their main
+# heartbeat clock so phase transitions remain visible during the
+# cold-start window without burning quota in lockstep with heartbeats.
+_COLD_START_MIN_OBS = 3
+_COLD_START_MIN_SPAN_S = 30
+_COLD_START_HEARTBEAT_FACTOR = 10.0
+_COLD_START_PHASE_CHANGE_GATE_S = 5
+
+# Env-var override (test seam). Tests set `ASPECT_RATE_LIMIT_COLD_START`
+# to "1" / "0" to force cold-start CI detection on or off without
+# touching the host CI markers. Unset (the default) falls through to
+# the real CI markers via `lifecycle._on_ci`. Kept private — production
+# callers never set it.
+_COLD_START_OVERRIDE_VAR = "ASPECT_RATE_LIMIT_COLD_START"
+
+# CI markers consulted by `_is_ci`. Mirrors `lifecycle._on_ci` rather
+# than reaching across modules, so this file stays self-contained for
+# test isolation (the lifecycle module pulls in trait machinery the
+# rate-limit tests don't want to depend on).
+_CI_ENV_MARKERS = ("CI", "BUILDKITE", "GITHUB_ACTIONS", "CIRCLECI", "GITLAB_CI")
 
 # ── Per-task state (file pattern) ───────────────────────────────────
 #
@@ -751,6 +817,59 @@ def time_throttle_factor(elapsed_s, min_interval_s):
     progress = float(elapsed_s - _TIME_THROTTLE_FAST_PERIOD_S) / ramp_span
     return 1.0 + (target_factor - 1.0) * progress
 
+def _is_ci(std):
+    """True iff one of `_CI_ENV_MARKERS` is set, or the
+    `_COLD_START_OVERRIDE_VAR` env var explicitly forces the answer
+    (test seam — `"1"` forces True, `"0"` forces False)."""
+    override = std.env.var(_COLD_START_OVERRIDE_VAR)
+    if override == "1":
+        return True
+    if override == "0":
+        return False
+    for marker in _CI_ENV_MARKERS:
+        if std.env.var(marker):
+            return True
+    return False
+
+def _in_cold_start(merged_obs):
+    """True iff the merged observation buffer is too sparse for
+    burn-rate inference to be stable. The cold-start floor applies
+    until BOTH `_COLD_START_MIN_OBS` observations have accumulated
+    AND the buffer spans at least `_COLD_START_MIN_SPAN_S` seconds.
+    Pure — operates on the buffer alone; callers gate on `_is_ci`
+    separately."""
+    if len(merged_obs) < _COLD_START_MIN_OBS:
+        return True
+    span_s = merged_obs[-1][0] - merged_obs[0][0]
+    return span_s < _COLD_START_MIN_SPAN_S
+
+def cold_start_phase_change_gate_seconds(ctx, bucket):
+    """Return the cold-start phase-change debounce gate in seconds.
+
+    Returns `_COLD_START_PHASE_CHANGE_GATE_S` (5s) when the task is
+    on a CI host AND `_in_cold_start` is true for `bucket`. Returns 0
+    once burn-rate inference is stable so callers fall back to their
+    normal heartbeat throttle for subsequent phase emits.
+
+    Callers track a separate `_last_phase_change_ms` from their main
+    heartbeat clock and gate phase-change emits on this debounce
+    (when > 0) instead of the 10× heartbeat factor — that keeps fast
+    early phases (preflight → detect → build inside a few seconds)
+    visible during the cold-start window without spending quota in
+    lockstep with the heartbeat floor.
+
+    Best-effort: returns 0 on an unknown bucket so callers don't have
+    to validate."""
+    if bucket not in _VALID_BUCKETS:
+        return 0
+    if not _is_ci(ctx.std):
+        return 0
+    state = _load(ctx)
+    obs = _merged_observations_from_state(state, bucket)
+    if _in_cold_start(obs):
+        return _COLD_START_PHASE_CHANGE_GATE_S
+    return 0
+
 def effective_throttle_factor(ctx, bucket, elapsed_s, min_interval_s):
     """Combine the quota-pressure and time-based throttles into a
     single multiplier ≥ 1.0. Callers multiply this into their native
@@ -766,14 +885,28 @@ def effective_throttle_factor(ctx, bucket, elapsed_s, min_interval_s):
         terminal-only). Step-bucketed so the linear ramp inside
         `time_throttle_factor` doesn't spam a log line per heartbeat.
 
+    Cold-start floor: when the merged observation buffer is too
+    sparse for burn-rate inference to be stable (see `_in_cold_start`)
+    AND the task is running on a recognized CI host (where a matrix
+    swarm is likely), the heartbeat factor floors at
+    `_COLD_START_HEARTBEAT_FACTOR`. That covers the gap between task
+    start and burn-rate stabilization where, today, every task in a
+    fresh swarm sees only its own setup-phase probe (100% remaining,
+    no siblings yet propagated through the artifact-share cycle) and
+    returns 1× from the threshold ladder. Phase-change emits use a
+    separate debounce gate via `cold_start_phase_change_gate_seconds`
+    so they don't disappear behind the 10× floor.
+
     Centralizes the composition every heartbeat call site uses so
     new throttle dimensions (or weight changes between the two
     existing ones) land in one place."""
     state = _load(ctx)
-    factor = max(
-        _throttle_factor_from_state(state, bucket, None, ctx.std),
-        time_throttle_factor(elapsed_s, min_interval_s),
-    )
+    quota_factor = _throttle_factor_from_state(state, bucket, None, ctx.std)
+    factor = max(quota_factor, time_throttle_factor(elapsed_s, min_interval_s))
+    if _is_ci(ctx.std):
+        obs = _merged_observations_from_state(state, bucket)
+        if _in_cold_start(obs):
+            factor = max(factor, _COLD_START_HEARTBEAT_FACTOR)
     _record_effective_factor_in_state(ctx, state, bucket, factor, elapsed_s)
     _save(ctx, state)
     return factor

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
@@ -21,6 +21,9 @@ load(
     "./rate_limit.axl",
     "BUCKET_APP",
     "BUCKET_ENV",
+    "PHASE_EMIT",
+    "PHASE_FALL_THROUGH",
+    "PHASE_SUPPRESS",
     "cold_start_phase_change_gate_seconds",
     "effective_throttle_factor",
     "export_observations",
@@ -31,24 +34,34 @@ load(
     "reset_for_test",
     "seed_from_rate_limit_body",
     "set_state_for_test",
+    "should_emit_phase_change",
     "throttle_factor",
     "time_throttle_factor",
     "usage_footer",
 )
 
-# CI env markers `_is_ci` consults — cleared at test setup so the
-# cold-start floor stays off for every test that doesn't explicitly
-# opt in. Without this, running `aspect dev test-rate-limit` under a
-# CI host (where one of these is set) would flip on the floor and
-# break the existing factor / footer assertions.
+# CI markers `_is_ci` consults via `environment.detect_ci`, plus the
+# `ASPECT_RATE_LIMIT_COLD_START` override seam — cleared at every
+# subtest setup so the cold-start floor stays off unless explicitly
+# enabled. Running `aspect dev test-rate-limit` on a host where any
+# of these is set would otherwise flip the floor on and break the
+# existing factor / footer assertions.
 _CI_ENV_MARKERS = (
-    "CI",
-    "BUILDKITE",
     "GITHUB_ACTIONS",
-    "CIRCLECI",
-    "GITLAB_CI",
+    "BUILDKITE_AGENT_ACCESS_TOKEN",
+    "CI_JOB_TOKEN",
+    "CIRCLE_PROJECT_REPONAME",
+    "CI",
     "ASPECT_RATE_LIMIT_COLD_START",
 )
+
+# Stub TaskUpdate-shaped value for tests of `should_emit_phase_change`.
+# The helper only reads `update.phase_change`; using a tiny local
+# record avoids depending on the full `lifecycle.TaskUpdate` type.
+_StubUpdate = record(phase_change = field(bool, default = False))
+
+def _stub_update(phase_change):
+    return _StubUpdate(phase_change = phase_change)
 
 def _eq(label, got, want):
     if got != want:
@@ -1018,6 +1031,149 @@ def _test_cold_start_phase_change_gate_invalid_bucket(ctx):
         0,
     )
 
+def _test_should_emit_phase_change_non_phase_emit(ctx):
+    """A non-phase-change emit always returns PHASE_FALL_THROUGH so
+    the caller falls back to its normal heartbeat throttle."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+    state = {}
+    _eq(
+        "phase-emit — heartbeat falls through",
+        should_emit_phase_change(ctx, BUCKET_APP, _stub_update(False), state, 1000, "_pc", "_emit"),
+        PHASE_FALL_THROUGH,
+    )
+
+def _test_should_emit_phase_change_outside_cold_start(ctx):
+    """A phase change outside the cold-start window returns
+    PHASE_FALL_THROUGH so steady-state phase emits use the normal
+    heartbeat throttle (avoiding the burst on chatty tasks past the
+    cold-start window)."""
+    _reset(ctx)
+    state = {}
+
+    # No CI marker — gate inactive, even for a phase emit.
+    _eq(
+        "phase-emit — off-CI phase change falls through",
+        should_emit_phase_change(ctx, BUCKET_APP, _stub_update(True), state, 1000, "_pc", "_emit"),
+        PHASE_FALL_THROUGH,
+    )
+
+def _test_should_emit_phase_change_first_emit_passes(ctx):
+    """The first phase emit in cold-start always passes — `last_pc=0`
+    means "never stamped" and the debounce only applies between
+    successive stamped emits. Without this carve-out a fast task
+    whose first stamped phase advance happens at t < 5s would lose
+    visibility."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+    state = {}
+
+    # First emit at t=50ms — `_pc` defaults to 0, would otherwise
+    # trip the 5s × 1000ms gate. The first-emit carve-out lets it
+    # through.
+    _eq(
+        "phase-emit — first emit passes regardless of `now`",
+        should_emit_phase_change(ctx, BUCKET_APP, _stub_update(True), state, 50, "_pc", "_emit"),
+        PHASE_EMIT,
+    )
+    _eq("phase-emit — first emit stamps phase clock", state["_pc"], 50)
+    _eq("phase-emit — first emit stamps heartbeat clock", state["_emit"], 50)
+
+def _test_should_emit_phase_change_within_debounce_suppresses(ctx):
+    """A second phase emit within the 5s debounce of a previously
+    stamped emit returns PHASE_SUPPRESS and does NOT re-stamp state."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+    state = {"_pc": 1000, "_emit": 1000}
+    _eq(
+        "phase-emit — within debounce → suppress",
+        should_emit_phase_change(ctx, BUCKET_APP, _stub_update(True), state, 3000, "_pc", "_emit"),
+        PHASE_SUPPRESS,
+    )
+    _eq("phase-emit — suppressed call leaves phase clock untouched", state["_pc"], 1000)
+    _eq("phase-emit — suppressed call leaves heartbeat clock untouched", state["_emit"], 1000)
+
+def _test_should_emit_phase_change_after_debounce_emits(ctx):
+    """A phase emit past the 5s × scale gap from the previous stamped
+    emit passes and re-stamps both clocks."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+    state = {"_pc": 1000, "_emit": 1000}
+
+    # 6s later (1000 + 6000 = 7000ms). Past the 5s × 1000ms gate.
+    _eq(
+        "phase-emit — past debounce → emit",
+        should_emit_phase_change(ctx, BUCKET_APP, _stub_update(True), state, 7000, "_pc", "_emit"),
+        PHASE_EMIT,
+    )
+    _eq("phase-emit — emit re-stamps phase clock", state["_pc"], 7000)
+    _eq("phase-emit — emit re-stamps heartbeat clock", state["_emit"], 7000)
+
+def _test_should_emit_phase_change_scale_seconds(ctx):
+    """A caller using a second-clock (`monotonic()`) passes `scale=1`
+    so the 5s gate compares directly against `now` in seconds."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+    state = {"_pc": 10.0, "_emit": 10.0}
+
+    # 3s later — still within the 5s gate.
+    _eq(
+        "phase-emit — second-clock within debounce → suppress",
+        should_emit_phase_change(ctx, BUCKET_APP, _stub_update(True), state, 13.0, "_pc", "_emit", scale = 1),
+        PHASE_SUPPRESS,
+    )
+
+    # 6s later — past the gate.
+    _eq(
+        "phase-emit — second-clock past debounce → emit",
+        should_emit_phase_change(ctx, BUCKET_APP, _stub_update(True), state, 16.0, "_pc", "_emit", scale = 1),
+        PHASE_EMIT,
+    )
+
+def _test_cold_start_floor_records_to_last_effective_factor(ctx):
+    """The cold-start floor must be recorded onto
+    `last_effective_factor[bucket]` so `usage_footer` renders the
+    correct `throttle 10×` clause during the cold-start window."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+    record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    effective_throttle_factor(ctx, BUCKET_APP, elapsed_s = 0, min_interval_s = 10)
+    _eq(
+        "cold-start floor — recorded as last_effective_factor",
+        inspect_for_test(ctx)["last_effective_factor"][BUCKET_APP],
+        10.0,
+    )
+    if "throttle 10×" not in usage_footer(ctx):
+        fail("cold-start floor — usage_footer should render `throttle 10×`: %r" % usage_footer(ctx))
+
+def _test_cold_start_floor_re_engages_after_reset_crossing(ctx):
+    """A reset-window crossing flushes the observation buffer (see
+    `_test_reset_crossing_flushes_buffer`). The cold-start floor must
+    re-engage in the new window because the post-reset buffer is
+    sparse again — otherwise a long-running CI task in the middle
+    of a fresh window would spend uncapped quota."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+
+    # Accumulate enough observations to release the floor:
+    # 4 obs across 45s, all in the same reset window (reset_epoch = 1000).
+    for (epoch, remaining) in [(1.0, 4900), (15.0, 4899), (30.0, 4898), (46.0, 4897)]:
+        record_observation(ctx, BUCKET_APP, remaining = remaining, limit = 5000, reset_epoch = 1000, epoch_s = epoch)
+    _eq(
+        "pre-reset — floor released with dense buffer",
+        effective_throttle_factor(ctx, BUCKET_APP, elapsed_s = 0, min_interval_s = 10),
+        1.0,
+    )
+
+    # Reset crossing — `reset_epoch` jumps +3600s (well past `_RESET_JUMP_S`).
+    # Buffer flushes; the new window has 1 observation.
+    record_observation(ctx, BUCKET_APP, remaining = 5000, limit = 5000, reset_epoch = 4600, epoch_s = 100.0)
+    _eq(
+        "post-reset — floor re-engages on fresh sparse buffer",
+        effective_throttle_factor(ctx, BUCKET_APP, elapsed_s = 0, min_interval_s = 10),
+        10.0,
+    )
+
 def _test_impl(ctx):
     _test_record_basic(ctx)
     _test_record_buffer_truncation(ctx)
@@ -1055,11 +1211,19 @@ def _test_impl(ctx):
     _test_cold_start_floor_on_ci_applies(ctx)
     _test_cold_start_floor_clears_when_buffer_dense(ctx)
     _test_cold_start_floor_does_not_lower_higher_pressure(ctx)
+    _test_cold_start_floor_records_to_last_effective_factor(ctx)
+    _test_cold_start_floor_re_engages_after_reset_crossing(ctx)
     _test_cold_start_phase_change_gate_off_ci(ctx)
     _test_cold_start_phase_change_gate_on_ci(ctx)
     _test_cold_start_phase_change_gate_uses_sibling_observations(ctx)
     _test_cold_start_phase_change_gate_invalid_bucket(ctx)
-    print("rate_limit.axl: OK (40 sections)")
+    _test_should_emit_phase_change_non_phase_emit(ctx)
+    _test_should_emit_phase_change_outside_cold_start(ctx)
+    _test_should_emit_phase_change_first_emit_passes(ctx)
+    _test_should_emit_phase_change_within_debounce_suppresses(ctx)
+    _test_should_emit_phase_change_after_debounce_emits(ctx)
+    _test_should_emit_phase_change_scale_seconds(ctx)
+    print("rate_limit.axl: OK (48 sections)")
     return 0
 
 rate_limit_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
@@ -21,6 +21,7 @@ load(
     "./rate_limit.axl",
     "BUCKET_APP",
     "BUCKET_ENV",
+    "cold_start_phase_change_gate_seconds",
     "effective_throttle_factor",
     "export_observations",
     "ingest_sibling_observations",
@@ -35,6 +36,20 @@ load(
     "usage_footer",
 )
 
+# CI env markers `_is_ci` consults — cleared at test setup so the
+# cold-start floor stays off for every test that doesn't explicitly
+# opt in. Without this, running `aspect dev test-rate-limit` under a
+# CI host (where one of these is set) would flip on the floor and
+# break the existing factor / footer assertions.
+_CI_ENV_MARKERS = (
+    "CI",
+    "BUILDKITE",
+    "GITHUB_ACTIONS",
+    "CIRCLECI",
+    "GITLAB_CI",
+    "ASPECT_RATE_LIMIT_COLD_START",
+)
+
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
@@ -45,8 +60,19 @@ def _assert(label, cond):
 
 def _reset(ctx):
     """Clear all rate-limit state between subtests so each
-    section runs from a known-empty starting point."""
+    section runs from a known-empty starting point. Also clears
+    every CI env marker the cold-start floor checks, so tests that
+    don't opt into cold-start CI detection don't pick up the host's
+    real CI markers."""
     reset_for_test(ctx)
+    for marker in _CI_ENV_MARKERS:
+        ctx.std.env.remove_var(marker)
+
+def _force_cold_start_ci(ctx):
+    """Force `_is_ci` to return True via the test-only override env
+    var. Use in tests that need the cold-start floor to apply
+    regardless of whether the host happens to be on CI."""
+    ctx.std.env.set_var("ASPECT_RATE_LIMIT_COLD_START", "1")
 
 def _tier(ctx, bucket):
     """Project the trait's `threshold_warned_tier[bucket]` for assertions."""
@@ -820,6 +846,178 @@ def _test_threshold_factor_swarm_scaling_skips_env_bucket(ctx):
         5.0,
     )
 
+def _test_cold_start_floor_off_ci(ctx):
+    """Without any CI marker set, `effective_throttle_factor` skips
+    the cold-start floor — solo / local invocations don't pay the
+    swarm-defensive 10× factor when no swarm is plausible."""
+    _reset(ctx)
+    record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq(
+        "cold-start off-CI — sparse buffer at 98% remaining → 1.0 (no floor)",
+        effective_throttle_factor(ctx, BUCKET_APP, elapsed_s = 0, min_interval_s = 10),
+        1.0,
+    )
+
+def _test_cold_start_floor_on_ci_applies(ctx):
+    """On a CI host with a sparse merged buffer (< 3 obs OR span < 30s),
+    `effective_throttle_factor` floors at 10× even when remaining
+    quota is high — the swarm could be burning quota in parallel that
+    this task can't see yet."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+
+    # 1 observation, 98% remaining. Without the floor: threshold ladder
+    # row at > 50% → 1×. With the floor: 10×.
+    record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq(
+        "cold-start on-CI — sparse buffer at 98% remaining → 10× floor",
+        effective_throttle_factor(ctx, BUCKET_APP, elapsed_s = 0, min_interval_s = 10),
+        10.0,
+    )
+
+def _test_cold_start_floor_clears_when_buffer_dense(ctx):
+    """The cold-start floor drops once the merged buffer has ≥ 3
+    observations spanning ≥ 30s — burn-rate inference is stable and
+    the floor is no longer needed. Below either bound it still applies.
+
+    `reset_epoch = 0` on each observation forces `_burn_rate_factor`
+    to return None (missing reset_epoch), so the threshold-ladder
+    fallback runs at the 98% remaining row (1×). That keeps the test
+    deterministic regardless of the test runner's wall clock — without
+    it, `_FAR_FUTURE` against the real clock makes `time_to_reset`
+    enormous and `safe_burn ≈ 0`, blowing up the factor."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+
+    # 3 obs but only a 10s span — still in cold start.
+    record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 5000, reset_epoch = 0, epoch_s = 1.0)
+    record_observation(ctx, BUCKET_APP, remaining = 4895, limit = 5000, reset_epoch = 0, epoch_s = 5.0)
+    record_observation(ctx, BUCKET_APP, remaining = 4890, limit = 5000, reset_epoch = 0, epoch_s = 11.0)
+    _eq(
+        "cold-start on-CI — 3 obs spanning 10s still in cold start",
+        effective_throttle_factor(ctx, BUCKET_APP, elapsed_s = 0, min_interval_s = 10),
+        10.0,
+    )
+
+    # Extend the span past 30s — burn-rate falls back to threshold
+    # ladder (1×), and the cold-start floor releases too. Factor
+    # drops to 1.0.
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+    record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 5000, reset_epoch = 0, epoch_s = 1.0)
+    record_observation(ctx, BUCKET_APP, remaining = 4899, limit = 5000, reset_epoch = 0, epoch_s = 15.0)
+    record_observation(ctx, BUCKET_APP, remaining = 4898, limit = 5000, reset_epoch = 0, epoch_s = 30.0)
+    record_observation(ctx, BUCKET_APP, remaining = 4897, limit = 5000, reset_epoch = 0, epoch_s = 46.0)
+    _eq(
+        "cold-start on-CI — 4 obs spanning 45s release the floor",
+        effective_throttle_factor(ctx, BUCKET_APP, elapsed_s = 0, min_interval_s = 10),
+        1.0,
+    )
+
+def _test_cold_start_floor_does_not_lower_higher_pressure(ctx):
+    """The cold-start floor is a *floor*, not a ceiling — when the
+    quota-pressure factor or time-throttle factor exceeds 10×, the
+    larger value still wins. Verifies the floor composes as `max(...)`."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+
+    # 1 obs at 8% remaining — threshold ladder picks the 5-10% row (50×).
+    record_observation(ctx, BUCKET_APP, remaining = 400, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq(
+        "cold-start floor — 50× quota pressure wins over 10× floor",
+        effective_throttle_factor(ctx, BUCKET_APP, elapsed_s = 0, min_interval_s = 10),
+        50.0,
+    )
+
+def _test_cold_start_phase_change_gate_off_ci(ctx):
+    """Without a CI marker, the phase-change gate is always 0 —
+    local invocations have no swarm pressure to debounce against."""
+    _reset(ctx)
+    _eq(
+        "phase-gate off-CI — empty state → 0s gate",
+        cold_start_phase_change_gate_seconds(ctx, BUCKET_APP),
+        0,
+    )
+
+    # Same answer with observations in hand.
+    record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    _eq(
+        "phase-gate off-CI — sparse buffer still → 0s gate",
+        cold_start_phase_change_gate_seconds(ctx, BUCKET_APP),
+        0,
+    )
+
+def _test_cold_start_phase_change_gate_on_ci(ctx):
+    """On CI, the gate is 5s while the merged buffer is sparse (< 3 obs
+    OR span < 30s), then drops to 0 once burn-rate inference stabilises."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+
+    # No observations yet — in cold start by the `< 3` branch.
+    _eq(
+        "phase-gate on-CI — empty buffer → 5s gate",
+        cold_start_phase_change_gate_seconds(ctx, BUCKET_APP),
+        5,
+    )
+
+    # 2 observations spanning 5s — still in cold start.
+    record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 1.0)
+    record_observation(ctx, BUCKET_APP, remaining = 4895, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 6.0)
+    _eq(
+        "phase-gate on-CI — 2 obs / 5s span → 5s gate",
+        cold_start_phase_change_gate_seconds(ctx, BUCKET_APP),
+        5,
+    )
+
+    # 3 obs spanning > 30s — gate releases to 0.
+    record_observation(ctx, BUCKET_APP, remaining = 4890, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 40.0)
+    _eq(
+        "phase-gate on-CI — 3 obs / 39s span → 0s gate (released)",
+        cold_start_phase_change_gate_seconds(ctx, BUCKET_APP),
+        0,
+    )
+
+def _test_cold_start_phase_change_gate_uses_sibling_observations(ctx):
+    """The merged-view check means a task with only one local
+    observation but enough sibling observations spanning > 30s
+    correctly leaves the cold-start window — every swarm member
+    agrees on whether the gate is open or closed."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+
+    # Only one local observation — `< 3` would normally trip cold start.
+    record_observation(ctx, BUCKET_APP, remaining = 4900, limit = 5000, reset_epoch = _FAR_FUTURE, epoch_s = 50.0)
+    _eq(
+        "phase-gate on-CI — solo with 1 obs → 5s gate",
+        cold_start_phase_change_gate_seconds(ctx, BUCKET_APP),
+        5,
+    )
+
+    # A sibling exports two observations spanning 40s — merged buffer
+    # now holds 3 obs across a 49s span. Gate releases.
+    ingest_sibling_observations(ctx, "sibling-a", {
+        BUCKET_APP: [
+            {"epoch_s": 1.0, "remaining": 4990, "limit": 5000, "reset_epoch": _FAR_FUTURE},
+            {"epoch_s": 41.0, "remaining": 4950, "limit": 5000, "reset_epoch": _FAR_FUTURE},
+        ],
+    })
+    _eq(
+        "phase-gate on-CI — merged view (1 local + 2 siblings, 49s span) → 0s gate",
+        cold_start_phase_change_gate_seconds(ctx, BUCKET_APP),
+        0,
+    )
+
+def _test_cold_start_phase_change_gate_invalid_bucket(ctx):
+    """Unknown bucket names short-circuit to 0 so callers don't have
+    to validate the bucket before calling."""
+    _reset(ctx)
+    _force_cold_start_ci(ctx)
+    _eq(
+        "phase-gate — unknown bucket → 0s gate",
+        cold_start_phase_change_gate_seconds(ctx, "no-such-bucket"),
+        0,
+    )
+
 def _test_impl(ctx):
     _test_record_basic(ctx)
     _test_record_buffer_truncation(ctx)
@@ -853,7 +1051,15 @@ def _test_impl(ctx):
     _test_merged_view_handles_flat_burn(ctx)
     _test_threshold_factor_scales_with_visible_swarm(ctx)
     _test_threshold_factor_swarm_scaling_skips_env_bucket(ctx)
-    print("rate_limit.axl: OK (32 sections)")
+    _test_cold_start_floor_off_ci(ctx)
+    _test_cold_start_floor_on_ci_applies(ctx)
+    _test_cold_start_floor_clears_when_buffer_dense(ctx)
+    _test_cold_start_floor_does_not_lower_higher_pressure(ctx)
+    _test_cold_start_phase_change_gate_off_ci(ctx)
+    _test_cold_start_phase_change_gate_on_ci(ctx)
+    _test_cold_start_phase_change_gate_uses_sibling_observations(ctx)
+    _test_cold_start_phase_change_gate_invalid_bucket(ctx)
+    print("rate_limit.axl: OK (40 sections)")
     return 0
 
 rate_limit_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
@@ -41,18 +41,18 @@ load(
 )
 
 # CI markers `_is_ci` consults via `environment.detect_ci`, plus the
-# `ASPECT_RATE_LIMIT_COLD_START` override seam — cleared at every
-# subtest setup so the cold-start floor stays off unless explicitly
-# enabled. Running `aspect dev test-rate-limit` on a host where any
-# of these is set would otherwise flip the floor on and break the
-# existing factor / footer assertions.
+# `ASPECT_WORKFLOWS_GITHUB_API_RATE_LIMIT_COLD_START` override seam —
+# cleared at every subtest setup so the cold-start floor stays off
+# unless explicitly enabled. Running `aspect dev test-rate-limit` on
+# a host where any of these is set would otherwise flip the floor on
+# and break the existing factor / footer assertions.
 _CI_ENV_MARKERS = (
     "GITHUB_ACTIONS",
     "BUILDKITE_AGENT_ACCESS_TOKEN",
     "CI_JOB_TOKEN",
     "CIRCLE_PROJECT_REPONAME",
     "CI",
-    "ASPECT_RATE_LIMIT_COLD_START",
+    "ASPECT_WORKFLOWS_GITHUB_API_RATE_LIMIT_COLD_START",
 )
 
 # Stub TaskUpdate-shaped value for tests of `should_emit_phase_change`.
@@ -85,7 +85,7 @@ def _force_cold_start_ci(ctx):
     """Force `_is_ci` to return True via the test-only override env
     var. Use in tests that need the cold-start floor to apply
     regardless of whether the host happens to be on CI."""
-    ctx.std.env.set_var("ASPECT_RATE_LIMIT_COLD_START", "1")
+    ctx.std.env.set_var("ASPECT_WORKFLOWS_GITHUB_API_RATE_LIMIT_COLD_START", "1")
 
 def _tier(ctx, bucket):
     """Project the trait's `threshold_warned_tier[bucket]` for assertions."""


### PR DESCRIPTION
## Summary

A large matrix swarm (motivating case: [rules_js' `ci-workflows.yaml`](https://github.com/aspect-build/rules_js/blob/main/.github/workflows/ci-workflows.yaml), ~100 jobs) uses more API token than ideal. Every task sees only its own setup-phase `/rate_limit` probe at 100% remaining, the threshold ladder picks 1× (no throttle), and siblings haven't yet propagated observations through the artifact-share cycle so the swarm-size multiplier is also 1. Every task runs at full cadence until the swarm catches up to itself.

Two-part defensive change closes that cold-start window:

- **Heartbeat floor.** `effective_throttle_factor` floors the heartbeat factor at 10× when on a CI host **and** the merged observation buffer is too sparse for burn-rate inference (< 3 obs **or** < 30s span). Once burn-rate stabilizes the floor releases.

- **Phase-change debounce.** A flat 10× factor on a 20s base would collapse fast early phases (preflight → detect → build inside a few seconds) into 200s of silence on short tasks. `TaskUpdate` carries a new `phase_change` field (set by `lifecycle.task_update()` on real phase transitions); GithubStatusChecks and GithubStatusComments route phase emits through a shared `should_emit_phase_change(...)` helper that applies a 5s debounce during the cold-start window instead, then falls back to the heartbeat throttle once burn-rate stabilizes.

CI detection delegates to `environment.detect_ci`. A private `ASPECT_WORKFLOWS_GITHUB_API_RATE_LIMIT_COLD_START=1|0` env var exists only as a test seam.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (module docstrings in `lib/rate_limit.axl`)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- GitHub API rate-limit cold-start floor for matrix swarms: when on a CI host with too few observations for burn-rate inference (< 3 obs or < 30s span), heartbeat status updates now apply a 10× throttle factor so a swarm of concurrent tasks doesn't burn through the shared App quota before reactive throttling kicks in.
- Phase-change emits during the cold-start window are gated on a separate 5s debounce so fast early phases stay visible without paying the 10× heartbeat factor.

### Test plan

- 16 new sections in [rate_limit_test.axl](crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl) covering: heartbeat floor on/off CI, floor release on dense buffer, floor composition with quota / time pressure, last-effective-factor recording, reset-crossing re-engagement, phase-change gate boundaries (off-CI / on-CI / sibling observations / unknown bucket), and the `should_emit_phase_change` helper (non-phase emits, outside cold-start, first-emit carve-out, within / past debounce, second-clock scale).
- `aspect dev test-rate-limit` — **48 sections pass** (was 32).
- Adjacent suites pass: `test-pr-comment-snapshots`, `test-template-snapshots`, `test-bk-annotation-snapshots`, `test-bazel-results`, `test-lint-template-snapshots`, `test-format-template-snapshots`, `test-gazelle-template-snapshots`, `test-delivery-template-snapshots`.

