### PR TITLE
feat(lint): drop --aspect requirement, detect zero-aspect runs

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -11,7 +11,7 @@ load("@aspect//lib/gazelle_results_test.axl", "gazelle_template_snapshot_tests")
 load("@aspect//lib/github_detect_test.axl", "github_detect_tests")
 load("@aspect//lib/gitlab_detect_test.axl", "gitlab_detect_tests")
 load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
-load("@aspect//lib/lint_results_test.axl", "lint_annotation_plan_tests", "lint_template_snapshot_tests", "linter_rows_tests")
+load("@aspect//lib/lint_results_test.axl", "detect_lint_tool_tests", "lint_annotation_plan_tests", "lint_template_snapshot_tests", "linter_rows_tests")
 load("@aspect//lib/rate_limit_test.axl", "rate_limit_tests")
 load("@aspect//lib/repro_commands_test.axl", "repro_commands_tests")
 load("@aspect//lib/runner_job_history_test.axl", "runner_job_history_tests")
@@ -180,6 +180,12 @@ def config(ctx: ConfigContext):
     # label always matches the rows beneath it.
     # Run with: aspect dev test-lint-linter-rows
     ctx.tasks.add(linter_rows_tests)
+
+    # Pins the BES filename shape that the zero-aspect safeguard keys
+    # off — must match `.AspectRulesLint<Tool>.<known_ext>` exactly so
+    # unrelated outputs can't bypass the "no lint aspect ran" check.
+    # Run with: aspect dev test-lint-detect-tool
+    ctx.tasks.add(detect_lint_tool_tests)
 
     # Inject a mix of secret-ish and safe Bazel flags on every task so the
     # status-check redaction path is exercised live against a real BES stream.

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -11,7 +11,7 @@ load("@aspect//lib/gazelle_results_test.axl", "gazelle_template_snapshot_tests")
 load("@aspect//lib/github_detect_test.axl", "github_detect_tests")
 load("@aspect//lib/gitlab_detect_test.axl", "gitlab_detect_tests")
 load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
-load("@aspect//lib/lint_results_test.axl", "lint_annotation_plan_tests", "lint_template_snapshot_tests")
+load("@aspect//lib/lint_results_test.axl", "lint_annotation_plan_tests", "lint_template_snapshot_tests", "linter_rows_tests")
 load("@aspect//lib/rate_limit_test.axl", "rate_limit_tests")
 load("@aspect//lib/repro_commands_test.axl", "repro_commands_tests")
 load("@aspect//lib/runner_job_history_test.axl", "runner_job_history_tests")
@@ -174,6 +174,12 @@ def config(ctx: ConfigContext):
     # between check-run annotations and PR-review comments.
     # Run with: aspect dev test-lint-annotation-plan
     ctx.tasks.add(lint_annotation_plan_tests)
+
+    # Pins the lint-data → per-linter row builder consumed by both the
+    # rendered chart and the section header count, so the "Linters (N)"
+    # label always matches the rows beneath it.
+    # Run with: aspect dev test-lint-linter-rows
+    ctx.tasks.add(linter_rows_tests)
 
     # Inject a mix of secret-ish and safe Bazel flags on every task so the
     # status-check redaction path is exercised live against a real BES stream.

--- a/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
+++ b/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
@@ -529,7 +529,8 @@ data = {
   ┌─ Per-kind extensions (added by lib/<kind>_results.init_data) ───┐
   │ # lint     → data["lint"]                                          │
   │   "diagnostics", "strategy", "build_failed", "linter_exit_code",   │
-  │   "changed_files", "counts_by_severity", "counts_by_tool"          │
+  │   "changed_files", "tools_run",                                    │
+  │   "counts_by_severity", "counts_by_tool"                           │
   │ # format   → data["format"]                                        │
   │   "scope", "formatter_target", "on_change_resolved",               │
   │   "affected_files", ...                                            │

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
@@ -133,6 +133,13 @@ def init_data():
         "linter_exit_code": 0,  # 0 = all linters clean; non-zero → at least one linter errored
         "changed_files": [],  # [{"file", "lines", "hunk_lines"}] — only populated for hold-the-line / hold-the-file
 
+        # Distinct rules_lint tool names seen via BES file-name
+        # markers (`*.AspectRulesLint<Tool>.*`). Populated even for
+        # clean linters that emit no diagnostics so the rendered
+        # chart can list every linter that ran, not just the noisy
+        # ones. Sorted ascending by lint.axl on terminal emit.
+        "tools_run": [],  # e.g. ["ESLint", "ShellCheck"]
+
         # Pre-computed aggregates populated by accumulate().
         "counts_by_severity": {},  # {"error": 3, ...}
         "counts_by_tool": {},  # {"eslint": 7, ...}
@@ -427,24 +434,29 @@ def _pad_left(s, width):
         return s
     return " " * n + s
 
-def _linters_chart(data):
-    """Build the per-linter breakdown as a column-aligned <pre> body.
+def linter_rows(data):
+    """Return per-linter aggregate rows as
+    `{tool: {errors, warnings, infos, fixes}}`.
 
-    Cross-tabulates `data["lint"]["diagnostics"]` and
-    `data["lint"]["suggestions"]` by tool, producing one row per
-    linter with error / warning / info / auto-fix counts. Sorted by
-    total finding+fix volume descending, then linter name ascending —
-    so the noisiest linter sits at the top, where it earns the eye.
+    Union of three sources:
+      1. diagnostics — severity-counted
+      2. suggestions — fix-counted
+      3. `data["lint"]["tools_run"]` — zero-row for clean linters
+         that didn't emit diagnostics or suggestions
 
-    Returns the chart body (no wrapping <pre> tags). Empty string
-    when no diagnostics and no suggestions were reported.
+    Source 3 dedupes against sources 1/2 case-insensitively because
+    the BES file-name marker ("ShellCheck") and the SARIF driver name
+    ("shellcheck") can disagree — one row per tool, not one per
+    casing. Shared by `_linters_chart` (renders the rows) and
+    `_build_details_data` (uses the row count for the section header)
+    so they always agree.
     """
-    counts = {}
+    rows = {}
 
     def _row(tool):
-        if tool not in counts:
-            counts[tool] = {"errors": 0, "warnings": 0, "infos": 0, "fixes": 0}
-        return counts[tool]
+        if tool not in rows:
+            rows[tool] = {"errors": 0, "warnings": 0, "infos": 0, "fixes": 0}
+        return rows[tool]
 
     for d in data["lint"].get("diagnostics", []) or []:
         tool = d.get("tool", "") or "unknown"
@@ -459,11 +471,29 @@ def _linters_chart(data):
     for s in data["lint"].get("suggestions", []) or []:
         _row(s.get("tool", "") or "unknown")["fixes"] += 1
 
-    if not counts:
+    known_lower = {t.lower(): True for t in rows}
+    for t in data["lint"].get("tools_run", []) or []:
+        if t.lower() not in known_lower:
+            _row(t)
+
+    return rows
+
+def _linters_chart(data):
+    """Render `linter_rows(data)` as a column-aligned <pre> body.
+
+    Sorted by total finding+fix volume descending, then linter name
+    ascending — the noisiest linter sits at the top where it earns
+    the eye; clean linters land at the bottom in alphabetical order.
+
+    Returns the chart body (no wrapping <pre> tags). Empty string
+    when nothing ran and nothing surfaced.
+    """
+    rows = linter_rows(data)
+    if not rows:
         return ""
 
     items = sorted(
-        [(t, counts[t]) for t in counts],
+        [(t, rows[t]) for t in rows],
         key = lambda kv: (
             -(kv[1]["errors"] + kv[1]["warnings"] + kv[1]["infos"] + kv[1]["fixes"]),
             kv[0],
@@ -587,7 +617,6 @@ def _build_details_data(data, render_ctx, status, links = None):
         if file_ and line:
             # Patch-derived suggestion comment — always fix-bearing.
             suggestion_links[(file_, line)] = {"url": url, "is_fix": True}
-    counts_by_tool = data["lint"].get("counts_by_tool", {}) or {}
     return {
         # str() everywhere we interpolate an int — Jinja2 receives
         # values as serde_json::Number for Python ints, which renders
@@ -595,7 +624,9 @@ def _build_details_data(data, render_ctx, status, links = None):
         # defensively at the template boundary.
         "total": str(total),
         "linters_chart": _linters_chart(data),
-        "linters_count": str(len(counts_by_tool)),
+        # Same source of truth as the chart so the section header and
+        # the row count never disagree.
+        "linters_count": str(len(linter_rows(data))),
         "groups": _groups_for_template(_group_diagnostics(data, suggestion_links)),
         # All auto-fixes — correlated AND uncorrelated — land in one
         # consolidated "Auto fixes" section. Correlated entries are

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
@@ -434,6 +434,44 @@ def _pad_left(s, width):
         return s
     return " " * n + s
 
+# BES output extensions emitted by rules_lint aspects (see
+# `aspect-build/rules_lint`). The full filename shape is
+# `<target>.AspectRulesLint<Tool>.<ext>` — anchoring on this exact
+# shape (segment-boundary `.AspectRulesLint` prefix + known suffix)
+# keeps `detect_lint_tool` from matching unrelated build outputs whose
+# name happens to contain `AspectRulesLint` as a free-floating
+# substring (e.g. a user target literally named that).
+_RULES_LINT_EXTS = (".report", ".patch", ".exit_code", ".out")
+_RULES_LINT_MARKER = ".AspectRulesLint"
+
+def detect_lint_tool(filename):
+    """Extract the rules_lint tool name from a BES output file name.
+
+    rules_lint outputs follow `<target>.AspectRulesLint<Tool>.<ext>`
+    (e.g. `hello.AspectRulesLintShellCheck.patch` → `ShellCheck`),
+    where `<ext>` is one of `_RULES_LINT_EXTS`. Returns the tool name
+    only when both the segment-boundary marker AND a known extension
+    are present; otherwise returns empty string. This double anchor
+    is what keeps the zero-aspect safeguard in `lint.axl` from being
+    bypassed by an unrelated output whose name happens to contain
+    `AspectRulesLint` as a substring.
+    """
+    has_ext = False
+    for ext in _RULES_LINT_EXTS:
+        if filename.endswith(ext):
+            has_ext = True
+            break
+    if not has_ext:
+        return ""
+    idx = filename.find(_RULES_LINT_MARKER)
+    if idx < 0:
+        return ""
+    start = idx + len(_RULES_LINT_MARKER)
+    end = filename.find(".", start)
+    if end < 0 or end == start:
+        return ""
+    return filename[start:end]
+
 def linter_rows(data):
     """Return per-linter aggregate rows as
     `{tool: {errors, warnings, infos, fixes}}`.

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
@@ -29,6 +29,7 @@ load(
     "accumulate",
     "chunk_annotations",
     "compute_annotations",
+    "detect_lint_tool",
     "init_data",
     "lint_annotation_plan",
     "linter_rows",
@@ -817,5 +818,61 @@ linter_rows_tests = task(
     name = "test-lint-linter-rows",
     group = ["dev"],
     implementation = _test_linter_rows,
+    args = {},
+)
+
+# ─── detect_lint_tool (BES filename parsing) ──────────────────────────────────
+
+def _test_detect_lint_tool(ctx):
+    """Pin the rules_lint filename shape so the zero-aspect safeguard
+    can't be bypassed by an unrelated build output whose name contains
+    `AspectRulesLint` as a substring. Match requires both the
+    segment-boundary `.AspectRulesLint` prefix AND a known
+    rules_lint extension."""
+
+    # 1. Canonical shapes — all four extensions parse to the tool name.
+    for ext in (".patch", ".report", ".exit_code", ".out"):
+        got = detect_lint_tool("examples/lint/hello.AspectRulesLintShellCheck" + ext)
+        _eq("canonical %s" % ext, got, "ShellCheck")
+
+    # 2. Multi-segment tool names — extract stops at the next `.`.
+    _eq(
+        "multi-camelcase tool",
+        detect_lint_tool("pkg/foo.AspectRulesLintGoogleJavaFormat.patch"),
+        "GoogleJavaFormat",
+    )
+
+    # 3. Substring without segment boundary — must NOT match. Guards
+    #    against a target literally named with the marker embedded.
+    _eq(
+        "no leading dot → no match",
+        detect_lint_tool("some_AspectRulesLintShellCheck_target.patch"),
+        "",
+    )
+
+    # 4. Marker present at segment boundary but unrecognised extension —
+    #    must NOT match. Guards against unrelated mnemonics that happen
+    #    to share the marker prefix.
+    _eq(
+        "unknown extension → no match",
+        detect_lint_tool("hello.AspectRulesLintShellCheck.txt"),
+        "",
+    )
+
+    # 5. Marker absent entirely — must NOT match.
+    _eq("no marker → no match", detect_lint_tool("hello.SomethingElse.patch"), "")
+
+    # 6. Empty tool segment (`.AspectRulesLint.<ext>`) — must NOT match.
+    #    Defensive; not a shape rules_lint emits, but if it ever did we
+    #    don't want a zero-length entry polluting lint_tools_run.
+    _eq("empty tool → no match", detect_lint_tool("hello.AspectRulesLint.patch"), "")
+
+    print("lint_results.axl::detect_lint_tool: all cases OK")
+    return 0
+
+detect_lint_tool_tests = task(
+    name = "test-lint-detect-tool",
+    group = ["dev"],
+    implementation = _test_detect_lint_tool,
     args = {},
 )

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
@@ -31,6 +31,7 @@ load(
     "compute_annotations",
     "init_data",
     "lint_annotation_plan",
+    "linter_rows",
     "render_check_output",
 )
 
@@ -742,5 +743,79 @@ lint_annotation_plan_tests = task(
     name = "test-lint-annotation-plan",
     group = ["dev"],
     implementation = _test_lint_annotation_plan,
+    args = {},
+)
+
+# ─── linter_rows (tools_run integration) ──────────────────────────────────────
+
+def _test_linter_rows(ctx):
+    """Verify the shared row builder consumed by `_linters_chart` and
+    the rendered section header. Covers the three sources of truth
+    (diagnostics, suggestions, tools_run) and the case-insensitive
+    dedupe between BES file-name markers and SARIF driver names."""
+
+    # 1. tools_run alone — clean linters get zero rows so the chart
+    #    can list every linter that fired, not just the noisy ones.
+    rows = linter_rows({"lint": {
+        "diagnostics": [],
+        "suggestions": [],
+        "tools_run": ["ShellCheck", "ESLint"],
+    }})
+    _eq("clean tools_run keys", sorted(rows.keys()), ["ESLint", "ShellCheck"])
+    _eq("clean tools_run counts", rows["ShellCheck"], {"errors": 0, "warnings": 0, "infos": 0, "fixes": 0})
+
+    # 2. Casing-collision dedupe: SARIF driver "shellcheck" and BES
+    #    marker "ShellCheck" must produce a single row. The diagnostic
+    #    name wins because it appears first (case-sensitive key).
+    rows = linter_rows({"lint": {
+        "diagnostics": [{"tool": "shellcheck", "severity": "warning", "file": "a.sh", "line": 1}],
+        "suggestions": [],
+        "tools_run": ["ShellCheck"],
+    }})
+    _eq("casing dedupe row count", len(rows), 1)
+    _eq("casing dedupe key", "shellcheck" in rows, True)
+
+    # 3. Mixed: noisy linter + clean linter. Both appear, the clean
+    #    one with all-zero counts.
+    rows = linter_rows({"lint": {
+        "diagnostics": [{"tool": "eslint", "severity": "error", "file": "a.ts", "line": 1}],
+        "suggestions": [{"tool": "eslint", "file": "a.ts", "start_line": 1, "end_line": 1}],
+        "tools_run": ["ShellCheck", "eslint"],
+    }})
+    _eq("mixed keys", sorted(rows.keys()), ["ShellCheck", "eslint"])
+    _eq("mixed eslint errors", rows["eslint"]["errors"], 1)
+    _eq("mixed eslint fixes", rows["eslint"]["fixes"], 1)
+    _eq("mixed ShellCheck clean", rows["ShellCheck"], {"errors": 0, "warnings": 0, "infos": 0, "fixes": 0})
+
+    # 4. Diagnostic with empty/missing tool falls into the "unknown"
+    #    bucket — pre-existing behaviour, just guard against regression.
+    rows = linter_rows({"lint": {
+        "diagnostics": [{"tool": "", "severity": "error", "file": "a", "line": 1}],
+        "suggestions": [],
+        "tools_run": [],
+    }})
+    _eq("empty tool → unknown", list(rows.keys()), ["unknown"])
+
+    # 5. Header count matches the rendered chart's row count. Renders
+    #    end-to-end and asserts the "🧹 Linters (N)" header agrees
+    #    with the linter_rows snapshot used by `_linters_chart`.
+    data = _make_base()
+    accumulate(data, [{"tool": "eslint", "file": "a.ts", "line": 1, "rule_id": "x", "severity": "error", "message": "m"}])
+    data["lint"]["tools_run"] = ["ESLint", "ShellCheck", "yamllint"]
+    out = render_check_output(ctx, data, "failed", _render_ctx(), _links())
+    expected_count = len(linter_rows(data))
+    if expected_count != 3:
+        fail("linter_rows union mismatch: got %d, want 3" % expected_count)
+    header = "🧹 Linters (%d)" % expected_count
+    if header not in out["text"]:
+        fail("header / chart disagree: expected %r in rendered details" % header)
+
+    print("lint_results.axl::linter_rows: all cases OK")
+    return 0
+
+linter_rows_tests = task(
+    name = "test-lint-linter-rows",
+    group = ["dev"],
+    implementation = _test_linter_rows,
     args = {},
 )

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -23,7 +23,7 @@ load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
-load("./lib/environment.axl", "color_enabled", "warn")
+load("./lib/environment.axl", "color_enabled", "error", "warn")
 load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
@@ -505,6 +505,20 @@ _SEV_CLI_ICON = {
     "info": "ℹ️",
 }
 
+def _print_linters_run(ctx, tools_run):
+    """Print a one-line summary of the linters that fired.
+
+    Paired with `_print_relevant_findings` to give a "what ran / what's
+    wrong" pair on the CLI. No-op when nothing ran.
+    """
+    if not tools_run:
+        return
+    ansi = color_enabled(ctx.std)
+    bold = "\033[1m" if ansi else ""
+    reset = "\033[0m" if ansi else ""
+    print("")
+    print("%s🧹 Linters%s (%d): %s" % (bold, reset, len(tools_run), ", ".join(tools_run)))
+
 def _print_relevant_findings(ctx, relevant, strategy_name):
     """Print the strategy-filtered findings to stderr.
 
@@ -713,6 +727,32 @@ def _body_text(status, data):
         return "Lint aborted"
     return ""
 
+def _has_aspect_flag(flags):
+    """True iff `flags` (post-rc-expansion) contains any `--aspects`
+    entry — `--aspects=<label>` or bare `--aspects` (the value lands
+    in the next arg). Used to differentiate "no aspect configured"
+    from "aspect configured but produced no rules_lint output" in
+    the post-build error path."""
+    for f in flags:
+        if f == "--aspects" or f.startswith("--aspects="):
+            return True
+    return False
+
+def _detect_lint_tool(filename):
+    """Extract the rules_lint tool name from a BES output file name.
+
+    rules_lint outputs follow `<target>.AspectRulesLint<Tool>.<ext>`
+    (e.g. `hello.AspectRulesLintShellCheck.patch` → `ShellCheck`).
+    Returns empty string if the marker is absent.
+    """
+    marker = "AspectRulesLint"
+    idx = filename.find(marker)
+    if idx < 0:
+        return ""
+    start = idx + len(marker)
+    end = filename.find(".", start)
+    return filename[start:] if end < 0 else filename[start:end]
+
 # buildifier: disable=function-docstring
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     lint_trait = ctx.traits[LintTrait]
@@ -864,8 +904,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         lifecycle,
         status,
         ProgressStyles(
-            body = "Running %s..." % pluralize(len(ctx.args.aspects), "lint aspect"),
-            stream = "Running " + pluralize(len(ctx.args.aspects), "lint aspect"),
+            body = "Running lint aspects...",
+            stream = "Running lint aspects",
         ),
         kind = "lint_results",
         data = data,
@@ -900,7 +940,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         lifecycle,
         status,
         ProgressStyles(
-            body = "Running %s..." % pluralize(len(ctx.args.aspects), "lint aspect"),
+            body = "Running lint aspects...",
         ),
         kind = "lint_results",
         data = data,
@@ -909,6 +949,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     linter_exit_code = 0
     patches = []
     github_output = ctx.std.env.var("GITHUB_OUTPUT")
+
+    # Set of rules_lint tool names observed in BES file-name markers.
+    lint_tools_run = {}
 
     # Tick-driven drain: each tick non-blocking-polls events and
     # emits at most once (interesting batch or heartbeat). Heartbeats
@@ -929,6 +972,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             if event.kind == "named_set_of_files":
                 for file in event.payload.files:
                     filepath = file_uri_to_path(file.file)
+                    tool = _detect_lint_tool(file.name)
+                    if tool:
+                        lint_tools_run[tool] = True
                     if file.name.endswith(".out"):
                         ctx.std.io.stderr.write(ctx.std.fs.read_to_string(filepath))
                     if file.name.endswith(".report"):
@@ -1051,16 +1097,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # 10. Apply strategy filter → relevant diagnostics for reporting and exit code.
     #
-    # Skip the `filter` phase emit when the build failed. The strategy
-    # filter still runs (any partial SARIF that did stream through
-    # gets surfaced), but we don't want a "Filter" entry in the closing
-    # phase breakdown — `close_active_phase` would mark it interrupted
-    # and the renderer would tag it `(failed)` even though the actual
-    # failure was in the lint phase. Without the phase boundary, the
-    # `lint` phase remains active until `_emit_final` runs, so the
-    # breakdown correctly tags `Lint (failed)` and the GHSC
-    # `_failed_in_phase` latch picks up "lint".
-    if not build_failed:
+    # Skip the `filter` phase emit when the build failed OR no lint
+    # aspect actually ran — in either case the failure originates in
+    # the `lint` phase, and emitting a `filter` phase boundary here
+    # would cause `close_active_phase` to tag Filter as `(failed)` in
+    # the breakdown instead of Lint. Without the boundary, the `lint`
+    # phase stays active until `_emit_final`, so the breakdown
+    # correctly tags `Lint (failed)` and the GHSC `_failed_in_phase`
+    # latch picks up "lint".
+    if not build_failed and lint_tools_run:
         status = _pick_status(data, had_failure = False, terminal = False)
         task_update(
             ctx,
@@ -1082,6 +1127,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # set. The `Filter` phase emit above is the UI / Task-timing
     # marker; no separate filtering pass is needed here.
     relevant = list(data["lint"]["diagnostics"])
+
+    # Thread the linter set onto data so the rendered "🧹 Linters"
+    # chart and the CLI summary share a sorted snapshot.
+    data["lint"]["tools_run"] = sorted(lint_tools_run.keys())
+    _print_linters_run(ctx, data["lint"]["tools_run"])
 
     # Print the post-filter findings on the CLI so users see *what
     # actually matters* after strategy filtering. The linter's raw
@@ -1118,8 +1168,24 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # for the per-finding-row link semantics.
     data["lint"]["comment_urls"] = dict(lint_trait.comment_urls)
 
-    # 12. Determine exit code
+    # 12. Determine exit code. `not lint_tools_run` guards against the
+    # silent zero-aspect case — in CI a green `aspect lint` must mean
+    # "lint passed", not "lint never ran".
     if build_failed:
+        exit_code = 1
+    elif not lint_tools_run:
+        if _has_aspect_flag(flags):
+            error(ctx.std, (
+                "Lint aspect(s) configured but produced no rules_lint output. " +
+                "Verify the configured aspect is from aspect_rules_lint and " +
+                "that your target pattern includes lintable targets."
+            ))
+        else:
+            error(ctx.std, (
+                "No lint aspect configured. Pass --aspect=<label> " +
+                "(e.g. --aspect=//tools/lint:linters.bzl%shellcheck) or add " +
+                "--aspects=… via a bazelrc --config."
+            ))
         exit_code = 1
     elif strategy.fail_on_severity and any([d["severity"] == strategy.fail_on_severity for d in relevant]):
         exit_code = 1
@@ -1190,8 +1256,7 @@ lint = task(
     args = {
         "aspects": args.string_list(
             long = "aspect",
-            required = True,
-            description = "Bazel aspect label(s) to apply for linting (e.g. //tools/lint:linters.bzl%eslint). Repeat the flag to run multiple aspects in a single invocation. At least one aspect is required.",
+            description = "Bazel aspect label(s) to apply for linting (e.g. //tools/lint:linters.bzl%eslint). Repeat the flag to run multiple aspects in a single invocation. Aspects may also be supplied via `--bazel-flag=--aspects=…` or a bazelrc `--config`; at least one rules_lint aspect must reach Bazel one way or another.",
         ),
         "announce_rc": args.boolean(
             default = False,

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -27,7 +27,7 @@ load("./lib/environment.axl", "color_enabled", "error", "warn")
 load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
-load("./lib/lint_results.axl", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
+load("./lib/lint_results.axl", "detect_lint_tool", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
 load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "task_cli_path")
 load("./lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics")
 load("./lib/tar.axl", "tar_create")
@@ -738,21 +738,6 @@ def _has_aspect_flag(flags):
             return True
     return False
 
-def _detect_lint_tool(filename):
-    """Extract the rules_lint tool name from a BES output file name.
-
-    rules_lint outputs follow `<target>.AspectRulesLint<Tool>.<ext>`
-    (e.g. `hello.AspectRulesLintShellCheck.patch` → `ShellCheck`).
-    Returns empty string if the marker is absent.
-    """
-    marker = "AspectRulesLint"
-    idx = filename.find(marker)
-    if idx < 0:
-        return ""
-    start = idx + len(marker)
-    end = filename.find(".", start)
-    return filename[start:] if end < 0 else filename[start:end]
-
 # buildifier: disable=function-docstring
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     lint_trait = ctx.traits[LintTrait]
@@ -972,7 +957,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             if event.kind == "named_set_of_files":
                 for file in event.payload.files:
                     filepath = file_uri_to_path(file.file)
-                    tool = _detect_lint_tool(file.name)
+                    tool = detect_lint_tool(file.name)
                     if tool:
                         lint_tools_run[tool] = True
                     if file.name.endswith(".out"):


### PR DESCRIPTION
## Summary

`aspect lint` silently exited 0 whenever no rules_lint aspect actually ran — no `--aspect` and no `--aspects=…` from a bazelrc `--config`, a non-rules_lint aspect, or a target pattern that matched no lintable targets all rendered as "Lint passed" in CI. This PR makes the `--aspect` flag optional (aspects can now arrive via `--bazel-flag=--aspects=…` or a bazelrc `--config`) and adds a hard-fail when nothing rules_lint-shaped actually fired.

Detection runs on the BES stream: rules_lint outputs follow `<target>.AspectRulesLint<Tool>.<ext>`, so the lint task collects the distinct `<Tool>` set during streaming. Post-build, an empty set drives a red `ERROR:` line — differentiated between "no aspect configured" and "aspect configured but produced no rules_lint output" — and an exit code of 1. The `lint` phase stays active for the closing breakdown so `Lint (failed)` is tagged rather than the no-op `Filter` phase.

The same set is surfaced positively in two places:

- **CLI**: one-line `🧹 Linters (N): A, B, C` summary after the build, so a fully-clean run no longer prints nothing post-lint.
- **Rendered status surfaces**: the existing `🧹 Linters (N)` chart on PR check-run details now lists every linter that ran, including clean ones (previously: only linters with diagnostics or suggestions). The chart and its header count are computed from a single shared `linter_rows()` helper so they can never disagree.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- `aspect lint`'s `--aspect` flag is now optional — aspects may be supplied via `--bazel-flag=--aspects=…` or a bazelrc `--config`. The task hard-fails when no rules_lint aspect actually fires, with a red `ERROR:` line distinguishing "no aspect configured" from "aspect configured but produced no rules_lint output".
- New `🧹 Linters (N): …` CLI summary line after the lint build, listing the linters that actually ran.
- The rendered `🧹 Linters` chart on PR check-run details now lists every linter that ran, including those that produced no findings.

### Test plan

- New test cases added — `aspect dev test-lint-linter-rows` pins the `linter_rows()` row builder and asserts the rendered section header count matches the chart's rows.
- Covered by existing test cases — `test-lint-template-snapshots` and `test-lint-annotation-plan` still pass unchanged (the `tools_run` field defaults to empty, preserving the existing scenarios' output exactly).
- Manual testing:
  - In `bazel-examples`: `aspect lint` exits 1 with the red `ERROR: aspect(s) configured but produced no rules_lint output…` line, and the phase breakdown tags `Lint (failed)` instead of `Filter`.
  - On a repo with rules_lint wired up: `aspect lint --bazel-flag=--config=lint -- //...` prints `🧹 Linters (N): …` after the build, and the same set populates the rendered chart on the PR check run.
