### PR TITLE
fix(lint): resolve BES files via path_prefix; skip unreadable outputs gracefully

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -938,6 +938,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Set of rules_lint tool names observed in BES file-name markers.
     lint_tools_run = {}
 
+    # Count of BES outputs we couldn't read off disk. Non-zero on CI
+    # hosts where bb_clientd isn't mounted: BES emits `bytestream://`
+    # URIs that resolve under `_BB_CLIENTD_ROOT`, which doesn't exist
+    # there, so `read_to_string` would crash on every read. We skip
+    # gracefully and surface a single summary warning after the drain.
+    unreadable_outputs = 0
+
     # Tick-driven drain: each tick non-blocking-polls events and
     # emits at most once (interesting batch or heartbeat). Heartbeats
     # fire every MIN_HEARTBEAT_INTERVAL_MS even when bazel is quiet —
@@ -956,10 +963,39 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 interesting = True
             if event.kind == "named_set_of_files":
                 for file in event.payload.files:
-                    filepath = file_uri_to_path(file.file)
                     tool = detect_lint_tool(file.name)
                     if tool:
                         lint_tools_run[tool] = True
+
+                    # `named_set_of_files` carries every build output;
+                    # narrow to the four rules_lint extensions before
+                    # any read so non-lint files don't inflate the
+                    # `unreadable_outputs` counter (which gates the
+                    # summary warn below).
+                    is_lint_output = (
+                        file.name.endswith(".out") or
+                        file.name.endswith(".report") or
+                        file.name.endswith(".patch") or
+                        file.name.endswith(".exit_code")
+                    )
+                    if not is_lint_output:
+                        continue
+                    filepath = file_uri_to_path(file.file)
+
+                    # On CI hosts without bb_clientd, BES emits
+                    # `bytestream://` URIs that resolve under
+                    # `_BB_CLIENTD_ROOT` — a path that doesn't exist
+                    # there. Skip + count so we don't crash mid-stream;
+                    # the post-drain warn surfaces the impact in one
+                    # line, and the lint aspect's tool name is still
+                    # in `lint_tools_run` (extracted from `file.name`
+                    # above) so the zero-aspect safeguard isn't
+                    # falsely tripped.
+                    if not ctx.std.fs.exists(filepath):
+                        unreadable_outputs += 1
+                        trace.log("lint: BES output not available locally, skipping: " + file.name)
+                        continue
+
                     if file.name.endswith(".out"):
                         ctx.std.io.stderr.write(ctx.std.fs.read_to_string(filepath))
                     if file.name.endswith(".report"):
@@ -987,10 +1023,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                         if github_output:
                             ctx.std.fs.write(github_output, "lint-report=" + filepath)
                     if file.name.endswith(".patch"):
-                        patch_path = file_uri_to_path(file.file)
-                        patches.append(patch_path)
+                        patches.append(filepath)
                         for hook in lint_trait.lint_patch:
-                            hook(ctx, patch_path, file.name)
+                            hook(ctx, filepath, file.name)
                     if file.name.endswith(".exit_code"):
                         if int(ctx.std.fs.read_to_string(filepath).rstrip()) != 0:
                             linter_exit_code = 1
@@ -1016,6 +1051,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             last_emit_ms = now_ms(ctx)
         if events.done:
             break
+
+    # Surface a single heads-up if any BES outputs were unavailable
+    # locally — results may be incomplete (missing diagnostics,
+    # missing patches, missing linter exit codes) but the task itself
+    # ran to completion rather than crashing mid-stream.
+    if unreadable_outputs > 0:
+        warn(ctx.std, "lint: %d BES output(s) were unavailable locally and skipped; lint results may be incomplete. Set ASPECT_DEBUG=1 to see the file names." % unreadable_outputs)
 
     # 7. Wait for build
     build_status = build.wait()

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -71,6 +71,37 @@ def file_uri_to_path(uri):
         return _BB_CLIENTD_ROOT + "/cas/" + host + "/blobs/" + digest_fn + "/file/" + blob_hash + "-" + blob_size
     return uri
 
+def resolve_bes_file_path(ctx, file):
+    """Pick the best local path for a BES `File` entry.
+
+    BES carries the file's location in two places:
+      - `file.path_prefix + [file.name]` → workspace-relative path
+        (e.g. `bazel-out/k8-fastbuild/bin/pkg/foo.AspectRulesLint…`).
+        Bazel materializes outputs here whenever it downloads them
+        (including for everything matching the lint task's
+        `--remote_download_regex='.*AspectRulesLint.*'`), so this is
+        the right answer on local dev machines and any CI host.
+      - `file.file` → the canonical URI. For locally-produced files
+        this is `file://…`; for remote-cached files it's
+        `bytestream://…`, which `file_uri_to_path` resolves to a
+        bb_clientd FUSE path (Workflows runners only).
+
+    Try the workspace-relative materialization first — it works on
+    any host as long as the file was downloaded. Fall back to the
+    URI resolution so we still pick up bytestream-only files on
+    Workflows runners. Returns "" when neither resolves; callers
+    treat that as "skip this entry".
+    """
+    if file.path_prefix:
+        rel = "/".join(list(file.path_prefix) + [file.name])
+        local = ctx.std.env.current_dir() + "/" + rel
+        if ctx.std.fs.exists(local):
+            return local
+    uri_path = file_uri_to_path(file.file)
+    if ctx.std.fs.exists(uri_path):
+        return uri_path
+    return ""
+
 # Filter functions — (all_diagnostics, changed_files) -> relevant_diagnostics
 def filter_all(diagnostics, changed_files):
     return diagnostics
@@ -980,18 +1011,17 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                     )
                     if not is_lint_output:
                         continue
-                    filepath = file_uri_to_path(file.file)
+                    filepath = resolve_bes_file_path(ctx, file)
 
-                    # On CI hosts without bb_clientd, BES emits
-                    # `bytestream://` URIs that resolve under
-                    # `_BB_CLIENTD_ROOT` — a path that doesn't exist
-                    # there. Skip + count so we don't crash mid-stream;
-                    # the post-drain warn surfaces the impact in one
-                    # line, and the lint aspect's tool name is still
-                    # in `lint_tools_run` (extracted from `file.name`
-                    # above) so the zero-aspect safeguard isn't
-                    # falsely tripped.
-                    if not ctx.std.fs.exists(filepath):
+                    # Empty means neither the workspace-relative
+                    # materialization nor the URI-based fallback
+                    # resolved to an existing file. Skip + count so
+                    # we don't crash mid-stream; the post-drain warn
+                    # surfaces the impact. The lint aspect's tool
+                    # name is already in `lint_tools_run` (extracted
+                    # from `file.name`) so the zero-aspect safeguard
+                    # isn't falsely tripped.
+                    if not filepath:
                         unreadable_outputs += 1
                         trace.log("lint: BES output not available locally, skipping: " + file.name)
                         continue


### PR DESCRIPTION
## Summary

`aspect lint` crashed with `No such file or directory (os error 2)` partway through the BES drain on non-Aspect-Workflows CI hosts ([example: bazel-examples GHA run](https://github.com/aspect-build/bazel-examples/actions/runs/26376140872/job/77636608034)). Two issues in the existing BES file handling:

1. Resolution went straight to `file_uri_to_path` which only understands the canonical `bytestream://` URI form and resolves it to a bb_clientd FUSE path (`/mnt/ephemeral/buildbarn/bb_clientd/...`) that only exists on Workflows runners.
2. The subsequent `read_to_string` had no guard against a missing path, so a single miss tanked the whole task mid-drain.

This PR teaches the lint task that the BES `File` proto carries the workspace-relative materialization path in `path_prefix + [name]` alongside the canonical content URI. Bazel writes downloaded outputs to that workspace path on every host, and the lint task's own `--remote_download_regex='.*AspectRulesLint.*'` flag guarantees lint outputs are downloaded — so on GHA / GitLab / CircleCI / local dev that path resolves correctly to `bazel-out/<config>/bin/<pkg>/<target>.AspectRulesLint<Tool>.<ext>`.

New `resolve_bes_file_path(ctx, file)` tries the `path_prefix` materialization first, falls back to the existing bytestream → bb_clientd resolution for Workflows runners where outputs may stay remote-only, and returns `""` when neither resolves. Callers skip empty results, increment an `unreadable_outputs` counter, and the post-drain code emits one summary `warn()` so the user knows results may be incomplete instead of a crash mid-stream.

The BES loop is also narrowed to the four rules_lint extensions (`.report`, `.patch`, `.exit_code`, `.out`) before any read, so non-lint outputs in `named_set_of_files` don't inflate the unreadable counter or cost a needless `fs.exists` call.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- Fixed `aspect lint` crashing with `No such file or directory (os error 2)` on non-Aspect-Workflows CI hosts (GHA, GitLab, CircleCI). The lint task now resolves BES file outputs via the workspace-relative materialization path (`bazel-out/...`) before falling back to bb_clientd, and gracefully skips + summarises any output that still can't be read locally.

### Test plan

- Covered by existing test cases — `test-lint-template-snapshots`, `test-lint-annotation-plan`, `test-lint-linter-rows`, and `test-lint-detect-tool` all still pass; the resolution helper is pure data flow into the existing readers and doesn't change the data shape.
- Manual testing:
  - On a project without rules_lint set up (`cd bazel-examples && aspect lint --aspect=//tools/lint:linters.bzl%shellcheck -- //...`) — the run still exits cleanly with the zero-aspect ERROR line; the new resolver doesn't regress the no-output path.
  - On the failing GHA scenario — `aspect lint` no longer crashes; lint outputs are read from `bazel-out/...` (Bazel downloads them per `--remote_download_regex`), and any output that still can't be resolved is counted into a single trailing `WARNING: lint: N BES output(s) were unavailable locally and skipped; lint results may be incomplete.` line.
