### PR TITLE
feat: support ctx.defer for cleanup tasks

### DIFF
--- a/crates/axl-runtime/src/engine/task_context.rs
+++ b/crates/axl-runtime/src/engine/task_context.rs
@@ -1,6 +1,9 @@
+use std::cell::RefCell;
+
 use allocative::Allocative;
 use derive_more::Display;
 
+use starlark::collections::SmallMap;
 use starlark::environment::Methods;
 use starlark::environment::MethodsBuilder;
 use starlark::environment::MethodsStatic;
@@ -12,9 +15,12 @@ use starlark::values::FrozenValueTyped;
 use starlark::values::NoSerialize;
 use starlark::values::ProvidesStaticType;
 use starlark::values::Trace;
+use starlark::values::Tracer;
 use starlark::values::ValueLike;
 use starlark::values::ValueTyped;
+use starlark::values::none::NoneType;
 use starlark::values::starlark_value;
+use starlark::values::tuple::UnpackTuple;
 
 use super::arguments::{Arguments, FrozenArguments};
 use super::aspect::Aspect;
@@ -27,13 +33,46 @@ use super::trait_map::{FrozenTraitMap, TraitMap};
 
 use super::wasm::Wasm;
 
-#[derive(Debug, Clone, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
+#[derive(Debug)]
+pub struct Defer<'v> {
+    pub callable: values::Value<'v>,
+    pub args: Vec<values::Value<'v>>,
+    pub kwargs: Vec<(&'v str, values::Value<'v>)>,
+}
+
+unsafe impl<'v> Trace<'v> for Defer<'v> {
+    fn trace(&mut self, tracer: &Tracer<'v>) {
+        self.callable.trace(tracer);
+        for a in self.args.iter_mut() {
+            a.trace(tracer);
+        }
+        for (_, v) in self.kwargs.iter_mut() {
+            v.trace(tracer);
+        }
+    }
+}
+
+#[derive(Debug, ProvidesStaticType, Display, NoSerialize, Allocative)]
 #[display("<TaskContext>")]
 pub struct TaskContext<'v> {
     pub args: values::Value<'v>,
     pub traits: values::Value<'v>,
     pub task: values::Value<'v>,
     bazel: values::Value<'v>,
+    #[allocative(skip)]
+    pub defers: RefCell<Vec<Defer<'v>>>,
+}
+
+unsafe impl<'v> Trace<'v> for TaskContext<'v> {
+    fn trace(&mut self, tracer: &Tracer<'v>) {
+        self.args.trace(tracer);
+        self.traits.trace(tracer);
+        self.task.trace(tracer);
+        self.bazel.trace(tracer);
+        for d in self.defers.get_mut().iter_mut() {
+            d.trace(tracer);
+        }
+    }
 }
 
 impl<'v> TaskContext<'v> {
@@ -48,7 +87,15 @@ impl<'v> TaskContext<'v> {
             traits,
             task,
             bazel,
+            defers: RefCell::new(Vec::new()),
         }
+    }
+
+    pub fn drain_defers(&self) -> Vec<Defer<'v>> {
+        let mut v = self.defers.borrow_mut();
+        let mut out: Vec<Defer<'v>> = std::mem::take(&mut *v);
+        out.reverse();
+        out
     }
 }
 
@@ -148,6 +195,25 @@ pub(crate) fn task_context_methods(registry: &mut MethodsBuilder) {
     fn http<'v>(#[allow(unused)] this: values::Value<'v>) -> starlark::Result<Http> {
         Ok(Http::new())
     }
+
+    /// Register a callable to run after `_impl` returns, modeled on Go's
+    /// `defer`: args bound at the defer site, LIFO order, fires even when
+    /// `_impl` aborts. Per-defer errors are logged and do not change the
+    /// task's exit code.
+    fn defer<'v>(
+        this: values::Value<'v>,
+        #[starlark(require = pos)] callable: values::Value<'v>,
+        #[starlark(args)] args: UnpackTuple<values::Value<'v>>,
+        #[starlark(kwargs)] kwargs: SmallMap<&'v str, values::Value<'v>>,
+    ) -> starlark::Result<NoneType> {
+        let ctx = this.downcast_ref_err::<TaskContext>()?;
+        ctx.defers.borrow_mut().push(Defer {
+            callable,
+            args: args.items,
+            kwargs: kwargs.into_iter().collect(),
+        });
+        Ok(NoneType)
+    }
 }
 
 #[derive(Debug, Display, ProvidesStaticType, NoSerialize, Allocative)]
@@ -244,5 +310,79 @@ fn frozen_task_context_methods(registry: &mut MethodsBuilder) {
     #[starlark(attribute)]
     fn wasm<'v>(#[allow(unused)] this: values::Value<'v>) -> starlark::Result<Wasm> {
         Ok(Wasm::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn defer_runs_lifo_on_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace.txt");
+        let trace_s = trace.to_string_lossy();
+        let exit = crate::test::eval(&format!(
+            r#"
+def _impl(ctx):
+    ctx.defer(ctx.std.fs.try_append, "{path}", "1\n")
+    ctx.defer(ctx.std.fs.try_append, "{path}", "2\n")
+    ctx.defer(ctx.std.fs.try_append, "{path}", "3\n")
+    return 0
+
+Test = task(implementation = _impl)
+"#,
+            path = trace_s,
+        ))
+        .run_task(0)
+        .expect("run_task");
+        assert_eq!(exit, Some(0));
+        let contents = std::fs::read_to_string(&trace).expect("trace file written by defers");
+        assert_eq!(contents, "3\n2\n1\n", "defers must run in LIFO order");
+    }
+
+    #[test]
+    fn defer_runs_on_hard_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace.txt");
+        let trace_s = trace.to_string_lossy();
+        let result = crate::test::eval(&format!(
+            r#"
+def _impl(ctx):
+    ctx.defer(ctx.std.fs.try_append, "{path}", "cleaned\n")
+    fail("boom")
+
+Test = task(implementation = _impl)
+"#,
+            path = trace_s,
+        ))
+        .run_task(0);
+        assert!(result.is_err(), "task must propagate the fail()");
+        let contents = std::fs::read_to_string(&trace).expect("defer ran despite hard error");
+        assert_eq!(contents, "cleaned\n");
+    }
+
+    #[test]
+    fn defer_error_does_not_stop_remaining_defers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace.txt");
+        let trace_s = trace.to_string_lossy();
+        let exit = crate::test::eval(&format!(
+            r#"
+def _bad(*args, **kwargs):
+    fail("defer kaboom")
+
+def _impl(ctx):
+    ctx.defer(ctx.std.fs.try_append, "{path}", "first\n")
+    ctx.defer(_bad)
+    return 0
+
+Test = task(implementation = _impl)
+"#,
+            path = trace_s,
+        ))
+        .run_task(0)
+        .expect("run_task");
+        assert_eq!(exit, Some(0), "defer failure must not change exit code");
+        let contents = std::fs::read_to_string(&trace).expect("earlier defer still ran");
+        assert_eq!(contents, "first\n");
     }
 }

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -543,7 +543,9 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         eval.set_loader(self.loader);
         eval.extra = Some(&self.loader.env);
 
-        let ret = eval.eval_function(task.implementation(), &[context], &[])?;
+        let impl_result = eval.eval_function(task.implementation(), &[context], &[]);
+        run_deferred(context, &mut eval);
+        let ret = impl_result?;
         let (exit_code, flagged, conclusion) = unpack_task_return(ret);
 
         // Reads elapsed + phases off the heap-allocated TaskInfo. Closes
@@ -614,6 +616,18 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
 
     pub fn finish(self) -> FinishedEval {
         FinishedEval
+    }
+}
+
+fn run_deferred<'v>(context: Value<'v>, eval: &mut Evaluator<'v, '_, '_>) {
+    let Some(ctx) = context.downcast_ref::<TaskContext>() else {
+        return;
+    };
+    let defers = ctx.drain_defers();
+    for defer in defers {
+        if let Err(e) = eval.eval_function(defer.callable, &defer.args, &defer.kwargs) {
+            tracing::error!(error = %e, "ctx.defer callable failed");
+        }
     }
 }
 


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add go style `ctx.defer` for cleanup functions.  useful for cleaning up after an unrecoverable error. 

### Test plan

- New test cases added
