### PR TITLE
fix(delivery): register ArtifactsTrait so ArtifactUpload hooks don't crash

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -100,6 +100,7 @@ User-facing migration guide: https://docs.aspect.build/cli/migration/delivery
 """
 
 load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
+load("@aspect//lib/artifacts.axl", "artifacts")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("@aspect//lib/ci.axl", "detect_build_url")
 load("@aspect//lib/delivery_results.axl", delivery_add_result = "add_result", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
@@ -1276,6 +1277,6 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         DeliveryTrait,
         HealthCheckTrait,
         TaskLifecycleTrait,
-    ] + tips.TRAITS,
+    ] + artifacts.TRAITS + tips.TRAITS,
     implementation = _delivery_impl,
 )


### PR DESCRIPTION
When `ArtifactUpload` is enabled in `config.axl`, its `_artifact_upload_impl` registers an `_on_build_end` hook on `BazelTrait.build_end`. That hook calls `ctx.traits[_ArtifactsTrait]` — but the delivery task never declared `_ArtifactsTrait` in its traits list, causing the runtime to raise:

```
error: Trait type 'anon' not found in TraitMap. Is it declared in a task's traits list?
   --> aspect/lib/artifacts.axl:157
    |
157 |     ctx.traits[_ArtifactsTrait].append(_Artifact(kind = kind, url = url, name = name))
```

Fix: import `artifacts` and add `artifacts.TRAITS` to the delivery task's traits list, matching the registration pattern documented in `lib/artifacts.axl`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- Fixed a runtime crash (`Trait type 'anon' not found in TraitMap`) in `aspect delivery` when `ArtifactUpload` is enabled in `config.axl`.

### Test plan

- Manual testing: reproduced the crash on silo's delivery pipeline (2026.22.3); confirmed the fix resolves it.