### PR TITLE
feat(format): stand-alone buildifier task + --include-pattern flag + bzlmod label fix

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -32,12 +32,25 @@ _user_task = task(
     args = {},
 )
 
-# `aspect buildifier` — alias of `aspect format` preset to the Starlark-only
-# formatter target. CI and local users can run `aspect buildifier` instead
-# of `aspect format --formatter-target=//tools/format:buildifier`.
 buildifier = format.alias(
     defaults = {
-        "formatter_target": "//tools/format:buildifier",
+        "formatter_target": "@buildifier_prebuilt//buildifier",
+        # buildifier only handles Starlark files; without include_patterns the
+        # raw binary receives all changed files and errors on non-Starlark ones.
+        # **/prefix is required: patterns use * (one segment) not ** (any depth).
+        "include_patterns": [
+            "**/BUCK",
+            "**/BUILD",
+            "**/BUILD.bazel",
+            "**/MODULE.bazel",
+            "**/*.MODULE.bazel",
+            "**/Tiltfile",
+            "**/WORKSPACE",
+            "**/WORKSPACE.bazel",
+            "**/*.axl",
+            "**/*.bzl",
+            "**/*.star",
+        ],
     },
     summary = "Format Starlark files using buildifier.",
 )
@@ -139,6 +152,11 @@ def config(ctx: ConfigContext):
     # defaults and config.axl overrides).
     # Run with: aspect dev test-repro-commands
     ctx.tasks.add(repro_commands_tests)
+
+    # canonical_label normalization — local labels, external labels, and bzlmod
+    # canonical @@module+version//... → @module//... conversion.
+    # Run with: aspect dev test-runnable
+    ctx.tasks.add(runnable_tests)
 
     # Adaptive rate-limit throttling — observations / burn-rate
     # inference / threshold ladder / tip firing / two-bucket

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,8 +78,8 @@ buildifier-task:
     - aspect-default
   script:
     - .aspect/bootstrap.sh
-    - ASPECT_DEBUG=1 aspect format --task-key buildifier-gl-debug --formatter-target=//tools/format:buildifier
-    - aspect format --task-key buildifier-gl --formatter-target=//tools/format:buildifier
+    - ASPECT_DEBUG=1 aspect buildifier --task-key buildifier-gl-debug
+    - aspect buildifier --task-key buildifier-gl
 
 format-task:
   stage: CI

--- a/crates/aspect-cli/src/builtins/aspect/README.md
+++ b/crates/aspect-cli/src/builtins/aspect/README.md
@@ -109,13 +109,13 @@ Renderer: `lint_results`. Body has by-severity counts, by-tool counts, per-sever
 [`format.axl`](format.axl) · build a formatter target, run it on the changed file list, diff before-and-after.
 
 ```sh
-aspect format                                                       # changed scope (default)
-aspect format --scope=all                                           # whole tree
-aspect format --formatter-target=//tools/format:buildifier          # buildifier-only
-aspect format --include-pattern='**/*.bzl'                          # only bzl files
-aspect format --exclude-pattern='**/*.md'                           # exclude all markdown files
-aspect format --on-change=warn                                      # warn but don't fail CI
-aspect format --upload-format-diff                                  # upload `format.patch`
+aspect format                                                        # changed scope (default)
+aspect format --scope=all                                            # whole tree
+aspect format --formatter-target=@buildifier_prebuilt//buildifier   # buildifier-only
+aspect format --include-pattern='**/*.bzl'                           # only Starlark
+aspect format --exclude-pattern='vendor/**'                          # skip vendor
+aspect format --on-change=warn                                       # warn but don't fail CI
+aspect format --upload-format-diff                                   # upload `format.patch`
 ```
 
 Verdict comes from a `git diff` between the pre-format and post-format working tree (after applying `--include-pattern` and `--exclude-pattern`). Non-empty diff + `--on-change=fail` → exit 1; `--on-change=warn` → exit 0 with status=warning; `--on-change=silent` → exit 0 with status=passed. The formatter binary's own non-zero exit fails the task regardless of `--on-change`.

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1009,7 +1009,7 @@ def _delivery_impl(ctx):
                 data.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
                 delivery_add_result(dr, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)
             elif not run_tracker.is_runnable(entrypoint):
-                warn_msg = "tagged deliverable but not runnable (no runfiles tree at {}.runfiles)".format(entrypoint)
+                warn_msg = "tagged deliverable but not runnable (no .runfiles_manifest in BES output for {})".format(entrypoint)
                 pending_count += 1
                 data.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
                 delivery_add_result(dr, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -1,18 +1,15 @@
 """Define the 'format' task
 
-Format builds a multi-formatter target and then runs it on the changed files.
-It's a simple example of interaction with version control, which Bazel only does via the workspace_status_command.
-
-Install:
-    Add rules_lint to MODULE.aspect.
-    See examples in https://github.com/bazel-starters
+Builds a formatter target and runs it against changed (or all) files in the
+workspace. Supports format_multirun targets from rules_lint as well as any
+standalone runnable formatter binary.
 
 Usage:
     # Format changed files (default)
     aspect format
     # Format every file the formatter knows how to handle
     aspect format --scope=all
-    # Specify the label of the format_multirun binary
+    # Specify the formatter target
     aspect format --formatter-target=//path/to:formatter_bin
 
 """
@@ -438,8 +435,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     include_patterns = list(ctx.args.include_patterns)
 
     # Positional files explicitly provided → bypass change-detection
-    # entirely. `--scope`, `--base-ref`, `--merge-base`, `--exclude-pattern`,
-    # and `--include-pattern` are silently ignored here; the formatter
+    # entirely. `--scope`, `--base-ref`, `--merge-base`, `--include-pattern`,
+    # and `--exclude-pattern` are silently ignored here; the formatter
     # receives exactly the listed paths. This is the typical local
     # repro path: the user copies the fix command from CI which
     # carries a positional file list, runs it as-is.
@@ -553,7 +550,18 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             data = data,
             phase = Phase(name = "format", description = "Format files", emoji = "✨"),
         )
-    exit = r.spawn(formatter, format_args).wait()
+
+    workspace_root = ctx.std.env.aspect_root_dir()
+    abs_format_args = [
+        workspace_root + "/" + f if (f and not f.startswith("/")) else f
+        for f in format_args
+    ]
+    # Raw binaries (no .runfiles tree) must start from the workspace root so
+    # --scope=all scans the right tree and relative file paths resolve.
+    # sh_binary wrappers (format_multirun) cd to BUILD_WORKSPACE_DIRECTORY
+    # internally, so their default cwd (the runfiles tree) is fine.
+    effective_cwd = None if r.is_runnable(formatter) else workspace_root
+    exit = r.spawn(formatter, abs_format_args, cwd = effective_cwd).wait()
 
     if not exit.success:
         # Formatter binary itself errored — surface that and skip the
@@ -608,11 +616,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         print("No files%s were modified." % scope_text)
         return _emit_final(ctx, lifecycle, data, 0)
 
-    # List the affected file set, then filter through --include-pattern and
-    # --exclude-pattern. Both hide files from the user-facing affected list
-    # and the failure decision below. They don't undo the formatter's changes —
-    # those still sit in the working tree — but they prevent unexpected files
-    # from failing this task.
+    # Pattern filters hide files from the user-facing affected list and the
+    # failure decision. They don't undo the formatter's changes — those still
+    # sit in the working tree — but they prevent unexpected files from failing.
     name_out, _, _ = _git_capture(ctx, "diff", "--name-only", pre_snap if pre_snap else "HEAD")
     affected_raw = [f for f in name_out.strip().split("\n") if f]
     affected = affected_raw
@@ -623,9 +629,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     filtered_count = len(affected_raw) - len(affected)
 
     if not affected:
-        # All formatter changes are hidden by pattern filters — task is OK
-        # from the user's perspective. Note the working-tree changes so they
-        # aren't surprising downstream.
         if filtered_count > 0:
             info(ctx.std, "Formatter modified %d file(s), all filtered by pattern rules; treating as OK." % filtered_count)
         return _emit_final(ctx, lifecycle, data, 0)
@@ -646,20 +649,16 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if filtered_count > 0:
         print("(also modified %d file(s) hidden by pattern filters; not counted toward failure)" % filtered_count)
 
-    # Populate data with the affected file set and filtered count for status checks.
     data["format"]["affected_files"] = affected
     data["format"]["filtered_count"] = filtered_count
 
     # Optional: archive the diff as a CI artifact so reviewers can apply
     # it locally without re-running the formatter. Off by default.
     #
-    # Scope the uploaded patch to `affected` (the post-filter file set) so
-    # it matches the failure-decision basis. In --scope=changed mode this
-    # is redundant — the formatter never saw filtered files, so the diff is
-    # already scoped. In --scope=all mode the formatter discovers files
-    # itself via `git ls-files` and rewrites filtered ones; without re-
-    # scoping, the patch would carry changes that don't contribute to
-    # failure or appear in the user-facing affected list.
+    # Scope the uploaded patch to `affected` so it matches the failure-decision
+    # basis. In --scope=all mode the formatter rewrites filtered files too;
+    # without re-scoping the uploaded patch would carry those changes even
+    # though they don't contribute to failure or appear in the affected list.
     if ctx.args.upload_format_diff:
         if filtered_count > 0:
             upload_diff, _, _ = _git_capture(

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -34,13 +34,11 @@ def _process_bes(state: struct, event):
     if event.kind == "named_set_of_files":
         state.filesets[event.id.id] = event.payload
     elif event.kind == "target_completed":
-        # Use a fresh local name to avoid shadowing the module-level `apparent_label`
-        # function on the right-hand side of the same assignment.
-        canonical = apparent_label(event.id.label)
-        if canonical in state.targets:
+        label_key = apparent_label(event.id.label)
+        if label_key in state.targets:
             for og in event.payload.output_group:
                 if og.name == "default":
-                    state.target_fileset[canonical] = og.file_sets
+                    state.target_fileset[label_key] = og.file_sets
     elif event.kind == "workspace_config":
         # WorkspaceConfig.local_exec_root is "<output_base>/execroot/<workspace_name>".
         # Its basename is the canonical repo name Bazel uses inside runfiles trees.
@@ -54,20 +52,22 @@ def _determine_entrypoint(state: struct, target: str) -> str | None:
     Picks the file whose basename matches the target name when present — that
     is the binary's executable (e.g. sh_binary materializes `<name>`, with the
     `.sh` sibling being the script srcs[0]). Falls back to the first derived
-    file. Does *not* check whether the result is actually runnable — the
-    caller pairs this with `is_runnable` to distinguish "not in BES" from
-    "in BES but no runfiles tree".
+    file. Also records whether the target has a runfiles tree in
+    `state.entrypoint_runfiles` so that `_is_runnable` can answer without a
+    disk check.
     """
     target = apparent_label(target)
     if target not in state.target_fileset:
         return None
 
     target_name = target.rsplit(":", 1)[-1]
+    manifest_name = target_name + ".runfiles_manifest"
 
     visited = {}
     frontier = [fs_ref.id for fs_ref in state.target_fileset[target]]
 
     candidates = []
+    has_manifest = False
     for _depth in range(32):
         if not frontier:
             break
@@ -81,7 +81,10 @@ def _determine_entrypoint(state: struct, target: str) -> str | None:
                 continue
             for file in payload.files:
                 if len(file.path_prefix):
-                    candidates.append(file.file.removeprefix("file://"))
+                    path = file.file.removeprefix("file://")
+                    candidates.append(path)
+                    if path.rsplit("/", 1)[-1] == manifest_name:
+                        has_manifest = True
             for child in payload.file_sets:
                 if child.id not in visited:
                     next_frontier.append(child.id)
@@ -90,26 +93,47 @@ def _determine_entrypoint(state: struct, target: str) -> str | None:
     if not candidates:
         return None
 
+    entrypoint = None
     for c in candidates:
         if c.rsplit("/", 1)[-1] == target_name:
-            return c
-    return candidates[0]
+            entrypoint = c
+            break
+    if entrypoint == None:
+        entrypoint = candidates[0]
+
+    state.entrypoint_runfiles[entrypoint] = has_manifest
+    return entrypoint
 
 def _is_runnable(state: struct, entrypoint: str) -> bool:
-    """True if `<entrypoint>.runfiles/` exists on disk.
+    """True if the BES output for `entrypoint` included a .runfiles_manifest.
 
-    `_spawn` sets current_dir to that path, so a missing runfiles tree means
-    spawn() will fail with a misleading ENOENT naming the executable. Lets
-    the caller distinguish "tagged deliverable but not runnable" (e.g. a
-    `gen_sh_binary` macro's internal genrule) from "not in BES at all".
+    Lets the caller distinguish "tagged deliverable but not runnable" (e.g. a
+    `gen_sh_binary` macro's internal genrule) from "not in BES at all", without
+    a disk check — the manifest's presence in the BES output is the canonical
+    signal that Bazel produced a runfiles tree for the target.
     """
-    return state.ctx.std.fs.exists(entrypoint + ".runfiles")
+    return state.entrypoint_runfiles.get(entrypoint, False)
 
-def _spawn(ctx: TaskContext, state: struct, entrypoint: str, args: list[str], capture: bool = False) -> std.process.Child:
+def _spawn(ctx: TaskContext, state: struct, entrypoint: str, args: list[str], capture: bool = False, cwd: str | None = None) -> std.process.Child:
+    """Spawn `entrypoint` with `args` in the Bazel runfiles environment.
+
+    Sets RUNFILES_DIR / RUNFILES_MANIFEST_FILE (absolute paths) so that
+    `rlocation` in sh_binary wrappers works regardless of the process's
+    working directory — the bash runfiles helper checks these env vars before
+    falling back to `$BASH_SOURCE[0].runfiles`. Also sets
+    BUILD_WORKSPACE_DIRECTORY / BUILD_WORKING_DIRECTORY so formatter wrappers
+    (e.g. rules_lint's format.sh) can cd to the workspace root.
+
+    `cwd` overrides the working directory. The default is the runfiles tree
+    (`entrypoint.runfiles/<workspace>`), matching `bazel run` behaviour.
+    Passing an explicit `cwd` is safe for sh_binary wrappers because their
+    runfiles resolution uses the env vars above, not the process cwd.
+    """
     runfiles = entrypoint + ".runfiles"
     workspace_name = state.workspace_name[0] or _DEFAULT_WORKSPACE_NAME
+    effective_cwd = cwd if cwd else (runfiles + "/" + workspace_name)
     cmd = ctx.std.process.command(entrypoint) \
-        .current_dir(runfiles + "/" + workspace_name) \
+        .current_dir(effective_cwd) \
         .env("RUNFILES_DIR", runfiles) \
         .env("JAVA_RUNFILES", runfiles) \
         .env("RUNFILES_MANIFEST_FILE", runfiles + "_manifest") \
@@ -126,6 +150,8 @@ def runnable(ctx, targets: list[str]) -> struct:
         targets = {apparent_label(t): t for t in targets},
         filesets = {},
         target_fileset = {},
+        # Maps entrypoint path → True when BES output included a .runfiles_manifest.
+        entrypoint_runfiles = {},
         # Single-element list so `_process_bes` can mutate it (struct fields are
         # otherwise read-only after construction).
         workspace_name = [""],
@@ -135,5 +161,5 @@ def runnable(ctx, targets: list[str]) -> struct:
         event = lambda event: _process_bes(state, event),
         determine_entrypoint = lambda target: _determine_entrypoint(state, target),
         is_runnable = lambda entrypoint: _is_runnable(state, entrypoint),
-        spawn = lambda entrypoint, args, capture = False: _spawn(ctx, state, entrypoint, args, capture),
+        spawn = lambda entrypoint, args, capture = False, cwd = None: _spawn(ctx, state, entrypoint, args, capture, cwd),
     )

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -6,6 +6,10 @@ def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
 
+# ---------------------------------------------------------------------------
+# apparent_label unit tests
+# ---------------------------------------------------------------------------
+
 def _test_local_label_with_colon(ctx):
     _eq("local label unchanged", apparent_label("//tools/format:format"), "//tools/format:format")
 
@@ -89,7 +93,7 @@ def _test_bzlmod_4seg_extension_repo(ctx):
 # ---------------------------------------------------------------------------
 
 def _make_fileset_event(set_id, file_path):
-    """Minimal named_set_of_files BES event."""
+    """Minimal named_set_of_files BES event with a single file."""
     return struct(
         kind = "named_set_of_files",
         id = struct(id = set_id),
@@ -98,6 +102,20 @@ def _make_fileset_event(set_id, file_path):
                 path_prefix = ["bazel-out/opt/bin"],
                 file = "file://" + file_path,
             )],
+            file_sets = [],
+        ),
+    )
+
+def _make_fileset_event_multi(set_id, file_paths):
+    """named_set_of_files BES event with multiple files."""
+    return struct(
+        kind = "named_set_of_files",
+        id = struct(id = set_id),
+        payload = struct(
+            files = [struct(
+                path_prefix = ["bazel-out/opt/bin"],
+                file = "file://" + p,
+            ) for p in file_paths],
             file_sets = [],
         ),
     )
@@ -156,6 +174,41 @@ def _test_bes_unknown_target_returns_none(ctx):
     if got != None:
         fail("bes unknown target: expected None, got %r" % got)
 
+# ---------------------------------------------------------------------------
+# is_runnable tests — BES-based runfiles manifest detection
+# ---------------------------------------------------------------------------
+
+def _test_is_runnable_true_when_manifest_present(ctx):
+    """is_runnable returns True when BES output includes a .runfiles_manifest."""
+    r = runnable(None, ["//tools/format:format"])
+    r.event(_make_fileset_event_multi("s1", [
+        "/out/bin/tools/format/format",
+        "/out/bin/tools/format/format.runfiles_manifest",
+    ]))
+    r.event(_make_target_event("//tools/format:format", "s1"))
+    ep = r.determine_entrypoint("//tools/format:format")
+    if ep == None:
+        fail("is_runnable/manifest: expected entrypoint, got None")
+    if not r.is_runnable(ep):
+        fail("is_runnable/manifest: expected True (manifest in BES), got False")
+
+def _test_is_runnable_false_when_no_manifest(ctx):
+    """is_runnable returns False when BES output has no .runfiles_manifest (raw binary)."""
+    r = runnable(None, ["@buildifier_prebuilt//buildifier"])
+    r.event(_make_fileset_event("s1", "/out/bin/external/buildifier_prebuilt/buildifier/buildifier"))
+    r.event(_make_target_event("@@buildifier_prebuilt+//buildifier:buildifier", "s1"))
+    ep = r.determine_entrypoint("@buildifier_prebuilt//buildifier")
+    if ep == None:
+        fail("is_runnable/no-manifest: expected entrypoint, got None")
+    if r.is_runnable(ep):
+        fail("is_runnable/no-manifest: expected False (no manifest in BES), got True")
+
+def _test_is_runnable_false_for_unknown_entrypoint(ctx):
+    """is_runnable returns False for an entrypoint that was never resolved."""
+    r = runnable(None, ["//tools/format:format"])
+    if r.is_runnable("/some/unknown/path"):
+        fail("is_runnable/unknown: expected False for unknown entrypoint, got True")
+
 _UNIT_TESTS = [
     _test_local_label_with_colon,
     _test_local_label_without_colon,
@@ -174,6 +227,9 @@ _UNIT_TESTS = [
     _test_bes_bzlmod_extension_repo,
     _test_bes_local_target,
     _test_bes_unknown_target_returns_none,
+    _test_is_runnable_true_when_manifest_present,
+    _test_is_runnable_false_when_no_manifest,
+    _test_is_runnable_false_for_unknown_entrypoint,
 ]
 
 def _test_impl(ctx):

--- a/crates/axl-runtime/src/engine/task.rs
+++ b/crates/axl-runtime/src/engine/task.rs
@@ -543,7 +543,7 @@ fn task_methods(builder: &mut MethodsBuilder) {
     ///
     /// buildifier = format.alias(
     ///     defaults = {
-    ///         "formatter_target": "//tools/format:buildifier",
+    ///         "formatter_target": "@buildifier_prebuilt//buildifier",
     ///     },
     ///     summary = "Format Starlark files with buildifier.",
     /// )

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -4,12 +4,3 @@ format_multirun(
     name = "format",
     rust = "@rules_rust//tools/upstream_wrapper:rustfmt",
 )
-
-# Starlark-only formatter for the dedicated buildifier CI step. Lets us run
-# buildifier in parallel with the multi-language `format` target while
-# `aspect format --task-key=format` ignores Starlark patterns to avoid
-# duplicate work. See https://docs.aspect.build/cli/migration/buildifier.
-format_multirun(
-    name = "buildifier",
-    starlark = "@buildifier_prebuilt//:buildifier",
-)


### PR DESCRIPTION
Adds `aspect buildifier` as a first-class task that formats Starlark files using `@buildifier_prebuilt//buildifier` directly, without requiring `rules_lint`.

Two changes in `format.axl` make standalone formatter binaries work:

**Absolute paths for formatter invocation** — `format_multirun` wrappers (`format.sh`) `cd` to `BUILD_WORKSPACE_DIRECTORY` before invoking the tool, so relative paths from git diff work. A raw binary doesn't do this. File paths are now made absolute before spawning. `r.is_runnable()` (BES-based, no disk I/O — see PR #1142) distinguishes `format_multirun` wrappers (have a `.runfiles_manifest`) from raw binaries (don't); wrappers keep the default runfiles-tree cwd, raw binaries run from the workspace root.

**`--include-pattern` flag** — raw formatter binaries handle one file type and error on others; `format_multirun` targets do their own per-language filtering internally. `--include-pattern` (repeatable, `**`-glob) whitelists files by glob before passing them to the formatter. The existing `--ignore-pattern` flag is renamed to `--exclude-pattern` for symmetry.

The `buildifier` alias in `.aspect/config.axl` uses `@buildifier_prebuilt//buildifier` directly with `include_patterns` set to all Starlark file extensions, replacing the `format_multirun(name = "buildifier", ...)` target in `tools/format/BUILD.bazel`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes — `--ignore-pattern` is renamed to `--exclude-pattern`. The API is documented as unstable and usage is minimal.
- Suggested release notes appear below: yes

- `aspect format` gains `--include-pattern` (repeatable, `**`-glob) to restrict formatting to specific file patterns, and renames `--ignore-pattern` to `--exclude-pattern` for symmetry.
- `aspect buildifier` can now target `@buildifier_prebuilt//buildifier` directly — no `format_multirun` wrapper required.
- `runnable.axl` correctly resolves bzlmod canonical labels (`@@module+version//...`) emitted in BES events, so any formatter target from an external bzlmod dependency works as `--formatter-target`.

### Test plan

- New test cases: `runnable_test.axl` — 20 tests covering `apparent_label` normalization, BES label matching, and `is_runnable` manifest detection
- New test cases: `repro_commands_test.axl` — `--include-pattern` / `--exclude-pattern` round-trip and independence tests
- Manual testing: `aspect buildifier` on this branch formats changed `.axl`/`BUILD.bazel` files and skips non-Starlark ones
