### PR TITLE
fix(launcher): retry GitHub releases download up to 3× on transient failure

### DIFF
--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -514,21 +514,46 @@ async fn configure_tool_task(
                             tool_dest_file
                         );
                     };
-                    let req = gh_request(&client, direct_url)
-                        .header(
-                            HeaderName::from_static("accept"),
-                            HeaderValue::from_static("application/octet-stream"),
-                        )
-                        .build()
-                        .into_diagnostic()?;
                     let download_msg = format!(
                         "downloading aspect cli version {} file {}",
                         resolved_tag, artifact
                     );
-                    if let err @ Err(_) =
-                        _download_into_cache(&client, &tool_dest_file, req, &download_msg).await
-                    {
-                        errs.push(err);
+
+                    // Retry up to 3 times with exponential backoff (0 s, 1 s, 2 s) to
+                    // survive transient failures such as a mid-stream connection reset.
+                    const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
+                    let mut download_err: Option<miette::Error> = None;
+                    for attempt in 0..MAX_DOWNLOAD_ATTEMPTS {
+                        if attempt > 0 {
+                            let delay = std::time::Duration::from_secs(1 << (attempt - 1));
+                            tokio::time::sleep(delay).await;
+                            eprintln!(
+                                "retrying download (attempt {}/{})",
+                                attempt + 1,
+                                MAX_DOWNLOAD_ATTEMPTS
+                            );
+                        }
+                        let req = gh_request(&client, direct_url.clone())
+                            .header(
+                                HeaderName::from_static("accept"),
+                                HeaderValue::from_static("application/octet-stream"),
+                            )
+                            .build()
+                            .into_diagnostic()?;
+                        match _download_into_cache(&client, &tool_dest_file, req, &download_msg)
+                            .await
+                        {
+                            Ok(()) => {
+                                download_err = None;
+                                break;
+                            }
+                            Err(e) => {
+                                download_err = Some(e);
+                            }
+                        }
+                    }
+                    if let Some(e) = download_err {
+                        errs.push(Err(e));
                         continue;
                     }
                     return Ok((


### PR DESCRIPTION
On CI environments without a `GITHUB_TOKEN`, downloading a pinned version directly from
`github.com/releases/download/…` can fail mid-stream with a connection reset (os error 104).
The launcher had no retry logic, so a single transient failure immediately exhausted the
(often single) source list and terminated the job.

Add up to 3 download attempts with exponential backoff (0 s, 1 s, 2 s) for the GitHub
direct-download path. The request is rebuilt on each attempt (reqwest `Request` is consumed
by the first execute call). A successful attempt short-circuits the loop; a permanent
failure after all attempts propagates as before.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**

- `fix(launcher)`: GitHub release downloads now retry up to 3 times on transient network
  failures (connection reset, mid-stream disconnects). Fixes jobs failing on first run
  when the pinned-version binary is not yet cached.

### Test plan

- Covered by existing test cases (all 54 launcher tests pass)
- Manual testing: reproduced the transient failure scenario via CircleCI logs showing
  `Connection reset by peer (os error 104)` mid-download; retry logic would have recovered
