### PR TITLE
feat: use @buildifier_prebuilt//buildifier directly in aspect buildifier alias

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -32,12 +32,22 @@ _user_task = task(
     args = {},
 )
 
-# `aspect buildifier` — alias of `aspect format` preset to the Starlark-only
-# formatter target. CI and local users can run `aspect buildifier` instead
-# of `aspect format --formatter-target=//tools/format:buildifier`.
 buildifier = format.alias(
     defaults = {
-        "formatter_target": "//tools/format:buildifier",
+        "formatter_target": "@buildifier_prebuilt//buildifier",
+        "include_patterns": [
+            "**/BUCK",
+            "**/BUILD",
+            "**/BUILD.bazel",
+            "**/MODULE.bazel",
+            "**/*.MODULE.bazel",
+            "**/Tiltfile",
+            "**/WORKSPACE",
+            "**/WORKSPACE.bazel",
+            "**/*.axl",
+            "**/*.bzl",
+            "**/*.star",
+        ],
     },
     summary = "Format Starlark files using buildifier.",
 )

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,8 +68,6 @@ lint-task:
     - aspect lint --task-key lint-gl --fix --aspect=//tools/lint:linters.bzl%shellcheck -- //examples/lint/... -//exclude/...
 
 # Dedicated buildifier-only step that runs in parallel with format-task.
-# Models the legacy Rosetta `buildifier` task using a Starlark-only
-# `format_multirun` target — see https://docs.aspect.build/cli/migration/buildifier.
 buildifier-task:
   stage: CI
   needs: [pre-build]
@@ -78,8 +76,8 @@ buildifier-task:
     - aspect-default
   script:
     - .aspect/bootstrap.sh
-    - ASPECT_DEBUG=1 aspect format --task-key buildifier-gl-debug --formatter-target=//tools/format:buildifier
-    - aspect format --task-key buildifier-gl --formatter-target=//tools/format:buildifier
+    - ASPECT_DEBUG=1 aspect buildifier --task-key buildifier-gl-debug
+    - aspect buildifier --task-key buildifier-gl
 
 format-task:
   stage: CI

--- a/crates/aspect-cli/src/builtins/aspect/README.md
+++ b/crates/aspect-cli/src/builtins/aspect/README.md
@@ -109,13 +109,13 @@ Renderer: `lint_results`. Body has by-severity counts, by-tool counts, per-sever
 [`format.axl`](format.axl) · build a formatter target, run it on the changed file list, diff before-and-after.
 
 ```sh
-aspect format                                                       # changed scope (default)
-aspect format --scope=all                                           # whole tree
-aspect format --formatter-target=//tools/format:buildifier          # buildifier-only
-aspect format --include-pattern='**/*.bzl'                          # only bzl files
-aspect format --exclude-pattern='**/*.md'                           # exclude all markdown files
-aspect format --on-change=warn                                      # warn but don't fail CI
-aspect format --upload-format-diff                                  # upload `format.patch`
+aspect format                                                        # changed scope (default)
+aspect format --scope=all                                            # whole tree
+aspect format --formatter-target=@buildifier_prebuilt//buildifier    # buildifier-only
+aspect format --include-pattern='**/*.bzl'                           # only bzl files
+aspect format --exclude-pattern='vendor/**'                          # skip vendor
+aspect format --on-change=warn                                       # warn but don't fail CI
+aspect format --upload-format-diff                                   # upload `format.patch`
 ```
 
 Verdict comes from a `git diff` between the pre-format and post-format working tree (after applying `--include-pattern` and `--exclude-pattern`). Non-empty diff + `--on-change=fail` → exit 1; `--on-change=warn` → exit 0 with status=warning; `--on-change=silent` → exit 0 with status=passed. The formatter binary's own non-zero exit fails the task regardless of `--on-change`.

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -1,18 +1,16 @@
 """Define the 'format' task
 
-Format builds a multi-formatter target and then runs it on the changed files.
-It's a simple example of interaction with version control, which Bazel only does via the workspace_status_command.
-
-Install:
-    Add rules_lint to MODULE.aspect.
-    See examples in https://github.com/bazel-starters
+Builds a formatter target and runs it against changed (or all) files in the
+workspace. Supports bazel binary targets such as format_multirun targets from
+rules_lint as well as any standalone runnable formatter binary targets such as
+@buildifier_prebuilt//buildifier.
 
 Usage:
     # Format changed files (default)
     aspect format
     # Format every file the formatter knows how to handle
     aspect format --scope=all
-    # Specify the label of the format_multirun binary
+    # Specify the formatter target
     aspect format --formatter-target=//path/to:formatter_bin
 
 """

--- a/crates/axl-runtime/src/engine/task.rs
+++ b/crates/axl-runtime/src/engine/task.rs
@@ -543,7 +543,7 @@ fn task_methods(builder: &mut MethodsBuilder) {
     ///
     /// buildifier = format.alias(
     ///     defaults = {
-    ///         "formatter_target": "//tools/format:buildifier",
+    ///         "formatter_target": "@buildifier_prebuilt//buildifier",
     ///     },
     ///     summary = "Format Starlark files with buildifier.",
     /// )

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -4,12 +4,3 @@ format_multirun(
     name = "format",
     rust = "@rules_rust//tools/upstream_wrapper:rustfmt",
 )
-
-# Starlark-only formatter for the dedicated buildifier CI step. Lets us run
-# buildifier in parallel with the multi-language `format` target while
-# `aspect format --task-key=format` ignores Starlark patterns to avoid
-# duplicate work. See https://docs.aspect.build/cli/migration/buildifier.
-format_multirun(
-    name = "buildifier",
-    starlark = "@buildifier_prebuilt//:buildifier",
-)


### PR DESCRIPTION
Switch the `aspect buildifier` alias from a `format_multirun(name = "buildifier", starlark = ...)` wrapper target to the `@buildifier_prebuilt//buildifier` binary directly. This eliminates the need to maintain a dedicated `format_multirun` BUILD target — the prebuilt binary works as a formatter target on its own.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing: `aspect buildifier` runs successfully against changed Starlark files
- `aspect buildifier --scope=all` formats all Starlark files in the repo
- `aspect format` (without buildifier alias) is unaffected
