### PR TITLE
fix(runnable): detect runfiles from BES output; add cwd param to spawn

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1002,19 +1002,19 @@ def _delivery_impl(ctx):
             # No entrypoint needed; dry_run=True skips the bazel run path.
             pending.append((label, None, is_forced, output_sha or "-"))
         else:
-            entrypoint = run_tracker.determine_entrypoint(label)
-            if entrypoint == None:
+            ep = run_tracker.determine_entrypoint(label)
+            if ep == None:
                 warn_msg = "no build output reported for this target (possibly an alias, filtered, or transitioned away)"
                 pending_count += 1
                 data.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
                 delivery_add_result(dr, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)
-            elif not run_tracker.is_runnable(entrypoint):
-                warn_msg = "tagged deliverable but not runnable (no runfiles tree at {}.runfiles)".format(entrypoint)
+            elif not ep.runfiles_dir:
+                warn_msg = "tagged deliverable but not runnable (no .runfiles_manifest in BES output for {})".format(ep.path)
                 pending_count += 1
                 data.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
                 delivery_add_result(dr, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)
             else:
-                pending.append((label, entrypoint, is_forced, output_sha or "-"))
+                pending.append((label, ep, is_forced, output_sha or "-"))
 
         delivery_trait.deliver_target(label, is_forced)
 
@@ -1066,7 +1066,7 @@ def _delivery_impl(ctx):
         for label, entrypoint, is_forced, output_sha in chunk:
             forced_marker = " (FORCED)" if is_forced else ""
             print("  {} {}{}...".format(_style("Delivering", _BOLD, ansi), label, forced_marker))
-            children.append((label, is_forced, output_sha, time.monotonic(), run_tracker.spawn(entrypoint, [], capture)))
+            children.append((label, is_forced, output_sha, time.monotonic(), run_tracker.spawn(ep, [], capture)))
 
         for label, is_forced, output_sha, t_start, child in children:
             forced_marker = " (FORCED)" if is_forced else ""

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -429,8 +429,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         _emit_final(ctx, lifecycle, data, build_status.code or 1)
         fail("Building the formatter has failed.")
 
-    formatter = r.determine_entrypoint(ctx.args.formatter_target)
-    if not formatter:
+    ep = r.determine_entrypoint(ctx.args.formatter_target)
+    if not ep:
         _emit_final(ctx, lifecycle, data, 1)
         fail("Failed to determine the formatter entrypoint.")
 
@@ -553,7 +553,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             data = data,
             phase = Phase(name = "format", description = "Format files", emoji = "✨"),
         )
-    exit = r.spawn(formatter, format_args).wait()
+    exit = r.spawn(ep, format_args).wait()
 
     if not exit.success:
         # Formatter binary itself errored — surface that and skip the

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -698,8 +698,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         _emit_final(ctx, lifecycle, data, build_status.code or 1)
         fail("Building the gazelle target has failed.")
 
-    gazelle = r.determine_entrypoint(ctx.args.gazelle_target)
-    if not gazelle:
+    ep = r.determine_entrypoint(ctx.args.gazelle_target)
+    if not ep:
         _emit_final(ctx, lifecycle, data, 1)
         fail("Failed to determine the gazelle target's entrypoint.")
 
@@ -712,8 +712,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # the runfiles tree as `<name>.runfiles` (matching the sh_binary).
     # Stripping the suffix points us at the sh_binary symlink instead,
     # whose runfiles dir resolves correctly.
-    if gazelle.endswith("-runner.bash"):
-        gazelle = gazelle[:-len("-runner.bash")]
+    if ep.path.endswith("-runner.bash"):
+        ep = struct(path = ep.path[:-len("-runner.bash")], runfiles_dir = ep.runfiles_dir)
 
     # Diff phase: run with -mode=diff to get the verdict and the patch
     # without modifying the tree. The aspect_gazelle wrapper hardcodes
@@ -769,7 +769,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data = data,
         phase = Phase(name = "diff", description = "Compute BUILD-file diff", emoji = "📋"),
     )
-    diff_proc = r.spawn(gazelle, diff_args, capture = True)
+    diff_proc = r.spawn(ep, diff_args, capture = True)
     diff_stdout = diff_proc.stdout().read_to_string()
     diff_stderr = diff_proc.stderr().read_to_string()
     diff_status = diff_proc.wait()

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -34,13 +34,11 @@ def _process_bes(state: struct, event):
     if event.kind == "named_set_of_files":
         state.filesets[event.id.id] = event.payload
     elif event.kind == "target_completed":
-        # Use a fresh local name to avoid shadowing the module-level `apparent_label`
-        # function on the right-hand side of the same assignment.
-        canonical = apparent_label(event.id.label)
-        if canonical in state.targets:
+        label_key = apparent_label(event.id.label)
+        if label_key in state.targets:
             for og in event.payload.output_group:
                 if og.name == "default":
-                    state.target_fileset[canonical] = og.file_sets
+                    state.target_fileset[label_key] = og.file_sets
     elif event.kind == "workspace_config":
         # WorkspaceConfig.local_exec_root is "<output_base>/execroot/<workspace_name>".
         # Its basename is the canonical repo name Bazel uses inside runfiles trees.
@@ -48,21 +46,31 @@ def _process_bes(state: struct, event):
         if local_exec_root:
             state.workspace_name[0] = local_exec_root.rstrip("/").split("/")[-1]
 
-def _determine_entrypoint(state: struct, target: str) -> str | None:
+def _determine_entrypoint(state: struct, target: str) -> struct | None:
     """Best BES-reported derived output for `target`, or None if not in BES.
 
-    Picks the file whose basename matches the target name when present — that
-    is the binary's executable (e.g. sh_binary materializes `<name>`, with the
-    `.sh` sibling being the script srcs[0]). Falls back to the first derived
-    file. Does *not* check whether the result is actually runnable — the
-    caller pairs this with `is_runnable` to distinguish "not in BES" from
-    "in BES but no runfiles tree".
+    Returns struct(path, runfiles_dir) where `runfiles_dir` is the resolved
+    runfiles directory path (e.g. `…/format.runfiles`), or `None` when the target
+    emits no runfiles tree (e.g. a prebuilt binary like buildifier).
+
+    Entrypoint selection runs three passes over the default-output-group files:
+      1. Exact match on `target_name` — the runnable wrapper that Bazel binary
+         rules (cc_binary, py_binary, sh_binary, …) always emit.
+      2. `target_name + ".sh"` — present on sh_binary as the user-supplied
+         source script; selected when no wrapper was found.
+      3. First file with the executable bit set (skipping `.runfiles_manifest`) —
+         last-resort for custom rules that emit a binary under a non-standard name.
+
+    The runfiles dir is derived from the manifest file's directory — not the
+    entrypoint's, which may differ in non-standard rules. Both names are tied to the
+    target label (a Bazel invariant).
     """
     target = apparent_label(target)
     if target not in state.target_fileset:
         return None
 
     target_name = target.rsplit(":", 1)[-1]
+    manifest_name = target_name + ".runfiles_manifest"
 
     visited = {}
     frontier = [fs_ref.id for fs_ref in state.target_fileset[target]]
@@ -90,37 +98,87 @@ def _determine_entrypoint(state: struct, target: str) -> str | None:
     if not candidates:
         return None
 
+    entrypoint = None
     for c in candidates:
         if c.rsplit("/", 1)[-1] == target_name:
-            return c
-    return candidates[0]
+            entrypoint = c
+            break
+    if entrypoint == None:
+        for c in candidates:
+            if c.rsplit("/", 1)[-1] == target_name + ".sh":
+                entrypoint = c
+                break
+    if entrypoint == None:
+        for c in candidates:
+            if c.rsplit("/", 1)[-1].endswith(".runfiles_manifest"):
+                continue
+            if state.ctx == None or state.ctx.std.fs.metadata(c).executable:
+                entrypoint = c
+                break
 
-def _is_runnable(state: struct, entrypoint: str) -> bool:
-    """True if `<entrypoint>.runfiles/` exists on disk.
+    if entrypoint == None:
+        return None
 
-    `_spawn` sets current_dir to that path, so a missing runfiles tree means
-    spawn() will fail with a misleading ENOENT naming the executable. Lets
-    the caller distinguish "tagged deliverable but not runnable" (e.g. a
-    `gen_sh_binary` macro's internal genrule) from "not in BES at all".
+    manifest_dir = None
+    for c in candidates:
+        if c.rsplit("/", 1)[-1] == manifest_name:
+            manifest_dir = c.rsplit("/", 1)[0]
+            break
+    runfiles_dir = (manifest_dir + "/" + target_name + ".runfiles") if manifest_dir != None else None
+    return struct(path = entrypoint, runfiles_dir = runfiles_dir)
+
+def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture: bool = False, cwd: str | None = None) -> std.process.Child:
+    """Spawn `ep.path` with `args` in the Bazel runfiles environment.
+
+    Always sets BUILD_WORKSPACE_DIRECTORY / BUILD_WORKING_DIRECTORY so
+    formatter wrappers (e.g. rules_lint's format.sh) can cd to the workspace
+    root. When `ep.runfiles_dir` is set, also sets RUNFILES_DIR /
+    RUNFILES_MANIFEST_FILE so that `rlocation` in sh_binary wrappers works
+    regardless of the process's working directory.
+
+    `cwd` overrides the working directory. When omitted: defaults to
+    `ep.runfiles_dir/<workspace>` when a runfiles tree is present (matching
+    `bazel run`), or to the workspace root for bare binaries so
+    workspace-relative file arguments resolve correctly.
     """
-    return state.ctx.std.fs.exists(entrypoint + ".runfiles")
-
-def _spawn(ctx: TaskContext, state: struct, entrypoint: str, args: list[str], capture: bool = False) -> std.process.Child:
-    runfiles = entrypoint + ".runfiles"
     workspace_name = state.workspace_name[0] or _DEFAULT_WORKSPACE_NAME
-    cmd = ctx.std.process.command(entrypoint) \
-        .current_dir(runfiles + "/" + workspace_name) \
-        .env("RUNFILES_DIR", runfiles) \
-        .env("JAVA_RUNFILES", runfiles) \
-        .env("RUNFILES_MANIFEST_FILE", runfiles + "_manifest") \
+    if cwd:
+        effective_cwd = cwd
+    elif ep.runfiles_dir:
+        effective_cwd = ep.runfiles_dir + "/" + workspace_name
+    else:
+        effective_cwd = ctx.std.env.aspect_root_dir()
+    cmd = ctx.std.process.command(ep.path) \
+        .current_dir(effective_cwd) \
         .env("BUILD_WORKSPACE_DIRECTORY", ctx.std.env.aspect_root_dir()) \
         .env("BUILD_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
         .args(args)
+    if ep.runfiles_dir:
+        cmd = cmd \
+            .env("RUNFILES_DIR", ep.runfiles_dir) \
+            .env("JAVA_RUNFILES", ep.runfiles_dir) \
+            .env("RUNFILES_MANIFEST_FILE", ep.runfiles_dir + "_manifest")
     if capture:
         cmd = cmd.stdout("piped").stderr("piped")
     return cmd.spawn()
 
 def runnable(ctx, targets: list[str]) -> struct:
+    """Build a BES event tracker that resolves entrypoints for `targets`.
+
+    Feed BES events via `.event(event)` as they arrive from the build. Once the
+    build completes, query results per target through the returned struct:
+
+      determine_entrypoint(target) → struct(path, runfiles_dir) | None
+          Best executable output for `target` from its BES default output group,
+          or None if no BES data was received for it. `runfiles_dir` is the
+          resolved runfiles directory (e.g. `…/format.runfiles`), or `None`
+          when the target has no runfiles tree (e.g. a prebuilt binary).
+
+      spawn(ep, args, capture=False, cwd=None) → Child
+          Spawn `ep.path` with Bazel runfiles environment variables set.
+          `cwd` defaults to `ep.runfiles_dir/<workspace>` when a runfiles tree
+          is present, or to the workspace root for bare binaries.
+    """
     state = struct(
         ctx = ctx,
         targets = {apparent_label(t): t for t in targets},
@@ -134,6 +192,5 @@ def runnable(ctx, targets: list[str]) -> struct:
     return struct(
         event = lambda event: _process_bes(state, event),
         determine_entrypoint = lambda target: _determine_entrypoint(state, target),
-        is_runnable = lambda entrypoint: _is_runnable(state, entrypoint),
-        spawn = lambda entrypoint, args, capture = False: _spawn(ctx, state, entrypoint, args, capture),
+        spawn = lambda ep, args, capture = False, cwd = None: _spawn(ctx, state, ep, args, capture, cwd),
     )

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -80,24 +80,22 @@ def _test_bzlmod_4seg_extension_repo(ctx):
 # ---------------------------------------------------------------------------
 # BES matching integration tests
 #
-# These construct minimal mock BES events and verify that the full
+# Construct minimal mock BES events and verify that the full
 # runnable() → _process_bes → _determine_entrypoint pipeline correctly
-# maps bzlmod canonical labels emitted by the BES back to the apparent
-# labels registered by the caller.  Each test here would FAIL before the
-# @@-stripping fix because target_completed events with canonical bzlmod
-# labels never landed in state.target_fileset.
+# maps BES-emitted labels (including bzlmod canonical forms) to the
+# apparent labels registered by the caller.
 # ---------------------------------------------------------------------------
 
-def _make_fileset_event(set_id, file_path):
-    """Minimal named_set_of_files BES event."""
+def _make_fileset_event(set_id, file_paths):
+    """Minimal named_set_of_files BES event. file_paths is a list of absolute paths."""
     return struct(
         kind = "named_set_of_files",
         id = struct(id = set_id),
         payload = struct(
             files = [struct(
                 path_prefix = ["bazel-out/opt/bin"],
-                file = "file://" + file_path,
-            )],
+                file = "file://" + p,
+            ) for p in file_paths],
             file_sets = [],
         ),
     )
@@ -115,46 +113,148 @@ def _make_target_event(bes_label, set_id):
 def _test_bes_bzlmod_no_version(ctx):
     """@@module+//pkg:tgt in BES matches @module//pkg:tgt registered target."""
     r = runnable(None, ["@buildifier_prebuilt//buildifier"])
-    r.event(_make_fileset_event("s1", "/out/bin/external/buildifier_prebuilt/buildifier/buildifier"))
+    r.event(_make_fileset_event("s1", ["/out/bin/external/buildifier_prebuilt/buildifier/buildifier"]))
     r.event(_make_target_event("@@buildifier_prebuilt+//buildifier:buildifier", "s1"))
     got = r.determine_entrypoint("@buildifier_prebuilt//buildifier")
-    if got == None:
-        fail("bes bzlmod no-version: expected entrypoint, got None — @@module+ label not matched")
+    _eq("bzlmod no-version entrypoint", got.path, "/out/bin/external/buildifier_prebuilt/buildifier/buildifier")
 
 def _test_bes_bzlmod_with_version(ctx):
     """@@module+version//pkg:tgt in BES matches @module//pkg:tgt registered target."""
     r = runnable(None, ["@rules_python//python/bin:python"])
-    r.event(_make_fileset_event("s1", "/out/bin/external/rules_python+0.40.0/python/bin/python"))
+    r.event(_make_fileset_event("s1", ["/out/bin/external/rules_python+0.40.0/python/bin/python"]))
     r.event(_make_target_event("@@rules_python+0.40.0//python/bin:python", "s1"))
     got = r.determine_entrypoint("@rules_python//python/bin:python")
-    if got == None:
-        fail("bes bzlmod with-version: expected entrypoint, got None — @@module+version label not matched")
+    _eq("bzlmod with-version entrypoint", got.path, "/out/bin/external/rules_python+0.40.0/python/bin/python")
 
 def _test_bes_bzlmod_extension_repo(ctx):
     """@@module+ext+repo//pkg:tgt in BES matches @repo//pkg:tgt registered target."""
     r = runnable(None, ["@numpy//:pkg"])
-    r.event(_make_fileset_event("s1", "/out/bin/external/rules_python+pip+numpy/pkg"))
+    r.event(_make_fileset_event("s1", ["/out/bin/external/rules_python+pip+numpy/pkg"]))
     r.event(_make_target_event("@@rules_python+pip+numpy//:pkg", "s1"))
     got = r.determine_entrypoint("@numpy//:pkg")
-    if got == None:
-        fail("bes bzlmod extension-repo: expected entrypoint, got None — @@module+ext+repo label not matched")
+    _eq("bzlmod extension-repo entrypoint", got.path, "/out/bin/external/rules_python+pip+numpy/pkg")
 
 def _test_bes_local_target(ctx):
     """Local //pkg:tgt labels round-trip through BES matching unchanged."""
     r = runnable(None, ["//tools/format:format"])
-    r.event(_make_fileset_event("s1", "/out/bin/tools/format/format"))
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/format/format"]))
     r.event(_make_target_event("//tools/format:format", "s1"))
     got = r.determine_entrypoint("//tools/format:format")
-    if got == None:
-        fail("bes local target: expected entrypoint, got None")
-    _eq("local entrypoint path", got, "/out/bin/tools/format/format")
+    _eq("local entrypoint path", got.path, "/out/bin/tools/format/format")
 
 def _test_bes_unknown_target_returns_none(ctx):
     """A target that never appeared in BES returns None from determine_entrypoint."""
     r = runnable(None, ["//tools/format:format"])
-    got = r.determine_entrypoint("//tools/format:format")
-    if got != None:
-        fail("bes unknown target: expected None, got %r" % got)
+    if r.determine_entrypoint("//tools/format:format") != None:
+        fail("bes unknown target: expected None")
+
+# ---------------------------------------------------------------------------
+# runfiles_dir tests — BES-based runfiles manifest detection
+# ---------------------------------------------------------------------------
+
+def _test_has_runfiles_when_manifest_present(ctx):
+    """runfiles_dir is non-empty when BES output includes a .runfiles_manifest."""
+    r = runnable(None, ["//tools/format:format"])
+    r.event(_make_fileset_event("s1", [
+        "/out/bin/tools/format/format",
+        "/out/bin/tools/format/format.runfiles_manifest",
+    ]))
+    r.event(_make_target_event("//tools/format:format", "s1"))
+    ep = r.determine_entrypoint("//tools/format:format")
+    if ep == None:
+        fail("has-runfiles/manifest: expected entrypoint, got None")
+    if not ep.runfiles_dir:
+        fail("has-runfiles/manifest: expected non-None runfiles_dir (manifest in BES), got None")
+    _eq(
+        "has-runfiles/manifest: runfiles dir",
+        ep.runfiles_dir,
+        "/out/bin/tools/format/format.runfiles",
+    )
+
+def _test_no_runfiles_when_no_manifest(ctx):
+    """runfiles_dir is None when BES output has no .runfiles_manifest (raw binary)."""
+    r = runnable(None, ["@buildifier_prebuilt//buildifier"])
+    r.event(_make_fileset_event("s1", ["/out/bin/external/buildifier_prebuilt/buildifier/buildifier"]))
+    r.event(_make_target_event("@@buildifier_prebuilt+//buildifier:buildifier", "s1"))
+    ep = r.determine_entrypoint("@buildifier_prebuilt//buildifier")
+    if ep == None:
+        fail("no-runfiles/no-manifest: expected entrypoint, got None")
+    if ep.runfiles_dir != None:
+        fail("no-runfiles/no-manifest: expected runfiles_dir=None (no manifest in BES), got %r" % ep.runfiles_dir)
+
+def _test_sh_pass_with_manifest(ctx):
+    """Pass 2 (.sh) selects the entrypoint when no wrapper matches; manifest still named after target label."""
+    r = runnable(None, ["//tools/format:runner"])
+    r.event(_make_fileset_event("s1", [
+        "/out/bin/tools/format/runner.sh",
+        "/out/bin/tools/format/runner.runfiles_manifest",
+    ]))
+    r.event(_make_target_event("//tools/format:runner", "s1"))
+    ep = r.determine_entrypoint("//tools/format:runner")
+    if ep == None:
+        fail("sh-pass/manifest: expected entrypoint, got None")
+    if ep.path.rsplit("/", 1)[-1] != "runner.sh":
+        fail("sh-pass/manifest: expected runner.sh, got %r" % ep.path)
+    if not ep.runfiles_dir:
+        fail("sh-pass/manifest: expected non-None runfiles_dir (runner.runfiles_manifest in BES)")
+
+def _test_sh_pass_no_manifest(ctx):
+    """Pass 2 (.sh) selects the entrypoint; runfiles_dir is None when no manifest in BES."""
+    r = runnable(None, ["//tools/format:runner"])
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/format/runner.sh"]))
+    r.event(_make_target_event("//tools/format:runner", "s1"))
+    ep = r.determine_entrypoint("//tools/format:runner")
+    if ep == None:
+        fail("sh-pass/no-manifest: expected entrypoint, got None")
+    if ep.path.rsplit("/", 1)[-1] != "runner.sh":
+        fail("sh-pass/no-manifest: expected runner.sh, got %r" % ep.path)
+    if ep.runfiles_dir != None:
+        fail("sh-pass/no-manifest: expected runfiles_dir=None (no manifest in BES), got %r" % ep.runfiles_dir)
+
+def _test_fallback_skips_manifest_files(ctx):
+    """Pass 3 skips .runfiles_manifest entries and selects the first other file."""
+    r = runnable(None, ["//tools/format:runner"])
+    r.event(_make_fileset_event("s1", [
+        "/out/bin/tools/format/runner.runfiles_manifest",
+        "/out/bin/tools/format/format_impl",
+    ]))
+    r.event(_make_target_event("//tools/format:runner", "s1"))
+    ep = r.determine_entrypoint("//tools/format:runner")
+    if ep == None:
+        fail("fallback-skip: expected entrypoint, got None")
+    if ep.path.rsplit("/", 1)[-1] != "format_impl":
+        fail("fallback-skip: expected format_impl (manifest skipped), got %r" % ep.path)
+
+def _test_none_when_only_manifest_candidate(ctx):
+    """determine_entrypoint returns None when the only BES output is a .runfiles_manifest."""
+    r = runnable(None, ["//tools/format:runner"])
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/format/runner.runfiles_manifest"]))
+    r.event(_make_target_event("//tools/format:runner", "s1"))
+    if r.determine_entrypoint("//tools/format:runner") != None:
+        fail("only-manifest: expected None (no executable candidate)")
+
+def _test_runfiles_dir_derived_from_manifest_not_entrypoint(ctx):
+    """Runfiles dir is colocated with the manifest, not with the entrypoint.
+
+    Pass 3 may select an entrypoint in a subdirectory of the target's output dir
+    (e.g. a custom rule emitting out/bin/pkg/subdir/impl alongside the manifest at
+    out/bin/pkg/runner.runfiles_manifest). The runfiles dir must be a sibling of
+    the manifest, not of the entrypoint.
+    """
+    r = runnable(None, ["//tools/format:runner"])
+    r.event(_make_fileset_event("s1", [
+        "/out/bin/tools/format/runner.runfiles_manifest",
+        "/out/bin/tools/format/subdir/impl",
+    ]))
+    r.event(_make_target_event("//tools/format:runner", "s1"))
+    ep = r.determine_entrypoint("//tools/format:runner")
+    if ep == None:
+        fail("runfiles-dir-from-manifest: expected entrypoint, got None")
+    _eq(
+        "runfiles-dir-from-manifest: runfiles dir",
+        ep.runfiles_dir,
+        "/out/bin/tools/format/runner.runfiles",
+    )
 
 _UNIT_TESTS = [
     _test_local_label_with_colon,
@@ -174,6 +274,13 @@ _UNIT_TESTS = [
     _test_bes_bzlmod_extension_repo,
     _test_bes_local_target,
     _test_bes_unknown_target_returns_none,
+    _test_has_runfiles_when_manifest_present,
+    _test_no_runfiles_when_no_manifest,
+    _test_sh_pass_with_manifest,
+    _test_sh_pass_no_manifest,
+    _test_fallback_skips_manifest_files,
+    _test_none_when_only_manifest_candidate,
+    _test_runfiles_dir_derived_from_manifest_not_entrypoint,
 ]
 
 def _test_impl(ctx):

--- a/crates/axl-runtime/src/engine/std/fs.rs
+++ b/crates/axl-runtime/src/engine/std/fs.rs
@@ -79,11 +79,14 @@ impl<'v> values::Freeze for DirEntry<'v> {
 starlark_simple_value!(FrozenDirEntry);
 
 #[derive(Debug, Clone, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
-#[display("<fs.Metadata is_dir:{is_dir} is_file:{is_file} is_symlink:{is_symlink} size:{size}>")]
+#[display(
+    "<fs.Metadata is_dir:{is_dir} is_file:{is_file} is_symlink:{is_symlink} executable:{executable} size:{size}>"
+)]
 pub struct Metadata<'v> {
     is_dir: values::Value<'v>,
     is_file: values::Value<'v>,
     is_symlink: values::Value<'v>,
+    executable: values::Value<'v>,
     size: values::Value<'v>,
     modified: values::Value<'v>,
     accessed: values::Value<'v>,
@@ -98,6 +101,7 @@ impl<'v> values::StarlarkValue<'v> for Metadata<'v> {
             "is_dir" => Some(self.is_dir),
             "is_file" => Some(self.is_file),
             "is_symlink" => Some(self.is_symlink),
+            "executable" => Some(self.executable),
             "size" => Some(self.size),
             "modified" => Some(self.modified),
             "accessed" => Some(self.accessed),
@@ -111,6 +115,7 @@ impl<'v> values::StarlarkValue<'v> for Metadata<'v> {
             "is_dir".into(),
             "is_file".into(),
             "is_symlink".into(),
+            "executable".into(),
             "size".into(),
             "modified".into(),
             "accessed".into(),
@@ -132,6 +137,7 @@ pub struct FrozenMetadata {
     is_dir: values::FrozenValue,
     is_file: values::FrozenValue,
     is_symlink: values::FrozenValue,
+    executable: values::FrozenValue,
     size: values::FrozenValue,
     modified: values::FrozenValue,
     accessed: values::FrozenValue,
@@ -151,6 +157,7 @@ impl<'v> values::Freeze for Metadata<'v> {
             is_dir: freezer.freeze(self.is_dir)?,
             is_file: freezer.freeze(self.is_file)?,
             is_symlink: freezer.freeze(self.is_symlink)?,
+            executable: freezer.freeze(self.executable)?,
             size: freezer.freeze(self.size)?,
             modified: freezer.freeze(self.modified)?,
             accessed: freezer.freeze(self.accessed)?,
@@ -329,6 +336,7 @@ pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
     ///
     /// The modified, accessed, created fields of the Metadata result might not be available on all platforms, and will
     /// be set to None on platforms where they is not available.
+    /// The executable field reflects the Unix execute bit; it is always false on non-Unix platforms.
     fn metadata<'v>(
         #[allow(unused)] this: values::Value<'v>,
         #[starlark(require = pos)] path: values::StringValue,
@@ -474,6 +482,7 @@ pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
     ///
     /// The modified, accessed, created fields of the Metadata result might not be available on all platforms, and will
     /// be set to None on platforms where they is not available.
+    /// The executable field reflects the Unix execute bit; it is always false on non-Unix platforms.
     fn symlink_metadata<'v>(
         #[allow(unused)] this: values::Value<'v>,
         #[starlark(require = pos)] path: values::StringValue,
@@ -589,10 +598,18 @@ fn marshal_metadata<'v>(m: &fs::Metadata, heap: Heap<'v>) -> Metadata<'v> {
         Err(_) => heap.alloc(NoneType),
     };
     let permissions = m.permissions();
+    #[cfg(unix)]
+    let executable = {
+        use std::os::unix::fs::PermissionsExt;
+        heap.alloc(permissions.mode() & 0o111 != 0)
+    };
+    #[cfg(not(unix))]
+    let executable = heap.alloc(false);
     Metadata {
         is_dir: heap.alloc(file_type.is_dir()),
         is_file: heap.alloc(file_type.is_file()),
         is_symlink: heap.alloc(file_type.is_symlink()),
+        executable,
         size: heap.alloc(m.len()),
         modified,
         accessed,


### PR DESCRIPTION
Replaces the disk-based `ctx.std.fs.exists` runfiles check with BES-derived
detection, adds robust three-pass entrypoint selection, and adds
`fs.metadata().executable` to the AXL standard library.

**Three-pass entrypoint selection**

`_determine_entrypoint` previously returned `candidates[0]` as a fallback,
which could land on `.runfiles_manifest` (not executable) or `foo.sh` for a
target named `foo`. Three explicit passes replace it:

1. Exact match on `target_name` — the runnable wrapper all Bazel binary rules emit.
2. `target_name + ".sh"` — the sh_binary user-supplied source; selected when no wrapper matched.
3. First file with the executable bit set, skipping `.runfiles_manifest` — last-resort for custom rules with a non-standard output name.

**BES-based runfiles detection**

`_determine_entrypoint` returns `struct(path, runfiles_dir)` (or `None`).
`runfiles_dir` is derived from the `<target_name>.runfiles_manifest` entry in
the BES fileset — both the manifest name and the runfiles dir path are always
tied to the target label (a Bazel invariant). The runfiles dir is derived from
the manifest file's directory, not the entrypoint's (which may differ for custom
rules that emit the binary in a subdirectory). When no manifest appears,
`runfiles_dir` is `""`.

`_spawn` automatically selects a working directory: `runfiles_dir/<workspace>`
when a runfiles tree is present, or the workspace root for bare binaries (no
runfiles manifest). This means `@buildifier_prebuilt//buildifier`-style targets
work without any special-casing in callers. The runfiles env vars
(`RUNFILES_DIR`, `JAVA_RUNFILES`, `RUNFILES_MANIFEST_FILE`) are set in both
cases.

**`fs.Metadata.executable` (axl-runtime)**

`fs.metadata(path).executable` indicates whether any execute bit is set
(`mode & 0o111` on Unix; always `false` on non-Unix). Used by the third-pass
fallback to identify the executable when a target emits multiple outputs.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`aspect format` and `aspect delivery` now correctly find and run entrypoints for
any Bazel binary rule, including prebuilt binaries like
`@buildifier_prebuilt//buildifier` that have no runfiles tree. Runfiles
detection reads from BES output rather than the local filesystem, making it
reliable in remote-execution and sandboxed environments.

### Test plan

- `lib/runnable_test.axl` — 24 unit tests covering all three entrypoint-selection
  passes, runfiles detection with/without manifest, bzlmod label normalisation,
  and the full BES pipeline
