### PR TITLE
fix(runnable): apparent_label normalizes bzlmod canonical labels; consolidate delivery

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -26,7 +26,7 @@ load("@aspect//lib/github.axl", "detect_commit_sha", "github")
 load("@aspect//lib/path_glob.axl", "match_any", "match_path")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "dedup_and_attribute", "patch_download_cmd", "task_cli_path")
 load("@aspect//lib/result_text.axl", "severity_for_status")
-load("@aspect//lib/runnable.axl", "canonical_label", "runnable")
+load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
 load("@aspect//lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics", "sarif_to_review_comments")
 load("@aspect//lib/tips.axl", "tips")
 load("@aspect//lint.axl", "file_uri_to_path", "filter_all", "filter_changeset")
@@ -2690,16 +2690,12 @@ def test_repro_commands_lib(tc: int) -> int:
     return tc
 
 def test_process_bes_target_completed(ctx: TaskContext, tc: int) -> int:
-    """Regression test for the canonical_label-shadow bug in _process_bes.
+    """Regression test for the apparent_label-shadow bug in _process_bes.
 
-    When `_canonical` was renamed to `canonical_label` (matching the function
-    in lib/runnable.axl), the local `canonical_label = canonical_label(...)`
-    inside `_process_bes` started shadowing the module-level function for the
-    whole function scope, breaking the call with "referenced before assignment".
-
-    This test wires up `runnable()` and feeds a fake `target_completed` event
-    through `r.event(...)` — the same call path delivery and format use. Before
-    the fix this raised; after the fix it succeeds and populates target_fileset.
+    The local variable assigned inside `_process_bes` must not shadow the
+    module-level `apparent_label` function used on the right-hand side of the
+    same assignment. Before the fix, this raised "referenced before assignment";
+    after the fix it succeeds and populates target_fileset.
     """
     r = runnable(ctx, ["//foo:bar"])
     fake_event = struct(
@@ -2712,7 +2708,7 @@ def test_process_bes_target_completed(ctx: TaskContext, tc: int) -> int:
 
     # Pre-fix this call raised; post-fix it returns None and updates state.
     r.event(fake_event)
-    tc = test_case(tc, True, "_process_bes: target_completed does not raise (canonical_label shadow regression)")
+    tc = test_case(tc, True, "_process_bes: target_completed does not raise (apparent_label shadow regression)")
 
     # named_set_of_files event also goes through _process_bes — sanity check.
     fake_nsf = struct(
@@ -2785,8 +2781,8 @@ def test_json_try_decode(tc: int) -> int:
 
     return tc
 
-def test_canonical_label(tc: int) -> int:
-    """Coverage for runnable.canonical_label — Bazel label normalization."""
+def test_apparent_label(tc: int) -> int:
+    """Coverage for runnable.apparent_label — Bazel label normalization."""
     cases = [
         ("//foo", "//foo:foo", "//foo → //foo:foo"),
         ("//foo:bar", "//foo:bar", "explicit target unchanged"),
@@ -2797,10 +2793,13 @@ def test_canonical_label(tc: int) -> int:
         ("@repo//foo", "@repo//foo:foo", "repo-prefixed label"),
         ("@repo//foo:bar", "@repo//foo:bar", "repo-prefixed with target"),
         ("//foo:", "//foo:", "empty target name kept (caller error, not normalized)"),
+        ("@@buildifier_prebuilt+//buildifier:buildifier", "@buildifier_prebuilt//buildifier:buildifier", "bzlmod no-version"),
+        ("@@rules_python+0.40.0//python:python", "@rules_python//python:python", "bzlmod with-version"),
+        ("@@rules_python+pip+numpy//:pkg", "@numpy//:pkg", "bzlmod extension repo"),
     ]
     for (input, expected, desc) in cases:
-        got = canonical_label(input)
-        tc = test_case(tc, got == expected, "canonical_label: %s → %r (got %r)" % (desc, expected, got))
+        got = apparent_label(input)
+        tc = test_case(tc, got == expected, "apparent_label: %s → %r (got %r)" % (desc, expected, got))
     return tc
 
 def test_color_enabled(ctx: TaskContext, tc: int) -> int:
@@ -3046,7 +3045,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_sarif_lib(tc)
     tc = test_file_uri_to_path(tc)
     tc = test_json_try_decode(tc)
-    tc = test_canonical_label(tc)
+    tc = test_apparent_label(tc)
     tc = test_process_bes_target_completed(ctx, tc)
     tc = test_validate_role(tc)
     tc = test_lint_filters(tc)

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -14,6 +14,7 @@ load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
 load("@aspect//lib/lint_results_test.axl", "detect_lint_tool_tests", "lint_annotation_plan_tests", "lint_template_snapshot_tests", "linter_rows_tests")
 load("@aspect//lib/rate_limit_test.axl", "rate_limit_tests")
 load("@aspect//lib/repro_commands_test.axl", "repro_commands_tests")
+load("@aspect//lib/runnable_test.axl", "runnable_tests")
 load("@aspect//lib/runner_job_history_test.axl", "runner_job_history_tests")
 load("@aspect//lib/tar_test.axl", "tar_tests")
 load("@aspect//lib/tips_test.axl", "tips_tests")
@@ -127,6 +128,11 @@ def config(ctx: ConfigContext):
     # and unsupported host inputs.
     # Run with: aspect dev test-tar
     ctx.tasks.add(tar_tests)
+
+    # canonical_label normalization — local labels, external labels, and bzlmod
+    # canonical @@module+version//... → @module//... conversion.
+    # Run with: aspect dev test-runnable
+    ctx.tasks.add(runnable_tests)
 
     # Repro-command filtering — `explicit_flags` skips flags whose
     # values match the task's default (including alias-overridden

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -116,7 +116,7 @@ load("@aspect//lib/github.axl", "detect_commit_sha")
 load("@aspect//lib/health_check.axl", "HealthCheckTrait")
 load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "task_cli_path")
-load("@aspect//lib/runnable.axl", "runnable")
+load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
 load("@aspect//lib/tips.axl", "tips")
 load("@std//time.axl", "sleep_iter", "time")
@@ -181,12 +181,6 @@ def _print_captured_output(label, exit_code, stdout, stderr, ansi):
     if combined.strip():
         print(combined)
     print(_style(sep, _BOLD, ansi))
-
-def _canonical(label):
-    """Normalize a Bazel label to canonical form: //foo/bar -> //foo/bar:bar."""
-    if ":" not in label:
-        return label + ":" + label.split("/")[-1]
-    return label
 
 def _write_aspect_repo(ctx, repo_dir):
     ctx.std.fs.create_dir_all(repo_dir)
@@ -390,9 +384,9 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
         *targets
     ).wait()
 
-    # The grpc log always records the canonical label (//foo/bar:bar), so normalize
-    # the user-supplied targets before matching.
-    canonical_targets = {_canonical(t): t for t in targets}
+    # Normalize user-supplied targets to apparent form so they match however
+    # the gRPC log records the label (canonical @@module+// or apparent @module//).
+    apparent_targets = {apparent_label(t): t for t in targets}
 
     # output_shas: DeliveryHash action_digest per target (hit or miss).
     # misses_by_producer: non-OK entries for any other mnemonic, keyed by
@@ -404,19 +398,19 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
         if entry.method_name != "build.bazel.remote.execution.v2.ActionCache/GetActionResult":
             continue
         trace.log(entry)
-        canonical_label = entry.metadata.target_id
+        entry_label = apparent_label(entry.metadata.target_id)
         mnemonic = entry.metadata.action_mnemonic
         if mnemonic == _DELIVERY_HASH_MNEMONIC:
-            if canonical_label in canonical_targets:
-                output_shas[canonical_targets[canonical_label]] = entry.details.details.request.action_digest.hash
+            if entry_label in apparent_targets:
+                output_shas[apparent_targets[entry_label]] = entry.details.details.request.action_digest.hash
             continue
 
         # Non-DeliveryHash entry; record only the cache misses.
         if entry.status.code != 0:
-            existing = misses_by_producer.get(canonical_label, [])
+            existing = misses_by_producer.get(entry_label, [])
             if mnemonic not in existing:
                 existing.append(mnemonic)
-                misses_by_producer[canonical_label] = existing
+                misses_by_producer[entry_label] = existing
     ctx.std.fs.remove_file(log_path)
     _unresolved = len(targets) - len(output_shas)
     if _unresolved == 0:
@@ -979,7 +973,7 @@ def _delivery_impl(ctx):
             # (e.g. PyWriteBuildData with --stamp); otherwise give the
             # generic alias hint.
             pending_count += 1
-            mnemonics = non_hermetic_misses.get(_canonical(label), [])
+            mnemonics = non_hermetic_misses.get(apparent_label(label), [])
             if mnemonics:
                 msg = "no digest: non-cacheable upstream action(s) ({}); likely non-hermetic. Phase-2 raw log: {}".format(", ".join(mnemonics), _PHASE2_LOG_PATH.format(ctx.task.key))
             else:

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -1,6 +1,25 @@
 _DEFAULT_WORKSPACE_NAME = "_main"
 
 def canonical_label(label):
+    """Normalize a Bazel label to its user-visible apparent form.
+
+    Handles two cases:
+    - bzlmod canonical prefix → apparent form (BES emits canonical; users write apparent):
+        Module repo:    `@@module+version//pkg:tgt`     → `@module//pkg:tgt`
+        Extension repo: `@@module+ext+repo//pkg:tgt`    → `@repo//pkg:tgt`
+    - implicit target name: `@repo//pkg` → `@repo//pkg:pkg`
+    """
+    if label.startswith("@@"):
+        rest = label[2:]
+        idx = rest.find("//")
+        if idx >= 0:
+            canonical_repo = rest[:idx]
+            parts = canonical_repo.split("+")
+
+            # Module repos:    module+version     → apparent name is parts[0]
+            # Extension repos: module+ext+repo    → apparent name is parts[-1]
+            apparent_repo = parts[-1] if len(parts) >= 3 else parts[0]
+            label = "@" + apparent_repo + rest[idx:]
     if ":" not in label:
         return label + ":" + label.split("/")[-1]
     return label

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -1,13 +1,19 @@
 _DEFAULT_WORKSPACE_NAME = "_main"
 
-def canonical_label(label):
-    """Normalize a Bazel label to its user-visible apparent form.
+def apparent_label(label):
+    """Normalize any Bazel label form to apparent form with an explicit target name.
 
-    Handles two cases:
-    - bzlmod canonical prefix → apparent form (BES emits canonical; users write apparent):
-        Module repo:    `@@module+version//pkg:tgt`     → `@module//pkg:tgt`
-        Extension repo: `@@module+ext+repo//pkg:tgt`    → `@repo//pkg:tgt`
-    - implicit target name: `@repo//pkg` → `@repo//pkg:pkg`
+    Bazel surfaces two label forms depending on context:
+    - Apparent:   `@module//pkg:tgt`      — what users write; what BES emits for WORKSPACE repos
+    - Canonical:  `@@module+ver//pkg:tgt` — what BES emits for bzlmod repos
+
+    This function converts either input to apparent form and appends the
+    implicit target name when no `:` is present, yielding a stable key
+    suitable for matching user-supplied targets against BES event labels.
+
+    Canonical → apparent stripping rules:
+        Module repo:    `@@module+version//pkg:tgt`  → `@module//pkg:tgt`
+        Extension repo: `@@module+ext+repo//pkg:tgt` → `@repo//pkg:tgt`
     """
     if label.startswith("@@"):
         rest = label[2:]
@@ -28,11 +34,9 @@ def _process_bes(state: struct, event):
     if event.kind == "named_set_of_files":
         state.filesets[event.id.id] = event.payload
     elif event.kind == "target_completed":
-        # Bind to a fresh name; assigning to `canonical_label` here would shadow
-        # the module-level function (which gets called on the right-hand side)
-        # for the entire function body, breaking the call with
-        # "referenced before assignment".
-        canonical = canonical_label(event.id.label)
+        # Use a fresh local name to avoid shadowing the module-level `apparent_label`
+        # function on the right-hand side of the same assignment.
+        canonical = apparent_label(event.id.label)
         if canonical in state.targets:
             for og in event.payload.output_group:
                 if og.name == "default":
@@ -54,7 +58,7 @@ def _determine_entrypoint(state: struct, target: str) -> str | None:
     caller pairs this with `is_runnable` to distinguish "not in BES" from
     "in BES but no runfiles tree".
     """
-    target = canonical_label(target)
+    target = apparent_label(target)
     if target not in state.target_fileset:
         return None
 
@@ -119,7 +123,7 @@ def _spawn(ctx: TaskContext, state: struct, entrypoint: str, args: list[str], ca
 def runnable(ctx, targets: list[str]) -> struct:
     state = struct(
         ctx = ctx,
-        targets = {canonical_label(t): t for t in targets},
+        targets = {apparent_label(t): t for t in targets},
         filesets = {},
         target_fileset = {},
         # Single-element list so `_process_bes` can mutate it (struct fields are

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,31 +1,31 @@
-"""Unit tests for lib/runnable.axl: canonical_label and BES label matching."""
+"""Unit tests for lib/runnable.axl: apparent_label normalization and BES matching."""
 
-load("./runnable.axl", "canonical_label", "runnable")
+load("./runnable.axl", "apparent_label", "runnable")
 
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
 
 def _test_local_label_with_colon(ctx):
-    _eq("local label unchanged", canonical_label("//tools/format:format"), "//tools/format:format")
+    _eq("local label unchanged", apparent_label("//tools/format:format"), "//tools/format:format")
 
 def _test_local_label_without_colon(ctx):
-    _eq("appends :name", canonical_label("//tools/format"), "//tools/format:format")
+    _eq("appends :name", apparent_label("//tools/format"), "//tools/format:format")
 
 def _test_external_label_with_colon(ctx):
-    _eq("external label unchanged", canonical_label("@repo//pkg:target"), "@repo//pkg:target")
+    _eq("external label unchanged", apparent_label("@repo//pkg:target"), "@repo//pkg:target")
 
 def _test_external_label_without_colon(ctx):
-    _eq("external label gets :name", canonical_label("@repo//pkg"), "@repo//pkg:pkg")
+    _eq("external label gets :name", apparent_label("@repo//pkg"), "@repo//pkg:pkg")
 
 def _test_root_package_label(ctx):
-    _eq("root package alias", canonical_label("@repo//:alias"), "@repo//:alias")
+    _eq("root package alias", apparent_label("@repo//:alias"), "@repo//:alias")
 
 def _test_bzlmod_no_version(ctx):
     """@@module+//pkg:tgt — bzlmod canonical form with no version."""
     _eq(
         "bzlmod no version",
-        canonical_label("@@buildifier_prebuilt+//buildifier:buildifier"),
+        apparent_label("@@buildifier_prebuilt+//buildifier:buildifier"),
         "@buildifier_prebuilt//buildifier:buildifier",
     )
 
@@ -33,7 +33,7 @@ def _test_bzlmod_with_version(ctx):
     """@@module+version//pkg:tgt — bzlmod canonical form with version string."""
     _eq(
         "bzlmod with version",
-        canonical_label("@@rules_python+0.40.0//python:python"),
+        apparent_label("@@rules_python+0.40.0//python:python"),
         "@rules_python//python:python",
     )
 
@@ -41,7 +41,7 @@ def _test_bzlmod_without_colon(ctx):
     """@@module+//pkg — bzlmod canonical form that also needs :name appended."""
     _eq(
         "bzlmod without colon",
-        canonical_label("@@buildifier_prebuilt+//buildifier"),
+        apparent_label("@@buildifier_prebuilt+//buildifier"),
         "@buildifier_prebuilt//buildifier:buildifier",
     )
 
@@ -49,7 +49,7 @@ def _test_bzlmod_root_alias(ctx):
     """@@module+//:alias — bzlmod canonical alias in root package."""
     _eq(
         "bzlmod root alias",
-        canonical_label("@@buildifier_prebuilt+//:buildifier"),
+        apparent_label("@@buildifier_prebuilt+//:buildifier"),
         "@buildifier_prebuilt//:buildifier",
     )
 
@@ -57,7 +57,7 @@ def _test_bzlmod_extension_repo(ctx):
     """@@module+ext+repo//... — extension-generated repo; apparent name is the last segment."""
     _eq(
         "extension repo",
-        canonical_label("@@rules_python+pip+numpy//:pkg"),
+        apparent_label("@@rules_python+pip+numpy//:pkg"),
         "@numpy//:pkg",
     )
 
@@ -65,7 +65,7 @@ def _test_bzlmod_extension_repo_without_colon(ctx):
     """@@module+ext+repo//pkg — extension repo that also needs :name appended."""
     _eq(
         "extension repo without colon",
-        canonical_label("@@rules_python+pip+numpy//numpy"),
+        apparent_label("@@rules_python+pip+numpy//numpy"),
         "@numpy//numpy:numpy",
     )
 
@@ -73,7 +73,7 @@ def _test_bzlmod_4seg_extension_repo(ctx):
     """@@a+b+c+d//... — 4-segment canonical form; apparent name is still the last segment."""
     _eq(
         "4-segment extension repo",
-        canonical_label("@@rules_python+0.40.0+pip+numpy//numpy:pkg"),
+        apparent_label("@@rules_python+0.40.0+pip+numpy//numpy:pkg"),
         "@numpy//numpy:pkg",
     )
 
@@ -83,9 +83,9 @@ def _test_bzlmod_4seg_extension_repo(ctx):
 # These construct minimal mock BES events and verify that the full
 # runnable() → _process_bes → _determine_entrypoint pipeline correctly
 # maps bzlmod canonical labels emitted by the BES back to the apparent
-# labels registered by the caller.  A test here would FAIL on the old
-# canonical_label (before the @@-stripping fix) because target_completed
-# events would never land in state.target_fileset.
+# labels registered by the caller.  Each test here would FAIL before the
+# @@-stripping fix because target_completed events with canonical bzlmod
+# labels never landed in state.target_fileset.
 # ---------------------------------------------------------------------------
 
 def _make_fileset_event(set_id, file_path):
@@ -179,7 +179,7 @@ _UNIT_TESTS = [
 def _test_impl(ctx):
     for t in _UNIT_TESTS:
         t(ctx)
-    print("runnable.axl: OK (%d sections)" % len(_UNIT_TESTS))
+    print("runnable.axl: OK (%d tests)" % len(_UNIT_TESTS))
     return 0
 
 runnable_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,0 +1,97 @@
+"""Unit tests for `lib/runnable.axl::canonical_label`."""
+
+load("./runnable.axl", "canonical_label")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _test_local_label_with_colon(ctx):
+    _eq("local label unchanged", canonical_label("//tools/format:format"), "//tools/format:format")
+
+def _test_local_label_without_colon(ctx):
+    _eq("appends :name", canonical_label("//tools/format"), "//tools/format:format")
+
+def _test_external_label_with_colon(ctx):
+    _eq("external label unchanged", canonical_label("@repo//pkg:target"), "@repo//pkg:target")
+
+def _test_external_label_without_colon(ctx):
+    _eq("external label gets :name", canonical_label("@repo//pkg"), "@repo//pkg:pkg")
+
+def _test_root_package_label(ctx):
+    _eq("root package alias", canonical_label("@repo//:alias"), "@repo//:alias")
+
+def _test_bzlmod_no_version(ctx):
+    """@@module+//pkg:tgt — bzlmod canonical form with no version."""
+    _eq(
+        "bzlmod no version",
+        canonical_label("@@buildifier_prebuilt+//buildifier:buildifier"),
+        "@buildifier_prebuilt//buildifier:buildifier",
+    )
+
+def _test_bzlmod_with_version(ctx):
+    """@@module+version//pkg:tgt — bzlmod canonical form with version string."""
+    _eq(
+        "bzlmod with version",
+        canonical_label("@@rules_python+0.40.0//python:python"),
+        "@rules_python//python:python",
+    )
+
+def _test_bzlmod_without_colon(ctx):
+    """@@module+//pkg — bzlmod canonical form that also needs :name appended."""
+    _eq(
+        "bzlmod without colon",
+        canonical_label("@@buildifier_prebuilt+//buildifier"),
+        "@buildifier_prebuilt//buildifier:buildifier",
+    )
+
+def _test_bzlmod_root_alias(ctx):
+    """@@module+//:alias — bzlmod canonical alias in root package."""
+    _eq(
+        "bzlmod root alias",
+        canonical_label("@@buildifier_prebuilt+//:buildifier"),
+        "@buildifier_prebuilt//:buildifier",
+    )
+
+def _test_bzlmod_extension_repo(ctx):
+    """@@module+ext+repo//... — extension-generated repo; apparent name is the last segment."""
+    _eq(
+        "extension repo",
+        canonical_label("@@rules_python+pip+numpy//:pkg"),
+        "@numpy//:pkg",
+    )
+
+def _test_bzlmod_extension_repo_without_colon(ctx):
+    """@@module+ext+repo//pkg — extension repo that also needs :name appended."""
+    _eq(
+        "extension repo without colon",
+        canonical_label("@@rules_python+pip+numpy//numpy"),
+        "@numpy//numpy:numpy",
+    )
+
+_UNIT_TESTS = [
+    _test_local_label_with_colon,
+    _test_local_label_without_colon,
+    _test_external_label_with_colon,
+    _test_external_label_without_colon,
+    _test_root_package_label,
+    _test_bzlmod_no_version,
+    _test_bzlmod_with_version,
+    _test_bzlmod_without_colon,
+    _test_bzlmod_root_alias,
+    _test_bzlmod_extension_repo,
+    _test_bzlmod_extension_repo_without_colon,
+]
+
+def _test_impl(ctx):
+    for t in _UNIT_TESTS:
+        t(ctx)
+    print("runnable.axl: OK (%d sections)" % len(_UNIT_TESTS))
+    return 0
+
+runnable_tests = task(
+    name = "test-runnable",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,6 +1,6 @@
-"""Unit tests for `lib/runnable.axl::canonical_label`."""
+"""Unit tests for lib/runnable.axl: canonical_label and BES label matching."""
 
-load("./runnable.axl", "canonical_label")
+load("./runnable.axl", "canonical_label", "runnable")
 
 def _eq(label, got, want):
     if got != want:
@@ -69,6 +69,93 @@ def _test_bzlmod_extension_repo_without_colon(ctx):
         "@numpy//numpy:numpy",
     )
 
+def _test_bzlmod_4seg_extension_repo(ctx):
+    """@@a+b+c+d//... — 4-segment canonical form; apparent name is still the last segment."""
+    _eq(
+        "4-segment extension repo",
+        canonical_label("@@rules_python+0.40.0+pip+numpy//numpy:pkg"),
+        "@numpy//numpy:pkg",
+    )
+
+# ---------------------------------------------------------------------------
+# BES matching integration tests
+#
+# These construct minimal mock BES events and verify that the full
+# runnable() → _process_bes → _determine_entrypoint pipeline correctly
+# maps bzlmod canonical labels emitted by the BES back to the apparent
+# labels registered by the caller.  A test here would FAIL on the old
+# canonical_label (before the @@-stripping fix) because target_completed
+# events would never land in state.target_fileset.
+# ---------------------------------------------------------------------------
+
+def _make_fileset_event(set_id, file_path):
+    """Minimal named_set_of_files BES event."""
+    return struct(
+        kind = "named_set_of_files",
+        id = struct(id = set_id),
+        payload = struct(
+            files = [struct(
+                path_prefix = ["bazel-out/opt/bin"],
+                file = "file://" + file_path,
+            )],
+            file_sets = [],
+        ),
+    )
+
+def _make_target_event(bes_label, set_id):
+    """Minimal target_completed BES event."""
+    return struct(
+        kind = "target_completed",
+        id = struct(label = bes_label),
+        payload = struct(
+            output_group = [struct(name = "default", file_sets = [struct(id = set_id)])],
+        ),
+    )
+
+def _test_bes_bzlmod_no_version(ctx):
+    """@@module+//pkg:tgt in BES matches @module//pkg:tgt registered target."""
+    r = runnable(None, ["@buildifier_prebuilt//buildifier"])
+    r.event(_make_fileset_event("s1", "/out/bin/external/buildifier_prebuilt/buildifier/buildifier"))
+    r.event(_make_target_event("@@buildifier_prebuilt+//buildifier:buildifier", "s1"))
+    got = r.determine_entrypoint("@buildifier_prebuilt//buildifier")
+    if got == None:
+        fail("bes bzlmod no-version: expected entrypoint, got None — @@module+ label not matched")
+
+def _test_bes_bzlmod_with_version(ctx):
+    """@@module+version//pkg:tgt in BES matches @module//pkg:tgt registered target."""
+    r = runnable(None, ["@rules_python//python/bin:python"])
+    r.event(_make_fileset_event("s1", "/out/bin/external/rules_python+0.40.0/python/bin/python"))
+    r.event(_make_target_event("@@rules_python+0.40.0//python/bin:python", "s1"))
+    got = r.determine_entrypoint("@rules_python//python/bin:python")
+    if got == None:
+        fail("bes bzlmod with-version: expected entrypoint, got None — @@module+version label not matched")
+
+def _test_bes_bzlmod_extension_repo(ctx):
+    """@@module+ext+repo//pkg:tgt in BES matches @repo//pkg:tgt registered target."""
+    r = runnable(None, ["@numpy//:pkg"])
+    r.event(_make_fileset_event("s1", "/out/bin/external/rules_python+pip+numpy/pkg"))
+    r.event(_make_target_event("@@rules_python+pip+numpy//:pkg", "s1"))
+    got = r.determine_entrypoint("@numpy//:pkg")
+    if got == None:
+        fail("bes bzlmod extension-repo: expected entrypoint, got None — @@module+ext+repo label not matched")
+
+def _test_bes_local_target(ctx):
+    """Local //pkg:tgt labels round-trip through BES matching unchanged."""
+    r = runnable(None, ["//tools/format:format"])
+    r.event(_make_fileset_event("s1", "/out/bin/tools/format/format"))
+    r.event(_make_target_event("//tools/format:format", "s1"))
+    got = r.determine_entrypoint("//tools/format:format")
+    if got == None:
+        fail("bes local target: expected entrypoint, got None")
+    _eq("local entrypoint path", got, "/out/bin/tools/format/format")
+
+def _test_bes_unknown_target_returns_none(ctx):
+    """A target that never appeared in BES returns None from determine_entrypoint."""
+    r = runnable(None, ["//tools/format:format"])
+    got = r.determine_entrypoint("//tools/format:format")
+    if got != None:
+        fail("bes unknown target: expected None, got %r" % got)
+
 _UNIT_TESTS = [
     _test_local_label_with_colon,
     _test_local_label_without_colon,
@@ -81,6 +168,12 @@ _UNIT_TESTS = [
     _test_bzlmod_root_alias,
     _test_bzlmod_extension_repo,
     _test_bzlmod_extension_repo_without_colon,
+    _test_bzlmod_4seg_extension_repo,
+    _test_bes_bzlmod_no_version,
+    _test_bes_bzlmod_with_version,
+    _test_bes_bzlmod_extension_repo,
+    _test_bes_local_target,
+    _test_bes_unknown_target_returns_none,
 ]
 
 def _test_impl(ctx):


### PR DESCRIPTION
Under bzlmod, Bazel's BES emits target labels in canonical form (`@@module+version//pkg:tgt` for module repos, `@@module+ext+repo//pkg:tgt` for extension-generated repos), while users and config files write apparent form (`@module//pkg:tgt`). The mismatch caused `_determine_entrypoint` to silently return `None` for any external bzlmod target used as a formatter, gazelle target, or deliverable — the `target_completed` BES event never matched the registered target, so `state.target_fileset` was never populated.

**`runnable.axl`** — introduces `apparent_label(label)`, which accepts either form and normalizes to apparent form with an explicit target name. The previous `canonical_label` was a misnomer (it returned apparent form, not Bazel's true canonical form).

Stripping rules:
- Module repos: `@@module+version//pkg:tgt` → `@module//pkg:tgt`
- Extension repos: `@@module+ext+repo//pkg:tgt` → `@repo//pkg:tgt` (apparent name is the last `+`-segment)
- Apparent/local labels pass through unchanged; implicit `:name` is appended when absent

**`delivery.axl`** — replaces the local `_canonical` helper (which only handled implicit target names) with `apparent_label`. The gRPC log's `target_id` is now also normalized through `apparent_label` before matching, so external bzlmod delivery targets resolve correctly regardless of whether the user supplied apparent or canonical form.

**`runnable_test.axl`** — 17 tests covering all label forms:
- `apparent_label` unit tests: local, external, root-package, bzlmod no-version, bzlmod with-version, bzlmod without colon, bzlmod root alias, extension repo, extension repo without colon, 4-segment extension repo
- BES integration tests using `runnable()` + mock events: each would fail before this fix because `target_completed` events with canonical `@@` labels never landed in `state.target_fileset`

---

### Changes are visible to end-users: no

### Test plan

- New test cases added: `lib/runnable_test.axl` (run with `aspect dev test-runnable`)
- Manual testing: `aspect buildifier` resolves `@buildifier_prebuilt//buildifier` correctly under bzlmod
