### PR TITLE
feat(format): add --include-pattern; rename --ignore-pattern to --exclude-pattern

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/README.md
+++ b/crates/aspect-cli/src/builtins/aspect/README.md
@@ -106,20 +106,21 @@ Renderer: `lint_results`. Body has by-severity counts, by-tool counts, per-sever
 
 ## format
 
-[`format.axl`](format.axl) · build a `format_multirun` target, run it on the changed file list, diff before-and-after.
+[`format.axl`](format.axl) · build a formatter target, run it on the changed file list, diff before-and-after.
 
 ```sh
-aspect format                                                    # changed scope (default)
-aspect format --scope=all                                        # whole tree
-aspect format --formatter-target=//tools/format:buildifier.      # buildifier-only
-aspect format --ignore-pattern='**/*.bzl'                        # exclude Starlark
-aspect format --on-change=warn                                   # warn but don't fail CI
-aspect format --upload-format-diff                               # upload `format.patch`
+aspect format                                                       # changed scope (default)
+aspect format --scope=all                                           # whole tree
+aspect format --formatter-target=//tools/format:buildifier          # buildifier-only
+aspect format --include-pattern='**/*.bzl'                          # only bzl files
+aspect format --exclude-pattern='**/*.md'                           # exclude all markdown files
+aspect format --on-change=warn                                      # warn but don't fail CI
+aspect format --upload-format-diff                                  # upload `format.patch`
 ```
 
-Verdict comes from a `git diff` between the pre-format and post-format working tree (after applying `--ignore-pattern`). Non-empty diff + `--on-change=fail` → exit 1; `--on-change=warn` → exit 0 with status=warning; `--on-change=silent` → exit 0 with status=passed. The formatter binary's own non-zero exit fails the task regardless of `--on-change`.
+Verdict comes from a `git diff` between the pre-format and post-format working tree (after applying `--include-pattern` and `--exclude-pattern`). Non-empty diff + `--on-change=fail` → exit 1; `--on-change=warn` → exit 0 with status=warning; `--on-change=silent` → exit 0 with status=passed. The formatter binary's own non-zero exit fails the task regardless of `--on-change`.
 
-Renderer: `format_results`. The check-run / annotation summary shows the formatter-target label in the title (e.g. `Format //tools/format:buildifier · 3 files need formatting`); the body lists affected files with a `aspect format` repro command and (when `--upload-format-diff`) a download link to the captured patch.
+Renderer: `format_results`. The check-run / annotation summary shows the formatter-target label in the title (e.g. `Format //tools/format · 3 files need formatting`); the body lists affected files with a `aspect format` repro command and (when `--upload-format-diff`) a download link to the captured patch.
 
 ---
 

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -740,9 +740,9 @@ format = task(
         ),
         # Positional file list. When non-empty, the formatter receives
         # these files directly — change-detection is skipped, and
-        # `--scope`, `--base-ref`, `--merge-base`, and
-        # `--exclude-pattern` are silently ignored. This is the "format
-        # these specific files" mode reviewers use locally after
+        # `--scope`, `--base-ref`, `--merge-base`, `--include-pattern`,
+        # and `--exclude-pattern` are silently ignored. This is the
+        # "format these specific files" mode reviewers use locally after
         # picking up a fix command from CI:
         #
         #   aspect format -- crates/aspect-cli/src/foo.axl crates/aspect-cli/src/bar.axl
@@ -753,7 +753,7 @@ format = task(
         # format -- file1 file2`).
         "files": args.positional(
             default = [],
-            description = "Optional positional list of files to format. When non-empty the formatter runs on exactly these paths and the change-detection flags (--scope / --base-ref / --merge-base / --exclude-pattern) are ignored. When empty, the task auto-discovers files via the configured --scope.",
+            description = "Optional positional list of files to format. When non-empty the formatter runs on exactly these paths and the change-detection flags (--scope / --base-ref / --merge-base / --include-pattern / --exclude-pattern) are ignored. When empty, the task auto-discovers files via the configured --scope.",
             maximum = 4096,
             minimum = 0,
         ),

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -198,8 +198,8 @@ def _append_fix_commands(ctx, data):
     task_path = task_cli_path(ctx.task)
 
     # Positional file list bypasses --scope / --base-ref / --merge-base /
-    # --exclude-pattern, so the explicit-file fix command omits them
-    # and only preserves the user-explicit `--formatter-target`.
+    # --include-pattern / --exclude-pattern, so the explicit-file fix command
+    # omits them and only preserves the user-explicit `--formatter-target`.
     positional_flags = ([("--on-change", "silent")] +
                         explicit_flags(ctx, [("formatter_target", "--formatter-target")]))
     if len(affected) <= _FIX_FILES_LIMIT:

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -158,7 +158,8 @@ _FIX_FILES_LIMIT = 20
 _DETECTION_PAIRS = [
     ("scope", "--scope"),
     ("formatter_target", "--formatter-target"),
-    ("ignore_patterns", "--ignore-pattern"),
+    ("exclude_patterns", "--exclude-pattern"),
+    ("include_patterns", "--include-pattern"),
     ("merge_base", "--merge-base"),
 ]
 
@@ -197,7 +198,7 @@ def _append_fix_commands(ctx, data):
     task_path = task_cli_path(ctx.task)
 
     # Positional file list bypasses --scope / --base-ref / --merge-base /
-    # --ignore-pattern, so the explicit-file fix command omits them
+    # --exclude-pattern, so the explicit-file fix command omits them
     # and only preserves the user-explicit `--formatter-target`.
     positional_flags = ([("--on-change", "silent")] +
                         explicit_flags(ctx, [("formatter_target", "--formatter-target")]))
@@ -433,11 +434,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         _emit_final(ctx, lifecycle, data, 1)
         fail("Failed to determine the formatter entrypoint.")
 
-    ignore_patterns = list(ctx.args.ignore_patterns)
+    exclude_patterns = list(ctx.args.exclude_patterns)
+    include_patterns = list(ctx.args.include_patterns)
 
     # Positional files explicitly provided → bypass change-detection
-    # entirely. `--scope`, `--base-ref`, `--merge-base`, and
-    # `--ignore-pattern` are silently ignored here; the formatter
+    # entirely. `--scope`, `--base-ref`, `--merge-base`, `--exclude-pattern`,
+    # and `--include-pattern` are silently ignored here; the formatter
     # receives exactly the listed paths. This is the typical local
     # repro path: the user copies the fix command from CI which
     # carries a positional file list, runs it as-is.
@@ -490,11 +492,17 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             format_args = []
         else:
             changed_files = detect_result["files"]
-            if ignore_patterns:
-                kept = [f for f in changed_files if not match_any(ignore_patterns, f)]
-                ignored_count = len(changed_files) - len(kept)
-                if ignored_count > 0:
-                    info(ctx.std, "Filtered %d file(s) via --ignore-pattern." % ignored_count)
+            if include_patterns:
+                kept = [f for f in changed_files if match_any(include_patterns, f)]
+                skipped_count = len(changed_files) - len(kept)
+                if skipped_count > 0:
+                    info(ctx.std, "Skipped %d file(s) not matching --include-pattern." % skipped_count)
+                changed_files = kept
+            if exclude_patterns:
+                kept = [f for f in changed_files if not match_any(exclude_patterns, f)]
+                n_excluded = len(changed_files) - len(kept)
+                if n_excluded > 0:
+                    info(ctx.std, "Filtered %d file(s) via --exclude-pattern." % n_excluded)
                 changed_files = kept
             if not changed_files:
                 info(ctx.std, "No files to format")
@@ -504,7 +512,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             # Surface the input file count so the Configuration row can show
             # `Scope: changed — N file(s)` (analogous to lint's
             # "Strategy: hold-the-line — filtered to N changed files"). This
-            # is the post-ignore-pattern set the formatter actually saw.
+            # is the post-filter set the formatter actually sees.
             data["changed_files_count"] = len(changed_files)
             format_args = changed_files
 
@@ -600,27 +608,26 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         print("No files%s were modified." % scope_text)
         return _emit_final(ctx, lifecycle, data, 0)
 
-    # List the affected file set, then filter through --ignore-pattern.
-    # Ignore patterns hide files from BOTH the user-facing affected list
-    # and the failure decision below. They don't undo the formatter's
-    # changes — those still sit in the working tree — but they prevent
-    # files in (e.g.) nested Bazel workspaces or vendored directories
+    # List the affected file set, then filter through --include-pattern and
+    # --exclude-pattern. Both hide files from the user-facing affected list
+    # and the failure decision below. They don't undo the formatter's changes —
+    # those still sit in the working tree — but they prevent unexpected files
     # from failing this task.
     name_out, _, _ = _git_capture(ctx, "diff", "--name-only", pre_snap if pre_snap else "HEAD")
-    affected_all = [f for f in name_out.strip().split("\n") if f]
-    if ignore_patterns:
-        affected = [f for f in affected_all if not match_any(ignore_patterns, f)]
-        ignored_count = len(affected_all) - len(affected)
-    else:
-        affected = affected_all
-        ignored_count = 0
+    affected_raw = [f for f in name_out.strip().split("\n") if f]
+    affected = affected_raw
+    if include_patterns and not explicit_files:
+        affected = [f for f in affected if match_any(include_patterns, f)]
+    if exclude_patterns:
+        affected = [f for f in affected if not match_any(exclude_patterns, f)]
+    filtered_count = len(affected_raw) - len(affected)
 
     if not affected:
-        # All formatter changes are in ignored paths — task is OK from the
-        # user's perspective. Note any working-tree changes the formatter
-        # made so they aren't surprising downstream.
-        if ignored_count > 0:
-            info(ctx.std, "Formatter modified %d file(s), all matching --ignore-pattern; treating as OK." % ignored_count)
+        # All formatter changes are hidden by pattern filters — task is OK
+        # from the user's perspective. Note the working-tree changes so they
+        # aren't surprising downstream.
+        if filtered_count > 0:
+            info(ctx.std, "Formatter modified %d file(s), all filtered by pattern rules; treating as OK." % filtered_count)
         return _emit_final(ctx, lifecycle, data, 0)
 
     n = len(affected)
@@ -636,26 +643,25 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         print("%d files%s were modified:" % (n, scope_qual))
     for f in affected:
         print("  - %s" % f)
-    if ignored_count > 0:
-        print("(also modified %d file(s) matching --ignore-pattern; not counted toward failure)" % ignored_count)
+    if filtered_count > 0:
+        print("(also modified %d file(s) hidden by pattern filters; not counted toward failure)" % filtered_count)
 
-    # Populate data with the affected file set and ignore count for status checks.
+    # Populate data with the affected file set and filtered count for status checks.
     data["format"]["affected_files"] = affected
-    data["format"]["ignored_count"] = ignored_count
+    data["format"]["filtered_count"] = filtered_count
 
     # Optional: archive the diff as a CI artifact so reviewers can apply
     # it locally without re-running the formatter. Off by default.
     #
-    # Scope the uploaded patch to `affected` (the post-ignore file set)
-    # so it matches the failure-decision basis. In --scope=changed mode
-    # this is redundant — the formatter never saw ignored files, so
-    # `formatter_diff` is already scoped to un-ignored paths. In
-    # --scope=all mode the formatter discovers files itself via
-    # `git ls-files` and rewrites ignored ones; without re-scoping, the
-    # uploaded patch would carry those changes even though they don't
-    # contribute to failure or appear in the user-facing affected list.
+    # Scope the uploaded patch to `affected` (the post-filter file set) so
+    # it matches the failure-decision basis. In --scope=changed mode this
+    # is redundant — the formatter never saw filtered files, so the diff is
+    # already scoped. In --scope=all mode the formatter discovers files
+    # itself via `git ls-files` and rewrites filtered ones; without re-
+    # scoping, the patch would carry changes that don't contribute to
+    # failure or appear in the user-facing affected list.
     if ctx.args.upload_format_diff:
-        if ignored_count > 0:
+        if filtered_count > 0:
             upload_diff, _, _ = _git_capture(
                 ctx,
                 "diff",
@@ -701,9 +707,13 @@ format = task(
             long = "on-change",
             description = "Verdict when the formatter modified files. 'silent' exits 0 (status=passed). 'warn' exits 0 with status=warning — a non-fatal yellow signal in CI surfaces. 'fail' exits 1 with status=failed — the CI gate. 'auto' (default) resolves to 'fail' on a recognized CI host and 'silent' off CI. The formatter binary's own non-zero exits surface as task failures regardless.",
         ),
-        "ignore_patterns": args.string_list(
-            long = "ignore-pattern",
-            description = "Glob pattern(s) of paths to exclude from formatting. Repeat the flag to pass multiple — e.g. `--ignore-pattern='vendor/**' --ignore-pattern='**/*.generated.go'`. Patterns match against repo-relative file paths. In `--scope=changed` (default), filtered files are dropped from the file list passed to the formatter. In `--scope=all`, the formatter discovers files itself, so ignored files may still be rewritten on disk; in either scope, ignored files are excluded from the post-format diff used to decide whether the task fails. Useful for nested Bazel workspaces (where running the parent's formatter would stomp the child's files) and for vendored / generated directories. Pattern syntax: `*` (one segment), `**` (zero or more segments), `?` (one char); case-sensitive.",
+        "include_patterns": args.string_list(
+            long = "include-pattern",
+            description = "Glob pattern(s) of paths to include in formatting. When set, only files matching at least one pattern are passed to the formatter; all others are silently skipped. Repeat the flag to pass multiple — e.g. `--include-pattern='**/*.bzl' --include-pattern='**/BUILD'`. Patterns match against repo-relative file paths (note: `*` matches within one directory level, so use `**/*.bzl` not `*.bzl` to match files at any depth). Useful when the formatter_target is a raw binary that handles only a single file type. In `--scope=changed` (default), non-matching files are dropped from the file list before invoking the formatter. Applied before --exclude-pattern. Pattern syntax: `*` (one segment), `**` (zero or more segments), `?` (one char); case-sensitive.",
+        ),
+        "exclude_patterns": args.string_list(
+            long = "exclude-pattern",
+            description = "Glob pattern(s) of paths to exclude from formatting. Repeat the flag to pass multiple — e.g. `--exclude-pattern='vendor/**' --exclude-pattern='**/*.generated.go'`. Patterns match against repo-relative file paths. In `--scope=changed` (default), filtered files are dropped from the file list passed to the formatter. In `--scope=all`, the formatter discovers files itself, so excluded files may still be rewritten on disk; in either scope, excluded files are omitted from the post-format diff used to decide whether the task fails. Useful for nested Bazel workspaces (where running the parent's formatter would stomp the child's files) and for vendored / generated directories. Pattern syntax: `*` (one segment), `**` (zero or more segments), `?` (one char); case-sensitive.",
         ),
         "upload_format_diff": args.boolean(
             default = True,
@@ -731,7 +741,7 @@ format = task(
         # Positional file list. When non-empty, the formatter receives
         # these files directly — change-detection is skipped, and
         # `--scope`, `--base-ref`, `--merge-base`, and
-        # `--ignore-pattern` are silently ignored. This is the "format
+        # `--exclude-pattern` are silently ignored. This is the "format
         # these specific files" mode reviewers use locally after
         # picking up a fix command from CI:
         #
@@ -743,7 +753,7 @@ format = task(
         # format -- file1 file2`).
         "files": args.positional(
             default = [],
-            description = "Optional positional list of files to format. When non-empty the formatter runs on exactly these paths and the change-detection flags (--scope / --base-ref / --merge-base / --ignore-pattern) are ignored. When empty, the task auto-discovers files via the configured --scope.",
+            description = "Optional positional list of files to format. When non-empty the formatter runs on exactly these paths and the change-detection flags (--scope / --base-ref / --merge-base / --exclude-pattern) are ignored. When empty, the task auto-discovers files via the configured --scope.",
             maximum = 4096,
             minimum = 0,
         ),

--- a/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
@@ -121,7 +121,7 @@ def color_enabled(std):
 #                       narrative because a specific branch fired.
 #                       "Skipping upload — not on a recognized CI
 #                       host", "Filtered N files via
-#                       --ignore-pattern", "Auto-resolved Z". What
+#                       --exclude-pattern", "Auto-resolved Z". What
 #                       the task *noticed*.
 #   warn(std, msg)    — yellow `WARNING:` — subsystem-level problem;
 #                       task continues. Artifact upload failures, GH

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
@@ -47,7 +47,7 @@ def init_data():
     r = bazel_init_data()
     r["format"] = {
         "affected_files": [],  # file paths that need formatting
-        "ignored_count": 0,  # files filtered by --ignore-pattern
+        "filtered_count": 0,  # files hidden by --include-pattern / --exclude-pattern
         "scope": "",  # "changed" | "all"
         "formatter_target": "",  # Bazel label of the formatter binary
         # Resolved `--on-change` policy: "silent" | "warn" | "fail".
@@ -206,8 +206,8 @@ The formatter rewrote {{ total }} {{ noun }} in your working tree. Review and co
 {% if has_overflow %}
 _… {{ overflow }} more file(s) not shown._
 {% endif %}
-{% if has_ignored %}
-_({{ ignored_count }} file(s) matching `--ignore-pattern` were excluded from this check.)_
+{% if has_filtered %}
+_({{ filtered_count }} file(s) hidden by pattern filters; not counted toward failure.)_
 {% endif %}
 {% if warn_signal %}
 > ⚠️ `--on-change=warn` is set — this task returned 0 with a warning signal despite formatting being required.
@@ -240,7 +240,7 @@ def _config_items(data):
         formatter touches and the changed-files preamble in the body
         only signals the changed-scope path, so make the actual scope
         explicit at-a-glance). When `scope == "changed"` and the task
-        recorded the post-ignore-pattern file count, append it as
+        recorded the post-filter file count, append it as
         " — filtered to N changed files" — analogous to lint's
         "Strategy: hold-the-line — filtered to N changed files".
         ("changed files" is OK here because the "filtered to" prefix
@@ -269,7 +269,7 @@ def _build_details_data(data, status):
     total = len(affected)
     shown = affected[:_FILES_LIMIT]
     overflow = total - len(shown)
-    ignored = data["format"].get("ignored_count", 0) or 0
+    filtered = data["format"].get("filtered_count", 0) or 0
 
     return {
         # Display strings (Jinja2 treats these as truthy even when "0" — use
@@ -280,7 +280,7 @@ def _build_details_data(data, status):
         "verb_suffix": "s" if total == 1 else "",
         "file_list": "\n".join(shown),
         "overflow": str(overflow) if overflow > 0 else "",
-        "ignored_count": str(ignored),
+        "filtered_count": str(filtered),
         # Boolean flags for Jinja2 conditions. `total == 0` guards
         # ensure the files-list `else` branch wins whenever the
         # formatter produced affected_files, even on non-passing
@@ -305,7 +305,7 @@ def _build_details_data(data, status):
         # falls back to the no-count phrasing.
         "checked_count": str(data.get("changed_files_count", 0) or "") if (data.get("changed_files_count", 0) or 0) > 0 else "",
         "has_overflow": overflow > 0,
-        "has_ignored": ignored > 0,
+        "has_filtered": filtered > 0,
         "warn_signal": data["format"].get("on_change_resolved") == "warn",
         "formatter_error": bool(data["format"].get("formatter_error")),
         "formatter_error_code": str(data["format"].get("formatter_error_code", 0) or 0),

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
@@ -77,7 +77,7 @@ def _make_clean():
 def _make_files_need_format():
     r = _make_base()
 
-    # changed_files_count is the input set the formatter saw (post-ignore-pattern);
+    # changed_files_count is the input set the formatter saw (post-exclude-pattern);
     # affected_files is the post-format diff (what the formatter rewrote).
     # Both populated to exercise the Scope-with-count Configuration row.
     r["changed_files_count"] = 42

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -61,17 +61,44 @@ def _test_preserves_input_pair_order(ctx):
         [("--scope", "all"), ("--formatter-target", "//x"), ("--merge-base", "abc")],
     )
 
-def _test_handles_list_valued_args(ctx):
-    """List-valued args round-trip without conversion — the rendered
-    command emits `--name=a --name=b` via `build_aspect_command`."""
+def _test_handles_exclude_pattern_list(ctx):
+    """--exclude-pattern list-valued args round-trip."""
     fake = struct(args = struct(
-        is_explicit = _explicit_in(["ignore_patterns"]),
-        ignore_patterns = ["*.txt", "vendor/*"],
+        is_explicit = _explicit_in(["exclude_patterns"]),
+        exclude_patterns = ["*.txt", "vendor/*"],
     ))
     _eq(
-        "list-valued args round-trip",
-        explicit_flags(fake, [("ignore_patterns", "--ignore-pattern")]),
-        [("--ignore-pattern", ["*.txt", "vendor/*"])],
+        "exclude_patterns round-trip",
+        explicit_flags(fake, [("exclude_patterns", "--exclude-pattern")]),
+        [("--exclude-pattern", ["*.txt", "vendor/*"])],
+    )
+
+def _test_handles_include_pattern_list(ctx):
+    """--include-pattern list-valued args round-trip."""
+    fake = struct(args = struct(
+        is_explicit = _explicit_in(["include_patterns"]),
+        include_patterns = ["**/*.bzl", "**/BUILD"],
+    ))
+    _eq(
+        "include_patterns round-trip",
+        explicit_flags(fake, [("include_patterns", "--include-pattern")]),
+        [("--include-pattern", ["**/*.bzl", "**/BUILD"])],
+    )
+
+def _test_include_and_exclude_patterns_independent(ctx):
+    """include_patterns and exclude_patterns are independent — only explicit ones appear."""
+    fake = struct(args = struct(
+        is_explicit = _explicit_in(["include_patterns"]),
+        include_patterns = ["**/*.bzl"],
+        exclude_patterns = ["vendor/**"],
+    ))
+    _eq(
+        "only include_patterns is explicit",
+        explicit_flags(fake, [
+            ("include_patterns", "--include-pattern"),
+            ("exclude_patterns", "--exclude-pattern"),
+        ]),
+        [("--include-pattern", ["**/*.bzl"])],
     )
 
 def _test_empty_pairs_list_returns_empty(ctx):
@@ -85,7 +112,9 @@ _UNIT_TESTS = [
     _test_returns_empty_when_no_explicit,
     _test_includes_only_explicit_pairs,
     _test_preserves_input_pair_order,
-    _test_handles_list_valued_args,
+    _test_handles_exclude_pattern_list,
+    _test_handles_include_pattern_list,
+    _test_include_and_exclude_patterns_independent,
     _test_empty_pairs_list_returns_empty,
 ]
 


### PR DESCRIPTION
Two additions to `aspect format` / `format.axl`:

**`--include-pattern`** — when set, only files matching at least one include pattern are passed to the formatter; all others are silently skipped. Repeatable, `**`-glob syntax (consistent with `--exclude-pattern`). Composable with `--exclude-pattern`. Applied before `--exclude-pattern`. Enables formatter aliases like `aspect buildifier` (PR #1141) to restrict themselves to specific file types without requiring users to pass patterns on every invocation.

**`--exclude-pattern`** (renamed from `--ignore-pattern`) — renames the existing flag for symmetry with `--include-pattern`. `--exclude-pattern` reads naturally as the opposite of `--include-pattern`; the previous name `--ignore-pattern` implied a different semantic. No behavioural change — patterns, matching logic, and scope semantics are unchanged.

Also updates README.md to document both flags and skips include/exclude-pattern filtering in positional-file mode (where `explicit_files` is set — patterns are irrelevant when the caller provides an exact file list).

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes — `--ignore-pattern` is renamed to `--exclude-pattern`; the old flag no longer exists. The API is documented as unstable and usage is minimal.
- Suggested release notes appear below: yes

`aspect format` gains `--include-pattern` (repeatable, `**`-glob syntax) to restrict formatting to specific file patterns. The existing `--ignore-pattern` flag is renamed to `--exclude-pattern` for symmetry.

### Test plan

- New test cases added (`repro_commands_test.axl` updated to cover `--exclude-pattern` round-trip)
- Manual testing: `aspect buildifier` with `include_patterns` set to Starlark file patterns formats only `.bzl`/`.axl`/`BUILD`/etc. files
