### PR TITLE
Bump aspect-cli to v2026.22.11

### DIFF
--- a/.aspect/version.axl
+++ b/.aspect/version.axl
@@ -1,5 +1,5 @@
 version(
-    "2026.22.3",
+    "2026.22.11",
     sources = [
         # Cargo build
         local("target/debug/aspect-cli"),


### PR DESCRIPTION
Bump aspect-cli to v2026.22.11 and update launcher version in CI.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing CI workflows (launcher version bump only)