### PR TITLE
Add root BUILD aliases for buildifier, format, and gazelle tasks

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,3 +26,18 @@ exports_files(
     ],
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "buildifier",
+    actual = "@buildifier_prebuilt//buildifier",
+)
+
+alias(
+    name = "format",
+    actual = "//tools/format",
+)
+
+alias(
+    name = "gazelle",
+    actual = "//tools/gazelle",
+)


### PR DESCRIPTION
Add convenience `//:buildifier`, `//:format`, and `//:gazelle` aliases in the root BUILD.bazel so developers can run `bazel run //:buildifier`, `bazel run //:format`, and `bazel run //:gazelle` directly.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing CI