### PR TITLE
Bump aspect-cli to v2026.22.13

### DIFF
--- a/.aspect/version.axl
+++ b/.aspect/version.axl
@@ -1,5 +1,5 @@
 version(
-    "2026.22.11",
+    "2026.22.13",
     sources = [
         # Cargo build
         local("target/debug/aspect-cli"),


### PR DESCRIPTION
Pins the Aspect CLI version to [v2026.22.13](https://github.com/aspect-build/aspect-cli/releases/tag/v2026.22.13).

---

### Changes are visible to end-users: no

### Test plan

- CI