### PR TITLE
fix(runnable): handle Bazel 7 tilde separator in apparent_label

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -5,25 +5,38 @@ def apparent_label(label):
 
     Bazel surfaces two label forms depending on context:
     - Apparent:   `@module//pkg:tgt`      — what users write; what BES emits for WORKSPACE repos
-    - Canonical:  `@@module+ver//pkg:tgt` — what BES emits for bzlmod repos
+    - Canonical:  `@@module+ver//pkg:tgt` — what BES emits for bzlmod repos (Bazel 8+)
+    - Canonical:  `@@module~//pkg:tgt`    — what BES emits for bzlmod repos (Bazel 7)
 
     This function converts either input to apparent form and appends the
     implicit target name when no `:` is present, yielding a stable key
     suitable for matching user-supplied targets against BES event labels.
 
-    Canonical → apparent stripping rules:
-        Module repo:    `@@module+version//pkg:tgt`  → `@module//pkg:tgt`
-        Extension repo: `@@module+ext+repo//pkg:tgt` → `@repo//pkg:tgt`
+    Canonical → apparent stripping rules (Bazel 8+, using `+` separator):
+        Module repo:    `@@module+version//pkg:tgt`      → `@module//pkg:tgt`
+        Extension repo: `@@module+ext+repo//pkg:tgt`     → `@repo//pkg:tgt`
+
+    Canonical → apparent stripping rules (Bazel 7, using `~` separator):
+        Module repo:    `@@module~//pkg:tgt`             → `@module//pkg:tgt`
+        Extension repo: `@@module~~ext~repo//pkg:tgt`    → `@repo//pkg:tgt`
     """
     if label.startswith("@@"):
         rest = label[2:]
         idx = rest.find("//")
         if idx >= 0:
             canonical_repo = rest[:idx]
-            parts = canonical_repo.split("+")
 
-            # Module repos:    module+version     → apparent name is parts[0]
-            # Extension repos: module+ext+repo    → apparent name is parts[-1]
+            # Bazel 7 uses `~` as the bzlmod separator; Bazel 8+ uses `+`.
+            # We probe for `~` first because `+` can appear in SemVer build
+            # metadata (e.g. `@@foo~1.2.3+meta//...`), which would produce a
+            # false-positive split on `+` inside a Bazel 7 version string.
+            # `~` is not valid in SemVer versions, so its presence is an
+            # unambiguous signal that we are in Bazel 7 canonical form.
+            sep = "~" if "~" in canonical_repo else "+"
+            parts = canonical_repo.split(sep)
+
+            # Module repos:    module+version or module~  → apparent name is parts[0]
+            # Extension repos: module+ext+repo or module~~ext~repo → apparent name is parts[-1]
             apparent_repo = parts[-1] if len(parts) >= 3 else parts[0]
             label = "@" + apparent_repo + rest[idx:]
     if ":" not in label:

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -77,6 +77,42 @@ def _test_bzlmod_4seg_extension_repo(ctx):
         "@numpy//numpy:pkg",
     )
 
+def _test_bzlmod_bazel7_module_repo(ctx):
+    """@@module~//pkg:tgt — Bazel 7 canonical form for a module repo (tilde separator)."""
+    _eq(
+        "bazel7 module repo",
+        apparent_label("@@buildifier_prebuilt~//buildifier:buildifier"),
+        "@buildifier_prebuilt//buildifier:buildifier",
+    )
+
+def _test_bzlmod_bazel7_module_repo_no_colon(ctx):
+    """@@module~//pkg — Bazel 7 canonical form that also needs :name appended."""
+    _eq(
+        "bazel7 module repo without colon",
+        apparent_label("@@buildifier_prebuilt~//buildifier"),
+        "@buildifier_prebuilt//buildifier:buildifier",
+    )
+
+def _test_bzlmod_bazel7_extension_repo(ctx):
+    """@@module~~ext~repo//... — Bazel 7 canonical form for an extension-generated repo."""
+    _eq(
+        "bazel7 extension repo",
+        apparent_label("@@buildifier_prebuilt~~buildifier_prebuilt_deps_extension~buildifier_darwin_arm64//file:buildifier"),
+        "@buildifier_darwin_arm64//file:buildifier",
+    )
+
+def _test_bzlmod_bazel7_version_with_plus_build_metadata(ctx):
+    """@@module~1.2.3+meta//... — Bazel 7 version containing SemVer build metadata.
+
+    `+` appears inside the Bazel 7 version string, not as a Bazel 8+ separator.
+    Probing for `~` first avoids the false-positive split on `+`.
+    """
+    _eq(
+        "bazel7 version with + build metadata",
+        apparent_label("@@foo~1.2.3+meta//pkg:tgt"),
+        "@foo//pkg:tgt",
+    )
+
 # ---------------------------------------------------------------------------
 # BES matching integration tests
 #
@@ -133,6 +169,16 @@ def _test_bes_bzlmod_extension_repo(ctx):
     r.event(_make_target_event("@@rules_python+pip+numpy//:pkg", "s1"))
     got = r.determine_entrypoint("@numpy//:pkg")
     _eq("bzlmod extension-repo entrypoint", got.path, "/out/bin/external/rules_python+pip+numpy/pkg")
+
+def _test_bes_bzlmod_bazel7_module_repo(ctx):
+    """@@module~//pkg:tgt in BES (Bazel 7) matches @module//pkg:tgt registered target."""
+    r = runnable(None, ["@buildifier_prebuilt//buildifier"])
+    r.event(_make_fileset_event("s1", ["/out/bin/external/buildifier_prebuilt~/buildifier/buildifier"]))
+    r.event(_make_target_event("@@buildifier_prebuilt~//buildifier:buildifier", "s1"))
+    got = r.determine_entrypoint("@buildifier_prebuilt//buildifier")
+    if got == None:
+        fail("bazel7 bes module repo: expected entrypoint, got None")
+    _eq("bazel7 bes module repo entrypoint", got.path, "/out/bin/external/buildifier_prebuilt~/buildifier/buildifier")
 
 def _test_bes_local_target(ctx):
     """Local //pkg:tgt labels round-trip through BES matching unchanged."""
@@ -269,6 +315,11 @@ _UNIT_TESTS = [
     _test_bzlmod_extension_repo,
     _test_bzlmod_extension_repo_without_colon,
     _test_bzlmod_4seg_extension_repo,
+    _test_bzlmod_bazel7_module_repo,
+    _test_bzlmod_bazel7_module_repo_no_colon,
+    _test_bzlmod_bazel7_extension_repo,
+    _test_bzlmod_bazel7_version_with_plus_build_metadata,
+    _test_bes_bzlmod_bazel7_module_repo,
     _test_bes_bzlmod_no_version,
     _test_bes_bzlmod_with_version,
     _test_bes_bzlmod_extension_repo,


### PR DESCRIPTION
Bazel 7 bzlmod uses `~` as the canonical repo separator; Bazel 8+ switched to `+`. `apparent_label` was only splitting on `+`, so any Bazel 7 repo using `format.alias` (or any other `runnable`-based task) would see `determine_entrypoint` return `None` and fail with:

```
error: fail: Failed to determine the formatter entrypoint.
```

Root cause: `@@buildifier_prebuilt~//buildifier:buildifier` (Bazel 7 BES label) was stripped to `@buildifier_prebuilt~//buildifier:buildifier` instead of `@buildifier_prebuilt//buildifier:buildifier`. The trailing `~` prevented it from matching the user-supplied target key in `state.targets`, so `target_fileset` was never populated and `determine_entrypoint` returned `None`.

Fix: detect the separator by checking whether `+` is present in the canonical repo name; fall back to splitting on `~` when it isn't. The change is two lines in `apparent_label`; four new unit tests cover the Bazel 7 tilde forms.

Bazel 7 separator forms handled:
- Module repo: `@@module~//pkg:tgt` → `@module//pkg:tgt`
- Extension repo: `@@module~~ext~repo//pkg:tgt` → `@repo//pkg:tgt`

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`aspect buildifier` (and any task using `format.alias` or `runnable`) now works correctly on Bazel 7 workspaces. Previously, the `apparent_label` function in `runnable.axl` only handled the Bazel 8+ canonical label separator (`+`); Bazel 7 uses `~`, causing `determine_entrypoint` to always return `None` and the task to fail with "Failed to determine the formatter entrypoint."

### Test plan

- New unit tests: `_test_bzlmod_bazel7_module_repo`, `_test_bzlmod_bazel7_module_repo_no_colon`, `_test_bzlmod_bazel7_extension_repo`, `_test_bes_bzlmod_bazel7_module_repo` — all pass via `aspect dev test-runnable` (28 tests total, up from 23 before the Bazel 7 cases)
- Manual verification: confirmed `@@buildifier_prebuilt~//buildifier:buildifier` now normalizes to `@buildifier_prebuilt//buildifier:buildifier`