### PR TITLE
Bump aspect-cli to v2026.22.15

### DIFF
--- a/.aspect/version.axl
+++ b/.aspect/version.axl
@@ -1,5 +1,5 @@
 version(
-    "2026.22.13",
+    "2026.22.15",
     sources = [
         # Cargo build
         local("target/debug/aspect-cli"),


### PR DESCRIPTION
Bump aspect-cli to v2026.22.15.

See https://github.com/aspect-build/aspect-cli/releases/tag/v2026.22.15

---

### Changes are visible to end-users: no

### Test plan

- CI