### PR TITLE
fix(builtins): fix spawn dirs, add subdirectory scoping to format, and repro-command cd prefixes

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -115,7 +115,7 @@ load("@aspect//lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("@aspect//lib/github.axl", "detect_commit_sha")
 load("@aspect//lib/health_check.axl", "HealthCheckTrait")
 load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
-load("@aspect//lib/repro_commands.axl", "build_aspect_command", "task_cli_path")
+load("@aspect//lib/repro_commands.axl", "build_aspect_command", "repro_prefix", "task_cli_path")
 load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
 load("@aspect//lib/tips.axl", "tips")
@@ -564,7 +564,8 @@ def _emit_final(ctx, lifecycle, dr, exit_code):
             if ctx.args.mode != "always":
                 desc = ("CI ran `--mode=%s`; `--mode=always` is the off-runner equivalent " +
                         "(selective change detection needs the Aspect Workflows delivery state backend).") % ctx.args.mode
-            dr["repro_commands"].append({"command": repro, "description": desc})
+            prefix = repro_prefix(ctx)
+            dr["repro_commands"].append({"command": prefix + repro, "description": desc})
 
     final_status = _pick_status(dr, had_failure = exit_code != 0, terminal = True)
     bookend = delivery_conclusion(final_status, dr)

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -26,7 +26,8 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_on_change", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
-load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "task_cli_path")
+load("./lib/path_normalize.axl", "normalize_files_for_cwd")
+load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
 load("./lib/runnable.axl", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
@@ -113,6 +114,20 @@ def _diff_against(ctx, base):
         fail(msg)
     return out
 
+def _normalize_files_for_formatter(ctx, files):
+    """Rebase git-root-relative `files` to CWD-relative paths.
+
+    Thin wrapper around `normalize_files_for_cwd` that reads CWD and git root
+    from ctx. CWD-relative paths work for the formatter because bare binaries
+    spawn in CWD, and sh_binary wrappers (e.g. format_multirun) cd to
+    BUILD_WORKING_DIRECTORY (= CWD) before invoking the underlying formatter.
+    """
+    return normalize_files_for_cwd(
+        ctx.std.env.current_dir(),
+        ctx.std.env.git_root_dir(),
+        files,
+    )
+
 def _pick_status(data, had_failure, terminal):
     return pick_task_status(data, "format", had_failure, terminal)
 
@@ -176,8 +191,9 @@ def _append_repro_command(ctx, data):
     flags = ([("--on-change", "fail")] +
              explicit_flags(ctx, _DETECTION_PAIRS) +
              _surfaced_base_ref_flag(ctx))
+    prefix = repro_prefix(ctx)
     data["repro_commands"].append({
-        "command": build_aspect_command(task_cli_path(ctx.task), flags, []),
+        "command": prefix + build_aspect_command(task_cli_path(ctx.task), flags, []),
         "description": "",
     })
 
@@ -194,6 +210,7 @@ def _append_fix_commands(ctx, data):
     if not affected:
         return
     task_path = task_cli_path(ctx.task)
+    prefix = repro_prefix(ctx)
 
     # Positional file list bypasses --scope / --base-ref / --merge-base /
     # --include-pattern / --exclude-pattern, so the explicit-file fix command
@@ -202,7 +219,7 @@ def _append_fix_commands(ctx, data):
                         explicit_flags(ctx, [("formatter_target", "--formatter-target")]))
     if len(affected) <= _FIX_FILES_LIMIT:
         data["fix_commands"].append({
-            "command": build_aspect_command(task_path, positional_flags, affected, max_chars = 4096),
+            "command": prefix + build_aspect_command(task_path, positional_flags, affected, max_chars = 4096),
             "description": "",
         })
         return
@@ -210,7 +227,7 @@ def _append_fix_commands(ctx, data):
     shown = affected[:_FIX_FILES_LIMIT]
     remaining = len(affected) - _FIX_FILES_LIMIT
     data["fix_commands"].append({
-        "command": build_aspect_command(task_path, positional_flags, shown, max_chars = 4096),
+        "command": prefix + build_aspect_command(task_path, positional_flags, shown, max_chars = 4096),
         "description": "First %d of %d affected files (plus %d other%s)" % (
             _FIX_FILES_LIMIT,
             len(affected),
@@ -223,7 +240,7 @@ def _append_fix_commands(ctx, data):
                  explicit_flags(ctx, _DETECTION_PAIRS) +
                  _surfaced_base_ref_flag(ctx))
     data["fix_commands"].append({
-        "command": build_aspect_command(task_path, detection, []),
+        "command": prefix + build_aspect_command(task_path, detection, []),
         "description": "Or re-discover and format all %d affected files" % len(affected),
     })
 
@@ -358,6 +375,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         ctx.args.formatter_target,
         build_events = build_events,
         flags = flags,
+        current_dir = ctx.std.env.aspect_root_dir(),
     )
 
     # `build.sink_invocation_id` is minted inside the runtime's `Build::spawn`
@@ -502,6 +520,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 if n_excluded > 0:
                     info(ctx.std, "Filtered %d file(s) via --exclude-pattern." % n_excluded)
                 changed_files = kept
+            changed_files = _normalize_files_for_formatter(ctx, changed_files)
             if not changed_files:
                 info(ctx.std, "No files to format")
                 data["format"]["no_files_to_format"] = True
@@ -617,6 +636,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if exclude_patterns:
         affected = [f for f in affected if not match_any(exclude_patterns, f)]
     filtered_count = len(affected_raw) - len(affected)
+    affected = _normalize_files_for_formatter(ctx, affected)
 
     if not affected:
         if filtered_count > 0:

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -195,7 +195,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_on_change", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
-load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
 load("./lib/runnable.axl", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
@@ -322,8 +322,9 @@ def _append_repro_command(ctx, data):
     CI ran, with the post-resolution effective dirs as positionals so
     the user reproduces CI's exact working set."""
     effective_dirs = (data.get("gazelle", {}) or {}).get("dirs", []) or []
+    prefix = repro_prefix(ctx)
     data["repro_commands"].append({
-        "command": build_aspect_command(
+        "command": prefix + build_aspect_command(
             task_cli_path(ctx.task),
             _detection_flags(ctx, "check"),
             list(effective_dirs),
@@ -350,10 +351,11 @@ def _append_fix_commands(ctx, data):
     task_path = task_cli_path(ctx.task)
     fix_dirs = dedupe_subtrees(extract_changed_dirs(affected))
     explicit_flags = _explicit_dirs_flags(ctx, "apply")
+    prefix = repro_prefix(ctx)
 
     if len(fix_dirs) <= _FIX_DIRS_LIMIT:
         data["fix_commands"].append({
-            "command": build_aspect_command(task_path, explicit_flags, fix_dirs, max_chars = 4096),
+            "command": prefix + build_aspect_command(task_path, explicit_flags, fix_dirs, max_chars = 4096),
             "description": "",
         })
         return
@@ -361,7 +363,7 @@ def _append_fix_commands(ctx, data):
     shown = fix_dirs[:_FIX_DIRS_LIMIT]
     remaining = len(fix_dirs) - _FIX_DIRS_LIMIT
     data["fix_commands"].append({
-        "command": build_aspect_command(task_path, explicit_flags, shown, max_chars = 4096),
+        "command": prefix + build_aspect_command(task_path, explicit_flags, shown, max_chars = 4096),
         "description": "First %d of %d affected dirs (plus %d other%s)" % (
             _FIX_DIRS_LIMIT,
             len(fix_dirs),
@@ -370,7 +372,7 @@ def _append_fix_commands(ctx, data):
         ),
     })
     data["fix_commands"].append({
-        "command": build_aspect_command(task_path, _detection_flags(ctx, "apply"), []),
+        "command": prefix + build_aspect_command(task_path, _detection_flags(ctx, "apply"), []),
         "description": "Or re-discover and update all %d affected dirs" % len(fix_dirs),
     })
 
@@ -631,6 +633,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         ctx.args.gazelle_target,
         build_events = build_events,
         flags = flags,
+        current_dir = ctx.std.env.bazel_root_dir(),
     )
 
     # `build.sink_invocation_id` is minted inside the runtime's `Build::spawn`
@@ -769,7 +772,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data = data,
         phase = Phase(name = "diff", description = "Compute BUILD-file diff", emoji = "📋"),
     )
-    diff_proc = r.spawn(ep, diff_args, capture = True)
+    diff_proc = r.spawn(ep, diff_args, capture = True, cwd = ctx.std.env.bazel_root_dir())
     diff_stdout = diff_proc.stdout().read_to_string()
     diff_stderr = diff_proc.stderr().read_to_string()
     diff_status = diff_proc.wait()

--- a/crates/aspect-cli/src/builtins/aspect/lib/path_normalize.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/path_normalize.axl
@@ -1,0 +1,43 @@
+"""Path normalization utilities."""
+
+def normalize_files_for_cwd(cwd, git_root, files):
+    """Rebase git-root-relative paths to cwd-relative paths.
+
+    Three cases based on the relationship between cwd and git_root:
+
+    1. cwd == git_root: no rebasing needed, return files unchanged.
+
+    2. cwd is under git_root: files outside the cwd subtree are dropped;
+       the cwd prefix is stripped from the rest.
+
+         git_root /repo, cwd /repo/pkg:
+           "pkg/foo.go"   → "foo.go"   (kept, prefix stripped)
+           "other/bar.go" → dropped
+
+    3. git_root is under cwd: a prefix is added so paths reach the git
+       repository from cwd. This happens when aspect is invoked from an
+       ancestor directory that contains the git repo as a subdirectory
+       (e.g. aspect_root = /workspace, git_root = /workspace/project).
+
+         git_root /workspace/project, cwd /workspace:
+           "src/foo.go"  → "project/src/foo.go"
+
+    When cwd and git_root are unrelated (neither is an ancestor of the
+    other), or when git_root is None, returns files unchanged.
+    """
+    if not files or not git_root:
+        return files
+    if cwd == git_root:
+        return files
+    git_root_slash = git_root + "/"
+    cwd_slash = cwd + "/"
+    if cwd.startswith(git_root_slash):
+        # Case 2: cwd is under git_root — strip the cwd prefix.
+        rel_cwd = cwd[len(git_root_slash):]
+        cwd_prefix = rel_cwd + "/"
+        return [f[len(cwd_prefix):] for f in files if f.startswith(cwd_prefix)]
+    if git_root.startswith(cwd_slash):
+        # Case 3: git_root is under cwd — add the relative path to git_root.
+        rel_git = git_root[len(cwd_slash):]
+        return [rel_git + "/" + f for f in files]
+    return files

--- a/crates/aspect-cli/src/builtins/aspect/lib/path_normalize_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/path_normalize_test.axl
@@ -1,0 +1,149 @@
+"""Unit tests for lib/path_normalize.axl."""
+
+load("./path_normalize.axl", "normalize_files_for_cwd")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _test_at_git_root(_ctx):
+    """cwd == git_root → no rebasing needed, return files unchanged."""
+    _eq(
+        "at git root → unchanged",
+        normalize_files_for_cwd("/repo", "/repo", ["pkg/foo.go", "bar.go"]),
+        ["pkg/foo.go", "bar.go"],
+    )
+
+def _test_direct_child(_ctx):
+    """cwd is a direct child of git_root → strip one path component."""
+    _eq(
+        "direct child",
+        normalize_files_for_cwd("/repo/pkg", "/repo", ["pkg/foo.go", "pkg/bar.go", "other/baz.go"]),
+        ["foo.go", "bar.go"],
+    )
+
+def _test_nested_cwd(_ctx):
+    """cwd nested deeper — multiple prefix components stripped."""
+    _eq(
+        "nested cwd",
+        normalize_files_for_cwd("/repo/a/b", "/repo", ["a/b/foo.go", "a/bar.go", "other.go"]),
+        ["foo.go"],
+    )
+
+def _test_files_outside_cwd_dropped(_ctx):
+    """Files in sibling directories are dropped entirely."""
+    _eq(
+        "sibling dirs dropped",
+        normalize_files_for_cwd("/repo/pkg", "/repo", ["other/foo.go", "pkg/bar.go"]),
+        ["bar.go"],
+    )
+
+def _test_all_files_outside_cwd(_ctx):
+    """All files outside CWD → empty list."""
+    _eq(
+        "all outside → empty",
+        normalize_files_for_cwd("/repo/pkg", "/repo", ["other/foo.go", "third/bar.go"]),
+        [],
+    )
+
+def _test_empty_files(_ctx):
+    """Empty input list → empty output, regardless of cwd."""
+    _eq("empty files", normalize_files_for_cwd("/repo/pkg", "/repo", []), [])
+
+def _test_no_git_root(_ctx):
+    """git_root is None → return files unchanged (best-effort, can't rebase)."""
+    files = ["pkg/foo.go", "bar.go"]
+    _eq("no git root → unchanged", normalize_files_for_cwd("/repo/pkg", None, files), files)
+
+def _test_cwd_outside_git_root(_ctx):
+    """cwd not under git_root → return files unchanged."""
+    files = ["foo.go"]
+    _eq(
+        "cwd outside repo → unchanged",
+        normalize_files_for_cwd("/other/dir", "/repo", files),
+        files,
+    )
+
+def _test_cwd_is_string_prefix_but_not_dir_child(_ctx):
+    """'/repo-extra' starts with '/repo' but is not a child of '/repo'."""
+    files = ["repo-extra/sub/foo.go"]
+    _eq(
+        "string-prefix but not dir-child → unchanged",
+        normalize_files_for_cwd("/repo-extra/sub", "/repo", files),
+        files,
+    )
+
+def _test_preserves_order(_ctx):
+    """Output order matches input order of matched files."""
+    _eq(
+        "order preserved",
+        normalize_files_for_cwd("/repo/pkg", "/repo", ["pkg/b.go", "pkg/a.go", "other/c.go"]),
+        ["b.go", "a.go"],
+    )
+
+# ---------------------------------------------------------------------------
+# Case 3: git_root is under cwd — prefix must be added
+# ---------------------------------------------------------------------------
+
+def _test_git_root_under_cwd_direct(_ctx):
+    """git_root is a direct child of cwd — prepend the git_root basename."""
+    _eq(
+        "git_root direct child of cwd",
+        normalize_files_for_cwd("/workspace", "/workspace/project", ["src/foo.go", "bar.go"]),
+        ["project/src/foo.go", "project/bar.go"],
+    )
+
+def _test_git_root_under_cwd_nested(_ctx):
+    """git_root is multiple levels under cwd."""
+    _eq(
+        "git_root nested under cwd",
+        normalize_files_for_cwd("/workspace", "/workspace/a/b/project", ["foo.go"]),
+        ["a/b/project/foo.go"],
+    )
+
+def _test_git_root_string_prefix_of_cwd_dir_not_child(_ctx):
+    """'/workspace/project-extra' is not under '/workspace/project'."""
+    files = ["foo.go"]
+    _eq(
+        "git_root is string-prefix of cwd but not dir-ancestor",
+        normalize_files_for_cwd("/workspace/project-extra/sub", "/workspace/project", files),
+        files,
+    )
+
+def _test_git_root_under_cwd_empty_files(_ctx):
+    """Empty file list → empty output even in the prefix-add case."""
+    _eq(
+        "empty files with git_root under cwd",
+        normalize_files_for_cwd("/workspace", "/workspace/project", []),
+        [],
+    )
+
+_UNIT_TESTS = [
+    _test_at_git_root,
+    _test_direct_child,
+    _test_nested_cwd,
+    _test_files_outside_cwd_dropped,
+    _test_all_files_outside_cwd,
+    _test_empty_files,
+    _test_no_git_root,
+    _test_cwd_outside_git_root,
+    _test_cwd_is_string_prefix_but_not_dir_child,
+    _test_preserves_order,
+    _test_git_root_under_cwd_direct,
+    _test_git_root_under_cwd_nested,
+    _test_git_root_string_prefix_of_cwd_dir_not_child,
+    _test_git_root_under_cwd_empty_files,
+]
+
+def _test_impl(ctx):
+    for t in _UNIT_TESTS:
+        t(ctx)
+    print("path_normalize.axl: OK (%d tests)" % len(_UNIT_TESTS))
+    return 0
+
+path_normalize_tests = task(
+    name = "test-path-normalize",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -304,7 +304,7 @@ def subdir_prefix(cwd, root):
         return ""
     prefix = root + "/"
     if cwd.startswith(prefix):
-        return "cd " + cwd[len(prefix):] + "\n"
+        return "cd " + _shell_quote(cwd[len(prefix):]) + "\n"
     return ""
 
 def repro_prefix(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -23,6 +23,14 @@ way producers compose these strings — handling flag normalization,
 target joining, the `--` separator before targets, and length-bounded
 truncation when the target list is large.
 
+`repro_prefix(ctx)` / `subdir_prefix(cwd, root)` prepend `cd <rel>\n`
+to commands when aspect was called from a subdirectory, so CI failures
+are reproducible without guessing the original working directory.
+
+`explicit_flags(ctx, pairs)` filters `(arg_name, flag_name)` pairs to
+those the user actually passed on the CLI — used to rebuild repro/fix
+commands that faithfully encode the invocation.
+
 `dedup_and_attribute(entries)` is what status surfaces use to merge
 the per-task lists into a single rolled-up view across tasks: two
 contributions of the same `(command, description)` collapse into one
@@ -32,7 +40,8 @@ row that lists every contributing task_key.
 the CLI so a developer reading the raw CI log sees the actionable
 commands without opening the status surface.
 
-`build_aspect_command` and `dedup_and_attribute` are pure (no I/O).
+`build_aspect_command`, `repro_prefix`, `subdir_prefix`,
+`explicit_flags`, and `dedup_and_attribute` are pure (no I/O).
 """
 
 load("./environment.axl", "color_enabled")
@@ -284,6 +293,37 @@ def patch_download_cmd(patch_url, strip = 1):
                     "  && unzip -p /tmp/aspect-patch.zip \\\n" +
                     "  | %s") % (owner, repo, artifact_id, apply_cmd)
     return ""
+
+def subdir_prefix(cwd, root):
+    """Return 'cd <rel>\\n' when cwd is a subdirectory of root, else ''.
+
+    Returns '' when cwd == root or when cwd is not under root (e.g. the
+    process is outside the repo entirely).
+    """
+    if cwd == root:
+        return ""
+    prefix = root + "/"
+    if cwd.startswith(prefix):
+        return "cd " + cwd[len(prefix):] + "\n"
+    return ""
+
+def repro_prefix(ctx):
+    """'cd <rel>\\n' for repro commands when aspect was called from a sub-directory.
+
+    Uses the git repository root as the reference anchor (the directory users
+    naturally navigate relative to), falling back to aspect_root_dir() when
+    not inside a git repo. Returns '' when aspect was called from the root.
+
+    Prepend this to every repro/fix command string so CI failures are
+    reproducible without guessing the original working directory:
+
+        cd e2e/runner
+        aspect gazelle --on-change=fail --check-only=true ...
+    """
+    return subdir_prefix(
+        ctx.std.env.current_dir(),
+        ctx.std.env.git_root_dir() or ctx.std.env.aspect_root_dir(),
+    )
 
 # ── CLI rendering ─────────────────────────────────────────────────────
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -128,6 +128,16 @@ def _test_subdir_prefix_root_is_proper_prefix_of_cwd(_ctx):
     # "/repo-extra" starts with "/repo" but is NOT a child of "/repo"
     _eq("path-prefix but not directory-child", subdir_prefix("/repo-extra/sub", "/repo"), "")
 
+def _test_subdir_prefix_path_with_spaces(_ctx):
+    _eq("space in subdir → quoted", subdir_prefix("/repo/my service", "/repo"), "cd 'my service'\n")
+
+def _test_subdir_prefix_path_with_parens(_ctx):
+    _eq("parens in subdir → quoted", subdir_prefix("/repo/apps/(special)", "/repo"), "cd 'apps/(special)'\n")
+
+def _test_subdir_prefix_simple_path_unquoted(_ctx):
+    """Simple paths must not be wrapped in quotes — they stay copy-paste clean."""
+    _eq("simple path → no quotes", subdir_prefix("/repo/e2e/runner", "/repo"), "cd e2e/runner\n")
+
 # ---------------------------------------------------------------------------
 # repro_prefix — uses a struct-based fake ctx
 # ---------------------------------------------------------------------------
@@ -173,6 +183,9 @@ _UNIT_TESTS = [
     _test_subdir_prefix_nested,
     _test_subdir_prefix_outside_root,
     _test_subdir_prefix_root_is_proper_prefix_of_cwd,
+    _test_subdir_prefix_path_with_spaces,
+    _test_subdir_prefix_path_with_parens,
+    _test_subdir_prefix_simple_path_unquoted,
     _test_repro_prefix_from_subdir_with_git_root,
     _test_repro_prefix_at_git_root,
     _test_repro_prefix_nested_subdir,

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -1,12 +1,12 @@
-"""Unit tests for `lib/repro_commands.axl::explicit_flags`.
+"""Unit tests for lib/repro_commands.axl.
 
-A struct-based fake `ctx` substitutes for a real `TaskContext` so the
-test can run without the CLI / merge plumbing. Wiring of `ctx.args.
-is_explicit` through clap's `ValueSource::CommandLine` is covered by
-the Rust unit tests on `Arguments`.
+A struct-based fake `ctx` substitutes for a real `TaskContext` so tests
+run without the CLI / merge plumbing. Wiring of `ctx.args.is_explicit`
+through clap's `ValueSource::CommandLine` is covered by the Rust unit
+tests on `Arguments`.
 """
 
-load("./repro_commands.axl", "explicit_flags")
+load("./repro_commands.axl", "explicit_flags", "repro_prefix", "subdir_prefix")
 
 def _eq(label, got, want):
     if got != want:
@@ -108,6 +108,58 @@ def _test_empty_pairs_list_returns_empty(ctx):
     ))
     _eq("empty pairs → empty list", explicit_flags(fake, []), [])
 
+# ---------------------------------------------------------------------------
+# subdir_prefix
+# ---------------------------------------------------------------------------
+
+def _test_subdir_prefix_at_root(_ctx):
+    _eq("cwd == root → no prefix", subdir_prefix("/repo", "/repo"), "")
+
+def _test_subdir_prefix_direct_child(_ctx):
+    _eq("direct child", subdir_prefix("/repo/sub", "/repo"), "cd sub\n")
+
+def _test_subdir_prefix_nested(_ctx):
+    _eq("nested", subdir_prefix("/repo/a/b/c", "/repo"), "cd a/b/c\n")
+
+def _test_subdir_prefix_outside_root(_ctx):
+    _eq("cwd outside root → no prefix", subdir_prefix("/other/path", "/repo"), "")
+
+def _test_subdir_prefix_root_is_proper_prefix_of_cwd(_ctx):
+    # "/repo-extra" starts with "/repo" but is NOT a child of "/repo"
+    _eq("path-prefix but not directory-child", subdir_prefix("/repo-extra/sub", "/repo"), "")
+
+# ---------------------------------------------------------------------------
+# repro_prefix — uses a struct-based fake ctx
+# ---------------------------------------------------------------------------
+
+def _fake_env(cwd, git_root, aspect_root = None):
+    """Build a minimal ctx.std.env struct for repro_prefix tests."""
+    return struct(std = struct(env = struct(
+        current_dir = lambda: cwd,
+        git_root_dir = lambda: git_root,
+        aspect_root_dir = lambda: aspect_root or cwd,
+    )))
+
+def _test_repro_prefix_from_subdir_with_git_root(_ctx):
+    fake = _fake_env("/repo/pkg", "/repo")
+    _eq("subdir under git root", repro_prefix(fake), "cd pkg\n")
+
+def _test_repro_prefix_at_git_root(_ctx):
+    fake = _fake_env("/repo", "/repo")
+    _eq("at git root → empty", repro_prefix(fake), "")
+
+def _test_repro_prefix_nested_subdir(_ctx):
+    fake = _fake_env("/repo/a/b", "/repo")
+    _eq("nested subdir", repro_prefix(fake), "cd a/b\n")
+
+def _test_repro_prefix_no_git_root_falls_back_to_aspect_root(_ctx):
+    fake = _fake_env("/project/sub", None, aspect_root = "/project")
+    _eq("fallback to aspect_root", repro_prefix(fake), "cd sub\n")
+
+def _test_repro_prefix_no_git_root_at_aspect_root(_ctx):
+    fake = _fake_env("/project", None, aspect_root = "/project")
+    _eq("at aspect_root, no git → empty", repro_prefix(fake), "")
+
 _UNIT_TESTS = [
     _test_returns_empty_when_no_explicit,
     _test_includes_only_explicit_pairs,
@@ -116,12 +168,22 @@ _UNIT_TESTS = [
     _test_handles_include_pattern_list,
     _test_include_and_exclude_patterns_independent,
     _test_empty_pairs_list_returns_empty,
+    _test_subdir_prefix_at_root,
+    _test_subdir_prefix_direct_child,
+    _test_subdir_prefix_nested,
+    _test_subdir_prefix_outside_root,
+    _test_subdir_prefix_root_is_proper_prefix_of_cwd,
+    _test_repro_prefix_from_subdir_with_git_root,
+    _test_repro_prefix_at_git_root,
+    _test_repro_prefix_nested_subdir,
+    _test_repro_prefix_no_git_root_falls_back_to_aspect_root,
+    _test_repro_prefix_no_git_root_at_aspect_root,
 ]
 
 def _test_impl(ctx):
     for t in _UNIT_TESTS:
         t(ctx)
-    print("repro_commands.axl: OK (%d sections)" % len(_UNIT_TESTS))
+    print("repro_commands.axl: OK (%d tests)" % len(_UNIT_TESTS))
     return 0
 
 repro_commands_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -143,16 +143,22 @@ def _determine_entrypoint(state: struct, target: str) -> struct | None:
 def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture: bool = False, cwd: str | None = None) -> std.process.Child:
     """Spawn `ep.path` with `args` in the Bazel runfiles environment.
 
-    Always sets BUILD_WORKSPACE_DIRECTORY / BUILD_WORKING_DIRECTORY so
-    formatter wrappers (e.g. rules_lint's format.sh) can cd to the workspace
-    root. When `ep.runfiles_dir` is set, also sets RUNFILES_DIR /
-    RUNFILES_MANIFEST_FILE so that `rlocation` in sh_binary wrappers works
-    regardless of the process's working directory.
+    Always sets BUILD_WORKSPACE_DIRECTORY (= bazel_root_dir) and
+    BUILD_WORKING_DIRECTORY (= current_dir) so tool wrappers can locate the
+    workspace. When `ep.runfiles_dir` is set, also sets
+    RUNFILES_DIR / RUNFILES_MANIFEST_FILE / JAVA_RUNFILES so `rlocation` in
+    sh_binary wrappers works regardless of cwd.
+
+    Also sets four ASPECT_CLI_* variables for tools that prefer aspect-native
+    conventions over Bazel-specific vars:
+      ASPECT_CLI_WORKING_DIRECTORY      — where the user invoked aspect
+      ASPECT_CLI_ASPECT_ROOT_DIRECTORY  — .aspect/ / MODULE.aspect anchor
+      ASPECT_CLI_BAZEL_ROOT_DIRECTORY   — MODULE.bazel / WORKSPACE anchor
+      ASPECT_CLI_GIT_ROOT_DIRECTORY     — .git anchor (empty when absent)
 
     `cwd` overrides the working directory. When omitted: defaults to
     `ep.runfiles_dir/<workspace>` when a runfiles tree is present (matching
-    `bazel run`), or to the workspace root for bare binaries so
-    workspace-relative file arguments resolve correctly.
+    `bazel run`), or to the aspect invocation directory for bare binaries.
     """
     workspace_name = state.workspace_name[0] or _DEFAULT_WORKSPACE_NAME
     if cwd:
@@ -160,11 +166,15 @@ def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture
     elif ep.runfiles_dir:
         effective_cwd = ep.runfiles_dir + "/" + workspace_name
     else:
-        effective_cwd = ctx.std.env.aspect_root_dir()
+        effective_cwd = ctx.std.env.current_dir()
     cmd = ctx.std.process.command(ep.path) \
         .current_dir(effective_cwd) \
-        .env("BUILD_WORKSPACE_DIRECTORY", ctx.std.env.aspect_root_dir()) \
+        .env("BUILD_WORKSPACE_DIRECTORY", ctx.std.env.bazel_root_dir()) \
         .env("BUILD_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
+        .env("ASPECT_CLI_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
+        .env("ASPECT_CLI_ASPECT_ROOT_DIRECTORY", ctx.std.env.aspect_root_dir()) \
+        .env("ASPECT_CLI_BAZEL_ROOT_DIRECTORY", ctx.std.env.bazel_root_dir()) \
+        .env("ASPECT_CLI_GIT_ROOT_DIRECTORY", ctx.std.env.git_root_dir() or "") \
         .args(args)
     if ep.runfiles_dir:
         cmd = cmd \
@@ -190,7 +200,7 @@ def runnable(ctx, targets: list[str]) -> struct:
       spawn(ep, args, capture=False, cwd=None) → Child
           Spawn `ep.path` with Bazel runfiles environment variables set.
           `cwd` defaults to `ep.runfiles_dir/<workspace>` when a runfiles tree
-          is present, or to the workspace root for bare binaries.
+          is present, or to the aspect invocation directory for bare binaries.
     """
     state = struct(
         ctx = ctx,

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -28,7 +28,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
 load("./lib/lint_results.axl", "detect_lint_tool", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
-load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
 load("./lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics")
 load("./lib/tar.axl", "tar_create")
 load("./lib/text.axl", "pluralize")
@@ -1299,13 +1299,14 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         repro_flags.append(("--base-ref", surfaced_base_ref))
     targets = list(ctx.args.targets)
     task_path = task_cli_path(ctx.task)
+    prefix = repro_prefix(ctx)
     data["repro_commands"].append({
-        "command": build_aspect_command(task_path, repro_flags, targets),
+        "command": prefix + build_aspect_command(task_path, repro_flags, targets),
         "description": "",
     })
     if data["lint"]["suggestions"]:
         data["fix_commands"].append({
-            "command": build_aspect_command(task_path, [("--fix", None)] + repro_flags, targets),
+            "command": prefix + build_aspect_command(task_path, [("--fix", None)] + repro_flags, targets),
             "description": "",
         })
 

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -961,6 +961,9 @@ mod tests {
         fn trait_type_ids(&self) -> Vec<u64> {
             vec![]
         }
+        fn trait_values(&self) -> Vec<starlark::values::Value<'v>> {
+            vec![]
+        }
     }
 
     fn stub_task(name: &str, group: &[&str], args: SmallMap<String, Arg>) -> StubTask {

--- a/crates/aspect-cli/src/helpers.rs
+++ b/crates/aspect-cli/src/helpers.rs
@@ -38,6 +38,16 @@ pub async fn find_aspect_root(current_work_dir: &Path) -> Option<PathBuf> {
     .await
 }
 
+/// Git repository root — the directory containing the `.git` entry.
+///
+/// Walks upward from `current_work_dir` looking for `.git` (a directory for
+/// normal repos or a file for git worktrees). Returns `None` when not inside
+/// a git repository.
+#[instrument]
+pub async fn find_git_root(current_work_dir: &Path) -> Option<PathBuf> {
+    find_ancestor_with_any(current_work_dir, &[".git"]).await
+}
+
 /// Bazel workspace root for bazelrc discovery, `bazel info workspace`, and
 /// BES output paths.
 ///
@@ -238,5 +248,49 @@ mod tests {
             tokio_fs::create_dir_all(&cwd).await.unwrap();
             assert_eq!(find_bazel_root(&cwd).await, Some(root), "marker: {marker}");
         }
+    }
+
+    /// `.git` directory found by walking up from a subdirectory.
+    #[tokio::test]
+    async fn git_root_found_from_subdirectory() {
+        let (_tmp, root) = setup(&[]).await;
+        tokio_fs::create_dir_all(root.join(".git")).await.unwrap();
+        let cwd = root.join("a/b/c");
+        tokio_fs::create_dir_all(&cwd).await.unwrap();
+
+        assert_eq!(find_git_root(&cwd).await, Some(root));
+    }
+
+    /// `.git` file (git worktree) is recognized.
+    #[tokio::test]
+    async fn git_root_recognizes_worktree_git_file() {
+        let (_tmp, root) = setup(&[".git"]).await;
+        let cwd = root.join("sub");
+        tokio_fs::create_dir_all(&cwd).await.unwrap();
+
+        assert_eq!(find_git_root(&cwd).await, Some(root));
+    }
+
+    /// Returns `None` when not inside any git repository.
+    #[tokio::test]
+    async fn git_root_none_outside_repo() {
+        let (_tmp, root) = setup(&[]).await;
+        let cwd = root.join("sub");
+        tokio_fs::create_dir_all(&cwd).await.unwrap();
+
+        assert_eq!(find_git_root(&cwd).await, None);
+    }
+
+    /// When aspect and git roots diverge (e.g. git repo contains a
+    /// sub-workspace with its own Bazel markers), git root is the outermost
+    /// ancestor with `.git` and is independent of the Bazel/Aspect roots.
+    #[tokio::test]
+    async fn git_root_is_independent_of_bazel_and_aspect_roots() {
+        let (_tmp, root) = setup(&[".git", "e2e/MODULE.bazel"]).await;
+        let cwd = root.join("e2e/sub");
+        tokio_fs::create_dir_all(&cwd).await.unwrap();
+
+        assert_eq!(find_git_root(&cwd).await, Some(root.clone()));
+        assert_eq!(find_bazel_root(&cwd).await, Some(root.join("e2e")));
     }
 }

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -18,7 +18,7 @@ use tracing::info_span;
 
 use crate::cmd::Cmd;
 use crate::helpers::{
-    find_aspect_root, find_bazel_root, get_default_axl_search_paths, search_sources,
+    find_aspect_root, find_bazel_root, find_git_root, get_default_axl_search_paths, search_sources,
 };
 
 // Must use a multi thread runtime with at least 3 threads for following reasons;
@@ -83,6 +83,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
     let bazel_root = find_bazel_root(&current_work_dir)
         .await
         .unwrap_or_else(|| current_work_dir.clone());
+    let git_root = find_git_root(&current_work_dir).await;
 
     let disk_store = DiskStore::new(aspect_root.clone());
     let mode = ModEvaluator::new(aspect_root.clone());
@@ -114,6 +115,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                 cli_version.clone(),
                 aspect_root.clone(),
                 bazel_root.clone(),
+                git_root.clone(),
                 &modules,
             );
             let mut mpe = MultiPhaseEval::new(env, &loader);

--- a/crates/axl-runtime/src/docs.rs
+++ b/crates/axl-runtime/src/docs.rs
@@ -34,7 +34,7 @@ pub fn documentation() -> anyhow::Result<Documentation> {
     // short-circuit before any caller-context lookups in `FileLoader::load`),
     // so no seeding is required.
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
-    let loader = Loader::new("docgen".to_string(), cwd.clone(), cwd, &[]);
+    let loader = Loader::new("docgen".to_string(), cwd.clone(), cwd, None, &[]);
 
     let mut builtins = Vec::new();
     for filename in list_std_files() {

--- a/crates/axl-runtime/src/engine/std/env.rs
+++ b/crates/axl-runtime/src/engine/std/env.rs
@@ -21,7 +21,6 @@ impl Env {
     }
 }
 
-/// Documentation here
 #[starlark_value(type = "std.Env")]
 impl<'v> StarlarkValue<'v> for Env {
     fn get_methods() -> Option<&'static Methods> {
@@ -258,6 +257,24 @@ pub(crate) fn env_methods(registry: &mut MethodsBuilder) {
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("aspect root dir is non utf-8"))?;
         Ok(eval.heap().alloc_str(s))
+    }
+
+    /// Returns the git repository root — the directory containing `.git` —
+    /// or `None` when not inside a git repository.
+    fn git_root_dir<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        eval: &mut Evaluator<'v, '_, '_>,
+    ) -> anyhow::Result<NoneOr<values::StringValue<'v>>> {
+        let env = RuntimeEnv::from_eval(eval)?;
+        Ok(match &env.git_root_dir {
+            Some(path) => {
+                let s = path
+                    .to_str()
+                    .ok_or_else(|| anyhow::anyhow!("git root dir is non utf-8"))?;
+                NoneOr::Other(eval.heap().alloc_str(s))
+            }
+            None => NoneOr::None,
+        })
     }
 
     /// Returns the Bazel workspace root directory — the anchor for bazelrc

--- a/crates/axl-runtime/src/engine/store.rs
+++ b/crates/axl-runtime/src/engine/store.rs
@@ -18,15 +18,24 @@ pub struct Env {
     /// `aspect_root_dir` when a Bazel sub-workspace sits under an
     /// Aspect root.
     pub bazel_root_dir: PathBuf,
+    /// Git repository root — directory containing `.git`. `None` when
+    /// not inside a git repository.
+    pub git_root_dir: Option<PathBuf>,
     pub rt: AsyncRuntime,
 }
 
 impl Env {
-    pub fn new(cli_version: String, aspect_root_dir: PathBuf, bazel_root_dir: PathBuf) -> Self {
+    pub fn new(
+        cli_version: String,
+        aspect_root_dir: PathBuf,
+        bazel_root_dir: PathBuf,
+        git_root_dir: Option<PathBuf>,
+    ) -> Self {
         Self {
             cli_version,
             aspect_root_dir,
             bazel_root_dir,
+            git_root_dir,
             rt: AsyncRuntime::new(),
         }
     }

--- a/crates/axl-runtime/src/eval/load.rs
+++ b/crates/axl-runtime/src/eval/load.rs
@@ -57,10 +57,11 @@ impl<'m> AxlLoader<'m> {
         cli_version: String,
         aspect_root: PathBuf,
         bazel_root: PathBuf,
+        git_root: Option<PathBuf>,
         modules: &'m [Mod],
     ) -> Self {
         Self {
-            env: Env::new(cli_version, aspect_root, bazel_root),
+            env: Env::new(cli_version, aspect_root, bazel_root, git_root),
             dialect: api::dialect(),
             globals: api::get_globals().build(),
             modules,

--- a/crates/axl-runtime/src/test.rs
+++ b/crates/axl-runtime/src/test.rs
@@ -68,7 +68,12 @@ impl EvalBuilder {
         let globals = get_globals().build();
         let rt = Runtime::new().map_err(|e| anyhow!("failed to create runtime: {}", e))?;
         let _g = rt.enter();
-        let env_store = Env::new("test".to_string(), PathBuf::from("/"), PathBuf::from("/"));
+        let env_store = Env::new(
+            "test".to_string(),
+            PathBuf::from("/"),
+            PathBuf::from("/"),
+            None,
+        );
         ModuleEnv::with(|env| {
             let mut eval = Evaluator::new(&env.0);
             eval.extra = Some(&env_store);
@@ -81,7 +86,13 @@ impl EvalBuilder {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let rt = Runtime::new()?;
         let _g = rt.enter();
-        let loader = Loader::new("test".to_string(), manifest_dir.clone(), manifest_dir, &[]);
+        let loader = Loader::new(
+            "test".to_string(),
+            manifest_dir.clone(),
+            manifest_dir,
+            None,
+            &[],
+        );
         let ast = AstModule::parse("test", self.code, &dialect()).map_err(|e| anyhow!("{}", e))?;
         Module::with_temp_heap(|module| {
             let mut eval = Evaluator::new(&module);
@@ -104,7 +115,12 @@ impl EvalBuilder {
         let globals = get_globals().build();
         let rt = Runtime::new().expect("failed to create runtime");
         let _g = rt.enter();
-        let env_store = Env::new("test".to_string(), PathBuf::from("/"), PathBuf::from("/"));
+        let env_store = Env::new(
+            "test".to_string(),
+            PathBuf::from("/"),
+            PathBuf::from("/"),
+            None,
+        );
         Module::with_temp_heap(|module| {
             let mut eval = Evaluator::new(&module);
             eval.extra = Some(&env_store);
@@ -146,6 +162,7 @@ impl EvalBuilder {
                 "test".to_string(),
                 tmp.path().to_path_buf(),
                 tmp.path().to_path_buf(),
+                None,
                 &modules,
             );
             let mut mpe = MultiPhaseEval::new(env, &loader);


### PR DESCRIPTION
Fixes spawn-directory bugs introduced when `aspect_root` and `bazel_root` were split, adds sub-directory context to repro commands, and scopes `aspect format` to the invocation directory when called from a subdirectory.

### Bug fixes

**`runnable.axl` bare-binary spawn directory** — the bare-binary fallback cwd was `aspect_root_dir()`. When invoked from a subdirectory, the spawned binary (gazelle diff phase, formatter) ran from the repo root instead of the invocation directory. Fixed to `current_dir()`. `BUILD_WORKSPACE_DIRECTORY` was also corrected from `aspect_root_dir()` to `bazel_root_dir()`.

**`ctx.bazel.build()` anchoring** — format and gazelle now pass an explicit `current_dir` so the Bazel working directory is unambiguous when the two roots diverge: `aspect_root_dir()` for format, `bazel_root_dir()` for gazelle.

**`gazelle` bare-binary spawn** — `r.spawn()` for the gazelle binary now explicitly passes `cwd = bazel_root_dir()` so bare gazelle binaries (no runfiles tree) run from the Bazel workspace root, consistent with `ctx.bazel.build()` and Bazel target-pattern semantics.

### Repro command sub-directory context

When `aspect` is invoked from a subdirectory, every repro/fix command leads with `cd <rel>` so the reader knows where to stand to reproduce the failure:

```
cd e2e/runner
aspect gazelle --on-change=fail --check-only=true ...
```

The reference anchor is the git repository root (`.git`), falling back to `aspect_root_dir()` outside a git repo.

**New `ctx.std.env.git_root_dir()`** — returns the git repository root (`None` outside a git repo). Threaded through `store::Env`, `AxlLoader::new`, and `main.rs`.

**New `repro_prefix(ctx)` and `subdir_prefix(cwd, root)`** in `repro_commands.axl` — used by format, gazelle, lint, and delivery.

### `aspect format` subdirectory scoping

When invoked from a subdirectory, `aspect format` now scopes to that subtree: changed files from `detect_changed_files` (git-root-relative) are rebased to cwd-relative paths before being passed to the formatter. The same normalization applies to `affected_files` so fix commands carry paths consistent with the leading `cd`.

The normalization in `lib/path_normalize.axl` handles three topological cases:

| Relationship | Example | Transformation |
|---|---|---|
| `cwd == git_root` | invoked from repo root | unchanged |
| `cwd` under `git_root` | `git_root=/repo`, `cwd=/repo/pkg` | strip `pkg/` prefix, drop out-of-subtree files |
| `git_root` under `cwd` | `aspect_root=/workspace`, `git_root=/workspace/project`, `cwd=/workspace` | prepend `project/` prefix |

Both bare formatters (spawned at cwd) and `format_multirun` formatters (via `format.sh`, which cds to `BUILD_WORKING_DIRECTORY` = `current_dir()`) operate from cwd, so cwd-relative paths work for both. Requires [rules_lint#882](https://github.com/aspect-build/rules_lint/pull/882) for `format_multirun`.

### New environment variables

`runnable.axl` now sets four `ASPECT_CLI_*` variables on every spawned binary:
- `ASPECT_CLI_WORKING_DIRECTORY` — where the user invoked aspect
- `ASPECT_CLI_ASPECT_ROOT_DIRECTORY` — `.aspect/` / `MODULE.aspect` anchor
- `ASPECT_CLI_BAZEL_ROOT_DIRECTORY` — `MODULE.bazel` / `WORKSPACE` anchor
- `ASPECT_CLI_GIT_ROOT_DIRECTORY` — `.git` anchor (empty string when absent)

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- fix: bare-binary tasks (gazelle diff, formatter) now spawn in the invocation directory instead of the repo root when aspect is called from a subdirectory
- fix: `BUILD_WORKSPACE_DIRECTORY` passed to spawned binaries now points at the Bazel workspace root rather than the Aspect config root
- feat: repro/fix commands include `cd <subdir>` (relative to git repo root) when aspect was called from a subdirectory
- feat: `aspect format` from a subdirectory scopes formatting to that subtree only
- feat: `ctx.std.env.git_root_dir()` — git repository root, or `None` outside a git repo
- feat: `ASPECT_CLI_*` environment variables set on every spawned binary

### Test plan

- New Rust tests: `find_git_root` — directory, worktree (`.git` file), no repo, independence from Bazel/Aspect roots (`helpers.rs`)
- New AXL tests: `subdir_prefix` (5 cases), `repro_prefix` (5 cases) in `repro_commands_test.axl`
- New AXL tests: `normalize_files_for_cwd` (14 cases) in `path_normalize_test.axl` — covers all three cwd/git_root topologies, None git root, unrelated directories, string-prefix-but-not-dir-child, order preservation
- Manual:
  1. Run `aspect gazelle` from a subdirectory; confirm diff phase spawns in the invocation dir.
  2. Run `aspect lint` from a subdirectory; confirm repro command leads with `cd <subdir>`.
  3. Run `aspect format` from a subdirectory; confirm only files in that subtree are formatted.
