### PR TITLE
fix(delivery): run targets without a runfiles manifest

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1009,11 +1009,6 @@ def _delivery_impl(ctx):
                 pending_count += 1
                 data.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
                 delivery_add_result(dr, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)
-            elif not ep.runfiles_dir:
-                warn_msg = "tagged deliverable but not runnable (no .runfiles_manifest in BES output for {})".format(ep.path)
-                pending_count += 1
-                data.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
-                delivery_add_result(dr, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)
             else:
                 pending.append((label, ep, is_forced, output_sha or "-"))
 

--- a/examples/deliverable/BUILD.bazel
+++ b/examples/deliverable/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load(":gen_sh_binary.bzl", "gen_sh_binary")
 
 genrule(
     name = "delivery_payload",
@@ -11,6 +12,14 @@ sh_binary(
     name = "deliverable",
     srcs = ["deliver.sh"],
     data = [":delivery_payload"],
+    tags = ["deliverable"],
+)
+
+# A custom rule emitting a .sh script with no runfiles tree. Delivery must run
+# it without requiring a .runfiles_manifest in BES output.
+gen_sh_binary(
+    name = "custom_sh_deliverable",
+    content = "#!/usr/bin/env bash\necho 'custom rule delivery works'\n",
     tags = ["deliverable"],
 )
 

--- a/examples/deliverable/gen_sh_binary.bzl
+++ b/examples/deliverable/gen_sh_binary.bzl
@@ -1,0 +1,16 @@
+"""A custom rule that emits a .sh script as its executable without a runfiles tree.
+
+Used to verify that delivery handles targets that have no .runfiles_manifest in
+BES output — a valid pattern for scripts that don't use rlocation.
+"""
+
+def _gen_sh_binary_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".sh")
+    ctx.actions.write(out, ctx.attr.content, is_executable = True)
+    return [DefaultInfo(executable = out)]
+
+gen_sh_binary = rule(
+    implementation = _gen_sh_binary_impl,
+    executable = True,
+    attrs = {"content": attr.string()},
+)


### PR DESCRIPTION
Custom rules that emit a `.sh` script directly (without `sh_binary`) produce no `.runfiles_manifest` in BES output — they don't use Bazel's runfiles protocol and don't need one. The guard added in #1142 treated a missing manifest as proof that a target is not runnable and blocked delivery with a warning, silently skipping all such targets.

`_spawn` already handles `ep.runfiles_dir = None` correctly: it skips the runfiles env vars and falls back to `current_dir()` as cwd. The guard was both incorrect (a missing manifest is valid for custom rules) and redundant. Removing it restores the previous behaviour.

Adds a `gen_sh_binary` custom rule to `examples/deliverable` to cover this shape in the delivery CI task and prevent future regressions.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**
- `aspect delivery` now correctly runs targets from custom rules that emit a `.sh` script without a runfiles tree. Previously these targets were silently skipped with a "not runnable" warning.

### Test plan

- `gen_sh_binary` target added to `examples/deliverable` — exercised by the existing delivery CI task on every run