### PR TITLE
fix(delivery): fix executable file detection

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -37,6 +37,10 @@ _user_task = task(
 buildifier = format.alias(
     defaults = {
         "formatter_target": "@buildifier_prebuilt//buildifier",
+        # buildifier_binary is a symlink to the raw Go binary; it does not
+        # switch to $BUILD_WORKING_DIRECTORY on its own, so we run it in
+        # the user's cwd to make workspace-relative paths resolve.
+        "run_in_cwd": True,
         "include_patterns": [
             "**/BUCK",
             "**/BUILD",

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -391,5 +391,5 @@ steps:
     command: |
       export ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS=$$(buildkite-agent meta-data get force_targets --default '')
       cd examples/deliverable
-      ASPECT_DEBUG=1 aspect delivery --task-key delivery-bk-debug --query 'attr(tags, deliverable, //...)'
-      aspect delivery --task-key delivery-bk --query 'attr(tags, deliverable, //...)'
+      ASPECT_DEBUG=1 aspect delivery --task-key delivery-bk-debug --warn-not-runnable --query 'attr(tags, deliverable, //...)'
+      aspect delivery --task-key delivery-bk --warn-not-runnable --query 'attr(tags, deliverable, //...)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,8 +186,8 @@ jobs:
       - run:
           name: Delivery Task (ASPECT_DEBUG=1)
           working_directory: /mnt/ephemeral/workdir/examples/deliverable
-          command: ASPECT_DEBUG=1 aspect delivery --task-key delivery-cci-debug --query 'attr(tags, deliverable, //...)'
+          command: ASPECT_DEBUG=1 aspect delivery --task-key delivery-cci-debug --warn-not-runnable --query 'attr(tags, deliverable, //...)'
       - run:
           name: Delivery Task
           working_directory: /mnt/ephemeral/workdir/examples/deliverable
-          command: aspect delivery --task-key delivery-cci --query 'attr(tags, deliverable, //...)'
+          command: aspect delivery --task-key delivery-cci --warn-not-runnable --query 'attr(tags, deliverable, //...)'

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -172,7 +172,7 @@ jobs:
         run: .aspect/bootstrap.sh
       - name: Delivery Task (ASPECT_DEBUG=1)
         working-directory: examples/deliverable
-        run: ASPECT_DEBUG=1 aspect delivery --task-key delivery-gha-debug --query 'attr(tags, deliverable, //...)'
+        run: ASPECT_DEBUG=1 aspect delivery --task-key delivery-gha-debug --warn-not-runnable --query 'attr(tags, deliverable, //...)'
       - name: Delivery Task
         working-directory: examples/deliverable
-        run: aspect delivery --task-key delivery-gha --query 'attr(tags, deliverable, //...)'
+        run: aspect delivery --task-key delivery-gha --warn-not-runnable --query 'attr(tags, deliverable, //...)'

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -600,7 +600,6 @@ def _delivery_impl(ctx):
     # later failure still produces a check run rather than a silent no-op.
     dr = delivery_init_data()
     dr["start_time_ms"] = now_ms(ctx)
-    dr["delivery"]["prefix"] = ctx.task.key
     dr["delivery"]["commit_sha"] = ctx.args.commit_sha
     dr["delivery"]["build_url"] = ctx.args.build_url
     dr["delivery"]["ci_host"] = ctx.args.ci_host
@@ -681,6 +680,12 @@ def _delivery_impl(ctx):
     else:
         prefix = ctx.task.key
         prefix_source = "--task-key"
+
+    # Surface the salt-augmented prefix to renderers so the "KEY" column
+    # shows `<prefix>:<hash>` — the change-detection identity. The raw
+    # output_sha alone is identical across salt namespaces, hiding that
+    # records are stored separately per salt.
+    dr["delivery"]["prefix"] = prefix
 
     # iter handles are created per attempt inside the retry loop.
     build_events = list(bazel_trait.build_event_sinks)
@@ -991,10 +996,15 @@ def _delivery_impl(ctx):
                 data.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
                 delivery_add_result(dr, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)
             elif not ep.runfiles_dir:
-                warn_msg = "tagged deliverable but not runnable (no .runfiles_manifest in BES output for {})".format(ep.path)
-                pending_count += 1
-                data.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
-                delivery_add_result(dr, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)
+                not_runnable_msg = "tagged 'deliverable' but not runnable: no runfiles directory at {}.runfiles (target may not be an executable rule)".format(ep.path)
+                if ctx.args.warn_not_runnable:
+                    pending_count += 1
+                    data.append((label, "WARN", "warn", not_runnable_msg, output_sha or "-", "-"))
+                    delivery_add_result(dr, label, "warn", message = not_runnable_msg, output_sha = output_sha or "", is_forced = is_forced)
+                else:
+                    failed_count += 1
+                    data.append((label, "FAIL", "fail", not_runnable_msg, output_sha or "-", "-"))
+                    delivery_add_result(dr, label, "fail", message = not_runnable_msg, output_sha = output_sha or "", is_forced = is_forced)
             else:
                 pending.append((label, ep, is_forced, output_sha or "-"))
 
@@ -1048,7 +1058,7 @@ def _delivery_impl(ctx):
         for label, entrypoint, is_forced, output_sha in chunk:
             forced_marker = " (FORCED)" if is_forced else ""
             print("  {} {}{}...".format(_style("Delivering", _BOLD, ansi), label, forced_marker))
-            children.append((label, is_forced, output_sha, time.monotonic(), run_tracker.spawn(ep, [], capture)))
+            children.append((label, is_forced, output_sha, time.monotonic(), run_tracker.spawn(entrypoint, [], capture)))
 
         for label, is_forced, output_sha, t_start, child in children:
             forced_marker = " (FORCED)" if is_forced else ""
@@ -1128,25 +1138,29 @@ def _delivery_impl(ctx):
         "fail": _BOLD + _RED,
     }
 
+    # KEY = <prefix>:<hash[:12]> — the change-detection identity that
+    # uniquely names this delivery (namespace + content).
+    key_width = max(len("KEY"), len(prefix) + 13)
+
     print("")
     header = "  {}  {}  {}  {}  {}".format(
         pad("TARGET", max_label_width),
         pad("STATUS", max_status_width),
         pad("DURATION", max_duration_width),
-        pad("HASH", 32),
+        pad("KEY", key_width),
         "BUILD URL",
     )
     print(_style(header, _BOLD, ansi))
     for label, status_text, status_type, delivered_by, output_sha, duration in data:
         styled_status = _style(status_text, status_styles[status_type], ansi)
         padding = " " * (max_status_width - len(status_text))
-        short_hash = output_sha[:32] if output_sha != "-" else "-"
+        key = prefix + ":" + output_sha[:12] if output_sha and output_sha != "-" else "-"
         print("  {}  {}{}  {}  {}  {}".format(
             pad(label, max_label_width),
             styled_status,
             padding,
             pad(duration, max_duration_width),
-            pad(short_hash, 32),
+            pad(key, key_width),
             delivered_by,
         ))
 
@@ -1245,6 +1259,10 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         "max_parallelization": args.int(
             default = 1,
             description = "Maximum number of delivery targets to run concurrently. When greater than 1, stdout/stderr is captured and printed atomically after each target finishes.",
+        ),
+        "warn_not_runnable": args.boolean(
+            default = False,
+            description = "Downgrade a non-runnable deliverable from a hard failure (exit 1) to a warning. A target tagged 'deliverable' whose entrypoint has no runfiles tree fails by default. Set this flag if your repo intentionally tags non-executable targets as deliverable.",
         ),
         # TODO: Support a long --pattern_file like bazel does (@./targets)
         # TODO: Support - (list from stdin)

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -531,7 +531,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             data = data,
             phase = Phase(name = "format", description = "Format files", emoji = "✨"),
         )
-    exit = r.spawn(ep, format_args).wait()
+
+    spawn_cwd = ctx.std.env.current_dir() if ctx.args.run_in_cwd else None
+    exit = r.spawn(ep, format_args, cwd = spawn_cwd).wait()
 
     if not exit.success:
         # Formatter binary itself errored — surface that and skip the
@@ -699,6 +701,10 @@ format = task(
         "formatter_target": args.string(
             default = "//tools/format",
             description = "Bazel label of the format_multirun target (or any runnable target) to invoke as the formatter. The target is built first, then run with the changed-file list passed as positional arguments.",
+        ),
+        "run_in_cwd": args.boolean(
+            default = False,
+            description = "Spawn the formatter with the current working directory as cwd, rather than the `bazel run` default of `<runfiles_dir>/<workspace>`. Mirrors Bazel's `--run_in_cwd` flag. Set this for formatter targets that do not switch to `$BUILD_WORKSPACE_DIRECTORY` on their own and instead resolve workspace-relative file arguments against the process cwd — for example, `@buildifier_prebuilt//buildifier`, which is a `buildifier_binary` rule (symlink to the raw Go binary, no shell wrapper). Wrapper-based formatters such as `format_multirun` from rules_lint already `cd $BUILD_WORKSPACE_DIRECTORY` on entry, so this flag is a no-op for them. (A truly bare binary — one with no runfiles tree at all — already spawns in cwd because there is no `runfiles_dir/<workspace>` to fall back to.)",
         ),
         "announce_rc": args.boolean(
             default = False,

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -735,7 +735,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data = data,
         phase = Phase(name = "diff", description = "Compute BUILD-file diff", emoji = "📋"),
     )
-    diff_proc = r.spawn(ep, diff_args, capture = True, cwd = ctx.std.env.bazel_root_dir())
+    diff_proc = r.spawn(ep, diff_args, capture = True)
     diff_stdout = diff_proc.stdout().read_to_string()
     diff_stderr = diff_proc.stderr().read_to_string()
     diff_status = diff_proc.wait()

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
@@ -266,14 +266,19 @@ def _truncate(s, max_len):
         return s[:max_len]
     return s[:max_len - 3] + "..."
 
-def _outcome_table(diags, outcome):
-    """Render a small table per outcome: label, hash, context.
+def _outcome_table(diags, outcome, prefix):
+    """Render a small table per outcome: label, key, context.
+
+    `prefix` is the salt-augmented change-detection prefix (`task_key`
+    optionally extended by `:salt`); each row's key is rendered as
+    `<prefix>:<output_sha[:12]>` so two runs collide iff they would resolve
+    to the same deliveryd record.
 
     Column shape depends on outcome to surface the most useful context:
-      - fail    → label, hash, error message
-      - skip    → label, hash, delivered-by URL  (rendered as <a> link)
+      - fail    → label, key, error message
+      - skip    → label, key, delivered-by URL  (rendered as <a> link)
       - warn    → label, reason
-      - ok      → label, hash, build URL         (rendered as <a> link)
+      - ok      → label, key, build URL         (rendered as <a> link)
       - pending → label, marker
 
     Rendered inside `<pre>` so HTML anchors in the context column are
@@ -286,26 +291,27 @@ def _outcome_table(diags, outcome):
     rows = []
     for d in diags:
         label = _truncate(d["label"] + (" *" if d.get("is_forced") else ""), _LABEL_MAX)
-        sha = (d["output_sha"] or "-")[:12]
+        sha = d["output_sha"] or ""
+        key = prefix + ":" + sha[:12] if sha else "-"
         ctx = d.get("message", "") or "-"
 
         # Don't truncate URL context — a truncated URL is useless as a
         # link. Non-URL context columns still truncate.
         if not url_context:
             ctx = _truncate(ctx, _MESSAGE_MAX)
-        rows.append((label, sha, ctx))
+        rows.append((label, key, ctx))
 
     if not rows:
         return ""
 
     label_w = max([len("Target")] + [len(r[0]) for r in rows])
-    sha_w = max([len("Hash")] + [len(r[1]) for r in rows])
+    key_w = max([len("Key")] + [len(r[1]) for r in rows])
     ctx_w = max([len(ctx_col)] + [len(r[2]) for r in rows])
 
     lines = []
-    lines.append(_pad_right("Target", label_w) + "  " + _pad_right("Hash", sha_w) + "  " + ctx_col)
-    lines.append("-" * label_w + "  " + "-" * sha_w + "  " + "-" * ctx_w)
-    for label, sha, ctx in rows:
+    lines.append(_pad_right("Target", label_w) + "  " + _pad_right("Key", key_w) + "  " + ctx_col)
+    lines.append("-" * label_w + "  " + "-" * key_w + "  " + "-" * ctx_w)
+    for label, key, ctx in rows:
         if url_context and ctx and ctx != "-":
             # HTML-escape both halves — URLs can carry `&`, `"`, etc.
             # in query strings, which would break the anchor and the
@@ -313,7 +319,7 @@ def _outcome_table(diags, outcome):
             ctx_out = '<a href="%s">%s</a>' % (html_escape(ctx), html_escape(ctx))
         else:
             ctx_out = ctx
-        lines.append(_pad_right(label, label_w) + "  " + _pad_right(sha, sha_w) + "  " + ctx_out)
+        lines.append(_pad_right(label, label_w) + "  " + _pad_right(key, key_w) + "  " + ctx_out)
     return "\n".join(lines)
 
 def _ctx_column_for(outcome):
@@ -328,6 +334,7 @@ def _ctx_column_for(outcome):
     return "Build URL"
 
 def _group_deliveries(data):
+    prefix = data["delivery"].get("prefix", "") or ""
     by_outcome = {}
     for d in data["delivery"].get("deliveries", []):
         outcome = d.get("outcome", "pending") or "pending"
@@ -350,7 +357,7 @@ def _group_deliveries(data):
             "count": str(count),
             "heading": _OUTCOME_GROUP_HEADINGS.get(outcome, outcome),
             "label_singular": _OUTCOME_LABELS_SINGULAR.get(outcome, outcome),
-            "table": _outcome_table(shown, outcome),
+            "table": _outcome_table(shown, outcome, prefix),
             "overflow": str(overflow) if overflow > 0 else "",
             # Open the actionable / informative outcomes (delivered,
             # warned, failed). Skipped / pending stay collapsed.

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -20,6 +20,16 @@ LOCAL_SPAWN_FLAGS = [
     "--build_runfile_links",
 ]
 
+# Pass-2 entrypoint selection: rules that declare
+# ctx.actions.declare_file(ctx.label.name + EXT) produce no no-extension
+# wrapper, so the extensioned file itself is the entrypoint.
+# Ordered from most to least common in the Bazel ecosystem.
+#   .sh   — oci_image_sign, ad-hoc wrappers
+#   .bash — rules_multirun (format_multirun, lint_multirun, etc.)
+#   .exe  — rules_img push (hermetic_launcher), Windows binaries
+#   .bat  — buildifier-prebuilt's `buildifier` rule on Windows, generic Windows wrappers
+_SCRIPT_EXTENSIONS = [".sh", ".bash", ".exe", ".bat"]
+
 def apparent_label(label, current_package = ""):
     """Normalize any Bazel label form to apparent form with an explicit target name.
 
@@ -108,30 +118,36 @@ def _process_bes(state: struct, event):
             state.workspace_name[0] = local_exec_root.rstrip("/").split("/")[-1]
 
 def _determine_entrypoint(state: struct, target: str) -> struct | None:
-    """Best BES-reported derived output for `target`, or None if not in BES.
+    """Resolve `target` to an executable path and runfiles directory.
 
-    Returns struct(path, runfiles_dir) where `runfiles_dir` is the resolved
-    runfiles directory path (e.g. `…/format.runfiles`), or `None` when the target
-    emits no runfiles tree (e.g. a prebuilt binary like buildifier).
+    Returns `struct(path, runfiles_dir)` or `None` when the target produced
+    no BES `target_completed` event or its default output group has no
+    selectable executable. `runfiles_dir` is the resolved runfiles directory
+    path (e.g. `…/format.runfiles`), or `None` when no
+    `<entrypoint>.runfiles` directory exists on disk.
 
-    Entrypoint selection runs three passes over the default-output-group files:
-      1. Exact match on `target_name` — the runnable wrapper that Bazel binary
-         rules (cc_binary, py_binary, sh_binary, …) always emit.
-      2. `target_name + ".sh"` — present on sh_binary as the user-supplied
-         source script; selected when no wrapper was found.
-      3. First file with the executable bit set (skipping `.runfiles_manifest`) —
-         last-resort for custom rules that emit a binary under a non-standard name.
+    Entrypoint selection — three passes over the default-output-group files:
+      1. Exact match on `target_name`.
+      2. `target_name + EXT` for each extension in `_SCRIPT_EXTENSIONS`
+         (.sh, .bash, .exe, .bat).
+      3. First file with the executable bit set —
+         last-resort for any remaining non-standard output name.
 
-    The runfiles dir is derived from the manifest file's directory — not the
-    entrypoint's, which may differ in non-standard rules. Both names are tied to the
-    target label (a Bazel invariant).
+    Runfiles detection — Bazel names the runfiles dir after the
+    executable FILE (including any extension), not the target label:
+      sh_binary //foo:bar  →  bar (no ext)    →  bar.runfiles
+      other rule :bar      →  bar.sh          →  bar.sh.runfiles
+    Source: RunfilesSupport.java
+    https://github.com/bazelbuild/bazel/blob/9.0.0rc1/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java#L83-L84
+
+    Detection checks `<entrypoint>.runfiles` on disk, materialized
+    by `--build_runfile_links` (included in `LOCAL_SPAWN_FLAGS`).
     """
     target = apparent_label(target, state.current_package)
     if target not in state.target_fileset:
         return None
 
     target_name = target.rsplit(":", 1)[-1]
-    manifest_name = target_name + ".runfiles_manifest"
 
     visited = {}
     frontier = [fs_ref.id for fs_ref in state.target_fileset[target]]
@@ -165,14 +181,15 @@ def _determine_entrypoint(state: struct, target: str) -> struct | None:
             entrypoint = c
             break
     if entrypoint == None:
-        for c in candidates:
-            if c.rsplit("/", 1)[-1] == target_name + ".sh":
-                entrypoint = c
+        for ext in _SCRIPT_EXTENSIONS:
+            for c in candidates:
+                if c.rsplit("/", 1)[-1] == target_name + ext:
+                    entrypoint = c
+                    break
+            if entrypoint != None:
                 break
     if entrypoint == None:
         for c in candidates:
-            if c.rsplit("/", 1)[-1].endswith(".runfiles_manifest"):
-                continue
             if state.ctx == None or state.ctx.std.fs.metadata(c).executable:
                 entrypoint = c
                 break
@@ -180,41 +197,39 @@ def _determine_entrypoint(state: struct, target: str) -> struct | None:
     if entrypoint == None:
         return None
 
-    manifest_dir = None
-    for c in candidates:
-        if c.rsplit("/", 1)[-1] == manifest_name:
-            manifest_dir = c.rsplit("/", 1)[0]
-            break
-    runfiles_dir = (manifest_dir + "/" + target_name + ".runfiles") if manifest_dir != None else None
+    runfiles_dir = None
+    if state.ctx != None:
+        if state.ctx.std.fs.exists(entrypoint + ".runfiles"):
+            runfiles_dir = entrypoint + ".runfiles"
+
     return struct(path = entrypoint, runfiles_dir = runfiles_dir)
+
+def _runfiles_cwd(state: struct, ep: struct) -> str | None:
+    """`bazel run` default cwd: <runfiles_dir>/<workspace>, or None if no runfiles."""
+    if not ep.runfiles_dir:
+        return None
+    return ep.runfiles_dir + "/" + (state.workspace_name[0] or _DEFAULT_WORKSPACE_NAME)
 
 def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture: bool = False, cwd: str | None = None) -> std.process.Child:
     """Spawn `ep.path` with `args` in the Bazel runfiles environment.
 
-    Always sets BUILD_WORKSPACE_DIRECTORY (= bazel_root_dir) and
-    BUILD_WORKING_DIRECTORY (= current_dir) so tool wrappers can locate the
-    workspace. When `ep.runfiles_dir` is set, also sets
-    RUNFILES_DIR / RUNFILES_MANIFEST_FILE / JAVA_RUNFILES so `rlocation` in
-    sh_binary wrappers works regardless of cwd.
+    Always sets BUILD_WORKSPACE_DIRECTORY / BUILD_WORKING_DIRECTORY so tool
+    wrappers can locate the workspace, and the four ASPECT_CLI_* variables for
+    tools that prefer aspect-native conventions.
 
-    Also sets four ASPECT_CLI_* variables for tools that prefer aspect-native
-    conventions over Bazel-specific vars:
-      ASPECT_CLI_WORKING_DIRECTORY      — where the user invoked aspect
-      ASPECT_CLI_ASPECT_ROOT_DIRECTORY  — .aspect/ / MODULE.aspect anchor
-      ASPECT_CLI_BAZEL_ROOT_DIRECTORY   — MODULE.bazel / WORKSPACE anchor
-      ASPECT_CLI_GIT_ROOT_DIRECTORY     — .git anchor (empty when absent)
+    When `ep.runfiles_dir` is set, also injects RUNFILES_DIR /
+    RUNFILES_MANIFEST_FILE / JAVA_RUNFILES so `rlocation` in sh_binary wrappers
+    and the bash runfiles library resolve data deps regardless of cwd.
 
-    `cwd` overrides the working directory. When omitted: defaults to
-    `ep.runfiles_dir/<workspace>` when a runfiles tree is present (matching
-    `bazel run`), or to the aspect invocation directory for bare binaries.
+    Working directory defaults to `runfiles_dir/<workspace>` (matching `bazel run`)
+    when a runfiles tree is present, falling back to the aspect invocation directory
+    when the target has no runfiles tree. Pass `cwd` explicitly to override — e.g.
+    `format.axl` passes the invocation directory under `--run-in-cwd` so targets
+    that don't switch to `$BUILD_WORKSPACE_DIRECTORY` on their own (such as
+    `@buildifier_prebuilt//buildifier`) resolve workspace-relative arguments
+    against the user's cwd.
     """
-    workspace_name = state.workspace_name[0] or _DEFAULT_WORKSPACE_NAME
-    if cwd:
-        effective_cwd = cwd
-    elif ep.runfiles_dir:
-        effective_cwd = ep.runfiles_dir + "/" + workspace_name
-    else:
-        effective_cwd = ctx.std.env.current_dir()
+    effective_cwd = cwd or _runfiles_cwd(state, ep) or ctx.std.env.current_dir()
     cmd = ctx.std.process.command(ep.path) \
         .current_dir(effective_cwd) \
         .env("BUILD_WORKSPACE_DIRECTORY", ctx.std.env.bazel_root_dir()) \
@@ -243,12 +258,14 @@ def runnable(ctx, targets: list[str]) -> struct:
           Best executable output for `target` from its BES default output group,
           or None if no BES data was received for it. `runfiles_dir` is the
           resolved runfiles directory (e.g. `…/format.runfiles`), or `None`
-          when the target has no runfiles tree (e.g. a prebuilt binary).
+          when no `<entrypoint>.runfiles` directory exists on disk.
 
       spawn(ep, args, capture=False, cwd=None) → Child
           Spawn `ep.path` with Bazel runfiles environment variables set.
           `cwd` defaults to `ep.runfiles_dir/<workspace>` when a runfiles tree
-          is present, or to the aspect invocation directory for bare binaries.
+          is present (matching `bazel run`), falling back to the aspect
+          invocation directory when there is no runfiles tree. Pass an
+          explicit `cwd` to override — e.g. for `--run-in-cwd` semantics.
     """
     current_package = _current_package(ctx) if ctx else ""
     state = struct(

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,4 +1,5 @@
-"""Unit tests for lib/runnable.axl: apparent_label normalization and BES matching."""
+"""Unit tests for lib/runnable.axl: apparent_label normalization, BES matching,
+entrypoint selection (passes 1–3), and runfiles directory detection."""
 
 load("./runnable.axl", "apparent_label", "runnable")
 
@@ -225,112 +226,169 @@ def _test_bes_unknown_target_returns_none(ctx):
         fail("bes unknown target: expected None")
 
 # ---------------------------------------------------------------------------
-# runfiles_dir tests — BES-based runfiles manifest detection
+# runfiles_dir tests — runfiles directory detection
 # ---------------------------------------------------------------------------
 
-def _test_has_runfiles_when_manifest_present(ctx):
-    """runfiles_dir is non-empty when BES output includes a .runfiles_manifest."""
-    r = runnable(None, ["//tools/format:format"])
-    r.event(_make_fileset_event("s1", [
-        "/out/bin/tools/format/format",
-        "/out/bin/tools/format/format.runfiles_manifest",
-    ]))
-    r.event(_make_target_event("//tools/format:format", "s1"))
-    ep = r.determine_entrypoint("//tools/format:format")
-    if ep == None:
-        fail("has-runfiles/manifest: expected entrypoint, got None")
-    if not ep.runfiles_dir:
-        fail("has-runfiles/manifest: expected non-None runfiles_dir (manifest in BES), got None")
-    _eq(
-        "has-runfiles/manifest: runfiles dir",
-        ep.runfiles_dir,
-        "/out/bin/tools/format/format.runfiles",
-    )
+def _test_no_runfiles_dir_when_ctx_none(ctx):
+    """runfiles_dir is None when ctx is None — filesystem probe requires ctx.
 
-def _test_no_runfiles_when_no_manifest(ctx):
-    """runfiles_dir is None when BES output has no .runfiles_manifest (raw binary)."""
+    `_test_filesystem_*` cover the ctx-present detection paths.
+    """
     r = runnable(None, ["@buildifier_prebuilt//buildifier"])
     r.event(_make_fileset_event("s1", ["/out/bin/external/buildifier_prebuilt/buildifier/buildifier"]))
     r.event(_make_target_event("@@buildifier_prebuilt+//buildifier:buildifier", "s1"))
     ep = r.determine_entrypoint("@buildifier_prebuilt//buildifier")
     if ep == None:
-        fail("no-runfiles/no-manifest: expected entrypoint, got None")
+        fail("no-runfiles/ctx-none: expected entrypoint, got None")
     if ep.runfiles_dir != None:
-        fail("no-runfiles/no-manifest: expected runfiles_dir=None (no manifest in BES), got %r" % ep.runfiles_dir)
+        fail("no-runfiles/ctx-none: expected runfiles_dir=None (no ctx for fs check), got %r" % ep.runfiles_dir)
 
-def _test_sh_pass_with_manifest(ctx):
-    """Pass 2 (.sh) selects the entrypoint when no wrapper matches; manifest still named after target label."""
-    r = runnable(None, ["//tools/format:runner"])
-    r.event(_make_fileset_event("s1", [
-        "/out/bin/tools/format/runner.sh",
-        "/out/bin/tools/format/runner.runfiles_manifest",
-    ]))
-    r.event(_make_target_event("//tools/format:runner", "s1"))
-    ep = r.determine_entrypoint("//tools/format:runner")
+def _test_bash_pass2_selected(ctx):
+    """Pass 2 selects .bash-extensioned entrypoint (rules_multirun pattern)."""
+    r = runnable(None, ["//tools:my_target"])
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/my_target.bash"]))
+    r.event(_make_target_event("//tools:my_target", "s1"))
+    ep = r.determine_entrypoint("//tools:my_target")
     if ep == None:
-        fail("sh-pass/manifest: expected entrypoint, got None")
-    if ep.path.rsplit("/", 1)[-1] != "runner.sh":
-        fail("sh-pass/manifest: expected runner.sh, got %r" % ep.path)
-    if not ep.runfiles_dir:
-        fail("sh-pass/manifest: expected non-None runfiles_dir (runner.runfiles_manifest in BES)")
+        fail("bash-pass2: expected entrypoint, got None")
+    _eq("bash-pass2: path", ep.path, "/out/bin/tools/my_target.bash")
 
-def _test_sh_pass_no_manifest(ctx):
-    """Pass 2 (.sh) selects the entrypoint; runfiles_dir is None when no manifest in BES."""
+def _test_exe_pass2_selected(ctx):
+    """Pass 2 selects .exe-extensioned entrypoint (hermetic_launcher / rules_img pattern)."""
+    r = runnable(None, ["//tools:my_target"])
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/my_target.exe"]))
+    r.event(_make_target_event("//tools:my_target", "s1"))
+    ep = r.determine_entrypoint("//tools:my_target")
+    if ep == None:
+        fail("exe-pass2: expected entrypoint, got None")
+    _eq("exe-pass2: path", ep.path, "/out/bin/tools/my_target.exe")
+
+def _test_bat_pass2_selected(ctx):
+    """Pass 2 selects .bat-extensioned entrypoint (Windows wrappers, buildifier-prebuilt buildifier rule)."""
+    r = runnable(None, ["//tools:my_target"])
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/my_target.bat"]))
+    r.event(_make_target_event("//tools:my_target", "s1"))
+    ep = r.determine_entrypoint("//tools:my_target")
+    if ep == None:
+        fail("bat-pass2: expected entrypoint, got None")
+    _eq("bat-pass2: path", ep.path, "/out/bin/tools/my_target.bat")
+
+def _test_sh_pass2_selected(ctx):
+    """Pass 2 selects .sh-extensioned entrypoint (oci_image_sign / ad-hoc wrapper pattern)."""
     r = runnable(None, ["//tools/format:runner"])
     r.event(_make_fileset_event("s1", ["/out/bin/tools/format/runner.sh"]))
     r.event(_make_target_event("//tools/format:runner", "s1"))
     ep = r.determine_entrypoint("//tools/format:runner")
     if ep == None:
-        fail("sh-pass/no-manifest: expected entrypoint, got None")
-    if ep.path.rsplit("/", 1)[-1] != "runner.sh":
-        fail("sh-pass/no-manifest: expected runner.sh, got %r" % ep.path)
-    if ep.runfiles_dir != None:
-        fail("sh-pass/no-manifest: expected runfiles_dir=None (no manifest in BES), got %r" % ep.runfiles_dir)
+        fail("sh-pass2: expected entrypoint, got None")
+    _eq("sh-pass2: path", ep.path, "/out/bin/tools/format/runner.sh")
 
-def _test_fallback_skips_manifest_files(ctx):
-    """Pass 3 skips .runfiles_manifest entries and selects the first other file."""
+def _test_pass2_extension_priority(ctx):
+    """Pass 2 honours _SCRIPT_EXTENSIONS order: .sh wins over .bash when both are present."""
+    r = runnable(None, ["//tools:my_target"])
+    r.event(_make_fileset_event("s1", [
+        "/out/bin/tools/my_target.bash",
+        "/out/bin/tools/my_target.sh",
+    ]))
+    r.event(_make_target_event("//tools:my_target", "s1"))
+    ep = r.determine_entrypoint("//tools:my_target")
+    if ep == None:
+        fail("pass2-priority: expected entrypoint, got None")
+    _eq("pass2-priority: .sh wins over .bash", ep.path, "/out/bin/tools/my_target.sh")
+
+def _test_pass3_first_executable(ctx):
+    """Pass 3 picks the first file with the executable bit set when passes 1 and 2 fail."""
     r = runnable(None, ["//tools/format:runner"])
     r.event(_make_fileset_event("s1", [
-        "/out/bin/tools/format/runner.runfiles_manifest",
+        "/out/bin/tools/format/format_impl",
+        "/out/bin/tools/format/extra_artifact",
+    ]))
+    r.event(_make_target_event("//tools/format:runner", "s1"))
+    ep = r.determine_entrypoint("//tools/format:runner")
+    if ep == None:
+        fail("pass3: expected entrypoint, got None")
+    if ep.path.rsplit("/", 1)[-1] != "format_impl":
+        fail("pass3: expected format_impl, got %r" % ep.path)
+
+def _test_pass3_skips_non_executable(ctx):
+    """Pass 3 with a real ctx skips files whose executable bit is not set."""
+    mock = _make_mock_ctx(
+        existing_paths = [],
+        executable_paths = ["/out/bin/tools/format/format_impl"],
+    )
+    r = runnable(mock, ["//tools/format:runner"])
+    r.event(_make_fileset_event("s1", [
+        "/out/bin/tools/format/data_file",
         "/out/bin/tools/format/format_impl",
     ]))
     r.event(_make_target_event("//tools/format:runner", "s1"))
     ep = r.determine_entrypoint("//tools/format:runner")
     if ep == None:
-        fail("fallback-skip: expected entrypoint, got None")
-    if ep.path.rsplit("/", 1)[-1] != "format_impl":
-        fail("fallback-skip: expected format_impl (manifest skipped), got %r" % ep.path)
+        fail("pass3-exec-bit: expected entrypoint, got None")
+    _eq("pass3-exec-bit: non-executable skipped", ep.path, "/out/bin/tools/format/format_impl")
 
-def _test_none_when_only_manifest_candidate(ctx):
-    """determine_entrypoint returns None when the only BES output is a .runfiles_manifest."""
-    r = runnable(None, ["//tools/format:runner"])
-    r.event(_make_fileset_event("s1", ["/out/bin/tools/format/runner.runfiles_manifest"]))
-    r.event(_make_target_event("//tools/format:runner", "s1"))
-    if r.determine_entrypoint("//tools/format:runner") != None:
-        fail("only-manifest: expected None (no executable candidate)")
+# ---------------------------------------------------------------------------
+# Filesystem detection tests — exercise `<entrypoint>.runfiles` discovery on
+# disk with a minimal mock ctx.
+# ---------------------------------------------------------------------------
 
-def _test_runfiles_dir_derived_from_manifest_not_entrypoint(ctx):
-    """Runfiles dir is colocated with the manifest, not with the entrypoint.
+def _make_mock_ctx(existing_paths, executable_paths = None):
+    """Minimal TaskContext mock for filesystem detection tests.
 
-    Pass 3 may select an entrypoint in a subdirectory of the target's output dir
-    (e.g. a custom rule emitting out/bin/pkg/subdir/impl alongside the manifest at
-    out/bin/pkg/runner.runfiles_manifest). The runfiles dir must be a sibling of
-    the manifest, not of the entrypoint.
+    existing_paths: absolute paths that `std.fs.exists()` returns True for.
+    executable_paths: absolute paths that `std.fs.metadata().executable` is True
+        for. None means "every path is executable" — the right default for tests
+        that don't exercise pass-3's executable-bit check.
     """
-    r = runnable(None, ["//tools/format:runner"])
-    r.event(_make_fileset_event("s1", [
-        "/out/bin/tools/format/runner.runfiles_manifest",
-        "/out/bin/tools/format/subdir/impl",
-    ]))
+    is_executable = (lambda path: True) if executable_paths == None else (lambda path: path in executable_paths)
+    return struct(
+        std = struct(
+            env = struct(
+                bazel_root_dir = lambda: "/workspace",
+                current_dir = lambda: "/workspace",
+            ),
+            fs = struct(
+                exists = lambda path: path in existing_paths,
+                metadata = lambda path: struct(executable = is_executable(path)),
+            ),
+        ),
+    )
+
+def _test_filesystem_sh_extension(ctx):
+    """.sh-extensioned executable: runfiles dir found on disk as runner.sh.runfiles."""
+    mock = _make_mock_ctx(["/out/bin/tools/format/runner.sh.runfiles"])
+    r = runnable(mock, ["//tools/format:runner"])
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/format/runner.sh"]))
     r.event(_make_target_event("//tools/format:runner", "s1"))
     ep = r.determine_entrypoint("//tools/format:runner")
     if ep == None:
-        fail("runfiles-dir-from-manifest: expected entrypoint, got None")
-    _eq(
-        "runfiles-dir-from-manifest: runfiles dir",
-        ep.runfiles_dir,
-        "/out/bin/tools/format/runner.runfiles",
-    )
+        fail("fs/sh: expected entrypoint, got None")
+    _eq("fs/sh: path", ep.path, "/out/bin/tools/format/runner.sh")
+    _eq("fs/sh: runfiles_dir", ep.runfiles_dir, "/out/bin/tools/format/runner.sh.runfiles")
+
+def _test_filesystem_bash_extension(ctx):
+    """.bash-extensioned executable (mirrors rules_multirun): pass-2 selects .bash, filesystem finds the runfiles dir."""
+    mock = _make_mock_ctx(["/out/bin/tools/my_target.bash.runfiles"])
+    r = runnable(mock, ["//tools:my_target"])
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/my_target.bash"]))
+    r.event(_make_target_event("//tools:my_target", "s1"))
+    ep = r.determine_entrypoint("//tools:my_target")
+    if ep == None:
+        fail("fs/bash: expected entrypoint, got None")
+    _eq("fs/bash: path", ep.path, "/out/bin/tools/my_target.bash")
+    _eq("fs/bash: runfiles_dir", ep.runfiles_dir, "/out/bin/tools/my_target.bash.runfiles")
+
+def _test_filesystem_no_runfiles(ctx):
+    """Bare binary with no .runfiles on disk: runfiles_dir stays None even with a real ctx."""
+    mock = _make_mock_ctx([])  # nothing on disk
+    r = runnable(mock, ["@buildifier_prebuilt//buildifier"])
+    r.event(_make_fileset_event("s1", ["/out/bin/external/buildifier_prebuilt/buildifier/buildifier"]))
+    r.event(_make_target_event("@@buildifier_prebuilt+//buildifier:buildifier", "s1"))
+    ep = r.determine_entrypoint("@buildifier_prebuilt//buildifier")
+    if ep == None:
+        fail("fs/no-runfiles: expected entrypoint, got None")
+    if ep.runfiles_dir != None:
+        fail("fs/no-runfiles: expected runfiles_dir=None (no .runfiles on disk), got %r" % ep.runfiles_dir)
 
 _UNIT_TESTS = [
     _test_local_label_with_colon,
@@ -362,13 +420,17 @@ _UNIT_TESTS = [
     _test_bes_bzlmod_extension_repo,
     _test_bes_local_target,
     _test_bes_unknown_target_returns_none,
-    _test_has_runfiles_when_manifest_present,
-    _test_no_runfiles_when_no_manifest,
-    _test_sh_pass_with_manifest,
-    _test_sh_pass_no_manifest,
-    _test_fallback_skips_manifest_files,
-    _test_none_when_only_manifest_candidate,
-    _test_runfiles_dir_derived_from_manifest_not_entrypoint,
+    _test_no_runfiles_dir_when_ctx_none,
+    _test_sh_pass2_selected,
+    _test_bash_pass2_selected,
+    _test_exe_pass2_selected,
+    _test_bat_pass2_selected,
+    _test_pass2_extension_priority,
+    _test_pass3_first_executable,
+    _test_pass3_skips_non_executable,
+    _test_filesystem_sh_extension,
+    _test_filesystem_bash_extension,
+    _test_filesystem_no_runfiles,
 ]
 
 def _test_impl(ctx):

--- a/examples/deliverable/BUILD.bazel
+++ b/examples/deliverable/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load(":custom_deliverable.bzl", "bash_deliverable", "custom_deliverable")
 
 genrule(
     name = "delivery_payload",
@@ -14,7 +15,7 @@ sh_binary(
     tags = ["deliverable"],
 )
 
-# Delivery should find this target but skip it as not runnable.
+# Non-executable genrule tagged deliverable — exercises --warn-not-runnable.
 genrule(
     name = "non_executable_deliverable",
     outs = ["non_executable_deliverable.txt"],
@@ -22,9 +23,23 @@ genrule(
     tags = ["deliverable"],
 )
 
-# rules_python's stamping injects an uncachable_version_file action into the
-# build. Delivery should still succeed: the action's output is marked as
-# constant_metadata so downstream action keys stay stable across phases.
+# Custom .sh executable — exercises runfiles discovery for extensioned binaries.
+custom_deliverable(
+    name = "custom_deliverable",
+    data = [":delivery_payload"],
+    tags = ["deliverable"],
+)
+
+# Custom .bash executable — mirrors the rules_multirun naming convention.
+bash_deliverable(
+    name = "bash_deliverable",
+    data = [":delivery_payload"],
+    tags = ["deliverable"],
+)
+
+# py_binary with stamp=1 — exercises delivery with stamped actions
+# (rules_python injects a constant_metadata version file that must not
+# invalidate downstream action keys across delivery phases).
 py_binary(
     name = "py_deliverable",
     srcs = ["py_deliverable.py"],

--- a/examples/deliverable/MODULE.bazel.lock
+++ b/examples/deliverable/MODULE.bazel.lock
@@ -1,0 +1,281 @@
+{
+  "lockFileVersion": 26,
+  "registryFileHashes": {
+    "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/MODULE.bazel": "51f2312901470cdab0dbdf3b88c40cd21c62a7ed58a3de45b365ddc5b11bcab2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/source.json": "cea3901d7e299da7320700abbaafe57a65d039f10d0d7ea601c4a66938ea4b0c",
+    "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
+    "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
+    "https://bcr.bazel.build/modules/apple_support/1.21.0/MODULE.bazel": "ac1824ed5edf17dee2fdd4927ada30c9f8c3b520be1b5fd02a5da15bc10bff3e",
+    "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
+    "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
+    "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
+    "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
+    "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
+    "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
+    "https://bcr.bazel.build/modules/bazel_features/1.42.1/source.json": "fcd4396b2df85f64f2b3bb436ad870793ecf39180f1d796f913cc9276d355309",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/source.json": "34a3c8bcf233b835eb74be9d628899bb32999d3e0eadef1947a0a562a2b16ffb",
+    "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
+    "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
+    "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
+    "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
+    "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
+    "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
+    "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
+    "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
+    "https://bcr.bazel.build/modules/protobuf/33.4/MODULE.bazel": "114775b816b38b6d0ca620450d6b02550c60ceedfdc8d9a229833b34a223dc42",
+    "https://bcr.bazel.build/modules/protobuf/33.4/source.json": "555f8686b4c7d6b5ba731fbea13bf656b4bfd9a7ff629c1d9d3f6e1d6155de79",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
+    "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
+    "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
+    "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
+    "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
+    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
+    "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
+    "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/1.3.0/MODULE.bazel": "8361d57eafb67c09b75bf4bbe6be360e1b8f4f18118ab48037f2bd50aa2ccb13",
+    "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
+    "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
+    "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
+    "https://bcr.bazel.build/modules/rules_python/2.0.1/MODULE.bazel": "294fbfe4dc3b24a925172e5487e1e8d3c2927cf4fba1eaddd7bad0ce50701da1",
+    "https://bcr.bazel.build/modules/rules_python/2.0.1/source.json": "f2bacc75d3fc496dfd3e6a5986200b10e70169aaaf4ee5f1cea573c8d347e7c4",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
+    "https://bcr.bazel.build/modules/rules_shell/0.7.1/MODULE.bazel": "257dd8d667371de804918dfceb86f6ddd2e1b5e025f5d9322878d4a73dc8aa58",
+    "https://bcr.bazel.build/modules/rules_shell/0.7.1/source.json": "9e6c3ea5766b584f60a44dd36520c4be16a12bb173aad238e018f73083e8feb6",
+    "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
+    "https://bcr.bazel.build/modules/rules_swift/2.4.0/MODULE.bazel": "1639617eb1ede28d774d967a738b4a68b0accb40650beadb57c21846beab5efd",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/MODULE.bazel": "72c8f5cf9d26427cee6c76c8e3853eb46ce6b0412a081b2b6db6e8ad56267400",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/source.json": "e85761f3098a6faf40b8187695e3de6d97944e98abd0d8ce579cb2daf6319a66",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/MODULE.bazel": "75aab2373a4bbe2a1260b9bf2a1ebbdbf872d3bd36f80bff058dccd82e89422f",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/source.json": "5fba48bbe0ba48761f9e9f75f92876cafb5d07c0ce059cc7a8027416de94a05b",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
+  },
+  "selectedYankedVersions": {},
+  "moduleExtensions": {
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
+        ],
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "@@rules_python+//python/uv:uv.bzl%uv": {
+      "general": {
+        "bzlTransitiveDigest": "I8FPZMevE2oI/peSpMBRVIN++WOtfjtJVjbPsBZQ87A=",
+        "usagesDigest": "KI88AZslgI1K52IZ7PfBqhuXb5hke0gUD9N73XeVqaI=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,platforms platforms"
+        ],
+        "generatedRepoSpecs": {
+          "uv": {
+            "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
+            "attributes": {
+              "toolchain_type": "'@@rules_python+//python/uv:uv_toolchain_type'",
+              "toolchain_names": [
+                "none"
+              ],
+              "toolchain_implementations": {
+                "none": "'@@rules_python+//python:none'"
+              },
+              "toolchain_compatible_with": {
+                "none": [
+                  "@platforms//:incompatible"
+                ]
+              },
+              "toolchain_target_settings": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "facts": {}
+}

--- a/examples/deliverable/custom_deliverable.bzl
+++ b/examples/deliverable/custom_deliverable.bzl
@@ -1,0 +1,61 @@
+"""Custom executable rules for delivery e2e testing.
+
+Both rules use a non-standard executable file extension (.sh and .bash), which
+exercises the naming fix: Bazel places the runfiles tree at <exec>.runfiles
+(after the executable file, including extension), not <target_name>.runfiles.
+"""
+
+def _custom_deliverable_impl(ctx):
+    runner = ctx.actions.declare_file(ctx.label.name + ".sh")
+    ctx.actions.write(
+        output = runner,
+        is_executable = True,
+        content = """\
+#!/usr/bin/env bash
+set -euo pipefail
+runfiles_dir="${RUNFILES_DIR:-$0.runfiles}"
+manifest_file="${RUNFILES_MANIFEST_FILE:-}"
+
+rlocation() {
+  local path="$1"
+  if [[ -n "$manifest_file" && -f "$manifest_file" ]]; then
+    awk -v p="$path" '$1 == p { print substr($0, length($1)+2); found=1; exit } END { if (!found) exit 1 }' "$manifest_file"
+  else
+    printf '%s/%s\n' "$runfiles_dir" "$path"
+  fi
+}
+
+payload="$(rlocation "_main/delivery_payload.txt")"
+echo "custom_deliverable ran; payload contents: $(cat "$payload")"
+""",
+    )
+    return [DefaultInfo(
+        files = depset([runner]),
+        executable = runner,
+        runfiles = ctx.runfiles(files = ctx.files.data),
+    )]
+
+custom_deliverable = rule(
+    implementation = _custom_deliverable_impl,
+    executable = True,
+    attrs = {"data": attr.label_list(allow_files = True)},
+)
+
+def _bash_deliverable_impl(ctx):
+    runner = ctx.actions.declare_file(ctx.label.name + ".bash")
+    ctx.actions.write(
+        output = runner,
+        is_executable = True,
+        content = "#!/usr/bin/env bash\necho 'bash_deliverable ran'\n",
+    )
+    return [DefaultInfo(
+        files = depset([runner]),
+        executable = runner,
+        runfiles = ctx.runfiles(files = ctx.files.data),
+    )]
+
+bash_deliverable = rule(
+    implementation = _bash_deliverable_impl,
+    executable = True,
+    attrs = {"data": attr.label_list(allow_files = True)},
+)


### PR DESCRIPTION
## Summary

**1. Runfiles directory naming.** Bazel names `<exec>.runfiles` after the executable file artifact (including extension), see [`RunfilesSupport.java`](https://github.com/bazelbuild/bazel/blob/9.0.0rc1/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java#L83-L84). Detection now checks `<entrypoint>.runfiles` on disk.

**2. Pass-2 entrypoint selection extended.** A new `_SCRIPT_EXTENSIONS` list (`.sh`, `.bash`, `.exe`, `.bat`) drives the second pass of entrypoint selection so any of the common custom-executable extensions resolve directly without falling through to the pass-3 first-executable scan.

**3. `--run-in-cwd` flag (format only).** `_spawn`'s default cwd now matches `bazel run` (`<runfiles_dir>/<workspace>`). A new `--run-in-cwd` flag on `format` switches to the invocation cwd, mirroring Bazel's `--run_in_cwd`. Required for targets that don't switch to `$BUILD_WORKING_DIRECTORY` themselves — e.g. `@buildifier_prebuilt//buildifier`, a plain symlink to the Go binary. The `aspect buildifier` alias sets this by default.

**4. Delivery hard-fails non-runnable targets.** A target tagged `deliverable` whose entrypoint has no runfiles tree now fails delivery (exit 1) instead of silently warning. Pass `--warn-not-runnable` to keep the warn-and-continue behaviour.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): yes — `deliverable`-tagged targets with no runfiles tree now fail by default; pass `--warn-not-runnable` to restore the old behaviour.
- Suggested release notes appear below: yes

`aspect delivery` now correctly delivers custom rules whose declared output carries a file extension (`.sh`, `.bash`, etc...). `aspect format` gains a `--run-in-cwd` flag (mirrors Bazel's `--run_in_cwd`) for formatter targets that resolve workspace-relative arguments against process cwd. A `deliverable`-tagged target with no runfiles tree now hard-fails delivery; pass `--warn-not-runnable` to restore warning behaviour.

### Test plan

- `lib/runnable_test.axl` — 40 unit tests covering pass-2 selection for each extension and the priority order, pass-3 executable-bit filtering, and `<entrypoint>.runfiles` filesystem detection
- `examples/deliverable/custom_deliverable.bzl` — two e2e fixtures (`custom_deliverable` for `.sh`, `bash_deliverable` for `.bash`); both deliver successfully in CI on Buildkite, CircleCI, and GitHub Actions
- The existing non-executable genrule fixture (`non_executable_deliverable`) keeps CI delivery green via `--warn-not-runnable`
