### PR TITLE
fix(health-check): align Bazel health-check startup flags with the build

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -4,6 +4,7 @@ load("@aspect//feature/buildkite_annotations_test.axl", "bk_annotation_snapshot_
 load("@aspect//feature/github_status_checks.axl", "GithubStatusChecks")
 load("@aspect//feature/github_status_comments_test.axl", "pr_comment_snapshot_tests")
 load("@aspect//format.axl", "format")
+load("@aspect//lib/bazel_flags_test.axl", "bazel_flags_tests")
 load("@aspect//lib/bazel_results_test.axl", "bazel_results_unit_tests", "template_snapshot_tests")
 load("@aspect//lib/delivery_results_test.axl", "delivery_template_snapshot_tests")
 load("@aspect//lib/format_results_test.axl", "format_template_snapshot_tests")
@@ -11,6 +12,7 @@ load("@aspect//lib/gazelle_results_test.axl", "gazelle_template_snapshot_tests")
 load("@aspect//lib/github_detect_test.axl", "github_detect_tests")
 load("@aspect//lib/gitlab_detect_test.axl", "gitlab_detect_tests")
 load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
+load("@aspect//lib/health_check_ready_test.axl", "health_check_ready_tests")
 load("@aspect//lib/lint_results_test.axl", "detect_lint_tool_tests", "lint_annotation_plan_tests", "lint_template_snapshot_tests", "linter_rows_tests")
 load("@aspect//lib/rate_limit_test.axl", "rate_limit_tests")
 load("@aspect//lib/repro_commands_test.axl", "repro_commands_tests")
@@ -162,6 +164,17 @@ def config(ctx: ConfigContext):
     # file's module docstring.
     # Run with: aspect dev test-runner-job-history
     ctx.tasks.add(runner_job_history_tests)
+
+    # Bazel health check ordering — locks in the contract that
+    # ctx.bazel.startup_flags must contain --output_base before the
+    # health check runs on a Workflows runner. Catches regressions of
+    # the silent "wrong server" bug.
+    # Run with: aspect dev test-health-check-ready
+    ctx.tasks.add(health_check_ready_tests)
+
+    # Bazel flag-resolution helper unit tests.
+    # Run with: aspect dev test-bazel-flags
+    ctx.tasks.add(bazel_flags_tests)
 
     # Delivery template snapshot tests — renders delivery_results templates.
     # Run with: aspect dev test-delivery-template-snapshots

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -53,10 +53,6 @@ build = task(
             default = False,
             description = "Cancel any running Bazel invocation before starting the build.",
         ),
-        "output_base": args.string(
-            default = "",
-            description = "Bazel output base path. Use to target a specific Bazel server instance — distinct paths run independent JVMs and cache contents.",
-        ),
     },
     traits = [
         BazelTrait,

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -101,6 +101,7 @@ User-facing migration guide: https://docs.aspect.build/cli/migration/delivery
 
 load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@aspect//lib/artifacts.axl", "artifacts")
+load("@aspect//lib/bazel_flags.axl", "setup_bazel_command")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("@aspect//lib/ci.axl", "detect_build_url")
 load("@aspect//lib/delivery_results.axl", delivery_add_result = "add_result", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
@@ -116,7 +117,7 @@ load("@aspect//lib/github.axl", "detect_commit_sha")
 load("@aspect//lib/health_check.axl", "HealthCheckTrait")
 load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "repro_prefix", "task_cli_path")
-load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
+load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "apparent_label", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
 load("@aspect//lib/tips.axl", "tips")
 load("@std//time.axl", "sleep_iter", "time")
@@ -620,6 +621,18 @@ def _delivery_impl(ctx):
     for handler in lifecycle.task_started:
         handler(ctx, targets_subject)
 
+    # phase1/2/3_flags layer on top of expanded_flags later.
+    # --remote_download_outputs=minimal is mandatory for phases 1/2 (we
+    # never download outputs while computing shas). Phase 3 additionally
+    # appends ctx.args.release_bazel_flags for release-only Bazel flags
+    # like --stamp.
+    expanded_flags = setup_bazel_command(
+        ctx,
+        "build",
+        bazel_trait,
+        base_flags = ["--remote_download_outputs=minimal"],
+    )
+
     preflight_phase(ctx, lifecycle, hc_trait)
 
     delivery_trait = ctx.traits[DeliveryTrait]
@@ -669,42 +682,11 @@ def _delivery_impl(ctx):
         prefix = ctx.task.key
         prefix_source = "--task-key"
 
-    # Flags: accumulate data, then optionally transform. --remote_download_outputs=minimal
-    # is mandatory for phase 1/2 (we never want to download outputs while computing shas).
-    flags = ["--remote_download_outputs=minimal"]
-    flags.extend(ctx.args.bazel_flags)
-    flags.extend(bazel_trait.extra_flags)
-    if not ctx.args.bazel_flags:
-        flags.append("--stamp")
-    if bazel_trait.flags:
-        flags = bazel_trait.flags(flags)
-
-    startup_flags = list(ctx.args.bazel_startup_flags)
-    startup_flags.extend(bazel_trait.extra_startup_flags)
-    if bazel_trait.startup_flags:
-        startup_flags = bazel_trait.startup_flags(startup_flags)
-
     # iter handles are created per attempt inside the retry loop.
     build_events = list(bazel_trait.build_event_sinks)
 
     for handler in bazel_trait.build_start:
         handler(ctx)
-
-    # Expand .bazelrc so remote cache config flows in automatically.
-    rc = ctx.bazel.parse_rc(
-        flags = flags,
-        startup_flags = startup_flags,
-    )
-    rc_startup_flags, expanded_flags = rc.expand_all(command = "build")
-    ctx.bazel.startup_flags.extend(startup_flags + rc_startup_flags + ["--ignore_all_rc_files"])
-
-    # Parsed-rc disclosure is verbose; print on user opt-in via
-    # --announce-rc, otherwise gate behind trace.log so it only
-    # surfaces under ASPECT_DEBUG.
-    if ctx.args.announce_rc:
-        print(rc.announce(command = "build", ansi = ansi))
-    else:
-        trace.log(rc.announce(command = "build", ansi = False))
 
     # Delivery requires a remote cache (and may surface via common
     # section as --default_override=0:common=--remote_cache=...).
@@ -785,7 +767,7 @@ def _delivery_impl(ctx):
         _emit_final(ctx, lifecycle, dr, exit_code = 1)
         fail(msg)
 
-    _print_header(ansi, endpoint, ci_host, commit_sha, prefix, prefix_source, build_url, flags, targets, forced_targets, mode, dry_run, track_state)
+    _print_header(ansi, endpoint, ci_host, commit_sha, prefix, prefix_source, build_url, expanded_flags, targets, forced_targets, mode, dry_run, track_state)
 
     run_tracker = runnable(ctx, targets)
 
@@ -888,16 +870,15 @@ def _delivery_impl(ctx):
             phase = Phase(name = "download", description = "Download runfiles", emoji = "📥"),
         )
 
-        # Appended LAST so they override any --config=X expansion in
-        # expanded_flags and any user rc / trait flag that would flip
-        # them. Each flag is required for the delivery spawn to succeed:
-        # local artifacts for the spawn, no spurious cache uploads, the
-        # binary on disk, runfiles tree materialized.
-        phase3_flags = list(expanded_flags) + [
-            "--experimental_build_event_upload_strategy=local",
+        # release_bazel_flags sit between expanded_flags and the trailing
+        # spawn-required flags so release-only values (e.g. --stamp) win
+        # over --config=X expansion. The trailing block is appended LAST
+        # and overrides everything — must take effect for the delivery
+        # spawn to succeed.
+        # --noremote_upload_local_results: release artifacts shouldn't
+        #     pollute the shared remote cache (delivery-specific).
+        phase3_flags = list(expanded_flags) + list(ctx.args.release_bazel_flags) + LOCAL_SPAWN_FLAGS + [
             "--noremote_upload_local_results",
-            "--remote_download_outputs=toplevel",
-            "--build_runfile_links",
         ]
         _t_download = time.monotonic()
 
@@ -1223,7 +1204,12 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         "bazel_flags": args.string_list(
             long = "bazel-flag",
             default = [],
-            description = "Additional Bazel flags passed to every build phase. When unset, --stamp is added automatically; passing any --bazel-flag replaces this default, so include --bazel-flag=--stamp explicitly if you still want stamping alongside your custom flags.",
+            description = "Additional Bazel flags passed to every build phase (change detection + final delivery build). Flags that add non-determinism to release artifacts (e.g. --stamp, --workspace_status_command) belong in --release-bazel-flag instead so they apply only to the final delivery build and don't shift the change-detection digest.",
+        ),
+        "release_bazel_flags": args.string_list(
+            long = "release-bazel-flag",
+            default = ["--stamp"],
+            description = "Bazel flags applied ONLY to the final delivery build, not to the change-detection phases. Use this for flags that add non-determinism to release artifacts and would otherwise spuriously shift the change-detection digest — e.g. --stamp, --workspace_status_command=<path>. Defaults to [\"--stamp\"] so delivered binaries embed workspace status; pass --release-bazel-flag=--nostamp to opt out.",
         ),
         "bazel_startup_flags": args.string_list(
             long = "bazel-startup-flag",

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -18,6 +18,7 @@ Usage:
 load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
+load("./lib/bazel_flags.axl", "setup_bazel_command")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "error", "info", "warn")
@@ -28,7 +29,7 @@ load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "Ta
 load("./lib/path_glob.axl", "match_any")
 load("./lib/path_normalize.axl", "normalize_files_for_cwd")
 load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("./lib/runnable.axl", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
 
@@ -297,50 +298,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for handler in lifecycle.task_started:
         handler(ctx, ctx.args.formatter_target)
 
-    # Pre-flight: Workflows' `print_environment_info` +
-    # `agent_health_check` hooks fire here, printing the
-    # `--- :computer: Workflows runner environment` and health check
-    # BK section markers.
+    flags = setup_bazel_command(ctx, "build", bazel_trait)
     preflight_phase(ctx, lifecycle, hc_trait)
 
-    flags = []
-    flags.extend(ctx.args.bazel_flags)
-    flags.extend(bazel_trait.extra_flags)
-
-    # Task-time flag contributors — features register hooks that need ctx.task
-    # (e.g. --build_metadata=ASPECT_TASK_NAME=...) which features can't produce
-    # at activation time because FeatureContext has no task.
-    # See Workflows in feature/workflows.axl.
-    for hook in bazel_trait.task_flags:
-        flags.extend(hook(ctx))
-    if bazel_trait.flags:
-        flags = bazel_trait.flags(flags)
-
-    # Required flags — appended LAST so they win over any --config=X
-    # expansion introduced by user / trait flags (e.g. a customer .bazelrc
-    # with `common:workflows-ci --remote_download_outputs=minimal
-    # --nobuild_runfile_links` would otherwise shadow our settings and
-    # spawn would ENOENT on the formatter binary). We set these explicitly
-    # even when Bazel's default agrees, since user rc / trait flags can
-    # flip the effective value otherwise. See delivery.axl phase 3 for the
-    # same pattern.
-    #   * upload strategy `local`: keep BES artifact references as local
-    #     paths. We're about to spawn the formatter binary locally, so
-    #     re-uploading it via BES is wasted bandwidth and can stall when
-    #     the remote cache is slow.
-    #   * remote_download_outputs `toplevel`: ensure the formatter binary
-    #     lands on local disk so we can spawn it.
-    #   * build_runfile_links: materialize the runfiles tree so the
-    #     binary's wrappers / data deps resolve at runtime.
-    flags.append("--experimental_build_event_upload_strategy=local")
-    flags.append("--remote_download_outputs=toplevel")
-    flags.append("--build_runfile_links")
-
-    startup_flags = list(ctx.args.bazel_startup_flags)
-    startup_flags.extend(bazel_trait.extra_startup_flags)
-    if bazel_trait.startup_flags:
-        startup_flags = bazel_trait.startup_flags(startup_flags)
-    ctx.bazel.startup_flags.extend(startup_flags)
+    flags.extend(LOCAL_SPAWN_FLAGS)
 
     r = runnable(ctx, [ctx.args.formatter_target])
 
@@ -738,6 +699,10 @@ format = task(
         "formatter_target": args.string(
             default = "//tools/format",
             description = "Bazel label of the format_multirun target (or any runnable target) to invoke as the formatter. The target is built first, then run with the changed-file list passed as positional arguments.",
+        ),
+        "announce_rc": args.boolean(
+            default = False,
+            description = "Print the resolved Bazel `.bazelrc` flags before running the formatter build. Useful when debugging which config sections fired or what the final flag set looks like. ASPECT_DEBUG=1 logs the same disclosure regardless of this flag.",
         ),
         "bazel_flags": args.string_list(
             long = "bazel-flag",

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -187,6 +187,7 @@ Usage:
 load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
+load("./lib/bazel_flags.axl", "setup_bazel_command")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
@@ -196,7 +197,7 @@ load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_on_change", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
 load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("./lib/runnable.axl", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
 
@@ -560,48 +561,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data["gazelle"]["no_changed_dirs"] = True
         return _emit_final(ctx, lifecycle, data, 0)
 
-    # Pre-flight: Workflows' `print_environment_info` +
-    # `agent_health_check` hooks fire here, printing the
-    # `--- :computer: Workflows runner environment` and health check
-    # BK section markers.
+    flags = setup_bazel_command(ctx, "build", bazel_trait)
     preflight_phase(ctx, lifecycle, hc_trait)
 
-    flags = []
-    flags.extend(ctx.args.bazel_flag)
-    flags.extend(bazel_trait.extra_flags)
-
-    # Task-time flag contributors — features register hooks that need
-    # ctx.task (e.g. --build_metadata=ASPECT_TASK_NAME=...).
-    for hook in bazel_trait.task_flags:
-        flags.extend(hook(ctx))
-    if bazel_trait.flags:
-        flags = bazel_trait.flags(flags)
-
-    # Required flags — appended LAST so they win over any --config=X
-    # expansion introduced by user / trait flags (e.g. a customer .bazelrc
-    # with `common:workflows-ci --remote_download_outputs=minimal
-    # --nobuild_runfile_links` would otherwise shadow our settings and
-    # spawn would ENOENT on the gazelle binary). We set these explicitly
-    # even when Bazel's default agrees, since user rc / trait flags can
-    # flip the effective value otherwise. See delivery.axl phase 3 for the
-    # same pattern.
-    #   * upload strategy `local`: keep BES artifact references as local
-    #     paths. We're about to spawn the gazelle binary locally, so
-    #     re-uploading it via BES is wasted bandwidth and can stall when
-    #     the remote cache is slow.
-    #   * remote_download_outputs `toplevel`: ensure the gazelle binary
-    #     lands on local disk so we can spawn it.
-    #   * build_runfile_links: materialize the runfiles tree so the
-    #     binary's wrappers / data deps resolve at runtime.
-    flags.append("--experimental_build_event_upload_strategy=local")
-    flags.append("--remote_download_outputs=toplevel")
-    flags.append("--build_runfile_links")
-
-    startup_flags = list(ctx.args.bazel_startup_flag)
-    startup_flags.extend(bazel_trait.extra_startup_flags)
-    if bazel_trait.startup_flags:
-        startup_flags = bazel_trait.startup_flags(startup_flags)
-    ctx.bazel.startup_flags.extend(startup_flags)
+    flags.extend(LOCAL_SPAWN_FLAGS)
 
     r = runnable(ctx, [ctx.args.gazelle_target])
 
@@ -940,11 +903,17 @@ gazelle = task(
             maximum = 4096,
             description = "Directories gazelle should update BUILD files in. When empty (default), gazelle considers every directory in the workspace. Combine with --scope=changed to take the intersection with directories that contain changed files. Useful for scoping to a sub-workspace within a monorepo. CAUTION: under --scope=changed, supplying narrow dirs intersection-filters the derived set. Changed dirs that fall outside the listed roots are dropped, so the BUILD updates those changes would have triggered are silently missed. NOTE: positional dirs only narrow the BUILD-regeneration step. Under gazelle's default `-index=all`, gazelle still traverses every workspace directory, parses every BUILD, and re-determines target exports (often re-parsing source) repo-wide. Pair with `--gazelle-flag=-index=lazy` (plus `# gazelle:go_search` / `# gazelle:proto_search` directives) to also narrow that traversal + parse + indexing work. Optionally also pass `--gazelle-flag=-r=false` to skip recursion on top of that, but some gazelle language extensions are incompatible with non-recursive mode — test against your plugin set first. See https://github.com/bazel-contrib/bazel-gazelle#lazy-indexing-in-fix-and-update.",
         ),
-        "bazel_flag": args.string_list(
-            description = "Additional Bazel flags forwarded to the gazelle build. Repeat the flag to pass multiple — e.g. `--bazel-flag=--config=ci --bazel-flag=--keep_going`.",
+        "announce_rc": args.boolean(
+            default = False,
+            description = "Print the resolved Bazel `.bazelrc` flags before running the gazelle build. Useful when debugging which config sections fired or what the final flag set looks like. ASPECT_DEBUG=1 logs the same disclosure regardless of this flag.",
         ),
-        "bazel_startup_flag": args.string_list(
-            description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
+        "bazel_flags": args.string_list(
+            description = "Additional Bazel flags forwarded to the gazelle build. Repeat the flag to pass multiple — e.g. `--bazel-flag=--config=ci --bazel-flag=--keep_going`.",
+            long = "bazel-flag",
+        ),
+        "bazel_startup_flags": args.string_list(
+            description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
+            long = "bazel-startup-flag",
         ),
     },
     traits = [

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
@@ -1,0 +1,141 @@
+"""Helpers for resolving and applying Bazel flags in tasks that compose
+`BazelTrait` and `HealthCheckTrait`.
+
+Tasks that use these helpers MUST declare three CLI args (the helpers
+enforce this with a clear error if a task forgets):
+
+  - `bazel_flags`         (read by `resolve_flags`)
+  - `bazel_startup_flags` (read by `resolve_startup_flags`)
+  - `announce_rc`         (read by `setup_bazel_command`)
+
+Ordering contract: startup flags must be on `ctx.bazel.startup_flags`
+BEFORE `preflight_phase` runs, so the Bazel health check inside
+preflight targets the correct server. The contract is enforced at
+runtime by `assert_ctx_bazel_ready_for_health_check` (see
+`lib/health_check.axl`).
+
+  - `setup_bazel_command` — the one-stop entry point. Resolves startup
+    flags + command flags, parses `.bazelrc`, populates
+    `ctx.bazel.startup_flags` with the full startup-flag set
+    (including any rc-derived `startup …` lines), emits the parsed-rc
+    disclosure, and returns the command flag list ready for
+    `ctx.bazel.build` / `ctx.bazel.test`. Use this from every
+    Bazel-calling task; the smaller building blocks below exist mostly
+    for testing and unusual layering needs.
+
+  - `resolve_startup_flags` — combine `ctx.args.bazel_startup_flags`
+    with `BazelTrait.extra_startup_flags` + transform. Returns the list
+    without mutating `ctx.bazel.startup_flags`.
+
+  - `resolve_flags` — combine CLI bazel-flags + `BazelTrait` additions
+    + task-time hooks + transform into a single command flag list.
+"""
+
+load("./environment.axl", "color_enabled")
+
+def _require_arg(ctx, name):
+    """Fail with a clear contract error when a helper's required CLI
+    arg is missing from the calling task."""
+    if not hasattr(ctx.args, name):
+        fail(
+            ("Task is missing required `%s` arg. Tasks that use " +
+             "lib/bazel_flags.axl helpers must declare " +
+             "bazel_flags, bazel_startup_flags, and announce_rc on " +
+             "the task definition.") % name,
+        )
+
+def resolve_startup_flags(ctx, bazel_trait):
+    """Build the startup flag list:
+
+        ctx.args.bazel_startup_flags + bazel_trait.extra_startup_flags
+            then bazel_trait.startup_flags(flags) transform if set.
+
+    Requires the task to declare a `bazel_startup_flags` CLI arg.
+
+    Returns:
+      list[str]: resolved startup flags, ready to apply to
+      `ctx.bazel.startup_flags`.
+    """
+    _require_arg(ctx, "bazel_startup_flags")
+    flags = list(ctx.args.bazel_startup_flags)
+    flags.extend(bazel_trait.extra_startup_flags)
+    if bazel_trait.startup_flags:
+        flags = bazel_trait.startup_flags(flags)
+    return flags
+
+def resolve_flags(ctx, bazel_trait):
+    """Build the common Bazel command flag list:
+
+        ctx.args.bazel_flags + bazel_trait.extra_flags
+            + bazel_trait.task_flags(ctx) hooks
+            then bazel_trait.flags(flags) transform if set.
+
+    Requires the task to declare a `bazel_flags` CLI arg.
+
+    Returns:
+      list[str]: resolved command flags.
+    """
+    _require_arg(ctx, "bazel_flags")
+    flags = list(ctx.args.bazel_flags)
+    flags.extend(bazel_trait.extra_flags)
+    for hook in bazel_trait.task_flags:
+        flags.extend(hook(ctx))
+    if bazel_trait.flags:
+        flags = bazel_trait.flags(flags)
+    return flags
+
+def setup_bazel_command(ctx, command, bazel_trait, base_flags = []):
+    """Prepare `ctx.bazel` for an upcoming `ctx.bazel.<command>` call
+    and return the command flag list.
+
+    Resolves startup flags + command flags, parses the workspace
+    `.bazelrc`, populates `ctx.bazel.startup_flags` with the full
+    startup-flag set, emits the parsed-rc disclosure, and returns the
+    command flag list ready for `ctx.bazel.build` / `ctx.bazel.test`.
+
+    Composed flag order:
+
+        base_flags + ctx.args.bazel_flags + bazel_trait.extra_flags
+            + bazel_trait.task_flags(ctx) hooks
+            then bazel_trait.flags(flags) transform
+            then rc expansion for `--config=…` keys.
+
+    MUST be called before `preflight_phase` so the Bazel health check
+    inside preflight sees the same startup flags every other Bazel
+    call sees, including any rc-derived `startup --output_base=...`.
+
+    The parsed-rc disclosure is emitted via `trace.log` unconditionally
+    (visible under `ASPECT_DEBUG`); the user-facing terminal print fires
+    only when `--announce-rc` is set.
+
+    Args:
+      ctx: TaskContext.
+      command: Bazel subcommand whose rc sections to expand
+        (e.g. `"build"`, `"test"`). Tasks that ultimately spawn
+        `bazel build` (lint, delivery, run, format, gazelle) should
+        pass `"build"`.
+      bazel_trait: `BazelTrait` instance from `ctx.traits`.
+      base_flags: task-injected defaults the user can override via
+        `--bazel-flag=...` (last-wins after rc expansion). Examples:
+        build/test's `--isatty=...`, lint's `--aspects=...`,
+        delivery's `--remote_download_outputs=minimal`.
+
+    Requires the task to declare `bazel_startup_flags`, `bazel_flags`,
+    and `announce_rc` CLI args.
+
+    Returns:
+      list[str]: command flags after `:config` expansion.
+    """
+    startup_flags = resolve_startup_flags(ctx, bazel_trait)
+    flags = list(base_flags) + resolve_flags(ctx, bazel_trait)
+    rc = ctx.bazel.parse_rc(startup_flags = startup_flags, flags = flags)
+    trace.event("bazel.flags", fields = {"command": command, "flags": flags, "startup_flags": startup_flags})
+    rc_startup_flags, expanded_flags = rc.expand_all(command = command)
+    ctx.bazel.startup_flags.extend(startup_flags + rc_startup_flags + ["--ignore_all_rc_files"])
+
+    _require_arg(ctx, "announce_rc")
+    if ctx.args.announce_rc:
+        print(rc.announce(command = command, ansi = color_enabled(ctx.std)))
+    trace.log(rc.announce(command = command, ansi = False))
+
+    return expanded_flags

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
@@ -1,0 +1,171 @@
+"""Tests for `lib/bazel_flags.axl`.
+
+Run with:
+  aspect dev test-bazel-flags
+"""
+
+load("./bazel_flags.axl", "resolve_flags", "resolve_startup_flags", "setup_bazel_command")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _fake_trait(extra_startup = [], startup_transform = None, extra = [], task_flags = [], transform = None):
+    """Stand-in for `BazelTrait` covering both startup-flag and
+    command-flag fields."""
+    return struct(
+        extra_startup_flags = extra_startup,
+        startup_flags = startup_transform,
+        extra_flags = extra,
+        task_flags = task_flags,
+        flags = transform,
+    )
+
+def _fake_ctx(bazel_startup_flags = [], bazel_flags = []):
+    """Stand-in for `TaskContext` with the CLI args the helpers read.
+    `hasattr` returns True for declared fields, so the `_require_arg`
+    contract check inside the helpers is satisfied."""
+    return struct(args = struct(
+        bazel_startup_flags = bazel_startup_flags,
+        bazel_flags = bazel_flags,
+    ))
+
+# ── resolve_startup_flags ────────────────────────────────────────────────
+
+def _test_startup_cli_only(ctx):
+    """CLI flags pass through when the trait contributes nothing."""
+    _eq(
+        "startup cli-only",
+        resolve_startup_flags(_fake_ctx(bazel_startup_flags = ["--client"]), _fake_trait()),
+        ["--client"],
+    )
+
+def _test_startup_trait_extra_appended(ctx):
+    """`bazel_trait.extra_startup_flags` is appended after CLI flags."""
+    _eq(
+        "startup trait extras after CLI",
+        resolve_startup_flags(_fake_ctx(bazel_startup_flags = ["--client"]), _fake_trait(extra_startup = ["--trait"])),
+        ["--client", "--trait"],
+    )
+
+def _test_startup_transform_replaces_list(ctx):
+    """`bazel_trait.startup_flags` is a list→list transform; the return
+    value is used as-is, not merged."""
+    transform = lambda flags: flags + ["--from-transform"]
+    _eq(
+        "startup transform appended",
+        resolve_startup_flags(
+            _fake_ctx(bazel_startup_flags = ["--client"]),
+            _fake_trait(extra_startup = ["--trait"], startup_transform = transform),
+        ),
+        ["--client", "--trait", "--from-transform"],
+    )
+
+def _test_startup_transform_can_filter(ctx):
+    """A transform can also drop or rewrite flags."""
+    transform = lambda flags: [f for f in flags if f != "--drop-me"]
+    _eq(
+        "startup transform filters",
+        resolve_startup_flags(
+            _fake_ctx(bazel_startup_flags = ["--keep"]),
+            _fake_trait(extra_startup = ["--drop-me"], startup_transform = transform),
+        ),
+        ["--keep"],
+    )
+
+def _test_startup_input_list_not_mutated(ctx):
+    """`resolve_startup_flags` must not mutate the caller's CLI flag list
+    (`ctx.args.bazel_startup_flags` is a live reference)."""
+    cli = ["--client"]
+    resolve_startup_flags(_fake_ctx(bazel_startup_flags = cli), _fake_trait(extra_startup = ["--trait"]))
+    _eq("startup cli list untouched", cli, ["--client"])
+
+# ── resolve_flags ────────────────────────────────────────────────────────
+
+def _test_flags_full_chain_order(ctx):
+    """Slot ordering:
+        ctx.args.bazel_flags + bazel_trait.extra_flags
+            + task_flags hooks → transform.
+    Verify each slot lands where the contract promises."""
+    task_hook = lambda c: ["--from-hook"]
+    transform = lambda fs: fs + ["--from-transform"]
+    _eq(
+        "resolve_flags full chain",
+        resolve_flags(
+            _fake_ctx(bazel_flags = ["--cli"]),
+            _fake_trait(extra = ["--trait-extra"], task_flags = [task_hook], transform = transform),
+        ),
+        ["--cli", "--trait-extra", "--from-hook", "--from-transform"],
+    )
+
+def _test_flags_empty_defaults(ctx):
+    """No CLI flags, no trait additions → empty result."""
+    _eq(
+        "resolve_flags empty",
+        resolve_flags(_fake_ctx(), _fake_trait()),
+        [],
+    )
+
+# ── setup_bazel_command (integration) ────────────────────────────────────
+
+def _test_setup_bazel_command_applies_to_ctx_bazel(ctx):
+    """End-to-end check on a real `ctx`:
+      - the caller's `base_flags` appear in the returned flag list
+        (Bazel's rc expansion may interleave them with rc-derived
+        flags, so we don't assert a specific position);
+      - the trait's `extra_startup_flags` land on
+        `ctx.bazel.startup_flags`;
+      - `--ignore_all_rc_files` is appended so the bazel subprocess
+        doesn't re-parse rc.
+    The workspace `.bazelrc` is parsed as a side effect, which is fine
+    for a dev test."""
+    sentinel = "/tmp/test-setup-bazel-command-sentinel"
+    bazel_trait = _fake_trait(extra_startup = ["--output_base=" + sentinel])
+
+    flags = setup_bazel_command(ctx, "build", bazel_trait, base_flags = ["--from-base"])
+
+    if "--from-base" not in flags:
+        fail("setup_bazel_command — base_flag not in result: %r" % flags)
+
+    startup = list(ctx.bazel.startup_flags)
+    if ("--output_base=" + sentinel) not in startup:
+        fail("setup_bazel_command — trait --output_base not on ctx.bazel.startup_flags: %r" % startup)
+    if "--ignore_all_rc_files" not in startup:
+        fail("setup_bazel_command — --ignore_all_rc_files not appended: %r" % startup)
+
+# ── contract enforcement ─────────────────────────────────────────────────
+#
+# The helpers fail with a clear message when a calling task omits the
+# required args (`bazel_flags`, `bazel_startup_flags`, `announce_rc`).
+# Happy-path coverage is implicit in every other subtest — the test
+# task declares all three args. Failure-path coverage would require a
+# second task without the args, which isn't worth the test plumbing.
+
+def _test_impl(ctx):
+    _test_startup_cli_only(ctx)
+    _test_startup_trait_extra_appended(ctx)
+    _test_startup_transform_replaces_list(ctx)
+    _test_startup_transform_can_filter(ctx)
+    _test_startup_input_list_not_mutated(ctx)
+    _test_flags_full_chain_order(ctx)
+    _test_flags_empty_defaults(ctx)
+
+    # setup_bazel_command mutates the real `ctx.bazel.startup_flags`;
+    # run last so the mutation can't bleed into earlier pure subtests.
+    _test_setup_bazel_command_applies_to_ctx_bazel(ctx)
+    print("bazel_flags_test.axl: OK (8 sections)")
+    return 0
+
+bazel_flags_tests = task(
+    name = "test-bazel-flags",
+    group = ["dev"],
+    implementation = _test_impl,
+    # The helpers exercised here read CLI args off `ctx.args`. Declare
+    # the standard arg set so the test task satisfies the helper
+    # contracts.
+    args = {
+        "announce_rc": args.boolean(default = False),
+        "bazel_flags": args.string_list(long = "bazel-flag"),
+        "bazel_startup_flags": args.string_list(long = "bazel-startup-flag"),
+    },
+)

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -13,8 +13,8 @@ applies uniformly to both tasks.
 """
 
 load("@std//time.axl", "sleep_iter")
+load("./bazel_flags.axl", "setup_bazel_command")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "init_data", "now_ms", "process_event", "repro_targets", bazel_conclusion = "conclusion")
-load("./environment.axl", "color_enabled")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
 load("./repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "task_cli_path")
@@ -206,24 +206,24 @@ def _emit_terminal(ctx, lifecycle, command, data, exit_code):
         flagged = final_status == "warning",
     )
 
-def run_bazel_task(ctx: TaskContext, command: str, extra_flags = [], targets = None) -> TaskConclusion:
+def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclusion:
     """Shared impl for build/test tasks.
 
     Args:
         ctx:     TaskContext with the standard build/test args (targets,
                  bazel_flags, bazel_startup_flags, bazel_retry_attempts,
-                 bes_backends, bes_headers, cancel, output_base,
-                 optionally target_pattern_file). Task-specific args (e.g.
-                 build's remote_executor) are not touched here — tasks can
-                 still read them from `ctx.args` before/after calling this
-                 function.
+                 bes_backends, bes_headers, optionally
+                 target_pattern_file). Task-specific args (e.g. build's
+                 remote_executor) are not touched here — tasks can still
+                 read them from `ctx.args` before/after calling this
+                 function. Tasks needing to layer additional flags onto
+                 every bazel call should append to
+                 `ctx.traits[BazelTrait].extra_flags` before invoking
+                 `run_bazel_task` (e.g. test.axl's `--coverage`).
         command: "build" or "test" — selects which Bazel subcommand to invoke
                  and which rc section to expand. The shape of the BES event
                  stream (including the presence of test_summary events for
                  tests) follows naturally from this.
-        extra_flags: Task-supplied Bazel flags appended after `--bazel-flag`
-                 values (e.g. test's `--collect_code_coverage`). The caller
-                 owns their meaning; the runner just forwards them.
         targets: Target-pattern override. When `None` the runner honors
                  `--target-pattern-file` (if the task declares it) by
                  forwarding `--target_pattern_file=<path>` to Bazel
@@ -233,20 +233,22 @@ def run_bazel_task(ctx: TaskContext, command: str, extra_flags = [], targets = N
     bazel_trait = ctx.traits[BazelTrait]
     lifecycle = ctx.traits[TaskLifecycleTrait]
 
+    # Runner-injected base flags Bazel must see verbatim: the TTY signal
+    # for progress rendering and, optionally, --target_pattern_file=…
+    # forwarded as a flag rather than expanded to argv (the flag exists
+    # to bypass OS command-line length limits). These are defaults the
+    # user can still override via --bazel-flag=...
+    base_flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))]
+
     if targets == None:
-        # Optional arg — only honored when the task declares it. Tasks that
-        # don't expose --target-pattern-file behave as before.
+        # --target-pattern-file is only honored when the task declares it.
         pattern_file = getattr(ctx.args, "target_pattern_file", "") if hasattr(ctx.args, "target_pattern_file") else ""
         if pattern_file:
             if ctx.args.is_explicit("targets"):
                 fail("--target-pattern-file cannot be combined with command-line target patterns")
             if not ctx.std.fs.exists(pattern_file):
                 fail("--target-pattern-file: file not found: " + pattern_file)
-
-            # Forward the flag to Bazel instead of expanding the file into
-            # argv. Expanding would defeat the flag's purpose: it exists to
-            # let huge target lists bypass OS command-line length limits.
-            extra_flags = list(extra_flags) + ["--target_pattern_file=" + pattern_file]
+            base_flags.append("--target_pattern_file=" + pattern_file)
             targets = []
         else:
             targets = ctx.args.targets
@@ -266,6 +268,8 @@ def run_bazel_task(ctx: TaskContext, command: str, extra_flags = [], targets = N
     for handler in lifecycle.task_started:
         handler(ctx, " ".join(targets))
 
+    flags = setup_bazel_command(ctx, command, bazel_trait, base_flags = base_flags)
+
     preflight_phase(ctx, lifecycle, hc_trait)
 
     for hook in hc_trait.post_health_check:
@@ -273,28 +277,6 @@ def run_bazel_task(ctx: TaskContext, command: str, extra_flags = [], targets = N
         if result != None:
             _emit_terminal(ctx, lifecycle, command, data, 1)
             fail(result)
-
-    # Flags: accumulate data, then optionally transform.
-    flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))]
-    flags.extend(ctx.args.bazel_flags)
-    flags.extend(extra_flags)
-    flags.extend(bazel_trait.extra_flags)
-
-    # Task-time flag contributors — features register hooks that need
-    # ctx.task (e.g. --build_metadata=ASPECT_TASK_NAME=...) which features
-    # can't produce at activation time because FeatureContext has no task.
-    # See Workflows in feature/workflows.axl for the metadata registration.
-    for hook in bazel_trait.task_flags:
-        flags.extend(hook(ctx))
-    if bazel_trait.flags:
-        flags = bazel_trait.flags(flags)
-
-    startup_flags = list(ctx.args.bazel_startup_flags)
-    startup_flags.extend(bazel_trait.extra_startup_flags)
-    if ctx.args.output_base:
-        startup_flags.insert(0, "--output_base=" + ctx.args.output_base)
-    if bazel_trait.startup_flags:
-        startup_flags = bazel_trait.startup_flags(startup_flags)
 
     bes_sinks = _collect_bes_from_args(ctx)
     if bazel_trait.build_event_sinks:
@@ -308,23 +290,6 @@ def run_bazel_task(ctx: TaskContext, command: str, extra_flags = [], targets = N
         trace.event("build.cancel", fields = {"cancelling": True})
         cancellation = ctx.bazel.cancel_invocation()
         cancellation.wait()
-
-    rc = ctx.bazel.parse_rc(
-        startup_flags = startup_flags,
-        flags = flags,
-    )
-
-    trace.event("build.flags", fields = {"flags": flags})
-    rc_startup_flags, flags = rc.expand_all(command = command)
-    ctx.bazel.startup_flags.extend(startup_flags + rc_startup_flags + ["--ignore_all_rc_files"])
-
-    # Parsed-rc disclosure is verbose; print on user opt-in via
-    # --announce-rc, otherwise gate behind trace.log so it only
-    # surfaces under ASPECT_DEBUG.
-    if ctx.args.announce_rc:
-        print(rc.announce(command = command, ansi = color_enabled(ctx.std)))
-    else:
-        trace.log(rc.announce(command = command, ansi = False))
 
     base_desc = "Run bazel tests" if command == "test" else "Build bazel targets"
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
@@ -1,13 +1,20 @@
-"""
-Agent Health Check Library
+"""HealthCheckTrait and the Workflows runner-agent health check.
 
-Implements the runner agent health check step that runs at the start of every
-job. It does two things:
+`HealthCheckTrait` lets tasks register pre/post hooks around their
+bazel invocation. `agent_health_check` is the Workflows-registered
+`pre_health_check` hook that:
 
-1. Waits for warming — polls until the runner's cache warming completes, then
-   reports the result.
-2. Displays the last runner health check — reads the JSON file written by the
-   fleet service between jobs and prints its contents.
+  1. Waits for runner cache warming to complete.
+  2. Displays the last runner health check.
+  3. Verifies `ctx.bazel.startup_flags` targets the project-specific
+     Bazel server (`assert_ctx_bazel_ready_for_health_check`).
+  4. Runs `ctx.bazel.health_check()` and displays the result.
+  5. Signals the agent if the Bazel server is unhealthy.
+
+The `assert_ctx_bazel_ready_for_health_check` guard is exported so
+custom tasks composing `BazelTrait` + `HealthCheckTrait` get the same
+fail-loud contract enforcement — see `lib/bazel_flags.axl` for the
+canonical helpers that satisfy it.
 """
 
 load("@std//time.axl", "time")
@@ -192,20 +199,54 @@ HealthCheckTrait = trait(
     post_health_check = attr(list[typing.Callable[[TaskContext], str | None]], default = [], description = "Hooks called after the build; return a non-None string to report a warning"),
 )
 
-def agent_health_check(ctx, environment):
+def ctx_bazel_ready_for_health_check(ctx, environment):
+    """True if `ctx.bazel.startup_flags` is populated such that the Bazel
+    health check would target the project-specific server.
+
+    Returns True off-runner (no project-specific server to protect) or
+    when `--output_base=` appears in `ctx.bazel.startup_flags`. Returns
+    False on a Workflows runner with no `--output_base` configured.
+
+    Pure predicate; see `assert_ctx_bazel_ready_for_health_check` for
+    the failing variant used as the runtime guard.
     """
-    Post health check hook for HealthCheckFragment.
+    if environment.runner == None:
+        return True
+    for flag in ctx.bazel.startup_flags:
+        if flag.startswith("--output_base="):
+            return True
+    return False
 
-    Runs the agent health check at the start of every job:
-    1. Waits for warming to complete
-    2. Displays the last runner health check
-    3. Runs the Bazel health check and displays the result
+def assert_ctx_bazel_ready_for_health_check(ctx, environment):
+    """Fail if a Workflows runner is in use and `ctx.bazel.startup_flags`
+    is missing `--output_base`.
 
-    Args:
-        ctx: TaskContext
+    Custom tasks composing `BazelTrait` + `HealthCheckTrait` must apply
+    startup flags onto `ctx.bazel.startup_flags` before calling
+    `preflight_phase`. The canonical entry point is
+    `lib/bazel_flags.axl::setup_bazel_command`.
+    """
+    if ctx_bazel_ready_for_health_check(ctx, environment):
+        return
+    fail(
+        "Bazel health check would target the wrong server: " +
+        "ctx.bazel.startup_flags is missing --output_base on a Workflows " +
+        "runner. Call lib/bazel_flags.axl::setup_bazel_command BEFORE " +
+        "preflight_phase to populate ctx.bazel.startup_flags.",
+    )
+
+def agent_health_check(ctx, environment):
+    """Workflows pre-health-check hook that runs at the start of every job.
+
+    1. Waits for runner cache warming to complete.
+    2. Displays the last runner health check.
+    3. Asserts the `ctx.bazel.startup_flags` ordering contract holds.
+    4. Runs `ctx.bazel.health_check()` and displays the result.
+    5. Signals the agent if the Bazel server is unhealthy.
 
     Returns:
-        None if healthy, or a str error message if the Bazel server is unhealthy.
+      None if healthy, or a str error message if the Bazel server is
+      unhealthy.
     """
     if environment.ci and environment.ci.host == "buildkite":
         print("--- :thermometer: Workflows runner health check")
@@ -213,6 +254,7 @@ def agent_health_check(ctx, environment):
     environment = _wait_for_warming(ctx.std, environment)
     _display_runner_health(environment)
     _display_warming(environment)
+    assert_ctx_bazel_ready_for_health_check(ctx, environment)
     health = ctx.bazel.health_check()
     _display_bazel_health(health)
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
@@ -1,0 +1,61 @@
+"""Tests for `ctx_bazel_ready_for_health_check` — the predicate
+underlying the runtime guard that enforces the
+`ctx.bazel.startup_flags` ordering contract on Workflows runners.
+
+Run with:
+  aspect dev test-health-check-ready
+"""
+
+load("./health_check.axl", "ctx_bazel_ready_for_health_check")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+_ON_RUNNER = struct(runner = struct(bazel_root_dir = "/tmp/health-check-ready-test"))
+_OFF_RUNNER = struct(runner = None)
+
+def _test_off_runner_passes(ctx):
+    """Off-runner: no project-specific server to protect, predicate is
+    True regardless of `ctx.bazel.startup_flags`."""
+    _eq(
+        "off-runner — predicate True",
+        ctx_bazel_ready_for_health_check(ctx, _OFF_RUNNER),
+        True,
+    )
+
+def _test_on_runner_missing_output_base_returns_false(ctx):
+    """On-runner with no --output_base in `ctx.bazel.startup_flags` — the
+    exact regression signature the guard exists to catch."""
+    _eq(
+        "on-runner missing --output_base — predicate False",
+        ctx_bazel_ready_for_health_check(ctx, _ON_RUNNER),
+        False,
+    )
+
+def _test_on_runner_with_output_base_passes(ctx):
+    """Once --output_base is in `ctx.bazel.startup_flags`, the predicate
+    transitions to True."""
+    ctx.bazel.startup_flags.extend(["--output_base=/tmp/health-check-ready-test/sentinel"])
+    _eq(
+        "on-runner with --output_base — predicate True",
+        ctx_bazel_ready_for_health_check(ctx, _ON_RUNNER),
+        True,
+    )
+
+def _test_impl(ctx):
+    # `ctx.bazel.startup_flags` is shared mutable state across subtests
+    # (no clear() method). The "missing" subtest must run BEFORE the
+    # "with_output_base" subtest, which permanently appends the sentinel.
+    _test_off_runner_passes(ctx)
+    _test_on_runner_missing_output_base_returns_false(ctx)
+    _test_on_runner_with_output_base_passes(ctx)
+    print("health_check_ready_test.axl: OK (3 sections)")
+    return 0
+
+health_check_ready_tests = task(
+    name = "test-health-check-ready",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -615,6 +615,16 @@ def _probe_rate_limit_quota(ctx):
 def preflight_phase(ctx, lifecycle, hc_trait):
     """Mark the `preflight` phase and run the pre-health-check hooks.
 
+    ⚠️  Contract: when the calling task composes `BazelTrait` alongside
+    `HealthCheckTrait`, `ctx.bazel.startup_flags` MUST be populated
+    before this function is called so the Bazel health check
+    (`agent_health_check`, registered as a `pre_health_check`) targets
+    the project-specific server. Use `setup_bazel_command` from
+    `lib/bazel_flags.axl` — it handles startup-flag resolution, rc
+    parsing, and populating `ctx.bazel.startup_flags`. The
+    `assert_ctx_bazel_ready_for_health_check` guard fails loudly if
+    the contract is violated on a Workflows runner.
+
     On CI hosts (BK / GHA / CircleCI / GitLab / generic CI), the
     pre-health-check hooks Workflows registers print substantial
     structural output: the `--- :computer: Workflows runner environment`

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -1,5 +1,25 @@
 _DEFAULT_WORKSPACE_NAME = "_main"
 
+# Bazel flags required for a task that immediately spawns the built binary
+# (format, gazelle, run, delivery phase 3). Append these LAST so they win
+# over any rc or trait flag that would flip them — user .bazelrc can carry
+# `common:-ci --remote_download_outputs=minimal --nobuild_runfile_links`
+# which would otherwise ENOENT the spawn.
+#
+#   --experimental_build_event_upload_strategy=local: have BES report
+#       artifacts as local file:// paths so we can locate the binary
+#       on disk to spawn it. With the remote strategy, BES reports
+#       bytestream:// URIs, which aren't on-disk paths.
+#   --remote_download_outputs=toplevel: materialize the binary itself on
+#       disk so we can spawn it.
+#   --build_runfile_links: lay down the runfiles tree so the binary's
+#       wrappers and data deps resolve at runtime.
+LOCAL_SPAWN_FLAGS = [
+    "--experimental_build_event_upload_strategy=local",
+    "--remote_download_outputs=toplevel",
+    "--build_runfile_links",
+]
+
 def apparent_label(label, current_package = ""):
     """Normalize any Bazel label form to apparent form with an explicit target name.
 

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -21,6 +21,7 @@ Usage:
 load("@std//time.axl", "sleep", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
+load("./lib/bazel_flags.axl", "setup_bazel_command")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "detect_ci", "error", "warn")
@@ -840,6 +841,36 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for handler in lifecycle.task_started:
         handler(ctx, data["target_pattern"])
 
+    # Lint-specific base flags. Flag computation happens here (not after
+    # detect_changed_files) so parse_rc + ctx.bazel.startup_flags are ready
+    # before preflight.
+    base_flags = ["--remote_download_regex='.*AspectRulesLint.*'"]
+    for aspect in ctx.args.aspects:
+        base_flags.append("--aspects=" + aspect)
+
+    # Patch production is gated by --fix OR any registered lint_patch
+    # hook (e.g. GithubLintComments translates hunks into review-comment
+    # suggestion blocks). Applying patches still requires --fix; a
+    # hook-only run produces patches without mutating the working tree.
+    fix_apply = ctx.args.fix
+    fix_produce = fix_apply or bool(lint_trait.lint_patch)
+    if fix_produce:
+        base_flags.append("--output_groups=rules_lint_patch")
+        base_flags.append("--@aspect_rules_lint//lint:fix")
+
+    # rules_lint_human and rules_lint_machine are separate action sets:
+    # requesting both runs each linter twice. Human gives colored terminal
+    # output; machine gives exit codes + SARIF. detect_ci() guards against
+    # CI hosts (e.g. GHA) that allocate a pseudo-TTY while still needing
+    # machine output.
+    is_interactive = ctx.std.io.stdout.is_tty and not detect_ci(ctx.std.env)
+    if is_interactive:
+        base_flags.append("--output_groups=rules_lint_human")
+    if lint_trait.lint_report or not is_interactive:
+        base_flags.append("--output_groups=rules_lint_machine")
+
+    flags = setup_bazel_command(ctx, "build", bazel_trait, base_flags = base_flags)
+
     # 1. Pre-flight (env table, health checks).
     preflight_phase(ctx, lifecycle, hc_trait)
 
@@ -893,77 +924,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for hook in lint_trait.lint_start:
         hook(ctx)
 
-    # 3. Build flags — lint-specific first, then BazelTrait additions.
-    # Each --aspect=<label> from the user becomes a Bazel --aspects=<label>.
-    # At least one aspect is required (enforced by args.string_list(required=True)).
-    flags = [
-        "--remote_download_regex='.*AspectRulesLint.*'",
-    ]
-    for aspect in ctx.args.aspects:
-        flags.append("--aspects=" + aspect)
-
-    # Patch production is gated by EITHER:
-    #   - `--fix` is set (we'll apply the patches locally afterward), or
-    #   - a feature registered a `lint_patch` hook (e.g.
-    #     GithubLintComments wants to translate hunks into review-comment
-    #     suggestion blocks). The apply step itself remains gated on
-    #     `ctx.args.fix` alone, so a hook-only run produces patches but
-    #     doesn't modify the working tree — that's the "auto" behavior:
-    #     suggestions surface on CI, local trees stay clean.
-    fix_apply = ctx.args.fix
-    fix_produce = fix_apply or bool(lint_trait.lint_patch)
-    if fix_produce:
-        flags.append("--output_groups=rules_lint_patch")
-        flags.append("--@aspect_rules_lint//lint:fix")
-
-    # rules_lint_human and rules_lint_machine are separate action sets: requesting
-    # both runs each linter twice. Human gives colored terminal output; machine
-    # gives exit codes + SARIF. detect_ci() guards against CI hosts (e.g. GHA)
-    # that allocate a pseudo-TTY — making is_tty True while still needing machine output.
-    is_interactive = ctx.std.io.stdout.is_tty and not detect_ci(ctx.std.env)
-    if is_interactive:
-        flags.append("--output_groups=rules_lint_human")
-
-    if lint_trait.lint_report or not is_interactive:
-        flags.append("--output_groups=rules_lint_machine")
-
-    flags.extend(ctx.args.bazel_flags)
-    flags.extend(bazel_trait.extra_flags)
-
-    # Task-time flag contributors — features register hooks that need
-    # ctx.task (e.g. --build_metadata=ASPECT_TASK_NAME=...) which features
-    # can't produce at activation time because FeatureContext has no task.
-    # See Workflows in feature/workflows.axl.
-    for hook in bazel_trait.task_flags:
-        flags.extend(hook(ctx))
-    if bazel_trait.flags:
-        flags = bazel_trait.flags(flags)
-
-    startup_flags = list(ctx.args.bazel_startup_flags)
-    startup_flags.extend(bazel_trait.extra_startup_flags)
-    if bazel_trait.startup_flags:
-        startup_flags = bazel_trait.startup_flags(startup_flags)
-
     events = bazel.build_events.iterator()
     build_events = [events] + list(bazel_trait.build_event_sinks)
 
-    # 4. BazelTrait.build_start hooks
     for hook in bazel_trait.build_start:
         hook(ctx)
-
-    # 5. Parse bazelrc and hand startup flags to the Bazel server.
-    rc = ctx.bazel.parse_rc(
-        startup_flags = startup_flags,
-        flags = flags,
-    )
-    rc_startup_flags, flags = rc.expand_all(command = "build")
-    ctx.bazel.startup_flags.extend(startup_flags + rc_startup_flags + ["--ignore_all_rc_files"])
-
-    if ctx.args.announce_rc:
-        print(rc.announce(command = "build", ansi = color_enabled(ctx.std)))
-    else:
-        # Always available under ASPECT_DEBUG without --announce-rc.
-        trace.log(rc.announce(command = "build", ansi = False))
 
     status = _pick_status(data, had_failure = False, terminal = False)
     task_update(

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -2,11 +2,12 @@
 
 load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
+load("./lib/bazel_flags.axl", "setup_bazel_command")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
 load("./lib/environment.axl", "error")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
-load("./lib/runnable.axl", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "runnable")
 load("./lib/tips.axl", "tips")
 
 def _terminal_status(data, exit_code):
@@ -71,6 +72,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for handler in lifecycle.task_started:
         handler(ctx, target)
 
+    # Expand the "build" rc section, not "run": this task ultimately
+    # invokes `ctx.bazel.build`, which spawns a literal `bazel build`.
+    # The `run:` rc section can contain options Bazel's `build` command
+    # rejects as unrecognized (e.g. `--script_path`).
+    flags = setup_bazel_command(ctx, "build", bazel_trait)
+
     preflight_phase(ctx, lifecycle, hc_trait)
 
     for hook in hc_trait.post_health_check:
@@ -79,39 +86,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             _emit_terminal(ctx, lifecycle, data, 1)
             fail(result)
 
-    flags = []
-    flags.extend(bazel_trait.extra_flags)
-    for hook in bazel_trait.task_flags:
-        flags.extend(hook(ctx))
-    if bazel_trait.flags:
-        flags = bazel_trait.flags(flags)
-
-    startup_flags = list(bazel_trait.extra_startup_flags)
-    if bazel_trait.startup_flags:
-        startup_flags = bazel_trait.startup_flags(startup_flags)
-
-    rc = ctx.bazel.parse_rc(
-        flags = flags,
-        startup_flags = startup_flags,
-    )
-
-    # Expand for `build`, not `run`: this task invokes `ctx.bazel.build`, which
-    # spawns a literal `bazel build`. Expanding for `run` would inject run-only
-    # options (e.g. `--script_path`, listed under Bazel's Run Options) that
-    # `bazel build` rejects as "unrecognized option", so users with entries in
-    # the `run:` section of their .bazelrc would fail before execution. Aspect
-    # spawns the runnable itself after the build, so the run-section is not
-    # the right source of flags here.
-    rc_startup_flags, flags = rc.expand_all(command = "build")
-    ctx.bazel.startup_flags.extend(startup_flags + rc_startup_flags + ["--ignore_all_rc_files"])
-
-    # Required for the spawn to succeed: keep BES artifact references
-    # local, materialize the binary on disk, and lay down the runfiles
-    # tree. Appended LAST so they win over any --config=X expansion
-    # introduced by the rc.
-    flags.append("--experimental_build_event_upload_strategy=local")
-    flags.append("--remote_download_outputs=toplevel")
-    flags.append("--build_runfile_links")
+    flags.extend(LOCAL_SPAWN_FLAGS)
 
     r = runnable(ctx, [target])
     events = bazel.build_events.iterator()
@@ -186,6 +161,18 @@ run = task(
         ),
         "run_args": args.trailing_var_args(
             description = "Arguments forwarded to the target binary. Separate from `aspect run`'s own flags with `--`, e.g. `aspect run //foo:bar -- --binary-arg value`.",
+        ),
+        "announce_rc": args.boolean(
+            default = False,
+            description = "Print the resolved Bazel `.bazelrc` flags before running the build. Useful when debugging which config sections fired or what the final flag set looks like. ASPECT_DEBUG=1 logs the same disclosure regardless of this flag.",
+        ),
+        "bazel_flags": args.string_list(
+            description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
+            long = "bazel-flag",
+        ),
+        "bazel_startup_flags": args.string_list(
+            description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
+            long = "bazel-startup-flag",
         ),
     },
     traits = [

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -72,11 +72,12 @@ def _run_coverage_tool(ctx, bin, raw_args, report_path):
         )
 
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
-    extra_flags = []
     if ctx.args.coverage:
-        extra_flags = ["--collect_code_coverage", "--combined_report=lcov"]
+        bazel_trait = ctx.traits[BazelTrait]
+        bazel_trait.extra_flags.append("--collect_code_coverage")
+        bazel_trait.extra_flags.append("--combined_report=lcov")
 
-    conclusion = run_bazel_task(ctx, command = "test", extra_flags = extra_flags)
+    conclusion = run_bazel_task(ctx, command = "test")
 
     if ctx.args.coverage:
         report_path = _resolve_report(ctx)
@@ -150,10 +151,6 @@ test = task(
         "cancel": args.boolean(
             default = False,
             description = "Cancel any running Bazel invocation before starting the test.",
-        ),
-        "output_base": args.string(
-            default = "",
-            description = "Bazel output base path. Use to target a specific Bazel server instance — distinct paths run independent JVMs and cache contents.",
         ),
     },
     traits = [

--- a/crates/axl-runtime/src/engine/bazel/health_check.rs
+++ b/crates/axl-runtime/src/engine/bazel/health_check.rs
@@ -202,26 +202,50 @@ fn cleanup_stranded_sandbox_state(output_base: &Path) -> bool {
     }
 }
 
-pub fn run(startup_flags: &[String]) -> HealthCheckResult {
-    // Step 1: Determine server directories
-    let output_base = get_output_base(startup_flags);
-
-    // Step 1.5: Clean up stranded sandbox state from any prior SIGKILL'd
-    // invocation before bazel touches the sandbox in this command. See
-    // `cleanup_stranded_sandbox_state` for context.
-    if let Some(ref base) = output_base {
-        let _ = cleanup_stranded_sandbox_state(base);
+/// Extract `--output_base=<path>` from the passed startup flags without
+/// invoking bazel. Returns `None` when no `--output_base` flag is present
+/// or its value is empty.
+///
+/// Used in failure-path recovery where we can't safely run `bazel info
+/// output_base` — the server is wedged holding the workspace lock, and
+/// `bazel info` (without `--noblock_for_lock`) would queue behind it.
+fn output_base_from_flags(startup_flags: &[String]) -> Option<PathBuf> {
+    for flag in startup_flags {
+        if let Some(value) = flag.strip_prefix("--output_base=") {
+            if !value.is_empty() {
+                return Some(PathBuf::from(value));
+            }
+        }
     }
+    None
+}
 
-    let server_pid_file = output_base
-        .as_ref()
-        .map(|base| base.join("server").join("server.pid.txt"));
-
-    // Step 2: Run health check
+/// Probe the Bazel server and recover from a wedged-lock state when possible.
+///
+/// Outcomes:
+///   - `healthy` — `--noblock_for_lock info server_pid` returned 0 (either
+///     on the first try or after the recovery SIGKILL + retry).
+///   - `inconclusive` — non-retryable error (likely a configuration issue).
+///   - `unhealthy` — retryable failure we couldn't recover from (PID file
+///     missing, or retry probe still fails after SIGKILL).
+///
+/// The `--noblock_for_lock` probe is intentionally the FIRST bazel call.
+/// Any other invocation (in particular `bazel info output_base`) lacks the
+/// flag and would queue behind a wedged server holding the workspace lock
+/// — defeating the entire purpose of the health check. On the recovery
+/// path we extract `--output_base` from the passed startup flags rather
+/// than asking bazel, for the same reason.
+///
+/// On success, best-effort cleans up stranded sandbox state from a prior
+/// SIGKILL'd invocation (bazelbuild/bazel#23880) before the next bazel
+/// command runs.
+pub fn run(startup_flags: &[String]) -> HealthCheckResult {
     let result = check_bazel_server(startup_flags);
 
-    // Step 3: Success
     if result.success {
+        if let Some(base) = get_output_base(startup_flags) {
+            let _ = cleanup_stranded_sandbox_state(&base);
+        }
         return HealthCheckResult {
             outcome: "healthy".to_string(),
             message: None,
@@ -229,10 +253,8 @@ pub fn run(startup_flags: &[String]) -> HealthCheckResult {
         };
     }
 
-    // Step 4: Failure
     let exit_code = result.exit_code;
 
-    // 4a: Non-retryable error → inconclusive
     if let Some(code) = exit_code {
         if !RETRYABLE_EXIT_CODES.contains(&code) {
             return HealthCheckResult {
@@ -246,17 +268,15 @@ pub fn run(startup_flags: &[String]) -> HealthCheckResult {
         }
     }
 
-    // 4b: Retryable error → attempt recovery
+    // Retryable failure: the server is wedged holding the workspace lock.
+    // Find its PID via the on-disk PID file (asking bazel would block),
+    // SIGKILL it, and retry the noblock probe.
     let diagnostic = format!(
         "Bazel server returned an exit code ({}) that has caused the health check to fail",
         exit_code.map_or("unknown".to_string(), |c| c.to_string())
     );
 
-    // 4b.i: Extract server PID from filesystem
-    let pid = extract_server_pid(server_pid_file.as_deref());
-
-    // 4b.ii: PID cannot be determined
-    let Some(pid) = pid else {
+    let Some(output_base) = output_base_from_flags(startup_flags) else {
         return HealthCheckResult {
             outcome: "unhealthy".to_string(),
             message: Some(diagnostic),
@@ -264,15 +284,23 @@ pub fn run(startup_flags: &[String]) -> HealthCheckResult {
         };
     };
 
-    // 4b.iii / 4b.iv: Kill if running, then retry
+    let server_pid_file = output_base.join("server").join("server.pid.txt");
+    let Some(pid) = extract_server_pid(Some(&server_pid_file)) else {
+        return HealthCheckResult {
+            outcome: "unhealthy".to_string(),
+            message: Some(diagnostic),
+            exit_code,
+        };
+    };
+
     if super::process::is_pid_running(pid) {
         super::process::sigkill(pid);
     }
 
-    // Retry health check
     let retry = check_bazel_server(startup_flags);
 
     if retry.success {
+        let _ = cleanup_stranded_sandbox_state(&output_base);
         HealthCheckResult {
             outcome: "healthy".to_string(),
             message: None,
@@ -318,8 +346,7 @@ mod tests {
     #[test]
     fn cleanup_preserves_sandbox_stash() {
         // `sandbox_stash` is the persistent --reuse_sandbox_directories
-        // cache; the health check must NOT touch it. Regression test
-        // against an earlier draft that wiped it on every invocation.
+        // cache; the health check must NOT touch it.
         let base = make_output_base();
         let stash = base.path().join("sandbox").join("sandbox_stash");
         std::fs::create_dir(&stash).unwrap();
@@ -350,5 +377,43 @@ mod tests {
         // No sandbox subdirectory at all — e.g. fresh output_base.
         let base = tempfile::tempdir().expect("tempdir");
         assert!(!cleanup_stranded_sandbox_state(base.path()));
+    }
+
+    #[test]
+    fn output_base_from_flags_finds_explicit_flag() {
+        let flags = vec![
+            "--nohome_rc".to_string(),
+            "--output_base=/mnt/ephemeral/output/repo".to_string(),
+            "--nosystem_rc".to_string(),
+        ];
+        assert_eq!(
+            output_base_from_flags(&flags),
+            Some(PathBuf::from("/mnt/ephemeral/output/repo"))
+        );
+    }
+
+    #[test]
+    fn output_base_from_flags_absent_returns_none() {
+        let flags = vec![
+            "--nohome_rc".to_string(),
+            "--output_user_root=/mnt/ephemeral/bazel".to_string(),
+        ];
+        assert_eq!(output_base_from_flags(&flags), None);
+    }
+
+    #[test]
+    fn output_base_from_flags_empty_value_returns_none() {
+        // Defensive: malformed `--output_base=` should not silently
+        // produce PathBuf::from("") which would join into nonsense.
+        let flags = vec!["--output_base=".to_string()];
+        assert_eq!(output_base_from_flags(&flags), None);
+    }
+
+    #[test]
+    fn output_base_from_flags_prefix_match_only() {
+        // `--output_user_root` shares a `--output_` prefix; must not
+        // accidentally match.
+        let flags = vec!["--output_user_root=/mnt/foo".to_string()];
+        assert_eq!(output_base_from_flags(&flags), None);
     }
 }


### PR DESCRIPTION
The Bazel health check on Workflows runners now receives the same startup flags as the rest of the build. Includes a refactor of the Bazel flag-resolution path used by every built-in task that calls Bazel.

## What changed

**Health-check correctness**

- The `--noblock_for_lock` probe in `health_check::run` is the FIRST Bazel call. On the recovery path, `--output_base` is parsed out of the passed startup flags rather than asked from a server we already know is wedged.
- Every built-in task (build, test, run, lint, format, gazelle, delivery) populates `ctx.bazel.startup_flags` BEFORE calling `preflight_phase`.
- A runtime guard (`assert_ctx_bazel_ready_for_health_check`) fails loudly when the contract is violated on a Workflows runner.
- `preflight_phase` documents the contract for custom-task authors.

**New shared helpers — `lib/bazel_flags.axl`**

- `setup_bazel_command(ctx, command, bazel_trait, prefix=[])` — one-stop entry point. Resolves startup flags + command flags, parses `.bazelrc`, populates `ctx.bazel.startup_flags`, emits the parsed-rc disclosure, returns the command flag list. Every Bazel-calling task uses this.
- `resolve_startup_flags` / `resolve_flags` — testable building blocks `setup_bazel_command` composes.
- The helpers fail with a clear message when a calling task omits any of the required CLI args (`bazel_flags`, `bazel_startup_flags`, `announce_rc`).

**New shared constant — `lib/runnable.axl`**

- `LOCAL_SPAWN_FLAGS` — the three Bazel flags every task that immediately spawns the built binary needs. Replaces a duplicated 17-line block across format/gazelle/run/delivery.

**Delivery-task API**

- New `--release-bazel-flag` arg for flags that should affect the delivered binary but NOT the change-detection digest (e.g. `--stamp`, `--workspace_status_command=<path>`). Defaults to `["--stamp"]`. Phase 3 layers these between `expanded_flags` and the trailing spawn-required flags; phases 1/2 don't see them.
- Delivery now picks up `bazel_trait.task_flags` hooks (carries `--build_metadata=ASPECT_TASK_NAME=…` etc. in BES events).
- Fixed delivery header rendering to display the rc-expanded flag set (was passing the pre-expansion list).

**CLI surface consistency**

- `run` now exposes `--bazel-flag`, `--bazel-startup-flag`, and `--announce-rc` (previously ignored them and crashed at runtime trying to read `announce_rc`).
- `format` and `gazelle` now also expose `--announce-rc` and route their Bazel invocation through `setup_bazel_command`, so workspace `startup …` lines are visible to the health check.
- Removed `--output-base` from `build` / `test`. Use `--bazel-startup-flag=--output_base=<path>` instead — one channel for all startup-flag customization.
- `test.axl`'s `--coverage` mutates `bazel_trait.extra_flags` rather than threading through a `run_bazel_task` parameter.
- Internal attribute naming aligned across tasks (`bazel_flags`, `bazel_startup_flags` plural everywhere with explicit `long=` for the singular CLI form).

**Other**

- `--announce-rc` always emits `trace.log` (visible under `ASPECT_DEBUG`); the user-facing `print` is gated on the flag.

## Tests

- `aspect dev test-health-check-ready` — locks in the `ctx.bazel.startup_flags` ordering contract via the predicate.
- `aspect dev test-bazel-flags` — covers `resolve_startup_flags` and `resolve_flags`.
- Rust unit tests in `health_check::tests` cover sandbox cleanup and `output_base_from_flags`.

## Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change: minor — `--output-base` is no longer recognized on `build` / `test`. Equivalent: `--bazel-startup-flag=--output_base=<path>`.
- Suggested release notes appear below: yes

**Suggested release notes:**
- Improved Bazel health-check accuracy on Workflows runners.
- New `--release-bazel-flag` on `aspect delivery` for release-only Bazel flags (e.g. `--stamp`, `--workspace_status_command`) that should not influence change-detection digests.
- `aspect run`, `aspect format`, `aspect gazelle` now accept `--announce-rc`. `aspect run` additionally accepts `--bazel-flag` and `--bazel-startup-flag`.
- `--output-base` removed from `aspect build` / `aspect test`. Use `--bazel-startup-flag=--output_base=<path>` instead.

## Test plan

- `cargo test -p axl-runtime --lib engine::bazel::health_check`
- `cargo build -p aspect-cli`
- `aspect dev test-health-check-ready`
- `aspect dev test-bazel-flags`
- `aspect build`, `aspect run` smoke test on `//crates/aspect-cli:aspect-cli`
