### PR TITLE
fix(format): include pure renames from GitHub PR Files API

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -1284,15 +1284,18 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
                     # Bucket each entry:
                     #   - `removed` and zero-change entries land in
                     #     `skipped` so they appear in the diagnostic
-                    #     listing (deleted files; rename-only and
-                    #     rebase-stale modified entries with +0/-0)
-                    #     but don't poison the strategy filter
-                    #     (deleted files have no content to lint;
-                    #     rebase-stale entries have no line diff to
-                    #     anchor comments / annotations on).
+                    #     listing (deleted files; rebase-stale modified
+                    #     entries with +0/-0) but don't poison the
+                    #     strategy filter (deleted files have no content
+                    #     to lint; rebase-stale entries have no line
+                    #     diff to anchor comments / annotations on).
                     #   - everything else (modified with real
-                    #     additions+deletions, added, renamed with a
-                    #     real content change) flows into `files`.
+                    #     additions+deletions, added, renamed) flows
+                    #     into `files`. Pure renames (status=renamed
+                    #     with +0/-0) MUST flow through: format needs
+                    #     to format the destination, and lint's
+                    #     `line_level=True` path naturally produces no
+                    #     findings on a zero-line diff anyway.
                     if line_level:
                         added_lines, hunk_lines = _parse_github_pr_patch(f.get("patch", "") or "")
                         entry = {
@@ -1306,7 +1309,7 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
                         }
                     else:
                         entry = filename
-                    is_skipped = status == "removed" or additions + deletions == 0
+                    is_skipped = status == "removed" or (status != "renamed" and additions + deletions == 0)
                     if is_skipped:
                         skipped.append(entry)
                     else:

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -1290,12 +1290,25 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
                     #     to lint; rebase-stale entries have no line
                     #     diff to anchor comments / annotations on).
                     #   - everything else (modified with real
-                    #     additions+deletions, added, renamed) flows
-                    #     into `files`. Pure renames (status=renamed
-                    #     with +0/-0) MUST flow through: format needs
-                    #     to format the destination, and lint's
-                    #     `line_level=True` path naturally produces no
-                    #     findings on a zero-line diff anyway.
+                    #     additions+deletions, added, renamed with a
+                    #     real content change) flows into `files`.
+                    #
+                    # Pure renames (status=renamed with +0/-0) get
+                    # line_level-conditional treatment:
+                    #   - line_level=False (format) → flow through into
+                    #     `files`. format needs to format the
+                    #     destination; the local-git path's
+                    #     `git diff --name-only` lists it too, so this
+                    #     keeps the two sources aligned.
+                    #   - line_level=True (lint) → stay in `skipped`.
+                    #     The local-git path's `git diff --unified=0`
+                    #     emits no `+++ b/...` for a 100%-rename, so
+                    #     the file isn't in `changed_files` there
+                    #     either. Including it would also regress
+                    #     `--strategy=hold-the-file`, which surfaces
+                    #     every pre-existing finding in any "changed"
+                    #     file — a pure rename would suddenly fail
+                    #     lint on stale findings unrelated to the PR.
                     if line_level:
                         added_lines, hunk_lines = _parse_github_pr_patch(f.get("patch", "") or "")
                         entry = {
@@ -1309,7 +1322,8 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
                         }
                     else:
                         entry = filename
-                    is_skipped = status == "removed" or (status != "renamed" and additions + deletions == 0)
+                    rename_passthrough = status == "renamed" and not line_level
+                    is_skipped = status == "removed" or (not rename_passthrough and additions + deletions == 0)
                     if is_skipped:
                         skipped.append(entry)
                     else:

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -1118,6 +1118,29 @@ def _local_diff_exhausted_prefix(diff_base_source):
     tried and why it didn't yield a diff."""
     return "Local `git diff` couldn't determine a base for change detection (%s)" % (diff_base_source or "no base candidate")
 
+def _pr_file_is_skipped(status, additions, deletions, line_level):
+    """Decide whether a GitHub PR Files API entry belongs in the
+    diagnostic-only `skipped` bucket (vs. the actionable `files` bucket).
+
+    Skipped entries:
+      - `removed`: deleted file — no content to lint or format.
+      - `modified` / `added` with `+0/-0`: rebase-stale or empty
+        change — no line diff to anchor comments or annotations.
+      - `renamed` with `+0/-0` AND `line_level=True` (lint only): the
+        local `git diff --unified=0` path emits no `+++ b/...` for a
+        100%-rename, so the file isn't in `changed_files` on that path
+        either. Including it would also regress `--strategy=hold-the-file`
+        by surfacing pre-existing findings unrelated to the PR.
+
+    Pure renames flow into `files` for `line_level=False` (format) so
+    the formatter actually runs on the destination — matches the local
+    `git diff --name-only` path."""
+    if status == "removed":
+        return True
+    if status == "renamed" and not line_level:
+        return False
+    return additions + deletions == 0
+
 def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = None):
     """Detect changed files for a build.
 
@@ -1281,34 +1304,6 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
                     if status == "modified" and additions == 0 and deletions == 0:
                         suspects.append("%s — API says modified with +0/-0 (no line diff to operate on)" % filename)
 
-                    # Bucket each entry:
-                    #   - `removed` and zero-change entries land in
-                    #     `skipped` so they appear in the diagnostic
-                    #     listing (deleted files; rebase-stale modified
-                    #     entries with +0/-0) but don't poison the
-                    #     strategy filter (deleted files have no content
-                    #     to lint; rebase-stale entries have no line
-                    #     diff to anchor comments / annotations on).
-                    #   - everything else (modified with real
-                    #     additions+deletions, added, renamed with a
-                    #     real content change) flows into `files`.
-                    #
-                    # Pure renames (status=renamed with +0/-0) get
-                    # line_level-conditional treatment:
-                    #   - line_level=False (format) → flow through into
-                    #     `files`. format needs to format the
-                    #     destination; the local-git path's
-                    #     `git diff --name-only` lists it too, so this
-                    #     keeps the two sources aligned.
-                    #   - line_level=True (lint) → stay in `skipped`.
-                    #     The local-git path's `git diff --unified=0`
-                    #     emits no `+++ b/...` for a 100%-rename, so
-                    #     the file isn't in `changed_files` there
-                    #     either. Including it would also regress
-                    #     `--strategy=hold-the-file`, which surfaces
-                    #     every pre-existing finding in any "changed"
-                    #     file — a pure rename would suddenly fail
-                    #     lint on stale findings unrelated to the PR.
                     if line_level:
                         added_lines, hunk_lines = _parse_github_pr_patch(f.get("patch", "") or "")
                         entry = {
@@ -1322,9 +1317,7 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
                         }
                     else:
                         entry = filename
-                    rename_passthrough = status == "renamed" and not line_level
-                    is_skipped = status == "removed" or (not rename_passthrough and additions + deletions == 0)
-                    if is_skipped:
+                    if _pr_file_is_skipped(status, additions, deletions, line_level):
                         skipped.append(entry)
                     else:
                         files.append(entry)
@@ -2276,6 +2269,7 @@ github = struct(
     # raw GitHub PR-file or `git diff --unified=0` output.
     parse_pr_patch = _parse_github_pr_patch,
     parse_local_diff = _parse_local_diff_output,
+    pr_file_is_skipped = _pr_file_is_skipped,
     extract_owner_repo = _extract_github_owner_repo_from_url,
     format_http_failure_detail = _format_http_failure_detail,
 )

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -435,8 +435,46 @@ def _test_impl(ctx):
     # installation is mid-rotation or scope-pruned).
     _test_pr_files_4xx_auth_fallback(ctx)
 
+    # ── pr_file_is_skipped bucketing decision ─────────────────────────
+    _test_pr_file_is_skipped()
+
     print("github_detect.axl smoke: OK")
     return 0
+
+def _test_pr_file_is_skipped():
+    """The bucketing predicate that splits GitHub PR Files API entries
+    between `files` (actionable for lint / format) and `skipped`
+    (diagnostic listing only). Pure renames are the asymmetric case
+    that motivated the helper — present in `files` for format,
+    skipped for lint."""
+
+    # `removed`: always skipped (no content).
+    _eq("removed +0/-0 → skipped (format)", github.pr_file_is_skipped("removed", 0, 0, False), True)
+    _eq("removed +0/-0 → skipped (lint)", github.pr_file_is_skipped("removed", 0, 0, True), True)
+    _eq("removed with -N still skipped", github.pr_file_is_skipped("removed", 0, 7, False), True)
+
+    # `modified` with line changes: actionable.
+    _eq("modified +3/-1 → kept (format)", github.pr_file_is_skipped("modified", 3, 1, False), False)
+    _eq("modified +3/-1 → kept (lint)", github.pr_file_is_skipped("modified", 3, 1, True), False)
+
+    # `modified` with +0/-0: rebase-stale, skipped on both paths.
+    _eq("modified +0/-0 → skipped (format)", github.pr_file_is_skipped("modified", 0, 0, False), True)
+    _eq("modified +0/-0 → skipped (lint)", github.pr_file_is_skipped("modified", 0, 0, True), True)
+
+    # `added` with +0: legit empty new file but nothing to lint/format.
+    _eq("added +0 → skipped (format)", github.pr_file_is_skipped("added", 0, 0, False), True)
+    _eq("added +0 → skipped (lint)", github.pr_file_is_skipped("added", 0, 0, True), True)
+    _eq("added +5 → kept (format)", github.pr_file_is_skipped("added", 5, 0, False), False)
+
+    # `renamed` with content change: kept on both paths.
+    _eq("renamed +2/-1 → kept (format)", github.pr_file_is_skipped("renamed", 2, 1, False), False)
+    _eq("renamed +2/-1 → kept (lint)", github.pr_file_is_skipped("renamed", 2, 1, True), False)
+
+    # `renamed` with +0/-0 (pure rename): the customer-reported bug.
+    # Format MUST format the destination; lint must skip to mirror the
+    # local `git diff --unified=0` path and avoid hold-the-file regressions.
+    _eq("renamed +0/-0 → kept (format) — fixes customer bug", github.pr_file_is_skipped("renamed", 0, 0, False), False)
+    _eq("renamed +0/-0 → skipped (lint) — preserves hold-the-file scoping", github.pr_file_is_skipped("renamed", 0, 0, True), True)
 
 def _http_stub(responses):
     """Stub `ctx.http()` returning canned responses in order. `responses`


### PR DESCRIPTION
A renamed file with no content change comes back from GitHub's PR Files API as `status: "renamed"` with `+0/-0`. The legacy CLI and the new CLI's PR Files API fallback path were bucketing those entries as diagnostic-only, so `aspect format` silently omitted the renamed destination from the formatter's arg list.

The fix is a `line_level`-conditional rule:

- **Format (`line_level=False`)**: pure renames flow into the actionable file list — the formatter needs to run on the destination. Matches the local `git diff --name-only` path that already includes them.
- **Lint (`line_level=True`)**: pure renames remain skipped — the local `git diff --unified=0` path emits no `+++ b/...` for a 100%-rename, and surfacing the file would regress `--strategy=hold-the-file` by exposing pre-existing findings unrelated to the PR.

Logic is factored into `_pr_file_is_skipped(status, additions, deletions, line_level)` with a unit test covering every `(status, +N/-N, line_level)` combination.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**

- `aspect format` now includes pure renames (files moved without content changes) reported by the GitHub PR Files API fallback path. Previously these were silently dropped from the formatter's file list.

### Test plan

- 12 new unit-test cases in `test-github-detect` covering the bucketing predicate across every `(status, additions, deletions, line_level)` combination.
- `test-format-template-snapshots` and `test-lint-template-snapshots` confirm no regression on the rendered surfaces.
