### PR TITLE
fix(http): synchronously close download fd to prevent ETXTBSY on exec

### DIFF
--- a/crates/axl-runtime/src/engine/http.rs
+++ b/crates/axl-runtime/src/engine/http.rs
@@ -201,6 +201,16 @@ pub(crate) fn http_methods(registry: &mut MethodsBuilder) {
                 .finalize()
                 .map_err(|e| anyhow::anyhow!("{}: {}", output, e))?;
 
+            // Ensure the fd is synchronously closed before returning.
+            // tokio::fs::File::drop is non-async: it sends the underlying
+            // std::fs::File to a blocking thread for closure. If the caller
+            // renames this file and exec()s it before that thread runs, the
+            // kernel sees an open write fd on the inode and returns ETXTBSY
+            // (errno 26). into_std().await completes all pending blocking
+            // ops and returns a std::fs::File whose drop is synchronous,
+            // guaranteeing the write fd is gone before we return.
+            drop(file.into_std().await);
+
             Ok(response)
         };
 


### PR DESCRIPTION
`tokio::fs::File::drop` is non-async — it ships the underlying `std::fs::File` to a blocking thread pool for closure. This means the write fd can remain open against the inode after the download future resolves, right while the AXL caller renames the staged file into place and exec()'s it. On Linux that produces `ETXTBSY` (errno 26): the kernel refuses to exec a file with an open write fd.

Fix: call `file.into_std().await` before returning. This completes all pending blocking ops on the tokio file wrapper and yields a `std::fs::File` whose drop is synchronous — the fd is guaranteed gone before `into_std()` returns.

Reproducer path: `bsdtar()` in `tar.axl` downloads to a staging path and renames into the cache. If a second concurrent task races to exec the binary while the first task's download fd is still live in the thread pool, the exec fails. Reported as an intermittent "Text file busy" flake on Aspect Workflows CI runners across multiple rulesets.

Resolves flake seen on rules_js CI: https://github.com/aspect-build/bazel-examples/actions/runs/26669095609/job/78608514799?pr=568

```
error: Traceback (most recent call last):
  File <builtin>, in <module>
  * /mnt/ephemeral/caches/aspect-cli/axl/deps/f824e25f663f4bfbaec0ae42ccc0b3853be9aaaba00fd514fa5ce4e90fbbd4ad/aspect/format.axl:333, in _impl
      handler(ctx, ctx.args.formatter_target)
  * /mnt/ephemeral/caches/aspect-cli/axl/deps/f824e25f663f4bfbaec0ae42ccc0b3853be9aaaba00fd514fa5ce4e90fbbd4ad/aspect/feature/github_status_comments.axl:1520, in _task_started
      _publish(ctx)
  * /mnt/ephemeral/caches/aspect-cli/axl/deps/f824e25f663f4bfbaec0ae42ccc0b3853be9aaaba00fd514fa5ce4e90fbbd4ad/aspect/feature/github_status_comments.axl:1334, in _publish
      if not _publish_self(ctx, token):
  * /mnt/ephemeral/caches/aspect-cli/axl/deps/f824e25f663f4bfbaec0ae42ccc0b3853be9aaaba00fd514fa5ce4e90fbbd4ad/aspect/feature/github_status_comments.axl:1118, in _publish_self
      up = github.upload_artifact(ctx, payload_path, _state["_my_artifact_name"], e...
  * /mnt/ephemeral/caches/aspect-cli/axl/deps/f824e25f663f4bfbaec0ae42ccc0b3853be9aaaba00fd514fa5ce4e90fbbd4ad/aspect/lib/github.axl:1889, in _upload_artifact
      if not zip_create(ctx, zip_path, mtree):
  * /mnt/ephemeral/caches/aspect-cli/axl/deps/f824e25f663f4bfbaec0ae42ccc0b3853be9aaaba00fd514fa5ce4e90fbbd4ad/aspect/lib/tar.axl:206, in zip_create
      return _create_archive(ctx, archive_path, mtree_spec, ["--format=zip", "-cf"])
  * /mnt/ephemeral/caches/aspect-cli/axl/deps/f824e25f663f4bfbaec0ae42ccc0b3853be9aaaba00fd514fa5ce4e90fbbd4ad/aspect/lib/tar.axl:158, in _create_archive
      child = ctx.std.process.command(bin_path) \
error: failed to spawn command /home/aspect-runner/.cache/aspect/bsdtar/v3.8.1-fix.1/tar "--format=zip" "-cf" "/tmp/aspect-ci-status-e0422004-9119-4a4b-b3b9-c5f297c8cb7b/task.json.upload.zip" "@/tmp/aspect-ci-status-e0422004-9119-4a4b-b3b9-c5f297c8cb7b/task.json.upload.zip.mtree": Text file busy (os error 26)
   --> /mnt/ephemeral/caches/aspect-cli/axl/deps/f824e25f663f4bfbaec0ae42ccc0b3853be9aaaba00fd514fa5ce4e90fbbd4ad/aspect/lib/tar.axl:158:13
    |
158 |       child = ctx.std.process.command(bin_path) \
    |  _____________^
159 | |         .args(format_args + [archive_path, "@" + mtree_path]) \
160 | |         .stdout("inherit").stderr("inherit").spawn()
    | |____________________________________________________^
    |
```

---

### Changes are visible to end-users: no

### Suggested release notes

- Fixed intermittent `Text file busy (os error 26)` flake when downloading and exec-ing the bsdtar binary on Linux CI runners.

### Test plan

- Manual: the race is hard to unit-test reliably, but the fix is a standard tokio pattern (`into_std().await`) with well-understood semantics.
- CI green