### PR TITLE
fix(bazel): tolerate non-release Bazel versions, assume latest for flag gating

### DIFF
--- a/crates/axl-runtime/src/engine/bazel/info.rs
+++ b/crates/axl-runtime/src/engine/bazel/info.rs
@@ -4,15 +4,33 @@ use std::process::Stdio;
 
 use anyhow::anyhow;
 
+/// Parse the value of `bazel info release` into a semver version.
+///
+/// The value looks like `release 9.0.0`, or `release 9.0.0-rc1` for a
+/// release candidate. Non-release builds report a value with no version
+/// number — `development version` (built from source) or `no_version` —
+/// and return `None` rather than erroring, so a non-release Bazel doesn't
+/// abort the task. Callers treat `None` as "version unknown".
+fn parse_release(value: &str) -> Option<semver::Version> {
+    let ver_str = value.trim().trim_start_matches("release ").trim();
+    // Drop any pre-release suffix so an rc/pre build (`9.0.0-rc1`) matches the
+    // same constraints its eventual release will.
+    let ver_str = ver_str.split('-').next().unwrap_or(ver_str);
+    semver::Version::parse(ver_str).ok()
+}
+
 /// Query bazel server info (server_pid, release version).
-pub fn server_info() -> io::Result<(u32, semver::Version)> {
+///
+/// The version is `None` when Bazel reports a non-release build (see
+/// [`parse_release`]); the pid is always required.
+pub fn server_info() -> io::Result<(u32, Option<semver::Version>)> {
     server_info_with_startup_flags(&[])
 }
 
 /// Query bazel server info with startup flags prepended before the subcommand.
 pub fn server_info_with_startup_flags(
     startup_flags: &[String],
-) -> io::Result<(u32, semver::Version)> {
+) -> io::Result<(u32, Option<semver::Version>)> {
     let mut cmd = Command::new(super::bazel_binary());
     cmd.args(startup_flags);
     cmd.arg("info");
@@ -52,19 +70,16 @@ pub fn server_info_with_startup_flags(
                     pid = value.trim().parse::<u32>().ok();
                 }
                 "release" => {
-                    // Value is like "release 9.0.0" or "release 9.0.0-rc1"
-                    let ver_str = value.trim().trim_start_matches("release ").trim();
-                    // Strip pre-release suffix: "9.0.0-rc1" -> "9.0.0"
-                    let ver_str = ver_str.split('-').next().unwrap_or(ver_str);
-                    version = semver::Version::parse(ver_str)
-                        .map_err(|e| {
-                            io::Error::other(anyhow!(
-                                "failed to parse Bazel version '{}': {}",
-                                ver_str,
-                                e
-                            ))
-                        })
-                        .ok();
+                    version = parse_release(value);
+                    if version.is_none() {
+                        // Not an error; version-conditional flags assume latest.
+                        // Logged for diagnosability when flag resolution looks off.
+                        tracing::debug!(
+                            release = %value.trim(),
+                            "bazel reported a non-release version; \
+                             version-conditional flags will assume latest"
+                        );
+                    }
                 }
                 _ => {}
             }
@@ -73,11 +88,6 @@ pub fn server_info_with_startup_flags(
 
     let pid =
         pid.ok_or_else(|| io::Error::other(anyhow!("bazel info did not return server_pid")))?;
-    let version = version.ok_or_else(|| {
-        io::Error::other(anyhow!(
-            "bazel info did not return a parseable release version"
-        ))
-    })?;
 
     Ok((pid, version))
 }
@@ -151,4 +161,37 @@ pub fn server_pid_nonblocking(startup_flags: &[String]) -> Option<u32> {
     let pid_path = std::path::Path::new(output_base.trim()).join("server/server.pid.txt");
     let contents = std::fs::read_to_string(pid_path).ok()?;
     contents.trim().parse::<u32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_release;
+
+    #[test]
+    fn parses_a_plain_release() {
+        assert_eq!(
+            parse_release("release 9.0.0"),
+            Some(semver::Version::new(9, 0, 0))
+        );
+    }
+
+    #[test]
+    fn strips_rc_and_pre_suffixes() {
+        assert_eq!(
+            parse_release("release 9.0.0-rc1"),
+            Some(semver::Version::new(9, 0, 0))
+        );
+        assert_eq!(
+            parse_release("release 8.0.0-pre.20251201.1"),
+            Some(semver::Version::new(8, 0, 0))
+        );
+    }
+
+    #[test]
+    fn non_release_builds_have_no_version() {
+        assert_eq!(parse_release("development version"), None);
+        assert_eq!(parse_release("no_version"), None);
+        assert_eq!(parse_release(""), None);
+        assert_eq!(parse_release("   "), None);
+    }
 }

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -102,8 +102,8 @@ fn partition_build_events(
 }
 
 /// Resolve a mixed list of plain flags and conditional `(flag, constraint)` tuples into
-/// a `Vec<String>`. Returns only the flags whose semver constraint matches `version`.
-/// When `version` is `None` all items must be plain strings (i.e. `Either::Left`).
+/// a `Vec<String>`. Plain flags are always included; conditional flags are
+/// included only when [`constraint_matches`] holds for `version`.
 fn resolve_flags<'v>(
     items: &[Either<values::StringValue<'v>, (values::StringValue<'v>, values::StringValue<'v>)>],
     version: Option<&semver::Version>,
@@ -113,22 +113,29 @@ fn resolve_flags<'v>(
         match item {
             Either::Left(s) => result.push(s.as_str().to_string()),
             Either::Right((flag, constraint)) => {
-                let version =
-                    version.expect("server_info must be called when conditional flags are present");
-                let req = semver::VersionReq::parse(constraint.as_str()).map_err(|e| {
-                    anyhow::anyhow!(
-                        "invalid version constraint '{}': {}",
-                        constraint.as_str(),
-                        e
-                    )
-                })?;
-                if req.matches(version) {
+                if constraint_matches(constraint.as_str(), version)? {
                     result.push(flag.as_str().to_string());
                 }
             }
         }
     }
     Ok(result)
+}
+
+/// Whether a semver `constraint` is satisfied by the running Bazel `version`.
+///
+/// `version` is `None` when Bazel reports a non-release build (a
+/// `development version` has no version number to parse). Such a build is
+/// compiled from HEAD, so it is effectively newer than any release: it is
+/// matched against a max version, so lower-bound gates (`>=N`, the usual
+/// shape) match and upper-bound gates (`<N`) don't.
+///
+/// An unparseable constraint is a hard error naming the offending value.
+fn constraint_matches(constraint: &str, version: Option<&semver::Version>) -> anyhow::Result<bool> {
+    let req = semver::VersionReq::parse(constraint)
+        .map_err(|e| anyhow::anyhow!("invalid version constraint '{}': {}", constraint, e))?;
+    let assumed_latest = semver::Version::new(u64::MAX, u64::MAX, u64::MAX);
+    Ok(req.matches(version.unwrap_or(&assumed_latest)))
 }
 
 #[derive(Debug, Display, ProvidesStaticType, Trace, NoSerialize, Allocative)]
@@ -295,10 +302,12 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             Either::Right(sinks) => (true, sinks.items),
         };
         let has_conditional = flags.items.iter().any(|f| f.is_right());
+        // `server_info` returns `None` for the version on a non-release Bazel;
+        // `resolve_flags` then assumes the latest version for conditional flags.
         let bazel_version = if has_conditional {
             let (_, version) = info::server_info()
                 .map_err(|e| anyhow::anyhow!("failed to get Bazel server info: {}", e))?;
-            Some(version)
+            version
         } else {
             None
         };
@@ -403,10 +412,12 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             Either::Right(sinks) => (true, sinks.items),
         };
         let has_conditional = flags.items.iter().any(|f| f.is_right());
+        // `server_info` returns `None` for the version on a non-release Bazel;
+        // `resolve_flags` then assumes the latest version for conditional flags.
         let bazel_version = if has_conditional {
             let (_, version) = info::server_info()
                 .map_err(|e| anyhow::anyhow!("failed to get Bazel server info: {}", e))?;
-            Some(version)
+            version
         } else {
             None
         };
@@ -850,4 +861,38 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         register_execlog_types(globals);
         register_execlog_sinks(globals);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::constraint_matches;
+
+    fn version(s: &str) -> semver::Version {
+        semver::Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn matches_against_a_known_version() {
+        let v = version("8.5.1");
+        assert!(constraint_matches(">=8", Some(&v)).unwrap());
+        assert!(constraint_matches(">=8, <9", Some(&v)).unwrap());
+        assert!(!constraint_matches(">=9", Some(&v)).unwrap());
+        assert!(!constraint_matches("<7", Some(&v)).unwrap());
+    }
+
+    #[test]
+    fn unknown_version_assumes_latest() {
+        // A non-release build is newer than any release: lower-bound gates
+        // match, upper-bound gates and old-major ranges don't.
+        assert!(constraint_matches(">=8", None).unwrap());
+        assert!(constraint_matches(">=9", None).unwrap());
+        assert!(!constraint_matches("<7", None).unwrap());
+        assert!(!constraint_matches(">=8, <9", None).unwrap());
+    }
+
+    #[test]
+    fn invalid_constraint_is_an_error() {
+        let err = constraint_matches("not-a-constraint", None).unwrap_err();
+        assert!(err.to_string().contains("invalid version constraint"));
+    }
 }


### PR DESCRIPTION
A non-release Bazel — one that reports `development version` (built from source) or `no_version` from `bazel info release` — has no parseable semver. `server_info()` required one and aborted build/test tasks with `bazel info did not return a parseable release version`, even when the version was never used.

The version is only consulted for version-conditional flags (`(flag, ">=N")` tuples). This change makes the version optional and assumes the latest version for a non-release build (it is built from HEAD, so it is newer than any release):

- `server_info()` returns `(u32, Option<semver::Version>)`. The pid stays required; an unparseable release degrades to `None` (with a debug log carrying the raw string).
- Conditional flags resolve against a max version when the version is unknown, so lower-bound gates (`>=N`) apply and upper-bound gates (`<N`) don't. Plain flags are unaffected.

`parse_release` and `constraint_matches` are extracted as pure, unit-tested helpers.

### Behavior

| Bazel | conditional flags | before | after |
|---|---|---|---|
| release | any | works | works |
| non-release | none | errors | works |
| non-release | `>=N` / `<N` | errors | works — `>=N` applies, `<N` doesn't |

### Effect on the conditional flags in use today

All conditional flags in the codebase (`lib/environment.axl`) are single-sided bounds anchored at majors ≤ 8, so an undefined version resolves to the **same flag set as the latest Bazel 9 release** — assume-latest is behavior-preserving here, it only removes the hard error.

| Flag | Constraint | Latest Bazel 9 | Undefined (assume latest) |
|---|---|---|---|
| `--noexperimental_remote_cache_compression` | `<8.0.0` | not set | not set |
| `--noremote_cache_compression` | `>=8.0.0` | set | set |
| `--incompatible_remote_results_ignore_disk` | `<7.0.0` | not set | not set |

A divergence would only arise for a *bounded* constraint (e.g. `>=8, <9`), where assume-latest falls outside the upper bound. No such constraint exists today in aspect-cli build-in tasks but they could in 3rd party user axl code.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change: no
- Suggested release notes appear below: yes

### Suggested release notes

- A non-release Bazel (e.g. a `development version` build) no longer aborts build/test tasks; version-conditional flags assume the latest version for such builds.

### Test plan

- Unit tests: `parse_release` (release / rc / pre / development version / no_version / empty) and `constraint_matches` (known version, unknown→latest, invalid constraint).
- CI
