### PR TITLE
feat(bazel): announce version/command per spawn; unify setup phase + collapse lifecycle to one hook

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -644,7 +644,7 @@ def test_template_rendering(ctx: TaskContext, tc: int) -> int:
     }
     render_ctx = {
         "triggered_by": "tester",
-        "targets": "//...",
+        "subject": "//...",
         "started_ms": 1744630000000,
         "ended_ms": 1744630002000,
         "progress": "",

--- a/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
+++ b/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
@@ -32,10 +32,8 @@ This guide explains *why* the existing tasks look the way they do and how to kee
               │ trait hook lists                                 │
               │   bazel_trait.build_start / build_event /        │
               │     build_end / build_event_sinks / task_flags   │
-              │   hc_trait.pre_health_check /                    │
-              │     hc_trait.post_health_check                   │
-              │   lifecycle.task_started / task_update /         │
-              │     task_complete                                │
+              │   hc_trait.health_check                          │
+              │   lifecycle.task_update                          │
               └────────────┬─────────────────┬──────────────────┘
                            │                 │
               registered by │                 │ consumed by
@@ -68,29 +66,31 @@ Tasks own the *flow* (which Bazel command runs when, what extra processing happe
 
 ## The per-task lifecycle
 
-`TaskLifecycleTrait` (defined in [`traits.axl`](traits.axl)) defines three slots that every task fires in order:
+`TaskLifecycleTrait` (defined in [`lib/lifecycle.axl`](lib/lifecycle.axl)) has a **single** slot, **`task_update(ctx, TaskUpdate)`**, fired zero or more times during the task. The *first* and *last* updates carry extra meaning, so one hook covers the whole lifecycle:
 
-1. **`task_started(ctx, subject)`** — fires once at the start of the task, before any health check or build. The `subject` is whatever the task wants to display in the rendered title (e.g. the target pattern for build/test/lint, the formatter target for format, the gazelle target for gazelle, the delivery targets for delivery).
+- **First update → init.** A handler's first `task_update` is its cue to initialize: authenticate, create the GitHub check run / first BK annotation, and read `update.subject` for the rendered title. `setup_phase` (see below) emits this first update — the `🔧 Setup` phase mark — at the very start of every task, so init always lands inside the Setup phase. Each handler guards init with a private `_state["_initialized"]` flag.
 
-   Features that subscribe here typically post the *initial* "running" surface (a creating GitHub check run, a first BK annotation in `--style info`).
+- **Middle updates → progress.** Tasks emit running updates as they make progress (lint emits one per SARIF report; build/test emit on every BES event that updates the failure / test-summary state). The per-surface throttle in `lib/check_dispatch` collapses chatty updates.
 
-2. **`task_update(ctx, TaskUpdate)`** — fires zero or more times during the task. Each `TaskUpdate` carries:
-   - `kind` — the result-library identifier (e.g. `"lint_results"`). Drives renderer dispatch.
-   - `status` — `"running"`, `"failing"`, `"passed"`, or `"failed"`.
-   - `data` — kind-specific data dict (the `init_data()` accumulator, see [Results dict shape](#results-dict-shape)).
+- **Last update → terminal.** The producer's final emit carries `final = True` with a terminal `status` (`"passed"`, `"failed"`, `"warning"`, `"aborted"`). Features take that as the cue to complete the check run / finalise the annotation, and the throttle always lets `final` through. `task_update` returns a `TaskConclusion` on the `final` emit for `_impl` to return.
 
-   Tasks emit running updates as they make progress (e.g. lint emits one per SARIF report; build/test emit on every BES event that updates the failure / test-summary state). The two final values `"passed"` / `"failed"` are *terminal*: features take that as the cue to complete the check run / finalise the annotation, and the throttle in `lib/check_dispatch.should_emit_update` always lets terminals through.
+Each `TaskUpdate` carries:
+- `kind` — the result-library identifier (e.g. `"lint_results"`). Drives renderer dispatch.
+- `status` — `"running"`, `"failing"`, `"passed"`, `"failed"`, `"warning"`, or `"aborted"`.
+- `data` — kind-specific data dict (the `init_data()` accumulator, see [Results dict shape](#results-dict-shape)).
+- `subject` — the task's target patterns / formatter target / etc. `setup_phase` sets it on the first emit so handlers can read it during init; a later emit may carry a refined subject (handlers latch the last non-empty value and refresh the surface title).
+- `final` — `True` on the terminal emit.
 
-3. **`task_complete(ctx, exit_code)`** — fires once with the integer exit code the task is about to return. Features subscribe here for cleanup that needs the exit code rather than the rendered status (e.g. updating telemetry counters, posting to follow-up systems).
+There is **no** separate `task_started` / `task_complete` hook — the first and last `task_update` carry that intent. The `subject` rides on the first update so init has what it needs without a dedicated start signal.
 
 The order at runtime, end-to-end:
 
 ```
-lifecycle.task_started("//...")
-  └─ GithubStatusChecks creates the check run
-  └─ BuildkiteAnnotations posts the first "info" annotation
-hc_trait.pre_health_check
-  └─ Workflows prints `--- :computer: Workflows runner environment` / health check
+setup_phase(ctx, lifecycle, subject, …)          # FIRST thing in every _impl
+  └─ lifecycle.task_update(🔧 Setup, subject=…)   # the first update
+       └─ GithubStatusChecks inits → creates the check run
+       └─ BuildkiteAnnotations inits → posts the first "info" annotation
+  └─ hc_trait.health_check                        # Workflows env table / server health check
 bazel_trait.build_start
   └─ Workflows prints `--- :bazel: Running bazel <task> [<task-key>] <targets>`
 events = bazel.build_events.iterator()           # create handle BEFORE the spawn
@@ -104,10 +104,8 @@ for event in events:
 build_status = build.wait()
 bazel_trait.build_end(ctx, build_status.code)    # ArtifactUpload uploads
 ... task-specific work (run formatter, parse SARIF, etc.) ...
-lifecycle.task_update(passed | failed)           # terminal — final body
-lifecycle.task_complete(exit_code)
-hc_trait.post_health_check
-return exit_code
+lifecycle.task_update(passed | failed, final=True)  # terminal — final body
+return <TaskConclusion>
 ```
 
 ---
@@ -119,8 +117,8 @@ return exit_code
 | Trait                        | Defined in                                                                | Slots                                                                                                       | Status / Purpose |
 |------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|------------------|
 | **`BazelTrait`**             | [bazel.axl](bazel.axl)                                                    | `build_start`, `build_event`, `build_end`, `build_retry`, `build_event_sinks`, `task_flags`, `flags`, `startup_flags`, `extra_flags`, `extra_startup_flags`, `execution_log_sinks` | ✅ Clean. Shape every Bazel invocation in the task: extra flags, BES sinks, per-event hooks, build-end cleanup. All fields are callables / hook lists / declarative config the task reads. |
-| **`HealthCheckTrait`**       | [lib/health_check.axl](lib/health_check.axl)                              | `pre_health_check`, `post_health_check`                                                                     | ✅ Clean. Hook lists only. |
-| **`TaskLifecycleTrait`**     | [lib/lifecycle.axl](lib/lifecycle.axl)                                    | `task_started`, `task_update`, `task_complete`                                                              | ✅ Clean. Hook lists only. The three lifecycle slots above. |
+| **`HealthCheckTrait`**       | [lib/health_check.axl](lib/health_check.axl)                              | `health_check`                                                                                              | ✅ Clean. Hook lists only. |
+| **`TaskLifecycleTrait`**     | [lib/lifecycle.axl](lib/lifecycle.axl)                                    | `task_update`                                                                                               | ✅ Clean. Single hook list. First update inits, `final=True` update concludes — see the lifecycle section above. |
 | **`DeliveryTrait`**          | [delivery.axl](delivery.axl)                                              | `delivery_start`, `deliver_target`, `delivery_end`                                                          | ✅ Clean. Hook lists only. |
 | **`ArtifactsTrait`**         | [lib/artifacts.axl](lib/artifacts.axl)                                    | `artifacts_browse_url`, `artifact_urls`, `testlogs_label_urls`                                              | ⚠️ **Legacy** — data fields used as cross-feature state. Migrating to Pattern 2 (feature-owned + Callable trait). See [Artifact uploads](#artifact-uploads). |
 | **`GitHubStatusChecksTrait`**| [feature/github_status_checks.axl](feature/github_status_checks.axl)      | `templates`, `metadata_keys`                                                                                | ⚠️ **Legacy** — user-facing config on a trait. Migrating to feature `args`. |
@@ -680,131 +678,77 @@ The check-run / annotation features consume artifact URLs via the wrapper's deri
 The canonical flow, with annotations. Use it as a checklist when reading or writing a task:
 
 ```python
-def _impl(ctx: TaskContext) -> int:
+def _impl(ctx: TaskContext) -> int | TaskConclusion:
     bazel_trait = ctx.traits[BazelTrait]
     hc_trait    = ctx.traits[HealthCheckTrait]
     lifecycle   = ctx.traits[TaskLifecycleTrait]
 
-    # 1. Build the data dict and fire task_started FIRST so any later
-    #    failure (a pre-build hook, a config error) still produces a
-    #    visible status check / annotation.
     data = init_data()
     data["start_time_ms"]  = now_ms(ctx)
     data["target_pattern"] = " ".join(ctx.args.targets)
-    ... task-specific bookkeeping ...
-    for handler in lifecycle.task_started:
-        handler(ctx, data["target_pattern"])   # subject (str) shown in the title
 
-    # 2. Pre-health checks. The `Workflows` feature registers
-    #    `print_environment_info` + `agent_health_check` here, which print
-    #    the `--- :computer: Workflows runner environment` and health check
-    #    BK section markers when running on an Aspect Workflows runner.
-    for hook in hc_trait.pre_health_check:
-        hook(ctx)
+    # 1. The single pre-task setup phase — FIRST thing in every _impl. It emits
+    #    the `🔧 Setup` phase mark (the task's first task_update): inits every
+    #    status surface AND renders their first body from `kind` + `data`.
+    #    `subject` rides along for the surface title. It also resolves Bazel
+    #    flags + parses the workspace .bazelrc and runs the health_check hooks —
+    #    a failed health check concludes the surface and fail()s the task inside
+    #    setup_phase (it does not return). Returns the resolved command flags
+    #    (None for a non-Bazel task). See `setup_phase` in lib/lifecycle.axl.
+    flags = setup_phase(ctx, lifecycle, data["target_pattern"], "<task>_results", data, hc_trait, bazel_trait, "build")
 
-    # 3. Compose flags. Trait `extra_flags` first, then `task_flags`
-    #    callbacks (which need ctx.task.{name,key} so they have to run at
-    #    invocation time), then user-supplied --bazel-flag values.
-    flags = list(ctx.args.bazel_flags)
-    flags.extend(bazel_trait.extra_flags)
-    for hook in bazel_trait.task_flags:
-        flags.extend(hook(ctx))
-    if bazel_trait.flags:
-        flags = bazel_trait.flags(flags)
-    startup_flags = list(ctx.args.bazel_startup_flags)
-    startup_flags.extend(bazel_trait.extra_startup_flags)
-    if bazel_trait.startup_flags:
-        startup_flags = bazel_trait.startup_flags(startup_flags)
-    ctx.bazel.startup_flags.extend(startup_flags)
-
-    # 4. Pass build_event_sinks (gRPC sinks the runtime registers BEFORE
-    #    `Build::spawn` returns) so BES events reach the Aspect backend
-    #    and the "Aspect Workflows" link resolves to a real invocation.
-    #    The iter handle subscribes pre-spawn — no late-subscribe race.
+    # 2. Pass build_event_sinks (gRPC sinks the runtime registers BEFORE
+    #    `Build::spawn` returns) so BES events reach the Aspect backend and
+    #    the "Aspect Workflows" link resolves to a real invocation. The iter
+    #    handle subscribes pre-spawn — no late-subscribe race.
     events = bazel.build_events.iterator()
     build_events = [events] + list(bazel_trait.build_event_sinks)
 
-    # 5. Fire build_start hooks BEFORE spawning Bazel. The `Workflows`
+    # 3. Fire build_start hooks BEFORE spawning Bazel. The `Workflows`
     #    feature registers the `--- :bazel: Running bazel <task> [<key>]
     #    <targets>` BK section marker here.
     for hook in bazel_trait.build_start:
         hook(ctx)
 
-    build = ctx.bazel.build(
-        flags = flags,
-        build_events = build_events,
-        *ctx.args.targets,
-    )
+    build = ctx.bazel.build(flags = flags, build_events = build_events, *ctx.args.targets)
 
-    # 7. Capture sink_invocation_id (the runtime mints it inside
-    #    Build::spawn before returning, so it's available now without
-    #    waiting for build.wait()). Emit a running task_update so the
-    #    "Aspect Workflows" link surfaces in the live annotation as
-    #    soon as the build is spawned.
+    # 4. Capture sink_invocation_id (the runtime mints it inside Build::spawn
+    #    before returning) and emit a running update so the "Aspect Workflows"
+    #    link surfaces in the live annotation as soon as the build is spawned.
     data["sink_invocation_id"] = build.sink_invocation_id
-    for handler in lifecycle.task_update:
-        handler(ctx, TaskUpdate(
-            kind   = "<task>_results",
-            status = "running",
-            data   = data,
-        ))
+    task_update(ctx, lifecycle, "running", "Building...", kind = "<task>_results", data = data,
+                phase = Phase(name = "build", description = "Build targets", emoji = "🔨"))
 
-    # 8. Drain the event iterator. Two things per event:
-    #    - bazel_trait.build_event hooks (ArtifactUpload records testlog
-    #      paths; user features can hook here too)
-    #    - process_event(data, event) to populate the bazel state +
-    #      stream metadata into the live annotation
+    # 5. Drain the event iterator. Per event: bazel_trait.build_event hooks
+    #    (ArtifactUpload records testlog paths) + process_event to populate the
+    #    bazel state and stream metadata into the live annotation.
     for event in events:
         for handler in bazel_trait.build_event:
             handler(ctx, event)
         if process_event(data, event):
-            for handler in lifecycle.task_update:
-                handler(ctx, TaskUpdate(
-                    kind   = "<task>_results",
-                    status = "running",
-                    data   = data,
-                ))
+            task_update(ctx, lifecycle, "running", "Building...", kind = "<task>_results", data = data)
 
-    # 9. Wait for bazel, then fire build_end hooks. ArtifactUpload's
-    #    `_on_build_end` runs the actual upload step here.
+    # 6. Wait for bazel, then fire build_end hooks (ArtifactUpload uploads).
     build_status = build.wait()
     for hook in bazel_trait.build_end:
         hook(ctx, build_status.code)
 
     if not build_status.success:
-        # Emit terminal task_update + task_complete BEFORE returning.
         data["<kind>"]["build_failed"] = True   # kind-specific failure flag
-        for handler in lifecycle.task_update:
-            handler(ctx, TaskUpdate(
-                kind   = "<task>_results",
-                status = "failed",
-                data   = data,
-            ))
-        for handler in lifecycle.task_complete:
-            handler(ctx, 1)
-        return 1
+        return task_update(ctx, lifecycle, "failed", "Build failed", kind = "<task>_results",
+                           data = data, final = True, exit_code = 1, conclusion = conclusion("failed", data))
 
-    # 10. ... task-specific post-build work (run binary, parse output, etc.)
+    # 7. ... task-specific post-build work (run binary, parse output, etc.)
 
-    # 11. Terminal task_update + task_complete + post_health_check.
+    # 8. Terminal task_update (final=True returns a TaskConclusion)
     status = "passed" if exit_code == 0 else "failed"
     if not data.get("finish_time_ms"):
         data["finish_time_ms"] = now_ms(ctx)
     if data.get("start_time_ms") and not data["bazel"].get("wall_time_ms"):
         data["bazel"]["wall_time_ms"] = data["finish_time_ms"] - data["start_time_ms"]
-    for handler in lifecycle.task_update:
-        handler(ctx, TaskUpdate(
-            kind   = "<task>_results",
-            status = status,
-            data   = data,
-        ))
-    for handler in lifecycle.task_complete:
-        handler(ctx, exit_code)
-    for hook in hc_trait.post_health_check:
-        result = hook(ctx)
-        if result != None:
-            fail(result)
-    return exit_code
+    result = task_update(ctx, lifecycle, status, "Done", kind = "<task>_results",
+                         data = data, final = True, exit_code = exit_code, conclusion = conclusion(status, data))
+    return result
 ```
 
 The `lint.axl` impl is the closest to this template; `format.axl` and `gazelle.axl` are similar but pass a single target instead of a list and build the entrypoint in step 10. `delivery.axl` does multiple Bazel invocations (one per phase) — the same pattern just runs once per phase.
@@ -897,9 +841,9 @@ When writing a new task, feature, or library, sanity-check:
 
 - [ ] If the task iterates BES events, create the iterator handle with `bazel.build_events.iterator()` *before* calling `ctx.bazel.build(...)`, and include it in the `build_events=[...]` list. The runtime subscribes it pre-spawn; the race is closed by construction.
 - [ ] Capture `data["sink_invocation_id"] = build.sink_invocation_id` after `ctx.bazel.build` returns, then emit a running `task_update` so the Aspect Workflows link surfaces live.
+- [ ] Call `setup_phase(ctx, lifecycle, subject, kind, data, hc_trait, bazel_trait, ...)` as the FIRST thing in `_impl` — it emits the Setup phase mark (the first `task_update`, which inits the status surfaces and renders their first body from `kind` + `data`), resolves Bazel flags, and runs `health_check` (a failed check concludes the surface and fails the task).
 - [ ] Iterate `bazel_trait.build_start` / `build_event` / `build_end` so features fire (BK section markers, artifact upload).
-- [ ] Iterate `hc_trait.pre_health_check` / `post_health_check` so the runner-env sections render and post-failures surface.
-- [ ] Emit terminal `task_update` (`status="passed"` or `"failed"`) and `task_complete(exit_code)` *before* every `return`.
+- [ ] Emit a terminal `task_update` with `final=True` and a terminal `status` (`"passed"` / `"failed"` / `"warning"` / `"aborted"`) on every `return` path, and return the `TaskConclusion` it hands back. There is no separate `task_complete` hook.
 - [ ] If a feature subscribes to `bazel_trait.build_event`, your BES loop must call those hooks per event — otherwise `_on_build_event` callbacks never run.
 - [ ] For tasks that retry the bazel invocation, create a fresh `iterator()` handle per attempt — handles are single-use.
 

--- a/crates/aspect-cli/src/builtins/aspect/README.md
+++ b/crates/aspect-cli/src/builtins/aspect/README.md
@@ -17,12 +17,10 @@ Aspect-CLI ships with six built-in tasks that drive Bazel for the most common CI
 
 Every task:
 
-- emits a **`task_started`** lifecycle event (drives an initial GitHub check run + BK annotation),
-- emits **`task_update`** events as the build streams BES events (live-rendered status),
-- emits a **`task_complete`** event with the final exit code,
+- emits **`task_update`** events through its lifecycle — the *first* (the `🔧 Setup` phase mark from `setup_phase`) drives surface init (GitHub check run + BK annotation) and carries the `subject`; middle ones live-render BES progress; the *last* (`final=True`) concludes the surfaces. There is a single lifecycle hook; the first and last updates carry the start/complete intent,
 - captures the gRPC sink's invocation UUID into `results["sink_invocation_id"]` immediately after `ctx.bazel.build(...)` returns so the **Aspect Workflows** link surfaces in the live annotation rather than only on completion,
 - runs `bazel_trait.build_start` / `bazel_trait.build_event` / `bazel_trait.build_end` hooks so features (artifact upload, BK section markers) fire,
-- runs `hc_trait.pre_health_check` / `hc_trait.post_health_check` hooks so the runner-environment / health-check BK sections render and so a failed post-check fails the task.
+- runs `hc_trait.health_check` hooks inside `setup_phase` so the runner-environment / health-check BK sections render before the build.
 
 ---
 

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -4,6 +4,7 @@ A default 'build' task that wraps a 'bazel build' command.
 
 load("./bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("./lib/artifacts.axl", "artifacts")
+load("./lib/bazel_flags.axl", "announce_bazel_args")
 load("./lib/bazel_runner.axl", "run_bazel_task")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "TaskLifecycleTrait")
@@ -24,10 +25,6 @@ build = task(
         "target_pattern_file": args.string(
             default = "",
             description = "Read newline-separated target patterns from this file instead of the command line (mirrors Bazel's --target_pattern_file). Blank lines and `#` comments are ignored. Cannot be combined with command-line target patterns.",
-        ),
-        "announce_rc": args.boolean(
-            default = False,
-            description = "Print the resolved Bazel `.bazelrc` flags before running the build. Useful when debugging which config sections fired or what the final flag set looks like. ASPECT_DEBUG=1 logs the same disclosure regardless of this flag.",
         ),
         "bazel_flags": args.string_list(
             description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
@@ -53,7 +50,7 @@ build = task(
             default = False,
             description = "Cancel any running Bazel invocation before starting the build.",
         ),
-    },
+    } | announce_bazel_args("the build"),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -101,7 +101,7 @@ User-facing migration guide: https://docs.aspect.build/cli/migration/delivery
 
 load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@aspect//lib/artifacts.axl", "artifacts")
-load("@aspect//lib/bazel_flags.axl", "setup_bazel_command")
+load("@aspect//lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("@aspect//lib/ci.axl", "detect_build_url")
 load("@aspect//lib/delivery_results.axl", delivery_add_result = "add_result", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
@@ -115,7 +115,7 @@ load(
 load("@aspect//lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("@aspect//lib/github.axl", "detect_commit_sha")
 load("@aspect//lib/health_check.axl", "HealthCheckTrait")
-load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
+load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "setup_phase", "task_update")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "repro_prefix", "task_cli_path")
 load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "apparent_label", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
@@ -233,10 +233,11 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
 
     phase1_flags = bazel_flags + ["--nokeep_state_after_build"]
     _t_phase1 = time.monotonic()
+    announce_version, announce_command = resolve_bazel_announce(ctx)
 
     # Snapshot pre-loop state so retries reset BES-derived counters
     # without re-running caller-managed setup. Restored via clear+update
-    # to keep the caller's `dr` reference valid.
+    # to keep the caller's `data` reference valid.
     pre_loop_state = dict(data)
 
     # `hasattr` guard so a future caller of `_get_output_shas` without
@@ -270,6 +271,8 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             flags = phase1_flags,
             build_events = [events] + build_events,
             execution_log = phase1_execlog_sinks,
+            announce_version = announce_version,
+            announce_command = announce_command,
             *targets
         )
 
@@ -382,6 +385,8 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
         flags = phase2_flags,
         stdout = None,
         stderr = ctx.std.fs.create(phase2_log_path),
+        announce_version = announce_version,
+        announce_command = announce_command,
         *targets
     ).wait()
 
@@ -460,25 +465,25 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
 
     return output_shas, non_hermetic_misses, 0
 
-def _pick_status(dr, had_failure, terminal):
+def _pick_status(data, had_failure, terminal):
     """Decide a delivery task's lifecycle status from accumulated data.
 
     Aborted (bazel terminated mid-build of phase 1/2/3) → "aborted".
     Hard failure (`fail` count > 0 or build failed) → "failing"/"failed".
     `warn` count > 0 → "warning" (soft signal).
     Else → "running"/"passed"."""
-    if dr.get("bazel", {}).get("aborted"):
+    if data.get("bazel", {}).get("aborted"):
         return "aborted"
     if had_failure:
         return "failed" if terminal else "failing"
-    counts = (dr.get("delivery", {}) or {}).get("counts", {}) or {}
+    counts = (data.get("delivery", {}) or {}).get("counts", {}) or {}
     if counts.get("warn", 0) > 0:
         return "warning"
     return "passed" if terminal else "running"
 
-def _compact_text(status, dr):
+def _compact_text(status, data):
     """Compact Result-cell text for the PR-comment surface."""
-    counts = (dr.get("delivery", {}) or {}).get("counts", {}) or {}
+    counts = (data.get("delivery", {}) or {}).get("counts", {}) or {}
     ok = counts.get("ok", 0)
     skip = counts.get("skip", 0)
     warn = counts.get("warn", 0)
@@ -500,16 +505,16 @@ def _compact_text(status, dr):
         return "no deliveries" if status == "passed" else ""
     if status == "running":
         done = ok + skip + warn + fail
-        total = (dr.get("delivery", {}) or {}).get("targets_total", 0) or 0
+        total = (data.get("delivery", {}) or {}).get("targets_total", 0) or 0
         if done > 0:
             if total > 0:
                 return "%d/%d delivered" % (done, total)
             return "%d delivered" % done
     return ""
 
-def _body_text(status, dr):
+def _body_text(status, data):
     """Narrative-form `progress.body` for the PR-comment 💬 line."""
-    compact = _compact_text(status, dr)
+    compact = _compact_text(status, data)
     if status == "passed" or status == "warning":
         return "Delivery complete" + ((" (" + compact + ")") if compact else "")
     if status == "failed":
@@ -518,42 +523,42 @@ def _body_text(status, dr):
         return "Delivery aborted"
     return ""
 
-def _emit_update(ctx, lifecycle, dr, had_failure = False):
+def _emit_update(ctx, lifecycle, data, had_failure = False):
     """Emit a bare task_update carrying the accumulating delivery data.
 
     Used for data-only refreshes during phase 1 BES streaming — the
     feature side preserves the most recent phase label when
-    `update.progress` is empty, so these emits push updated `dr` state
+    `update.progress` is empty, so these emits push updated `data` state
     without disturbing the displayed "Last update" line. Phase
     transitions go through `task_update()` instead.
     """
-    status = _pick_status(dr, had_failure = had_failure, terminal = False)
+    status = _pick_status(data, had_failure = had_failure, terminal = False)
     for handler in lifecycle.task_update:
         handler(ctx, TaskUpdate(
             kind = "delivery_results",
             status = status,
-            data = dr,
+            data = data,
             progress = ProgressStyles(),
         ))
 
-def _emit_final(ctx, lifecycle, dr, exit_code):
-    """Emit the terminal task_update + task_complete hooks for delivery.
+def _emit_final(ctx, lifecycle, data, exit_code):
+    """Emit the terminal `task_update(final=True)` for delivery.
 
     Called at every return path out of _delivery_impl so a check run is always
     completed — even on early error exits before any per-target data exist.
     """
-    if not dr.get("finish_time_ms"):
-        dr["finish_time_ms"] = now_ms(ctx)
-    if not dr.get("wall_time_ms") and dr.get("start_time_ms"):
-        dr["wall_time_ms"] = dr["finish_time_ms"] - dr["start_time_ms"]
+    if not data.get("finish_time_ms"):
+        data["finish_time_ms"] = now_ms(ctx)
+    if not data.get("wall_time_ms") and data.get("start_time_ms"):
+        data["wall_time_ms"] = data["finish_time_ms"] - data["start_time_ms"]
 
     # Build a local-repro command pinned to `--mode=always --dry-run
     # --track-state=false` (the only combo that runs off a Workflows
     # runner). Skipped when zero targets resolved (repro would be noise).
-    targets_total = (dr.get("delivery", {}) or {}).get("targets_total", 0) or 0
+    targets_total = (data.get("delivery", {}) or {}).get("targets_total", 0) or 0
     if targets_total > 0:
         flags = []
-        commit_sha = (dr.get("delivery", {}) or {}).get("commit_sha", "") or ctx.args.commit_sha
+        commit_sha = (data.get("delivery", {}) or {}).get("commit_sha", "") or ctx.args.commit_sha
         if commit_sha and commit_sha != "-":
             flags.append(("--commit-sha", commit_sha))
         flags.append(("--mode", "always"))
@@ -565,10 +570,10 @@ def _emit_final(ctx, lifecycle, dr, exit_code):
             if ctx.args.mode != "always":
                 desc = "CI ran --mode=%s; --mode=always --track-state=false for off-runner with no state backend." % ctx.args.mode
             prefix = repro_prefix(ctx)
-            dr["repro_commands"].append({"command": prefix + repro, "description": desc})
+            data["repro_commands"].append({"command": prefix + repro, "description": desc})
 
-    final_status = _pick_status(dr, had_failure = exit_code != 0, terminal = True)
-    bookend = delivery_conclusion(final_status, dr)
+    final_status = _pick_status(data, had_failure = exit_code != 0, terminal = True)
+    bookend = delivery_conclusion(final_status, data)
 
     for handler in lifecycle.task_update:
         handler(ctx, TaskUpdate(
@@ -576,14 +581,12 @@ def _emit_final(ctx, lifecycle, dr, exit_code):
             status = final_status,
             final = True,
             conclusion = bookend,
-            data = dr,
+            data = data,
             progress = ProgressStyles(
-                body = _body_text(final_status, dr),
+                body = _body_text(final_status, data),
             ),
         ))
-    print_repro_and_fix(ctx.std, dr, final_status)
-    for handler in lifecycle.task_complete:
-        handler(ctx, exit_code)
+    print_repro_and_fix(ctx.std, data, final_status)
 
     return TaskConclusion(
         exit_code = exit_code,
@@ -596,43 +599,47 @@ def _delivery_impl(ctx):
     bazel_trait = ctx.traits[BazelTrait]
     lifecycle = ctx.traits[TaskLifecycleTrait]
 
-    # Build the delivery-data shell and fire task_started early so any
-    # later failure still produces a check run rather than a silent no-op.
-    dr = delivery_init_data()
-    dr["start_time_ms"] = now_ms(ctx)
-    dr["delivery"]["commit_sha"] = ctx.args.commit_sha
-    dr["delivery"]["build_url"] = ctx.args.build_url
-    dr["delivery"]["ci_host"] = ctx.args.ci_host
+    # Build the delivery-data shell up front so an early failure (before
+    # setup_phase opens the status surface) still has data to render.
+    data = delivery_init_data()
+    data["start_time_ms"] = now_ms(ctx)
+    data["delivery"]["commit_sha"] = ctx.args.commit_sha
+    data["delivery"]["build_url"] = ctx.args.build_url
+    data["delivery"]["ci_host"] = ctx.args.ci_host
 
     # Surface the run-shape so the check-run / annotation summary shows
     # `Mode: selective` or `Mode: always (dry-run, untracked)` above the
     # data table — analogous to lint's `Strategy:` line.
-    dr["delivery"]["mode"] = ctx.args.mode
-    dr["delivery"]["dry_run"] = bool(ctx.args.dry_run)
-    dr["delivery"]["track_state"] = bool(ctx.args.track_state)
+    data["delivery"]["mode"] = ctx.args.mode
+    data["delivery"]["dry_run"] = bool(ctx.args.dry_run)
+    data["delivery"]["track_state"] = bool(ctx.args.track_state)
 
-    # `subject` feeds the status-check "Explicit command line" block;
-    # without it the rendered command is missing the target list.
     ansi = color_enabled(ctx.std)
 
+    # The requested targets feed setup_phase's `subject`, which the status
+    # check renders in its "Explicit command line" block; without it the
+    # rendered command is missing the target list. Often empty for query-based
+    # delivery — the resolved set is pushed into the data later.
     targets_subject = " ".join(list(ctx.args.targets)) if ctx.args.targets else ""
-    setup_phase(ctx, lifecycle)
-    for handler in lifecycle.task_started:
-        handler(ctx, targets_subject)
 
-    # phase1/2/3_flags layer on top of expanded_flags later.
-    # --remote_download_outputs=minimal is mandatory for phases 1/2 (we
-    # never download outputs while computing shas). Phase 3 additionally
-    # appends ctx.args.release_bazel_flags for release-only Bazel flags
-    # like --stamp.
-    expanded_flags = setup_bazel_command(
+    # The single pre-task setup phase (status surface, rc parse, health
+    # checks); returns expanded_flags (a failed health check fails the task
+    # inside setup_phase). phase1/2/3_flags layer on top later.
+    # --remote_download_outputs=minimal is mandatory for phases 1/2 (we never
+    # download outputs while computing shas); phase 3 appends
+    # ctx.args.release_bazel_flags for release-only flags like --stamp.
+    expanded_flags = setup_phase(
         ctx,
-        "build",
+        lifecycle,
+        targets_subject,
+        "delivery_results",
+        data,
+        hc_trait,
         bazel_trait,
-        base_flags = ["--remote_download_outputs=minimal"],
+        "build",
+        bazel_base_flags = ["--remote_download_outputs=minimal"],
     )
-
-    preflight_phase(ctx, lifecycle, hc_trait)
+    announce_version, announce_command = resolve_bazel_announce(ctx)
 
     delivery_trait = ctx.traits[DeliveryTrait]
     delivery_trait.delivery_start()
@@ -645,7 +652,7 @@ def _delivery_impl(ctx):
 
     if mode == "selective" and not track_state:
         msg = "--mode=selective requires --track-state=true. Change detection cannot decide what to deliver without persisted state. Either use --track-state=true (the default), or switch to --mode=always to deliver without change detection (combine with --dry-run for a preview)."
-        _emit_final(ctx, lifecycle, dr, exit_code = 1)
+        _emit_final(ctx, lifecycle, data, exit_code = 1)
         fail(msg)
 
     # phase 1/2 runs whenever digests are needed (recorded or previewed).
@@ -658,7 +665,7 @@ def _delivery_impl(ctx):
     # automatically and expose its Unix socket via the env var below.
     endpoint = ctx.std.env.var("ASPECT_WORKFLOWS_DELIVERY_API_ENDPOINT")
     if not endpoint and track_state:
-        _emit_final(ctx, lifecycle, dr, exit_code = 1)
+        _emit_final(ctx, lifecycle, data, exit_code = 1)
         fail("ASPECT_WORKFLOWS_DELIVERY_API_ENDPOINT is not set. The delivery state backend must be running. (Pass --track-state=false to run without state tracking; allowed in combination with --dry-run or --mode=always.)")
 
     # commit-sha / build-url auto-detect from CI env vars. commit_sha is
@@ -667,7 +674,7 @@ def _delivery_impl(ctx):
     commit_sha = ctx.args.commit_sha or detect_commit_sha(ctx.std)
     if not commit_sha and track_state:
         msg = "Could not determine commit SHA. Pass --commit-sha=<sha>, or run on a CI host that exposes GITHUB_SHA, BUILDKITE_COMMIT, CIRCLE_SHA1, or CI_COMMIT_SHA."
-        _emit_final(ctx, lifecycle, dr, exit_code = 1)
+        _emit_final(ctx, lifecycle, data, exit_code = 1)
         fail(msg)
     if not commit_sha:
         commit_sha = "-"
@@ -685,7 +692,7 @@ def _delivery_impl(ctx):
     # shows `<prefix>:<hash>` — the change-detection identity. The raw
     # output_sha alone is identical across salt namespaces, hiding that
     # records are stored separately per salt.
-    dr["delivery"]["prefix"] = prefix
+    data["delivery"]["prefix"] = prefix
 
     # iter handles are created per attempt inside the retry loop.
     build_events = list(bazel_trait.build_event_sinks)
@@ -718,7 +725,7 @@ def _delivery_impl(ctx):
         else:
             error(ctx.std, "Delivery requires a remote cache but no --remote_cache or --remote_executor was found." +
                            " (Use --mode=always --track-state=false to deliver every target without change detection.)")
-            return _emit_final(ctx, lifecycle, dr, exit_code = 1)
+            return _emit_final(ctx, lifecycle, data, exit_code = 1)
 
     query_expr = ctx.args.query
     if query_expr:
@@ -738,14 +745,18 @@ def _delivery_impl(ctx):
         if tok and tok not in forced_targets:
             forced_targets.append(tok)
 
-    # task_started fired earlier with an empty subject; now that the
-    # target set is resolved, push it so the check run reflects it.
-    dr["target_pattern"] = " ".join(list(targets)) if targets else ""
+    # Setup opened the surface with the *requested* subject (often a query,
+    # so empty here); now that the target set is resolved, record it. It goes
+    # into the data (so the check-run table reflects the actual targets) and
+    # onto the task_update as a refined `subject` so the surface title updates
+    # from the requested subject to the resolved one. `summary_title` caps a
+    # long target list, so the full pattern is fine to pass here.
+    data["target_pattern"] = " ".join(list(targets)) if targets else ""
 
     # Total target count for the "X/N delivered" running compact.
-    dr["delivery"]["targets_total"] = len(targets)
+    data["delivery"]["targets_total"] = len(targets)
     targets_label = pluralize(len(targets), "target")
-    status = _pick_status(dr, had_failure = False, terminal = False)
+    status = _pick_status(data, had_failure = False, terminal = False)
     task_update(
         ctx,
         lifecycle,
@@ -755,13 +766,14 @@ def _delivery_impl(ctx):
             stream = "Resolving {} to deliver".format(targets_label),
         ),
         kind = "delivery_results",
-        data = dr,
+        data = data,
         phase = Phase(name = "resolve", description = "Resolve targets to deliver", emoji = "🎯"),
+        subject = data["target_pattern"],
     )
 
     if not targets:
         info(ctx.std, "No targets to deliver")
-        return _emit_final(ctx, lifecycle, dr, exit_code = 0)
+        return _emit_final(ctx, lifecycle, data, exit_code = 0)
 
     # Hard-fail on forced labels not in the resolved set: force-target
     # only flips change detection, it doesn't add labels. Catches typos
@@ -769,7 +781,7 @@ def _delivery_impl(ctx):
     unmatched_forced = [t for t in forced_targets if t not in targets]
     if unmatched_forced:
         msg = "--force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS labels not in the resolved delivery set: " + ", ".join(unmatched_forced) + ". Force-target re-delivers labels already selected by --query or positional args; it does not add new labels. Either fix the typo or update --query / positional targets to include them."
-        _emit_final(ctx, lifecycle, dr, exit_code = 1)
+        _emit_final(ctx, lifecycle, data, exit_code = 1)
         fail(msg)
 
     _print_header(ansi, endpoint, ci_host, commit_sha, prefix, prefix_source, build_url, expanded_flags, targets, forced_targets, mode, dry_run, track_state)
@@ -781,7 +793,7 @@ def _delivery_impl(ctx):
     # Phase 1/2 — skipped only in --mode=always + --track-state=false.
     if phase_1_2_runs:
         _t_build = time.monotonic()
-        output_shas, non_hermetic_misses, build_code = _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, expanded_flags, remote_cache_uri, ansi, dr)
+        output_shas, non_hermetic_misses, build_code = _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, expanded_flags, remote_cache_uri, ansi, data)
         print("  Build+checksum total: {}.".format(fmt_elapsed(time.monotonic() - _t_build)))
 
         for handler in bazel_trait.build_end:
@@ -793,19 +805,19 @@ def _delivery_impl(ctx):
             # Synthetic warn rows so the check run conveys WHY it failed.
             for label in targets:
                 delivery_add_result(
-                    dr,
+                    data,
                     label,
                     "warn",
                     message = "build failed (exit {})".format(build_code),
                 )
-            return _emit_final(ctx, lifecycle, dr, exit_code = build_code)
+            return _emit_final(ctx, lifecycle, data, exit_code = build_code)
     else:
         output_shas = {}
         non_hermetic_misses = {}
 
     # Record each target's digest with deliveryd. Skipped when --track-state=false.
     if track_state:
-        status = _pick_status(dr, had_failure = False, terminal = False)
+        status = _pick_status(data, had_failure = False, terminal = False)
         task_update(
             ctx,
             lifecycle,
@@ -815,7 +827,7 @@ def _delivery_impl(ctx):
                 stream = "Recording delivery digests",
             ),
             kind = "delivery_results",
-            data = dr,
+            data = data,
             phase = Phase(name = "record", description = "Record delivery digests", emoji = "📝"),
         )
         for label in targets:
@@ -825,7 +837,7 @@ def _delivery_impl(ctx):
     # Query deliveryd. Skipped when --track-state=false (no endpoint) or
     # in --mode=always (every target is a candidate regardless of state).
     if track_state and mode != "always":
-        status = _pick_status(dr, had_failure = False, terminal = False)
+        status = _pick_status(data, had_failure = False, terminal = False)
         task_update(
             ctx,
             lifecycle,
@@ -835,7 +847,7 @@ def _delivery_impl(ctx):
                 stream = "Checking which targets have already been delivered",
             ),
             kind = "delivery_results",
-            data = dr,
+            data = data,
             phase = Phase(name = "query", description = "Query delivery state", emoji = "❓"),
         )
         delivery_state = deliveryd_query(ctx, endpoint, ci_host, commit_sha, prefix)
@@ -861,7 +873,7 @@ def _delivery_impl(ctx):
     # run, no entrypoints needed).
     if delivery_targets and not preview_only:
         delivery_targets_label = pluralize(len(delivery_targets), "target")
-        status = _pick_status(dr, had_failure = False, terminal = False)
+        status = _pick_status(data, had_failure = False, terminal = False)
         task_update(
             ctx,
             lifecycle,
@@ -871,7 +883,7 @@ def _delivery_impl(ctx):
                 stream = "Downloading runfiles for {} being delivered".format(delivery_targets_label),
             ),
             kind = "delivery_results",
-            data = dr,
+            data = data,
             phase = Phase(name = "download", description = "Download runfiles", emoji = "📥"),
         )
 
@@ -898,6 +910,8 @@ def _delivery_impl(ctx):
             build_events = [phase3_events],
             stdout = None,
             stderr = ctx.std.fs.create(phase3_log_path),
+            announce_version = announce_version,
+            announce_command = announce_command,
             *delivery_targets
         )
         for event in phase3_events:
@@ -913,23 +927,23 @@ def _delivery_impl(ctx):
             error(ctx.std, "Build failed with exit code {}. Phase-3 raw log: {}".format(status.code, phase3_log_path))
             for label in delivery_targets:
                 delivery_add_result(
-                    dr,
+                    data,
                     label,
                     "warn",
                     message = "download failed (exit {})".format(status.code),
                     output_sha = output_shas.get(label, ""),
                 )
-            return _emit_final(ctx, lifecycle, dr, exit_code = status.code)
+            return _emit_final(ctx, lifecycle, data, exit_code = status.code)
         print("  Download took {}.".format(fmt_elapsed(time.monotonic() - _t_download)))
 
     max_par = ctx.args.max_parallelization
     if max_par < 1:
         error(ctx.std, "--max-parallelization must be >= 1, got {}.".format(max_par))
-        return _emit_final(ctx, lifecycle, dr, exit_code = 1)
+        return _emit_final(ctx, lifecycle, data, exit_code = 1)
     capture = max_par > 1
 
     # Step 1: collect targets needing delivery; record WARN/SKIP immediately
-    status = _pick_status(dr, had_failure = False, terminal = False)
+    status = _pick_status(data, had_failure = False, terminal = False)
     task_update(
         ctx,
         lifecycle,
@@ -939,10 +953,10 @@ def _delivery_impl(ctx):
             stream = "Selecting targets for delivery",
         ),
         kind = "delivery_results",
-        data = dr,
+        data = data,
         phase = Phase(name = "deliver", description = "Deliver targets", emoji = "🚚"),
     )
-    data = []
+    rows = []
     skipped_count = 0
     pending_count = 0
     success_count = 0
@@ -965,9 +979,9 @@ def _delivery_impl(ctx):
                 msg = "no digest: non-cacheable upstream action(s) ({}); likely non-hermetic. Phase-2 raw log: {}".format(", ".join(mnemonics), _PHASE2_LOG_PATH.format(ctx.task.key))
             else:
                 msg = "no output_sha (not in grpc log; target may be an alias — use the actual target label)"
-            data.append((label, "WARN", "warn", msg, "-", "-"))
+            rows.append((label, "WARN", "warn", msg, "-", "-"))
             delivery_add_result(
-                dr,
+                data,
                 label,
                 "warn",
                 message = msg,
@@ -976,9 +990,9 @@ def _delivery_impl(ctx):
         elif not is_forced and target_state and target_state.get("delivered"):
             skipped_count += 1
             delivered_by = target_state.get("delivered_by") or "-"
-            data.append((label, "SKIP", "skip", delivered_by, output_sha, "-"))
+            rows.append((label, "SKIP", "skip", delivered_by, output_sha, "-"))
             delivery_add_result(
-                dr,
+                data,
                 label,
                 "skip",
                 message = delivered_by,
@@ -993,18 +1007,18 @@ def _delivery_impl(ctx):
             if ep == None:
                 warn_msg = "no build output reported for this target (possibly an alias, filtered, or transitioned away)"
                 pending_count += 1
-                data.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
-                delivery_add_result(dr, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)
+                rows.append((label, "WARN", "warn", warn_msg, output_sha or "-", "-"))
+                delivery_add_result(data, label, "warn", message = warn_msg, output_sha = output_sha or "", is_forced = is_forced)
             elif not ep.runfiles_dir:
                 not_runnable_msg = "tagged 'deliverable' but not runnable: no runfiles directory at {}.runfiles (target may not be an executable rule)".format(ep.path)
                 if ctx.args.warn_not_runnable:
                     pending_count += 1
-                    data.append((label, "WARN", "warn", not_runnable_msg, output_sha or "-", "-"))
-                    delivery_add_result(dr, label, "warn", message = not_runnable_msg, output_sha = output_sha or "", is_forced = is_forced)
+                    rows.append((label, "WARN", "warn", not_runnable_msg, output_sha or "-", "-"))
+                    delivery_add_result(data, label, "warn", message = not_runnable_msg, output_sha = output_sha or "", is_forced = is_forced)
                 else:
                     failed_count += 1
-                    data.append((label, "FAIL", "fail", not_runnable_msg, output_sha or "-", "-"))
-                    delivery_add_result(dr, label, "fail", message = not_runnable_msg, output_sha = output_sha or "", is_forced = is_forced)
+                    rows.append((label, "FAIL", "fail", not_runnable_msg, output_sha or "-", "-"))
+                    delivery_add_result(data, label, "fail", message = not_runnable_msg, output_sha = output_sha or "", is_forced = is_forced)
             else:
                 pending.append((label, ep, is_forced, output_sha or "-"))
 
@@ -1022,7 +1036,7 @@ def _delivery_impl(ctx):
     else:
         prepass_progress = "No targets to deliver"
         prepass_cli = "No targets to deliver"
-    status = _pick_status(dr, had_failure = False, terminal = False)
+    status = _pick_status(data, had_failure = False, terminal = False)
     task_update(
         ctx,
         lifecycle,
@@ -1032,7 +1046,7 @@ def _delivery_impl(ctx):
             stream = prepass_cli,
         ),
         kind = "delivery_results",
-        data = dr,
+        data = data,
     )
 
     # Step 2: dispatch in chunks of max_par — spawn all in chunk, poll for completions
@@ -1043,9 +1057,9 @@ def _delivery_impl(ctx):
             for label, _, is_forced, output_sha in chunk:
                 forced_marker = " (FORCED)" if is_forced else ""
                 pending_count += 1
-                data.append((label, "DRY-RUN" + forced_marker, "pending", "-", output_sha, "-"))
+                rows.append((label, "DRY-RUN" + forced_marker, "pending", "-", output_sha, "-"))
                 delivery_add_result(
-                    dr,
+                    data,
                     label,
                     "pending",
                     message = "dry-run" + (" (forced)" if is_forced else ""),
@@ -1074,9 +1088,9 @@ def _delivery_impl(ctx):
                 if track_state:
                     deliveryd_deliver(ctx, endpoint, ci_host, output_sha, prefix, build_url)
                 success_count += 1
-                data.append((label, "OK" + forced_marker, "ok", build_url, output_sha, duration))
+                rows.append((label, "OK" + forced_marker, "ok", build_url, output_sha, duration))
                 delivery_add_result(
-                    dr,
+                    data,
                     label,
                     "ok",
                     message = build_url,
@@ -1087,9 +1101,9 @@ def _delivery_impl(ctx):
                 if track_state:
                     deliveryd_delete_artifact(ctx, endpoint, ci_host, output_sha, prefix)
                 failed_count += 1
-                data.append((label, "FAIL" + forced_marker, "fail", "-", output_sha, duration))
+                rows.append((label, "FAIL" + forced_marker, "fail", "-", output_sha, duration))
                 delivery_add_result(
-                    dr,
+                    data,
                     label,
                     "fail",
                     message = "exit {}".format(exit_code),
@@ -1101,7 +1115,7 @@ def _delivery_impl(ctx):
             # / GHSC PATCHes; stream="" suppresses the CLI line since the
             # per-target "Delivering <label>..." already ticks.
             done = success_count + failed_count
-            status = _pick_status(dr, had_failure = failed_count > 0, terminal = False)
+            status = _pick_status(data, had_failure = failed_count > 0, terminal = False)
             task_update(
                 ctx,
                 lifecycle,
@@ -1110,23 +1124,23 @@ def _delivery_impl(ctx):
                     body = "Delivering {} of {}...".format(done, pluralize(len(pending), "target")),
                 ),
                 kind = "delivery_results",
-                data = dr,
+                data = data,
                 priority = False,
             )
 
     # Calculate column widths for alignment
     max_label_width = len("TARGET")
-    for label, _, _, _, _, _ in data:
+    for label, _, _, _, _, _ in rows:
         if len(label) > max_label_width:
             max_label_width = len(label)
 
     max_status_width = len("STATUS")
-    for _, status_text, _, _, _, _ in data:
+    for _, status_text, _, _, _, _ in rows:
         if len(status_text) > max_status_width:
             max_status_width = len(status_text)
 
     max_duration_width = len("DURATION")
-    for _, _, _, _, _, duration in data:
+    for _, _, _, _, _, duration in rows:
         if len(duration) > max_duration_width:
             max_duration_width = len(duration)
 
@@ -1151,7 +1165,7 @@ def _delivery_impl(ctx):
         "BUILD URL",
     )
     print(_style(header, _BOLD, ansi))
-    for label, status_text, status_type, delivered_by, output_sha, duration in data:
+    for label, status_text, status_type, delivered_by, output_sha, duration in rows:
         styled_status = _style(status_text, status_styles[status_type], ansi)
         padding = " " * (max_status_width - len(status_text))
         key = prefix + ":" + output_sha[:12] if output_sha and output_sha != "-" else "-"
@@ -1176,13 +1190,8 @@ def _delivery_impl(ctx):
 
     delivery_trait.delivery_end()
 
-    for hook in hc_trait.post_health_check:
-        result = hook(ctx)
-        if result != None:
-            fail(result)
-
     exit_code = 1 if failed_count > 0 else 0
-    return _emit_final(ctx, lifecycle, dr, exit_code = exit_code)
+    return _emit_final(ctx, lifecycle, data, exit_code = exit_code)
 
 delivery = task(
     name = "delivery",
@@ -1210,10 +1219,6 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         "limit": args.int(
             default = 0,
             description = "Maximum number of targets to deliver when using --query. 0 means no limit.",
-        ),
-        "announce_rc": args.boolean(
-            default = False,
-            description = "Print the resolved Bazel `.bazelrc` flags before running the delivery build phases. Useful when debugging which config sections fired or what the final flag set looks like. ASPECT_DEBUG=1 logs the same disclosure regardless of this flag.",
         ),
         "bazel_flags": args.string_list(
             long = "bazel-flag",
@@ -1270,7 +1275,7 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
             maximum = 1000000000,
             description = "Bazel target labels to deliver.",
         ),
-    },
+    } | announce_bazel_args("the delivery build phases"),
     traits = [
         BazelTrait,
         DeliveryTrait,

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -23,7 +23,6 @@ load("../lib/bazel_results.axl", "format_run_date", "html_escape", "now_ms", "re
 load(
     "../lib/check_dispatch.axl",
     "apply_artifact_links",
-    "kind_for_task",
     "make_render_ctx",
     "renderer_for_kind",
     "should_emit_update",
@@ -249,8 +248,13 @@ def _buildkite_annotations(ctx: FeatureContext):
         links["bes_url"] = render_bes_url(data)
         return links
 
-    def _task_started(ctx, subject):
-        _state["_subject"] = subject
+    def _init(ctx):
+        # One-time init on the first task_update — cache identity for
+        # `make_render_ctx` (FeatureContext has no .task). The subject was
+        # already latched into `_state` by the caller. The "in progress"
+        # annotation is written by the render path below, not here: the first
+        # task_update is the Setup phase mark, which carries a `kind`, so the
+        # normal render emits the initial annotation.
         _state["_started_ms"] = now_ms(ctx)
         _state["_task_name"] = ctx.task.name
         _state["_triggered_by"] = (ctx.std.env.var("BUILDKITE_BUILD_CREATOR") or
@@ -258,29 +262,23 @@ def _buildkite_annotations(ctx: FeatureContext):
         _state["_context_id"] = "aspect-%s-%s" % (ctx.task.name, ctx.task.key)
         _state["_task_label"] = _task_label(ctx.task.key)
 
+        subject = _state.get("_subject", "")
         subject_str = (" " + subject) if subject else ""
         _LOG.trace("aspect/%s (%s)%s (ctx=%s)" %
                    (ctx.task.name, ctx.task.key, subject_str, _state["_context_id"]))
 
-        # Emit "in progress" up-front so the annotation appears on the
-        # BK build page immediately. Aspect Web UI link fills in later
-        # when the terminal task_update has a sink_invocation_id.
-        initial_kind = kind_for_task(ctx.task.name)
-        renderer = renderer_for_kind(initial_kind) or renderer_for_kind("bazel_results")
-        initial_results = renderer.init()
-        out = renderer.render(
-            ctx,
-            initial_results,
-            "running",
-            make_render_ctx(_state, tips = collect_tips_sorted(ctx), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
-            _make_links(initial_results),
-            None,
-            None,
-        )
-        body = _format_body(out, initial_kind, "running", task_label = _state["_task_label"])
-        _write_annotation(ctx, "info", body, _state["_context_id"])
-
     def _task_update(ctx, update):
+        # Latch the subject before init/render: `setup_phase` sets it on the
+        # first update, but a later update may refine it (e.g. a query task
+        # resolving its targets). Empty means "no change", so keep the prior
+        # value. Init reads `_state["_subject"]`, so this must run first.
+        if update.subject:
+            _state["_subject"] = update.subject
+
+        if not _state.get("_initialized"):
+            _state["_initialized"] = True
+            _init(ctx)
+
         status = update.status
         final = update.final
 
@@ -334,7 +332,6 @@ def _buildkite_annotations(ctx: FeatureContext):
                        (context_id, style, len(body)))
         _write_annotation(ctx, style, body, context_id)
 
-    lifecycle.task_started.append(_task_started)
     lifecycle.task_update.append(_task_update)
 
 BuildkiteAnnotations = feature(

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations_test.axl
@@ -45,6 +45,7 @@ load(
     "../lib/bazel_results.axl",
     bazel_render_check_output = "render_check_output",
 )
+load("../lib/check_dispatch.axl", "make_render_ctx")
 load(
     "../lib/delivery_results.axl",
     delivery_render_check_output = "render_check_output",
@@ -93,15 +94,21 @@ def _bk_links():
         "testlogs_label_urls": {},
     }
 
-def _render_ctx(targets, task_name):
-    return {
-        "triggered_by": "Greg Magolan (BUILDKITE_BUILD_CREATOR)",
-        "targets": targets,
-        "started_ms": 1744630000000,
-        "ended_ms": 1744630004500,
-        "progress": "",
-        "task_name": task_name,
+def _render_ctx(subject, task_name):
+    """Build the render_ctx via the real `make_render_ctx` (not hand-rolled)
+    so the test exercises the same wiring as the live BK feature. `subject`
+    is the task subject (target pattern); pass "" for the empty-subject case,
+    which renders with no subject in the title.
+    """
+    state = {
+        "_triggered_by": "Greg Magolan (BUILDKITE_BUILD_CREATOR)",
+        "_subject": subject,
+        "_started_ms": 1744630000000,
+        "_ended_ms": 1744630004500,
+        "_progress": "",
+        "_task_name": task_name,
     }
+    return make_render_ctx(state)
 
 _RENDERERS = {
     "bazel_results": bazel_render_check_output,
@@ -113,7 +120,7 @@ _RENDERERS = {
 
 def _test_impl(ctx):
     scenarios = [
-        # (label,                                       kind,                data,                               status,    final, targets,      task_name)
+        # (label,                                       kind,                data,                               status,    final, subject,      task_name)
         ("1. build-passed", "bazel_results", _make_build_passed(), "passed", True, "//...", "build"),
         ("2. test-failed", "bazel_results", _make_test_failed(), "failed", True, "//...", "test"),
         ("3. lint-passed-clean", "lint_results", _make_lint_passed_clean(), "passed", True, "//...", "lint"),
@@ -140,13 +147,16 @@ def _test_impl(ctx):
         ("20. test-warning-terminal-flaky-only", "bazel_results", _make_test_passed_flaky_only(), "warning", True, "//...", "test"),
         # Mixed — real failure plus flakes. Failures dominate; stripe stays red.
         ("21. test-failing-with-flaky", "bazel_results", _make_test_failing_with_flaky(), "failing", False, "//...", "test"),
+        # Empty subject (query-driven task with no explicit target list): the
+        # title omits the subject entirely — there is no synthetic placeholder.
+        ("22. build-passed (empty subject)", "bazel_results", _make_build_passed(), "passed", True, "", "build"),
     ]
 
     sep = "=" * 70
 
-    for (label, kind, data, status, final, targets, task_name) in scenarios:
+    for (label, kind, data, status, final, subject, task_name) in scenarios:
         renderer = _RENDERERS[kind]
-        rc = _render_ctx(targets, task_name)
+        rc = _render_ctx(subject, task_name)
         out = renderer(ctx, data, status, rc, _bk_links(), None, None)
 
         # Mirror the live wiring: include a `:aspect: task <code>key</code>`

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -81,18 +81,6 @@ load("../lint.axl", "LintTrait")
 
 _LOG = feature_logger("GitHub status checks")
 
-_SUBJECT_MAX_LEN = 60
-
-def _truncate_subject(subject):
-    """Truncate subject at a word boundary if it exceeds _SUBJECT_MAX_LEN characters."""
-    if len(subject) <= _SUBJECT_MAX_LEN:
-        return subject
-    window = subject[:_SUBJECT_MAX_LEN - 3]
-    last_space = window.rfind(" ")
-    if last_space > 0:
-        return window[:last_space] + "..."
-    return window + "..."
-
 def _detect_triggered_by(env):
     """Return a short string describing who/what triggered this build."""
     if env.var("GITHUB_ACTIONS"):
@@ -243,7 +231,7 @@ def _github_status_checks(ctx: FeatureContext):
             ctx,
             initial_renderer.init(),
             "running",
-            make_render_ctx(_state, default_targets = "//...", tips = collect_tips_sorted(ctx), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
+            make_render_ctx(_state, tips = collect_tips_sorted(ctx), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             dict(_ci_links_base),
             templates,
             metadata_keys,
@@ -339,14 +327,15 @@ def _github_status_checks(ctx: FeatureContext):
     # TaskLifecycleTrait hooks
     # -------------------------------------------------------------------------
 
-    def _task_started(ctx, subject):
+    def _init(ctx):
+        # One-time init on the first task_update: stash the task name (the
+        # shared `make_render_ctx` helper reads it — FeatureContext has no
+        # .task), then create the check run. The subject was already latched
+        # into `_state` by the caller. The title's leading emoji is derived
+        # from the status at compose time (verdict, not kind).
+        subject = _state.get("_subject", "")
         subject_str = (" " + subject) if subject else ""
         _LOG.trace("aspect/%s (%s)%s" % (ctx.task.name, ctx.task.key, subject_str))
-        _state["_subject"] = _truncate_subject(subject)
-
-        # Stash for the shared `make_render_ctx` helper (FeatureContext
-        # has no .task). The title's leading emoji is derived from the
-        # status at compose time (verdict, not kind).
         _state["_task_name"] = ctx.task.name
         _create_check_run(ctx)
 
@@ -404,6 +393,26 @@ def _github_status_checks(ctx: FeatureContext):
                 return
 
     def _task_update(ctx, update):
+        # Latch the subject (raw) before init/render: `setup_phase` sets it on
+        # the first update, but a later update may refine it (e.g. a query task
+        # resolving its targets). Empty means "no change", so keep the prior
+        # value. Stored untruncated — the title composer (`summary_title`) caps
+        # it, while the "Explicit command line" block needs the full pattern.
+        # `_create_check_run` (in `_init`) reads it for the initial title, so
+        # this must run before the init guard.
+        if update.subject:
+            _state["_subject"] = update.subject
+
+        if not _state.get("_initialized"):
+            _state["_initialized"] = True
+            _init(ctx)
+
+            # `_init` (`_create_check_run`) already created the check run and
+            # PATCHed its initial "running" body + details_url. Don't re-render
+            # this same (Setup-mark) update — that would be a redundant PATCH
+            # against the App quota. Subsequent updates render normally.
+            return
+
         status = update.status
         final = update.final
 
@@ -478,7 +487,7 @@ def _github_status_checks(ctx: FeatureContext):
             ctx,
             data,
             status,
-            make_render_ctx(_state, default_targets = "//...", tips = collect_tips_sorted(ctx), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
+            make_render_ctx(_state, tips = collect_tips_sorted(ctx), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             _make_links(data),
             templates,
             metadata_keys,
@@ -526,7 +535,6 @@ def _github_status_checks(ctx: FeatureContext):
         if final and extra_batches:
             _send_extra_annotation_batches(ctx, token, check_run_id, output, extra_batches)
 
-    lifecycle.task_started.append(_task_started)
     lifecycle.task_update.append(_task_update)
 
 GithubStatusChecks = feature(

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1019,8 +1019,8 @@ def _github_status_comments(ctx: FeatureContext):
     _state = {}
 
     def _empty_results_subset():
-        """Default _results_subset for the brief window between
-        _task_started and the first BES update."""
+        """Default _results_subset for the brief window between the first
+        task_update (init) and the first BES-data update."""
         return _results_subset(
             init_data(),
             0,  # elapsed_ms
@@ -1483,13 +1483,13 @@ def _github_status_comments(ctx: FeatureContext):
         # immediately via the state block we just PATCHed.
         _state["_last_pr_comment_upsert_epoch_s"] = now_epoch
 
-    def _task_started(ctx, subject):
-        # Cache task identity from TaskContext so the FeatureContext-level closure
-        # can build the artifact name without reaching for ctx.task (which doesn't
-        # exist on FeatureContext).
+    def _init(ctx):
+        # One-time init on the first task_update. Caches task identity from
+        # TaskContext so the FeatureContext-level closure can build the artifact
+        # name without reaching for ctx.task (which doesn't exist on
+        # FeatureContext), then authenticates so `_publish` has a token.
         _state["_task_name"] = ctx.task.name
         _state["_task_key"] = ctx.task.key
-        _state["_status"] = "running"
 
         # Anchor for the time-based throttle in `_task_update`.
         _state["_task_started_at"] = monotonic()
@@ -1503,6 +1503,8 @@ def _github_status_comments(ctx: FeatureContext):
             _reason = auth_reason,
         )
         if not token:
+            # `_publish` no-ops without `_github_token`, so leaving it unset
+            # disables this surface for the rest of the task.
             _LOG.warn(ctx.std, "Authentication failed for %s/%s — %s" % (
                 owner,
                 repo,
@@ -1517,9 +1519,11 @@ def _github_status_comments(ctx: FeatureContext):
         if upgraded:
             _state["_ci_link_url"] = upgraded
 
-        _publish(ctx)
-
     def _task_update(ctx, update):
+        if not _state.get("_initialized"):
+            _state["_initialized"] = True
+            _init(ctx)
+
         _state["_status"] = update.status
 
         # Latch the producer-supplied progress record. Mirrors the BK /
@@ -1620,7 +1624,6 @@ def _github_status_comments(ctx: FeatureContext):
                 _state["_last_publish_s"] = now
         _publish(ctx, final = update.final)
 
-    lifecycle.task_started.append(_task_started)
     lifecycle.task_update.append(_task_update)
 
 # ─── Public test hooks ────────────────────────────────────────────────────────

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -247,8 +247,8 @@ def _gazelle_compact(status, data):
         return ""
     return ""
 
-def _delivery_compact(status, dr):
-    counts = (dr.get("delivery", {}) or {}).get("counts", {}) or {}
+def _delivery_compact(status, data):
+    counts = (data.get("delivery", {}) or {}).get("counts", {}) or {}
     ok = counts.get("ok", 0)
     skip = counts.get("skip", 0)
     warn = counts.get("warn", 0)
@@ -270,7 +270,7 @@ def _delivery_compact(status, dr):
         return "no deliveries" if status == "passed" else ""
     if status == "running":
         done = ok + skip + warn + fail
-        total = (dr.get("delivery", {}) or {}).get("targets_total", 0) or 0
+        total = (data.get("delivery", {}) or {}).get("targets_total", 0) or 0
         if done > 0:
             if total > 0:
                 return "%d/%d delivered" % (done, total)

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -12,7 +12,7 @@ load("../lib/health_check.axl", "HealthCheckTrait", "agent_health_check")
 def _workflows_impl(ctx: FeatureContext):
     environment = get_workflows_environment(ctx.std)
 
-    health_check = ctx.traits[HealthCheckTrait]
+    hc_trait = ctx.traits[HealthCheckTrait]
     bazel_trait = ctx.traits[BazelTrait]
 
     # Register task-identity --build_metadata as a task_flags hook. Runs
@@ -39,13 +39,11 @@ def _workflows_impl(ctx: FeatureContext):
         bazel_trait.extra_flags.append("--color=yes")
 
     if environment.runner != None:
-        # BK section markers per-phase are emitted by lifecycle.task_update
-        # when `phase=` is set (see `_emit_bk_phase_section`). The
-        # pre_health_check hooks below print their own intra-phase BK
-        # section markers (Workflows runner environment, health check),
-        # so the preflight phase mark itself skips the auto-emit.
-        health_check.pre_health_check.append(lambda ctx: print_environment_info(ctx.std, environment))
-        health_check.pre_health_check.append(lambda ctx: agent_health_check(ctx, environment))
+        # On a Workflows runner, register the runner-environment table and the
+        # Bazel server health check as `health_check` hooks. `setup_phase` runs
+        # them inside the Setup phase; each prints its own BK section marker.
+        hc_trait.health_check.append(lambda ctx: print_environment_info(ctx.std, environment))
+        hc_trait.health_check.append(lambda ctx: agent_health_check(ctx, environment))
 
         # Flags to optimize build & test
         (startup_flags, build_flags) = get_bazelrc_flags(

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -18,14 +18,14 @@ Usage:
 load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
-load("./lib/bazel_flags.axl", "setup_bazel_command")
+load("./lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("./lib/format_results.axl", fmt_init_data = "init_data", format_conclusion = "conclusion")
 load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./lib/health_check.axl", "HealthCheckTrait")
-load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_severity", "setup_phase", "task_update")
+load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
 load("./lib/path_normalize.axl", "normalize_files_for_cwd")
 load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
@@ -280,7 +280,7 @@ def _append_fix_commands(ctx, data):
     })
 
 def _emit_final(ctx, lifecycle, data, exit_code):
-    """Emit the terminal task_update and task_complete for status-check consumers."""
+    """Emit the terminal task_update for status-check consumers."""
     status = _pick_status(data, had_failure = exit_code != 0, terminal = True)
     if not data.get("finish_time_ms"):
         data["finish_time_ms"] = now_ms(ctx)
@@ -304,8 +304,6 @@ def _emit_final(ctx, lifecycle, data, exit_code):
             ),
         ))
     print_repro_and_fix(ctx.std, data, status)
-    for handler in lifecycle.task_complete:
-        handler(ctx, exit_code)
 
     return TaskConclusion(
         exit_code = exit_code,
@@ -320,20 +318,19 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     lifecycle = ctx.traits[TaskLifecycleTrait]
     ansi = color_enabled(ctx.std)
 
-    # Initialize data and fire task_started FIRST so any subsequent failure
-    # still creates a visible status check.
+    # Initialize data for status-check emission.
     data = fmt_init_data()
     data["start_time_ms"] = now_ms(ctx)
     data["format"]["scope"] = ctx.args.scope
     data["format"]["formatter_target"] = ctx.args.formatter_target
     severity_resolved = resolve_severity(ctx)
     data["format"]["severity_resolved"] = severity_resolved
-    setup_phase(ctx, lifecycle)
-    for handler in lifecycle.task_started:
-        handler(ctx, ctx.args.formatter_target)
 
-    flags = setup_bazel_command(ctx, "build", bazel_trait)
-    preflight_phase(ctx, lifecycle, hc_trait)
+    # The single pre-task setup phase (status surface, rc parse, health
+    # checks); returns the resolved flags (a failed health check fails the task
+    # inside setup_phase).
+    flags = setup_phase(ctx, lifecycle, ctx.args.formatter_target, "format_results", data, hc_trait, bazel_trait)
+    announce_version, announce_command = resolve_bazel_announce(ctx)
 
     flags.extend(LOCAL_SPAWN_FLAGS)
 
@@ -371,6 +368,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         build_events = build_events,
         flags = flags,
         current_dir = ctx.std.env.aspect_root_dir(),
+        announce_version = announce_version,
+        announce_command = announce_command,
     )
 
     # `build.sink_invocation_id` is minted inside the runtime's `Build::spawn`
@@ -748,10 +747,6 @@ format = task(
             long = "formatter-arg",
             description = "Extra positional arguments forwarded to the formatter binary on every invocation, before the file list. Set this in a format alias's `defaults` to encode formatter-specific flags (e.g. `--check=false`, language toggles). Threaded through both the aspect-task spawn (`<formatter_target> <formatter_args> <files>`) and the vanilla-bazel alternate fix command (`bazel run <formatter_target> -- <formatter_args> <files>`).",
         ),
-        "announce_rc": args.boolean(
-            default = False,
-            description = "Print the resolved Bazel `.bazelrc` flags before running the formatter build. Useful when debugging which config sections fired or what the final flag set looks like. ASPECT_DEBUG=1 logs the same disclosure regardless of this flag.",
-        ),
         "bazel_flags": args.string_list(
             long = "bazel-flag",
             description = "Additional Bazel flags forwarded to the formatter build. Repeat the flag to pass multiple — e.g. `--bazel-flag=--config=ci --bazel-flag=--keep_going`.",
@@ -779,7 +774,7 @@ format = task(
             maximum = 4096,
             minimum = 0,
         ),
-    },
+    } | announce_bazel_args("the formatter build"),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -187,14 +187,14 @@ Usage:
 load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
-load("./lib/bazel_flags.axl", "setup_bazel_command")
+load("./lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
 load("./lib/gazelle_results.axl", "dedupe_subtrees", "dir_at_or_below", "extract_changed_dirs", gaz_init_data = "init_data", gazelle_conclusion = "conclusion")
 load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./lib/health_check.axl", "HealthCheckTrait")
-load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "preflight_phase", "resolve_severity", "setup_phase", "task_update")
+load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
 load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
 load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "runnable")
@@ -506,10 +506,9 @@ def _resolve_effective_dirs(ctx, lifecycle, data):
     return effective, False
 
 def _emit_final(ctx, lifecycle, data, exit_code):
-    """Emit the terminal `task_update` + `task_complete` and return a
-    `TaskConclusion` for `_impl` to return. Always appends the repro
-    command; appends fix commands when gazelle reported something to
-    update."""
+    """Emit the terminal `task_update` and return a `TaskConclusion` for
+    `_impl` to return. Always appends the repro command; appends fix
+    commands when gazelle reported something to update."""
     status = _pick_status(data, had_failure = exit_code != 0, terminal = True)
     if not data.get("finish_time_ms"):
         data["finish_time_ms"] = now_ms(ctx)
@@ -533,8 +532,6 @@ def _emit_final(ctx, lifecycle, data, exit_code):
             ),
         ))
     print_repro_and_fix(ctx.std, data, status)
-    for handler in lifecycle.task_complete:
-        handler(ctx, exit_code)
 
     return TaskConclusion(
         exit_code = exit_code,
@@ -549,8 +546,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     lifecycle = ctx.traits[TaskLifecycleTrait]
     ansi = color_enabled(ctx.std)
 
-    # Initialize data and fire task_started FIRST so any subsequent failure
-    # still creates a visible status check.
+    # Initialize data for status-check emission.
     data = gaz_init_data()
     data["start_time_ms"] = now_ms(ctx)
     data["gazelle"]["gazelle_target"] = ctx.args.gazelle_target
@@ -562,9 +558,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     check_only = _resolve_check_only(ctx)
     data["gazelle"]["severity_resolved"] = severity_resolved
     data["gazelle"]["check_only"] = check_only
-    setup_phase(ctx, lifecycle)
-    for handler in lifecycle.task_started:
-        handler(ctx, ctx.args.gazelle_target)
+
+    # The single pre-task setup phase (status surface, rc parse, health
+    # checks); returns the resolved flags (a failed health check fails the task
+    # inside setup_phase).
+    flags = setup_phase(ctx, lifecycle, ctx.args.gazelle_target, "gazelle_results", data, hc_trait, bazel_trait)
+    announce_version, announce_command = resolve_bazel_announce(ctx)
 
     # Resolve effective dirs before the bazel build phase: gazelle
     # needs the dir list when spawned, the no-op short-circuit lets
@@ -576,9 +575,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if no_op:
         data["gazelle"]["no_changed_dirs"] = True
         return _emit_final(ctx, lifecycle, data, 0)
-
-    flags = setup_bazel_command(ctx, "build", bazel_trait)
-    preflight_phase(ctx, lifecycle, hc_trait)
 
     flags.extend(LOCAL_SPAWN_FLAGS)
 
@@ -613,6 +609,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         build_events = build_events,
         flags = flags,
         current_dir = ctx.std.env.bazel_root_dir(),
+        announce_version = announce_version,
+        announce_command = announce_command,
     )
 
     # `build.sink_invocation_id` is minted inside the runtime's `Build::spawn`
@@ -918,10 +916,6 @@ gazelle = task(
             maximum = 4096,
             description = "Directories gazelle should update BUILD files in. When empty (default), gazelle considers every directory in the workspace. Combine with --scope=changed to take the intersection with directories that contain changed files. Useful for scoping to a sub-workspace within a monorepo. CAUTION: under --scope=changed, supplying narrow dirs intersection-filters the derived set. Changed dirs that fall outside the listed roots are dropped, so the BUILD updates those changes would have triggered are silently missed. NOTE: positional dirs only narrow the BUILD-regeneration step. Under gazelle's default `-index=all`, gazelle still traverses every workspace directory, parses every BUILD, and re-determines target exports (often re-parsing source) repo-wide. Pair with `--gazelle-flag=-index=lazy` (plus `# gazelle:go_search` / `# gazelle:proto_search` directives) to also narrow that traversal + parse + indexing work. Optionally also pass `--gazelle-flag=-r=false` to skip recursion on top of that, but some gazelle language extensions are incompatible with non-recursive mode — test against your plugin set first. See https://github.com/bazel-contrib/bazel-gazelle#lazy-indexing-in-fix-and-update.",
         ),
-        "announce_rc": args.boolean(
-            default = False,
-            description = "Print the resolved Bazel `.bazelrc` flags before running the gazelle build. Useful when debugging which config sections fired or what the final flag set looks like. ASPECT_DEBUG=1 logs the same disclosure regardless of this flag.",
-        ),
         "bazel_flags": args.string_list(
             description = "Additional Bazel flags forwarded to the gazelle build. Repeat the flag to pass multiple — e.g. `--bazel-flag=--config=ci --bazel-flag=--keep_going`.",
             long = "bazel-flag",
@@ -930,7 +924,7 @@ gazelle = task(
             description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
             long = "bazel-startup-flag",
         ),
-    },
+    } | announce_bazel_args("the gazelle build"),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
@@ -1,27 +1,35 @@
 """Helpers for resolving and applying Bazel flags in tasks that compose
 `BazelTrait` and `HealthCheckTrait`.
 
-Tasks that use these helpers MUST declare three CLI args (the helpers
+Tasks that use these helpers MUST declare these CLI args (the helpers
 enforce this with a clear error if a task forgets):
 
-  - `bazel_flags`         (read by `resolve_flags`)
-  - `bazel_startup_flags` (read by `resolve_startup_flags`)
-  - `announce_rc`         (read by `setup_bazel_command`)
+  - `bazel_flags`             (read by `resolve_flags`)
+  - `bazel_startup_flags`     (read by `resolve_startup_flags`)
+  - `announce_bazel_rc`       (read by `setup_bazel_command`)
+  - `announce_bazel_version`  (read by `resolve_bazel_announce`)
+  - `announce_bazel_command`  (read by `resolve_bazel_announce`)
 
-Ordering contract: startup flags must be on `ctx.bazel.startup_flags`
-BEFORE `preflight_phase` runs, so the Bazel health check inside
-preflight targets the correct server. The contract is enforced at
-runtime by `assert_ctx_bazel_ready_for_health_check` (see
+The three `announce_bazel_*` args are `"auto" | "true" | "false"`
+enums; `resolve_announce` maps `"auto"` to on-under-CI. `_rc` gates the
+parsed-rc disclosure here; `_version` / `_command` gate the per-spawn
+`INFO:` lines and are passed to `ctx.bazel.build` / `.test` by the task
+(see `resolve_bazel_announce`).
+
+Ordering contract: `ctx.bazel.startup_flags` must be populated before the
+Bazel health check runs, so the check targets the correct server. The
+`setup_phase` helper in `lib/lifecycle.axl` enforces this by calling
+`setup_bazel_command` ahead of the `health_check` hooks; the invariant is
+also checked at runtime by `assert_ctx_bazel_ready_for_health_check` (see
 `lib/health_check.axl`).
 
-  - `setup_bazel_command` — the one-stop entry point. Resolves startup
-    flags + command flags, parses `.bazelrc`, populates
-    `ctx.bazel.startup_flags` with the full startup-flag set
-    (including any rc-derived `startup …` lines), emits the parsed-rc
-    disclosure, and returns the command flag list ready for
-    `ctx.bazel.build` / `ctx.bazel.test`. Use this from every
-    Bazel-calling task; the smaller building blocks below exist mostly
-    for testing and unusual layering needs.
+  - `setup_bazel_command` — resolves startup flags + command flags,
+    parses `.bazelrc`, populates `ctx.bazel.startup_flags` with the full
+    startup-flag set (including any rc-derived `startup …` lines), emits
+    the parsed-rc disclosure, and returns the command flag list ready for
+    `ctx.bazel.build` / `ctx.bazel.test`. Built-in tasks reach this via
+    `lib/lifecycle.axl::setup_phase`; call it directly only for unusual
+    layering. The smaller building blocks below exist mostly for testing.
 
   - `resolve_startup_flags` — combine `ctx.args.bazel_startup_flags`
     with `BazelTrait.extra_startup_flags` + transform. Returns the list
@@ -29,9 +37,14 @@ runtime by `assert_ctx_bazel_ready_for_health_check` (see
 
   - `resolve_flags` — combine CLI bazel-flags + `BazelTrait` additions
     + task-time hooks + transform into a single command flag list.
+
+  - `resolve_announce` / `resolve_bazel_announce` — resolve the
+    `announce_bazel_*` flag values (`"auto"|"true"|"false"`) to bools;
+    `auto` is on under CI. `resolve_bazel_announce` returns the
+    `(version, command)` pair tasks pass to `ctx.bazel.build` / `.test`.
 """
 
-load("./environment.axl", "color_enabled")
+load("./environment.axl", "color_enabled", "detect_ci")
 
 def _require_arg(ctx, name):
     """Fail with a clear contract error when a helper's required CLI
@@ -40,9 +53,68 @@ def _require_arg(ctx, name):
         fail(
             ("Task is missing required `%s` arg. Tasks that use " +
              "lib/bazel_flags.axl helpers must declare " +
-             "bazel_flags, bazel_startup_flags, and announce_rc on " +
+             "bazel_flags, bazel_startup_flags, announce_bazel_rc, " +
+             "announce_bazel_version, and announce_bazel_command on " +
              "the task definition.") % name,
         )
+
+def resolve_announce(ctx, value):
+    """Resolve an `"auto" | "true" | "false"` announce-flag value to a bool.
+
+    `"auto"` is on under CI and off locally — CI logs are where the bazel
+    disclosure is useful, while a local run stays quiet. `"true"` / `"false"`
+    force the choice regardless of environment.
+    """
+    if value == "auto":
+        return bool(detect_ci(ctx.std.env))
+    return value == "true"
+
+def resolve_bazel_announce(ctx):
+    """Resolve the per-spawn announce flags to `(version, command)` bools.
+
+    Tasks pass these to `ctx.bazel.build` / `.test` as `announce_version=` /
+    `announce_command=` so the runtime can print the `INFO:` lines just before
+    spawning bazel. See `resolve_announce` for the `auto` semantics.
+    """
+    _require_arg(ctx, "announce_bazel_version")
+    _require_arg(ctx, "announce_bazel_command")
+    return (
+        resolve_announce(ctx, ctx.args.announce_bazel_version),
+        resolve_announce(ctx, ctx.args.announce_bazel_command),
+    )
+
+_ANNOUNCE_AUTO = "'auto' (default) prints on a recognized CI host and is quiet locally."
+
+def announce_bazel_args(rc_phrase):
+    """The three `announce_bazel_*` CLI args every Bazel-spawning task declares.
+
+    Returns a dict to splat into a task's `args = {...}`. Identical across
+    tasks except for the rc disclosure's noun — pass `rc_phrase` as the thing
+    being run, e.g. `"the build"`, `"the lint build"`, `"the delivery build
+    phases"`. The resolved values are read back by `resolve_announce` /
+    `resolve_bazel_announce` / `setup_bazel_command`.
+    """
+    enum = ["auto", "true", "false"]
+    return {
+        "announce_bazel_rc": args.string(
+            default = "auto",
+            values = enum,
+            long = "announce-bazel-rc",
+            description = "Print the resolved Bazel `.bazelrc` flags before running %s. %s ASPECT_DEBUG=1 logs the same disclosure regardless." % (rc_phrase, _ANNOUNCE_AUTO),
+        ),
+        "announce_bazel_version": args.string(
+            default = "auto",
+            values = enum,
+            long = "announce-bazel-version",
+            description = "Print the detected Bazel version before each bazel spawn. %s" % _ANNOUNCE_AUTO,
+        ),
+        "announce_bazel_command": args.string(
+            default = "auto",
+            values = enum,
+            long = "announce-bazel-command",
+            description = "Print the exact bazel command line before each bazel spawn. %s" % _ANNOUNCE_AUTO,
+        ),
+    }
 
 def resolve_startup_flags(ctx, bazel_trait):
     """Build the startup flag list:
@@ -100,13 +172,14 @@ def setup_bazel_command(ctx, command, bazel_trait, base_flags = []):
             then bazel_trait.flags(flags) transform
             then rc expansion for `--config=…` keys.
 
-    MUST be called before `preflight_phase` so the Bazel health check
-    inside preflight sees the same startup flags every other Bazel
-    call sees, including any rc-derived `startup --output_base=...`.
+    Built-in tasks reach this through `lib/lifecycle.axl::setup_phase`,
+    which calls it before the Bazel health-check hooks so the check sees the
+    same startup flags every other Bazel call does (including any rc-derived
+    `startup --output_base=...`). Call it directly only for unusual layering.
 
     The parsed-rc disclosure is emitted via `trace.log` unconditionally
     (visible under `ASPECT_DEBUG`); the user-facing terminal print fires
-    only when `--announce-rc` is set.
+    when `--announce-bazel-rc` resolves on (on under CI by default).
 
     Args:
       ctx: TaskContext.
@@ -121,7 +194,7 @@ def setup_bazel_command(ctx, command, bazel_trait, base_flags = []):
         delivery's `--remote_download_outputs=minimal`.
 
     Requires the task to declare `bazel_startup_flags`, `bazel_flags`,
-    and `announce_rc` CLI args.
+    and `announce_bazel_rc` CLI args.
 
     Returns:
       list[str]: command flags after `:config` expansion.
@@ -133,8 +206,8 @@ def setup_bazel_command(ctx, command, bazel_trait, base_flags = []):
     rc_startup_flags, expanded_flags = rc.expand_all(command = command)
     ctx.bazel.startup_flags.extend(startup_flags + rc_startup_flags + ["--ignore_all_rc_files"])
 
-    _require_arg(ctx, "announce_rc")
-    if ctx.args.announce_rc:
+    _require_arg(ctx, "announce_bazel_rc")
+    if resolve_announce(ctx, ctx.args.announce_bazel_rc):
         print(rc.announce(command = command, ansi = color_enabled(ctx.std)))
     trace.log(rc.announce(command = command, ansi = False))
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
@@ -4,7 +4,7 @@ Run with:
   aspect dev test-bazel-flags
 """
 
-load("./bazel_flags.axl", "resolve_flags", "resolve_startup_flags", "setup_bazel_command")
+load("./bazel_flags.axl", "announce_bazel_args", "resolve_announce", "resolve_bazel_announce", "resolve_flags", "resolve_startup_flags", "setup_bazel_command")
 
 def _eq(label, got, want):
     if got != want:
@@ -29,6 +29,41 @@ def _fake_ctx(bazel_startup_flags = [], bazel_flags = []):
         bazel_startup_flags = bazel_startup_flags,
         bazel_flags = bazel_flags,
     ))
+
+def _ctx_with_ci(on_ci):
+    """Stand-in `ctx` whose `std.env.var` reports a CI marker (or not),
+    so `resolve_announce`'s `auto` branch can be exercised deterministically."""
+    env_vars = {"CI": "1"} if on_ci else {}
+    return struct(std = struct(env = struct(var = lambda name: env_vars.get(name))))
+
+# ── resolve_announce ─────────────────────────────────────────────────────
+
+def _test_resolve_announce_auto_follows_ci(ctx):
+    _eq("auto on CI", resolve_announce(_ctx_with_ci(True), "auto"), True)
+    _eq("auto off CI", resolve_announce(_ctx_with_ci(False), "auto"), False)
+
+def _test_resolve_announce_explicit_overrides_ci(ctx):
+    # Explicit true/false ignore the environment.
+    _eq("true off CI", resolve_announce(_ctx_with_ci(False), "true"), True)
+    _eq("false on CI", resolve_announce(_ctx_with_ci(True), "false"), False)
+
+def _test_resolve_bazel_announce_maps_args_to_tuple(_ctx):
+    # Distinct version/command values catch a swapped or copy-pasted read.
+    ctx = struct(
+        std = struct(env = struct(var = lambda name: None)),  # off CI
+        args = struct(announce_bazel_version = "true", announce_bazel_command = "false"),
+    )
+    _eq("(version, command) order", resolve_bazel_announce(ctx), (True, False))
+
+def _test_announce_bazel_args_shape(_ctx):
+    """`announce_bazel_args` returns exactly the three flags every
+    Bazel-spawning task must declare (the `resolve_*` contract)."""
+    aa = announce_bazel_args("the build")
+    _eq(
+        "announce arg keys",
+        sorted(aa.keys()),
+        ["announce_bazel_command", "announce_bazel_rc", "announce_bazel_version"],
+    )
 
 # ── resolve_startup_flags ────────────────────────────────────────────────
 
@@ -136,10 +171,10 @@ def _test_setup_bazel_command_applies_to_ctx_bazel(ctx):
 # ── contract enforcement ─────────────────────────────────────────────────
 #
 # The helpers fail with a clear message when a calling task omits the
-# required args (`bazel_flags`, `bazel_startup_flags`, `announce_rc`).
-# Happy-path coverage is implicit in every other subtest — the test
-# task declares all three args. Failure-path coverage would require a
-# second task without the args, which isn't worth the test plumbing.
+# required args (`bazel_flags`, `bazel_startup_flags`, the `announce_bazel_*`
+# trio). Happy-path coverage is implicit in every other subtest — the test
+# task declares them all. Failure-path coverage would require a second task
+# without the args, which isn't worth the test plumbing.
 
 def _test_impl(ctx):
     _test_startup_cli_only(ctx)
@@ -149,11 +184,15 @@ def _test_impl(ctx):
     _test_startup_input_list_not_mutated(ctx)
     _test_flags_full_chain_order(ctx)
     _test_flags_empty_defaults(ctx)
+    _test_resolve_announce_auto_follows_ci(ctx)
+    _test_resolve_announce_explicit_overrides_ci(ctx)
+    _test_resolve_bazel_announce_maps_args_to_tuple(ctx)
+    _test_announce_bazel_args_shape(ctx)
 
     # setup_bazel_command mutates the real `ctx.bazel.startup_flags`;
     # run last so the mutation can't bleed into earlier pure subtests.
     _test_setup_bazel_command_applies_to_ctx_bazel(ctx)
-    print("bazel_flags_test.axl: OK (8 sections)")
+    print("bazel_flags_test.axl: OK (12 sections)")
     return 0
 
 bazel_flags_tests = task(
@@ -164,7 +203,9 @@ bazel_flags_tests = task(
     # the standard arg set so the test task satisfies the helper
     # contracts.
     args = {
-        "announce_rc": args.boolean(default = False),
+        "announce_bazel_rc": args.string(default = "auto", values = ["auto", "true", "false"], long = "announce-bazel-rc"),
+        "announce_bazel_version": args.string(default = "auto", values = ["auto", "true", "false"], long = "announce-bazel-version"),
+        "announce_bazel_command": args.string(default = "auto", values = ["auto", "true", "false"], long = "announce-bazel-command"),
         "bazel_flags": args.string_list(long = "bazel-flag"),
         "bazel_startup_flags": args.string_list(long = "bazel-startup-flag"),
     },

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -56,7 +56,7 @@ load(
 load("./path_glob.axl", "match_path")
 load("./repro_commands.axl", "ASPECT_CLI_INSTALL_HINT_MARKDOWN")
 load("./result_text.axl", "emoji_for_status")
-load("./text.axl", "format_int_comma", "pluralize")
+load("./text.axl", "SUBJECT_TITLE_MAX", "format_int_comma", "pluralize", "truncate_for_title")
 load("./tips.axl", "decorate_tip")
 
 # Max number of unique failed build target labels to track detail for. Entries
@@ -1232,18 +1232,10 @@ def compute_reproducer_command(data, task_name, max_chars = MAX_REPRO_CHARS):
     cmd, _ = _repro_with_prefix("aspect " + task_name, labels, max_chars)
     return (cmd, len(labels))
 
+# GitHub caps a check-run title at 160 chars; the whole composed title is
+# truncated to this. The subject within it is capped tighter at
+# `SUBJECT_TITLE_MAX` (shared with the other surfaces).
 _TITLE_MAX_LEN = 160
-_TITLE_SUBJECT_MAX = 60
-
-def _truncate_for_title(text, max_len):
-    """Truncate text for a GitHub check title, preserving word boundaries where possible."""
-    if len(text) <= max_len:
-        return text
-    window = text[:max_len - 1]
-    last_space = window.rfind(" ")
-    if last_space > max_len // 2:
-        return window[:last_space] + "…"
-    return window + "…"
 
 def summary_title(data, status, target_pattern = "", task_name = ""):
     """Build the check run title in the form '<status_emoji> <task_name> <subject> · <state>'.
@@ -1267,7 +1259,7 @@ def summary_title(data, status, target_pattern = "", task_name = ""):
     Returns:
         str — max 160 chars (GitHub check title limit)
     """
-    subject = _truncate_for_title(target_pattern, _TITLE_SUBJECT_MAX) if target_pattern else ""
+    subject = truncate_for_title(target_pattern, SUBJECT_TITLE_MAX) if target_pattern else ""
     state = compute_invocation_state(data, status)
     icon = emoji_for_status(status)
 
@@ -1288,7 +1280,7 @@ def summary_title(data, status, target_pattern = "", task_name = ""):
         title = front
     else:
         title = state
-    return _truncate_for_title(title, _TITLE_MAX_LEN)
+    return truncate_for_title(title, _TITLE_MAX_LEN)
 
 def conclusion(status, data):
     """Bazel build/test task's terminal bookend conclusion. Delegates
@@ -2371,11 +2363,27 @@ def _redact_env_value(value, allow_env):
         return var_name + "=" + _strip_url_creds(var_value)
     return var_name + "=" + _REDACTED
 
+def _redact_header_value(value):
+    """Redact a request-header flag value, keeping the header name and hiding
+    only the value. Bazel accepts both `Name=Value` and `Name: Value` forms,
+    so split on the first `=` or `:` (whichever comes first):
+      `X-Aspect=tok`            -> `X-Aspect=<REDACTED>`
+      `Authorization: Bearer t` -> `Authorization:<REDACTED>`
+    A value with no separator has nothing to keep and is fully redacted.
+    """
+    eq = value.find("=")
+    colon = value.find(":")
+    seps = [i for i in [eq, colon] if i >= 0]
+    if not seps:
+        return _REDACTED
+    i = min(seps)
+    return value[:i + 1] + _REDACTED
+
 def _redact_arg(arg, allow_env):
     """Redact one command-line token:
 
       1. Header flags (`--remote_header=...`, `--bes_header=...`, etc.) —
-         value wholly replaced with <REDACTED>.
+         header name kept, value replaced with <REDACTED> (see `_redact_header_value`).
       2. Env-passthrough flags (`--client_env=KEY=VALUE`, ...) — value handled
          per allowlist / safe-values / known-git-URL rules (see `_redact_env_value`).
       3. Any other flag value — URL credentials stripped (`scheme://user:pass@`
@@ -2390,7 +2398,7 @@ def _redact_arg(arg, allow_env):
     # Bare flag name: strip leading dashes, stop at `=` (already stripped).
     bare = name[2:] if name.startswith("--") else name
     if _is_header_option(bare):
-        return name + "=" + _REDACTED
+        return name + "=" + _redact_header_value(value)
     if _is_env_option(bare):
         return name + "=" + _redact_env_value(value, allow_env)
 
@@ -2635,9 +2643,8 @@ def _titlecase(s):
     `Bazel query` for display. Subsequent words stay lowercase — the
     input is an identifier, not a sentence, so leading-cap-only
     matches how renderers and CLIs typically format programmatic
-    names. Callers that need a non-naive display label (e.g.
-    `preflight` → `Pre-flight`) set `Phase.display_name`; the
-    renderer prefers that over this helper.
+    names. Callers that need a non-naive display label set
+    `Phase.display_name`; the renderer prefers that over this helper.
     """
     if not s:
         return s
@@ -2668,9 +2675,9 @@ def format_elapsed_with_phases(ctx, status):
 
     Shapes:
       No phases used:                    "12.4s"
-      Phases, running:                   "4m13s · 🔨 Build 4m11s | ⚙ Setup 1.7s · 🔍 Detect 1.2s"
-      Phases, failing:                   "4m13s · 🔨 Build (failing 4m11s) | ⚙ Setup 1.7s · 🔍 Detect 1.2s"
-      Phases, passed (terminal):         "46.8s — ⚙ Setup 1.7s · 🔍 Detect 1.2s · 🔨 Build 45.3s"
+      Phases, running:                   "4m13s · 🔨 Build 4m11s | 🔧 Setup 1.7s · 🔍 Detect 1.2s"
+      Phases, failing:                   "4m13s · 🔨 Build (failing 4m11s) | 🔧 Setup 1.7s · 🔍 Detect 1.2s"
+      Phases, passed (terminal):         "46.8s — 🔧 Setup 1.7s · 🔍 Detect 1.2s · 🔨 Build 45.3s"
       Phases, failed-during-phase:       "1m 15s · 🔨 Build (failed after 1m 12s) | 🌱 Init 2.3s"
       Phases, failed-after-phase-bound:  "1m 15s — 🌱 Init 2.3s · 🔨 Build 1m 12s"
 
@@ -2755,8 +2762,8 @@ def _phase_label(phase, emoji, display_name):
     `display_name` is the producer-supplied label override via
     `Phase(display_name=...)`. When non-empty it's used verbatim;
     when empty, fall back to `_titlecase(phase)` (so `bazel_query` →
-    `Bazel query` works out of the box and only the irregulars need
-    an explicit override — currently just `preflight` → `Pre-flight`).
+    `Bazel query` works out of the box and only irregular names need
+    an explicit override).
     """
     name_t = display_name or _titlecase(phase)
     if emoji:
@@ -3569,7 +3576,7 @@ def build_summary_data(ctx, data, status, render_ctx, links, metadata_keys, run_
     return {
         "last_update": last_update,
         "config_items": config_items or [],
-        "target_pattern": render_ctx.get("targets", "") if render_ctx else "",
+        "target_pattern": render_ctx.get("subject", "") if render_ctx else "",
         "branch": html_escape(meta.get("BRANCH_NAME", "")),
         "tag": html_escape(meta.get("TAG", "")),
         "short_sha": sha[:7] if sha else "",
@@ -3924,7 +3931,7 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
     # applied when not set). See _redact_arg for the redaction rules.
     allow_env = _allow_env_patterns(data["bazel"].get("metadata", {}))
     opts_parsed = data["bazel"].get("options_parsed", {}) or {}
-    target_pattern_for_cmd = (render_ctx or {}).get("targets", "") if render_ctx else ""
+    target_pattern_for_cmd = (render_ctx or {}).get("subject", "") if render_ctx else ""
     _explicit_cmd = _assemble_explicit_command(
         data["bazel"].get("build_command", ""),
         target_pattern_for_cmd,
@@ -4445,7 +4452,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         ctx:           TaskContext
         data:       dict from init_data(), updated by process_event
         status:        "running" | "failing" | "passed" | "failed"
-        render_ctx:    display context from the feature (triggered_by, targets,
+        render_ctx:    display context from the feature (triggered_by, subject,
                        started_ms, ended_ms, progress) — see build_summary_data
         links:         dict with ci_label, ci_url, aspect_url
         templates:     optional override dict — keys "summary" and/or "details"
@@ -4657,7 +4664,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         trace.log("debug [render_check_output] --- details (first 5000 chars) ---")
         trace.log(details_text[:5000])
 
-    target_pattern = render_ctx.get("targets", "") if render_ctx else ""
+    target_pattern = render_ctx.get("subject", "") if render_ctx else ""
     task_name = render_ctx.get("task_name", "") if render_ctx else ""
     return {
         "title": summary_title(

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -458,10 +458,10 @@ def _make_results_large():
 # Shared render context and links
 # ---------------------------------------------------------------------------
 
-def _render_ctx(targets = "//...", task_name = "test", progress = ""):
+def _render_ctx(subject = "//...", task_name = "test", progress = ""):
     return {
         "triggered_by": "ci-bot (workflow_dispatch)",
-        "targets": targets,
+        "subject": subject,
         "started_ms": 1744630000000,
         "ended_ms": 1744630002200,
         "progress": progress,
@@ -614,7 +614,7 @@ def _test_impl(ctx):
     sep = "=" * 70
 
     for (label, data, status, targets, with_artifact, ci, metadata_keys, progress) in scenarios:
-        rc = _render_ctx(targets = targets, progress = progress)
+        rc = _render_ctx(subject = targets, progress = progress)
         lk = _links(with_artifact = with_artifact, ci = ci)
         out = render_check_output(ctx, data, status, rc, lk, metadata_keys = metadata_keys)
         print(sep)

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -13,10 +13,10 @@ applies uniformly to both tasks.
 """
 
 load("@std//time.axl", "sleep_iter")
-load("./bazel_flags.axl", "setup_bazel_command")
+load("./bazel_flags.axl", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "init_data", "now_ms", "process_event", "repro_targets", bazel_conclusion = "conclusion")
 load("./health_check.axl", "HealthCheckTrait")
-load("./lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
+load("./lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "setup_phase", "task_update")
 load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "print_repro_and_fix", "task_cli_path")
 load("./text.axl", "pluralize")
 load("../bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
@@ -178,11 +178,10 @@ def _collect_bes_from_args(ctx):
     return sinks
 
 def _emit_terminal(ctx, lifecycle, command, data, exit_code):
-    """Fire the terminal `task_update(final=True)` + `task_complete`
-    hooks and return a `TaskConclusion` for `run_bazel_task` to return.
-    Called from both the happy path and the early-fail bailouts (e.g.
-    post_health_check rejecting) so status surfaces always conclude
-    rather than stick at "running".
+    """Fire the terminal `task_update(final=True)` and return a
+    `TaskConclusion` for `run_bazel_task` to return, so status surfaces
+    conclude rather than stick at "running". (A failed setup health check
+    concludes the surface separately, inside `setup_phase`.)
     """
     final_status = _pick_status(command, data, had_failure = exit_code != 0, terminal = True)
     bookend = bazel_conclusion(final_status, data)
@@ -197,8 +196,6 @@ def _emit_terminal(ctx, lifecycle, command, data, exit_code):
             progress = _live_progress(data, command, final_status),
         ))
     print_repro_and_fix(ctx.std, data, final_status)
-    for handler in lifecycle.task_complete:
-        handler(ctx, exit_code)
 
     return TaskConclusion(
         exit_code = exit_code,
@@ -255,28 +252,11 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
 
     data = init_data()
 
-    # Mark the `setup` phase BEFORE `task_started` so the time spent in
-    # CI-platform handlers (GitHub check-run create, Buildkite annotate)
-    # is tracked as a named phase rather than absorbed into init. CI-only
-    # gate; locally it's a no-op (handlers are fast). See setup_phase().
-    setup_phase(ctx, lifecycle)
-
-    # Fire task_started FIRST so any subsequent failure (pre_health_check
-    # throwing, rc parse error) still surfaces as a failed check run
-    # rather than a silent no-op. This matches the lint / format /
-    # gazelle / delivery convention.
-    for handler in lifecycle.task_started:
-        handler(ctx, " ".join(targets))
-
-    flags = setup_bazel_command(ctx, command, bazel_trait, base_flags = base_flags)
-
-    preflight_phase(ctx, lifecycle, hc_trait)
-
-    for hook in hc_trait.post_health_check:
-        result = hook(ctx)
-        if result != None:
-            _emit_terminal(ctx, lifecycle, command, data, 1)
-            fail(result)
+    # The single pre-task `setup` phase: status-surface init + first render, rc
+    # parse, health checks. Returns the resolved Bazel command flags (a failed
+    # health check concludes the surface and fails the task inside setup_phase).
+    flags = setup_phase(ctx, lifecycle, " ".join(targets), "bazel_results", data, hc_trait, bazel_trait, command, bazel_base_flags = base_flags)
+    announce_version, announce_command = resolve_bazel_announce(ctx)
 
     bes_sinks = _collect_bes_from_args(ctx)
     if bazel_trait.build_event_sinks:
@@ -361,6 +341,8 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
                 flags = flags,
+                announce_version = announce_version,
+                announce_command = announce_command,
                 *targets
             )
         else:
@@ -368,6 +350,8 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
                 flags = flags,
+                announce_version = announce_version,
+                announce_command = announce_command,
                 *targets
             )
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
@@ -14,8 +14,7 @@ Split here, not in the features:
   kind_for_task(task_name)   Initial kind to use before the first
                              task_update has fired.
   to_display_name(name)      snake_case → CamelCase task display name.
-  make_render_ctx(state, default_targets="")
-                             Build the render_ctx dict the per-kind
+  make_render_ctx(state)     Build the render_ctx dict the per-kind
                              renderers consume from a feature's
                              closure-state dict.
   apply_artifact_links(ctx, links)
@@ -118,18 +117,17 @@ def to_display_name(name):
     """
     return "".join([w[0].upper() + w[1:] for w in name.split("_") if w])
 
-def make_render_ctx(state, default_targets = "", tips = None, api_usage = "", last_updated_at = ""):
+def make_render_ctx(state, tips = None, api_usage = "", last_updated_at = ""):
     """Build the render_ctx dict the per-kind renderers consume.
 
     Reads from `state` — the feature-private dict the caller maintains
     across hook calls. Expected slots: `_triggered_by`, `_subject`,
     `_started_ms`, `_ended_ms`, `_progress`, `_task_name`.
 
-    `default_targets` is the placeholder for the `targets` field when
-    `_subject` hasn't been set yet (an early render before
-    task_started). GitHubStatusChecks uses `"//..."` so the initial
-    "running" check-run has *something* readable in the title;
-    BuildkiteAnnotations leaves it empty.
+    `subject` is the task's target patterns / formatter target / etc.,
+    rendered in the title. Empty when the task hasn't supplied one (e.g. a
+    query-driven delivery before its targets resolve) — the title simply
+    omits it; there is no synthetic placeholder.
 
     `tips` is the caller-supplied list of tips (typically
     `collect_tips_sorted(ctx)`); each entry is rendered as a
@@ -149,7 +147,7 @@ def make_render_ctx(state, default_targets = "", tips = None, api_usage = "", la
     """
     return {
         "triggered_by": state.get("_triggered_by", ""),
-        "targets": state.get("_subject") or default_targets,
+        "subject": state.get("_subject", ""),
         "started_ms": state.get("_started_ms", 0),
         "ended_ms": state.get("_ended_ms", 0),
         "progress": state.get("_progress", ""),

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
@@ -23,6 +23,7 @@ load(
     bazel_init_data = "init_data",
 )
 load("./result_text.axl", "emoji_for_status")
+load("./text.axl", "truncate_for_title")
 
 # ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -141,7 +142,7 @@ def delivery_summary_title(data, status, target_pattern = "", task_name = ""):
     "delivery" when no name is provided.
     """
     display = emoji_for_status(status) + " " + (task_name or "delivery")
-    target = target_pattern or data.get("target_pattern", "")
+    target = truncate_for_title(target_pattern or data.get("target_pattern", ""))
     base = display + ((" " + target) if target else "")
 
     counts = data["delivery"].get("counts", {})
@@ -498,7 +499,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         details_data["groups"] = []
         details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
-    target_pattern = render_ctx.get("targets", "") if render_ctx else ""
+    target_pattern = render_ctx.get("subject", "") if render_ctx else ""
     task_name = render_ctx.get("task_name", "") if render_ctx else ""
     if not target_pattern:
         target_pattern = data.get("target_pattern", "")

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results_test.axl
@@ -20,6 +20,12 @@ Scenarios:
 """
 
 load("./delivery_results.axl", "add_result", "init_data", "render_check_output")
+load("./text.axl", "SUBJECT_TITLE_MAX")
+
+# A resolved subject far longer than the title's character budget (60),
+# as a query-driven delivery over many labels would produce. The title
+# must truncate it; see `_check_long_subject_title_is_capped`.
+_LONG_SUBJECT = " ".join(["//apps/service_%d:release" % i for i in range(12)])
 
 # ─── Fake-data builders ───────────────────────────────────────────────────────
 
@@ -245,10 +251,10 @@ def _make_build_failed():
 
 # ─── Test harness ─────────────────────────────────────────────────────────────
 
-def _render_ctx(targets = "//apps/...", task_name = "delivery", progress = ""):
+def _render_ctx(subject = "//apps/...", task_name = "delivery", progress = ""):
     return {
         "triggered_by": "Greg Magolan (workflow_dispatch)",
-        "targets": targets,
+        "subject": subject,
         "started_ms": 1744630000000,
         "ended_ms": 1744630012500,
         "progress": progress,
@@ -280,7 +286,7 @@ def _links(ci = "buildkite"):
 
 def _test_impl(ctx):
     scenarios = [
-        # (label,                            data,                     status,     targets,        ci,          metadata_keys, progress)
+        # (label,                            data,                     status,     subject,        ci,          metadata_keys, progress)
         ("1. all-delivered · BK", _make_all_delivered(), "passed", "//apps/...", "buildkite", None, ""),
         ("2. mixed-outcomes · BK", _make_mixed(), "failed", "//apps/...", "buildkite", None, ""),
         ("3. all-skipped · GH", _make_all_skipped(), "passed", "//apps/...", "github", None, ""),
@@ -301,12 +307,16 @@ def _test_impl(ctx):
         # all-modifiers path. The dry-run scenario above covers the
         # single-modifier case.
         ("13. mode=always · dry-run · untracked", _make_always_dry_run_untracked(), "passed", "//apps/...", "buildkite", None, ""),
+        # Long resolved subject — a query-driven delivery resolves many
+        # labels and emits them as a refined `subject`. The title must cap
+        # it (asserted in `_check_long_subject_title_is_capped`).
+        ("14. long resolved subject (capped)", _make_all_delivered(), "passed", _LONG_SUBJECT, "buildkite", None, ""),
     ]
 
     sep = "=" * 70
 
-    for (label, data, status, targets, ci, metadata_keys, progress) in scenarios:
-        rc = _render_ctx(targets = targets, progress = progress)
+    for (label, data, status, subject, ci, metadata_keys, progress) in scenarios:
+        rc = _render_ctx(subject = subject, progress = progress)
         lk = _links(ci = ci)
         out = render_check_output(ctx, data, status, rc, lk, metadata_keys = metadata_keys)
         print(sep)
@@ -321,9 +331,29 @@ def _test_impl(ctx):
         print(out["text"][:4000])
         print("")
 
+    _check_long_subject_title_is_capped(ctx)
+
     print(sep)
     print("All " + str(len(scenarios)) + " delivery scenarios rendered without error.")
     return 0
+
+def _check_long_subject_title_is_capped(ctx):
+    """A resolved subject longer than the title budget is truncated with a
+    `…` in the rendered title, not emitted whole."""
+    rc = _render_ctx(subject = _LONG_SUBJECT)
+    out = render_check_output(ctx, _make_all_delivered(), "passed", rc, _links())
+    title = out["title"]
+    if _LONG_SUBJECT in title:
+        fail("long subject not truncated in title: %r" % title)
+    if "…" not in title:
+        fail("truncated title missing `…` ellipsis: %r" % title)
+
+    # The subject is capped at SUBJECT_TITLE_MAX; the rest of the title is the
+    # emoji + " delivery " + " · N delivered" verdict (~30 chars). A bound just
+    # past that catches a partial- or non-truncation regression — a full
+    # untruncated subject (300+ chars) would blow well past it.
+    if len(title) > SUBJECT_TITLE_MAX + 40:
+        fail("title unexpectedly long (%d chars): %r" % (len(title), title))
 
 delivery_template_snapshot_tests = task(
     name = "test-delivery-template-snapshots",

--- a/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
@@ -222,7 +222,7 @@ def color_enabled(std):
 #     an `info()`.
 #
 #     The narrow exception: features may register **display hooks**
-#     that fire at deterministic task phases (preflight, terminal)
+#     that fire at deterministic task phases (setup, terminal)
 #     and render structured multi-line blocks (section headers,
 #     status tables) where per-line `INFO:` prefixes would be
 #     visually wrong. The discipline that keeps this clean: factor
@@ -686,7 +686,7 @@ def print_environment_info(std: std.Std, env: WorkflowsEnvironment) -> None:
     title = "Workflows runner metadata"
     if color:
         # Bold + underline + blue, mirrors `_display_runner_health` in
-        # health_check.axl so the two preflight CLI sections share a look.
+        # health_check.axl so the two setup-phase CLI sections share a look.
         print("\x1b[1;4;34m" + title + "\x1b[0m")
     else:
         print(title)

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
@@ -377,7 +377,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
     task_name = render_ctx.get("task_name", "") if render_ctx else ""
-    target_pattern = render_ctx.get("targets", "") if render_ctx else ""
+    target_pattern = render_ctx.get("subject", "") if render_ctx else ""
     return {
         "title": format_summary_title(
             data,

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
@@ -203,7 +203,7 @@ def _make_failing_with_drift():
 def _render_ctx(task_name = "format"):
     return {
         "triggered_by": "Greg Magolan (pull_request)",
-        "targets": "",
+        "subject": "",
         "started_ms": 1744630000000,
         "ended_ms": 1744630003200,
         "progress": "",

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
@@ -433,7 +433,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
     task_name = render_ctx.get("task_name", "") if render_ctx else ""
-    target_pattern = render_ctx.get("targets", "") if render_ctx else ""
+    target_pattern = render_ctx.get("subject", "") if render_ctx else ""
     return {
         "title": gazelle_summary_title(
             data,

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
@@ -216,7 +216,7 @@ def _make_failing_with_drift():
 def _render_ctx(task_name = "gazelle"):
     return {
         "triggered_by": "Greg Magolan (pull_request)",
-        "targets": "",
+        "subject": "",
         "started_ms": 1744630000000,
         "ended_ms": 1744630005800,
         "progress": "",

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -25,7 +25,6 @@ load(
     "BUCKET_APP",
     "BUCKET_ENV",
     "record_from_headers",
-    "seed_from_rate_limit_body",
 )
 load("./tar.axl", "zip_create")
 load("./text.axl", "pluralize")
@@ -2176,58 +2175,10 @@ def delete_review_comment(ctx, token, owner, repo, comment_id, api_base = DEFAUL
     success, status_code, _ = _do_request(ctx, "DELETE", url, token)
     return {"success": success}
 
-def _probe_rate_limit(ctx, owner, repo, profile = None, api_base = DEFAULT_GITHUB_API):
-    """Probe `GET /rate_limit` once at task init to seed both buckets
-    of lib/rate_limit.axl for the App bucket only. The endpoint
-    doesn't count against the primary quota
-    ([docs](https://docs.github.com/en/rest/rate-limit/rate-limit)).
-
-    Env-bucket probing is deliberately skipped: env is only used as a
-    4xx-auth fallback for supporting calls, and a probe-time seed
-    would surface `GITHUB_TOKEN` in `usage_footer` and in the startup
-    `INFO:` log even when we never actually fell back to it. The first
-    real env-bucket observation (from a fallback call) is what seeds
-    the trait and triggers the starting-quota INFO log.
-
-    Silent on any failure — never blocks `setup_phase`.
-
-    Doesn't go through `_do_request` because that path records the
-    response's `X-RateLimit-*` headers into the buffer, which would
-    double-count the probe's own response on top of the JSON body's
-    `resources.core` block.
-    """
-
-    # Mint the App token. We don't pass `existing_app_token` (we ARE
-    # the first auth call this task makes) so this is the canonical
-    # App-token resolution path.
-    app_token = _authenticate(ctx, owner = owner, repo = repo, profile = profile)
-    if not app_token:
-        return
-    url = api_base + "/rate_limit"
-    headers = {
-        "Authorization": "Bearer " + app_token,
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    fut = ctx.http().get(url = url, headers = headers)
-    response = fut.map_err(lambda e: str(e)).block()
-    if type(response) == "string":
-        return
-    if response.status < 200 or response.status >= 300:
-        return
-    body = response.body
-    if not body:
-        return
-    parsed = json.try_decode(body, None)
-    if parsed == None:
-        return
-    seed_from_rate_limit_body(ctx, BUCKET_APP, parsed)
-
 github = struct(
     VALID_ROLES = VALID_ROLES,
     authenticate = _authenticate,
     preferred_token_pair = _preferred_token_pair,
-    probe_rate_limit = _probe_rate_limit,
     missing_credentials_reason = _missing_credentials_reason,
     validate_role = validate_role,
     check_token = _check_token,

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
@@ -1,8 +1,9 @@
 """HealthCheckTrait and the Workflows runner-agent health check.
 
-`HealthCheckTrait` lets tasks register pre/post hooks around their
-bazel invocation. `agent_health_check` is the Workflows-registered
-`pre_health_check` hook that:
+`HealthCheckTrait` lets features register `health_check` hooks that run
+during the task's Setup phase (via `lib/lifecycle.axl::setup_phase`); a
+hook returning a non-None message fails the task. `agent_health_check`
+is the Workflows-registered hook that:
 
   1. Waits for runner cache warming to complete.
   2. Displays the last runner health check.
@@ -195,9 +196,25 @@ def _display_runner_health(environment):
     print(data["output"])
 
 HealthCheckTrait = trait(
-    pre_health_check = attr(list[typing.Callable[[TaskContext], None]], default = [], description = "Hooks called before the build to validate preconditions (e.g. auth, connectivity)"),
-    post_health_check = attr(list[typing.Callable[[TaskContext], str | None]], default = [], description = "Hooks called after the build; return a non-None string to report a warning"),
+    health_check = attr(list[typing.Callable[[TaskContext], str | None]], default = [], description = "Hooks run during the task's setup phase to validate system health. Return a non-None error message to fail the task (e.g. an unhealthy Bazel server); return None when healthy."),
 )
+
+def run_health_checks(ctx, hc_trait):
+    """Run every `hc_trait.health_check` hook and return the first non-None
+    error message, or `None` when all pass (or `hc_trait` is `None`).
+
+    Every hook runs even after one reports an error, so diagnostic hooks (e.g.
+    the Workflows runner-env table) always print. A non-None result means the
+    environment is unhealthy; the hook has already signaled the agent, and the
+    caller (`lifecycle.setup_phase`) fails the task on it."""
+    if hc_trait == None:
+        return None
+    health_error = None
+    for hook in hc_trait.health_check:
+        result = hook(ctx)
+        if result != None and health_error == None:
+            health_error = result
+    return health_error
 
 def ctx_bazel_ready_for_health_check(ctx, environment):
     """True if `ctx.bazel.startup_flags` is populated such that the Bazel
@@ -221,22 +238,23 @@ def assert_ctx_bazel_ready_for_health_check(ctx, environment):
     """Fail if a Workflows runner is in use and `ctx.bazel.startup_flags`
     is missing `--output_base`.
 
-    Custom tasks composing `BazelTrait` + `HealthCheckTrait` must apply
-    startup flags onto `ctx.bazel.startup_flags` before calling
-    `preflight_phase`. The canonical entry point is
-    `lib/bazel_flags.axl::setup_bazel_command`.
+    Built-in tasks satisfy this via `lib/lifecycle.axl::setup_phase`, which
+    populates `ctx.bazel.startup_flags` (through `setup_bazel_command`) before
+    running the `health_check` hooks. Custom tasks running the health check
+    outside `setup_phase` must populate the startup flags first.
     """
     if ctx_bazel_ready_for_health_check(ctx, environment):
         return
     fail(
         "Bazel health check would target the wrong server: " +
         "ctx.bazel.startup_flags is missing --output_base on a Workflows " +
-        "runner. Call lib/bazel_flags.axl::setup_bazel_command BEFORE " +
-        "preflight_phase to populate ctx.bazel.startup_flags.",
+        "runner. Run the health check via lib/lifecycle.axl::setup_phase, " +
+        "or populate ctx.bazel.startup_flags (e.g. via setup_bazel_command) " +
+        "before the health_check hooks.",
     )
 
 def agent_health_check(ctx, environment):
-    """Workflows pre-health-check hook that runs at the start of every job.
+    """Workflows `health_check` hook that runs during the Setup phase.
 
     1. Waits for runner cache warming to complete.
     2. Displays the last runner health check.

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
@@ -1,12 +1,15 @@
-"""Tests for `ctx_bazel_ready_for_health_check` — the predicate
-underlying the runtime guard that enforces the
-`ctx.bazel.startup_flags` ordering contract on Workflows runners.
+"""Tests for `health_check.axl`:
+  - `ctx_bazel_ready_for_health_check` — the predicate underlying the runtime
+    guard that enforces the `ctx.bazel.startup_flags` ordering contract on
+    Workflows runners.
+  - `run_health_checks` — runs the `health_check` hooks and surfaces the first
+    error, the signal that fails a task on an unhealthy environment.
 
 Run with:
   aspect dev test-health-check-ready
 """
 
-load("./health_check.axl", "ctx_bazel_ready_for_health_check")
+load("./health_check.axl", "ctx_bazel_ready_for_health_check", "run_health_checks")
 
 def _eq(label, got, want):
     if got != want:
@@ -43,6 +46,29 @@ def _test_on_runner_with_output_base_passes(ctx):
         True,
     )
 
+def _test_run_health_checks_no_trait_passes(ctx):
+    """No HealthCheckTrait (hc_trait=None) → no error."""
+    _eq("no trait → None", run_health_checks(ctx, None), None)
+
+def _test_run_health_checks_all_pass(ctx):
+    """All hooks return None (healthy) → no error."""
+    trait = struct(health_check = [lambda ctx: None, lambda ctx: None])
+    _eq("all healthy → None", run_health_checks(ctx, trait), None)
+
+def _test_run_health_checks_surfaces_first_error(ctx):
+    """A hook returning a message → that message; the FIRST error wins, and
+    later hooks still run (no short-circuit). This is the latent-bug fix: a
+    non-None result must fail the task, not be discarded."""
+    ran = []
+    trait = struct(health_check = [
+        lambda ctx: ran.append("a"),  # append() → None: healthy
+        lambda ctx: "server unhealthy",
+        lambda ctx: "second error (ignored)",
+        lambda ctx: ran.append("d"),  # still runs despite the earlier error
+    ])
+    _eq("first error wins", run_health_checks(ctx, trait), "server unhealthy")
+    _eq("all hooks ran (no short-circuit)", ran, ["a", "d"])
+
 def _test_impl(ctx):
     # `ctx.bazel.startup_flags` is shared mutable state across subtests
     # (no clear() method). The "missing" subtest must run BEFORE the
@@ -50,7 +76,10 @@ def _test_impl(ctx):
     _test_off_runner_passes(ctx)
     _test_on_runner_missing_output_base_returns_false(ctx)
     _test_on_runner_with_output_base_passes(ctx)
-    print("health_check_ready_test.axl: OK (3 sections)")
+    _test_run_health_checks_no_trait_passes(ctx)
+    _test_run_health_checks_all_pass(ctx)
+    _test_run_health_checks_surfaces_first_error(ctx)
+    print("health_check_ready_test.axl: OK (6 sections)")
     return 0
 
 health_check_ready_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -49,13 +49,13 @@ the verdict.
 # ---------------------------------------------------------------------------
 # TaskUpdate record + TaskLifecycleTrait
 #
-# Moved here from `traits.axl` so the record + trait + canonical emitter
-# (`task_update()`) sit together. `traits.axl` now re-exports these for
-# user `config.axl` files.
+# The record, trait, and canonical emitter (`task_update()`) sit together
+# here; `traits.axl` re-exports them for user `config.axl` files.
 # ---------------------------------------------------------------------------
 
+load("./bazel_flags.axl", "setup_bazel_command")
 load("./environment.axl", "color_enabled", "detect_ci")
-load("./github.axl", "detect_github_repo", "github")
+load("./health_check.axl", "run_health_checks")
 load("./runner_job_history.axl", "append_runner_job_history")
 
 # Structured update passed to task_update hooks.
@@ -120,6 +120,14 @@ TaskUpdate = record(
     status = field(str, default = "running"),
     kind = field(str, default = ""),
     priority = field(bool, default = False),
+    # The task's subject — its target patterns / formatter target / etc.,
+    # rendered in the status-surface title. `setup_phase` sets it on the first
+    # update (the Setup phase mark) so a handler has it at init time, but a
+    # later update may carry a refined subject (e.g. a query task that only
+    # knows its resolved targets after the resolve phase). Empty means "no
+    # change" — handlers latch the last non-empty value, so consumers must
+    # check it on EVERY update, not only the first.
+    subject = field(str, default = ""),
     # True iff this update crossed a phase boundary — set by
     # `task_update(...)` when `phase.name` differs from the previous
     # `ctx.task.current_phase().name`. Surfaces with a cold-start
@@ -127,11 +135,10 @@ TaskUpdate = record(
     # it to gate phase emits on a debounce separate from the heartbeat
     # throttle. Same condition that triggers the BK section header.
     phase_change = field(bool, default = False),
-    # True iff this is the final TaskUpdate the producer will emit before
-    # `task_complete` fires. Used by surfaces that distinguish live from
-    # terminal renders even when status alone wouldn't (e.g. `warning`
-    # being both live and terminal). Producers pass `final = True` on
-    # their final emit; everywhere else defaults to False.
+    # True iff this is the final TaskUpdate the producer will emit. Used by
+    # surfaces that distinguish live from terminal renders even when status
+    # alone wouldn't (e.g. `warning` being both live and terminal). Producers
+    # pass `final = True` on their final emit; everywhere else defaults to False.
     final = field(bool, default = False),
     # Short, plain-text, one-line terminal summary (`"58/58 passed"`,
     # `"Reformatted 12 files"`, `"3 errors in 2 files"`). Only meaningful
@@ -151,7 +158,7 @@ TaskUpdate = record(
 # Phase is intentionally input-only; TaskPhase is intentionally
 # output-only.
 Phase = record(
-    # Phase id — lowercase identifier (`build`, `test`, `preflight`,
+    # Phase id — lowercase identifier (`setup`, `build`, `test`,
     # `detect`, …). Used as the key for same-name no-op detection in
     # `ctx.task.phase()` and as the input to titlecase for the
     # display label when `display_name` is unset.
@@ -170,26 +177,25 @@ Phase = record(
 
     # Display-label override. Non-empty wins over titlecase(name);
     # empty falls back to `<name>[0].upper() + <name>[1:].replace("_",
-    # " ")`. Use when naive titlecase reads oddly (`preflight` →
-    # `Pre-flight`).
+    # " ")`. Use when naive titlecase reads oddly.
     display_name = field(str, default = ""),
 )
 
 # Lifecycle hooks that any task can fire, allowing features like GithubStatusChecks
 # to observe task progress without coupling to Bazel-specific hooks.
 TaskLifecycleTrait = trait(
-    # Called once at the start of the task. Features should create their status
-    # check here. Receives (ctx, subject: str) where subject is a human-readable
-    # description of what the task is operating on (e.g. "//app/..." for a build,
-    # "production" for a deploy). Pass "" if unused.
-    # Features close over their own state dict rather than receiving one.
-    task_started = attr(list[typing.Callable[[TaskContext, str], None]], default = []),
-
-    # Called to push a structured update during the task. Receives (ctx, update: TaskUpdate).
+    # The single lifecycle hook. Called for every structured update during the
+    # task; receives (ctx, update: TaskUpdate). Features close over their own
+    # state dict rather than receiving one.
+    #
+    # The FIRST update a handler sees is its cue to initialize — create the
+    # status surface (GHSC check run / BK annotation), authenticate, read
+    # `update.subject` for the title. `setup_phase` emits that first update (the
+    # Setup phase mark, carrying `subject`) at the very start of every task, so
+    # init lands inside the Setup phase. The update carrying `final = True` is
+    # the LAST one — handlers conclude the surface there. There is no separate
+    # started/complete hook: the first and last `task_update` carry that intent.
     task_update = attr(list[typing.Callable[[TaskContext, TaskUpdate], None]], default = []),
-
-    # Called once when the task finishes. Receives (ctx, exit_code: int).
-    task_complete = attr(list[typing.Callable[[TaskContext, int], None]], default = []),
 )
 
 # ---------------------------------------------------------------------------
@@ -301,9 +307,9 @@ def _emit_bk_phase_section(ctx, phase, progress_styles = None):
 
 def _titlecase_phase(phase):
     """Title-case a phase id for display. Underscores → spaces; first
-    char upper-cased. Callers that need a non-naive display label
-    (e.g. `preflight` → `Pre-flight`) set `Phase.display_name`; this
-    helper is the fallback when that field is empty.
+    char upper-cased. Callers that need a non-naive display label set
+    `Phase.display_name`; this helper is the fallback when that field
+    is empty.
     """
     if not phase:
         return ""
@@ -333,7 +339,7 @@ def _resolve_progress_styles(progress):
     # of context to fix the call.
     return progress
 
-def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priority = True, phase = None, final = False, conclusion = "", exit_code = 0):
+def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priority = True, phase = None, final = False, conclusion = "", exit_code = 0, subject = ""):
     """Emit a TaskUpdate to all `lifecycle.task_update` handlers and
     print a `→ <progress>` line to stderr. When `final = True`,
     returns a `TaskConclusion` carrying `exit_code`, `conclusion`, and
@@ -376,8 +382,8 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
                    on every surface (BK section header / CLI `→` line
                    / Task-timing strip). `phase.display_name` wins
                    over `titlecase(phase.name)` when non-empty.
-        final:     `True` on the producer's last `task_update` before
-                   `task_complete`. Causes `task_update` to return a
+        final:     `True` on the producer's last `task_update` — the
+                   terminal emit. Causes `task_update` to return a
                    `TaskConclusion(exit_code=exit_code, text=conclusion,
                    flagged=(status == "warning"))` that the task should
                    return from `_impl` — the runtime reads it to render
@@ -394,6 +400,12 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
                    check-run titles.
         exit_code: The task's exit code. Threaded onto the returned
                    `TaskConclusion` when `final=True`; ignored otherwise.
+        subject:   The task's subject — its target patterns / formatter
+                   target / etc., rendered in the status-surface title.
+                   `setup_phase` sets it on the first emit so handlers have
+                   it at init; a later emit may carry a refined subject.
+                   Empty means "no change" — handlers latch the last
+                   non-empty value (see `TaskUpdate.subject`).
     """
 
     # Validate the status against the `Status` enum — typos raise here
@@ -472,6 +484,7 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
         final = final,
         conclusion = conclusion,
         data = data if data != None else {},
+        subject = subject,
     )
     for handler in lifecycle.task_update:
         handler(ctx, update)
@@ -483,16 +496,6 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
             flagged = status == "warning",
         )
     return None
-
-def _on_ci(ctx):
-    """True when running on a recognized CI host."""
-    return bool(
-        ctx.std.env.var("CI") or
-        ctx.std.env.var("BUILDKITE") or
-        ctx.std.env.var("GITHUB_ACTIONS") or
-        ctx.std.env.var("CIRCLECI") or
-        ctx.std.env.var("GITLAB_CI"),
-    )
 
 # ---------------------------------------------------------------------------
 # --severity policy: shared resolver + lifecycle-status helper
@@ -548,137 +551,124 @@ def pick_task_status(data, kind_key, had_failure, terminal):
             return "failed" if terminal else "failing"
     return "passed" if terminal else "running"
 
-def setup_phase(ctx, lifecycle):
-    """Open the `setup` phase covering CI-platform task setup.
+def setup_phase(ctx, lifecycle, subject, kind, data, hc_trait = None, bazel_trait = None, bazel_command = "build", bazel_base_flags = []):
+    """Run the `setup` phase — all pre-task work — and return the resolved
+    Bazel command flags (or `None` for a task that doesn't build).
 
-    `lifecycle.task_started` handlers do non-trivial work on CI:
-      - GitHub status check: 3-4 network round-trips (App auth, optional
-        job-URL resolve, create check run, initial PATCH update).
-        Typically 500ms-2s end-to-end depending on cold-cache + latency.
-      - Buildkite annotation: spawns `buildkite-agent annotate` with a
-        ~1.7KB body via stdin. Typically 100-300ms.
+    Every built-in task opens with this single phase, locally and on CI, as
+    the first thing in its `_impl`. It is the one place pre-task work lives,
+    in execution order:
 
-    Without an explicit phase mark, that 600ms-2.3s gets swallowed into
-    the synthetic `init` phase — the breakdown line shows
-    `🌱 Init 1.5s · ✈ Pre-flight 245ms` and users wonder where the
-    1.5s went. Opening a `setup` phase here makes it explicit:
-    `⚙ Setup 1.5s — Authenticating and creating CI status checks · ✈ Pre-flight 245ms`.
+      1. `append_runner_job_history` — self-gates on the Workflows
+         runner-job-history env var; a no-op elsewhere.
+      2. Open the `🔧 Setup` phase mark (the timing-table row + `→ Setup`
+         line / BK section), carrying `kind`, `data`, and the initial
+         `subject`. Always emitted, so the phase is uniform across tasks and
+         environments. This is the first `task_update` of the task: each
+         status-surface handler runs its one-time init (creating the GHSC
+         check run / BK annotation) and, because the update carries `kind`,
+         renders the task's first surface body from `data`. See `task_update`.
+         It runs before the steps that can fail (rc parse, health check) so a
+         failure surfaces on an already-created check run.
+      3. Bazel setup, only when `bazel_trait` is given: `setup_bazel_command`
+         resolves startup + command flags, parses the workspace `.bazelrc`,
+         populates `ctx.bazel.startup_flags`, emits the parsed-rc disclosure,
+         and its flag list is returned. Skipped (returns `None`) for tasks
+         that never invoke Bazel.
+      4. `hc_trait.health_check` hooks, when `hc_trait` is given —
+         Workflows runner env table and Bazel server health check. The health
+         check reads the startup flags step 3 populated, so it must run after;
+         an empty hook list (the local case) is fine. If a hook reports the
+         environment unhealthy, `setup_phase` concludes the surface
+         ("Health check failed") and `fail()`s the task — it never returns.
 
-    Locally those handlers are no-ops (no GitHub App auth, no
-    `buildkite-agent`), so the time is negligible (~10ms) and the
-    mark is skipped — it folds into init like before.
+    Args:
+      ctx:         TaskContext.
+      lifecycle:   TaskLifecycleTrait — dispatch target for the phase-boundary
+                   TaskUpdate (whose handlers self-initialize on first sight).
+      subject:     Short task subject (the target patterns / formatter target /
+                   etc. the task acts on) carried on this first `task_update`
+                   so surface handlers can latch it for the title. A later
+                   `task_update` may refine it — see `TaskUpdate.subject`.
+      kind:        The task's result-library kind (e.g. `"bazel_results"`,
+                   `"lint_results"`) so the first surface render dispatches to
+                   the right renderer.
+      data:        The task's results dict (from `init_data()`), typically just
+                   the seed fields at this point. Rendered on the first surface
+                   body and on the health-failure terminal.
+      hc_trait:    HealthCheckTrait, or `None`. When given, its
+                   `health_check` hooks run inside the open phase.
+      bazel_trait:      BazelTrait, or `None`. When given, Bazel flags are
+                        resolved and the workspace `.bazelrc` is parsed; the
+                        flag list is returned. `None` for non-Bazel tasks.
+      bazel_command:    Bazel subcommand whose rc sections to expand
+                        ("build"/"test"). Ignored when `bazel_trait` is `None`.
+      bazel_base_flags: Task-injected default flags forwarded to
+                        `setup_bazel_command`. Ignored when `bazel_trait`
+                        is `None`.
 
-    Call this from each task's `_impl` immediately *before* iterating
-    `lifecycle.task_started` handlers. No-op when:
-      - the trait has no started handlers, or
-      - we're not running on a recognized CI host.
-
-    `append_runner_job_history` fires up top — it self-gates on
-    `ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE`, so every task on a
-    Workflows runner records an entry independent of CI detection.
+    Returns:
+      list[str] | None: the resolved command flags when `bazel_trait` is given,
+      otherwise `None`. Does not return when a `health_check` hook fails (see
+      step 4) — the task is `fail()`ed after its surface is concluded.
     """
     append_runner_job_history(ctx)
-    if not lifecycle.task_started:
-        return
-    if not _on_ci(ctx):
-        return
-    _probe_rate_limit_quota(ctx)
+
+    # Open the Setup phase — the task's first `task_update`. Carrying `kind` +
+    # `data` makes it both init the status surfaces and render their first
+    # body (see the docstring).
     task_update(
         ctx,
         lifecycle,
         "running",
         ProgressStyles(
-            body = "Authenticating and creating CI status checks...",
-            stream = "Authenticating and creating CI status checks",
+            body = "Running setup...",
+            stream = "Running setup",
         ),
+        kind = kind,
+        data = data,
         phase = Phase(
             name = "setup",
-            description = "Authenticate and create CI status checks",
-            emoji = "⚙",
+            description = "Prepare the task environment",
+            emoji = "🔧",
         ),
+        subject = subject,
     )
 
-def _probe_rate_limit_quota(ctx):
-    """Seed lib/rate_limit.axl's per-task state with a fresh `GET /rate_limit` snapshot
-    before the task starts spending tokens. The probe is free
-    (doesn't count against the primary quota) and lets `throttle_factor`
-    fall back to threshold-based rather than no-data behavior for
-    early API calls.
+    # Bazel flag resolution + rc parse, only for tasks that build. Must run
+    # before the health-check hooks, which read the startup flags it sets.
+    flags = None
+    if bazel_trait != None:
+        flags = setup_bazel_command(ctx, bazel_command, bazel_trait, base_flags = bazel_base_flags)
 
-    Silent on any failure: missing owner/repo, no Aspect credential,
-    transport error — none of these should hold up `setup_phase`."""
-    owner, repo = detect_github_repo(ctx.std)
-    if not owner or not repo:
-        return
-    github.probe_rate_limit(ctx, owner = owner, repo = repo)
+    # Health checks last (they read the startup flags above). A non-None result
+    # is fatal: conclude the surface and fail the task — never returns.
+    health_error = run_health_checks(ctx, hc_trait)
+    if health_error != None:
+        _fail_health_check(ctx, lifecycle, kind, data, health_error)
 
-def preflight_phase(ctx, lifecycle, hc_trait):
-    """Mark the `preflight` phase and run the pre-health-check hooks.
+    return flags
 
-    ⚠️  Contract: when the calling task composes `BazelTrait` alongside
-    `HealthCheckTrait`, `ctx.bazel.startup_flags` MUST be populated
-    before this function is called so the Bazel health check
-    (`agent_health_check`, registered as a `pre_health_check`) targets
-    the project-specific server. Use `setup_bazel_command` from
-    `lib/bazel_flags.axl` — it handles startup-flag resolution, rc
-    parsing, and populating `ctx.bazel.startup_flags`. The
-    `assert_ctx_bazel_ready_for_health_check` guard fails loudly if
-    the contract is violated on a Workflows runner.
+# Surface progress body + conclusion shown when a `health_check` hook fails the
+# task. Uniform across tasks; the detailed reason goes to the CLI/log instead.
+_HEALTH_CHECK_FAILED = "Health check failed"
 
-    On CI hosts (BK / GHA / CircleCI / GitLab / generic CI), the
-    pre-health-check hooks Workflows registers print substantial
-    structural output: the `--- :computer: Workflows runner environment`
-    section table, the `--- :thermometer: Workflows runner health check`
-    section, and the bazel server health check result. The phase
-    boundary is marked BEFORE the hooks run so their time is
-    attributed to Pre-flight in the timing table; the surface
-    `→ Running pre-flight...` line lands AFTER the hooks so on BK
-    the section markers open the chronologically-first content for
-    the phase.
+def _fail_health_check(ctx, lifecycle, kind, data, reason):
+    """Conclude the status surface for a failed `setup_phase` health check,
+    then `fail(reason)`. Internal to `setup_phase`.
 
-    Locally, the same hooks collapse to a couple of terminal prints
-    that aren't worth a separate phase. They fold into the synthetic
-    `init` phase instead — no phase mark, no `→` print, but the
-    hooks still run so the env table + health check info show up.
-
-    Call this from each task's `_impl` instead of iterating
-    `hc_trait.pre_health_check` directly. No-op when the trait has
-    no hooks registered.
-
-    Args:
-      ctx:       TaskContext.
-      lifecycle: TaskLifecycleTrait — dispatch target for the phase-
-                 boundary TaskUpdate so status surfaces see the
-                 transition.
-      hc_trait:  HealthCheckTrait. Skipped when its pre_health_check
-                 hook list is empty (no work to bracket).
-    """
-    if not hc_trait.pre_health_check:
-        return
-
-    if _on_ci(ctx):
-        # task_update marks the phase, emits the BK section header
-        # (`--- :airplane: Pre-flight · …`), prints the styled `→`
-        # phase entry on the CLI, and dispatches the surface update —
-        # all leading the hook content below so the phase entry
-        # consistently introduces the phase work.
-        task_update(
-            ctx,
-            lifecycle,
-            "running",
-            ProgressStyles(
-                body = "Running pre-flight...",
-                stream = "Running pre-flight",
-            ),
-            phase = Phase(
-                name = "preflight",
-                description = "Run pre-flight checks",
-                emoji = "✈",
-                # `preflight` titlecases naively to `Preflight`;
-                # override to the hyphenated form that reads better.
-                display_name = "Pre-flight",
-            ),
-        )
-
-    for hook in hc_trait.pre_health_check:
-        hook(ctx)
+    Emits a terminal `task_update` (so the GHSC check run / BK annotation flips
+    to failed with a "Health check failed" body instead of sticking at
+    "running"), then aborts the task with the hook's detailed `reason` as the
+    CLI/log message. `kind` is the task's result kind so the surface renders;
+    `data` is its results dict (typically still just seed fields here)."""
+    for handler in lifecycle.task_update:
+        handler(ctx, TaskUpdate(
+            kind = kind,
+            status = "failed",
+            final = True,
+            conclusion = _HEALTH_CHECK_FAILED,
+            data = data,
+            progress = ProgressStyles(body = _HEALTH_CHECK_FAILED),
+        ))
+    fail(reason)

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
@@ -1072,7 +1072,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         details_data["groups"] = []
         details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
-    target_pattern = render_ctx.get("targets", "") if render_ctx else ""
+    target_pattern = render_ctx.get("subject", "") if render_ctx else ""
     task_name = render_ctx.get("task_name", "") if render_ctx else ""
     if not target_pattern:
         target_pattern = data.get("target_pattern", "")

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
@@ -357,10 +357,10 @@ def _make_results_annotations_changed_regions():
 
 # ─── Test harness ─────────────────────────────────────────────────────────────
 
-def _render_ctx(targets = "//...", task_name = "lint"):
+def _render_ctx(subject = "//...", task_name = "lint"):
     return {
         "triggered_by": "Greg Magolan (workflow_dispatch)",
-        "targets": targets,
+        "subject": subject,
         "started_ms": 1744630000000,
         "ended_ms": 1744630004500,
         "progress": "",
@@ -642,7 +642,7 @@ def _test_impl(ctx):
     sep = "=" * 70
 
     for (label, data, status, targets, with_artifact, ci, metadata_keys) in scenarios:
-        rc = _render_ctx(targets = targets)
+        rc = _render_ctx(subject = targets)
         lk = _links(with_artifact = with_artifact, ci = ci)
         out = render_check_output(ctx, data, status, rc, lk, metadata_keys = metadata_keys)
         print(sep)

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
@@ -29,11 +29,11 @@ response.headers)` after every response. The trait keeps:
   - `threshold_warned_tier[bucket]` — highest WARN tier already fired
     (0 / LOW / IMPORTANT).
 
-A free `GET /rate_limit` probe in `lifecycle.setup_phase` seeds the
-App bucket before the task starts spending tokens — see
-`github.probe_rate_limit` and `seed_from_rate_limit_body` here. The
-env bucket self-announces on first observation (typically a
-4xx-auth fallback).
+Both buckets self-announce on their first observation: the App bucket
+on the first status-check API response (`record_from_headers` parses
+its `X-RateLimit-*` headers), the env bucket on its first 4xx-auth
+fallback call. Until then the buffer is empty and the cold-start
+heartbeat factor governs throttling.
 
 # Swarm-shared observations
 
@@ -72,11 +72,11 @@ the cadence.
 # Cold-start window (swarm defensive floor)
 
 When a matrix swarm of tasks all start at once (rules_js' ~100-job
-matrix is the motivating case), each task's merged buffer initially
-holds only the setup-phase probe — burn-rate inference can't fire,
-the threshold ladder reads 100% remaining and returns 1×, and the
-swarm-size multiplier is 1 because no sibling has propagated an
-observation through the artifact-share cycle yet. Every task runs
+matrix is the motivating case), each task's merged buffer is initially
+empty (or holds one observation from its first API response) — burn-rate
+inference can't fire, the threshold ladder reads 100% remaining and
+returns 1×, and the swarm-size multiplier is 1 because no sibling has
+propagated an observation through the artifact-share cycle yet. Every task runs
 at full cadence for ~30–60s and the shared App-bucket can be largely
 spent in that window.
 
@@ -110,8 +110,7 @@ footer rendered by `usage_footer` is enough surface for reviewers.
 
 A rate-limit observation must NEVER fail a task. Every code path
 here is best-effort: malformed headers are silently skipped; an
-absent trait or empty buffer returns `1.0`. The probe at `setup_phase`
-catches all errors and returns silently. There are no `fail()` calls.
+absent trait or empty buffer returns `1.0`. There are no `fail()` calls.
 """
 
 load("./environment.axl", "detect_ci", "info", "warn")
@@ -407,9 +406,9 @@ def record_observation(ctx, bucket, remaining, limit, reset_epoch, epoch_s = Non
     _save(ctx, state)
 
     # Log the starting-quota line on the first observation per bucket
-    # (for App: the setup-phase probe; for env: first 4xx-auth
-    # fallback). Reset-crossing flushes count as "first" so the new
-    # window's quota is re-logged on long-running tasks. Logged after
+    # (for App: the first status-check API response; for env: first
+    # 4xx-auth fallback). Reset-crossing flushes count as "first" so the
+    # new window's quota is re-logged on long-running tasks. Logged after
     # save so the I/O doesn't sit between observation and the next op.
     if is_first:
         _log_rate_limit_quota(ctx, bucket, remaining, limit, reset_epoch)
@@ -954,23 +953,6 @@ def _format_factor(factor):
         return "terminal-only"
     return "%d×" % int(factor + 0.5)
 
-# ── Seeding from `/rate_limit` JSON ──────────────────────────────────
-
-def _parse_rate_limit_body(body):
-    """Extract `(remaining, limit, reset_epoch)` from the JSON body
-    returned by `GET /rate_limit`. Returns `None` on a malformed body
-    so callers can short-circuit without further branching."""
-    if type(body) != "dict":
-        return None
-    resources = body.get("resources", {}) or {}
-    core = resources.get("core", {}) or {}
-    remaining = core.get("remaining", -1)
-    limit = core.get("limit", 0)
-    reset_epoch = core.get("reset", 0)
-    if remaining < 0 or limit <= 0:
-        return None
-    return (remaining, limit, reset_epoch)
-
 def _log_rate_limit_quota(ctx, bucket, remaining, limit, reset_epoch):
     """Emit an `INFO: GitHub API quota — <label>: …` line on the
     first observation per bucket. Unlike `usage_footer` (App-only,
@@ -998,24 +980,6 @@ def _resets_in_clause(std, reset_epoch):
     if now_epoch <= 0:
         return ""
     return ", resets in " + _format_duration(max(0, reset_epoch - now_epoch))
-
-def seed_from_rate_limit_body(ctx, bucket, body):
-    """Parse the JSON body returned by `GET /rate_limit` and record
-    its `resources.core` sub-object as a fresh observation for
-    `bucket`. Used by `github.probe_rate_limit` at task init for the
-    App bucket (the bucket aspect-cli actively manages).
-
-    The starting-quota `INFO` line is emitted by `record_observation`
-    on the first observation, so the probe doesn't need to log
-    separately. Env-bucket observations come from real fallback calls
-    later in the task — the probe doesn't seed them, so env is silent
-    at startup and self-announces on first use. Silent no-op on a
-    malformed body."""
-    parsed = _parse_rate_limit_body(body)
-    if parsed == None:
-        return
-    remaining, limit, reset_epoch = parsed
-    record_observation(ctx, bucket, remaining, limit, reset_epoch)
 
 # ── Surface rendering ────────────────────────────────────────────────
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
@@ -10,8 +10,6 @@ Covers:
                             crossings fire. The WARN line itself is a
                             side effect on the CLI log; tests pin the
                             tier-state machine.
-  - `seed_from_rate_limit_body`     — JSON body parses into a fresh
-                                      observation + INFO line.
 
 Run with:
   aspect dev test-rate-limit
@@ -32,7 +30,6 @@ load(
     "record_from_headers",
     "record_observation",
     "reset_for_test",
-    "seed_from_rate_limit_body",
     "set_state_for_test",
     "should_emit_phase_change",
     "throttle_factor",
@@ -441,37 +438,6 @@ def _test_effective_throttle_factor_picks_larger(ctx):
         50.0,
     )
 
-def _test_seed_from_rate_limit_body(ctx):
-    """`/rate_limit` JSON parses into the App bucket and seeds the
-    ring buffer with the embedded `resources.core` values."""
-    _reset(ctx)
-    body = {
-        "resources": {
-            "core": {
-                "limit": 5000,
-                "used": 100,
-                "remaining": 4900,
-                "reset": _FAR_FUTURE,
-            },
-        },
-    }
-    seed_from_rate_limit_body(ctx, BUCKET_APP, body)
-    obs = inspect_for_test(ctx)["observations"][BUCKET_APP]
-    _eq("seed — single entry", len(obs), 1)
-    _eq("seed — remaining recorded", obs[0][1], 4900)
-    _eq("seed — limit recorded", obs[0][2], 5000)
-    _eq("seed — watermark seeded", inspect_for_test(ctx)["watermark"][BUCKET_APP], 4900)
-
-    # Malformed body — silent no-op.
-    _reset(ctx)
-    seed_from_rate_limit_body(ctx, BUCKET_APP, "not a dict")
-    _eq("seed — non-dict body no-ops", len(inspect_for_test(ctx)["observations"][BUCKET_APP]), 0)
-
-    # Missing resources.core — silent no-op.
-    _reset(ctx)
-    seed_from_rate_limit_body(ctx, BUCKET_APP, {"resources": {}})
-    _eq("seed — missing core no-ops", len(inspect_for_test(ctx)["observations"][BUCKET_APP]), 0)
-
 def _test_record_from_headers(ctx):
     """Header-list parsing path: case-insensitive name lookup, lenient
     integer parsing, silent no-op when `X-RateLimit-Remaining` isn't
@@ -578,29 +544,6 @@ def _test_burn_rate_falls_back_on_degenerate_inputs(ctx):
 
     # 12% remaining on the threshold ladder → 20×.
     _eq("no reset_epoch — falls back to threshold (12% → 20×)", throttle_factor(ctx, BUCKET_APP, now_epoch_s = 0), 20.0)
-
-def _test_seed_from_rate_limit_body_edge_cases(ctx):
-    """`seed_from_rate_limit_body` ignores partially-missing bodies
-    without polluting the buffer or watermark."""
-
-    # Missing `resources` key entirely.
-    _reset(ctx)
-    seed_from_rate_limit_body(ctx, BUCKET_APP, {})
-    _eq("seed edge — missing resources no-ops", len(inspect_for_test(ctx)["observations"][BUCKET_APP]), 0)
-
-    # `resources.core.remaining = -1` (sentinel for unset in our parser).
-    _reset(ctx)
-    seed_from_rate_limit_body(ctx, BUCKET_APP, {
-        "resources": {"core": {"limit": 5000, "remaining": -1, "reset": _FAR_FUTURE}},
-    })
-    _eq("seed edge — negative remaining no-ops", len(inspect_for_test(ctx)["observations"][BUCKET_APP]), 0)
-
-    # `resources.core.limit = 0` (invalid; can't compute fraction).
-    _reset(ctx)
-    seed_from_rate_limit_body(ctx, BUCKET_APP, {
-        "resources": {"core": {"limit": 0, "remaining": 100, "reset": _FAR_FUTURE}},
-    })
-    _eq("seed edge — zero limit no-ops", len(inspect_for_test(ctx)["observations"][BUCKET_APP]), 0)
 
 def _test_usage_footer(ctx):
     """`usage_footer` is App-bucket-only — env-bucket pressure is
@@ -1194,8 +1137,6 @@ def _test_impl(ctx):
     _test_reset_crossing_exact_boundary(ctx)
     _test_reset_crossing_rebaselines_watermark(ctx)
     _test_burn_rate_replenishment_returns_floor(ctx)
-    _test_seed_from_rate_limit_body(ctx)
-    _test_seed_from_rate_limit_body_edge_cases(ctx)
     _test_usage_footer(ctx)
     _test_time_throttle_factor_sliding_scale(ctx)
     _test_effective_throttle_factor_picks_larger(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/lib/text.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/text.axl
@@ -4,8 +4,10 @@ Currently:
   - `format_int_comma(n)` — thousands separators on integers.
   - `pluralize(count, singular, plural=None)` — `"N noun"` / `"N nouns"`
     with thousands-separated count.
+  - `truncate_for_title(text, max_len)` — word-boundary truncation with a
+    `…` suffix, for status-surface titles.
 
-Both are stateless, pure-string helpers. Add a new function here when
+All are stateless, pure-string helpers. Add a new function here when
 it's wanted by more than one module and not specific to any one
 domain (bazel results, lint results, etc.).
 """
@@ -46,3 +48,25 @@ def pluralize(count, singular, plural = None):
     if plural == None:
         plural = singular + "s"
     return format_int_comma(count) + " " + (singular if count == 1 else plural)
+
+# Default character budget for the subject (target pattern / formatter
+# target / …) embedded in a status-surface title. Long target lists —
+# e.g. a delivery run over dozens of resolved labels — are truncated to
+# this so the title stays scannable.
+SUBJECT_TITLE_MAX = 60
+
+def truncate_for_title(text, max_len = SUBJECT_TITLE_MAX):
+    """Truncate `text` to `max_len` chars for a status-surface title,
+    preferring a word boundary in the back half and appending a `…`.
+
+    Returns `text` unchanged when it already fits. Used by the per-kind
+    `summary_title` helpers to cap the subject, and by the bazel renderer
+    to cap the whole composed title to GitHub's length limit.
+    """
+    if len(text) <= max_len:
+        return text
+    window = text[:max_len - 1]
+    last_space = window.rfind(" ")
+    if last_space > max_len // 2:
+        return window[:last_space] + "…"
+    return window + "…"

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -21,13 +21,13 @@ Usage:
 load("@std//time.axl", "sleep", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
-load("./lib/bazel_flags.axl", "setup_bazel_command")
+load("./lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "detect_ci", "error", "warn")
 load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./lib/health_check.axl", "HealthCheckTrait")
-load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
+load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "setup_phase", "task_update")
 load("./lib/lint_results.axl", "detect_lint_tool", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
 load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
 load("./lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics")
@@ -644,7 +644,7 @@ def _pick_status(data, had_failure, terminal):
     """Decide a lint task's lifecycle status from accumulated data.
 
     `had_failure` — hard-fail signal (build failed, fail_on_severity hit).
-    `terminal`    — True iff this is the final emit before task_complete.
+    `terminal`    — True iff this is the task's final `task_update` emit.
 
     Aborted check rides on `data["bazel"]["aborted"]` since lint's build
     phase shares the BES counter shape — when bazel aborts (timeout,
@@ -831,19 +831,14 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # (after the build has already run).
     validate_findings_destination(lint_trait.findings_destination)
 
-    # Initialize lint data for status-check emission. Fire task_started
-    # FIRST so any subsequent hook failure still produces a visible check run.
+    # Initialize lint data for status-check emission.
     data = lint_init_data()
     data["start_time_ms"] = now_ms(ctx)
     data["lint"]["strategy"] = _strategy_name(strategy)
     data["target_pattern"] = " ".join(list(ctx.args.targets)) if ctx.args.targets else ""
-    setup_phase(ctx, lifecycle)
-    for handler in lifecycle.task_started:
-        handler(ctx, data["target_pattern"])
 
-    # Lint-specific base flags. Flag computation happens here (not after
-    # detect_changed_files) so parse_rc + ctx.bazel.startup_flags are ready
-    # before preflight.
+    # Lint-specific base flags, computed before setup_phase since it forwards
+    # them to setup_bazel_command.
     base_flags = ["--remote_download_regex='.*AspectRulesLint.*'"]
     for aspect in ctx.args.aspects:
         base_flags.append("--aspects=" + aspect)
@@ -869,12 +864,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if lint_trait.lint_report or not is_interactive:
         base_flags.append("--output_groups=rules_lint_machine")
 
-    flags = setup_bazel_command(ctx, "build", bazel_trait, base_flags = base_flags)
+    # The single pre-task setup phase (status surface, rc parse, health
+    # checks); returns the resolved flags (a failed health check fails the task
+    # inside setup_phase).
+    flags = setup_phase(ctx, lifecycle, data["target_pattern"], "lint_results", data, hc_trait, bazel_trait, "build", bazel_base_flags = base_flags)
+    announce_version, announce_command = resolve_bazel_announce(ctx)
 
-    # 1. Pre-flight (env table, health checks).
-    preflight_phase(ctx, lifecycle, hc_trait)
-
-    # 2. Detect changed files BEFORE lint_start hooks so features can read
+    # Detect changed files BEFORE lint_start hooks so features can read
     # lint_trait.changed_files as the canonical set. Prefers the GitHub
     # PR Files API when authenticated and in a PR context (works on any
     # CI host), falling back to local `git diff <base> --unified=0`.
@@ -952,6 +948,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     build = ctx.bazel.build(
         flags = flags,
         build_events = build_events,
+        announce_version = announce_version,
+        announce_command = announce_command,
         *ctx.args.targets
     )
 
@@ -960,7 +958,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # here — well before `build.wait()`. Emitting a running task_update at
     # this point lets the BK annotation / status check pick up the Aspect
     # Workflows link as soon as the build is spawned, instead of waiting for
-    # the first SARIF report (or task_complete) to surface it.
+    # the first SARIF report (or terminal task_update) to surface it.
     data["sink_invocation_id"] = build.sink_invocation_id
 
     # Re-emit (now that the sink_invocation_id is known so we can show
@@ -1292,13 +1290,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             ),
         ))
     print_repro_and_fix(ctx.std, data, final_status)
-    for handler in lifecycle.task_complete:
-        handler(ctx, exit_code)
-
-    for hook in hc_trait.post_health_check:
-        result = hook(ctx)
-        if result != None:
-            fail(result)
 
     return TaskConclusion(
         exit_code = exit_code,
@@ -1311,10 +1302,6 @@ lint = task(
         "aspects": args.string_list(
             long = "aspect",
             description = "Bazel aspect label(s) to apply for linting (e.g. //tools/lint:linters.bzl%eslint). Repeat the flag to run multiple aspects in a single invocation. Aspects may also be supplied via `--bazel-flag=--aspects=…` or a bazelrc `--config`; at least one rules_lint aspect must reach Bazel one way or another.",
-        ),
-        "announce_rc": args.boolean(
-            default = False,
-            description = "Print the resolved Bazel `.bazelrc` flags before running the lint build. Useful when debugging which config sections fired or what the final flag set looks like.",
         ),
         "bazel_flags": args.string_list(
             description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
@@ -1365,7 +1352,7 @@ lint = task(
             default = ["..."],
             description = "Bazel target patterns to lint. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory. Pass multiple patterns to combine includes and excludes; when any pattern is hyphen-led, separate them from flags with `--` (e.g. `aspect lint -- //... -//experimental/...`).",
         ),
-    },
+    } | announce_bazel_args("the lint build"),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -2,11 +2,11 @@
 
 load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
-load("./lib/bazel_flags.axl", "setup_bazel_command")
+load("./lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
 load("./lib/environment.axl", "error")
 load("./lib/health_check.axl", "HealthCheckTrait")
-load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "preflight_phase", "setup_phase", "task_update")
+load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "setup_phase", "task_update")
 load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "runnable")
 load("./lib/tips.axl", "tips")
 
@@ -23,15 +23,15 @@ def _terminal_status(data, exit_code):
     return "passed" if exit_code == 0 else "failed"
 
 def _emit_terminal(ctx, lifecycle, data, exit_code, conclusion_text = None):
-    """Fire the terminal `task_update(final=True)` + `task_complete` hooks
-    and return a `TaskConclusion` for `_impl` to return.
+    """Fire the terminal `task_update(final=True)` and return a
+    `TaskConclusion` for `_impl` to return.
 
     Mirrors `bazel_runner._emit_terminal` so the run task concludes its
     status surfaces (GitHub check runs, Buildkite annotations) the same
     way `build`/`test` do — without this the surfaces stay stuck at
-    "running" because nothing ever delivers a final update or fires
-    `task_complete`. Called from every exit path (build failure,
-    run-setup failure, and the spawned binary's exit).
+    "running" because nothing ever delivers a final update. Called from
+    every exit path (build failure, run-setup failure, and the spawned
+    binary's exit).
 
     `conclusion_text` overrides the bookend summary for cases the bazel
     bucket logic can't describe (e.g. a built target whose binary exits
@@ -50,8 +50,6 @@ def _emit_terminal(ctx, lifecycle, data, exit_code, conclusion_text = None):
             data = data,
             progress = ProgressStyles(body = bookend),
         ))
-    for handler in lifecycle.task_complete:
-        handler(ctx, exit_code)
 
     return TaskConclusion(
         exit_code = exit_code,
@@ -68,23 +66,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     forward_args = list(ctx.args.run_args)
 
     data = init_data()
-    setup_phase(ctx, lifecycle)
-    for handler in lifecycle.task_started:
-        handler(ctx, target)
 
-    # Expand the "build" rc section, not "run": this task ultimately
-    # invokes `ctx.bazel.build`, which spawns a literal `bazel build`.
-    # The `run:` rc section can contain options Bazel's `build` command
+    # The single pre-task setup phase (status surface, rc parse, health
+    # checks); returns the resolved flags (a failed health check fails the task
+    # inside setup_phase). Expand the "build" rc section, not "run": this task
+    # ultimately invokes `ctx.bazel.build`, which spawns a literal `bazel
+    # build`. The `run:` rc section can contain options Bazel's `build` command
     # rejects as unrecognized (e.g. `--script_path`).
-    flags = setup_bazel_command(ctx, "build", bazel_trait)
-
-    preflight_phase(ctx, lifecycle, hc_trait)
-
-    for hook in hc_trait.post_health_check:
-        result = hook(ctx)
-        if result != None:
-            _emit_terminal(ctx, lifecycle, data, 1)
-            fail(result)
+    flags = setup_phase(ctx, lifecycle, target, "bazel_results", data, hc_trait, bazel_trait, "build")
+    announce_version, announce_command = resolve_bazel_announce(ctx)
 
     flags.extend(LOCAL_SPAWN_FLAGS)
 
@@ -108,7 +98,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         phase = Phase(name = "build", description = "Build run target", emoji = "🔨"),
     )
 
-    build = ctx.bazel.build(target, build_events = build_events, flags = flags)
+    build = ctx.bazel.build(
+        target,
+        build_events = build_events,
+        flags = flags,
+        announce_version = announce_version,
+        announce_command = announce_command,
+    )
 
     for _tick in sleep_iter(BES_DRAIN_TICK_MS):
         for _ in range(10000):
@@ -162,10 +158,6 @@ run = task(
         "run_args": args.trailing_var_args(
             description = "Arguments forwarded to the target binary. Separate from `aspect run`'s own flags with `--`, e.g. `aspect run //foo:bar -- --binary-arg value`.",
         ),
-        "announce_rc": args.boolean(
-            default = False,
-            description = "Print the resolved Bazel `.bazelrc` flags before running the build. Useful when debugging which config sections fired or what the final flag set looks like. ASPECT_DEBUG=1 logs the same disclosure regardless of this flag.",
-        ),
         "bazel_flags": args.string_list(
             description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
             long = "bazel-flag",
@@ -174,7 +166,7 @@ run = task(
             description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
             long = "bazel-startup-flag",
         ),
-    },
+    } | announce_bazel_args("the build"),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -4,6 +4,7 @@ A default 'test' task that wraps a 'bazel test' command.
 
 load("./bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("./lib/artifacts.axl", "artifacts")
+load("./lib/bazel_flags.axl", "announce_bazel_args")
 load("./lib/bazel_runner.axl", "run_bazel_task")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "TaskLifecycleTrait")
@@ -124,10 +125,6 @@ test = task(
             long = "coverage-tool-arg",
             description = "Argument forwarded to --coverage-tool. Repeat the flag to pass multiple. The `{report}` (or `{lcov}`) placeholder is replaced with the absolute path of the merged LCOV report. Example: `--coverage-tool=codecov --coverage-tool-arg=-f --coverage-tool-arg={report}`.",
         ),
-        "announce_rc": args.boolean(
-            default = False,
-            description = "Print the resolved Bazel `.bazelrc` flags before running the test. Useful when debugging which config sections fired or what the final flag set looks like. ASPECT_DEBUG=1 logs the same disclosure regardless of this flag.",
-        ),
         "bazel_flags": args.string_list(
             long = "bazel-flag",
             description = "Additional Bazel flags forwarded to the test invocation (e.g. --bazel-flag=--config=ci --bazel-flag=--test_filter=foo). Repeat the flag to pass multiple.",
@@ -152,7 +149,7 @@ test = task(
             default = False,
             description = "Cancel any running Bazel invocation before starting the test.",
         ),
-    },
+    } | announce_bazel_args("the test"),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -623,6 +623,60 @@ fn payload_discriminant(p: &axl_proto::build_event_stream::build_event::Payload)
     }
 }
 
+/// Optionally print the detected Bazel version and/or the exact command being
+/// spawned, one `INFO:` line each, before a `bazel build`/`test`/`run`
+/// invocation. Gated by the `--announce-bazel-version` / `--announce-bazel-command`
+/// task flags, resolved in AXL and passed through as `announce`.
+///
+/// Plain (unstyled) to match Bazel's own `INFO:` output, which interleaves
+/// with these lines.
+fn announce_spawn(announce: AnnounceSpawn, version: Option<&semver::Version>, cmd: &Command) {
+    if announce.version {
+        eprintln!("INFO: {}", version_line(version));
+    }
+    if announce.command {
+        eprintln!("INFO: Spawning: {}", render_command(cmd));
+    }
+}
+
+/// The version `INFO:` text. `version` is `None` for a non-release build (see
+/// [`super::info::parse_release`]), which notes the assume-latest behavior.
+fn version_line(version: Option<&semver::Version>) -> String {
+    match version {
+        Some(v) => format!("Bazel {v}"),
+        None => "Bazel development version (version-conditional flags assume latest)".to_string(),
+    }
+}
+
+/// Render `cmd` as a space-joined `program arg…` line for display. Read back
+/// from the fully assembled `Command`, so it shows the full argument set
+/// aspect-cli passes Bazel (including the internal BES/execlog flags).
+///
+/// Secrets (env-var values, request headers, URL credentials) are redacted via
+/// [`super::stream::redaction::redact_command_args`] — the same rules the BES
+/// sink redaction uses — since this line is printed to CI logs by default.
+/// Args are space-joined for readability, not shell-quoted: a value with a
+/// space (or a `<REDACTED>` placeholder) is not guaranteed copy-paste-safe.
+fn render_command(cmd: &Command) -> String {
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    let redacted = super::stream::redaction::redact_command_args(args.iter().map(String::as_str));
+    std::iter::once(cmd.get_program().to_string_lossy().into_owned())
+        .chain(redacted)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Which pre-spawn `INFO:` lines to emit. Resolved from task flags in AXL
+/// (`auto` → on under CI) and threaded down through `ctx.bazel.build` / `.test`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AnnounceSpawn {
+    pub version: bool,
+    pub command: bool,
+}
+
 #[derive(Debug, Display, ProvidesStaticType, Trace, NoSerialize, Allocative)]
 #[display("<bazel.build.Build>")]
 pub struct Build {
@@ -673,9 +727,10 @@ impl Build {
         stdout: Stdio,
         stderr: Stdio,
         current_dir: Option<String>,
+        announce: AnnounceSpawn,
         rt: AsyncRuntime,
     ) -> Result<Build, std::io::Error> {
-        let (pid, _) = super::info::server_info()?;
+        let (pid, version) = super::info::server_info()?;
 
         let span = tracing::info_span!(
             "ctx.bazel.build",
@@ -769,6 +824,7 @@ impl Build {
         cmd.args(targets);
 
         crate::trace!("exec: {:?}", cmd.get_args());
+        announce_spawn(announce, version.as_ref(), &cmd);
 
         cmd.stdout(stdout);
         cmd.stderr(stderr);
@@ -1371,5 +1427,43 @@ Test = task(implementation = _impl)
             err.to_string().contains("still Live"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn version_line_text() {
+        use super::version_line;
+        assert_eq!(
+            version_line(Some(&semver::Version::new(9, 0, 1))),
+            "Bazel 9.0.1"
+        );
+        assert_eq!(
+            version_line(None),
+            "Bazel development version (version-conditional flags assume latest)"
+        );
+    }
+
+    #[test]
+    fn render_command_joins_program_and_args() {
+        use super::render_command;
+        let mut cmd = std::process::Command::new("bazel");
+        cmd.args(["--bazelrc=/dev/null", "build", "--", "//foo:bar"]);
+        assert_eq!(
+            render_command(&cmd),
+            "bazel --bazelrc=/dev/null build -- //foo:bar"
+        );
+    }
+
+    #[test]
+    fn render_command_redacts_env_secrets() {
+        // Delegates to stream::redaction; this asserts the wiring (secret env
+        // values are hidden, the command shape is preserved). The redaction
+        // rules themselves are covered in stream::redaction's own tests.
+        use super::render_command;
+        let mut cmd = std::process::Command::new("bazel");
+        cmd.args(["build", "--action_env=DB_PASSWORD=hunter2", "//foo"]);
+        let rendered = render_command(&cmd);
+        assert!(rendered.starts_with("bazel build --action_env=DB_PASSWORD="));
+        assert!(rendered.ends_with(" //foo"));
+        assert!(!rendered.contains("hunter2"), "secret leaked: {rendered}");
     }
 }

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -246,6 +246,11 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///   `Stdio` bundle (typically `ctx.std.io`). Cannot be combined with
     ///   `stdout`/`stderr`.
     /// * `current_dir` - Working directory for the Bazel invocation.
+    /// * `announce_version` - Print an `INFO: Bazel <version>` line before
+    ///   spawning. Resolved from the `--announce-bazel-version` task flag.
+    /// * `announce_command` - Print an `INFO: Spawning: <command>` line (the
+    ///   exact bazel command line) before spawning. Resolved from the
+    ///   `--announce-bazel-command` task flag.
     ///
     /// # Arguments
     /// * `execution_log`: Enable Bazel execution log collection. Pass `True` to
@@ -294,6 +299,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named)] stderr: Option<NoneOr<Writable>>,
         #[starlark(require = named, default = NoneOr::None)] stdio: NoneOr<StdStdio>,
         #[starlark(require = named, default = NoneOr::None)] current_dir: NoneOr<String>,
+        #[starlark(require = named, default = false)] announce_version: bool,
+        #[starlark(require = named, default = false)] announce_command: bool,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<build::Build> {
         let build_events = partition_build_events(build_events);
@@ -326,6 +333,10 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             stdout,
             stderr,
             current_dir.into_option(),
+            build::AnnounceSpawn {
+                version: announce_version,
+                command: announce_command,
+            },
             env.rt.clone(),
         )?;
         Ok(build)
@@ -358,6 +369,11 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///   `Stdio` bundle (typically `ctx.std.io`). Cannot be combined with
     ///   `stdout`/`stderr`.
     /// * `current_dir` - Working directory for the Bazel invocation.
+    /// * `announce_version` - Print an `INFO: Bazel <version>` line before
+    ///   spawning. Resolved from the `--announce-bazel-version` task flag.
+    /// * `announce_command` - Print an `INFO: Spawning: <command>` line (the
+    ///   exact bazel command line) before spawning. Resolved from the
+    ///   `--announce-bazel-command` task flag.
     ///
     /// # Arguments
     /// * `execution_log`: Enable Bazel execution log collection. Pass `True` to
@@ -404,6 +420,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named)] stderr: Option<NoneOr<Writable>>,
         #[starlark(require = named, default = NoneOr::None)] stdio: NoneOr<StdStdio>,
         #[starlark(require = named, default = NoneOr::None)] current_dir: NoneOr<String>,
+        #[starlark(require = named, default = false)] announce_version: bool,
+        #[starlark(require = named, default = false)] announce_command: bool,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<build::Build> {
         let build_events = partition_build_events(build_events);
@@ -436,6 +454,10 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             stdout,
             stderr,
             current_dir.into_option(),
+            build::AnnounceSpawn {
+                version: announce_version,
+                command: announce_command,
+            },
             env.rt.clone(),
         )?;
         Ok(test)

--- a/crates/axl-runtime/src/engine/bazel/rc.rs
+++ b/crates/axl-runtime/src/engine/bazel/rc.rs
@@ -154,15 +154,29 @@ fn bazelrc_methods(registry: &mut MethodsBuilder) {
     /// print(rc.announce(command = "build"))
     /// print(rc.announce(command = "build", ansi = True))
     /// ```
-    fn announce(
+    fn announce<'v>(
         this: &StarlarkBazelRC,
         #[starlark(require = named)] command: String,
         #[starlark(require = named, default = false)] ansi: bool,
         #[starlark(require = named, default = 120)] max_width: i64,
+        eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<String> {
-        Ok(this
-            .inner
-            .announce(&command, ansi, max_width.max(0) as usize))
+        // Display rc paths relative to the workspace root / home dir, and
+        // scrub secrets out of flag values (the rc disclosure prints to CI
+        // logs). Both use the same anchors / redaction as the rest of the CLI.
+        let root = crate::engine::store::Env::from_eval(eval)?
+            .bazel_root_dir
+            .clone();
+        let home = std::env::home_dir();
+        let redact = super::stream::redaction::redactor(this.inner.all_option_values());
+        Ok(this.inner.announce(
+            &command,
+            ansi,
+            max_width.max(0) as usize,
+            &root,
+            home.as_deref(),
+            redact,
+        ))
     }
 
     /// Return the list of source file paths that were loaded.

--- a/crates/axl-runtime/src/engine/bazel/stream/redaction.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/redaction.rs
@@ -22,6 +22,13 @@
 //! event we're redacting — command-line events carry the flag in their own
 //! args list, so there's no ordering dependency on BuildMetadata arrival.
 //! Glob patterns (`*`, `?`) are supported, matching the AXL semantics.
+//!
+//! Limitation: redaction matches only the single-token `--name=value` form. A
+//! space-separated `--remote_header Authorization: Bearer <token>` (two argv
+//! tokens) is not scrubbed. BEP canonicalizes flags to the `=`-joined form, so
+//! the BES path is covered; the per-spawn command line (`render_command`) and
+//! the `.bazelrc` disclosure (`bazelrc::announce`) reuse these helpers and
+//! inherit the same assumption — a space-separated secret there would leak.
 
 use axl_proto::build_event_stream::BuildEvent;
 use axl_proto::build_event_stream::build_event::Payload;
@@ -426,6 +433,36 @@ fn redact_option(opt: &mut CmdOption, allow_env: &[&str]) -> bool {
     modified
 }
 
+/// Redact a whole command-line arg list for safe display, returning each arg
+/// scrubbed by [`redact_flag`]. The `ALLOW_ENV` allowlist is collected from the
+/// same args (`--build_metadata=ALLOW_ENV=…`), so callers needn't thread it.
+///
+/// Use when echoing a bazel command to a log (e.g. `--announce-bazel-command`)
+/// — it applies the same header / env-var / URL-credential rules the BES sink
+/// redaction uses, from one source of truth.
+pub fn redact_command_args<'a>(args: impl IntoIterator<Item = &'a str> + Clone) -> Vec<String> {
+    let user_patterns = collect_allow_env(args.clone());
+    let allow_env = effective_allow_env(&user_patterns);
+    args.into_iter()
+        .map(|a| redact_flag(a, &allow_env).into_owned())
+        .collect()
+}
+
+/// Build a redactor closure that scrubs a single flag string via [`redact_flag`].
+///
+/// The `ALLOW_ENV` allowlist is collected once from `flags` (which should be
+/// the full set the closure will be applied across, so inline
+/// `--build_metadata=ALLOW_ENV=…` is honored). Use when flags are redacted
+/// one at a time rather than as a list — e.g. the `--announce-bazel-rc`
+/// disclosure, which renders each rc option individually.
+pub fn redactor<'a>(flags: impl IntoIterator<Item = &'a str>) -> impl Fn(&str) -> String {
+    let user_patterns = collect_allow_env(flags);
+    move |flag: &str| {
+        let allow_env = effective_allow_env(&user_patterns);
+        redact_flag(flag, &allow_env).into_owned()
+    }
+}
+
 /// Scrub a single flag string (`--name=value` / `--name value` / positional).
 ///
 /// - Name-only flags (no `=`): leave untouched.
@@ -446,7 +483,7 @@ pub fn redact_flag<'a>(arg: &'a str, allow_env: &[&str]) -> Cow<'a, str> {
     let value = &arg[eq + 1..];
 
     if HEADER_OPTION_NAMES.contains(&name) {
-        return Cow::Owned(format!("--{}={}", name, REDACTED));
+        return Cow::Owned(format!("--{}={}", name, redact_header_value(value)));
     }
     if ENV_VAR_OPTION_NAMES.contains(&name) {
         let new_value = redact_env_value(value, allow_env);
@@ -467,7 +504,7 @@ pub fn redact_flag<'a>(arg: &'a str, allow_env: &[&str]) -> Cow<'a, str> {
 /// we don't have to reconstruct `--name=value`.
 fn redact_option_value<'a>(name: &str, value: &'a str, allow_env: &[&str]) -> Cow<'a, str> {
     if HEADER_OPTION_NAMES.contains(&name) {
-        return Cow::Owned(REDACTED.to_string());
+        return Cow::Owned(redact_header_value(value));
     }
     if ENV_VAR_OPTION_NAMES.contains(&name) {
         return redact_env_value(value, allow_env);
@@ -503,6 +540,23 @@ fn redact_env_value<'a>(value: &'a str, allow_env: &[&str]) -> Cow<'a, str> {
         };
     }
     Cow::Owned(format!("{}={}", key, REDACTED))
+}
+
+/// Redact a request-header flag value, keeping the header name and hiding only
+/// the value. Bazel accepts both `Name=Value` and `Name: Value` forms, so we
+/// split on the first `=` or `:` (whichever comes first) and replace the rest:
+///   `X-Aspect=tok`            → `X-Aspect=<REDACTED>`
+///   `Authorization: Bearer t` → `Authorization:<REDACTED>`
+/// A value with no separator has nothing to keep and is fully redacted.
+fn redact_header_value(value: &str) -> String {
+    let sep = [value.find('='), value.find(':')]
+        .into_iter()
+        .flatten()
+        .min();
+    match sep {
+        Some(i) => format!("{}{}{}", &value[..i], &value[i..=i], REDACTED),
+        None => REDACTED.to_string(),
+    }
 }
 
 /// Replace `scheme://user:password@host/...` with `scheme://<REDACTED>@host/...`.
@@ -560,7 +614,7 @@ mod tests {
         assert_eq!(
             ucl.args,
             vec![
-                "--remote_header=<REDACTED>".to_string(),
+                "--remote_header=Authorization:<REDACTED>".to_string(),
                 "--config=ci".to_string(),
                 "--bes_backend=grpcs://<REDACTED>@bes.example.com:443".to_string(),
             ]
@@ -631,7 +685,7 @@ mod tests {
             redacted,
             vec![
                 "--config=ci".to_string(),
-                "--remote_header=<REDACTED>".to_string(),
+                "--remote_header=Authorization:<REDACTED>".to_string(),
                 "--action_env=API_TOKEN=<REDACTED>".to_string(),
                 "--action_env=GITHUB_SHA=abc".to_string(), // allowlisted
             ]
@@ -731,12 +785,23 @@ mod tests {
     }
 
     #[test]
-    fn redacts_header_flag() {
+    fn redacts_header_flag_keeping_name() {
+        // `Name: Value` form — split on the colon, keep the header name.
         assert_eq!(
             redact_flag(
                 "--remote_header=Authorization: Bearer abc",
                 &default_allow()
             ),
+            "--remote_header=Authorization:<REDACTED>"
+        );
+        // `Name=Value` form — split on the equals.
+        assert_eq!(
+            redact_flag("--bes_header=X-Aspect=tok123", &default_allow()),
+            "--bes_header=X-Aspect=<REDACTED>"
+        );
+        // No separator — nothing to keep, redact whole value.
+        assert_eq!(
+            redact_flag("--remote_header=opaque", &default_allow()),
             "--remote_header=<REDACTED>"
         );
     }
@@ -874,5 +939,51 @@ mod tests {
         };
         assert_eq!(ucl.args[1], "--action_env=DEPLOY_ENV=prod"); // kept via user allowlist
         assert_eq!(ucl.args[2], "--action_env=MY_SECRET=<REDACTED>"); // redacted
+    }
+
+    #[test]
+    fn redact_command_args_scrubs_and_honors_inline_allowlist() {
+        let args = [
+            "build",
+            "--action_env=DB_PASSWORD=hunter2", // redacted (value hidden)
+            "--action_env=USER=alice",          // kept (default allowlist)
+            "--build_metadata=ALLOW_ENV=MY_*",  // extends allowlist from the args themselves
+            "--action_env=MY_TOKEN=abc",        // kept (matches inline MY_*)
+            "--remote_header=Authorization: Bearer t0ken", // value redacted, name kept
+            "//foo:bar",
+        ];
+        let out = redact_command_args(args.iter().copied());
+        assert_eq!(
+            out,
+            vec![
+                "build".to_string(),
+                format!("--action_env=DB_PASSWORD={REDACTED}"),
+                "--action_env=USER=alice".to_string(),
+                "--build_metadata=ALLOW_ENV=MY_*".to_string(),
+                "--action_env=MY_TOKEN=abc".to_string(),
+                format!("--remote_header=Authorization:{REDACTED}"),
+                "//foo:bar".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn redactor_scrubs_per_flag_and_honors_inline_allowlist() {
+        // The closure seeds its allowlist from all flags it's told about, then
+        // scrubs one flag at a time (the shape `--announce-bazel-rc` needs).
+        let redact = redactor(["--build_metadata=ALLOW_ENV=MY_*"]);
+        assert_eq!(
+            redact("--remote_header=Authorization: Bearer t"),
+            "--remote_header=Authorization:<REDACTED>"
+        );
+        assert_eq!(
+            redact("--action_env=DB_PASSWORD=hunter2"),
+            "--action_env=DB_PASSWORD=<REDACTED>"
+        );
+        // Honors the inline ALLOW_ENV pattern collected above.
+        assert_eq!(
+            redact("--action_env=MY_TOKEN=abc"),
+            "--action_env=MY_TOKEN=abc"
+        );
     }
 }

--- a/crates/axl-runtime/src/engine/task_info.rs
+++ b/crates/axl-runtime/src/engine/task_info.rs
@@ -42,9 +42,8 @@ use starlark::values::starlark_value;
 /// `display_name` is an optional caller-supplied override for the
 /// phase's display label. When non-empty, renderers use it verbatim;
 /// when empty, they titlecase `name` themselves (`build` → `Build`,
-/// `bazel_query` → `Bazel query`). The only standard phase that needs
-/// this is `preflight` → `Pre-flight` (naive titlecase produces
-/// `Preflight` which reads oddly).
+/// `bazel_query` → `Bazel query`). Set it only when naive titlecase
+/// reads oddly for a given phase id.
 #[derive(Debug, Clone)]
 pub struct PhaseRecord {
     pub name: String,
@@ -102,7 +101,7 @@ impl<'v> StarlarkValue<'v> for TaskPhase {
 
 #[starlark_module]
 fn task_phase_methods(registry: &mut MethodsBuilder) {
-    /// Phase id (`build`, `test`, `preflight`, `init`, …) — the
+    /// Phase id (`setup`, `build`, `test`, `init`, …) — the
     /// lowercase identifier callers passed as `Phase(name=...)`.
     #[starlark(attribute)]
     fn name<'v>(this: Value<'v>) -> anyhow::Result<String> {
@@ -143,9 +142,9 @@ fn task_phase_methods(registry: &mut MethodsBuilder) {
         Ok(this.downcast_ref::<TaskPhase>().unwrap().emoji.clone())
     }
 
-    /// Producer-supplied display-label override (e.g. `"Pre-flight"`)
-    /// from the input `Phase(display_name=...)`. Renderers use this
-    /// verbatim when non-empty; when empty, they titlecase `name`.
+    /// Producer-supplied display-label override from the input
+    /// `Phase(display_name=...)`. Renderers use this verbatim when
+    /// non-empty; when empty, they titlecase `name`.
     #[starlark(attribute)]
     fn display_name<'v>(this: Value<'v>) -> anyhow::Result<String> {
         Ok(this
@@ -383,9 +382,8 @@ fn task_info_methods(registry: &mut MethodsBuilder) {
     ///
     /// `display_name` is an optional display-label override. When
     /// non-empty, renderers use it verbatim; when empty, they
-    /// titlecase `name`. Use it when naive titlecasing diverges from
-    /// the natural English form (`preflight` → `Pre-flight`); regular
-    /// underscore-separated identifiers (`bazel_query` →
+    /// titlecase `name`. Use it when naive titlecasing reads oddly;
+    /// regular underscore-separated identifiers (`bazel_query` →
     /// `Bazel query`) don't need it.
     ///
     /// Same-name no-op calls don't update emoji or display_name on

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -807,12 +807,9 @@ fn render_phase_breakdown(phases: &[PhaseRecord], mode: TimingMode, failed: bool
     if visible.is_empty() {
         return String::new();
     }
-    // CLI surfaces only render the emoji the caller supplied via
-    // `Phase(emoji=...)`; empty stays bare. Emoji rendering on plain
-    // terminals varies (some terminfos double-width them and break
-    // column alignment, some render `?`), so we render bare rather
-    // than inconsistently. Users who want emoji on CLI supply it
-    // explicitly per phase.
+    // Prefix the caller-supplied `Phase(emoji=...)` when present; an empty
+    // emoji stays bare. The Detailed branch aligns columns by `display_width`
+    // (which counts the emoji as two cells); Summary mode has no columns.
     let phase_label = |p: &PhaseRecord| -> String {
         let name = if p.display_name.is_empty() {
             titlecase(&p.name)
@@ -841,12 +838,12 @@ fn render_phase_breakdown(phases: &[PhaseRecord], mode: TimingMode, failed: bool
             format!(" — {}", parts.join(" · "))
         }
         TimingMode::Detailed => {
-            // Compute column widths so durations align. Emoji gets
-            // prefixed inside the name column — names with emoji
-            // render slightly wider, but the dur+desc columns still
-            // line up.
+            // Pad the label column to align the duration column. Widths are
+            // in terminal display cells (see `display_width`) — the phase
+            // emoji renders two cells wide but is one codepoint, so a naive
+            // char or byte count would misalign rows with vs without emoji.
             let labels: Vec<String> = visible.iter().map(|p| phase_label(p)).collect();
-            let name_w = labels.iter().map(|s| s.chars().count()).max().unwrap_or(0);
+            let name_w = labels.iter().map(|s| display_width(s)).max().unwrap_or(0);
             let dur_strs: Vec<String> = visible
                 .iter()
                 .map(|p| format_duration(p.duration))
@@ -864,9 +861,7 @@ fn render_phase_breakdown(phases: &[PhaseRecord], mode: TimingMode, failed: bool
                 } else {
                     ""
                 };
-                // Pad the label to `name_w` *characters* (not bytes) —
-                // emoji sequences confuse byte-width Rust formatters.
-                let pad = name_w.saturating_sub(label.chars().count());
+                let pad = name_w.saturating_sub(display_width(label));
                 out.push_str(&format!(
                     "\n    {}{}  {:>dw$}  {}{}",
                     label,
@@ -887,9 +882,8 @@ fn render_phase_breakdown(phases: &[PhaseRecord], mode: TimingMode, failed: bool
 /// Phase names are lowercase identifiers (`detect`, `build`,
 /// `bazel_query`, `init`); this renders them as `Detect`, `Build`,
 /// `Bazel query`, `Init` for display. Callers that need a non-naive
-/// display label (e.g. `preflight` → `Pre-flight`) pass an explicit
-/// `display_name` to `ctx.task.phase(...)`; renderers prefer that
-/// over this helper.
+/// display label pass an explicit `display_name` to
+/// `ctx.task.phase(...)`; renderers prefer that over this helper.
 fn titlecase(s: &str) -> String {
     let mut chars = s.chars();
     match chars.next() {
@@ -906,6 +900,106 @@ fn titlecase(s: &str) -> String {
             out
         }
         None => String::new(),
+    }
+}
+
+/// Terminal display width of `s`, in cells, for column alignment.
+///
+/// Phase labels are `<emoji> <ascii-name>` or a bare ASCII name. ASCII is
+/// one cell; the variation selector U+FE0F is zero-width; every other
+/// (non-ASCII) char — i.e. the phase emoji — counts as two cells. This
+/// avoids a full Unicode width table.
+///
+/// The two-cell assumption holds only because every phase emoji is one that
+/// terminals render double-width: a single astral codepoint (`🔨` U+1F528
+/// and friends) or a BMP symbol with default *emoji* presentation (`✨`
+/// U+2728). It would mis-measure a symbol with default *text* presentation
+/// — e.g. the gear U+2699 or warning U+26A0, which render one cell even with
+/// a U+FE0F selector in many terminals — so phase emoji must be chosen from
+/// the double-width set (see the `Phase(emoji=…)` call sites). The U+FE0F
+/// case is handled as zero-width defensively; no current phase emoji uses it.
+fn display_width(s: &str) -> usize {
+    s.chars()
+        .map(|c| match c {
+            '\u{FE0F}' => 0,
+            c if c.is_ascii() => 1,
+            _ => 2,
+        })
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TimingMode, display_width, render_phase_breakdown};
+    use crate::engine::task_info::PhaseRecord;
+    use std::time::Duration;
+
+    fn phase(name: &str, emoji: &str, secs: u64) -> PhaseRecord {
+        PhaseRecord {
+            name: name.to_string(),
+            description: format!("{name} desc"),
+            duration: Duration::from_secs(secs),
+            interrupted: false,
+            emoji: emoji.to_string(),
+            display_name: String::new(),
+        }
+    }
+
+    #[test]
+    fn display_width_counts_emoji_as_two_ascii_as_one() {
+        assert_eq!(display_width("Setup"), 5);
+        assert_eq!(display_width("🔨 Build"), 8); // astral emoji 2 + " " + "Build"
+        assert_eq!(display_width("🔧 Setup"), 8); // wrench (astral) 2 + 1 + 5
+        assert_eq!(display_width("✨ Format"), 9); // default-emoji BMP 2 + 1 + 6
+        // VS16 is handled as zero-width (defensive; no phase emoji uses it).
+        assert_eq!(display_width("x\u{FE0F}"), 1);
+    }
+
+    /// Re-derives the expected cell width with the same FE0F/ascii/wide model
+    /// as `display_width`, but separately — so the alignment assertion below
+    /// catches a typo/regression in `display_width` (it would still miss a flaw
+    /// in the shared model itself, which the emoji set is curated to avoid).
+    fn cells(s: &str) -> usize {
+        s.chars()
+            .map(|c| {
+                if c == '\u{FE0F}' {
+                    0
+                } else if c.is_ascii() {
+                    1
+                } else {
+                    2
+                }
+            })
+            .sum()
+    }
+
+    #[test]
+    fn detailed_breakdown_aligns_description_column_across_rows() {
+        // Mix an emoji-prefixed phase with a bare-ASCII phase of a different
+        // name length, so codepoint-count and cell-count diverge between rows
+        // — the exact case the old `chars().count()` padding misaligned. The
+        // description column (after the fixed-width duration field) must land
+        // at the same display cell on every row.
+        let out = render_phase_breakdown(
+            &[phase("setup", "🔧", 2), phase("compute_digests", "", 1)],
+            TimingMode::Detailed,
+            false,
+        );
+        let desc_cols: Vec<usize> = out
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| {
+                // Description is the last column; it starts after the final
+                // run of 2+ spaces separating it from the duration field.
+                let gap = l.rfind("  ").unwrap();
+                cells(&l[..gap + 2])
+            })
+            .collect();
+        assert_eq!(desc_cols.len(), 2);
+        assert_eq!(
+            desc_cols[0], desc_cols[1],
+            "description columns misaligned: {out:?}"
+        );
     }
 }
 

--- a/crates/bazelrc/src/lib.rs
+++ b/crates/bazelrc/src/lib.rs
@@ -158,6 +158,15 @@ impl BazelRC {
         &self.sources
     }
 
+    /// Every option string across all command sections, in no particular
+    /// order. Used to seed redaction allowlists (e.g.
+    /// `--build_metadata=ALLOW_ENV=…`) before rendering the announce output.
+    pub fn all_option_values(&self) -> impl Iterator<Item = &str> {
+        self.options
+            .values()
+            .flat_map(|opts| opts.iter().map(|o| o.value.as_str()))
+    }
+
     /// Return the source file path for the given option.
     pub fn source_of(&self, option: &RcOption) -> &Path {
         &self.sources[option.source_index]
@@ -220,14 +229,28 @@ impl BazelRC {
         result
     }
 
-    /// Produce a human-readable summary of all options loaded for `command`.
+    /// Render a human-readable summary of all options loaded for `command`,
+    /// for the `--announce-bazel-rc` disclosure.
     ///
-    /// Output is grouped by source file, with flags wrapped at `max_width` columns.
-    /// When `ansi` is true, headers and section names are styled with ANSI escape codes.
+    /// Output is grouped by source file, with flags wrapped at `max_width`
+    /// columns; when `ansi` is true, headers and section names are styled with
+    /// ANSI escapes. Version-gated flags (from `try-import-if-bazel-version`)
+    /// are annotated with `[if <cond>]`.
     ///
-    /// Version-gated flags (from `try-import-if-bazel-version`) are annotated with
-    /// `[if <cond>]` so the condition is visible.
-    pub fn announce(&self, command: &str, ansi: bool, max_width: usize) -> String {
+    /// `root` is the workspace root and `home` the user's home directory; they
+    /// drive how source paths are displayed (see `shorten`). `redact` scrubs
+    /// each flag's value before it's printed — the caller passes the same
+    /// redaction the rest of the CLI uses, so secrets in `--remote_header=…` /
+    /// `--action_env=…` etc. don't leak into CI logs.
+    pub fn announce(
+        &self,
+        command: &str,
+        ansi: bool,
+        max_width: usize,
+        root: &Path,
+        home: Option<&Path>,
+        redact: impl Fn(&str) -> String,
+    ) -> String {
         let (b, d, y, r) = if ansi {
             ("\x1b[1m", "\x1b[2m", "\x1b[33m", "\x1b[0m")
         } else {
@@ -235,28 +258,31 @@ impl BazelRC {
         };
 
         let fmt_flag = |opt: &RcOption| -> String {
+            let value = redact(&opt.value);
             match &opt.version_condition {
-                None => opt.value.clone(),
-                Some(cond) => format!("{}[if {}]{} {}", y, cond, r, opt.value),
+                None => value,
+                Some(cond) => format!("{}[if {}]{} {}", y, cond, r, value),
             }
         };
 
-        // Shorten an absolute path to its last two components (e.g. "bazel/defaults.bazelrc").
+        // Display an rc source path relative to the most meaningful anchor:
+        //   - under the workspace root → `./relative/path`
+        //   - else under $HOME         → `~/relative/path`
+        //   - else                     → the absolute path
+        // so the reader can tell workspace, user, and system rc files apart.
         let shorten = |p: &Path| -> String {
             if p == Path::new("<command line>") {
                 return "client".to_owned();
             }
-            let comps: Vec<_> = p.components().collect();
-            if comps.len() <= 2 {
-                p.display().to_string()
-            } else {
-                let n = comps.len();
-                format!(
-                    "{}/{}",
-                    comps[n - 2].as_os_str().to_string_lossy(),
-                    comps[n - 1].as_os_str().to_string_lossy()
-                )
+            if let Ok(rel) = p.strip_prefix(root) {
+                return format!("./{}", rel.display());
             }
+            if let Some(home) = home
+                && let Ok(rel) = p.strip_prefix(home)
+            {
+                return format!("~/{}", rel.display());
+            }
+            p.display().to_string()
         };
 
         // Fit flags onto lines starting at `start_col`, wrapping at `max_width`.
@@ -555,6 +581,98 @@ import {}
 
         // d is imported twice → --jobs=4 appears twice
         assert_eq!(options.get("build").map(|v| v.len()), Some(2));
+    }
+
+    // ── announce ─────────────────────────────────────────────────────────────
+
+    fn rc_with(sources: &[&Path], options: &[(&str, usize, &str)]) -> BazelRC {
+        let mut map: HashMap<String, Vec<RcOption>> = HashMap::new();
+        for (key, source_index, value) in options {
+            map.entry(key.to_string()).or_default().push(RcOption {
+                value: value.to_string(),
+                command: key.to_string(),
+                source_index: *source_index,
+                version_condition: None,
+            });
+        }
+        BazelRC {
+            options: map,
+            sources: sources.iter().map(|p| p.to_path_buf()).collect(),
+        }
+    }
+
+    #[test]
+    fn announce_shortens_paths_by_anchor() {
+        let root = Path::new("/work/repo");
+        let home = Path::new("/home/dev");
+        let rc = rc_with(
+            &[
+                &root.join(".bazelrc"),          // → ./.bazelrc
+                &home.join(".bazelrc"),          // → ~/.bazelrc
+                Path::new("/etc/bazel.bazelrc"), // → absolute
+            ],
+            &[
+                ("common", 0, "--jobs=4"),
+                ("common", 1, "--keep_going"),
+                ("common", 2, "--curses=no"),
+            ],
+        );
+        let out = rc.announce("build", false, 200, root, Some(home), |s| s.to_string());
+        assert!(out.contains("./.bazelrc"), "{out}");
+        assert!(out.contains("~/.bazelrc"), "{out}");
+        assert!(out.contains("/etc/bazel.bazelrc"), "{out}");
+        assert!(
+            !out.contains("repo/.bazelrc"),
+            "should not show last-2-components: {out}"
+        );
+    }
+
+    #[test]
+    fn announce_anchor_matches_path_segments_not_string_prefix() {
+        // `/work/repo-foo` shares the string prefix `/work/repo` but is NOT a
+        // path-segment descendant, so it must render absolute, not `./-foo/…`.
+        let root = Path::new("/work/repo");
+        let rc = rc_with(
+            &[Path::new("/work/repo-foo/.bazelrc")],
+            &[("common", 0, "--jobs=4")],
+        );
+        let out = rc.announce("build", false, 200, root, None, |s| s.to_string());
+        assert!(out.contains("/work/repo-foo/.bazelrc"), "{out}");
+        assert!(!out.contains("./"), "string-prefix must not anchor: {out}");
+    }
+
+    #[test]
+    fn announce_anchor_prefers_root_when_root_under_home() {
+        // root is itself under home; an rc under root must anchor to the more
+        // specific `./`, not `~/repo/…` (root is checked first).
+        let home = Path::new("/home/dev");
+        let root = Path::new("/home/dev/repo");
+        let rc = rc_with(&[&root.join(".bazelrc")], &[("common", 0, "--jobs=4")]);
+        let out = rc.announce("build", false, 200, root, Some(home), |s| s.to_string());
+        assert!(out.contains("./.bazelrc"), "{out}");
+        assert!(
+            !out.contains("~/repo"),
+            "root anchor must win over home: {out}"
+        );
+    }
+
+    #[test]
+    fn announce_redacts_flag_values() {
+        let root = Path::new("/work/repo");
+        let rc = rc_with(
+            &[&root.join(".bazelrc")],
+            &[("common", 0, "--remote_header=Authorization: Bearer s3cr3t")],
+        );
+        // Redactor that drops everything after the first '=' for env/header-like flags.
+        let redact = |flag: &str| -> String {
+            match flag.split_once('=') {
+                Some((name, _)) => format!("{name}=<REDACTED>"),
+                None => flag.to_string(),
+            }
+        };
+        let out = rc.announce("build", false, 200, root, None, redact);
+        assert!(out.contains("--remote_header=<REDACTED>"), "{out}");
+        assert!(!out.contains("s3cr3t"), "secret leaked: {out}");
     }
 
     // ── Config expansion ─────────────────────────────────────────────────────


### PR DESCRIPTION
Improves pre-task / bazel-spawn diagnostics and unifies the pre-task lifecycle.

## 1. Announce the Bazel version and command on each spawn

Before each `bazel build`/`test`/`run` spawn, optionally print the detected Bazel version and the exact command line. The existing `--announce-rc` is renamed to `--announce-bazel-rc` so the three form one family, all `"auto" | "true" | "false"` defaulting to `auto` (shown on CI, quiet locally):

| Flag | Prints | Default |
|---|---|---|
| `--announce-bazel-rc` | resolved `.bazelrc` flags (was `--announce-rc`) | `auto` |
| `--announce-bazel-version` | `INFO: Bazel <version>` | `auto` |
| `--announce-bazel-command` | `INFO: Spawning: <command>` | `auto` |

- `auto` → on when a CI host is detected, off locally; `true`/`false` force it.
- The command and the rc disclosure are scrubbed through the existing redaction (`stream::redaction`): env-var values, request headers (header name kept, value hidden), and URL credentials become `<REDACTED>`.
- `--announce-bazel-rc` displays each rc source path relative to the most meaningful anchor: `./` under the workspace root, `~/` under `$HOME`, else absolute.
- A non-release Bazel prints `Bazel development version (version-conditional flags assume latest)`.
- The three flags are declared once by a shared `announce_bazel_args` helper that each Bazel-spawning task splats into its args.

## 2. Unify the pre-task lifecycle into one `setup` phase

`setup_phase` and `preflight_phase` are collapsed into a single `setup_phase` that every task opens with, locally and on CI, passing its result `kind` + `data`: append runner-job-history, open the `🔧 Setup` phase mark (the task's first `task_update` — it inits the status surfaces **and** renders their first body from `kind`/`data`), parse the `.bazelrc` + resolve flags (when given a `BazelTrait`), then run the `health_check` hooks. Bazel work is gated on the `BazelTrait` argument so a non-Bazel task can use the same phase.

`HealthCheckTrait` is also collapsed to a single `health_check` hook (was `pre_health_check` + `post_health_check`). A hook reporting an unhealthy environment now **fails the task** from inside `setup_phase`: it concludes the status surface (terminal "Health check failed") then aborts with the hook's detailed reason. Previously an unhealthy Bazel server signaled the runner but let the task proceed — a latent bug this fixes.

## 3. Collapse the lifecycle to a single `task_update` hook

`TaskLifecycleTrait` had three hooks — `task_started`, `task_update`, `task_complete`. `task_complete` had no subscribers (dead), and `task_started` only ever did one-time surface init. Both are removed, leaving **one** hook:

- A handler's **first** `task_update` is its cue to initialize (authenticate, create the GitHub check run / first Buildkite annotation). The first update is the `🔧 Setup` phase mark from `setup_phase`, which also renders the first surface body.
- The **last** update carries `final = True`; handlers conclude their surface there.
- The task subject (target patterns / formatter target / …) rides on the `TaskUpdate` (new `subject` field, named `subject` end-to-end). `setup_phase` sets it on the first update; a later update may refine it (e.g. `delivery` emits its resolved targets once a query resolves). Handlers latch the last non-empty value, so the surface title updates in place. An empty subject renders empty (no `//...` placeholder); the per-task `summary_title` helpers share one `truncate_for_title` so a long target list is capped identically.

This removes the ordering constraint between the (now gone) `task_started` and the first `task_update`. It also drops the startup `GET /rate_limit` probe: the first status-check API response already seeds the same App-bucket quota state, the first call is never throttle-gated, and the cold-start floor makes a zero- vs one-observation buffer identical — so the probe only cost a startup round-trip.

## 4. Timing-breakdown alignment

Pad the phase label column by display width (emoji = 2 cells) instead of codepoint count, and use a single-astral setup emoji (`🔧`) that renders two cells like the other phase emoji.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

### Suggested release notes

- Renamed `--announce-rc` to `--announce-bazel-rc`; added `--announce-bazel-version` and `--announce-bazel-command`. All three default to `auto` (shown on CI, quiet locally). The command and rc disclosures redact secrets and shorten rc paths.
- The separate "Pre-flight" task phase is merged into "Setup"; all pre-task work now reports under one phase, shown locally and on CI.
- A failed Bazel server health check now fails the task (and reports "Health check failed" on the status surface) instead of letting it proceed.

### Test plan

- Rust: `engine::bazel` build (19) + redaction (26), `bazelrc` (83, incl. path-anchor edge cases), `eval::multi_phase` (2), `task_info`.
- AXL: full `aspect tests axl`; template-snapshot dev tests (bazel-results, lint, format, gazelle, delivery — incl. a long-subject title-capping assertion, bk-annotation — incl. an empty-subject scenario); `test-bazel-flags` (incl. `announce_bazel_args`), `test-health-check-ready` (incl. `run_health_checks` first-error-wins), `test-rate-limit`, `test-github-detect`.
- Manual: local `aspect <task>` drives `setup_phase` → first `task_update` → terminal; `🔧 Setup` row aligns with `🔨 Build`; `--announce-bazel-version=true` prints the version line; an injected unhealthy `health_check` hook makes setup_phase render a "Health check failed" terminal and fail the task with the detailed reason.
- CI
