### PR TITLE
fix(cli): show Fix commands before Reproduce commands on all surfaces

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -168,9 +168,9 @@ _No tasks have reported yet._
 > {{ tip.silence_hint }}{% endif %}
 
 {% endfor %}{% endif -%}
-{% if repro_rows %}
-## 🔁 Reproduce
-{% for r in repro_rows %}{% if r.show_heading %}
+{% if fix_rows %}
+## 🛠️ Fix
+{% for r in fix_rows %}{% if r.show_heading %}
 #### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_keys %} ({{ r.task_keys|join(" · ") }}){% endif %}{% endif %}
 ```
 {% if r.description %}# {{ r.description }}
@@ -179,9 +179,9 @@ _No tasks have reported yet._
 {% endfor %}
 """ + ASPECT_CLI_INSTALL_HINT_MARKDOWN + """
 {% endif -%}
-{% if fix_rows %}
-## 🛠️ Fix
-{% for r in fix_rows %}{% if r.show_heading %}
+{% if repro_rows %}
+## 🔁 Reproduce
+{% for r in repro_rows %}{% if r.show_heading %}
 #### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_keys %} ({{ r.task_keys|join(" · ") }}){% endif %}{% endif %}
 ```
 {% if r.description %}# {{ r.description }}

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -3251,7 +3251,7 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 
 {% endif %}
 {% endif %}
-{% if render_repro_in_targets %}""" + REPRO_COMMANDS_BLOCK + FIX_COMMANDS_BLOCK + """{% endif %}
+{% if render_repro_in_targets %}""" + FIX_COMMANDS_BLOCK + REPRO_COMMANDS_BLOCK + """{% endif %}
 """
 
 # `SHARED_DETAILS_BODY_TEMPLATE` is the section block every task

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
@@ -251,7 +251,7 @@ _… {{ group.overflow }} more {{ group.label_singular }} not shown._
 {% endif %}
 </details>
 {% endfor %}{% endif %}
-""" + REPRO_COMMANDS_BLOCK + FIX_COMMANDS_BLOCK + SHARED_DETAILS_BODY_TEMPLATE
+""" + FIX_COMMANDS_BLOCK + REPRO_COMMANDS_BLOCK + SHARED_DETAILS_BODY_TEMPLATE
 
 # ─── Details body ─────────────────────────────────────────────────────────────
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
@@ -305,7 +305,7 @@ _… {{ group.overflow }} more {{ group.label_singular }} not shown._
 {{ linters_chart }}
 </pre>
 {% endif %}
-""" + REPRO_COMMANDS_BLOCK + FIX_COMMANDS_BLOCK + SHARED_DETAILS_BODY_TEMPLATE
+""" + FIX_COMMANDS_BLOCK + REPRO_COMMANDS_BLOCK + SHARED_DETAILS_BODY_TEMPLATE
 
 def _truncate(s, max_len):
     if len(s) <= max_len:

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
@@ -661,9 +661,30 @@ def _test_impl(ctx):
     # any failure surfaces with the renderer scenarios already validated.
     _annotation_scenarios(ctx)
 
+    _check_fix_renders_before_reproduce(ctx)
+
     print(sep)
     print("All " + str(len(scenarios)) + " lint scenarios + annotation pipeline rendered without error.")
     return 0
+
+def _check_fix_renders_before_reproduce(ctx):
+    """The Fix block renders before the Reproduce block in the details body.
+
+    lint is the canonical kind carrying both: a `--fix` command (Fix) and the
+    rerun command (Reproduce). The fix — the actionable command — must lead."""
+    data = _make_results_mixed()
+    data["fix_commands"] = [{"command": "aspect lint --fix //...", "description": ""}]
+    data["repro_commands"] = [{"command": "aspect lint //...", "description": ""}]
+    out = render_check_output(ctx, data, "failed", _render_ctx(), _links())
+    body = out["text"]
+    fix_at = body.find("### 🛠️ Fix")
+    repro_at = body.find("### 🔁 Reproduce")
+    if fix_at < 0:
+        fail("Fix block missing from rendered body: %r" % body[:400])
+    if repro_at < 0:
+        fail("Reproduce block missing from rendered body: %r" % body[:400])
+    if fix_at > repro_at:
+        fail("Fix block must render before Reproduce (fix@%d, repro@%d)" % (fix_at, repro_at))
 
 lint_template_snapshot_tests = task(
     name = "test-lint-template-snapshots",

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -413,12 +413,13 @@ def repro_prefix(ctx):
 # ── CLI rendering ─────────────────────────────────────────────────────
 
 def print_repro_and_fix(std, data, status):
-    """Print the `data["repro_commands"]` and `data["fix_commands"]`
+    """Print the `data["fix_commands"]` and `data["repro_commands"]`
     blocks to the CLI as a plain-text counterpart to the
-    `### 🔁 Reproduce` / `### 🛠️ Fix` Markdown sections that render on
-    status surfaces. Mirrors the same content so a developer reading
-    the raw CI log can copy the actionable command without opening
-    the status surface.
+    `### 🛠️ Fix` / `### 🔁 Reproduce` Markdown sections that render on
+    status surfaces. Fix leads, Reproduce follows (matching the
+    surfaces). Mirrors the same content so a developer reading the raw
+    CI log can copy the actionable command without opening the status
+    surface.
 
     Two independent gates, matching the status-surface behavior:
 
@@ -448,17 +449,19 @@ def print_repro_and_fix(std, data, status):
     if not fixes and (not on_ci or not repros):
         return
 
-    if on_ci and repros:
-        print("")
-        print(_repro_header(ansi, "🔁 Reproduce:"))
-        for i, entry in enumerate(repros):
-            if i > 0:
-                print("")
-            _print_repro_entry(ansi, entry)
+    # Fix before Reproduce: the actionable command (what to run to fix it)
+    # leads; the reproduce command (how CI ran it) follows.
     if fixes:
         print("")
         print(_repro_header(ansi, "🛠️ Fix:"))
         for i, entry in enumerate(fixes):
+            if i > 0:
+                print("")
+            _print_repro_entry(ansi, entry)
+    if on_ci and repros:
+        print("")
+        print(_repro_header(ansi, "🔁 Reproduce:"))
+        for i, entry in enumerate(repros):
             if i > 0:
                 print("")
             _print_repro_entry(ansi, entry)


### PR DESCRIPTION
Show the **Fix** command before the **Reproduce** command on every surface.

When a task surfaces both kinds of copy-pasteable command blocks, the actionable Fix command (what to run to resolve the failure — `aspect lint --fix`, `aspect format`, etc.) should lead, and the Reproduce command (how CI ran the task) should follow. Previously the relative order was decided in several independent places and was inconsistent: build/test, lint, and delivery rendered Reproduce-then-Fix, while format and gazelle already led with Fix.

This makes the order uniform (Fix → Reproduce) across:
- the CLI terminal output (`print_repro_and_fix`),
- the GitHub status-check run body and Buildkite annotation (the per-kind details templates — build/test, lint, delivery swapped; format/gazelle already Fix-first),
- the rolled-up GitHub PR comment (the aggregator template).

format and gazelle already rendered the Fix block before the Reproduce block (Fix sits mid-body, Reproduce at the end); their relative order already satisfied the requirement, so they're unchanged.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- On task failures, the "Fix" command now appears before the "Reproduce" command on the CLI, GitHub status checks, Buildkite annotations, and PR comments.

### Test plan

- New test cases added: `lint_results_test.axl` asserts the Fix block renders before the Reproduce block in the details body (verified the assertion fails if the order is flipped back).
- Covered by existing test cases: full `aspect tests axl` + the template-snapshot dev tests (bazel-results, lint, format, gazelle, delivery, bk-annotation, pr-comment) render without error; the PR-comment snapshot shows `## 🛠️ Fix` before `## 🔁 Reproduce`.
