### PR TITLE
refactor(runnable): rename ASPECT_CLI_* spawn env vars to ASPECT_*

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -214,7 +214,7 @@ def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture
     """Spawn `ep.path` with `args` in the Bazel runfiles environment.
 
     Always sets BUILD_WORKSPACE_DIRECTORY / BUILD_WORKING_DIRECTORY so tool
-    wrappers can locate the workspace, and the four ASPECT_CLI_* variables for
+    wrappers can locate the workspace, and the four ASPECT_* variables for
     tools that prefer aspect-native conventions.
 
     When `ep.runfiles_dir` is set, also injects RUNFILES_DIR /
@@ -234,10 +234,10 @@ def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture
         .current_dir(effective_cwd) \
         .env("BUILD_WORKSPACE_DIRECTORY", ctx.std.env.bazel_root_dir()) \
         .env("BUILD_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
-        .env("ASPECT_CLI_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
-        .env("ASPECT_CLI_ASPECT_ROOT_DIRECTORY", ctx.std.env.aspect_root_dir()) \
-        .env("ASPECT_CLI_BAZEL_ROOT_DIRECTORY", ctx.std.env.bazel_root_dir()) \
-        .env("ASPECT_CLI_GIT_ROOT_DIRECTORY", ctx.std.env.git_root_dir() or "") \
+        .env("ASPECT_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
+        .env("ASPECT_ROOT_DIRECTORY", ctx.std.env.aspect_root_dir()) \
+        .env("ASPECT_BAZEL_ROOT_DIRECTORY", ctx.std.env.bazel_root_dir()) \
+        .env("ASPECT_GIT_ROOT_DIRECTORY", ctx.std.env.git_root_dir() or "") \
         .args(args)
     if ep.runfiles_dir:
         cmd = cmd \


### PR DESCRIPTION
The four aspect-native env vars `_spawn` injects into spawned subprocesses (`ASPECT_CLI_WORKING_DIRECTORY` / `ASPECT_CLI_ASPECT_ROOT_DIRECTORY` / `ASPECT_CLI_BAZEL_ROOT_DIRECTORY` / `ASPECT_CLI_GIT_ROOT_DIRECTORY`) carried a redundant `CLI_` infix — every aspect-spawned process is by definition spawned by the CLI, so the prefix added no information. Drop the infix:

| before                              | after                          |
|-------------------------------------|--------------------------------|
| `ASPECT_CLI_WORKING_DIRECTORY`      | `ASPECT_WORKING_DIRECTORY`     |
| `ASPECT_CLI_ASPECT_ROOT_DIRECTORY`  | `ASPECT_ROOT_DIRECTORY`        |
| `ASPECT_CLI_BAZEL_ROOT_DIRECTORY`   | `ASPECT_BAZEL_ROOT_DIRECTORY`  |
| `ASPECT_CLI_GIT_ROOT_DIRECTORY`     | `ASPECT_GIT_ROOT_DIRECTORY`    |

No internal consumers read these by name (grep of the source tree turns up only the four set-sites in `lib/runnable.axl`), so the rename is fully contained.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes — external tools reading the old `ASPECT_CLI_*` env vars must rename
- Suggested release notes appear below: yes

### Suggested release notes

- The four `ASPECT_CLI_*` environment variables that aspect-cli sets on every spawned subprocess (`*_WORKING_DIRECTORY`, `*_ASPECT_ROOT_DIRECTORY`, `*_BAZEL_ROOT_DIRECTORY`, `*_GIT_ROOT_DIRECTORY`) are renamed to `ASPECT_*` (drop the redundant `CLI_` infix). Tools that read these variables must rename.

### Test plan

- `cargo check` clean.
- `aspect dev test-runnable` — 40/40 pass.
