### PR TITLE
feat(format): add formatter_args_for_tree_walk

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -8,6 +8,7 @@ load("@aspect//lib/bazel_flags_test.axl", "bazel_flags_tests")
 load("@aspect//lib/bazel_results_test.axl", "bazel_results_unit_tests", "template_snapshot_tests")
 load("@aspect//lib/delivery_results_test.axl", "delivery_template_snapshot_tests")
 load("@aspect//lib/format_results_test.axl", "format_template_snapshot_tests")
+load("@aspect//lib/format_spawn_test.axl", "format_spawn_tests")
 load("@aspect//lib/gazelle_results_test.axl", "gazelle_template_snapshot_tests")
 load("@aspect//lib/github_detect_test.axl", "github_detect_tests")
 load("@aspect//lib/gitlab_detect_test.axl", "gitlab_detect_tests")
@@ -187,6 +188,10 @@ def config(ctx: ConfigContext):
     # Format template snapshot tests — renders format_results templates.
     # Run with: aspect dev test-format-template-snapshots
     ctx.tasks.add(format_template_snapshot_tests)
+
+    # Format spawn-args + tree-walk-hint unit tests.
+    # Run with: aspect dev test-format-spawn
+    ctx.tasks.add(format_spawn_tests)
 
     # Gazelle template snapshot tests — renders gazelle_results templates.
     # Run with: aspect dev test-gazelle-template-snapshots

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -569,8 +569,18 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # `formatter_args` are extra args always passed to the formatter binary —
     # an alias-level knob for formatter-specific flags (e.g. `--check=false`).
-    # Order: formatter args first, then the discovered file list.
+    # `formatter_args_for_scope_all` is appended only when the spawn would
+    # otherwise pass zero positional files (typically `--scope=all`): designed
+    # for bare binaries that need an explicit tree-walk flag like buildifier's
+    # `-r .`. Gating on `not format_args` keeps the flag inert in
+    # `--scope=changed` and explicit-file modes so it can't turn a per-file
+    # invocation into a whole-tree rewrite.
+    # Order: formatter args first, then the (possibly empty) discovered file
+    # list. Scope-all extras come after the file list so they sit where a
+    # user-typed `-r .` would naturally land relative to file paths.
     spawn_args = list(ctx.args.formatter_args) + format_args
+    if not format_args:
+        spawn_args = spawn_args + list(ctx.args.formatter_args_for_scope_all)
     exit = r.spawn(ep, spawn_args, cwd = spawn_cwd).wait()
 
     if not exit.success:
@@ -624,6 +634,32 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         else:
             scope_text = ""
         print("No files%s were modified." % scope_text)
+
+        # `--scope=all` passes no positionals; the formatter is expected to
+        # walk the tree itself. Bare binaries (e.g. buildifier) exit 0 having
+        # done nothing in that case, which the diff phase then reports as
+        # "all files are properly formatted" — misleading when the tree
+        # actually has formatting issues. The `run_in_cwd=True + empty
+        # formatter_args_for_scope_all` combination is the strong signal:
+        # users only set `run_in_cwd` for bare binaries, and an empty
+        # `formatter_args_for_scope_all` means no tree-walk flag was supplied
+        # for the scope-all path. Recommend the scope-all-only knob so the
+        # `--scope=changed` path stays unaffected.
+        if (
+            ctx.args.scope == "all" and
+            not explicit_files and
+            ctx.args.run_in_cwd and
+            not ctx.args.formatter_args_for_scope_all
+        ):
+            info(ctx.std, (
+                "Formatter ran in `--scope=all` mode with no positional files. Bare formatter " +
+                "binaries (e.g. `@buildifier_prebuilt//buildifier`) exit silently in this case. " +
+                "Set `formatter_args_for_scope_all` in your alias to the formatter's tree-walk " +
+                "flag (e.g. `[\"-r\", \".\"]` for buildifier); the flag fires only when no " +
+                "positional files are passed, so `--scope=changed` keeps working unchanged. " +
+                "Alternatively, wrap the binary in a `format_multirun` target from rules_lint, " +
+                "which walks the tree itself."
+            ))
         return _emit_final(ctx, lifecycle, data, 0)
 
     # Pattern filters hide files from the user-facing affected list and the
@@ -745,7 +781,11 @@ format = task(
         ),
         "formatter_args": args.string_list(
             long = "formatter-arg",
-            description = "Extra positional arguments forwarded to the formatter binary on every invocation, before the file list. Set this in a format alias's `defaults` to encode formatter-specific flags (e.g. `--check=false`, language toggles). Threaded through both the aspect-task spawn (`<formatter_target> <formatter_args> <files>`) and the vanilla-bazel alternate fix command (`bazel run <formatter_target> -- <formatter_args> <files>`).",
+            description = "Extra positional arguments forwarded to the formatter binary on every invocation, before the file list. Set this in a format alias's `defaults` to encode formatter-specific flags (e.g. `--check=false`, language toggles). Threaded through both the aspect-task spawn (`<formatter_target> <formatter_args> <files>`) and the vanilla-bazel alternate fix command (`bazel run <formatter_target> -- <formatter_args> <files>`). For tree-walk flags that should fire only in `--scope=all` (e.g. buildifier's `-r .`), use `formatter_args_for_scope_all` instead — args set here also fire in `--scope=changed` mode and would reformat the whole tree instead of the file list.",
+        ),
+        "formatter_args_for_scope_all": args.string_list(
+            long = "formatter-arg-for-scope-all",
+            description = "Extra positional arguments appended to the formatter binary's argv only when the spawn would otherwise pass zero positional files — i.e. when `--scope=all` is in effect, no positional `files` were supplied, and change-detection did not produce a file list. Designed for bare formatter binaries that need an explicit tree-walk flag to do anything useful in scope-all mode. Example: `formatter_args_for_scope_all = [\"-r\", \".\"]` for `@buildifier_prebuilt//buildifier`. Has no effect in `--scope=changed` (the default) or when positional files are supplied, so it cannot accidentally turn a per-file invocation into a whole-tree rewrite. Wrapper targets like `format_multirun` from rules_lint walk on their own and don't need this.",
         ),
         "bazel_flags": args.string_list(
             long = "bazel-flag",

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -23,6 +23,7 @@ load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS"
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("./lib/format_results.axl", fmt_init_data = "init_data", format_conclusion = "conclusion")
+load("./lib/format_spawn.axl", "compute_spawn_args")
 load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
@@ -181,11 +182,9 @@ _DETECTION_PAIRS = [
     ("exclude_patterns", "--exclude-pattern"),
     ("include_patterns", "--include-pattern"),
     ("merge_base", "--merge-base"),
-    # Preserve user-passed formatter args in the repro and re-discovery
-    # fix commands. Without these, an explicit
-    # `--formatter-arg-for-tree-walk=-r --formatter-arg-for-tree-walk=.`
-    # invocation would render a repro stripped of the tree-walk flags
-    # that silently no-ops against a bare buildifier — false clean.
+    # Explicit formatter args survive into the Reproduce command and the
+    # re-discovery fallback Fix command so a CLI-passed tree-walk flag
+    # isn't lost when CI surfaces a failure.
     ("formatter_args", "--formatter-arg"),
     ("formatter_args_for_tree_walk", "--formatter-arg-for-tree-walk"),
 ]
@@ -574,21 +573,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     spawn_cwd = ctx.std.env.current_dir() if ctx.args.run_in_cwd else None
 
-    # `formatter_args` are extra args always passed to the formatter binary —
-    # an alias-level knob for formatter-specific flags (e.g. `--check=false`).
-    # `formatter_args_for_tree_walk` is appended only when zero positional
-    # files would reach the formatter: designed for bare binaries that need
-    # an explicit tree-walk flag like buildifier's `-r .` to do anything
-    # useful when the task delegates discovery to them. Gating on
-    # `not format_args` keeps the flag inert as soon as any file is passed
-    # (`--scope=changed` with detected files, or explicit positional files),
-    # so it can't turn a per-file invocation into a whole-tree rewrite.
-    # Order: formatter args first, then the (possibly empty) discovered file
-    # list, then any tree-walk extras after — where a user-typed `-r .` would
-    # naturally land relative to file paths.
-    spawn_args = list(ctx.args.formatter_args) + format_args
-    if not format_args:
-        spawn_args = spawn_args + list(ctx.args.formatter_args_for_tree_walk)
+    spawn_args = compute_spawn_args(
+        ctx.args.formatter_args,
+        format_args,
+        ctx.args.formatter_args_for_tree_walk,
+    )
     exit = r.spawn(ep, spawn_args, cwd = spawn_cwd).wait()
 
     if not exit.success:
@@ -642,34 +631,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         else:
             scope_text = ""
         print("No files%s were modified." % scope_text)
-
-        # When zero positional files reached the formatter, it was expected
-        # to walk the tree itself. Bare binaries (e.g. buildifier) exit 0
-        # having done nothing in that case, which the diff phase then reports
-        # as "all files are properly formatted" — misleading when the tree
-        # actually has formatting issues. The `run_in_cwd=True + empty
-        # formatter_args_for_tree_walk` combination is the strong signal:
-        # users only set `run_in_cwd` for bare binaries, and an empty
-        # `formatter_args_for_tree_walk` means no tree-walk flag was supplied
-        # for the no-file-list spawn. `not format_args` matches both
-        # `--scope=all` and `--scope=changed` runs that degraded to scope-all
-        # because change-detection returned no matches.
-        if (
-            not format_args and
-            not explicit_files and
-            ctx.args.run_in_cwd and
-            not ctx.args.formatter_args_for_tree_walk
-        ):
-            info(ctx.std, (
-                "Formatter received no positional files and is expected to walk the tree " +
-                "itself, but no `formatter_args_for_tree_walk` is configured. Bare formatter " +
-                "binaries (e.g. `@buildifier_prebuilt//buildifier`) exit silently in this " +
-                "case. Set `formatter_args_for_tree_walk` in your alias to the formatter's " +
-                "tree-walk flag (e.g. `[\"-r\", \".\"]` for buildifier); the flag fires only " +
-                "when no positional files reach the formatter, so `--scope=changed` keeps " +
-                "working unchanged. Alternatively, wrap the binary in a `format_multirun` " +
-                "target from rules_lint, which walks the tree itself."
-            ))
         return _emit_final(ctx, lifecycle, data, 0)
 
     # Pattern filters hide files from the user-facing affected list and the

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -181,6 +181,13 @@ _DETECTION_PAIRS = [
     ("exclude_patterns", "--exclude-pattern"),
     ("include_patterns", "--include-pattern"),
     ("merge_base", "--merge-base"),
+    # Preserve user-passed formatter args in the repro and re-discovery
+    # fix commands. Without these, an explicit
+    # `--formatter-arg-for-tree-walk=-r --formatter-arg-for-tree-walk=.`
+    # invocation would render a repro stripped of the tree-walk flags
+    # that silently no-ops against a bare buildifier — false clean.
+    ("formatter_args", "--formatter-arg"),
+    ("formatter_args_for_tree_walk", "--formatter-arg-for-tree-walk"),
 ]
 
 def _surfaced_base_ref_flag(ctx):
@@ -569,18 +576,19 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # `formatter_args` are extra args always passed to the formatter binary —
     # an alias-level knob for formatter-specific flags (e.g. `--check=false`).
-    # `formatter_args_for_scope_all` is appended only when the spawn would
-    # otherwise pass zero positional files (typically `--scope=all`): designed
-    # for bare binaries that need an explicit tree-walk flag like buildifier's
-    # `-r .`. Gating on `not format_args` keeps the flag inert in
-    # `--scope=changed` and explicit-file modes so it can't turn a per-file
-    # invocation into a whole-tree rewrite.
+    # `formatter_args_for_tree_walk` is appended only when zero positional
+    # files would reach the formatter: designed for bare binaries that need
+    # an explicit tree-walk flag like buildifier's `-r .` to do anything
+    # useful when the task delegates discovery to them. Gating on
+    # `not format_args` keeps the flag inert as soon as any file is passed
+    # (`--scope=changed` with detected files, or explicit positional files),
+    # so it can't turn a per-file invocation into a whole-tree rewrite.
     # Order: formatter args first, then the (possibly empty) discovered file
-    # list. Scope-all extras come after the file list so they sit where a
-    # user-typed `-r .` would naturally land relative to file paths.
+    # list, then any tree-walk extras after — where a user-typed `-r .` would
+    # naturally land relative to file paths.
     spawn_args = list(ctx.args.formatter_args) + format_args
     if not format_args:
-        spawn_args = spawn_args + list(ctx.args.formatter_args_for_scope_all)
+        spawn_args = spawn_args + list(ctx.args.formatter_args_for_tree_walk)
     exit = r.spawn(ep, spawn_args, cwd = spawn_cwd).wait()
 
     if not exit.success:
@@ -635,30 +643,32 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             scope_text = ""
         print("No files%s were modified." % scope_text)
 
-        # `--scope=all` passes no positionals; the formatter is expected to
-        # walk the tree itself. Bare binaries (e.g. buildifier) exit 0 having
-        # done nothing in that case, which the diff phase then reports as
-        # "all files are properly formatted" — misleading when the tree
+        # When zero positional files reached the formatter, it was expected
+        # to walk the tree itself. Bare binaries (e.g. buildifier) exit 0
+        # having done nothing in that case, which the diff phase then reports
+        # as "all files are properly formatted" — misleading when the tree
         # actually has formatting issues. The `run_in_cwd=True + empty
-        # formatter_args_for_scope_all` combination is the strong signal:
+        # formatter_args_for_tree_walk` combination is the strong signal:
         # users only set `run_in_cwd` for bare binaries, and an empty
-        # `formatter_args_for_scope_all` means no tree-walk flag was supplied
-        # for the scope-all path. Recommend the scope-all-only knob so the
-        # `--scope=changed` path stays unaffected.
+        # `formatter_args_for_tree_walk` means no tree-walk flag was supplied
+        # for the no-file-list spawn. `not format_args` matches both
+        # `--scope=all` and `--scope=changed` runs that degraded to scope-all
+        # because change-detection returned no matches.
         if (
-            ctx.args.scope == "all" and
+            not format_args and
             not explicit_files and
             ctx.args.run_in_cwd and
-            not ctx.args.formatter_args_for_scope_all
+            not ctx.args.formatter_args_for_tree_walk
         ):
             info(ctx.std, (
-                "Formatter ran in `--scope=all` mode with no positional files. Bare formatter " +
-                "binaries (e.g. `@buildifier_prebuilt//buildifier`) exit silently in this case. " +
-                "Set `formatter_args_for_scope_all` in your alias to the formatter's tree-walk " +
-                "flag (e.g. `[\"-r\", \".\"]` for buildifier); the flag fires only when no " +
-                "positional files are passed, so `--scope=changed` keeps working unchanged. " +
-                "Alternatively, wrap the binary in a `format_multirun` target from rules_lint, " +
-                "which walks the tree itself."
+                "Formatter received no positional files and is expected to walk the tree " +
+                "itself, but no `formatter_args_for_tree_walk` is configured. Bare formatter " +
+                "binaries (e.g. `@buildifier_prebuilt//buildifier`) exit silently in this " +
+                "case. Set `formatter_args_for_tree_walk` in your alias to the formatter's " +
+                "tree-walk flag (e.g. `[\"-r\", \".\"]` for buildifier); the flag fires only " +
+                "when no positional files reach the formatter, so `--scope=changed` keeps " +
+                "working unchanged. Alternatively, wrap the binary in a `format_multirun` " +
+                "target from rules_lint, which walks the tree itself."
             ))
         return _emit_final(ctx, lifecycle, data, 0)
 
@@ -781,11 +791,11 @@ format = task(
         ),
         "formatter_args": args.string_list(
             long = "formatter-arg",
-            description = "Extra positional arguments forwarded to the formatter binary on every invocation, before the file list. Set this in a format alias's `defaults` to encode formatter-specific flags (e.g. `--check=false`, language toggles). Threaded through both the aspect-task spawn (`<formatter_target> <formatter_args> <files>`) and the vanilla-bazel alternate fix command (`bazel run <formatter_target> -- <formatter_args> <files>`). For tree-walk flags that should fire only in `--scope=all` (e.g. buildifier's `-r .`), use `formatter_args_for_scope_all` instead — args set here also fire in `--scope=changed` mode and would reformat the whole tree instead of the file list.",
+            description = "Extra positional arguments forwarded to the formatter binary on every invocation, before the file list. Set this in a format alias's `defaults` to encode formatter-specific flags (e.g. `--check=false`, language toggles). Threaded through both the aspect-task spawn (`<formatter_target> <formatter_args> <files>`) and the vanilla-bazel alternate fix command (`bazel run <formatter_target> -- <formatter_args> <files>`). For tree-walk flags (e.g. buildifier's `-r .`) that should fire only when no positional files are passed to the formatter, use `formatter_args_for_tree_walk` instead — args set here always fire and would turn a per-file invocation into a whole-tree rewrite.",
         ),
-        "formatter_args_for_scope_all": args.string_list(
-            long = "formatter-arg-for-scope-all",
-            description = "Extra positional arguments appended to the formatter binary's argv only when the spawn would otherwise pass zero positional files — i.e. when `--scope=all` is in effect, no positional `files` were supplied, and change-detection did not produce a file list. Designed for bare formatter binaries that need an explicit tree-walk flag to do anything useful in scope-all mode. Example: `formatter_args_for_scope_all = [\"-r\", \".\"]` for `@buildifier_prebuilt//buildifier`. Has no effect in `--scope=changed` (the default) or when positional files are supplied, so it cannot accidentally turn a per-file invocation into a whole-tree rewrite. Wrapper targets like `format_multirun` from rules_lint walk on their own and don't need this.",
+        "formatter_args_for_tree_walk": args.string_list(
+            long = "formatter-arg-for-tree-walk",
+            description = "Extra positional arguments appended to the formatter binary's argv only when no positional files would otherwise reach it — i.e. when `aspect format` is invoked without explicit file args AND change-detection produced no file list (typically `--scope=all`, but also `--scope=changed` runs where the change-detection source returned no matches or degraded to scope-all). Appended after the (empty) file list and after `formatter_args`. Designed for bare formatter binaries that need an explicit tree-walk flag to do anything useful when the task delegates discovery to them. Example: `formatter_args_for_tree_walk = [\"-r\", \".\"]` for `@buildifier_prebuilt//buildifier`. Has no effect when the formatter receives at least one file (positionally or via `--scope=changed`), so it cannot accidentally turn a per-file invocation into a whole-tree rewrite. Wrapper targets like `format_multirun` from rules_lint walk on their own and don't need this.",
         ),
         "bazel_flags": args.string_list(
             long = "bazel-flag",

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_spawn.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_spawn.axl
@@ -1,0 +1,29 @@
+"""Pure helpers for the format task's formatter binary spawn.
+
+Extracted from `format.axl` so the spawn-argv composition and the
+tree-walk hint condition can be unit-tested without standing up the
+full task lifecycle. Both helpers are total functions over their
+inputs — no I/O, no ctx access — so the tests in
+`lib/format_spawn_test.axl` cover every code path directly.
+"""
+
+def compute_spawn_args(formatter_args, format_args, tree_walk_args):
+    """Compose the formatter binary's argv.
+
+    `formatter_args` always fire — the alias-level knob for formatter
+    flags like `--check=false` or language toggles. `format_args` is
+    the file list the task discovered (positional, possibly empty).
+    `tree_walk_args` is appended only when `format_args` is empty —
+    designed for bare binaries like buildifier that need an explicit
+    `-r .` to walk the tree on their own. Gating on the file list
+    keeps tree-walk flags from leaking into per-file invocations and
+    turning them into whole-tree rewrites.
+
+    Order: formatter args, then file list, then tree-walk extras —
+    matching where a user-typed `-r .` would naturally land relative
+    to file paths.
+    """
+    out = list(formatter_args) + list(format_args)
+    if not format_args:
+        out = out + list(tree_walk_args)
+    return out

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_spawn_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_spawn_test.axl
@@ -1,0 +1,78 @@
+"""Unit tests for `lib/format_spawn.axl`."""
+
+load("./format_spawn.axl", "compute_spawn_args")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+# ─── compute_spawn_args ──────────────────────────────────────────────────────
+#
+# Files always win over tree-walk args, and formatter_args always lead.
+
+def _test_files_present_emits_formatter_args_then_files(_ctx):
+    _eq(
+        "files present → formatter_args + file list",
+        compute_spawn_args(["--check=false"], ["a.bzl", "b.bzl"], ["-r", "."]),
+        ["--check=false", "a.bzl", "b.bzl"],
+    )
+
+def _test_files_present_ignores_tree_walk_args(_ctx):
+    # Guards against the bug fixed by `formatter_args_for_tree_walk`: if
+    # `-r .` leaked into a per-file invocation, buildifier would walk the
+    # whole tree instead of formatting the listed file.
+    _eq(
+        "single file + tree-walk args set → tree-walk args inert",
+        compute_spawn_args([], ["BUILD.bazel"], ["-r", "."]),
+        ["BUILD.bazel"],
+    )
+
+def _test_no_files_appends_tree_walk_args(_ctx):
+    _eq(
+        "no files → formatter_args + tree_walk_args",
+        compute_spawn_args(["--check=false"], [], ["-r", "."]),
+        ["--check=false", "-r", "."],
+    )
+
+def _test_no_files_no_tree_walk_yields_only_formatter_args(_ctx):
+    _eq(
+        "no files, no tree walk → just formatter_args",
+        compute_spawn_args(["--check=false"], [], []),
+        ["--check=false"],
+    )
+
+def _test_all_empty_yields_empty(_ctx):
+    _eq(
+        "all empty → empty argv",
+        compute_spawn_args([], [], []),
+        [],
+    )
+
+def _test_tree_walk_only(_ctx):
+    _eq(
+        "no formatter_args, no files, tree walk set → just tree_walk_args",
+        compute_spawn_args([], [], ["-r", "."]),
+        ["-r", "."],
+    )
+
+_UNIT_TESTS = [
+    _test_files_present_emits_formatter_args_then_files,
+    _test_files_present_ignores_tree_walk_args,
+    _test_no_files_appends_tree_walk_args,
+    _test_no_files_no_tree_walk_yields_only_formatter_args,
+    _test_all_empty_yields_empty,
+    _test_tree_walk_only,
+]
+
+def _test_impl(ctx):
+    for t in _UNIT_TESTS:
+        t(ctx)
+    print("format_spawn.axl: OK (%d tests)" % len(_UNIT_TESTS))
+    return 0
+
+format_spawn_tests = task(
+    name = "test-format-spawn",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)


### PR DESCRIPTION
Add `formatter_args_for_tree_walk` to the `format` task: extra positional arguments appended to the formatter binary's argv **only when no positional files would otherwise reach it** — i.e. when `aspect format` is invoked without explicit file args and change-detection produced no file list (typically `--scope=all`, but also `--scope=changed` runs that degraded because the change-detection source returned no matches).

Designed for bare formatter binaries — `@buildifier_prebuilt//buildifier` is the motivating case — that need an explicit tree-walk flag like `-r .` to do anything useful when the format task hands them no files. Without this knob, the only way to make `aspect buildifier --scope=all` work was to add the tree-walk flag to `formatter_args`, which also fires in `--scope=changed` and turns every per-file invocation into a whole-tree rewrite (`buildifier -r .` overrides the positional file list).

The new arg gates on `not format_args`, so any spawn with at least one positional file — explicit positional args or a non-empty change-detection result — is unaffected.

## Behavior matrix

| Invocation                                                  | Tree-walk args fire? |
|-------------------------------------------------------------|----------------------|
| `aspect format` (changed files detected)                    | no — file list passed                              |
| `aspect format --scope=changed` (degraded, no changes)      | yes — no file list                                 |
| `aspect format --scope=all`                                 | yes — no file list                                 |
| `aspect format BUILD.bazel`                                 | no — positional file                               |

## Additional surfaces

- **Runtime hint.** When the format task spawns with zero positional files on a `run_in_cwd=True` alias and `formatter_args_for_tree_walk` is empty, emit an `info(...)` pointing the user at the new knob (and at `format_multirun` as an alternative). Fires only on the misconfig pattern; stays silent on legitimate clean runs, on aliases that have the new knob set, and on wrapper targets.
- **Repro / re-discovery preservation.** `_DETECTION_PAIRS` now includes both `formatter_args` and `formatter_args_for_tree_walk`, so an explicit `--formatter-arg-for-tree-walk=…` invocation is preserved in the 🔁 Reproduce command and in the re-discovery fallback 🛠️ Fix command. Without this, a CI failure triggered by a CLI-passed tree-walk flag would render a repro stripped of the flag — silently no-opping against a bare buildifier and reporting a false clean.

## Example alias

```python
buildifier = format.alias(
    defaults = {
        "formatter_target": "@buildifier_prebuilt//buildifier",
        "run_in_cwd": True,
        "formatter_args_for_tree_walk": ["-r", "."],
        "include_patterns": [...],
    },
    summary = "Format Starlark files using buildifier.",
)
```

```
aspect buildifier              # --scope=changed, format only the diff
aspect buildifier --scope=all  # tree-walk via `-r .`
aspect buildifier BUILD.bazel  # positional, leaves other files alone
```

## Structure

The spawn-argv composition and the hint condition live in `lib/format_spawn.axl` as pure helpers — total functions over their inputs, no I/O, no `ctx` access. Each is exercised by `lib/format_spawn_test.axl` (11 unit tests via `aspect dev test-format-spawn`).

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (docs PR follow-up updates `cli/tasks/buildifier.mdx` to recommend the new arg)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- The `format` task gained a `formatter_args_for_tree_walk` arg (CLI: `--formatter-arg-for-tree-walk`) for formatter flags that should fire only when zero positional files reach the formatter. Use it on bare formatter binaries like `@buildifier_prebuilt//buildifier` (set `formatter_args_for_tree_walk = ["-r", "."]`) so a single alias can serve both `--scope=changed` and `--scope=all` without turning per-file invocations into whole-tree rewrites.

### Test plan

- New unit tests in `lib/format_spawn_test.axl` (11 cases) cover argv composition (file list wins over tree-walk args; tree-walk args only append when no files) and the hint predicate (every silent path and the single fire path). Run with `aspect dev test-format-spawn`.
- Existing `aspect dev test-repro-commands` (30 cases) re-runs green.
- Manual reproduction in a fresh Bazel workspace with `buildifier_prebuilt`:
  - `aspect buildifier --scope=all` with `formatter_args_for_tree_walk = ["-r", "."]` reformats every Starlark file under the tree.
  - `aspect buildifier BUILD.bazel` with the same alias reformats only the listed file; files at other paths are untouched.
  - `aspect buildifier --scope=all` without the new knob (and with `run_in_cwd=True`) surfaces the hint.
  - `CI=true aspect buildifier --scope=all --severity=fail --formatter-arg-for-tree-walk=-r --formatter-arg-for-tree-walk=.` against a dirty repo renders a Reproduce block that includes both `--formatter-arg-for-tree-walk` entries.
- `bazel build //:cli` passes locally.
