### PR TITLE
fix(health-check): pull job-history directly from job-history file

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
@@ -202,37 +202,31 @@ def _strip_ansi(s):
             i += 1
     return result
 
-def _is_bullet_header(line):
-    """True when `line`, after ANSI stripping, looks like a Vigor section
-    header `• <Section>`. Vigor emits headers as
-    `\\x1b[34m•\\x1b[0m \\x1b[34m<Section>\\x1b[0m`."""
-    stripped = _strip_ansi(line)
-    return stripped.startswith("• ")
-
 def _bullet_header_label(line):
-    """Return the post-`• ` label of a bullet header line, trimmed.
-    Caller is expected to have already verified `_is_bullet_header(line)`."""
-    return _strip_ansi(line)[2:].strip()
+    """Return the section label of a Vigor bullet-header line
+    (`• <label>` after ANSI stripping), or None if `line` isn't a bullet
+    header. Vigor emits headers as
+    `\\x1b[34m•\\x1b[0m \\x1b[34m<label>\\x1b[0m`."""
+    stripped = _strip_ansi(line)
+    if not stripped.startswith("• "):
+        return None
+    return stripped[2:].strip()
 
 def render_local_job_history(history):
     """Render a `• Job History` section from the raw history file contents.
 
-    `history` is the verbatim text of `runner_job_history` — one line per
-    `[<date>] <url> <path> <key>` entry (see `lib/runner_job_history.axl`).
-    Matches Vigor's section format (`Number of builds on this runner: N`
-    + `Most recently:` + up to 10 lines) but takes the *last* 10 entries
-    instead of the first. Emits a trailing blank line so the
-    inter-section spacing matches Vigor's `println!()`-terminated
-    sections.
+    `history` is the verbatim text of `runner_job_history` — one line
+    per `[<date>] <url> <path> <key>` entry, see
+    `lib/runner_job_history.axl`. Matches Vigor's section format
+    (`Number of builds on this runner: N` + `Most recently:` + up to
+    10 lines) but takes the *last* 10 entries instead of the first.
 
-    Bullet header is emitted directly here (rather than via
-    `_section_heading`) because this section replaces a Vigor section
-    inline — Vigor's preceding section already ends in a blank line, so
-    the leading `\\n` that `_section_heading` adds for *top-of-block*
-    use would produce a double-blank gap.
+    Emits the bullet header inline (no leading `\\n`) because the
+    surrounding rewrite drops it into a slot whose previous section
+    already ended with the inter-section blank line — using
+    `_section_heading` here would double-blank.
 
-    Returns the rendered section as a single string (with trailing
-    newline). Pure function for testability; the caller prints it.
+    Returns the rendered section with a trailing newline.
     """
     lines = [line for line in history.split("\n") if line]
     out = ["\x1b[34m• Job History\x1b[0m"]
@@ -246,27 +240,21 @@ def render_local_job_history(history):
     return "\n".join(out)
 
 def rewrite_runner_health_output(output, history):
-    """Rewrite Vigor's pre-formatted runner-health output, replacing its
-    `• Job History` section with a locally-rendered one.
+    """Rewrite Vigor's pre-formatted runner-health `output`, replacing
+    the `• Job History` section (which lists the first 10 entries
+    instead of the most recent — see `render_local_job_history`) with a
+    locally-rendered one built from `history`.
 
-    Vigor (silo `workflows/vigor/src/checks/runner_job_history_check.rs`)
-    currently prints the *first* 10 entries from the runner job history
-    file instead of the most recent 10 — a bug being fixed runner-side,
-    but we redact + re-render here so customers get the fix without a
-    Terraform upgrade.
+    Walks `output` line by line. The first bullet header whose label is
+    `Job History` and everything up to the next bullet header is
+    replaced with `render_local_job_history(history)`; every other line
+    passes through verbatim. ANSI codes on the header are stripped for
+    matching only.
 
-    Walks the output line-by-line, swapping the Job History section
-    (header + body up to the next bullet header) for the local render.
-    Other sections pass through verbatim, preserving Vigor's section
-    ordering and spacing. ANSI codes on the header are stripped for
-    matching only; surviving lines are emitted unchanged.
+    No-op if no Job History section is present — we don't synthesize a
+    section the upstream report didn't include.
 
-    If Vigor's output doesn't contain a Job History section (older or
-    future Vigor without that check), the output passes through verbatim
-    — we don't synthesize a section that wasn't part of the report,
-    since whoever owns that Vigor version owns the contract.
-
-    Pure function for testability; returns the rewritten string.
+    Returns the rewritten string.
     """
     lines = output.split("\n")
     n = len(lines)
@@ -276,42 +264,33 @@ def rewrite_runner_health_output(output, history):
     for _ in range(n):
         if i >= n:
             break
-        line = lines[i]
-        if not replaced and _is_bullet_header(line) and _bullet_header_label(line) == "Job History":
+        if not replaced and _bullet_header_label(lines[i]) == "Job History":
             out.append(render_local_job_history(history))
             replaced = True
             i += 1
             for _ in range(n - i):
                 if i >= n:
                     break
-                if _is_bullet_header(lines[i]):
+                if _bullet_header_label(lines[i]) != None:
                     break
                 i += 1
             continue
-        out.append(line)
+        out.append(lines[i])
         i += 1
     return "\n".join(out)
 
 def _display_runner_health(environment, job_history):
-    """
-    Display the last runner health check results.
+    """Display the last runner health check results.
 
-    Reads the JSON file written by the fleet service between jobs. The
-    `• Job History` section in the saved Vigor output is replaced inline
-    with a locally-rendered one so the "Most recently" list shows the
-    *last* 10 entries instead of the first — see
+    Reads the JSON snapshot the fleet service writes between jobs. The
+    Vigor `• Job History` section in that snapshot is rewritten inline
+    against `job_history` so the "Most recently" list shows the last 10
+    entries instead of the buggy first 10 — see
     `rewrite_runner_health_output`.
 
-    `job_history` is the **pre-append** runner-job-history snapshot —
-    `lib/lifecycle.axl::setup_phase` calls
-    `runner_job_history.axl::append_runner_job_history` before the
-    health-check hooks run, so by the time we render here, the file on
-    disk already contains the current task's entry. Reading the
-    refreshed `environment.runner.runner_job_history` would make our
-    local render disagree with Vigor's saved snapshot (count N vs N+1).
-    Caller must pass the history that corresponds to Vigor's report —
-    `agent_health_check` captures it from the feature-time `environment`
-    before `_wait_for_warming` re-reads.
+    `job_history` must correspond to the same point in time as Vigor's
+    saved report (i.e. before this task's `append_runner_job_history`
+    call). The caller is responsible for snapshotting it.
     """
     print("\x1b[1;4;34mRunner Health\x1b[0m")
 
@@ -324,8 +303,6 @@ def _display_runner_health(environment, job_history):
         print("Health check data is unavailable (malformed JSON)")
         return
 
-    # data.timestamp is a unix epoch integer
-    # data.output is a pre-formatted multi-line string
     print("Last run on " + str(data["timestamp"]) + "\n")
     print(rewrite_runner_health_output(data["output"], job_history))
 
@@ -403,15 +380,14 @@ def agent_health_check(ctx, environment):
     if environment.ci and environment.ci.host == "buildkite":
         print("--- :thermometer: Workflows runner health check")
 
-    # Snapshot the runner-job-history field BEFORE `_wait_for_warming`
-    # re-reads the environment. `setup_phase` calls
-    # `append_runner_job_history` ahead of the health-check hooks, so
-    # the file on disk now contains the current task's entry — but
-    # Vigor's saved snapshot (in `last_health_check`) was written
-    # before this task ran. Using the feature-time `environment.runner.
-    # runner_job_history` keeps the local Job History render consistent
-    # with Vigor's section count and timestamp. See
-    # `_display_runner_health` for the contract.
+    # Snapshot job-history before `_wait_for_warming` re-reads the
+    # environment. `setup_phase` runs `append_runner_job_history` ahead
+    # of this hook, so the file already contains the current task's
+    # entry — but Vigor's saved snapshot in `last_health_check` was
+    # written before this task ran. The feature-time `environment` was
+    # captured in phase 3 (before phase 4 ran setup_phase), so this
+    # field still reflects the pre-append state. Re-reading would
+    # desync the rewritten Job History count from Vigor's report.
     job_history = environment.runner.runner_job_history
 
     environment = _wait_for_warming(ctx.std, environment)

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
@@ -292,7 +292,7 @@ def rewrite_runner_health_output(output, history):
         i += 1
     return "\n".join(out)
 
-def _display_runner_health(environment):
+def _display_runner_health(environment, job_history):
     """
     Display the last runner health check results.
 
@@ -300,7 +300,18 @@ def _display_runner_health(environment):
     `• Job History` section in the saved Vigor output is replaced inline
     with a locally-rendered one so the "Most recently" list shows the
     *last* 10 entries instead of the first — see
-    `_print_runner_health_output`.
+    `rewrite_runner_health_output`.
+
+    `job_history` is the **pre-append** runner-job-history snapshot —
+    `lib/lifecycle.axl::setup_phase` calls
+    `runner_job_history.axl::append_runner_job_history` before the
+    health-check hooks run, so by the time we render here, the file on
+    disk already contains the current task's entry. Reading the
+    refreshed `environment.runner.runner_job_history` would make our
+    local render disagree with Vigor's saved snapshot (count N vs N+1).
+    Caller must pass the history that corresponds to Vigor's report —
+    `agent_health_check` captures it from the feature-time `environment`
+    before `_wait_for_warming` re-reads.
     """
     print("\x1b[1;4;34mRunner Health\x1b[0m")
 
@@ -316,7 +327,7 @@ def _display_runner_health(environment):
     # data.timestamp is a unix epoch integer
     # data.output is a pre-formatted multi-line string
     print("Last run on " + str(data["timestamp"]) + "\n")
-    print(rewrite_runner_health_output(data["output"], environment.runner.runner_job_history))
+    print(rewrite_runner_health_output(data["output"], job_history))
 
 HealthCheckTrait = trait(
     health_check = attr(list[typing.Callable[[TaskContext], str | None]], default = [], description = "Hooks run during the task's setup phase to validate system health. Return a non-None error message to fail the task (e.g. an unhealthy Bazel server); return None when healthy."),
@@ -392,8 +403,19 @@ def agent_health_check(ctx, environment):
     if environment.ci and environment.ci.host == "buildkite":
         print("--- :thermometer: Workflows runner health check")
 
+    # Snapshot the runner-job-history field BEFORE `_wait_for_warming`
+    # re-reads the environment. `setup_phase` calls
+    # `append_runner_job_history` ahead of the health-check hooks, so
+    # the file on disk now contains the current task's entry — but
+    # Vigor's saved snapshot (in `last_health_check`) was written
+    # before this task ran. Using the feature-time `environment.runner.
+    # runner_job_history` keeps the local Job History render consistent
+    # with Vigor's section count and timestamp. See
+    # `_display_runner_health` for the contract.
+    job_history = environment.runner.runner_job_history
+
     environment = _wait_for_warming(ctx.std, environment)
-    _display_runner_health(environment)
+    _display_runner_health(environment, job_history)
     _display_warming(environment)
     assert_ctx_bazel_ready_for_health_check(ctx, environment)
     health = ctx.bazel.health_check()

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
@@ -173,11 +173,134 @@ def _display_bazel_health(health):
         print("\t" + _status_marker("warn") +
               " bazel health check inconclusive: " + (health.message or "unknown"))
 
+def _strip_ansi(s):
+    """Strip CSI escape sequences (`\\x1b[...m`) from `s`.
+
+    Used only for line-shape matching when redacting Vigor's pre-formatted
+    output — we don't try to be a complete terminal emulator, just enough
+    to recognize a `• <Section>` bullet header regardless of how Vigor
+    colored it. Non-CSI escapes pass through unchanged.
+    """
+    result = ""
+    i = 0
+    n = len(s)
+    for _ in range(n):
+        if i >= n:
+            break
+        if i + 1 < n and s[i] == "\x1b" and s[i + 1] == "[":
+            j = i + 2
+            for _ in range(n - j):
+                if j >= n:
+                    break
+                if s[j] == "m":
+                    j += 1
+                    break
+                j += 1
+            i = j
+        else:
+            result += s[i]
+            i += 1
+    return result
+
+def _is_bullet_header(line):
+    """True when `line`, after ANSI stripping, looks like a Vigor section
+    header `• <Section>`. Vigor emits headers as
+    `\\x1b[34m•\\x1b[0m \\x1b[34m<Section>\\x1b[0m`."""
+    stripped = _strip_ansi(line)
+    return stripped.startswith("• ")
+
+def _bullet_header_label(line):
+    """Return the post-`• ` label of a bullet header line, trimmed.
+    Caller is expected to have already verified `_is_bullet_header(line)`."""
+    return _strip_ansi(line)[2:].strip()
+
+def render_local_job_history(history):
+    """Render a `• Job History` section from the raw history file contents.
+
+    `history` is the verbatim text of `runner_job_history` — one line per
+    `[<date>] <url> <path> <key>` entry (see `lib/runner_job_history.axl`).
+    Matches Vigor's section format (`Number of builds on this runner: N`
+    + `Most recently:` + up to 10 lines) but takes the *last* 10 entries
+    instead of the first. Emits a trailing blank line so the
+    inter-section spacing matches Vigor's `println!()`-terminated
+    sections.
+
+    Bullet header is emitted directly here (rather than via
+    `_section_heading`) because this section replaces a Vigor section
+    inline — Vigor's preceding section already ends in a blank line, so
+    the leading `\\n` that `_section_heading` adds for *top-of-block*
+    use would produce a double-blank gap.
+
+    Returns the rendered section as a single string (with trailing
+    newline). Pure function for testability; the caller prints it.
+    """
+    lines = [line for line in history.split("\n") if line]
+    out = ["\x1b[34m• Job History\x1b[0m"]
+    out.append("\tNumber of builds on this runner: %d" % len(lines))
+    if lines:
+        out.append("\tMost recently:")
+        recent = lines[-10:] if len(lines) > 10 else lines
+        for line in recent:
+            out.append("\t" + line)
+    out.append("")
+    return "\n".join(out)
+
+def rewrite_runner_health_output(output, history):
+    """Rewrite Vigor's pre-formatted runner-health output, replacing its
+    `• Job History` section with a locally-rendered one.
+
+    Vigor (silo `workflows/vigor/src/checks/runner_job_history_check.rs`)
+    currently prints the *first* 10 entries from the runner job history
+    file instead of the most recent 10 — a bug being fixed runner-side,
+    but we redact + re-render here so customers get the fix without a
+    Terraform upgrade.
+
+    Walks the output line-by-line, swapping the Job History section
+    (header + body up to the next bullet header) for the local render.
+    Other sections pass through verbatim, preserving Vigor's section
+    ordering and spacing. ANSI codes on the header are stripped for
+    matching only; surviving lines are emitted unchanged.
+
+    If Vigor's output doesn't contain a Job History section (older or
+    future Vigor without that check), the output passes through verbatim
+    — we don't synthesize a section that wasn't part of the report,
+    since whoever owns that Vigor version owns the contract.
+
+    Pure function for testability; returns the rewritten string.
+    """
+    lines = output.split("\n")
+    n = len(lines)
+    i = 0
+    replaced = False
+    out = []
+    for _ in range(n):
+        if i >= n:
+            break
+        line = lines[i]
+        if not replaced and _is_bullet_header(line) and _bullet_header_label(line) == "Job History":
+            out.append(render_local_job_history(history))
+            replaced = True
+            i += 1
+            for _ in range(n - i):
+                if i >= n:
+                    break
+                if _is_bullet_header(lines[i]):
+                    break
+                i += 1
+            continue
+        out.append(line)
+        i += 1
+    return "\n".join(out)
+
 def _display_runner_health(environment):
     """
     Display the last runner health check results.
 
-    Reads the JSON file written by the fleet service between jobs.
+    Reads the JSON file written by the fleet service between jobs. The
+    `• Job History` section in the saved Vigor output is replaced inline
+    with a locally-rendered one so the "Most recently" list shows the
+    *last* 10 entries instead of the first — see
+    `_print_runner_health_output`.
     """
     print("\x1b[1;4;34mRunner Health\x1b[0m")
 
@@ -193,7 +316,7 @@ def _display_runner_health(environment):
     # data.timestamp is a unix epoch integer
     # data.output is a pre-formatted multi-line string
     print("Last run on " + str(data["timestamp"]) + "\n")
-    print(data["output"])
+    print(rewrite_runner_health_output(data["output"], environment.runner.runner_job_history))
 
 HealthCheckTrait = trait(
     health_check = attr(list[typing.Callable[[TaskContext], str | None]], default = [], description = "Hooks run during the task's setup phase to validate system health. Return a non-None error message to fail the task (e.g. an unhealthy Bazel server); return None when healthy."),

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
@@ -4,16 +4,30 @@
     Workflows runners.
   - `run_health_checks` — runs the `health_check` hooks and surfaces the first
     error, the signal that fails a task on an unhealthy environment.
+  - `render_local_job_history` / `rewrite_runner_health_output` — the
+    Vigor-output rewrite that swaps the buggy first-10 Job History
+    section for a locally-rendered last-10 section. See the function
+    docstring in `health_check.axl` for the bug context.
 
 Run with:
   aspect dev test-health-check-ready
 """
 
-load("./health_check.axl", "ctx_bazel_ready_for_health_check", "run_health_checks")
+load(
+    "./health_check.axl",
+    "ctx_bazel_ready_for_health_check",
+    "render_local_job_history",
+    "rewrite_runner_health_output",
+    "run_health_checks",
+)
 
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
+
+def _assert(label, cond):
+    if not cond:
+        fail("%s: condition false" % label)
 
 _ON_RUNNER = struct(runner = struct(bazel_root_dir = "/tmp/health-check-ready-test"))
 _OFF_RUNNER = struct(runner = None)
@@ -69,6 +83,151 @@ def _test_run_health_checks_surfaces_first_error(ctx):
     _eq("first error wins", run_health_checks(ctx, trait), "server unhealthy")
     _eq("all hooks ran (no short-circuit)", ran, ["a", "d"])
 
+# Vigor-style ANSI-colored bullet header.
+_BULLET = "\x1b[34m•\x1b[0m"
+
+def _vigor_header(label):
+    """Reconstruct Vigor's `stylish::ansi::format!` bullet header so the
+    rewrite tests exercise the same byte sequence Vigor emits on the
+    runner."""
+    return "%s \x1b[34m%s\x1b[0m" % (_BULLET, label)
+
+def _entry(date, url, path, key):
+    """Build a `[<date>] <url> <path> <key>` job history line, matching
+    `lib/runner_job_history.axl::append_runner_job_history` output."""
+    return "[%s] %s %s %s" % (date, url, path, key)
+
+def _test_render_local_job_history_zero(ctx):
+    """Empty history → header + `Number of builds: 0` + trailing blank.
+    Mirrors Vigor's zero-count rendering shape (no `Most recently` block)."""
+    got = render_local_job_history("")
+    want = "\x1b[34m• Job History\x1b[0m\n\tNumber of builds on this runner: 0\n"
+    _eq("render empty history", got, want)
+
+def _test_render_local_job_history_under_ten(ctx):
+    """N=3 entries → all three appear in the `Most recently` block in
+    file order (oldest first), with the count matching."""
+    history = "\n".join([
+        _entry("Sun May 31 2026 18:05:44 GMT+0000", "https://example.com/builds/1#a", "test", "test-bk"),
+        _entry("Sun May 31 2026 18:06:19 GMT+0000", "https://example.com/builds/2#b", "test", "test-bk"),
+        _entry("Sun May 31 2026 18:07:32 GMT+0000", "https://example.com/builds/3#c", "test", "test-bk"),
+    ]) + "\n"
+    got = render_local_job_history(history)
+    _assert("under-10 — header", "• Job History" in got)
+    _assert("under-10 — count line", "Number of builds on this runner: 3" in got)
+    _assert("under-10 — has Most recently", "Most recently:" in got)
+    _assert("under-10 — first entry present", "https://example.com/builds/1#a" in got)
+    _assert("under-10 — last entry present", "https://example.com/builds/3#c" in got)
+    _assert("under-10 — trailing blank", got.endswith("\n"))
+
+def _test_render_local_job_history_over_ten_takes_last_ten(ctx):
+    """N=12 entries → count=12, `Most recently` shows entries 3..12 (the
+    LAST ten — the bug we're fixing on the Vigor side took the FIRST
+    ten). Entries 1 and 2 must be absent; 3 and 12 must be present."""
+    entries = []
+    for i in range(12):
+        entries.append(_entry(
+            "date-%d" % i,
+            "https://example.com/builds/%d#job-%d" % (i, i),
+            "test",
+            "test-bk",
+        ))
+    history = "\n".join(entries) + "\n"
+    got = render_local_job_history(history)
+    _assert("over-10 — count is 12", "Number of builds on this runner: 12" in got)
+    _assert("over-10 — entry 0 absent (oldest, dropped)", "#job-0 " not in got)
+    _assert("over-10 — entry 1 absent (dropped)", "#job-1 " not in got)
+    _assert("over-10 — entry 2 present (kept)", "#job-2 " in got)
+    _assert("over-10 — entry 11 present (newest)", "#job-11 " in got)
+
+def _test_rewrite_replaces_job_history_section(ctx):
+    """Inline rewrite swaps the buggy first-10 section for the local
+    last-10 render, leaves other sections verbatim, preserves ordering."""
+    output = "\n".join([
+        _vigor_header("Uptime"),
+        "\t25 min",
+        "",
+        _vigor_header("Job History"),
+        "\tNumber of builds on this runner: 12",
+        "\tMost recently:",
+        "\t[date-0] https://example.com/builds/0#job-0 test test-bk",
+        "\t[date-1] https://example.com/builds/1#job-1 test test-bk",
+        "",
+        _vigor_header("Workflows Version"),
+        "\t\x1b[32m✓\x1b[0m workflows version check passed",
+        "",
+    ]) + "\n"
+    history_entries = []
+    for i in range(12):
+        history_entries.append(_entry(
+            "date-%d" % i,
+            "https://example.com/builds/%d#job-%d" % (i, i),
+            "test",
+            "test-bk",
+        ))
+    history = "\n".join(history_entries) + "\n"
+
+    got = rewrite_runner_health_output(output, history)
+
+    # Other sections retained verbatim.
+    _assert("rewrite — Uptime header retained", _vigor_header("Uptime") in got)
+    _assert("rewrite — Uptime body retained", "\t25 min" in got)
+    _assert("rewrite — Workflows Version header retained", _vigor_header("Workflows Version") in got)
+
+    # Job History bullet still present (re-emitted by the local render).
+    _assert("rewrite — Job History header present after rewrite", "• Job History" in got)
+
+    # Buggy first-10 lines from Vigor are gone; last-10 are in.
+    _assert("rewrite — buggy job-0 line dropped", "#job-0 " not in got)
+    _assert("rewrite — buggy job-1 line dropped", "#job-1 " not in got)
+    _assert("rewrite — last entry job-11 present", "#job-11 " in got)
+
+    # Section ordering preserved: Job History must appear between Uptime
+    # and Workflows Version.
+    uptime_at = got.find(_vigor_header("Uptime"))
+    jh_at = got.find("• Job History")
+    wv_at = got.find(_vigor_header("Workflows Version"))
+    _assert("rewrite — ordering Uptime < Job History", uptime_at < jh_at)
+    _assert("rewrite — ordering Job History < Workflows Version", jh_at < wv_at)
+
+def _test_rewrite_idempotent_for_missing_section(ctx):
+    """If the Vigor output has no Job History section, the rewrite is a
+    no-op — we don't synthesize a section that wasn't part of the report."""
+    output = "\n".join([
+        _vigor_header("Uptime"),
+        "\t25 min",
+        "",
+        _vigor_header("Workflows Version"),
+        "\t\x1b[32m✓\x1b[0m workflows version check passed",
+        "",
+    ]) + "\n"
+    got = rewrite_runner_health_output(output, "anything\n")
+    _eq("rewrite missing-section is identity", got, output)
+    _assert("rewrite missing-section did NOT synthesize a Job History", "Job History" not in got)
+
+def _test_rewrite_only_replaces_first_match(ctx):
+    """Defensive: if the saved output somehow contained two Job History
+    sections (it shouldn't, but Vigor's structure doesn't forbid it), only
+    the first is replaced — keeps the rewrite deterministic and avoids
+    O(N²) bouncing through every match."""
+    section = "\n".join([
+        _vigor_header("Job History"),
+        "\tbogus body",
+    ])
+    output = "\n".join([
+        _vigor_header("Uptime"),
+        "\t25 min",
+        "",
+        section,
+        "",
+        section,
+        "",
+    ]) + "\n"
+    got = rewrite_runner_health_output(output, _entry("d", "u", "p", "k") + "\n")
+
+    # Second instance's `bogus body` must still be present.
+    _assert("rewrite — second match left intact", "bogus body" in got)
+
 def _test_impl(ctx):
     # `ctx.bazel.startup_flags` is shared mutable state across subtests
     # (no clear() method). The "missing" subtest must run BEFORE the
@@ -79,7 +238,13 @@ def _test_impl(ctx):
     _test_run_health_checks_no_trait_passes(ctx)
     _test_run_health_checks_all_pass(ctx)
     _test_run_health_checks_surfaces_first_error(ctx)
-    print("health_check_ready_test.axl: OK (6 sections)")
+    _test_render_local_job_history_zero(ctx)
+    _test_render_local_job_history_under_ten(ctx)
+    _test_render_local_job_history_over_ten_takes_last_ten(ctx)
+    _test_rewrite_replaces_job_history_section(ctx)
+    _test_rewrite_idempotent_for_missing_section(ctx)
+    _test_rewrite_only_replaces_first_match(ctx)
+    print("health_check_ready_test.axl: OK (12 sections)")
     return 0
 
 health_check_ready_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
@@ -5,9 +5,8 @@
   - `run_health_checks` — runs the `health_check` hooks and surfaces the first
     error, the signal that fails a task on an unhealthy environment.
   - `render_local_job_history` / `rewrite_runner_health_output` — the
-    Vigor-output rewrite that swaps the buggy first-10 Job History
-    section for a locally-rendered last-10 section. See the function
-    docstring in `health_check.axl` for the bug context.
+    Vigor-output rewrite that swaps Vigor's buggy first-10 Job History
+    section for a locally-rendered last-10 section.
 
 Run with:
   aspect dev test-health-check-ready
@@ -28,6 +27,27 @@ def _eq(label, got, want):
 def _assert(label, cond):
     if not cond:
         fail("%s: condition false" % label)
+
+# Vigor-style ANSI-colored bullet header (`stylish::ansi::format!`-shaped).
+_BULLET = "\x1b[34m•\x1b[0m"
+
+def _vigor_header(label):
+    return "%s \x1b[34m%s\x1b[0m" % (_BULLET, label)
+
+def _entry(date, url, path, key):
+    """Build a `[<date>] <url> <path> <key>` job history line, matching
+    `lib/runner_job_history.axl::append_runner_job_history` output."""
+    return "[%s] %s %s %s" % (date, url, path, key)
+
+def _build_history(count):
+    """N entries `date-i / #job-i`, line-per-entry with trailing newline."""
+    entries = [_entry(
+        "date-%d" % i,
+        "https://example.com/builds/%d#job-%d" % (i, i),
+        "test",
+        "test-bk",
+    ) for i in range(count)]
+    return "\n".join(entries) + "\n"
 
 _ON_RUNNER = struct(runner = struct(bazel_root_dir = "/tmp/health-check-ready-test"))
 _OFF_RUNNER = struct(runner = None)
@@ -83,20 +103,6 @@ def _test_run_health_checks_surfaces_first_error(ctx):
     _eq("first error wins", run_health_checks(ctx, trait), "server unhealthy")
     _eq("all hooks ran (no short-circuit)", ran, ["a", "d"])
 
-# Vigor-style ANSI-colored bullet header.
-_BULLET = "\x1b[34m•\x1b[0m"
-
-def _vigor_header(label):
-    """Reconstruct Vigor's `stylish::ansi::format!` bullet header so the
-    rewrite tests exercise the same byte sequence Vigor emits on the
-    runner."""
-    return "%s \x1b[34m%s\x1b[0m" % (_BULLET, label)
-
-def _entry(date, url, path, key):
-    """Build a `[<date>] <url> <path> <key>` job history line, matching
-    `lib/runner_job_history.axl::append_runner_job_history` output."""
-    return "[%s] %s %s %s" % (date, url, path, key)
-
 def _test_render_local_job_history_zero(ctx):
     """Empty history → header + `Number of builds: 0` + trailing blank.
     Mirrors Vigor's zero-count rendering shape (no `Most recently` block)."""
@@ -105,44 +111,41 @@ def _test_render_local_job_history_zero(ctx):
     _eq("render empty history", got, want)
 
 def _test_render_local_job_history_under_ten(ctx):
-    """N=3 entries → all three appear in the `Most recently` block in
+    """N < 10 → every entry appears in the `Most recently` block, in
     file order (oldest first), with the count matching."""
-    history = "\n".join([
-        _entry("Sun May 31 2026 18:05:44 GMT+0000", "https://example.com/builds/1#a", "test", "test-bk"),
-        _entry("Sun May 31 2026 18:06:19 GMT+0000", "https://example.com/builds/2#b", "test", "test-bk"),
-        _entry("Sun May 31 2026 18:07:32 GMT+0000", "https://example.com/builds/3#c", "test", "test-bk"),
-    ]) + "\n"
-    got = render_local_job_history(history)
+    got = render_local_job_history(_build_history(3))
     _assert("under-10 — header", "• Job History" in got)
     _assert("under-10 — count line", "Number of builds on this runner: 3" in got)
     _assert("under-10 — has Most recently", "Most recently:" in got)
-    _assert("under-10 — first entry present", "https://example.com/builds/1#a" in got)
-    _assert("under-10 — last entry present", "https://example.com/builds/3#c" in got)
+    _assert("under-10 — oldest entry present", "#job-0 " in got)
+    _assert("under-10 — newest entry present", "#job-2 " in got)
     _assert("under-10 — trailing blank", got.endswith("\n"))
 
 def _test_render_local_job_history_over_ten_takes_last_ten(ctx):
-    """N=12 entries → count=12, `Most recently` shows entries 3..12 (the
-    LAST ten — the bug we're fixing on the Vigor side took the FIRST
-    ten). Entries 1 and 2 must be absent; 3 and 12 must be present."""
-    entries = []
-    for i in range(12):
-        entries.append(_entry(
-            "date-%d" % i,
-            "https://example.com/builds/%d#job-%d" % (i, i),
-            "test",
-            "test-bk",
-        ))
-    history = "\n".join(entries) + "\n"
-    got = render_local_job_history(history)
+    """N > 10 → count reflects total; `Most recently` shows the LAST 10
+    entries (the bug we're fixing on the Vigor side took the first 10)."""
+    got = render_local_job_history(_build_history(12))
     _assert("over-10 — count is 12", "Number of builds on this runner: 12" in got)
-    _assert("over-10 — entry 0 absent (oldest, dropped)", "#job-0 " not in got)
-    _assert("over-10 — entry 1 absent (dropped)", "#job-1 " not in got)
-    _assert("over-10 — entry 2 present (kept)", "#job-2 " in got)
-    _assert("over-10 — entry 11 present (newest)", "#job-11 " in got)
+    _assert("over-10 — oldest (dropped)", "#job-0 " not in got)
+    _assert("over-10 — second-oldest (dropped)", "#job-1 " not in got)
+    _assert("over-10 — third entry (kept, oldest in window)", "#job-2 " in got)
+    _assert("over-10 — newest", "#job-11 " in got)
+
+def _test_render_local_job_history_skips_blank_lines(ctx):
+    """Stray blank lines (trailing newlines, partial-write artifacts) are
+    ignored — `Number of builds` reflects only non-empty lines."""
+    history = "%s\n\n%s\n\n" % (_entry("d", "u-1", "p", "k"), _entry("d", "u-2", "p", "k"))
+    got = render_local_job_history(history)
+    _assert("blank-lines — count excludes blanks", "Number of builds on this runner: 2" in got)
 
 def _test_rewrite_replaces_job_history_section(ctx):
-    """Inline rewrite swaps the buggy first-10 section for the local
-    last-10 render, leaves other sections verbatim, preserves ordering."""
+    """Rewrite swaps the buggy section for the local render, leaves
+    every other section verbatim, and preserves ordering.
+
+    Uses a Vigor-side body that the local render couldn't possibly
+    produce (`vigor-only`) so dropping it is a clean signal — not
+    accidentally coincident with the local render's own last-10 window.
+    """
     output = "\n".join([
         _vigor_header("Uptime"),
         "\t25 min",
@@ -150,49 +153,59 @@ def _test_rewrite_replaces_job_history_section(ctx):
         _vigor_header("Job History"),
         "\tNumber of builds on this runner: 12",
         "\tMost recently:",
-        "\t[date-0] https://example.com/builds/0#job-0 test test-bk",
-        "\t[date-1] https://example.com/builds/1#job-1 test test-bk",
+        "\t[date-x] vigor-only-entry-1",
+        "\t[date-y] vigor-only-entry-2",
         "",
         _vigor_header("Workflows Version"),
         "\t\x1b[32m✓\x1b[0m workflows version check passed",
         "",
     ]) + "\n"
-    history_entries = []
-    for i in range(12):
-        history_entries.append(_entry(
-            "date-%d" % i,
-            "https://example.com/builds/%d#job-%d" % (i, i),
-            "test",
-            "test-bk",
-        ))
-    history = "\n".join(history_entries) + "\n"
 
-    got = rewrite_runner_health_output(output, history)
+    got = rewrite_runner_health_output(output, _build_history(12))
 
-    # Other sections retained verbatim.
     _assert("rewrite — Uptime header retained", _vigor_header("Uptime") in got)
     _assert("rewrite — Uptime body retained", "\t25 min" in got)
     _assert("rewrite — Workflows Version header retained", _vigor_header("Workflows Version") in got)
+    _assert("rewrite — Job History header present", "• Job History" in got)
+    _assert("rewrite — Vigor body dropped (entry-1)", "vigor-only-entry-1" not in got)
+    _assert("rewrite — Vigor body dropped (entry-2)", "vigor-only-entry-2" not in got)
+    _assert("rewrite — local render newest entry present", "#job-11 " in got)
+    _assert("rewrite — local render older-than-window absent", "#job-0 " not in got)
 
-    # Job History bullet still present (re-emitted by the local render).
-    _assert("rewrite — Job History header present after rewrite", "• Job History" in got)
-
-    # Buggy first-10 lines from Vigor are gone; last-10 are in.
-    _assert("rewrite — buggy job-0 line dropped", "#job-0 " not in got)
-    _assert("rewrite — buggy job-1 line dropped", "#job-1 " not in got)
-    _assert("rewrite — last entry job-11 present", "#job-11 " in got)
-
-    # Section ordering preserved: Job History must appear between Uptime
-    # and Workflows Version.
     uptime_at = got.find(_vigor_header("Uptime"))
     jh_at = got.find("• Job History")
     wv_at = got.find(_vigor_header("Workflows Version"))
     _assert("rewrite — ordering Uptime < Job History", uptime_at < jh_at)
     _assert("rewrite — ordering Job History < Workflows Version", jh_at < wv_at)
 
-def _test_rewrite_idempotent_for_missing_section(ctx):
-    """If the Vigor output has no Job History section, the rewrite is a
-    no-op — we don't synthesize a section that wasn't part of the report."""
+def _test_rewrite_replaces_job_history_when_last_section(ctx):
+    """Job History as the final section (no trailing bullet header):
+    rewrite reads through end-of-output and the local render slots in
+    cleanly. The Vigor body's signature line is dropped; the local
+    render's entries are present."""
+    output = "\n".join([
+        _vigor_header("Uptime"),
+        "\t25 min",
+        "",
+        _vigor_header("Job History"),
+        "\tNumber of builds on this runner: 5",
+        "\tMost recently:",
+        "\t[vigor-side] dropped-by-rewrite",
+        "",
+    ]) + "\n"
+
+    got = rewrite_runner_health_output(output, _build_history(5))
+
+    _assert("last-section — Uptime retained", _vigor_header("Uptime") in got)
+    _assert("last-section — local Job History present", "• Job History" in got)
+    _assert("last-section — local count rendered", "Number of builds on this runner: 5" in got)
+    _assert("last-section — Vigor body line dropped", "dropped-by-rewrite" not in got)
+    _assert("last-section — newest local entry present", "#job-4 " in got)
+
+def _test_rewrite_no_section_is_identity(ctx):
+    """If Vigor's output has no Job History section, the rewrite passes
+    through verbatim — we don't synthesize a section the report didn't
+    include."""
     output = "\n".join([
         _vigor_header("Uptime"),
         "\t25 min",
@@ -202,14 +215,13 @@ def _test_rewrite_idempotent_for_missing_section(ctx):
         "",
     ]) + "\n"
     got = rewrite_runner_health_output(output, "anything\n")
-    _eq("rewrite missing-section is identity", got, output)
-    _assert("rewrite missing-section did NOT synthesize a Job History", "Job History" not in got)
+    _eq("no-section — identity", got, output)
+    _assert("no-section — did not synthesize Job History", "Job History" not in got)
 
 def _test_rewrite_only_replaces_first_match(ctx):
-    """Defensive: if the saved output somehow contained two Job History
-    sections (it shouldn't, but Vigor's structure doesn't forbid it), only
-    the first is replaced — keeps the rewrite deterministic and avoids
-    O(N²) bouncing through every match."""
+    """A second Job History section (shouldn't happen, but the format
+    doesn't forbid it) is left alone — the rewrite is deterministic and
+    applies once."""
     section = "\n".join([
         _vigor_header("Job History"),
         "\tbogus body",
@@ -224,8 +236,6 @@ def _test_rewrite_only_replaces_first_match(ctx):
         "",
     ]) + "\n"
     got = rewrite_runner_health_output(output, _entry("d", "u", "p", "k") + "\n")
-
-    # Second instance's `bogus body` must still be present.
     _assert("rewrite — second match left intact", "bogus body" in got)
 
 def _test_impl(ctx):
@@ -241,10 +251,12 @@ def _test_impl(ctx):
     _test_render_local_job_history_zero(ctx)
     _test_render_local_job_history_under_ten(ctx)
     _test_render_local_job_history_over_ten_takes_last_ten(ctx)
+    _test_render_local_job_history_skips_blank_lines(ctx)
     _test_rewrite_replaces_job_history_section(ctx)
-    _test_rewrite_idempotent_for_missing_section(ctx)
+    _test_rewrite_replaces_job_history_when_last_section(ctx)
+    _test_rewrite_no_section_is_identity(ctx)
     _test_rewrite_only_replaces_first_match(ctx)
-    print("health_check_ready_test.axl: OK (12 sections)")
+    print("health_check_ready_test.axl: OK (14 sections)")
     return 0
 
 health_check_ready_tests = task(


### PR DESCRIPTION
Workflows runners will produce a structured between job health check output in the future. At that point, this code can be simplified.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Runner health check now lists the 10 most recent jobs in the `• Job History` section of the inter-job runner-health report.

### Test plan

- Covered by existing test cases
- New test cases added — `aspect dev test-health-check-ready` covers `render_local_job_history` (zero / under-ten / over-ten taking the last 10 / blank-line tolerance) and `rewrite_runner_health_output` (replaces the section inline, handles Job History as the last section, no-ops when the section is absent, only replaces the first match).
