### PR TITLE
chore(config): add formatter_args_for_tree_walk to buildifier alias

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -42,6 +42,13 @@ buildifier = format.alias(
         # switch to $BUILD_WORKING_DIRECTORY on its own, so we run it in
         # the user's cwd to make relative paths resolve.
         "run_in_cwd": True,
+        # Fires only when the format task would otherwise pass zero files
+        # to the formatter (e.g. `--scope=all`, or a `--scope=changed` run
+        # that degraded because no changed files matched). The bare
+        # buildifier binary needs `-r .` to walk the tree on its own. Inert
+        # whenever a file list is passed, so `--scope=changed` (the default)
+        # and per-file invocations are unaffected.
+        "formatter_args_for_tree_walk": ["-r", "."],
         "include_patterns": [
             "**/BUCK",
             "**/BUILD",

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -48,6 +48,15 @@ buildifier = format.alias(
         # buildifier binary needs `-r .` to walk the tree on its own. Inert
         # whenever a file list is passed, so `--scope=changed` (the default)
         # and per-file invocations are unaffected.
+        #
+        # Caveat: `buildifier -r .` auto-discovers only BUILD, BUILD.bazel,
+        # MODULE.bazel, WORKSPACE, WORKSPACE.bazel, *.bzl, and *.star, so
+        # `--scope=all` silently skips *.axl, *.MODULE.bazel, Tiltfile, and
+        # BUCK files from the `include_patterns` list below. `--scope=changed`
+        # passes the changed file list positionally, so those extensions are
+        # covered there. See
+        # https://docs.aspect.build/cli/tasks/buildifier#run-it-locally for
+        # the user-facing reference.
         "formatter_args_for_tree_walk": ["-r", "."],
         "include_patterns": [
             "**/BUCK",


### PR DESCRIPTION
Set `formatter_args_for_tree_walk = ["-r", "."]` on the repo's own `buildifier` alias now that the arg shipped in v2026.22.39.

This matches the recommended configuration in the public docs ([cli/tasks/buildifier](https://docs.aspect.build/cli/tasks/buildifier)) and lets `aspect buildifier --scope=all` walk the tree via `-r .` while staying inert in `--scope=changed` and per-file invocations.

---

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: n/a (config-only change to this repo's own alias)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- `bazel build //:cli` passes locally.
- Inspection: the alias still registers `aspect buildifier` and the existing CI usage (`aspect buildifier --task-key buildifier-*`) is unaffected because none of the pipelines pass `--scope=all` — they rely on the `--scope=changed` default.