### PR TITLE
ci: drop fetch-depth: 2 from changed-file-detection jobs

### DIFF
--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -54,8 +54,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
       - uses: ./.github/actions/install-prebuilt-aspect-cli
       - name: Buildifier Task
         run: aspect buildifier --task-key buildifier-gha-ephemeral
@@ -66,8 +64,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
       - uses: ./.github/actions/install-prebuilt-aspect-cli
       # Starlark patterns are handled by buildifier-task; ignore them here so
       # the two steps don't do duplicate work.
@@ -81,8 +77,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
       - uses: ./.github/actions/install-prebuilt-aspect-cli
       - name: Gazelle Task
         run: aspect gazelle --task-key gazelle-gha-ephemeral

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -72,8 +72,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Lint Task (ASPECT_DEBUG=1)
@@ -97,8 +95,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Buildifier Task (ASPECT_DEBUG=1)
@@ -112,8 +108,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       # Starlark patterns are handled by buildifier-task; ignore them here so
@@ -131,8 +125,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Gazelle Task (ASPECT_DEBUG=1)
@@ -146,8 +138,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       # Regression test for the build-from-source gazelle path —


### PR DESCRIPTION
The aspect-cli's GitHub changed-file detection auto-fetches the base ref on demand, so `fetch-depth: 2` is a minor perf hint — not a correctness requirement.

`_resolve_merge_base` in [`crates/aspect-cli/src/builtins/aspect/lib/github.axl`](https://github.com/aspect-build/aspect-cli/blob/main/crates/aspect-cli/src/builtins/aspect/lib/github.axl) handles both cases:

- **PR builds**: `actions/checkout@v6` fetches the PR merge commit by default, so the base branch tip is already available as `HEAD^1` (merge commit's first parent).
- **Branch builds**: If `git merge-base HEAD origin/<base>` fails on a shallow checkout, the code runs `git fetch --depth=1 origin <base>` and retries — no preconfigured depth needed.

The lone warning that mentions `fetch-depth: 2` only fires *after* all local-git paths have already failed and we're falling back to the GitHub PR Files API; it's framed as "to avoid this on future runs," i.e. an optimization tip.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases — CI on this PR exercises both PR-build and branch-build code paths against the modified workflows.