### PR TITLE
ci: adopt aspect-build/setup-aspect across bazel/aspect jobs

### DIFF
--- a/.github/workflows/build_release_artifacts.yaml
+++ b/.github/workflows/build_release_artifacts.yaml
@@ -32,20 +32,10 @@ jobs:
           ref: ${{ inputs.ref || '' }}
           fetch-depth: 0 # need to see tags (https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches)
 
-      - name: Setup bazelisk
-        run: |
-          sudo curl -fssL https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-amd64 -o /usr/bin/bazel &&
-          sudo chmod +x /usr/bin/bazel
-
-      - name: Setup bazel
-        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
         with:
-          # Avoid downloading Bazel every time.
-          bazelisk-cache: true
-          # Store build cache per workflow.
-          disk-cache: true
-          # Share repository cache between workflows.
-          repository-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: ${{ github.workflow }}
 
       - name: Build release artifacts
         # `release.sh` (genrule output of //bazel/release:release.bzl) cps

--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -18,7 +18,6 @@ concurrency:
 # Both are no-ops if a secret isn't configured (unset env var = empty string,
 # config.axl skips registration).
 env:
-  ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
   DASH0_ENDPOINT: ${{ secrets.DASH0_ENDPOINT }}
   DASH0_TOKEN: ${{ secrets.DASH0_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -29,6 +28,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      # launcher-install: false — we're about to build the CLI from source
+      # via bootstrap.sh; no point installing a launcher we'd immediately
+      # shadow. aspect-api-token is also omitted: auth login would run
+      # before any `aspect` binary exists.
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          launcher-install: false
       - name: Pre-build CLI
         run: |
           echo "Build and upload CLI to remote cache"
@@ -54,7 +60,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      # install-prebuilt-aspect-cli only downloads an artifact and puts a
+      # binary on PATH — it doesn't need any environment setup, so it can
+      # run before setup-aspect. That order also lets setup-aspect's
+      # built-in `aspect auth login` find the prebuilt `aspect` on PATH.
       - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          launcher-install: false
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Buildifier Task
         run: aspect buildifier --task-key buildifier-gha-ephemeral
 
@@ -65,6 +79,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          launcher-install: false
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       # Starlark patterns are handled by buildifier-task; ignore them here so
       # the two steps don't do duplicate work.
       - name: Format Task
@@ -78,5 +96,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          launcher-install: false
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Gazelle Task
         run: aspect gazelle --task-key gazelle-gha-ephemeral

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -24,7 +24,6 @@ concurrency:
 # Both are no-ops if a secret isn't configured (unset env var = empty string,
 # config.axl skips registration).
 env:
-  ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
   DASH0_ENDPOINT: ${{ secrets.DASH0_ENDPOINT }}
   DASH0_TOKEN: ${{ secrets.DASH0_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,6 +34,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      # launcher-install: false — bootstrap.sh below builds the CLI from
+      # source. aspect-api-token also omitted (see ci-github-runners.yaml's
+      # pre-build for rationale). On Workflows runners launcher-install
+      # is a no-op since the runner image already ships `aspect`; setting
+      # it explicitly keeps both workflow files aligned.
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          launcher-install: false
       - name: Pre-build CLI
         run: |
           echo "Build and upload CLI to remote cache"
@@ -46,6 +53,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Build Task (ASPECT_DEBUG=1)
@@ -59,6 +69,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Test Task (ASPECT_DEBUG=1)
@@ -72,6 +85,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Lint Task (ASPECT_DEBUG=1)
@@ -95,6 +111,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Buildifier Task (ASPECT_DEBUG=1)
@@ -108,6 +127,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       # Starlark patterns are handled by buildifier-task; ignore them here so
@@ -125,6 +147,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Gazelle Task (ASPECT_DEBUG=1)
@@ -138,6 +163,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       # Regression test for the build-from-source gazelle path —
@@ -158,6 +186,9 @@ jobs:
       ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS: ${{ inputs.force_targets }}
     steps:
       - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Bootstrap
         run: .aspect/bootstrap.sh
       - name: Delivery Task (ASPECT_DEBUG=1)


### PR DESCRIPTION
Swap manual bazelisk install + `bazel-contrib/setup-bazel` + workflow-level `ASPECT_API_TOKEN` env wiring for the new [`aspect-build/setup-aspect`](https://github.com/aspect-build/setup-aspect) action across the three workflows that call bazel or aspect:

- `ci-github-runners.yaml` — pre-build job (Workflows runner) and the three ephemeral `ubuntu-latest` task jobs (`buildifier-task`, `format-task`, `gazelle-task`).
- `ci-workflows-runners.yaml` — all 9 jobs (pre-build + build/test/lint/buildifier/format/gazelle/gazelle-from-source/delivery).
- `build_release_artifacts.yaml` — replaces the manual bazelisk curl + `setup-bazel` with one `setup-aspect` step that handles bazelisk install + bazelisk/disk/repository caching.

`setup-aspect` is pinned to commit SHA `c22a8f64fb38f82f59ce809cd7eb9f8ae096da44` with the `# v2026.23.2` tag suffix, matching [the action's v2026.23.2 release](https://github.com/aspect-build/setup-aspect/releases/tag/v2026.23.2).

### Build-from-source pattern

aspect-cli is unusual: the CLI binary under test is built from source by the pre-build job, not installed from a release. Three things follow from that:

1. **Pre-build jobs pass `launcher-install: false`** — `bootstrap.sh` builds `//:cli`, so installing setup-aspect's launcher would be wasted work. They also omit `aspect-api-token` (no `aspect` binary exists yet at that point; auth runs later).
2. **Ephemeral task jobs install the prebuilt CLI first, then call `setup-aspect` for auth.** `install-prebuilt-aspect-cli` is a local composite action that downloads the artifact uploaded by pre-build and puts it on PATH. It doesn't run bazel and doesn't need any environment setup, so it can run before setup-aspect. Each ephemeral task job now reads:
   ```yaml
   - uses: actions/checkout@v6
   - uses: ./.github/actions/install-prebuilt-aspect-cli
   - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
     with:
       launcher-install: false
       aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
   - name: <Task>
     run: aspect <task> --task-key <task>-gha-ephemeral
   ```
   `setup-aspect`'s `aspect auth login --with-api-token` finds the just-installed prebuilt binary on PATH and exchanges the long-lived token for a short-lived JWT, which the subsequent task step picks up via `ctx.aspect.auth.credentials()`. The long-lived `<CLIENT_ID>:<SECRET>` is no longer set as a workflow-wide env var.
3. **Workflows-runner downstream jobs** — `setup-aspect` on these runners generates `/etc/bazel.bazelrc` via `rosetta bazelrc`, extending the runner's cache wiring to raw `bazel` calls outside `aspect <task>`. `bootstrap.sh` continues to drive the `//:cli` pre-build with `--nosystem_rc` (by design).

### Changes are visible to end-users: no

### Test plan

- Watch the CI runs that this PR triggers (CI - GitHub runners + CI - Workflows runners). They cover every modified workflow except `build_release_artifacts.yaml`.
- `build_release_artifacts.yaml` only fires on `workflow_dispatch` / `workflow_call` from `prerelease_build.yaml` and `publish_release.yaml`, so it isn't exercised by this PR's PR-triggered CI. Trigger `Pre-release Build` manually against this branch via the Actions UI to validate the swap.
