### PR TITLE
tip(github-actions): recommend aspect-build/setup-aspect for ASPECT_API_TOKEN

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -229,9 +229,18 @@ def _classify_missing_credentials(ctx):
     """Return `(kind, msg)` for `ctx.aspect.auth.credentials()` returning
     None. The kind discriminates the CI case (where setting
     `ASPECT_API_TOKEN` is the fix) from the local case (`aspect auth login`).
+
+    On GitHub Actions the recommended fix is the aspect-build/setup-aspect
+    action, which passes the token via stdin into `aspect auth login` so
+    the long-lived secret never lands in `GITHUB_ENV`. On Buildkite /
+    CircleCI / generic CI there's no equivalent action yet, so the fix
+    is still raw `ASPECT_API_TOKEN` in the job env.
     """
     setup_url = "https://docs.aspect.build/cli/authentication"
-    if ctx.std.env.var("BUILDKITE_AGENT_ACCESS_TOKEN"):
+    if ctx.std.env.var("GITHUB_ACTIONS"):
+        msg = "no Aspect credentials — use the aspect-build/setup-aspect action with aspect-api-token (https://github.com/aspect-build/setup-aspect)"
+        kind = _AUTH_KIND_NO_CREDENTIALS
+    elif ctx.std.env.var("BUILDKITE_AGENT_ACCESS_TOKEN"):
         msg = "no Aspect credentials — set ASPECT_API_TOKEN in the job env or provision it as a Buildkite secret (https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets)"
         kind = _AUTH_KIND_NO_CREDENTIALS
     elif ctx.std.env.var("CI"):

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -241,8 +241,16 @@ def _aspect_api_token_tip(host_id, degraded_features, host_advice):
 TIP_ADD_ASPECT_API_TOKEN_GHA = _aspect_api_token_tip(
     "github-actions",
     "PR check-run creation and updates, and PR summary comment aggregation",
-    "On GitHub Actions, expose the secret to your workflow:\n\n" +
-    "```yaml\nenv:\n  ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}\n```",
+    "On GitHub Actions, pass the token to the " +
+    "[aspect-build/setup-aspect]" +
+    "(https://github.com/aspect-build/setup-aspect) action:\n\n" +
+    "```yaml\n" +
+    "- uses: aspect-build/setup-aspect@<commit-sha>\n" +
+    "  with:\n" +
+    "    aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}\n" +
+    "```\n\n" +
+    "Find the latest release's commit SHA at " +
+    "https://github.com/aspect-build/setup-aspect/releases.",
 )
 
 TIP_ADD_ASPECT_API_TOKEN_BUILDKITE = _aspect_api_token_tip(

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -429,12 +429,23 @@ def _test_builtin_templates_shape(ctx):
     )
 
     # Body specialization sanity-check — wire-up advice differs per host.
-    if "workflow" not in TIP_ADD_ASPECT_API_TOKEN_GHA["body"]:
-        fail("GHA tip body missing GHA-specific advice")
+    # The GHA tip recommends the aspect-build/setup-aspect action (which
+    # passes the token via stdin into `aspect auth login`, so the
+    # long-lived secret never lands in GITHUB_ENV); there's no equivalent
+    # for Buildkite / CircleCI yet, so those still advise raw env wiring.
+    if "setup-aspect" not in TIP_ADD_ASPECT_API_TOKEN_GHA["body"]:
+        fail("GHA tip body should recommend aspect-build/setup-aspect")
     if "Buildkite's secrets docs" not in TIP_ADD_ASPECT_API_TOKEN_BUILDKITE["body"]:
         fail("Buildkite tip body missing Buildkite-specific advice")
     if "context" not in TIP_ADD_ASPECT_API_TOKEN_CIRCLECI["body"]:
         fail("CircleCI tip body missing CircleCI-specific advice")
+
+    # The GHA tip must NOT recommend the deprecated workflow-level env
+    # pattern (`env: ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}`)
+    # that leaks the long-lived token to every step in the job. Catch
+    # accidental regressions to that pattern.
+    if "env:\n  ASPECT_API_TOKEN" in TIP_ADD_ASPECT_API_TOKEN_GHA["body"]:
+        fail("GHA tip body should not recommend exposing ASPECT_API_TOKEN as a workflow-level env var (use setup-aspect instead)")
 
     # PR-summary-comment aggregation is GHA-only today, so only the GHA
     # tip should mention it. BK / CircleCI tips listing a feature that


### PR DESCRIPTION
## Summary

When aspect-cli detects a missing `ASPECT_API_TOKEN` in a CI job, it emits a host-specific tip explaining how to provision one. The **GitHub Actions** variant of that tip previously advised the workflow-level env pattern:

```yaml
env:
  ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
```

That pattern leaks the long-lived `client_id:secret` to every step in the job — any third-party action you call can read `process.env`. With [`aspect-build/setup-aspect`](https://github.com/aspect-build/setup-aspect) now released, the recommended pattern is to pass the token as a step input; setup-aspect pipes it via stdin into `aspect auth login --with-api-token` and only the short-lived JWT lands on disk.

```yaml
- uses: aspect-build/setup-aspect@<commit-sha>
  with:
    aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
```

The tip body now recommends setup-aspect with a pointer to https://github.com/aspect-build/setup-aspect/releases for the latest commit SHA (instead of hard-coding one that would go stale in user-facing strings).

The one-line error message preceding the tip (`_classify_missing_credentials` in `github.axl`) is updated in the same place so the message and the tip don't disagree.

Buildkite / CircleCI tips are unchanged — there's no equivalent action for those hosts yet, so the raw-env recommendation is still the right advice there.

A regression-guard test asserts the GHA tip body must not contain the deprecated `env:\n  ASPECT_API_TOKEN` snippet, so future edits don't accidentally re-introduce the leaky pattern.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- The GitHub Actions tip for missing `ASPECT_API_TOKEN` now recommends the [`aspect-build/setup-aspect`](https://github.com/aspect-build/setup-aspect) action with the `aspect-api-token` input instead of exporting the long-lived secret as a workflow-level env var.

### Test plan

- Covered by existing test cases (`aspect dev test-tips`, `aspect dev test-github-detect`).
- New test case added: regression-guard in `tips_test.axl` asserting the GHA tip body must recommend `setup-aspect` and must not contain the deprecated workflow-level env pattern.