### PR TITLE
Improve README

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -38,10 +38,6 @@ _user_task = task(
 buildifier = format.alias(
     defaults = {
         "formatter_target": "@buildifier_prebuilt//buildifier",
-        # buildifier_binary is a symlink to the raw Go binary; it does not
-        # switch to $BUILD_WORKING_DIRECTORY on its own, so we run it in
-        # the user's cwd to make relative paths resolve.
-        "run_in_cwd": True,
         # Fires only when the format task would otherwise pass zero files
         # to the formatter (e.g. `--scope=all`, or a `--scope=changed` run
         # that degraded because no changed files matched). The bare
@@ -58,6 +54,10 @@ buildifier = format.alias(
         # https://docs.aspect.build/cli/tasks/buildifier#run-it-locally for
         # the user-facing reference.
         "formatter_args_for_tree_walk": ["-r", "."],
+        # buildifier_binary is a symlink to the raw Go binary; it does not
+        # switch to $BUILD_WORKING_DIRECTORY on its own, so we run it in
+        # the user's cwd to make relative paths resolve.
+        "run_in_cwd": True,
         "include_patterns": [
             "**/BUCK",
             "**/BUILD",

--- a/README.md
+++ b/README.md
@@ -1,57 +1,214 @@
 # Aspect CLI
 
-Aspect CLI is a programmable task runner built on top of Bazel that "just fits" with your repository and developer workflows.
+`aspect` is a free, open-source, programmable task runner built on top of Bazel. It replaces the pile of bespoke shell scripts and CI YAML that every Bazel monorepo eventually grows — format pre-submits, lint enforcement, BUILD-file generation, release-tag delivery — with a single command-line tool that behaves identically on a developer laptop and in CI.
 
-## Bazel's Shortcoming
+```text
+$ aspect test //...
+→ 🎬 Running `test` task
 
-Bazel is Google's powerful polyglot build system.
+→ 🔧 Setup · Running setup
 
-It's excellent at loading a dependency graph from package declarations (`query`/`cquery`), and analyzing an action graph from rule implementations (`aquery`).
-It also has powerful and scalable execution for building action outputs and test results (`build`&`test`).
+→ 🧪 Test · Spawning bazel test
+INFO: Bazel 9.0.1
+INFO: Analyzed 147 targets (0 packages loaded, 0 targets configured).
+INFO: Found 122 targets and 25 test targets...
+INFO: Elapsed time: 0.866s, Critical Path: 0.07s
+INFO: 1 process: 31 action cache hit, 1 internal.
+INFO: Build completed successfully, 1 total action
 
-Bazel is extensible, but only for defining build rules that produce additional output files.
-It falls short on customizing developer workflows.
-In fact the Bazel commands not mentioned above are not-so-excellent attempts at adding a few developer workflows for use within Google.
+Executed 0 out of 25 tests: 25 tests pass.
+INFO: Build Event Protocol files produced successfully.
 
-The fact that many companies have scripted around Bazel, and the local development scripts drift from the CI testing scripts, show that something is missing: a "task runner" layer on top of `query` and `build` primitives.
+→ ✅ Passed `test` task in 1.2s · Tests passed (cached)
+    🔧 Setup   2ms  Prepare the task environment
+    🧪 Test   1.2s  Run bazel tests
+```
 
-## Introducing Aspect CLI
+Every `aspect <task>` ends with that per-phase breakdown, so the slow part of a CI step is always called out by name. The same content gets posted back to your PR as Buildkite annotations, GitHub Status Checks, and a PR task summary comment (see [examples below](#see-it-in-action)). [The CLI overview](https://docs.aspect.build/cli/overview#what-youll-see) shows `aspect format`, `aspect buildifier`, and `aspect lint` runs too — including the hold-the-line output (linter surfaces findings in unmodified files; the task still passes because no *new* violations were introduced).
 
-Aspect CLI lets you program custom commands using Aspect Extension Language (AXL), a Starlark dialect, for robust, maintainable workflows.
-Say goodbye to brittle Bash wrappers and delete your `Makefile`.
+## Configure and extend in AXL
 
-- New engineers on the team don't struggle to setup their machine and run the series of commands to get a working build or reproduce what happened on CI.
-- Product engineers finally regain control over their own productivity.
-- Developer Infrastructure teams can stop chasing reports of misbehavior on CI and integrate great tooling into every developers routine.
+[AXL, the Aspect Extension Language](https://docs.aspect.build/cli/overview#aspect-extension-language), is how you configure built-in tasks (in `.aspect/config.axl`) and add your own (as `.aspect/*.axl` files). It's a [typed Starlark](https://github.com/facebook/starlark-rust/blob/main/docs/types.md) dialect evaluated by the [Rust Starlark](https://github.com/facebook/starlark-rust) interpreter built by the [Buck2](https://buck2.build/) team, so `.axl` files catch type errors at parse time and parse fast even on huge repos.
 
-Whether you're streamlining CI/CD, enforcing code standards, or integrating tools, Aspect CLI boosts productivity. It's fast, safe, and open source—try it today and transform how your team builds!
+Here's an example `.aspect/config.axl` that exercises several built-ins (for a full live config running in CI, see [`aspect-build/bazel-examples`](https://github.com/aspect-build/bazel-examples/blob/main/.aspect/config.axl)):
 
-## Extensions
+```python
+"""Aspect CLI configuration."""
 
-We publish extensions to https://github.com/aspect-extensions.
+load("@aspect//feature/artifacts.axl", "ArtifactUpload")
+load("@aspect//format.axl", "format")
+load("@aspect//traits.axl", "BazelTrait")
 
-You can also search for the `aspect-extensions` topic:
-http://github.com/topics/aspect-extensions
+buildifier = format.alias(
+    defaults = {
+        "formatter_target": "@buildifier_prebuilt//buildifier",
+        "formatter_args_for_tree_walk": ["-r", "."],
+        "run_in_cwd": True,
+        "include_patterns": [
+            "**/BUILD",
+            "**/BUILD.bazel",
+            "**/MODULE.bazel",
+            "**/*.MODULE.bazel",
+            "**/WORKSPACE",
+            "**/WORKSPACE.bazel",
+            "**/*.axl",
+            "**/*.bzl",
+            "**/*.star",
+        ],
+    },
+    summary = "Format Starlark files using buildifier.",
+)
 
-You can write your own extensions as well. See the documentation.
+def config(ctx: ConfigContext):
+    # Set --config=ci on all bazel commands on all CI environments.
+    if bool(ctx.std.env.var("CI")):
+        ctx.traits[BazelTrait].extra_flags.extend([
+            "--config=ci",
+        ])
+
+    # Register the buildifier alias as a CLI command.
+    ctx.tasks.add(buildifier)
+
+    # Lint aspects — required by the built-in `aspect lint` task. Same set
+    # locally as on CI; CI invocations don't need to repeat the --aspect flags.
+    ctx.tasks["lint"].args.aspects = [
+        "//tools/lint:linters.bzl%buf",
+        "//tools/lint:linters.bzl%checkstyle",
+        "//tools/lint:linters.bzl%clippy",
+        "//tools/lint:linters.bzl%eslint",
+        "//tools/lint:linters.bzl%keep_sorted",
+        "//tools/lint:linters.bzl%pmd",
+        "//tools/lint:linters.bzl%ruff",
+        "//tools/lint:linters.bzl%shellcheck",
+    ]
+
+    # Delivery.
+    ctx.tasks["delivery"].args.query = "kind(\"oci_push rule\", //...)"
+    ctx.tasks["delivery"].args.bazel_flags = [
+        "--config=release",
+    ]
+
+    # Enable artifact uploads for testlogs, profile, and BEP.
+    # upload_test_logs="failed" — the logs from passing tests are noise;
+    # failing/flaky tests' logs are the ones anyone would actually open.
+    ctx.features[ArtifactUpload].args.upload_test_logs = "failed"
+    ctx.features[ArtifactUpload].args.upload_profile = True
+    ctx.features[ArtifactUpload].args.upload_bep = True
+```
+
+## Why another tool on top of Bazel?
+
+`bazel` is a build system, not a developer-workflow tool. Every Bazel monorepo eventually grows the same scaffolding by hand — format pre-submits, lint enforcement, BUILD-file generation, release-tag delivery — written in shell or YAML, copy-pasted across teams, behaving differently in CI than on a laptop.
+
+`aspect` replaces that scaffolding. It's a programmable task-runner layer on top of `bazel`: built-in tasks you tune in `.aspect/config.axl`, custom tasks you add as `.aspect/*.axl` files, and a clean fallthrough to raw `bazel` for anything `aspect` doesn't wrap. You're not switching build systems — you're extending the one you already have.
+
+**What's in the box:**
+
+- **Same command, every environment.** `aspect lint` on a laptop does the same thing as in a CI pipeline. Cuts an entire class of "works on my machine but not in CI" bugs.
+- **The CI scaffolding every Bazel repo eventually re-invents** — built in: hold-the-line lint (fails only on violations *you* introduced), selective delivery (re-deploys only services whose Bazel outputs actually changed), smart changed-file detection, bounded retry on transient Bazel errors, native artifact upload, and per-step status checks on GitHub, Buildkite, GitLab, and CircleCI.
+- **Custom CLI commands in ~10 lines of Starlark.** Drop a `.axl` file into `.aspect/` and `aspect <name>` is a real CLI command (see below). Tasks can shell out, read/write files, query the build graph, and subscribe to Bazel's Build Event Stream and Compact Execution Log.
+- **Per-repo version pin.** `.aspect/version.axl` pins the CLI version; the launcher fetches the matching binary on first invocation, so local and CI stay in sync.
+- **Standalone or with Aspect Workflows.** The CLI works on its own with any Bazel workspace. Pair it with [Aspect Workflows](https://docs.aspect.build/aspect-workflows) — Aspect's managed Bazel-CI runners, deployed in your AWS or GCP account or hosted by Aspect — for sub-minute cached builds, 2–3× faster CI, 40–80% cloud-compute savings, plus a Web UI, remote cache, and remote build execution.
+
+## Install
+
+```shell
+curl -fsSL https://install.aspect.build | bash
+```
+
+macOS and Linux. Apache-2.0. No Aspect account required.
+
+The [10-minute Quickstart](https://docs.aspect.build/quickstart) walks from install to writing a custom task. Full docs: [docs.aspect.build/cli](https://docs.aspect.build/cli/overview).
+
+## Built-in tasks
+
+Three tasks work in any Bazel workspace with no extra setup — they're `bazel build` / `bazel test` / `bazel run` plus the retry, BES streaming, artifact upload, status checks, and CI-platform reporting described above:
+
+| Task | What it does |
+|---|---|
+| [`aspect build`](https://docs.aspect.build/cli/tasks/build_test) | Build Bazel targets |
+| [`aspect test`](https://docs.aspect.build/cli/tasks/build_test) | Run Bazel tests, with optional LCOV coverage |
+| [`aspect run`](https://docs.aspect.build/cli/tasks/run) | Build and run a binary target |
+
+The remaining built-ins need both **Bazel-graph wiring** (a tool dependency in `MODULE.bazel`, plus a BUILD target or rule wired up to it) and **AXL wiring** (programmable configuration in `.aspect/config.axl`) to point the task at your repo's setup. Each task page walks through both:
+
+| Task | What it does | What it needs |
+|---|---|---|
+| [`aspect format`](https://docs.aspect.build/cli/tasks/format) | Format files changed in the PR | A `//tools:format` BUILD target (the task's default) that wraps a formatter binary — typically via [`aspect_rules_lint`](https://registry.bazel.build/modules/aspect_rules_lint) or [`buildifier_prebuilt`](https://registry.bazel.build/modules/buildifier_prebuilt), plus the matching `bazel_dep`. Override the target path with `formatter_target` in `.aspect/config.axl` if you put it somewhere else. |
+| [`aspect lint`](https://docs.aspect.build/cli/tasks/lint) | Run linters with hold-the-line strategy | [`aspect_rules_lint`](https://registry.bazel.build/modules/aspect_rules_lint) plus the linter rules of choice (eslint, ruff, golangci-lint, …); lint aspects declared in `.aspect/config.axl` |
+| [`aspect gazelle`](https://docs.aspect.build/cli/tasks/gazelle) | Generate and sync BUILD files | A `//tools:gazelle` BUILD target (the task's default) that wraps a Gazelle binary — typically via [`gazelle`](https://registry.bazel.build/modules/gazelle) or [`aspect_gazelle_prebuilt`](https://registry.bazel.build/modules/aspect_gazelle_prebuilt) (for Starlark-defined extensions), plus the matching `bazel_dep`. Override the target path with `gazelle_target` in `.aspect/config.axl` if you put it somewhere else. |
+| [`aspect delivery`](https://docs.aspect.build/cli/tasks/delivery) | Deliver only targets whose Bazel-built outputs changed | BUILD targets that implement delivery (e.g. `oci_push`, `helm_push`, custom `bazel_run`-able scripts); a `--query` (or `config.axl` equivalent) selecting which targets are deliverables |
+
+`aspect help` lists every task available in your repo (built-ins plus any custom ones you've added).
+
+## Custom tasks
+
+Drop a `.axl` file into `.aspect/`, define a task, and `aspect <name>` is a CLI command:
+
+```python
+# .aspect/codegen.axl
+def _impl(ctx: TaskContext) -> int:
+    return ctx.bazel.build(*ctx.args.targets).wait().code
+
+codegen = task(
+    summary = "Run the code generator.",
+    implementation = _impl,
+    args = {
+        "targets": args.positional(default = ["//gen/..."]),
+    },
+)
+```
+
+```shell
+aspect codegen //gen/services/...
+```
+
+Tasks can shell out to any subprocess, read and write files, query the build graph, subscribe to Bazel's Build Event Stream, and declare typed arguments. [How to run and define tasks](https://docs.aspect.build/cli/guides/basic) covers the full walkthrough. The [AXL reference](https://docs.aspect.build/axl/types) documents every type and built-in.
+
+## Running in CI
+
+The same `aspect <task>` command you run locally works identically in CI. [Running tasks in CI](https://docs.aspect.build/cli/tasks-ci) has ready-to-paste YAML for GitHub Actions, Buildkite, GitLab CI, and CircleCI — for both provider-hosted runners and Aspect Workflows CI runners.
+
+On GitHub Actions specifically, [`aspect-build/setup-aspect`](https://github.com/aspect-build/setup-aspect) handles the install, wires up GHA caching, and exchanges your `ASPECT_API_TOKEN` for a short-lived JWT — in one action step.
+
+## See it in action
+
+The [`aspect-build/bazel-examples`](https://github.com/aspect-build/bazel-examples) repo runs `aspect <task>` pipelines on every commit across all four supported CI providers. Click through to inspect a current build:
+
+| CI provider | Live pipeline |
+|---|---|
+| GitHub Actions | [Actions tab](https://github.com/aspect-build/bazel-examples/actions?query=branch%3Amain) |
+| Buildkite | [Recent builds](https://buildkite.com/aspect-build/bazel-examples/builds?branch=main) |
+| GitLab CI/CD | [Pipelines](https://gitlab.com/aspect-build/bazel-examples/-/pipelines?scope=all&ref=main) |
+| CircleCI | [Pipeline runs](https://app.circleci.com/pipelines/github/aspect-build/bazel-examples?branch=main) |
+
+`aspect <task>` posts task results to three surfaces:
+
+- **PR task summary comment** — a single comment summarising every task in the pipeline.
+- **GitHub Status Checks** — one check per `aspect <task>` invocation, named by `--task-key`.
+- **Buildkite annotations** _(when running on Buildkite)_ — one annotation per `aspect <task>` invocation, rendered at the top of the build page.
+
+Live links to each, from real runs of this repo's own CI: [What `aspect <task>` reports back](https://docs.aspect.build/cli/tasks-ci#what-aspect-%3Ctask%3E-reports-back).
 
 ## Comparison to older versions
 
 > [!NOTE]
-> This is a Rust rewrite, superseding the legacy Go version that was published in version 2025.41 and earlier.
+> This is a Rust rewrite, superseding the legacy Go version published as version 2025.41 and earlier.
 > The older implementation is now in maintenance mode at [aspect-build/aspect-cli-legacy](https://github.com/aspect-build/aspect-cli-legacy).
 
 Versions before 2025.42 differed in some notable ways:
 
-- Older versions shadowed the `bazel` command in our recommended installation, using homebrew or bazeliskrc to override `bazel`.
-  Now `aspect` works alongside `bazel`.
-- The plugin system used a gRPC client/server protocol. Now `aspect` uses a Starlark dialect called "Aspect Extension Language".
-- Older versions included a fully pre-compiled Gazelle binary along with some Gazelle extensions, using the `configure` command. This has moved to a standalone repo: https://github.com/aspect-build/aspect-gazelle
+- Older versions shadowed the `bazel` command in the recommended installation, using homebrew or `bazeliskrc` to override `bazel`. Now `aspect` works alongside `bazel`.
+- The plugin system used a gRPC client/server protocol. Now `aspect` uses Starlark via the Aspect Extension Language (AXL).
+- Older versions included a fully pre-compiled Gazelle binary along with some Gazelle extensions, using the `configure` command. This has moved to a standalone repo: [aspect-build/aspect-gazelle](https://github.com/aspect-build/aspect-gazelle).
 
-## Licenses
+## Community and support
 
-Aspect CLI is licensed under [Apache 2](./LICENSE).
+- Documentation: [docs.aspect.build/cli](https://docs.aspect.build/cli/overview)
+- Quickstart: [docs.aspect.build/quickstart](https://docs.aspect.build/quickstart)
+- Slack: [slack.aspect.build](https://slack.aspect.build/)
+- Issues and discussions: this repo
 
-## For Enterprise
+## License
 
-Built by [Aspect](http://aspect.build). Explore our products for advanced features.
+[Apache License 2.0](./LICENSE).


### PR DESCRIPTION
## Summary

Rewrite of the README to lead with what the CLI actually does and why a developer would adopt it.

- Open with a live `aspect test //...` run so the per-phase output and timing breakdown are the first thing on the page.
- New **Configure and extend in AXL** section introducing AXL (typed Starlark on the Rust Starlark interpreter from the Buck2 team) with a realistic `.aspect/config.axl` example.
- New **Why another tool on top of Bazel?** section enumerating what's in the box: hold-the-line lint, selective delivery, retry on transient errors, native artifact upload, per-step status checks on GitHub/Buildkite/GitLab/CircleCI.
- Split the **Built-in tasks** reference into a zero-config table (`build` / `test` / `run`) and a "needs Bazel-graph + AXL wiring" table (`format` / `lint` / `gazelle` / `delivery`) with BCR links for `aspect_rules_lint`, `buildifier_prebuilt`, `gazelle`, and `aspect_gazelle_prebuilt`.
- Compact custom-task example showing that a new `aspect <name>` CLI command is ~10 lines of AXL.
- New **See it in action** section linking to live pipelines across all four CI providers and to the per-task PR-feedback examples (PR summary comment, GitHub Status Checks, Buildkite annotations) on the docsite.
- Retain the Rust-rewrite / legacy-Go note.
