### PR TITLE
ci: register CI - Delivery workflow on main

### DIFF
--- a/.github/workflows/ci-workflows-delivery.yaml
+++ b/.github/workflows/ci-workflows-delivery.yaml
@@ -1,0 +1,16 @@
+name: CI - Delivery
+
+# Placeholder so GitHub registers this workflow on the default branch.
+#
+# `gh workflow run` / the workflow_dispatch REST API resolve a workflow by its
+# path on the default branch, so a file that only ever lived on a feature
+# branch 404s. This stub exists purely to register the `CI - Delivery` name;
+# a follow-up branch replaces it with the real delivery jobs.
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI - Delivery placeholder; real jobs land in a follow-up."


### PR DESCRIPTION
Registers the `CI - Delivery` workflow on `main` by landing a placeholder `ci-workflows-delivery.yaml`.

`gh workflow run` and the `workflow_dispatch` REST API resolve a workflow by its file path **on the default branch**. A delivery workflow that has only ever existed on a feature branch therefore returns `HTTP 404: workflow ci-workflows-delivery.yaml not found on the default branch` — which is exactly what `ci-workflows.yaml`'s dispatch step hit. Once this file is on `main`, GitHub registers the workflow and dispatch-by-name (targeting the same commit) works from any branch.

The contents are a deliberate no-op: just the `CI - Delivery` name, a `workflow_dispatch` trigger, and a single placeholder job. A follow-up branch replaces the no-op job with the real delivery jobs (dispatched from `ci-workflows.yaml` after pre-build, reusing the prebuilt CLI artifact cross-run).

---

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no

### Test plan

- Manual testing; please provide instructions so we can reproduce: After merge, confirm `CI - Delivery` appears under the repo's Actions workflows and `gh workflow run ci-workflows-delivery.yaml --ref <branch>` succeeds (no 404).
