### PR TITLE
Error on undeclared task/feature arg in config.axl

### DIFF
--- a/crates/axl-runtime/src/engine/arguments.rs
+++ b/crates/axl-runtime/src/engine/arguments.rs
@@ -37,6 +37,17 @@ use starlark::values::starlark_value;
 /// alias-overridden defaults and config.axl overrides). Empty for the
 /// config-time override store role — nothing is "explicit on the CLI"
 /// there.
+///
+/// `valid_keys` constrains which attribute names `set_attr` will accept:
+///
+/// - `Some(set)` — config-time override store. Assigning `.args.<name> = ...`
+///   in config.axl is rejected unless `<name>` is one of the task's / feature's
+///   declared args. This turns a typo (`warm_not_runnable` for
+///   `warn_not_runnable`) into a script error instead of a silent no-op that
+///   writes a junk key the runtime never reads.
+/// - `None` — runtime-args store (`ctx.args`), built by merging CLI + config +
+///   defaults. Stays permissive: callers insert resolved values directly and
+///   the key set is already known-good, so there's nothing to validate against.
 #[derive(Debug, Clone, ProvidesStaticType, Display, NoSerialize, Allocative)]
 #[display("<Arguments>")]
 pub struct Arguments<'v> {
@@ -44,13 +55,28 @@ pub struct Arguments<'v> {
     args: RefCell<SmallMap<String, Value<'v>>>,
     #[allocative(skip)]
     explicit_cli_keys: RefCell<SmallMap<String, ()>>,
+    #[allocative(skip)]
+    valid_keys: Option<SmallMap<String, ()>>,
 }
 
 impl<'v> Arguments<'v> {
+    /// Permissive store (runtime-args role) — `set_attr` accepts any name.
     pub fn new() -> Self {
         Self {
             args: RefCell::new(SmallMap::new()),
             explicit_cli_keys: RefCell::new(SmallMap::new()),
+            valid_keys: None,
+        }
+    }
+
+    /// Schema-checked override store (config-time role). `set_attr` rejects
+    /// any attribute name not in `valid_keys`. Pass the task's / feature's
+    /// declared arg names (e.g. `task.args().keys()`).
+    pub fn with_schema(valid_keys: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            args: RefCell::new(SmallMap::new()),
+            explicit_cli_keys: RefCell::new(SmallMap::new()),
+            valid_keys: Some(valid_keys.into_iter().map(|k| (k, ())).collect()),
         }
     }
 
@@ -107,6 +133,20 @@ impl<'v> StarlarkValue<'v> for Arguments<'v> {
     }
 
     fn set_attr(&self, attribute: &str, value: Value<'v>) -> starlark::Result<()> {
+        if let Some(valid) = &self.valid_keys {
+            if !valid.contains_key(attribute) {
+                let mut names: Vec<&str> = valid.keys().map(String::as_str).collect();
+                names.sort_unstable();
+                let known = if names.is_empty() {
+                    "(none)".to_owned()
+                } else {
+                    names.join(", ")
+                };
+                return Err(starlark::Error::new_other(anyhow::anyhow!(
+                    "no such arg `{attribute}`; valid args are: {known}"
+                )));
+            }
+        }
         self.args.borrow_mut().insert(attribute.to_owned(), value);
         Ok(())
     }
@@ -210,6 +250,7 @@ fn arguments_methods(builder: &mut MethodsBuilder) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use starlark::environment::Module;
 
     #[test]
     fn explicit_keys_default_to_unset() {
@@ -234,5 +275,54 @@ mod tests {
         args.mark_explicit("scope".to_string());
         args.mark_explicit("scope".to_string());
         assert!(args.is_explicit_key("scope"));
+    }
+
+    /// A permissive (runtime-args) store accepts any attribute name — this is
+    /// how `merge_args` populates `ctx.args` with resolved values.
+    #[test]
+    fn set_attr_permissive_accepts_unknown() {
+        Module::with_temp_heap(|module| {
+            let v = module.heap().alloc(true);
+            let args = Arguments::new();
+            args.set_attr("anything_at_all", v)
+                .expect("permissive store should accept any name");
+            assert!(args.contains_key("anything_at_all"));
+        });
+    }
+
+    /// A schema-checked (config-time override) store accepts a declared arg…
+    #[test]
+    fn set_attr_schema_accepts_known() {
+        Module::with_temp_heap(|module| {
+            let v = module.heap().alloc(true);
+            let args = Arguments::with_schema(["warn_not_runnable".to_owned(), "query".to_owned()]);
+            args.set_attr("warn_not_runnable", v)
+                .expect("declared arg should be accepted");
+            assert!(args.contains_key("warn_not_runnable"));
+        });
+    }
+
+    /// …and rejects a typo, naming the valid args. This is the regression test
+    /// for the silent `ctx.tasks["delivery"].args.warm_not_runnable = True`
+    /// no-op: an undeclared arg name must error rather than write a junk key.
+    #[test]
+    fn set_attr_schema_rejects_unknown() {
+        Module::with_temp_heap(|module| {
+            let v = module.heap().alloc(true);
+            let args = Arguments::with_schema(["warn_not_runnable".to_owned(), "query".to_owned()]);
+            let err = args
+                .set_attr("warm_not_runnable", v)
+                .expect_err("typo'd arg name must be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("warm_not_runnable"),
+                "names the bad key: {msg}"
+            );
+            assert!(msg.contains("warn_not_runnable"), "lists valid args: {msg}");
+            assert!(
+                !args.contains_key("warm_not_runnable"),
+                "junk key not written"
+            );
+        });
     }
 }

--- a/crates/axl-runtime/src/engine/feature.rs
+++ b/crates/axl-runtime/src/engine/feature.rs
@@ -164,7 +164,7 @@ impl<'v> Feature<'v> {
         let frozen = frozen_value
             .downcast_ref::<FrozenFeature>()
             .expect("from_frozen called with non-FrozenFeature value");
-        let overrides = heap.alloc(Arguments::new());
+        let overrides = heap.alloc(Arguments::with_schema(frozen.args.keys().cloned()));
         Feature {
             r#impl: frozen.r#impl.to_value(),
             args: frozen.args.clone(),
@@ -480,7 +480,6 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<Feature<'v>> {
         let path = Env::current_script_path(eval)?;
-        let overrides = eval.heap().alloc(Arguments::new());
         if !name.is_empty() {
             validate_command_name(&name, "feature name").map_err(|e| anyhow::anyhow!(e))?;
         }
@@ -537,6 +536,9 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             args_.insert(arg_name, cli_arg.clone());
         }
 
+        let overrides = eval
+            .heap()
+            .alloc(Arguments::with_schema(args_.keys().cloned()));
         Ok(Feature {
             r#impl: implementation.0,
             args: args_,

--- a/crates/axl-runtime/src/engine/task.rs
+++ b/crates/axl-runtime/src/engine/task.rs
@@ -188,7 +188,7 @@ impl<'v> Task<'v> {
         let frozen = frozen_value
             .downcast_ref::<FrozenTask>()
             .expect("from_frozen called with non-FrozenTask value");
-        let overrides = heap.alloc(Arguments::new());
+        let overrides = heap.alloc(Arguments::with_schema(frozen.args.keys().cloned()));
         let traits: Vec<Value<'v>> = frozen.traits.iter().map(|fv| fv.to_value()).collect();
         Task {
             r#impl: frozen.r#impl.to_value(),
@@ -496,6 +496,9 @@ fn build_alias<'v>(
         (false, _) => format!("{}\n\n{}", description, alias_hint),
     };
 
+    let overrides = eval
+        .heap()
+        .alloc(Arguments::with_schema(overlaid.keys().cloned()));
     Ok(Task {
         args: overlaid,
         r#impl: base.implementation(),
@@ -506,7 +509,7 @@ fn build_alias<'v>(
         name: RefCell::new(name),
         traits: base.trait_values(),
         path: Env::current_script_path(eval)?,
-        overrides: eval.heap().alloc(Arguments::new()),
+        overrides,
     })
 }
 
@@ -688,6 +691,9 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             }
         }
 
+        let overrides = eval
+            .heap()
+            .alloc(Arguments::with_schema(args_.keys().cloned()));
         Ok(Task {
             args: args_,
             r#impl: implementation.0,
@@ -698,7 +704,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             name: RefCell::new(name),
             traits: all_traits,
             path: Env::current_script_path(eval)?,
-            overrides: eval.heap().alloc(Arguments::new()),
+            overrides,
         })
     }
 }


### PR DESCRIPTION
Assigning an undeclared arg on a task's or feature's `.args` override store in `config.axl` silently succeeded, writing a junk key the runtime never reads. A typo like `ctx.tasks["delivery"].args.warm_not_runnable = True` (for `warn_not_runnable`) produced no error and no effect — the misspelled override was simply dropped.

`Arguments::set_attr` blindly inserted any attribute name into its map, with no validation against the task's/feature's declared args. (For contrast, reading an unknown arg already errors via `get_attr` returning `None`.)

This gives `Arguments` an optional `valid_keys` schema. The config-time override stores (`ctx.tasks[k].args`, `ctx.features[X].args`) are now constructed with `Arguments::with_schema(...)` from the declared arg names, so `set_attr` rejects an unknown name with `no such arg \`<name>\`; valid args are: ...`. The runtime-args store (`ctx.args`, built by merging CLI + config + defaults) stays permissive — its keys are already known-good and it inserts resolved values directly.

Wired into all five override-store creation sites: `Task::from_frozen`, the `task.alias(...)` builder, the `task(...)` global, `Feature::from_frozen`, and the `feature(...)` global.

---

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

- Assigning an undeclared argument on `ctx.tasks[...].args` / `ctx.features[...].args` in `config.axl` now raises a script error naming the valid args, instead of silently doing nothing. This surfaces typos (e.g. `warm_not_runnable` for `warn_not_runnable`) that previously went unnoticed. A config that set a bogus arg name will now fail until the name is corrected or removed.

- New test cases added
- Unit tests in `arguments.rs` cover: permissive store accepts any name; schema store accepts a declared arg; schema store rejects a typo, names the bad key and lists valid args, and does not write the junk key.

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
