### PR TITLE
Fix `aspect run` crash when ArtifactUpload uploads on build end

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -2,6 +2,7 @@
 
 load("@std//time.axl", "sleep_iter")
 load("./bazel.axl", "BazelTrait")
+load("./lib/artifacts.axl", "artifacts")
 load("./lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
 load("./lib/environment.axl", "error")
@@ -171,6 +172,6 @@ run = task(
         BazelTrait,
         HealthCheckTrait,
         TaskLifecycleTrait,
-    ] + tips.TRAITS,
+    ] + artifacts.TRAITS + tips.TRAITS,
     implementation = _impl,
 )


### PR DESCRIPTION
`aspect run` aborted with a runtime traceback whenever the ArtifactUpload feature tried to upload an artifact on build end:

```
aspect/lib/artifacts.axl:157, in _upload_file
    ctx.traits[_ArtifactsTrait].append(...)
error: Trait type 'anon' not found in TraitMap. Is it declared in a task's traits list?
```

The ArtifactUpload feature registers a `build_end` hook (`_on_build_end` → `_upload_file`) that records uploaded artifacts via `ctx.traits[_ArtifactsTrait]`. That trait has to be declared in the task's traits list — `build.axl` and `test.axl` both include `+ artifacts.TRAITS`, but `run.axl` did not. So once a build-end upload fired (profile / BEP / execlog / testlogs), `run` crashed accessing the missing trait.

Add `artifacts.TRAITS` to the `run` task's traits (and the `artifacts` load), matching build/test.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fixed a crash in `aspect run` ("Trait type 'anon' not found in TraitMap") that occurred when the Artifact Upload feature uploaded a profile / BEP / execlog / test log on build completion.

### Test plan

- Manual testing; please provide instructions so we can reproduce: With the ArtifactUpload feature enabled and `upload_profile`/`upload_bep` on (CI), `aspect run //some:target` now completes the build-end artifact upload instead of aborting. The CLI builds and loads the `run` task with the updated trait list.
