### PR TITLE
Fix task status row stuck on "Running" for warning/aborted outcomes

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -2605,10 +2605,16 @@ def format_run_date(ctx, epoch_ms):
             return val
     return ""
 
+# Terminal and live statuses. Must cover every value `_pick_status` / the
+# task lifecycle can emit — a missing key falls back to the 🔄/"Running"
+# default below, which leaves a finished task's status row stuck on "Running"
+# (e.g. a delivery that ends with `warning`). Icons mirror lib/result_text.axl.
 STATUS_ICONS = {
     "passed": "✅",
     "failed": "❌",
     "failing": "⚠️",
+    "warning": "⚠️",
+    "aborted": "🔥",
     "running": "🔄",
 }
 
@@ -2616,6 +2622,8 @@ STATUS_LABELS = {
     "passed": "Succeeded",
     "failed": "Failed",
     "failing": "Failing...",
+    "warning": "Flagged",
+    "aborted": "Aborted",
     "running": "Running...",
 }
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -8,7 +8,7 @@ Two task implementations live here:
     `compute_invocation_state`, `conclusion`, and skipped-bucket plumbing.
 """
 
-load("./bazel_results.axl", "MAX_TEST_TARGETS", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "init_data", "process_event", "render_check_output", "repro_targets")
+load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "init_data", "process_event", "render_check_output", "repro_targets")
 
 # ---------------------------------------------------------------------------
 # Fake data builders
@@ -1054,7 +1054,22 @@ def _test_repro_targets_dedups_fallback_input(ctx):
         ["//pkg/..."],
     )
 
+def _test_status_maps_cover_every_terminal_status(ctx):
+    """Every status `_pick_status` / the lifecycle can emit at terminal must
+    have an explicit icon AND label. A missing key falls back to 🔄/"Running"
+    in `build_invocation_rows`, which strands a finished task's status row on
+    "Running" (the delivery-ends-with-warning bug)."""
+    for status in ["passed", "failed", "failing", "warning", "aborted", "running"]:
+        _eq("STATUS_ICONS has %r" % status, status in STATUS_ICONS, True)
+        _eq("STATUS_LABELS has %r" % status, status in STATUS_LABELS, True)
+
+    # The terminal statuses specifically must not render as the live default.
+    for status in ["warning", "aborted"]:
+        _eq("%r icon is not the running default" % status, STATUS_ICONS[status] != "🔄", True)
+        _eq("%r label is not 'Running...'" % status, STATUS_LABELS[status] != "Running...", True)
+
 _UNIT_TESTS = [
+    _test_status_maps_cover_every_terminal_status,
     _test_failed_status_without_failure_bucket,
     _test_failed_status_with_explicit_action_failure,
     _test_passed_status_returns_successful_build,


### PR DESCRIPTION
A delivery task that finishes with warnings (or is aborted) left its status row stuck on "🔄 Running" forever, even though the run had completed:

```
⚠️ delivery //examples/deliverable:bash_deliverable… · 3 skipped, 2 warnings
🔄 Running · 📅 ... · ⏱ 30.3s · 🚚 Deliver 28ms | 🔧 Setup 7.7s · 🎯 Resolve 707ms · ...
```

The terminal `task_update(final=True)` is emitted correctly with `status="warning"`. The bug is in the status-row renderer: `STATUS_ICONS` / `STATUS_LABELS` in `bazel_results.axl` only had `passed` / `failed` / `failing` / `running`, and `build_invocation_rows` looks them up with a `🔄` / `"Running"` default. A terminal `warning` or `aborted` status had no entry, so it fell back to the live "Running" label — the row never reflected the terminal outcome.

Add the missing `warning` (⚠️ / "Flagged") and `aborted` (🔥 / "Aborted") entries, with icons matching `lib/result_text.axl`. This also affects `lint` / `format` / `test` / `build`, which can emit those terminal statuses.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fixed task status rows showing "🔄 Running" after a task had finished with a warning or aborted outcome (notably `aspect delivery` ending with warnings). The row now shows the terminal status.

### Test plan

- New test cases added
- `_test_status_maps_cover_every_terminal_status` asserts every status `_pick_status`/the lifecycle can emit has an explicit icon + label, and that `warning`/`aborted` don't render as the "Running" default. Verified live: `aspect dev test-bazel-results` passes (29 sections).
