### PR TITLE
fix(workflows): detect+repair bazel#23880 poisoning, replace sick runner

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -6,6 +6,7 @@ load("@aspect//feature/github_status_comments_test.axl", "pr_comment_snapshot_te
 load("@aspect//format.axl", "format")
 load("@aspect//lib/bazel_flags_test.axl", "bazel_flags_tests")
 load("@aspect//lib/bazel_results_test.axl", "bazel_results_unit_tests", "template_snapshot_tests")
+load("@aspect//lib/bazel_runner_test.axl", "bazel_runner_tests")
 load("@aspect//lib/delivery_results_test.axl", "delivery_template_snapshot_tests")
 load("@aspect//lib/format_results_test.axl", "format_template_snapshot_tests")
 load("@aspect//lib/format_spawn_test.axl", "format_spawn_tests")
@@ -19,6 +20,7 @@ load("@aspect//lib/rate_limit_test.axl", "rate_limit_tests")
 load("@aspect//lib/repro_commands_test.axl", "repro_commands_tests")
 load("@aspect//lib/runnable_test.axl", "runnable_tests")
 load("@aspect//lib/runner_job_history_test.axl", "runner_job_history_tests")
+load("@aspect//lib/sandbox_recovery_test.axl", "sandbox_recovery_tests")
 load("@aspect//lib/tar_test.axl", "tar_tests")
 load("@aspect//lib/tips_test.axl", "tips_tests")
 load("@aspect//traits.axl", "BazelTrait", "LintTrait")
@@ -171,6 +173,13 @@ def config(ctx: ConfigContext):
     # Run with: aspect dev test-tar
     ctx.tasks.add(tar_tests)
 
+    # Runner-side mitigations for bazelbuild/bazel#23880 and persistent
+    # server-internal failures — detect-and-repair + signal-instance-unhealthy
+    # policy for the bazel_attempt_end / build_end hooks the Workflows
+    # feature registers.
+    # Run with: aspect dev test-sandbox-recovery
+    ctx.tasks.add(sandbox_recovery_tests)
+
     # canonical_label normalization — local labels, external labels, and bzlmod
     # canonical @@module+version//... → @module//... conversion.
     # Run with: aspect dev test-runnable
@@ -205,6 +214,11 @@ def config(ctx: ConfigContext):
     # Bazel flag-resolution helper unit tests.
     # Run with: aspect dev test-bazel-flags
     ctx.tasks.add(bazel_flags_tests)
+
+    # bazel_runner.axl dispatch helpers — the seam every bazel-driving task
+    # uses to fire `bazel_trait.bazel_attempt_end` and `build_end` hooks.
+    # Run with: aspect dev test-bazel-runner
+    ctx.tasks.add(bazel_runner_tests)
 
     # Delivery template snapshot tests — renders delivery_results templates.
     # Run with: aspect dev test-delivery-template-snapshots

--- a/crates/aspect-cli/src/builtins/aspect/bazel.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazel.axl
@@ -81,5 +81,6 @@ BazelTrait = trait(
     build_start = attr(list[typing.Callable[[TaskContext], None]], default = [], description = "Hooks called once before the Bazel invocation starts"),
     build_event = attr(list[typing.Callable[[TaskContext, dict], None]], default = [], description = "Hooks called for each Build Event Protocol event received during the build"),
     build_retry = attr(typing.Callable[[int], bool], default = default_retry, description = "Predicate called with the exit code; return True to retry the build"),
-    build_end = attr(list[typing.Callable[[TaskContext, int], None]], default = [], description = "Hooks called once after the Bazel invocation completes, with the exit code"),
+    bazel_attempt_end = attr(list[typing.Callable[[TaskContext, int], None]], default = [], description = "Hooks called once after EACH Bazel invocation attempt (including retries), with that attempt's exit code. Runs after the wait() returns and before the retry decision, so a hook can take corrective action (e.g. clean stranded sandbox state) that might let the next retry succeed. Distinct from `build_end`, which fires once after the final attempt."),
+    build_end = attr(list[typing.Callable[[TaskContext, int], None]], default = [], description = "Hooks called once after the Bazel invocation completes (after all retries), with the final exit code"),
 )

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -103,6 +103,7 @@ load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DE
 load("@aspect//lib/artifacts.axl", "artifacts")
 load("@aspect//lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
+load("@aspect//lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@aspect//lib/ci.axl", "detect_build_url")
 load("@aspect//lib/delivery_results.axl", delivery_add_result = "add_result", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
 load(
@@ -340,6 +341,9 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
         # re-binding a Live sink errors.
         for sink in build_events:
             sink.wait()
+
+        dispatch_bazel_attempt_end(ctx, bazel_trait, status.code)
+
         if status.code == 0 or not bazel_trait.build_retry(status.code):
             break
 
@@ -381,7 +385,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     # delivery are noisy-but-expected, and the actionable signal lives in
     # the gRPC log we parse below. The log file is the escape hatch.
     phase2_log_path = _PHASE2_LOG_PATH.format(ctx.task.key)
-    ctx.bazel.build(
+    phase2_status = ctx.bazel.build(
         flags = phase2_flags,
         stdout = None,
         stderr = ctx.std.fs.create(phase2_log_path),
@@ -389,6 +393,10 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
         announce_command = announce_command,
         *targets
     ).wait()
+
+    # `build_end` deliberately not fired here — the outer caller dispatches
+    # it once with the aggregate build_code after `_get_output_shas` returns.
+    dispatch_bazel_attempt_end(ctx, bazel_trait, phase2_status.code)
 
     # Normalize user-supplied targets to apparent form so they match however
     # the gRPC log records the label (canonical @@module+// or apparent @module//).
@@ -918,11 +926,13 @@ def _delivery_impl(ctx):
             run_tracker.event(event)
         status = build.wait()
 
-        # When phase 1/2 was skipped, phase 3 is the only build that ran
-        # — dispatch build_end hooks here with its status.
+        dispatch_bazel_attempt_end(ctx, bazel_trait, status.code)
+
+        # When phase 1/2 was skipped, phase 3 is the only build that ran;
+        # otherwise the outer caller already fired `build_end` with the
+        # aggregate phase-1 build_code.
         if not phase_1_2_runs:
-            for handler in bazel_trait.build_end:
-                handler(ctx, status.code)
+            dispatch_bazel_build_end(ctx, bazel_trait, status.code)
         if status.code != 0:
             error(ctx.std, "Build failed with exit code {}. Phase-3 raw log: {}".format(status.code, phase3_log_path))
             for label in delivery_targets:

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -8,6 +8,11 @@ load(
     "print_environment_info",
 )
 load("../lib/health_check.axl", "HealthCheckTrait", "agent_health_check")
+load(
+    "../lib/sandbox_recovery.axl",
+    "make_attempt_end_hook",
+    "make_final_status_hook",
+)
 
 def _workflows_impl(ctx: FeatureContext):
     environment = get_workflows_environment(ctx.std)
@@ -44,6 +49,14 @@ def _workflows_impl(ctx: FeatureContext):
         # them inside the Setup phase; each prints its own BK section marker.
         hc_trait.health_check.append(lambda ctx: print_environment_info(ctx.std, environment))
         hc_trait.health_check.append(lambda ctx: agent_health_check(ctx, environment))
+
+        # Detect + repair stranded sandbox state (bazelbuild/bazel#23880) after
+        # every bazel attempt, and signal the runner unhealthy when the final
+        # exit is server-internal-error class. See `lib/sandbox_recovery.axl`
+        # for the full rationale; on-runner only because `signal_instance_unhealthy`
+        # is meaningless off-runner.
+        bazel_trait.bazel_attempt_end.append(make_attempt_end_hook(environment))
+        bazel_trait.build_end.append(make_final_status_hook(environment))
 
         # Flags to optimize build & test
         (startup_flags, build_flags) = get_bazelrc_flags(

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -20,6 +20,7 @@ load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
 load("./lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
+load("./lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("./lib/format_results.axl", fmt_init_data = "init_data", format_conclusion = "conclusion")
@@ -433,13 +434,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     build_status = build.wait()
     for sink in bazel_trait.build_event_sinks:
         sink.wait()
-
-    # Fire `bazel_trait.build_end` hooks. The ArtifactUpload feature's
-    # `_on_build_end` runs the actual artifact upload step here (Profile /
-    # BEP / Execlog / Testlogs); without it the format task never uploads
-    # any artifacts and the rendered "Artifacts" row is empty.
-    for hook in bazel_trait.build_end:
-        hook(ctx, build_status.code)
+    dispatch_bazel_attempt_end(ctx, bazel_trait, build_status.code)
+    dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 
     if not build_status.success:
         _emit_final(ctx, lifecycle, data, build_status.code or 1)

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -189,6 +189,7 @@ load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
 load("./lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
+load("./lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
 load("./lib/gazelle_results.axl", "dedupe_subtrees", "dir_at_or_below", "extract_changed_dirs", gaz_init_data = "init_data", gazelle_conclusion = "conclusion")
@@ -668,11 +669,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     build_status = build.wait()
     for sink in bazel_trait.build_event_sinks:
         sink.wait()
-
-    # Fire `bazel_trait.build_end` hooks. The ArtifactUpload feature's
-    # `_on_build_end` runs the actual artifact upload step here.
-    for hook in bazel_trait.build_end:
-        hook(ctx, build_status.code)
+    dispatch_bazel_attempt_end(ctx, bazel_trait, build_status.code)
+    dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 
     if not build_status.success:
         _emit_final(ctx, lifecycle, data, build_status.code or 1)

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -203,6 +203,32 @@ def _emit_terminal(ctx, lifecycle, command, data, exit_code):
         flagged = final_status == "warning",
     )
 
+def dispatch_bazel_attempt_end(ctx, bazel_trait, exit_code):
+    """Fire every `bazel_trait.bazel_attempt_end` hook with `exit_code`.
+
+    Call after a `ctx.bazel.build(...).wait()` (or `ctx.bazel.test(...).wait()`)
+    has returned and any per-invocation work that must complete before the
+    NEXT attempt is done (notably BES sink draining — re-binding a Live sink
+    errors). Inside a retry loop, fires BEFORE the retry decision so a hook
+    can repair state that would otherwise make the next attempt fail the same
+    way (e.g. `bazel.recover_poisoned_sandbox` for bazelbuild/bazel#23880).
+    Outside a retry loop (single-attempt tasks), fires exactly once.
+    """
+    for handler in bazel_trait.bazel_attempt_end:
+        handler(ctx, exit_code)
+
+def dispatch_bazel_build_end(ctx, bazel_trait, exit_code):
+    """Fire every `bazel_trait.build_end` hook with the FINAL `exit_code`.
+
+    Call after the retry loop has exited (or, for single-attempt tasks, after
+    the only `wait()`). Features hang task-finalization logic on this hook —
+    e.g. `ArtifactUpload._on_build_end` runs the Profile / BEP / Execlog /
+    Testlogs upload step here, and `sandbox_recovery.make_final_status_hook`
+    signals the runner unhealthy on a final server-internal-error exit.
+    """
+    for handler in bazel_trait.build_end:
+        handler(ctx, exit_code)
+
 def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclusion:
     """Shared impl for build/test tasks.
 
@@ -429,11 +455,12 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
         for sink in bes_sinks:
             sink.wait()
 
+        dispatch_bazel_attempt_end(ctx, bazel_trait, invocation_status.code)
+
         if invocation_status.code == 0 or not bazel_trait.build_retry(invocation_status.code):
             break
 
-    for handler in bazel_trait.build_end:
-        handler(ctx, invocation_status.code)
+    dispatch_bazel_build_end(ctx, bazel_trait, invocation_status.code)
 
     # When retries occurred, append the final attempt so
     # `data["bazel_attempts"]` holds the full history (failed priors

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner_test.axl
@@ -1,0 +1,101 @@
+"""Tests for `lib/bazel_runner.axl`.
+
+Exercises the public dispatch helpers, which are the seam every
+bazel-driving task calls after `build.wait()` / `test.wait()` to fire
+`bazel_trait.bazel_attempt_end` and `bazel_trait.build_end` hooks. The
+helpers are short, but they're the contract every task depends on —
+silent breakage here would skip every Workflows-feature recovery hook.
+
+Run with:
+  aspect dev test-bazel-runner
+"""
+
+load("./bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _record_into(recorder, key, name):
+    """Build a hook callable that appends `(name, exit_code)` into
+    `recorder[key]`. The name lets a test pin both order and per-hook
+    invocation."""
+
+    def _hook(_ctx, exit_code):
+        recorder[key].append((name, exit_code))
+
+    return _hook
+
+def _fake_trait(attempt_hooks = [], build_end_hooks = []):
+    """Stand-in for `BazelTrait`. The dispatchers read
+    `.bazel_attempt_end` and `.build_end` — that's the whole surface."""
+    return struct(
+        bazel_attempt_end = attempt_hooks,
+        build_end = build_end_hooks,
+    )
+
+def _test_attempt_dispatch_empty_is_noop(_):
+    """No hooks registered → dispatcher must not error."""
+    dispatch_bazel_attempt_end(None, _fake_trait(), 0)
+
+def _test_build_end_dispatch_empty_is_noop(_):
+    """No hooks registered → dispatcher must not error."""
+    dispatch_bazel_build_end(None, _fake_trait(), 0)
+
+def _test_attempt_dispatch_invokes_in_order(_):
+    """Multiple attempt_end hooks fire in registration order, each
+    receiving the exit_code passed to the dispatcher."""
+    recorder = {"attempt": []}
+    trait = _fake_trait(attempt_hooks = [
+        _record_into(recorder, "attempt", "first"),
+        _record_into(recorder, "attempt", "second"),
+        _record_into(recorder, "attempt", "third"),
+    ])
+    dispatch_bazel_attempt_end(None, trait, 37)
+    _eq(
+        "ordered invocation with exit_code passthrough",
+        recorder["attempt"],
+        [("first", 37), ("second", 37), ("third", 37)],
+    )
+
+def _test_build_end_dispatch_invokes_in_order(_):
+    """Same contract as attempt_end."""
+    recorder = {"build_end": []}
+    trait = _fake_trait(build_end_hooks = [
+        _record_into(recorder, "build_end", "a"),
+        _record_into(recorder, "build_end", "b"),
+    ])
+    dispatch_bazel_build_end(None, trait, 0)
+    _eq(
+        "ordered invocation with exit_code passthrough",
+        recorder["build_end"],
+        [("a", 0), ("b", 0)],
+    )
+
+def _test_attempt_dispatch_does_not_fire_build_end(_):
+    """Dispatchers are separately addressable; calling attempt_end must
+    not also fire the build_end list."""
+    recorder = {"attempt": [], "build_end": []}
+    trait = _fake_trait(
+        attempt_hooks = [_record_into(recorder, "attempt", "a")],
+        build_end_hooks = [_record_into(recorder, "build_end", "b")],
+    )
+    dispatch_bazel_attempt_end(None, trait, 0)
+    _eq("attempt fired", recorder["attempt"], [("a", 0)])
+    _eq("build_end not fired", recorder["build_end"], [])
+
+def _test_impl(ctx):
+    _test_attempt_dispatch_empty_is_noop(ctx)
+    _test_build_end_dispatch_empty_is_noop(ctx)
+    _test_attempt_dispatch_invokes_in_order(ctx)
+    _test_build_end_dispatch_invokes_in_order(ctx)
+    _test_attempt_dispatch_does_not_fire_build_end(ctx)
+    print("bazel_runner_test.axl: OK (5 sections)")
+    return 0
+
+bazel_runner_tests = task(
+    name = "test-bazel-runner",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/lib/sandbox_recovery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/sandbox_recovery.axl
@@ -1,0 +1,121 @@
+"""Runner-side mitigations for Bazel server states that poison a
+Workflows runner for subsequent jobs.
+
+Two failure modes, addressed by two trait hooks the Workflows feature
+registers when `environment.runner != None`:
+
+1. **Stranded sandbox subtree** (bazelbuild/bazel#23880). When a Bazel
+   8.x server hits an `IOException` during sandbox setup (typically
+   `fchmod (...) (Operation not permitted)` from a kernel/FS hiccup),
+   the offending spawn runner never gets registered. Bazel's
+   `afterCommand` cleanup loop iterates only registered runners, so
+   `<output_base>/sandbox/<strategy>/` is left behind on disk. Every
+   subsequent `bazel build/test` against the same output_base crashes
+   in `checkSandboxBaseTopOnlyContainsPersistentDirs`. Fixed upstream
+   by abe8d6090 (Bazel 9.0+). We detect via
+   `ctx.bazel.recover_poisoned_sandbox()` (lists entries under
+   `<output_base>/sandbox/` against Bazel's
+   `SANDBOX_BASE_PERSISTENT_DIRS` whitelist) and `rm -rf` the offending
+   entries. If repair fails (`still_poisoned`), we signal the instance
+   unhealthy immediately. Wired as `bazel_attempt_end` so retries get
+   a clean sandbox to try again on.
+
+2. **Persistent server-internal failure across all retries**. When
+   the FINAL attempt exits with `BLAZE_INTERNAL_ERROR (37)` or
+   `LOCAL_ENVIRONMENTAL_ERROR (36)`, the Bazel server is persistently
+   sick (could be #23880 the disk-scan missed, JVM OOM, native crash,
+   corrupt lock file, etc.). The retry loop in `bazel_runner.axl` only
+   continues retrying on these two codes — `bazel_trait.build_retry`
+   keys off `default_retry`. So a final exit code that is itself
+   retryable-class means *every* prior attempt was also retryable-class
+   (otherwise the loop would have broken on a non-retryable exit). The
+   final code alone is therefore sufficient to detect "all attempts
+   hit server-internal trouble" without tracking per-attempt history.
+   Wired as `build_end` so it fires once per task.
+
+Critical: a sequence like 37 → repair → real-build-failure (exit 1)
+does NOT signal unhealthy. The retry loop breaks on the non-retryable
+exit; the final code is 1 (build failure), not retryable; the build_end
+hook returns early. The runner is healthy enough to produce a verdict.
+"""
+
+load("../bazel.axl", "default_retry")
+
+def _signal_unhealthy(ctx, environment):
+    """Best-effort invoke the Workflows agent's `signal_instance_unhealthy`
+    binary. No-op when the binary isn't present (e.g. older agent versions
+    that pre-date the script). Caller is responsible for surfacing the
+    *reason* in a warning before calling — this helper only does the
+    side-effect."""
+    signal_bin = environment.runner.bin_dir + "/signal_instance_unhealthy"
+    if ctx.std.fs.exists(signal_bin):
+        ctx.std.process.command(signal_bin).spawn().wait()
+
+def make_attempt_end_hook(environment):
+    """Build a `bazel_attempt_end` hook closed over the resolved
+    Workflows runner environment.
+
+    The hook calls `ctx.bazel.recover_poisoned_sandbox()` and branches
+    on its outcome:
+
+      - `clean`: no-op (the common case).
+      - `repaired`: print a warning so CI logs show the recovery; the
+        retry (or the next job on this runner) can then proceed.
+      - `still_poisoned` (rm -rf failed for at least one entry): print a
+        warning and signal the instance unhealthy. Further bazel commands
+        on this runner will keep crashing the same way, so we accept the
+        current task's failure and ensure the next job lands on a fresh
+        instance.
+
+    Ignores `exit_code` — the recovery decision is purely on-disk.
+    """
+
+    def _hook(ctx, _exit_code):
+        result = ctx.bazel.recover_poisoned_sandbox()
+        if result.outcome == "clean":
+            return
+        if result.outcome == "repaired":
+            print(
+                "\x1b[33mWARNING\x1b[0m: cleaned up bazel#23880-poisoning " +
+                "sandbox entries: " + ", ".join(result.removed) + ". " +
+                "Retries (and future jobs on this runner) should now " +
+                "succeed. See bazelbuild/bazel#23880; fixed upstream in " +
+                "Bazel 9.0 via commit abe8d6090.",
+            )
+            return
+
+        remaining = ", ".join(result.remaining) if result.remaining else "(unknown)"
+        print(
+            "\x1b[31mWARNING\x1b[0m: bazel#23880-style sandbox poisoning " +
+            "detected and could not be cleaned (entries that survived " +
+            "removal: " + remaining + "). Marking this runner unhealthy " +
+            "so the next job lands on a fresh instance.",
+        )
+        _signal_unhealthy(ctx, environment)
+
+    return _hook
+
+def make_final_status_hook(environment):
+    """Build a `build_end` hook that marks the runner unhealthy when
+    the FINAL Bazel exit code is server-internal-error class.
+
+    The retry loop only continues on `default_retry`-matching codes, so
+    a final exit that is itself retryable-class implies every prior
+    attempt was also retryable-class — the server is persistently sick.
+    A final non-retryable code (success, build failure, test failure,
+    user error, …) means the server produced a verdict, so the runner
+    is fine; we no-op.
+    """
+
+    def _hook(ctx, exit_code):
+        if not default_retry(exit_code):
+            return
+        print(
+            "\x1b[31mWARNING\x1b[0m: Bazel exited " + str(exit_code) +
+            " after all retries (server-internal-error class). Marking " +
+            "this runner unhealthy so the next job lands on a fresh " +
+            "instance.",
+        )
+        _signal_unhealthy(ctx, environment)
+
+    return _hook

--- a/crates/aspect-cli/src/builtins/aspect/lib/sandbox_recovery_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/sandbox_recovery_test.axl
@@ -1,0 +1,199 @@
+"""Tests for `lib/sandbox_recovery.axl`.
+
+Exercises the per-attempt hook (detect + repair, escalate on
+`still_poisoned`) and the final-status hook (signal on server-internal
+final exit code).
+
+Run with:
+  aspect dev test-sandbox-recovery
+"""
+
+load("./sandbox_recovery.axl", "make_attempt_end_hook", "make_final_status_hook")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+# ── fakes ─────────────────────────────────────────────────────────────────
+
+def _fake_recovery_result(outcome, removed = [], remaining = []):
+    """Stand-in for `bazel.SandboxRecoveryResult`. The hooks read
+    `.outcome`, `.removed`, `.remaining` — that's the whole surface."""
+    return struct(outcome = outcome, removed = removed, remaining = remaining)
+
+def _fake_environment(signal_bin_exists = True):
+    """Stand-in for the resolved Workflows runner environment. Only the
+    `.runner.bin_dir` field is consulted (to build the signal-binary
+    path); the `signal_bin_exists` flag controls how the fake fs answers."""
+    return struct(
+        runner = struct(bin_dir = "/etc/aspect/workflows/bin"),
+        _signal_bin_exists = signal_bin_exists,
+    )
+
+def _fake_ctx(environment, recovery):
+    """Build a fake TaskContext wired up so the hook's `ctx.bazel.recover_poisoned_sandbox()`,
+    `ctx.std.fs.exists()`, and `ctx.std.process.command().spawn().wait()`
+    calls are observable via the returned `recorder` dict.
+
+    `recovery` is the `RecoveryResult`-shaped stand-in to return from
+    `recover_poisoned_sandbox`."""
+    recorder = {"spawned": []}
+
+    def _spawn():
+        # `.spawn().wait()` chain — both no-op; recording happens on
+        # `command()` because that's where the binary path is visible.
+        return struct(wait = lambda: None)
+
+    def _command(path):
+        recorder["spawned"].append(path)
+        return struct(spawn = _spawn)
+
+    def _exists(path):
+        # The hook checks the signal binary's existence before invoking
+        # it. Mirror the environment's flag.
+        if path == environment.runner.bin_dir + "/signal_instance_unhealthy":
+            return environment._signal_bin_exists
+        return False
+
+    ctx = struct(
+        bazel = struct(recover_poisoned_sandbox = lambda: recovery),
+        std = struct(
+            fs = struct(exists = _exists),
+            process = struct(command = _command),
+        ),
+    )
+    return ctx, recorder
+
+# ── attempt-end hook ──────────────────────────────────────────────────────
+
+def _test_attempt_hook_clean_is_quiet(_):
+    """Clean outcome: hook must NOT signal unhealthy. This is the
+    overwhelming-majority case (no poisoning on disk)."""
+    env = _fake_environment()
+    hook = make_attempt_end_hook(env)
+    ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
+    hook(ctx, 0)
+    _eq("clean → no signal", recorder["spawned"], [])
+
+def _test_attempt_hook_repaired_does_not_signal(_):
+    """Repaired outcome: rm -rf succeeded. Print a warning (not asserted
+    here) but do NOT signal — the retry can succeed on the cleaned state."""
+    env = _fake_environment()
+    hook = make_attempt_end_hook(env)
+    ctx, recorder = _fake_ctx(
+        env,
+        _fake_recovery_result("repaired", removed = ["linux-sandbox"]),
+    )
+    hook(ctx, 37)  # retryable code; hook ignores it on repair path
+    _eq("repaired → no signal", recorder["spawned"], [])
+
+def _test_attempt_hook_still_poisoned_signals(_):
+    """still_poisoned: rm -rf failed. Hook must signal unhealthy via
+    the agent binary so the next job lands on a fresh runner."""
+    env = _fake_environment()
+    hook = make_attempt_end_hook(env)
+    ctx, recorder = _fake_ctx(
+        env,
+        _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
+    )
+    hook(ctx, 37)
+    _eq(
+        "still_poisoned → signal invoked",
+        recorder["spawned"],
+        ["/etc/aspect/workflows/bin/signal_instance_unhealthy"],
+    )
+
+def _test_attempt_hook_still_poisoned_noops_when_binary_absent(_):
+    """When the signal binary doesn't exist (older agent), the hook must
+    skip the invocation rather than fail. The warning print still
+    happens — the agent's just missing the script."""
+    env = _fake_environment(signal_bin_exists = False)
+    hook = make_attempt_end_hook(env)
+    ctx, recorder = _fake_ctx(
+        env,
+        _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
+    )
+    hook(ctx, 37)
+    _eq("absent binary → no spawn", recorder["spawned"], [])
+
+# ── final-status hook ─────────────────────────────────────────────────────
+
+def _test_final_hook_signals_on_blaze_internal_error(_):
+    """Final exit 37 → server persistently sick → signal unhealthy.
+
+    Per `default_retry`, 37 (BLAZE_INTERNAL_ERROR) is the canonical
+    retryable-class code; a final exit of 37 means all retries hit it."""
+    env = _fake_environment()
+    hook = make_final_status_hook(env)
+    ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
+    hook(ctx, 37)
+    _eq(
+        "final 37 → signal invoked",
+        recorder["spawned"],
+        ["/etc/aspect/workflows/bin/signal_instance_unhealthy"],
+    )
+
+def _test_final_hook_signals_on_local_environmental_error(_):
+    """Final exit 36 → same policy as 37 (server-internal-error class)."""
+    env = _fake_environment()
+    hook = make_final_status_hook(env)
+    ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
+    hook(ctx, 36)
+    _eq(
+        "final 36 → signal invoked",
+        recorder["spawned"],
+        ["/etc/aspect/workflows/bin/signal_instance_unhealthy"],
+    )
+
+def _test_final_hook_quiet_on_success(_):
+    """Final exit 0 → success → no signal."""
+    env = _fake_environment()
+    hook = make_final_status_hook(env)
+    ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
+    hook(ctx, 0)
+    _eq("final 0 → no signal", recorder["spawned"], [])
+
+def _test_final_hook_quiet_on_real_failure(_):
+    """Final exit 1 (build failure) → server produced a verdict →
+    runner is fine → no signal. This is the critical contract: a
+    successful retry-after-repair that ends in a normal build failure
+    must NOT mark the runner unhealthy.
+
+    Standard non-retryable codes: 1 (build), 2 (cmdline), 3 (tests),
+    4 (no tests), 6 (run), 7 (analysis), 8 (interrupted)."""
+    env = _fake_environment()
+    hook = make_final_status_hook(env)
+    ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
+    for code in [1, 2, 3, 4, 6, 7, 8]:
+        recorder["spawned"] = []
+        hook(ctx, code)
+        _eq("final %d → no signal" % code, recorder["spawned"], [])
+
+def _test_final_hook_noops_when_binary_absent(_):
+    """Missing signal binary → no spawn (same defensiveness as the
+    attempt-end hook)."""
+    env = _fake_environment(signal_bin_exists = False)
+    hook = make_final_status_hook(env)
+    ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
+    hook(ctx, 37)
+    _eq("absent binary → no spawn", recorder["spawned"], [])
+
+def _test_impl(ctx):
+    _test_attempt_hook_clean_is_quiet(ctx)
+    _test_attempt_hook_repaired_does_not_signal(ctx)
+    _test_attempt_hook_still_poisoned_signals(ctx)
+    _test_attempt_hook_still_poisoned_noops_when_binary_absent(ctx)
+    _test_final_hook_signals_on_blaze_internal_error(ctx)
+    _test_final_hook_signals_on_local_environmental_error(ctx)
+    _test_final_hook_quiet_on_success(ctx)
+    _test_final_hook_quiet_on_real_failure(ctx)
+    _test_final_hook_noops_when_binary_absent(ctx)
+    print("sandbox_recovery_test.axl: OK (9 sections)")
+    return 0
+
+sandbox_recovery_tests = task(
+    name = "test-sandbox-recovery",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -23,6 +23,7 @@ load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
 load("./lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
+load("./lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./lib/environment.axl", "color_enabled", "detect_ci", "error", "warn")
 load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
@@ -1052,6 +1053,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for sink in bazel_trait.build_event_sinks:
         sink.wait()
 
+    dispatch_bazel_attempt_end(ctx, bazel_trait, build_status.code)
+
     # Final drain: build is complete; poll until all pending downloads land
     # or the timeout expires. Bazel schedules --remote_download_regex
     # transfers asynchronously, so files can still be in flight here even
@@ -1096,8 +1099,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data["bazel"]["wall_time_ms"] = data["finish_time_ms"] - data["start_time_ms"]
 
     # 8. BazelTrait.build_end hooks
-    for hook in bazel_trait.build_end:
-        hook(ctx, build_status.code)
+    dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 
     # Scope the patch set to the strategy: hold-the-line / hold-the-
     # file drop patches whose hunks don't overlap the user's PR diff,

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -5,6 +5,7 @@ load("./bazel.axl", "BazelTrait")
 load("./lib/artifacts.axl", "artifacts")
 load("./lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("./lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
+load("./lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./lib/environment.axl", "error")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "setup_phase", "task_update")
@@ -122,8 +123,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     build_status = build.wait()
     for sink in bazel_trait.build_event_sinks:
         sink.wait()
-    for hook in bazel_trait.build_end:
-        hook(ctx, build_status.code)
+    dispatch_bazel_attempt_end(ctx, bazel_trait, build_status.code)
+    dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 
     if not build_status.success:
         return _emit_terminal(ctx, lifecycle, data, build_status.code or 1)

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -41,6 +41,7 @@ pub mod live;
 mod process;
 mod query;
 mod rc;
+mod sandbox_recovery;
 mod sink;
 mod stream;
 
@@ -563,6 +564,65 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         Ok(health_check::run(&startup_flags))
     }
 
+    /// Detect and best-effort repair runner-poisoning sandbox state
+    /// described by bazelbuild/bazel#23880.
+    ///
+    /// Inspects `<output_base>/sandbox/` for entries outside Bazel's
+    /// `SANDBOX_BASE_PERSISTENT_DIRS` whitelist
+    /// (`{.DS_Store, sandbox_stash, sandbox_stash_temp, _moved_trash_dir}`).
+    /// Anything else present after a bazel command exited is the
+    /// poisoning signature: Bazel's own `afterCommand` cleanup left
+    /// state behind because its spawn-runner registry didn't include
+    /// the strategy that owned that subtree (see `LinuxSandboxedStrategy.
+    /// create` IOException path; fixed upstream by `abe8d6090` in 9.0+).
+    ///
+    /// When poisoning is detected, every offending entry is
+    /// `rm -rf`'d. The result distinguishes three cases:
+    ///
+    /// - `"clean"`: nothing to remove. Either the sandbox dir didn't
+    ///   exist or contained only whitelisted entries.
+    /// - `"repaired"`: at least one non-whitelisted entry was found
+    ///   and all of them were successfully removed. The runner is
+    ///   safe to keep serving jobs.
+    /// - `"still_poisoned"`: at least one entry survived the removal
+    ///   attempt (e.g. EPERM on the underlying filesystem). The runner
+    ///   will keep crashing every bazel command on the same output
+    ///   base — the caller should mark it unhealthy.
+    ///
+    /// Reads `--output_base=` from `ctx.bazel.startup_flags`. When
+    /// `--output_base` is not present (e.g. local dev), returns `"clean"`
+    /// — there's no way to know which output_base to inspect, and the
+    /// failure mode is a Workflows-runner-only concern in practice.
+    ///
+    /// Safe to call only AFTER the most recent bazel client invocation
+    /// has fully exited — a live `bazel build/test` against the same
+    /// output_base would race the removal.
+    ///
+    /// **Examples**
+    ///
+    /// ```python
+    /// def _post_bazel_hook(ctx, exit_code):
+    ///     if exit_code == 0:
+    ///         return
+    ///     r = ctx.bazel.recover_poisoned_sandbox()
+    ///     if r.outcome == "repaired":
+    ///         print("Recovered from bazel#23880 poisoning: " + ", ".join(r.removed))
+    ///     elif r.outcome == "still_poisoned":
+    ///         signal_instance_unhealthy()
+    /// ```
+    fn recover_poisoned_sandbox<'v>(
+        this: values::Value<'v>,
+    ) -> anyhow::Result<sandbox_recovery::SandboxRecoveryResult> {
+        let startup_flags = read_startup_flags(this)?;
+        let Some(output_base) = sandbox_recovery::output_base_from_flags(&startup_flags) else {
+            return Ok(sandbox_recovery::SandboxRecoveryResult::skipped());
+        };
+        let outcome = sandbox_recovery::recover(&output_base);
+        Ok(sandbox_recovery::SandboxRecoveryResult::from_outcome(
+            outcome,
+        ))
+    }
+
     /// Parse `.bazelrc` files rooted at `root` and return a `BazelRC` object.
     ///
     /// # Arguments
@@ -857,6 +917,8 @@ fn register_types(globals: &mut GlobalsBuilder) {
     const Bazel: StarlarkValueAsType<FrozenBazel> = StarlarkValueAsType::new();
     const BazelRC: StarlarkValueAsType<rc::StarlarkBazelRC> = StarlarkValueAsType::new();
     const HealthCheckResult: StarlarkValueAsType<health_check::HealthCheckResult> =
+        StarlarkValueAsType::new();
+    const SandboxRecoveryResult: StarlarkValueAsType<sandbox_recovery::SandboxRecoveryResult> =
         StarlarkValueAsType::new();
 }
 

--- a/crates/axl-runtime/src/engine/bazel/sandbox_recovery.rs
+++ b/crates/axl-runtime/src/engine/bazel/sandbox_recovery.rs
@@ -1,0 +1,401 @@
+//! Detect and recover from runner-poisoning sandbox state described by
+//! bazelbuild/bazel#23880.
+//!
+//! When `LinuxSandboxedStrategy.create` throws `IOException` (e.g. an
+//! `fchmod` rejected by the filesystem during sandbox setup), the
+//! `linux-sandbox` SpawnRunner is never registered. Bazel's
+//! `SandboxModule.afterCommand` cleanup loop iterates the registered
+//! runners only, so the partially-set-up `<output_base>/sandbox/linux-sandbox`
+//! subtree is never deleted. The follow-up
+//! `checkSandboxBaseTopOnlyContainsPersistentDirs` precondition then
+//! crashes the command. The on-disk subtree survives the crash and
+//! poisons every subsequent bazel invocation on the same output_base
+//! the same way.
+//!
+//! Bazel's whitelist of allowed entries directly under the sandbox base
+//! (`SANDBOX_BASE_PERSISTENT_DIRS`) is `{.DS_Store, sandbox_stash,
+//! sandbox_stash_temp, _moved_trash_dir}`. Anything else present after
+//! a bazel command exited is the poisoning signature.
+//!
+//! Fixed upstream by `abe8d6090` (Bazel 9.0+); 8.x users hit this until
+//! they upgrade. This module is the runner-side mitigation: detect the
+//! state post-invocation, attempt to remove the offending entries, and
+//! report whether anything remained so the caller can mark the runner
+//! unhealthy.
+
+use std::path::{Path, PathBuf};
+
+use allocative::Allocative;
+use derive_more::Display;
+use starlark::environment::{Methods, MethodsBuilder, MethodsStatic};
+use starlark::starlark_module;
+use starlark::starlark_simple_value;
+use starlark::values;
+use starlark::values::starlark_value;
+use starlark::values::{NoSerialize, ProvidesStaticType, ValueLike};
+
+/// Entries Bazel itself considers legitimate at the top level of the
+/// sandbox base. Mirrors `SandboxModule.SANDBOX_BASE_PERSISTENT_DIRS`
+/// in the Bazel source. Any other entry present after a bazel command
+/// has exited indicates the runner is in the bazel#23880 state.
+const SANDBOX_BASE_PERSISTENT_DIRS: &[&str] = &[
+    ".DS_Store",
+    "sandbox_stash",
+    "sandbox_stash_temp",
+    "_moved_trash_dir",
+];
+
+/// Outcome of a sandbox-recovery attempt. Drives the caller's decision
+/// to either log + continue (`Clean` / `Repaired`) or signal the runner
+/// unhealthy (`StillPoisoned`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecoveryOutcome {
+    /// `<output_base>/sandbox/` either doesn't exist or contains only
+    /// whitelisted entries. The runner is healthy.
+    Clean,
+    /// Non-whitelisted entries were present and successfully removed.
+    /// Caller should log the recovery; the runner can serve the next job.
+    Repaired { removed: Vec<String> },
+    /// Non-whitelisted entries were present and at least one could not
+    /// be removed. Caller should signal the runner unhealthy so the
+    /// next job lands on a fresh instance.
+    StillPoisoned {
+        removed: Vec<String>,
+        remaining: Vec<String>,
+    },
+}
+
+impl RecoveryOutcome {
+    /// Starlark-facing outcome tag.
+    fn tag(&self) -> &'static str {
+        match self {
+            RecoveryOutcome::Clean => "clean",
+            RecoveryOutcome::Repaired { .. } => "repaired",
+            RecoveryOutcome::StillPoisoned { .. } => "still_poisoned",
+        }
+    }
+
+    fn removed_entries(&self) -> Vec<String> {
+        match self {
+            RecoveryOutcome::Clean => Vec::new(),
+            RecoveryOutcome::Repaired { removed } => removed.clone(),
+            RecoveryOutcome::StillPoisoned { removed, .. } => removed.clone(),
+        }
+    }
+
+    fn remaining_entries(&self) -> Vec<String> {
+        match self {
+            RecoveryOutcome::Clean | RecoveryOutcome::Repaired { .. } => Vec::new(),
+            RecoveryOutcome::StillPoisoned { remaining, .. } => remaining.clone(),
+        }
+    }
+}
+
+/// Starlark-facing wrapper around [`RecoveryOutcome`]. Returned by
+/// `ctx.bazel.recover_poisoned_sandbox()`.
+#[derive(Debug, Display, ProvidesStaticType, NoSerialize, Allocative)]
+#[display("<bazel.SandboxRecoveryResult>")]
+pub struct SandboxRecoveryResult {
+    outcome: String,
+    removed: Vec<String>,
+    remaining: Vec<String>,
+}
+
+impl SandboxRecoveryResult {
+    pub(crate) fn from_outcome(outcome: RecoveryOutcome) -> Self {
+        Self {
+            outcome: outcome.tag().to_string(),
+            removed: outcome.removed_entries(),
+            remaining: outcome.remaining_entries(),
+        }
+    }
+
+    /// Builder used when the caller skipped recovery (e.g. no
+    /// `--output_base` in startup flags). Reads as `clean` so callers
+    /// can branch uniformly on the outcome tag.
+    pub(crate) fn skipped() -> Self {
+        Self {
+            outcome: "clean".to_string(),
+            removed: Vec::new(),
+            remaining: Vec::new(),
+        }
+    }
+}
+
+starlark_simple_value!(SandboxRecoveryResult);
+
+#[starlark_value(type = "bazel.SandboxRecoveryResult")]
+impl<'v> values::StarlarkValue<'v> for SandboxRecoveryResult {
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(sandbox_recovery_result_methods)
+    }
+}
+
+#[starlark_module]
+pub(crate) fn sandbox_recovery_result_methods(registry: &mut MethodsBuilder) {
+    /// Recovery outcome: `"clean"`, `"repaired"`, or `"still_poisoned"`.
+    ///
+    /// - `clean`: nothing to do. Either the sandbox dir didn't exist or
+    ///   contained only whitelisted entries.
+    /// - `repaired`: non-whitelisted entries were found and successfully
+    ///   removed. The runner is usable for the next job.
+    /// - `still_poisoned`: non-whitelisted entries were found and at least
+    ///   one could not be removed. Caller should signal the runner
+    ///   unhealthy.
+    #[starlark(attribute)]
+    fn outcome<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
+        Ok(this
+            .downcast_ref::<SandboxRecoveryResult>()
+            .unwrap()
+            .outcome
+            .clone())
+    }
+
+    /// Sorted names of sandbox-base entries that were successfully removed.
+    /// Empty when `outcome == "clean"`.
+    #[starlark(attribute)]
+    fn removed<'v>(this: values::Value<'v>) -> anyhow::Result<Vec<String>> {
+        Ok(this
+            .downcast_ref::<SandboxRecoveryResult>()
+            .unwrap()
+            .removed
+            .clone())
+    }
+
+    /// Sorted names of sandbox-base entries that survived the removal
+    /// attempt. Only non-empty when `outcome == "still_poisoned"`.
+    #[starlark(attribute)]
+    fn remaining<'v>(this: values::Value<'v>) -> anyhow::Result<Vec<String>> {
+        Ok(this
+            .downcast_ref::<SandboxRecoveryResult>()
+            .unwrap()
+            .remaining
+            .clone())
+    }
+}
+
+/// Snapshot non-whitelisted entries directly under `<output_base>/sandbox/`.
+///
+/// Returns the entries' file names (not full paths) sorted lexicographically
+/// for deterministic logging. An absent sandbox dir (fresh output_base, or
+/// `output_base` itself missing) returns an empty vector — not an error.
+fn list_unexpected_entries(output_base: &Path) -> Vec<String> {
+    let sandbox = output_base.join("sandbox");
+    let Ok(entries) = std::fs::read_dir(&sandbox) else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = entries
+        .filter_map(Result::ok)
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|name| !SANDBOX_BASE_PERSISTENT_DIRS.contains(&name.as_str()))
+        .collect();
+    out.sort();
+    out
+}
+
+/// Detect and (best-effort) repair bazel#23880-style sandbox poisoning.
+///
+/// Lists unexpected entries under `<output_base>/sandbox/`, then attempts
+/// to remove each one. Re-lists afterwards to report what (if anything)
+/// survived. Safe to call only AFTER the bazel client invocation has
+/// fully exited — a live `bazel build/test` would race the rm.
+///
+/// Each removal goes through `symlink_metadata` first so symlinks are
+/// inspected, not followed; then either `remove_dir_all` (for directories)
+/// or `remove_file` (for files / symlinks). A removal that fails is
+/// logged as a warning and the entry is left for the caller to handle
+/// via `signal_instance_unhealthy`.
+pub fn recover(output_base: &Path) -> RecoveryOutcome {
+    let initial = list_unexpected_entries(output_base);
+    if initial.is_empty() {
+        return RecoveryOutcome::Clean;
+    }
+    let sandbox = output_base.join("sandbox");
+    let mut removed = Vec::new();
+    for name in &initial {
+        let path = sandbox.join(name);
+        let res = match std::fs::symlink_metadata(&path) {
+            Ok(meta) if meta.file_type().is_dir() => std::fs::remove_dir_all(&path),
+            Ok(_) => std::fs::remove_file(&path),
+            Err(e) => Err(e),
+        };
+        match res {
+            Ok(()) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    "Removed bazel#23880-poisoning sandbox entry left by a previous \
+                     bazel invocation"
+                );
+                removed.push(name.clone());
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "Failed to remove bazel#23880-poisoning sandbox entry — the runner \
+                     will be marked unhealthy",
+                );
+            }
+        }
+    }
+    let remaining = list_unexpected_entries(output_base);
+    if remaining.is_empty() {
+        RecoveryOutcome::Repaired { removed }
+    } else {
+        RecoveryOutcome::StillPoisoned { removed, remaining }
+    }
+}
+
+/// Extract `--output_base=<path>` from the passed startup flags without
+/// invoking bazel. Returns `None` when no `--output_base` flag is present
+/// or its value is empty.
+///
+/// Same shape as the helper used by the health-check probe — kept local
+/// to this module so the recovery path doesn't depend on a wedged
+/// bazel server to resolve its own output_base.
+pub fn output_base_from_flags(startup_flags: &[String]) -> Option<PathBuf> {
+    for flag in startup_flags {
+        if let Some(value) = flag.strip_prefix("--output_base=") {
+            if !value.is_empty() {
+                return Some(PathBuf::from(value));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_output_base() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(dir.path().join("sandbox")).expect("create sandbox dir");
+        dir
+    }
+
+    #[test]
+    fn clean_when_sandbox_dir_absent() {
+        let base = tempfile::tempdir().expect("tempdir");
+        assert_eq!(recover(base.path()), RecoveryOutcome::Clean);
+    }
+
+    #[test]
+    fn clean_when_only_whitelisted_entries() {
+        let base = make_output_base();
+        for name in SANDBOX_BASE_PERSISTENT_DIRS {
+            std::fs::create_dir(base.path().join("sandbox").join(name)).unwrap();
+        }
+        assert_eq!(recover(base.path()), RecoveryOutcome::Clean);
+        // Whitelisted entries must survive the call.
+        for name in SANDBOX_BASE_PERSISTENT_DIRS {
+            assert!(
+                base.path().join("sandbox").join(name).exists(),
+                "whitelisted entry {} must survive recovery",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn repairs_linux_sandbox_subtree() {
+        // The canonical bazel#23880 failure mode: a partial
+        // `linux-sandbox/<pid>/...` tree survived a previous afterCommand.
+        let base = make_output_base();
+        let linux_sandbox = base.path().join("sandbox").join("linux-sandbox");
+        std::fs::create_dir_all(linux_sandbox.join("73541").join("execroot")).unwrap();
+        std::fs::write(
+            linux_sandbox.join("73541").join("execroot").join("junk"),
+            b"x",
+        )
+        .unwrap();
+
+        let outcome = recover(base.path());
+        assert_eq!(
+            outcome,
+            RecoveryOutcome::Repaired {
+                removed: vec!["linux-sandbox".to_string()]
+            }
+        );
+        assert!(!linux_sandbox.exists());
+    }
+
+    #[test]
+    fn repairs_multiple_per_strategy_subtrees() {
+        let base = make_output_base();
+        for name in &["linux-sandbox", "processwrapper-sandbox", "darwin-sandbox"] {
+            std::fs::create_dir(base.path().join("sandbox").join(name)).unwrap();
+        }
+        // Whitelisted entry alongside the unexpected ones should be preserved.
+        std::fs::create_dir(base.path().join("sandbox").join("sandbox_stash")).unwrap();
+
+        let outcome = recover(base.path());
+        match outcome {
+            RecoveryOutcome::Repaired { ref removed } => {
+                let mut expected =
+                    vec!["darwin-sandbox", "linux-sandbox", "processwrapper-sandbox"];
+                expected.sort();
+                let got: Vec<&str> = removed.iter().map(String::as_str).collect();
+                assert_eq!(got, expected);
+            }
+            other => panic!("expected Repaired, got {:?}", other),
+        }
+        assert!(base.path().join("sandbox").join("sandbox_stash").exists());
+    }
+
+    #[cfg(unix)]
+    fn chmod(path: &Path, mode: u32) {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(mode);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reports_still_poisoned_when_removal_fails() {
+        // A read-only parent makes unlinkat/rmdir of the child fail with
+        // EACCES — the case that drives a `still_poisoned` outcome.
+        let base = make_output_base();
+        let sandbox = base.path().join("sandbox");
+        std::fs::create_dir(sandbox.join("linux-sandbox")).unwrap();
+
+        chmod(&sandbox, 0o555);
+        let outcome = recover(base.path());
+        // Restore so the tempdir can be cleaned up.
+        chmod(&sandbox, 0o755);
+
+        assert!(
+            matches!(outcome, RecoveryOutcome::StillPoisoned { .. }),
+            "expected StillPoisoned, got {:?}",
+            outcome
+        );
+    }
+
+    #[test]
+    fn output_base_from_flags_picks_explicit_flag() {
+        let flags = vec![
+            "--nohome_rc".to_string(),
+            "--output_base=/mnt/ephemeral/output/repo".to_string(),
+        ];
+        assert_eq!(
+            output_base_from_flags(&flags),
+            Some(PathBuf::from("/mnt/ephemeral/output/repo"))
+        );
+    }
+
+    #[test]
+    fn output_base_from_flags_ignores_unrelated_prefix() {
+        // `--output_user_root` shares the `--output_` prefix but is a
+        // different flag — must not match.
+        let flags = vec!["--output_user_root=/mnt/foo".to_string()];
+        assert_eq!(output_base_from_flags(&flags), None);
+    }
+
+    #[test]
+    fn output_base_from_flags_rejects_empty_value() {
+        let flags = vec!["--output_base=".to_string()];
+        assert_eq!(output_base_from_flags(&flags), None);
+    }
+}


### PR DESCRIPTION
## Problem

Bazel 8.x can leave its sandbox base in a state that crashes every subsequent invocation on the same `output_base`:

```
ERROR: Failed to initialize sandbox: fchmod (.../sandbox/linux-sandbox/<pid>/.../tmp...) (Operation not permitted)
FATAL: bazel crashed due to an internal error.
java.lang.IllegalStateException: Found unexpected entries in sandbox base. ... The entries are: linux-sandbox, _moved_trash_dir
    at SandboxModule.checkSandboxBaseTopOnlyContainsPersistentDirs(SandboxModule.java:573)
    at SandboxModule.afterCommand(SandboxModule.java:611)
```

When `LinuxSandboxedStrategy.create` throws `IOException` during sandbox setup, the Linux spawn runner never gets added to `SandboxModule.spawnRunners`. `afterCommand`'s cleanup iterates only registered runners, so the partial `<output_base>/sandbox/linux-sandbox/...` subtree survives on disk and the next bazel command hard-fails in `checkSandboxBaseTopOnlyContainsPersistentDirs`. The runner stays poisoned across jobs — every retry hits the same wedge. (`_moved_trash_dir` in the error message is a red herring; it's on Bazel's `SANDBOX_BASE_PERSISTENT_DIRS` whitelist. The offending entry is `linux-sandbox`.)

Fixed upstream by [`abe8d6090`](https://github.com/bazelbuild/bazel/commit/abe8d6090e9ddea898867cc59f7cb434079df4da) in Bazel 9.0+; not backported to any 8.x release (verified through 8.7.0). See bazelbuild/bazel#23880.

## Approach

Two new `BazelTrait` hooks the Workflows feature registers when `environment.runner != None`:

- **`bazel_attempt_end(ctx, exit_code)`** — fires after every bazel invocation (each retry attempt) and BEFORE the retry decision. The Workflows-registered handler calls a new `ctx.bazel.recover_poisoned_sandbox()` Rust helper that lists entries directly under `<output_base>/sandbox/` against Bazel's whitelist and `rm -rf`'s anything else. Outcomes:
  - `clean` — nothing to do (the common case).
  - `repaired` — entries were removed; the retry (or next job on this runner) starts from a healthy sandbox.
  - `still_poisoned` — at least one entry survived `rm -rf` (would need EPERM/EROFS on the rm itself). Runs `signal_instance_unhealthy` so the autoscaler replaces the instance.

- **`build_end(ctx, exit_code)`** — fires once with the final exit code (existing attribute; the new policy is a fresh hook). Signals unhealthy when the final code is `BLAZE_INTERNAL_ERROR (37)` or `LOCAL_ENVIRONMENTAL_ERROR (36)` — the two codes `default_retry` keys off, so a final retryable-class exit means every retry hit a server-internal error and the server is persistently sick. A retry sequence ending in a normal build/test failure (`1`/`3`/...) does NOT signal — the server produced a verdict, the runner is fine.

Two public dispatch helpers in `lib/bazel_runner.axl` — `dispatch_bazel_attempt_end` / `dispatch_bazel_build_end` — are called from every site that spawns a bazel build/test in built-in tasks: `build`, `test`, `run`, `gazelle`, `lint`, `format`, and all three `delivery` phases. The retry loop in `bazel_runner.axl` dispatches `bazel_attempt_end` between `invocation.wait()` and the retry decision so a successful repair lets the next attempt proceed.

Bazel 9.0+ is unaffected by the upstream bug; the mitigation is benign there — the sandbox dir is always clean and the detector is a single `readdir`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Aspect Workflows runners now auto-recover from bazelbuild/bazel#23880-style sandbox poisoning across all built-in tasks (`build`, `test`, `run`, `gazelle`, `lint`, `format`, `delivery`). When `<output_base>/sandbox/` contains entries outside Bazel's whitelist after a bazel invocation, the offending subtrees are `rm -rf`'d so the next attempt (or next job on the runner) starts clean. If the removal fails, or if a bazel invocation exits with `BLAZE_INTERNAL_ERROR (37)` / `LOCAL_ENVIRONMENTAL_ERROR (36)`, the runner is marked unhealthy so the next job lands on a fresh instance.

### Test plan

- Rust unit tests in `engine::bazel::sandbox_recovery::tests` cover: empty/missing sandbox, whitelist-only entries (must survive), single `linux-sandbox` subtree repair, multiple per-strategy subtrees with `sandbox_stash` preserved alongside, `rm -rf` failure → `StillPoisoned`, and the three `output_base_from_flags` edge cases.
- AXL unit tests in `lib/sandbox_recovery_test.axl` (`aspect dev test-sandbox-recovery`) cover the attempt-end and build-end hook policies on clean / repaired / still_poisoned outcomes, retryable vs non-retryable exit codes, and the missing-signal-binary fallback.
- AXL unit tests in `lib/bazel_runner_test.axl` (`aspect dev test-bazel-runner`) pin the dispatcher contract: in-order invocation, exit-code passthrough, and that the two dispatchers are independently addressable.
