### PR TITLE
feat(cli): show CLI version + docs link on every help screen and task header

### DIFF
--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -14,6 +14,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
+use axl_runtime::banner;
 use axl_runtime::engine::arg::Arg;
 use axl_runtime::engine::arguments::Arguments;
 use axl_runtime::engine::feature::FeatureLike;
@@ -70,7 +71,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
             .filter_map(|f| feature_block(*f, self.aspect_root, self.modules))
             .collect();
 
-        let cli_header = cli_header(version);
+        let cli_header = banner::line(version);
 
         let mut tree = Tree::default();
         for (idx, task) in self.tasks.iter().enumerate() {
@@ -129,7 +130,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
                 "{cli_header}\n\n{{about-with-newline}}\n{{usage-heading}} {{usage}}\n\n\x1b[1;4mTasks:\x1b[0m\n{{subcommands}}{group_section}\n\x1b[1;4mCommands:\x1b[0m\n  \x1b[1mversion\x1b[0m  Print version\n  \x1b[1mhelp\x1b[0m     Print this message or the help of the given subcommand(s)\n\n\x1b[1;4mOptions:\x1b[0m\n{{options}}"
             ));
 
-        tree.attach(root)
+        tree.attach(root, version)
     }
 
     /// Walk the parsed matches to the deepest subcommand and extract task ids + uuids.
@@ -635,27 +636,6 @@ fn feature_block(
     })
 }
 
-/// Grey "Aspect CLI v… — docs URL" line shown at the top of every `--help`
-/// screen. Mirrors the line printed above each `→ 🎬 Running …` task header
-/// at runtime — same string, same color — so users always know which CLI
-/// they're holding and where to find docs.
-///
-/// `version` should be the resolved CLI version (passed through from
-/// `Cmd::build`). Callers that don't have a handle on it (deep in the
-/// subgroup template builder) can use `cli_header_from_pkg()` instead.
-fn cli_header(version: &str) -> String {
-    format!(
-        "\x1b[38;5;244mAspect CLI v{} — https://docs.aspect.build/cli\x1b[0m",
-        version,
-    )
-}
-
-/// Like `cli_header()` but pulls the version from the workspace crate
-/// metadata. Used by call sites that don't have the resolved version handy.
-fn cli_header_from_pkg() -> String {
-    cli_header(&aspect_telemetry::cargo_pkg_short_version())
-}
-
 // ── Per-task subcommand assembly ───────────────────────────────────────────
 
 fn task_command(
@@ -806,13 +786,13 @@ impl Tree {
         self.subgroups.keys().cloned().collect()
     }
 
-    fn attach(self, mut root: Command) -> Result<Command, CmdError> {
+    fn attach(self, mut root: Command, version: &str) -> Result<Command, CmdError> {
         // Subgroups (rendered hidden, with their own help template).
-        let header = cli_header_from_pkg();
+        let header = banner::line(version);
         for (name, sub) in self.subgroups {
             let sub_groups = sub.group_names();
             let mut template =
-                format!("{header}\n\n{{about-with-newline}}\n{{usage-heading}} {{usage}}",);
+                format!("{header}\n\n{{about-with-newline}}\n{{usage-heading}} {{usage}}");
             if !sub.tasks.is_empty() {
                 template.push_str("\n\n\x1b[1;4mTasks:\x1b[0m\n{subcommands}");
             }
@@ -834,7 +814,7 @@ impl Tree {
                 .display_order(TASK_GROUP_DISPLAY_ORDER)
                 .hide(true)
                 .help_template(template);
-            subcmd = sub.attach(subcmd)?;
+            subcmd = sub.attach(subcmd, version)?;
             if root.find_subcommand(&name).is_some() {
                 return Err(CmdError::NameConflict(name, vec![], String::new()));
             }
@@ -1048,6 +1028,37 @@ mod tests {
         let dev = root.find_subcommand("dev").expect("dev group present");
         assert!(dev.find_subcommand("a").is_some());
         assert!(dev.find_subcommand("b").is_some());
+    }
+
+    /// The identity banner (version + docs URL) is woven into the help
+    /// template of the root command, each task subcommand, and each task
+    /// group — so it shows on every `--help` screen.
+    #[test]
+    fn build_puts_identity_banner_on_every_help_screen() {
+        let t = stub_task("greet", &["dev"], SmallMap::new());
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let mut root = cmd.build("1.2.3").expect("build ok");
+
+        let banner = "Aspect CLI v1.2.3 — https://docs.aspect.build/cli";
+        let rendered = |c: &mut Command| c.render_help().to_string();
+
+        assert!(
+            rendered(&mut root).contains(banner),
+            "root help missing banner"
+        );
+
+        let dev = root.find_subcommand_mut("dev").expect("dev group present");
+        assert!(rendered(dev).contains(banner), "group help missing banner");
+
+        let greet = dev
+            .find_subcommand_mut("greet")
+            .expect("greet task present");
+        assert!(rendered(greet).contains(banner), "task help missing banner");
     }
 
     #[test]

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -70,15 +70,16 @@ impl<'a, 'v> Cmd<'a, 'v> {
             .filter_map(|f| feature_block(*f, self.aspect_root, self.modules))
             .collect();
 
+        let cli_header = cli_header(version);
+
         let mut tree = Tree::default();
         for (idx, task) in self.tasks.iter().enumerate() {
             let label = defined_in_label(task.path(), self.aspect_root, self.modules);
-            let task_cmd = task_command(idx, *task, &label, &feature_blocks);
+            let task_cmd = task_command(idx, *task, &label, &feature_blocks, &cli_header);
             tree.insert(*task, &label, task_cmd)?;
         }
 
         let group_section = group_section(&tree.group_names());
-
         let root = Command::new("aspect")
             .bin_name("aspect")
             .about("Aspect's programmable task runner built on top of Bazel\n{ Correct, Fast, Usable } -- Choose three")
@@ -125,7 +126,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
                     .hide(true),
             )
             .help_template(format!(
-                "{{about-with-newline}}\n{{usage-heading}} {{usage}}\n\n\x1b[1;4mTasks:\x1b[0m\n{{subcommands}}{group_section}\n\x1b[1;4mCommands:\x1b[0m\n  \x1b[1mversion\x1b[0m  Print version\n  \x1b[1mhelp\x1b[0m     Print this message or the help of the given subcommand(s)\n\n\x1b[1;4mOptions:\x1b[0m\n{{options}}"
+                "{cli_header}\n\n{{about-with-newline}}\n{{usage-heading}} {{usage}}\n\n\x1b[1;4mTasks:\x1b[0m\n{{subcommands}}{group_section}\n\x1b[1;4mCommands:\x1b[0m\n  \x1b[1mversion\x1b[0m  Print version\n  \x1b[1mhelp\x1b[0m     Print this message or the help of the given subcommand(s)\n\n\x1b[1;4mOptions:\x1b[0m\n{{options}}"
             ));
 
         tree.attach(root)
@@ -634,6 +635,27 @@ fn feature_block(
     })
 }
 
+/// Grey "Aspect CLI v… — docs URL" line shown at the top of every `--help`
+/// screen. Mirrors the line printed above each `→ 🎬 Running …` task header
+/// at runtime — same string, same color — so users always know which CLI
+/// they're holding and where to find docs.
+///
+/// `version` should be the resolved CLI version (passed through from
+/// `Cmd::build`). Callers that don't have a handle on it (deep in the
+/// subgroup template builder) can use `cli_header_from_pkg()` instead.
+fn cli_header(version: &str) -> String {
+    format!(
+        "\x1b[38;5;244mAspect CLI v{} — https://docs.aspect.build/cli\x1b[0m",
+        version,
+    )
+}
+
+/// Like `cli_header()` but pulls the version from the workspace crate
+/// metadata. Used by call sites that don't have the resolved version handy.
+fn cli_header_from_pkg() -> String {
+    cli_header(&aspect_telemetry::cargo_pkg_short_version())
+}
+
 // ── Per-task subcommand assembly ───────────────────────────────────────────
 
 fn task_command(
@@ -641,6 +663,7 @@ fn task_command(
     task: &dyn TaskLike<'_>,
     label: &str,
     feature_blocks: &[FeatureBlock],
+    cli_header: &str,
 ) -> Command {
     let name = task.name();
     let display_name = task.display_name();
@@ -708,11 +731,17 @@ fn task_command(
         }
     }
 
-    if let Some(header) = help_header {
-        cmd = cmd.help_template(format!(
-            "{header}\n\n{{usage-heading}} {{usage}}\n\n{{all-args}}\n"
-        ));
-    }
+    // Always use a custom template so the grey "Aspect CLI v… — docs URL"
+    // header lands at the top. When the task supplies its own help_header
+    // body (summary/description), use that as the about block; otherwise
+    // fall back to clap's `{about-with-newline}`.
+    let about_block = match help_header {
+        Some(h) => format!("{h}\n"),
+        None => "{about-with-newline}".to_string(),
+    };
+    cmd = cmd.help_template(format!(
+        "{cli_header}\n\n{about_block}\n{{usage-heading}} {{usage}}\n\n{{all-args}}"
+    ));
     cmd
 }
 
@@ -779,9 +808,11 @@ impl Tree {
 
     fn attach(self, mut root: Command) -> Result<Command, CmdError> {
         // Subgroups (rendered hidden, with their own help template).
+        let header = cli_header_from_pkg();
         for (name, sub) in self.subgroups {
             let sub_groups = sub.group_names();
-            let mut template = String::from("{about-with-newline}\n{usage-heading} {usage}");
+            let mut template =
+                format!("{header}\n\n{{about-with-newline}}\n{{usage-heading}} {{usage}}",);
             if !sub.tasks.is_empty() {
                 template.push_str("\n\n\x1b[1;4mTasks:\x1b[0m\n{subcommands}");
             }

--- a/crates/axl-runtime/BUILD.bazel
+++ b/crates/axl-runtime/BUILD.bazel
@@ -15,6 +15,7 @@ rust_library(
         "//crates/axl-lsp:__pkg__",
     ],
     deps = [
+        "//crates/aspect-telemetry",
         "//crates/axl-proto",
         "//crates/axl-types",
         "//crates/bazelrc",

--- a/crates/axl-runtime/src/banner.rs
+++ b/crates/axl-runtime/src/banner.rs
@@ -1,0 +1,86 @@
+//! The grey "Aspect CLI v… — docs URL" identity line.
+//!
+//! Shown in two places — at the top of every `--help` screen and above each
+//! `→ 🎬 Running …` task header at runtime — so users always know which CLI
+//! they're holding and where to find docs, even when aspect is invoked through
+//! a `tools/bazel` wrapper or a custom org alias. Both call sites render the
+//! same string in the same color from here so the two can't drift.
+
+use std::io::IsTerminal;
+
+use aspect_telemetry::cargo_pkg_short_version;
+
+use crate::ci::on_recognized_ci;
+
+/// SGR sequence for the banner's grey (256-color 244).
+const GREY: &str = "\x1b[38;5;244m";
+/// SGR reset.
+const RESET: &str = "\x1b[0m";
+
+/// Docs landing page advertised by the banner.
+const DOCS_URL: &str = "https://docs.aspect.build/cli";
+
+/// The grey banner line for `version`, e.g.
+/// `Aspect CLI v1.2.3 — https://docs.aspect.build/cli`, wrapped in ANSI grey.
+///
+/// No trailing newline — callers place it within their own layout.
+pub fn line(version: &str) -> String {
+    format!("{GREY}Aspect CLI v{version} — {DOCS_URL}{RESET}")
+}
+
+/// [`line`] resolving the version from workspace crate metadata. For call
+/// sites that don't have the resolved version handy.
+pub fn line_from_pkg() -> String {
+    line(&cargo_pkg_short_version())
+}
+
+/// Whether to print the banner above a runtime task header.
+///
+/// Shown only on an interactive TTY or a recognized CI host — never when
+/// stderr is piped to a non-CI consumer (e.g. a script parsing task output) —
+/// and suppressible everywhere via `ASPECT_CLI_NO_BANNER`.
+///
+/// (The `--help` banner is not gated this way: `--help` is an explicit request
+/// for output, so it always prints.)
+pub fn show_runtime_banner() -> bool {
+    show_runtime_banner_from(
+        std::io::stderr().is_terminal(),
+        on_recognized_ci(),
+        std::env::var_os("ASPECT_CLI_NO_BANNER").is_some(),
+    )
+}
+
+/// Pure core of [`show_runtime_banner`], parameterized over its inputs so the
+/// gating is testable without a real TTY or process env.
+fn show_runtime_banner_from(stderr_is_tty: bool, on_ci: bool, no_banner_set: bool) -> bool {
+    (stderr_is_tty || on_ci) && !no_banner_set
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_renders_grey_version_and_docs_url() {
+        let s = line("9.9.9");
+        assert_eq!(s, format!("{GREY}Aspect CLI v9.9.9 — {DOCS_URL}{RESET}"));
+        assert!(s.starts_with(GREY) && s.ends_with(RESET));
+    }
+
+    #[test]
+    fn runtime_banner_shows_on_tty_or_ci_unless_suppressed() {
+        // Shown on an interactive TTY or a recognized CI host…
+        assert!(show_runtime_banner_from(true, false, false));
+        assert!(show_runtime_banner_from(false, true, false));
+        assert!(show_runtime_banner_from(true, true, false));
+
+        // …but NOT when stderr is piped to a non-CI consumer (a scripted/piped
+        // run must not get an extra line).
+        assert!(!show_runtime_banner_from(false, false, false));
+
+        // ASPECT_CLI_NO_BANNER suppresses it on every surface.
+        assert!(!show_runtime_banner_from(true, false, true));
+        assert!(!show_runtime_banner_from(false, true, true));
+        assert!(!show_runtime_banner_from(false, false, true));
+    }
+}

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -66,6 +66,17 @@ fn running_verb_color() -> (String, &'static str) {
     (verb_seq, reset)
 }
 
+/// Whether to print the grey "Aspect CLI v…" runtime banner above a task
+/// header.
+///
+/// Shown only on an interactive TTY or a recognized CI host — never when
+/// stderr is piped to a non-CI consumer (e.g. a script parsing task output) —
+/// and suppressible everywhere via `ASPECT_CLI_NO_BANNER`. Pure over its
+/// inputs so the gating is testable without a real TTY or process env.
+fn show_runtime_banner(stderr_is_tty: bool, on_ci: bool, no_banner_set: bool) -> bool {
+    (stderr_is_tty || on_ci) && !no_banner_set
+}
+
 /// Wrapper around a live Starlark Module heap.
 ///
 /// All three evaluation phases share this heap so `Value<'v>` references
@@ -373,20 +384,17 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         // header. Helps users who arrived via a `tools/bazel` wrapper (or
         // a custom org CLI alias) recognize what tool is actually running
         // and where to learn more, without dominating the headline below.
-        // Same TTY/CI gating as the header itself; suppressed under
-        // `ASPECT_CLI_NO_BANNER=1` for users who want quieter output.
-        if std::env::var_os("ASPECT_CLI_NO_BANNER").is_none() {
-            let color = std::io::stderr().is_terminal() || on_recognized_ci();
-            let (grey, grey_reset) = if color {
-                ("\x1b[38;5;244m", SGR_RESET)
-            } else {
-                ("", "")
-            };
+        // When shown it's always on a surface that renders ANSI, so it's
+        // always grey.
+        if show_runtime_banner(
+            std::io::stderr().is_terminal(),
+            on_recognized_ci(),
+            std::env::var_os("ASPECT_CLI_NO_BANNER").is_some(),
+        ) {
             eprintln!(
-                "{}Aspect CLI v{} — https://docs.aspect.build/cli{}\n",
-                grey,
+                "\x1b[38;5;244mAspect CLI v{} — https://docs.aspect.build/cli{}\n",
                 cargo_pkg_short_version(),
-                grey_reset,
+                SGR_RESET,
             );
         }
         if std::env::var_os("BUILDKITE").is_some() {
@@ -940,7 +948,7 @@ fn display_width(s: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{TimingMode, display_width, render_phase_breakdown};
+    use super::{TimingMode, display_width, render_phase_breakdown, show_runtime_banner};
     use crate::engine::task_info::PhaseRecord;
     use std::time::Duration;
 
@@ -953,6 +961,23 @@ mod tests {
             emoji: emoji.to_string(),
             display_name: String::new(),
         }
+    }
+
+    #[test]
+    fn runtime_banner_shows_on_tty_or_ci_unless_suppressed() {
+        // Shown on an interactive TTY or a recognized CI host…
+        assert!(show_runtime_banner(true, false, false));
+        assert!(show_runtime_banner(false, true, false));
+        assert!(show_runtime_banner(true, true, false));
+
+        // …but NOT when stderr is piped to a non-CI consumer (the bug this
+        // gating fixes — a scripted/piped run must not get an extra line).
+        assert!(!show_runtime_banner(false, false, false));
+
+        // ASPECT_CLI_NO_BANNER suppresses it on every surface.
+        assert!(!show_runtime_banner(true, false, true));
+        assert!(!show_runtime_banner(false, true, true));
+        assert!(!show_runtime_banner(false, false, true));
     }
 
     #[test]

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -2,6 +2,7 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
+use aspect_telemetry::cargo_pkg_short_version;
 use starlark::environment::{FrozenModule, Module};
 use starlark::eval::Evaluator;
 use starlark::values::list::AllocList;
@@ -368,6 +369,26 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         } else {
             String::new()
         };
+        // Grey "Aspect CLI v… — docs URL" announce line above the task
+        // header. Helps users who arrived via a `tools/bazel` wrapper (or
+        // a custom org CLI alias) recognize what tool is actually running
+        // and where to learn more, without dominating the headline below.
+        // Same TTY/CI gating as the header itself; suppressed under
+        // `ASPECT_CLI_NO_BANNER=1` for users who want quieter output.
+        if std::env::var_os("ASPECT_CLI_NO_BANNER").is_none() {
+            let color = std::io::stderr().is_terminal() || on_recognized_ci();
+            let (grey, grey_reset) = if color {
+                ("\x1b[38;5;244m", SGR_RESET)
+            } else {
+                ("", "")
+            };
+            eprintln!(
+                "{}Aspect CLI v{} — https://docs.aspect.build/cli{}\n",
+                grey,
+                cargo_pkg_short_version(),
+                grey_reset,
+            );
+        }
         if std::env::var_os("BUILDKITE").is_some() {
             // The BK section header replaces the `→` line on BK (avoids
             // duplicating the same text in the BK log viewer).

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -2,13 +2,13 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
-use aspect_telemetry::cargo_pkg_short_version;
 use starlark::environment::{FrozenModule, Module};
 use starlark::eval::Evaluator;
 use starlark::values::list::AllocList;
 use starlark::values::{Heap, Value, ValueLike};
 use uuid::Uuid;
 
+use crate::banner;
 use crate::ci::on_recognized_ci;
 use crate::engine::arguments::Arguments;
 use crate::engine::bazel::Bazel;
@@ -64,17 +64,6 @@ fn running_verb_color() -> (String, &'static str) {
     };
     let reset = if color { SGR_RESET } else { "" };
     (verb_seq, reset)
-}
-
-/// Whether to print the grey "Aspect CLI v…" runtime banner above a task
-/// header.
-///
-/// Shown only on an interactive TTY or a recognized CI host — never when
-/// stderr is piped to a non-CI consumer (e.g. a script parsing task output) —
-/// and suppressible everywhere via `ASPECT_CLI_NO_BANNER`. Pure over its
-/// inputs so the gating is testable without a real TTY or process env.
-fn show_runtime_banner(stderr_is_tty: bool, on_ci: bool, no_banner_set: bool) -> bool {
-    (stderr_is_tty || on_ci) && !no_banner_set
 }
 
 /// Wrapper around a live Starlark Module heap.
@@ -380,22 +369,9 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         } else {
             String::new()
         };
-        // Grey "Aspect CLI v… — docs URL" announce line above the task
-        // header. Helps users who arrived via a `tools/bazel` wrapper (or
-        // a custom org CLI alias) recognize what tool is actually running
-        // and where to learn more, without dominating the headline below.
-        // When shown it's always on a surface that renders ANSI, so it's
-        // always grey.
-        if show_runtime_banner(
-            std::io::stderr().is_terminal(),
-            on_recognized_ci(),
-            std::env::var_os("ASPECT_CLI_NO_BANNER").is_some(),
-        ) {
-            eprintln!(
-                "\x1b[38;5;244mAspect CLI v{} — https://docs.aspect.build/cli{}\n",
-                cargo_pkg_short_version(),
-                SGR_RESET,
-            );
+        // Identity banner above the task header — see `crate::banner`.
+        if banner::show_runtime_banner() {
+            eprintln!("{}\n", banner::line_from_pkg());
         }
         if std::env::var_os("BUILDKITE").is_some() {
             // The BK section header replaces the `→` line on BK (avoids
@@ -948,7 +924,7 @@ fn display_width(s: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{TimingMode, display_width, render_phase_breakdown, show_runtime_banner};
+    use super::{TimingMode, display_width, render_phase_breakdown};
     use crate::engine::task_info::PhaseRecord;
     use std::time::Duration;
 
@@ -961,23 +937,6 @@ mod tests {
             emoji: emoji.to_string(),
             display_name: String::new(),
         }
-    }
-
-    #[test]
-    fn runtime_banner_shows_on_tty_or_ci_unless_suppressed() {
-        // Shown on an interactive TTY or a recognized CI host…
-        assert!(show_runtime_banner(true, false, false));
-        assert!(show_runtime_banner(false, true, false));
-        assert!(show_runtime_banner(true, true, false));
-
-        // …but NOT when stderr is piped to a non-CI consumer (the bug this
-        // gating fixes — a scripted/piped run must not get an extra line).
-        assert!(!show_runtime_banner(false, false, false));
-
-        // ASPECT_CLI_NO_BANNER suppresses it on every surface.
-        assert!(!show_runtime_banner(true, false, true));
-        assert!(!show_runtime_banner(false, true, true));
-        assert!(!show_runtime_banner(false, false, true));
     }
 
     #[test]

--- a/crates/axl-runtime/src/lib.rs
+++ b/crates/axl-runtime/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::new_without_default)]
+pub mod banner;
 pub mod builtins;
 pub mod ci;
 pub mod docs;


### PR DESCRIPTION
Adds a grey identity line — `Aspect CLI vX — https://docs.aspect.build/cli` — so users always know which CLI they're holding and where to find docs, even when aspect is invoked through a `tools/bazel` wrapper or a custom org alias.

It appears in two places, rendered from a single source (`axl_runtime::banner`) so the string and color can't drift:

- **Every `--help` screen** — root, each task, and each task group. Always shown (help is an explicit request for output).
- **Above each `→ 🎬 Running …` task header at runtime** — but only on an interactive TTY or a recognized CI host, never when stderr is piped to a non-CI consumer (so scripted/piped task runs don't get an extra line). Suppressible everywhere with `ASPECT_CLI_NO_BANNER`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`aspect --help` and task-runner output now show a grey `Aspect CLI vX — https://docs.aspect.build/cli` identity line. At runtime it appears only on a TTY or CI, and can be disabled with `ASPECT_CLI_NO_BANNER=1`.

### Test plan

- New unit tests for the banner (TTY/CI/suppression gating matrix and line rendering)
- New `cmd.rs` test asserting the banner appears on root, group, and task `--help` screens
- Covered by existing test cases
