### PR TITLE
feat(cli): add tools/bazel reference wrapper

### DIFF
--- a/.aspect/bootstrap.sh
+++ b/.aspect/bootstrap.sh
@@ -5,6 +5,15 @@
 # Exports: BAZEL_STARTUP_OPTS, BAZEL_BUILD_OPTS, DISABLE_PLUGINS_FLAG
 set -eu
 
+# Pre-build CI must use vanilla bazel — see the long comment around the
+# `bazel build //:cli` invocation below for the bootstrapping rationale.
+# This repo's tools/bazel wrapper routes `bazel build|test|run` through
+# `aspect`, which would either fail (no aspect binary built yet on a fresh
+# checkout) or hide the bootstrap failure mode we explicitly want to
+# surface on PRs. Eject from the wrapper for every bazel invocation in
+# this script and any pipeline step that inherits this shell.
+export ASPECT_WRAPPER_SKIP=1
+
 # Build remote cache/BES flags from ASPECT_WORKFLOWS_* env vars injected by the runner.
 BAZEL_REMOTE_FLAGS=""
 [ -n "${ASPECT_WORKFLOWS_BES_BACKEND:-}" ]                  && BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --bes_backend=${ASPECT_WORKFLOWS_BES_BACKEND}"

--- a/.github/workflows/build_release_artifacts.yaml
+++ b/.github/workflows/build_release_artifacts.yaml
@@ -25,6 +25,13 @@ jobs:
     runs-on: ubuntu-22.04-32core
     outputs:
       artifact: ${{steps.upload.outputs.artifact-url}}
+    env:
+      # Eject from this repo's tools/bazel wrapper. The wrapper routes
+      # `bazel build|test|run` through `aspect`, but the release build IS
+      # the aspect binary — using aspect to build itself defeats the
+      # `bazel`-only bootstrap (and would fail outright on a clean
+      # runner where aspect isn't installed yet).
+      ASPECT_WRAPPER_SKIP: "1"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -23,6 +23,17 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  # Pure-bash unit tests for the tools/bazel wrapper. No aspect, no bazel, no
+  # pre-build — runs on a stock ephemeral runner in seconds and guards the
+  # wrapper's routing/flag-classification logic against regressions.
+  wrapper-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: tools/bazel wrapper tests
+        run: ./tools/bazel-test.sh
+
   pre-build:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     timeout-minutes: 10

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -974,7 +974,7 @@ def _check_repro_dedup_consecutive_headings(ctx):
             ],
             "fix_commands": [
                 {"command": "aspect buildifier --severity=info BUILD.bazel", "description": ""},
-                {"command": "bazel run --run_in_cwd @buildifier_prebuilt//buildifier -- -r .", "description": "without Aspect CLI"},
+                {"command": "bazel run --run_in_cwd @buildifier_prebuilt//buildifier -- -r .", "description": "vanilla bazel"},
             ],
         },
     ]
@@ -1001,7 +1001,7 @@ def _check_repro_dedup_consecutive_headings(ctx):
         fail("repro dedup: aspect fix command missing from body")
     if "bazel run --run_in_cwd @buildifier_prebuilt//buildifier -- -r ." not in body:
         fail("repro dedup: bazel alt fix command missing from body")
-    if "# without Aspect CLI" not in body:
+    if "# vanilla bazel" not in body:
         fail("repro dedup: description-as-comment missing from body")
     if "Install `aspect`" not in body:
         fail("repro dedup: install hint missing from body")

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -283,7 +283,7 @@ def _append_fix_commands(ctx, data):
             flags = bazel_flags,
             max_chars = _BAZEL_ALT_MAX_CHARS,
         ),
-        "description": "without Aspect CLI",
+        "description": "vanilla bazel",
     })
 
 def _emit_final(ctx, lifecycle, data, exit_code):

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -391,7 +391,7 @@ def _append_fix_commands(ctx, data):
 
     data["fix_commands"].append({
         "command": prefix + build_bazel_command("run", [ctx.args.gazelle_target]),
-        "description": "without Aspect CLI",
+        "description": "vanilla bazel",
     })
 
 def _resolve_check_only(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -477,7 +477,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
         # installed. Flags are intentionally omitted — best-effort, not faithful.
         data["repro_commands"].append({
             "command": build_bazel_command(command, _repro_targets),
-            "description": "without Aspect CLI",
+            "description": "vanilla bazel",
         })
 
     return _emit_terminal(ctx, lifecycle, command, data, invocation_status.code)

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -743,7 +743,7 @@ impl Build {
 
         let targets: Vec<String> = targets.into_iter().collect();
 
-        let mut cmd = Command::new(super::bazel_binary());
+        let mut cmd = super::bazel_command();
         cmd.args(startup_flags);
         cmd.arg(verb);
         cmd.args(flags);

--- a/crates/axl-runtime/src/engine/bazel/health_check.rs
+++ b/crates/axl-runtime/src/engine/bazel/health_check.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use allocative::Allocative;
 use derive_more::Display;
@@ -78,7 +78,7 @@ struct CheckResult {
 
 /// Runs `bazel [startup_flags] --noblock_for_lock info server_pid` and returns the result.
 fn check_bazel_server(startup_flags: &[String]) -> CheckResult {
-    let mut cmd = Command::new(super::bazel_binary());
+    let mut cmd = super::bazel_command();
     cmd.args(startup_flags)
         .arg("--noblock_for_lock")
         .arg("info")
@@ -124,7 +124,7 @@ fn extract_server_pid(server_pid_file: Option<&Path>) -> Option<u32> {
 
 /// Tries to determine the Bazel output base by running `bazel [startup_flags] info output_base`.
 fn get_output_base(startup_flags: &[String]) -> Option<PathBuf> {
-    let mut cmd = Command::new(super::bazel_binary());
+    let mut cmd = super::bazel_command();
     cmd.args(startup_flags)
         .arg("info")
         .arg("output_base")

--- a/crates/axl-runtime/src/engine/bazel/info.rs
+++ b/crates/axl-runtime/src/engine/bazel/info.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::process::Command;
 use std::process::Stdio;
 
 use anyhow::anyhow;
@@ -31,7 +30,7 @@ pub fn server_info() -> io::Result<(u32, Option<semver::Version>)> {
 pub fn server_info_with_startup_flags(
     startup_flags: &[String],
 ) -> io::Result<(u32, Option<semver::Version>)> {
-    let mut cmd = Command::new(super::bazel_binary());
+    let mut cmd = super::bazel_command();
     cmd.args(startup_flags);
     cmd.arg("info");
     cmd.arg("server_pid");
@@ -98,7 +97,7 @@ pub fn server_info_with_startup_flags(
 ///   "Another command (pid=12345) is running. Exiting immediately."
 /// We parse the PID from that stderr message.
 pub fn client_pid(startup_flags: &[String]) -> Option<u32> {
-    let mut cmd = Command::new(super::bazel_binary());
+    let mut cmd = super::bazel_command();
     cmd.args(startup_flags);
     cmd.arg("--noblock_for_lock");
     cmd.arg("info");
@@ -122,7 +121,7 @@ pub fn client_pid(startup_flags: &[String]) -> Option<u32> {
 
 /// Check if the bazel server lock is currently held by a client.
 pub fn is_server_busy(startup_flags: &[String]) -> bool {
-    let mut cmd = Command::new(super::bazel_binary());
+    let mut cmd = super::bazel_command();
     cmd.args(startup_flags);
     cmd.arg("--noblock_for_lock");
     cmd.arg("info");
@@ -144,7 +143,7 @@ pub fn is_server_busy(startup_flags: &[String]) -> bool {
 ///
 /// Returns `None` only if the server is not running or bazel is not available.
 pub fn server_pid_nonblocking(startup_flags: &[String]) -> Option<u32> {
-    let mut cmd = Command::new(super::bazel_binary());
+    let mut cmd = super::bazel_command();
     cmd.args(startup_flags);
     cmd.arg("--noblock_for_lock");
     cmd.arg("info");

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -53,6 +53,24 @@ pub(crate) fn bazel_binary() -> String {
     std::env::var("BAZEL_REAL").unwrap_or_else(|_| "bazel".to_string())
 }
 
+/// Build a `Command` for spawning bazel, with the anti-inception env var set.
+///
+/// When `tools/bazel` wrapper scripts forward to `aspect` for build/test/run,
+/// aspect then needs to spawn its OWN child bazel. If `PATH` still has
+/// `tools/bazel` first, that child re-enters the wrapper and bounces right
+/// back into aspect — inception, repeated forever.
+///
+/// `ASPECT_CLI_RUNNING=1` breaks the cycle: cooperating wrapper scripts
+/// check for it on entry and short-circuit straight to the real bazel
+/// (matching the spirit of bazelisk's `BAZELISK_SKIP_WRAPPER`). All bazel
+/// spawns from inside aspect go through this helper so the env var is
+/// always set, regardless of which call site fired.
+pub(crate) fn bazel_command() -> std::process::Command {
+    let mut cmd = std::process::Command::new(bazel_binary());
+    cmd.env("ASPECT_CLI_RUNNING", "1");
+    cmd
+}
+
 /// Resolve the `(stdout, stderr)` `Stdio` slots from the Starlark args.
 ///
 /// Tri-state for each per-fd arg: not passed → inherit, Starlark `None` →
@@ -509,7 +527,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     fn info<'v>(this: values::Value<'v>) -> anyhow::Result<SmallMap<String, String>> {
         let startup_flags = read_startup_flags(this)?;
 
-        let mut cmd = std::process::Command::new(bazel_binary());
+        let mut cmd = bazel_command();
         cmd.args(&startup_flags);
         cmd.arg("info");
         cmd.stdout(Stdio::piped());

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 
 use std::cell::RefCell;
 use std::io::Read;
-use std::process::Command;
 use std::process::Stdio;
 
 use anyhow::Context;
@@ -159,7 +158,7 @@ impl Query {
     }
 
     pub fn query(expr: &str, startup_flags: &[String]) -> anyhow::Result<TargetSet> {
-        let mut cmd = Command::new(super::bazel_binary());
+        let mut cmd = super::bazel_command();
         cmd.args(startup_flags);
         cmd.arg("query");
         cmd.arg(expr);

--- a/tools/bazel
+++ b/tools/bazel
@@ -1,0 +1,869 @@
+#!/usr/bin/env bash
+# aspect-build/tools-bazel-wrapper
+#
+# tools/bazel — Bazel wrapper that transparently routes Aspect-specific
+# functionality through the `aspect` CLI without forcing developers to learn
+# a new command name.
+#
+# The marker comment above (`# aspect-build/tools-bazel-wrapper`) and the
+# ASPECT_BAZEL_WRAPPER_VERSION variable below identify this file as the
+# canonical Aspect-shipped wrapper. Aspect detects them to know that in
+# this workspace `bazel <verb>` is equivalent to `aspect <verb>` for
+# reproduce/fix commands and tooling that suggests "vanilla bazel"
+# alternatives. Do NOT remove these markers if you fork the script.
+#
+# Behavior (verb routing):
+#   - verb in ASPECT_VERBS_WITH_BAZEL_FLAGS  → exec aspect <verb> [rewritten]
+#       (the verbs aspect wraps plus the aspect verbs that drive bazel —
+#        bazel-native flags become --bazel-flag=<flag>; everything else
+#        passes through to aspect.)
+#   - verb in BAZEL_VERBS (not above)        → exec $BAZEL_REAL <args...>
+#       (query, info, clean, mod, version, … — vanilla bazel, untouched.)
+#   - any other verb (custom .axl task)      → exec aspect <verb> [args...]
+#       (forwarded verbatim — we don't assume an unknown verb is bazel's.)
+#   - no verb / ASPECT_CLI_RUNNING / SKIP    → exec $BAZEL_REAL <args...>
+#
+# When `aspect` is NOT on PATH but a command would route to it, the wrapper
+# prints install instructions. If the verb is also a real bazel command
+# (build/test/run/coverage) it then falls back to vanilla bazel so the command
+# still runs; otherwise (lint/format/custom .axl tasks, which bazel can't run)
+# it exits. Plain bazel verbs never need aspect and run regardless.
+#
+# Flag handling (for verbs routed to aspect with rewriting):
+#   Bazel is the closed set. A flag whose name is in one of the embedded
+#   BAZEL_*_FLAGS lists is wrapped as `--bazel-flag=<flag>` (post-verb) or
+#   `--bazel-startup-flag=<flag>` (pre-verb). Value-taking flags written
+#   space-separated (`--config ci`, `-c opt`) consume the next token and glue
+#   with `=` (`--bazel-flag=--config=ci`, `--bazel-flag=-c=opt`). Every other
+#   flag — aspect's own flags, and anything we don't recognize — passes
+#   through to aspect unchanged.
+#
+# Maintaining the lists (edit in your own repo copy):
+#   ASPECT_VERBS_WITH_BAZEL_FLAGS and the BAZEL_*_FLAGS lists at the top of
+#   this file are the source of truth. If Bazel adds a flag we don't know, or
+#   you add an aspect command that accepts bazel flags (e.g. a custom task
+#   that shells out to bazel), add it to the relevant list. An unknown bazel
+#   flag simply passes through to aspect until you add it.
+#
+# Drop this script at `tools/bazel` in your workspace and make it executable
+# (`chmod +x tools/bazel`). The `tools/bazel` hook is a Bazelisk feature (the
+# real bazel binary does not look for it; see
+# https://github.com/bazelbuild/bazelisk): Bazelisk execs this script and
+# passes the resolved real-bazel path in BAZEL_REAL. When BAZEL_REAL is unset
+# — the wrapper was invoked directly, or by an aspect child — we fall back to
+# finding the next `bazel` on PATH that isn't this wrapper.
+#
+# Environment variables:
+#   ASPECT_WRAPPER_SKIP=1    Forward EVERYTHING straight to bazel, untouched —
+#                            no verb parsing, no list checks, no flag rewriting.
+#                            A total escape hatch for a 1:1 vanilla-bazel
+#                            experience; reach for `aspect <verb>` directly when
+#                            you want the wrapped behavior.
+#   ASPECT_WRAPPER_TRACE=1   Always print the resolved command (in grey, on
+#                            stderr), even when forwarding straight to bazel.
+#                            By default the trace prints only when routing
+#                            to aspect, since plain bazel forwarding is
+#                            uninteresting.
+#   ASPECT_WRAPPER_QUIET=1   Suppress the trace line entirely.
+#
+# Implicit env var (set by aspect, not by users):
+#   ASPECT_CLI_RUNNING=1     Aspect sets this on every child bazel it spawns.
+#                            When the wrapper sees it, it bypasses ALL routing
+#                            and forwards straight to the real bazel,
+#                            preventing aspect → tools/bazel → aspect → …
+#                            recursion. Customers should never set this
+#                            manually. See bazelisk's BAZELISK_SKIP_WRAPPER
+#                            for the same pattern.
+#
+# Source of truth: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel
+
+set -euo pipefail
+
+# Wrapper schema version. Bumped when the routing rules or env-var contract
+# change in a way that downstream detection might care about. See the
+# `aspect-build/tools-bazel-wrapper` marker comment at the top of the file.
+ASPECT_BAZEL_WRAPPER_VERSION="1"
+export ASPECT_BAZEL_WRAPPER_VERSION
+
+# --- Anti-inception bypass ------------------------------------------------
+#
+# If aspect set ASPECT_CLI_RUNNING, we're being invoked as a CHILD of aspect.
+# Skip every code path that would re-enter aspect and forward to the real
+# bazel directly. Done before everything else so it costs nothing in the
+# common case and can't be defeated by later config.
+if [[ -n "${ASPECT_CLI_RUNNING:-}" ]]; then
+    if [[ -n "${BAZEL_REAL:-}" && -x "$BAZEL_REAL" ]]; then
+        exec "$BAZEL_REAL" "$@"
+    fi
+    # No BAZEL_REAL (aspect was invoked directly, not through Bazelisk).
+    # Find the next bazel on PATH that isn't us.
+    self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+    while IFS= read -r candidate; do
+        if [[ "$(cd "$(dirname "$candidate")" && pwd)/$(basename "$candidate")" != "$self" ]]; then
+            exec "$candidate" "$@"
+        fi
+    done < <(type -aP bazel 2>/dev/null || true)
+    echo "ERROR: tools/bazel: ASPECT_CLI_RUNNING is set but no real bazel found on PATH" >&2
+    exit 127
+fi
+
+
+# ============================================================================
+# Configuration — EDIT THESE in your own repo copy
+# ============================================================================
+#
+# Two kinds of list drive every routing decision; both are meant to be edited
+# by whoever owns the workspace copy of this script:
+#
+#   1. ASPECT_VERBS_WITH_BAZEL_FLAGS — which verbs go to `aspect` AND accept
+#      forwarded bazel flags.
+#   2. BAZEL_VERBS + the BAZEL_*_FLAGS lists — the closed set of "what Bazel
+#      understands". Anything outside it is treated as aspect's.
+#
+# If Bazel adds a command or flag we don't list, or you add an aspect command
+# that should accept bazel flags (e.g. a custom task that shells out to
+# bazel), add it to the relevant list below.
+
+# Verbs routed to `aspect` with bazel-flag rewriting: bazel-native flags after
+# the verb become `--bazel-flag=<flag>`, everything else passes through to
+# aspect. Includes the Bazel verbs aspect wraps (`build`/`test`/`run`) and the
+# aspect verbs that drive bazel internally (`lint`, `format`, …). Add your own
+# bazel-flag-aware aspect commands here.
+ASPECT_VERBS_WITH_BAZEL_FLAGS=(
+    build
+    buildifier
+    delivery
+    format
+    gazelle
+    lint
+    run
+    test
+)
+
+# The closed set of Bazel commands (Bazel 9). A verb here that is NOT in
+# ASPECT_VERBS_WITH_BAZEL_FLAGS forwards to vanilla bazel untouched (query,
+# info, clean, mod, …). Generated by: `bazel help` (the "Available commands"
+# list).
+BAZEL_VERBS=(
+    aquery build canonicalize-flags clean coverage cquery dump fetch help
+    info license mobile-install mod print_action query run shutdown test
+    vendor version
+)
+
+# Bazel flags that take a SPACE-separated value (e.g. `--config foo` rather
+# than `--config=foo`). Required so the wrapper consumes the following argv
+# element and rewrites the pair as one `--bazel-flag=--name=value` token.
+# Generated from `bazel help build|test|run|startup_options --long` at
+# Bazel 9.x. Booleans (--[no]name) live in BAZEL_BOOL_FLAGS, not here.
+BAZEL_VALUE_FLAGS=(
+    action_env allow_yanked_versions allowed_cpu_values
+    allowed_strategies_by_exec_platform analysis_testing_deps_limit
+    android_compiler android_dynamic_mode android_manifest_merger
+    android_manifest_merger_order android_platforms apk_signing_method
+    aspects aspects_parameters auto_output_filter bazelrc
+    bep_maximum_open_remote_upload_files bes_backend bes_header
+    bes_instance_name bes_keywords bes_oom_finish_upload_timeout
+    bes_outerr_buffer_size bes_outerr_chunk_size bes_proxy bes_results_url
+    bes_system_keywords bes_timeout bes_upload_mode
+    build_event_binary_file build_event_binary_file_upload_mode
+    build_event_json_file build_event_json_file_upload_mode
+    build_event_max_named_set_of_file_entries build_event_text_file
+    build_event_text_file_upload_mode build_event_upload_max_retries
+    build_metadata build_tag_filters cache_computed_file_digests
+    catalyst_cpus cc_output_directory_tag cc_proto_library_header_suffixes
+    cc_proto_library_source_suffixes check_bazel_compatibility
+    check_direct_dependencies color combined_report compilation_mode
+    compiler config conlyopt connect_timeout_secs copt
+    coverage_output_generator coverage_report_generator coverage_support
+    cpu credential_helper credential_helper_cache_duration
+    credential_helper_timeout cs_fdo_absolute_path cs_fdo_instrument
+    cs_fdo_profile curses custom_malloc cxxopt default_test_resources
+    define deleted_packages digest_function disk_cache distdir
+    downloader_config dynamic_local_execution_delay dynamic_local_strategy
+    dynamic_mode dynamic_remote_strategy embed_label exec_aspects
+    execution_log_binary_file execution_log_compact_file
+    execution_log_json_file experimental_action_cache_gc_idle_delay
+    experimental_action_cache_gc_max_age
+    experimental_action_cache_gc_threshold experimental_action_listener
+    experimental_active_directories
+    experimental_async_execution_max_concurrent_actions
+    experimental_build_event_output_group_mode
+    experimental_build_event_upload_retry_minimum_delay
+    experimental_build_event_upload_strategy experimental_cgroup_parent
+    experimental_circuit_breaker_strategy experimental_command_profile
+    experimental_disk_cache_gc_idle_delay
+    experimental_disk_cache_gc_max_age experimental_disk_cache_gc_max_size
+    experimental_docker_image experimental_dynamic_ignore_local_signals
+    experimental_dynamic_local_load_factor
+    experimental_dynamic_slow_remote_time experimental_extra_action_filter
+    experimental_frontier_violation_check
+    experimental_install_base_gc_max_age experimental_java_classpath
+    experimental_objc_fastbuild_options
+    experimental_one_version_enforcement experimental_output_paths
+    experimental_override_platform_cpu_name
+    experimental_profile_additional_tasks
+    experimental_remote_cache_compression_threshold
+    experimental_remote_cache_eviction_retries
+    experimental_remote_cache_ttl
+    experimental_remote_capture_corrupted_outputs
+    experimental_remote_downloader
+    experimental_remote_failure_rate_threshold
+    experimental_remote_failure_window_interval
+    experimental_remote_output_service
+    experimental_remote_output_service_output_path_prefix
+    experimental_remote_scrubbing_config
+    experimental_repository_downloader_retries
+    experimental_sandbox_async_tree_delete_idle_threads
+    experimental_sandbox_enforce_resources_regexp
+    experimental_sandbox_limits experimental_sandbox_memory_limit_mb
+    experimental_scale_timeouts experimental_skyfocus_dump_keys
+    experimental_spawn_scheduler experimental_starlark_types_allowed_paths
+    experimental_strict_java_deps
+    experimental_thread_dump_action_execution_inactivity_duration
+    experimental_thread_dump_interval
+    experimental_total_worker_memory_limit_mb
+    experimental_ui_max_stdouterr_bytes experimental_windows_sandbox_path
+    experimental_worker_allowlist experimental_worker_memory_limit_mb
+    experimental_worker_metrics_poll_interval
+    experimental_worker_sandbox_inmemory_tracking
+    experimental_workspace_rules_log_file explain extra_classpath
+    extra_execution_platforms extra_toolchains failure_detail_out
+    fdo_instrument fdo_optimize fdo_prefetch_hints fdo_profile features
+    fission flag_alias flaky_test_attempts gc_churning_threshold
+    gc_churning_threshold_if_multiple_top_level_targets
+    gc_thrashing_limits gc_thrashing_threshold genrule_strategy
+    google_auth_scopes google_credentials grpc_keepalive_time
+    grpc_keepalive_timeout grte_top host_action_env host_compilation_mode
+    host_compiler host_conlyopt host_copt host_cpu host_cxxopt
+    host_features host_grte_top host_java_launcher host_javacopt
+    host_jvm_args host_jvm_debug host_jvmopt host_linkopt
+    host_macos_minimum_os host_per_file_copt host_platform
+    http_connector_attempts http_connector_retry_max_timeout
+    http_max_parallel_downloads http_timeout_scaling
+    incompatible_autoload_externally incompatible_disable_select_on
+    incompatible_disable_transitions_on inject_repository
+    instrumentation_filter invocation_id io_nice_level ios_minimum_os
+    ios_multi_cpus ios_sdk_version ios_signing_cert_name
+    ios_simulator_device ios_simulator_version j2objc_translation_flags
+    java_debug java_language_version java_launcher java_runtime_version
+    javacopt jobs jvm_heap_histogram_internal_object_pattern jvmopt
+    legacy_main_dex_list_generator linkopt loading_phase_threads
+    local_resources local_startup_timeout_secs
+    local_termination_grace_seconds local_test_jobs lockfile_mode logging
+    ltobackendopt ltoindexopt macos_cpus macos_minimum_os macos_qos_class
+    macos_sdk_version max_computation_steps max_config_changes_to_show
+    max_idle_secs max_test_output_bytes memory_profile
+    memory_profile_stable_heap_parameters memprof_profile
+    minimum_os_version modify_execution_info module_mirrors
+    nested_set_depth_limit objccopt optimizing_dexer output_base
+    output_filter output_groups output_user_root override_module
+    override_repository package_path per_file_copt per_file_ltobackendopt
+    persistent_android_dex_desugar persistent_android_resource_processor
+    persistent_multiplex_android_dex_desugar
+    persistent_multiplex_android_resource_processor
+    persistent_multiplex_android_tools platform_mappings platform_suffix
+    platforms plugin profile profiles_to_retain progress_report_interval
+    proguard_top propeller_optimize propeller_optimize_absolute_cc_profile
+    propeller_optimize_absolute_ld_profile proto_compiler
+    proto_profile_path proto_toolchain_for_cc proto_toolchain_for_j2objc
+    proto_toolchain_for_java proto_toolchain_for_javalite protocopt
+    python_native_rules_allowlist python_path registry
+    remote_analysis_json_log remote_build_event_upload
+    remote_bytestream_uri_prefix remote_cache remote_cache_header
+    remote_default_exec_properties remote_download_all
+    remote_download_minimal remote_download_outputs remote_download_regex
+    remote_download_symlink_template remote_download_toplevel
+    remote_downloader_header remote_exec_header remote_execution_priority
+    remote_executor remote_grpc_log remote_header remote_instance_name
+    remote_local_fallback_strategy remote_max_concurrency_per_connection
+    remote_max_connections remote_print_execution_messages remote_proxy
+    remote_result_cache_priority remote_retries remote_retry_max_delay
+    remote_timeout repo_contents_cache repo_contents_cache_gc_idle_delay
+    repo_contents_cache_gc_max_age repo_env repositories_without_autoloads
+    repository_cache run_env run_under runs_per_test
+    sandbox_add_mount_pair sandbox_base sandbox_block_path
+    sandbox_tmpfs_path sandbox_writable_path script_path
+    serialized_frontier_profile server_javabase server_jvm_out
+    shell_executable show_progress_rate_limit show_result
+    skyframe_high_water_mark_full_gc_drops_per_invocation
+    skyframe_high_water_mark_minor_gc_drops_per_invocation
+    skyframe_high_water_mark_threshold spawn_strategy starlark_cpu_profile
+    strategy strategy_regexp strict_proto_deps strict_public_imports strip
+    stripopt symlink_prefix target_environment target_pattern_file
+    test_arg test_env test_filter test_lang_filters test_output
+    test_result_expiration test_sharding_strategy test_size_filters
+    test_strategy test_summary test_tag_filters test_timeout
+    test_timeout_filters test_tmpdir tls_certificate
+    tls_client_certificate tls_client_key tool_java_language_version
+    tool_java_runtime_version tool_tag toolchain_resolution_debug
+    tvos_cpus tvos_minimum_os tvos_sdk_version ui_actions_shown
+    ui_event_filters vendor_dir visionos_cpus watchos_cpus
+    watchos_minimum_os watchos_sdk_version worker_extra_flag
+    worker_max_instances worker_max_multiplex_instances
+    workspace_status_command xbinary_fdo xcode_version
+    xcode_version_config
+)
+
+# Bazel boolean (no-value) flags, in their bare name form (the wrapper also
+# matches the `--[no]` / `--no` negations). These wrap as a single
+# `--bazel-flag=<flag>` token — they never consume the next argv element.
+# Generated from `bazel help build|test|run|startup_options --long` (the
+# `--[no]name` annotations) at Bazel 9.x.
+BAZEL_BOOL_FLAGS=(
+    allow_analysis_cache_discard allow_analysis_failures
+    allow_experimental_loads allow_one_action_on_resource_unavailable
+    android_databinding_use_androidx android_databinding_use_v3_4_args
+    android_resource_shrinking announce_rc apple_generate_dsym
+    attempt_to_print_relative_paths autodetect_server_javabase batch
+    batch_cpu_scheduling bes_check_preceding_lifecycle_events
+    bes_lifecycle_events block_for_lock
+    break_build_on_parallel_dex2oat_failure build
+    build_event_binary_file_path_conversion
+    build_event_json_file_path_conversion build_event_publish_all_actions
+    build_event_text_file_path_conversion build_manual_tests
+    build_runfile_links build_runfile_manifests build_test_dwp
+    build_tests_only cache_test_results cc_dotd_files cc_include_scanning
+    check_bzl_visibility check_tests_up_to_date check_up_to_date
+    check_visibility client_debug collect_code_coverage
+    compile_one_dependency debug_spawn_scheduler desugar_for_android
+    desugar_java8_libs device_debug_entitlements discard_analysis_cache
+    enable_platform_specific_config
+    enable_propeller_optimize_absolute_paths
+    enable_remaining_fdo_absolute_paths enable_runfiles enforce_constraints
+    execution_log_sort expand_test_suites
+    experimental_android_compress_java_resources
+    experimental_android_databinding_v2
+    experimental_android_resource_shrinking
+    experimental_android_rewrite_dexes_with_rex
+    experimental_android_use_parallel_dex2oat experimental_async_execution
+    experimental_bep_target_summary
+    experimental_build_event_expand_filesets experimental_bzl_visibility
+    experimental_cancel_concurrent_tests experimental_cc_shared_library
+    experimental_check_desugar_deps
+    experimental_collect_code_coverage_for_generated_files
+    experimental_collect_load_average_in_profiler
+    experimental_collect_pressure_stall_indicators
+    experimental_collect_resource_estimation
+    experimental_collect_skyframe_counts_in_profiler
+    experimental_collect_system_network_usage
+    experimental_collect_worker_data_in_profiler
+    experimental_convenience_symlinks
+    experimental_convenience_symlinks_bep_event
+    experimental_cpu_load_scheduling experimental_disable_external_package
+    experimental_docker_privileged
+    experimental_docker_use_customized_images experimental_docker_verbose
+    experimental_dormant_deps experimental_dynamic_exclude_tools
+    experimental_enable_android_migration_apis
+    experimental_enable_docker_sandbox
+    experimental_enable_first_class_macros experimental_enable_scl_dialect
+    experimental_enable_skyfocus experimental_enable_starlark_set
+    experimental_enable_thread_dump
+    experimental_enforce_transitive_visibility
+    experimental_extra_action_top_level_only
+    experimental_fetch_all_coverage_outputs
+    experimental_filter_library_jar_with_program_jar
+    experimental_frontier_violation_verbose experimental_generate_llvm_lcov
+    experimental_google_legacy_api
+    experimental_include_xcode_execution_requirements
+    experimental_inmemory_dotd_files experimental_inmemory_jdeps_files
+    experimental_inmemory_sandbox_stashes
+    experimental_isolated_extension_usages
+    experimental_materialize_param_files_directly experimental_omitfp
+    experimental_persistent_aar_extractor
+    experimental_platform_in_output_dir experimental_platforms_api
+    experimental_prefer_mutual_xcode
+    experimental_profile_include_primary_output
+    experimental_profile_include_target_configuration
+    experimental_profile_include_target_label
+    experimental_proto_descriptor_sets_include_source_info
+    experimental_py_binaries_include_label
+    experimental_record_metrics_for_all_mnemonics
+    experimental_record_skyframe_metrics
+    experimental_remotable_source_manifests
+    experimental_remote_cache_lease_extension
+    experimental_remote_discard_merkle_trees
+    experimental_remote_downloader_local_fallback
+    experimental_remote_downloader_propagate_credentials
+    experimental_remote_mark_tool_inputs
+    experimental_remote_repo_contents_cache
+    experimental_remote_require_cached experimental_repo_remote_exec
+    experimental_repository_cache_hardlinks
+    experimental_repository_ctx_execute_wasm
+    experimental_retain_test_configuration_across_testonly
+    experimental_rule_extension_api
+    experimental_run_android_lint_on_java_rules
+    experimental_run_bep_event_include_residue
+    experimental_run_in_user_cgroup
+    experimental_sandboxfs_map_symlink_targets
+    experimental_save_feature_state experimental_shrink_worker_pool
+    experimental_sibling_repository_layout
+    experimental_single_package_toolchain_binding
+    experimental_skyfocus_dump_post_gc_stats
+    experimental_split_coverage_postprocessing
+    experimental_starlark_type_checking experimental_starlark_type_syntax
+    experimental_stream_log_file_uploads experimental_strict_fileset_output
+    experimental_strict_repo_env
+    experimental_unsupported_and_brittle_include_scanning
+    experimental_use_hermetic_linux_sandbox experimental_use_llvm_covmap
+    experimental_use_platforms_in_output_dir_legacy_heuristic
+    experimental_use_validation_aspect experimental_use_windows_sandbox
+    experimental_windows_watchfs experimental_worker_cancellation
+    experimental_worker_multiplex_sandboxing
+    experimental_worker_sandbox_hardening
+    experimental_worker_strict_flagfiles explicit_java_test_deps
+    fat_apk_hwasan fetch force_pic force_starlark_stack_trace
+    generate_json_trace_profile google_default_credentials
+    guard_against_concurrent_changes heap_dump_on_oom
+    heuristically_drop_nodes home_rc idle_server_tasks ignore_all_rc_files
+    ignore_dev_dependency incompatible_allow_tags_propagation
+    incompatible_always_check_depset_elements
+    incompatible_always_include_files_in_data incompatible_auto_exec_groups
+    incompatible_bazel_test_exec_run_under
+    incompatible_builtin_objc_strip_action
+    incompatible_check_sharding_support
+    incompatible_check_testonly_for_output_files
+    incompatible_compact_repo_mapping_manifest
+    incompatible_config_setting_private_default_visibility
+    incompatible_default_to_explicit_init_py
+    incompatible_disable_autoloads_in_main_repo
+    incompatible_disable_native_android_rules
+    incompatible_disable_native_apple_binary_rule
+    incompatible_disable_non_executable_java_binary
+    incompatible_disable_objc_library_transition
+    incompatible_disable_starlark_host_transitions
+    incompatible_disable_target_default_provider_fields
+    incompatible_disallow_ctx_resolve_tools
+    incompatible_disallow_empty_glob
+    incompatible_disallow_sdk_frameworks_attributes
+    incompatible_do_not_split_linking_cmdline
+    incompatible_dont_enable_host_nonhost_crosstool_features
+    incompatible_enable_apple_toolchain_resolution
+    incompatible_enable_deprecated_label_apis
+    incompatible_enable_proto_toolchain_resolution
+    incompatible_enforce_config_setting_visibility
+    incompatible_enforce_starlark_utf8
+    incompatible_exclusive_test_sandboxed
+    incompatible_fail_on_unknown_attributes
+    incompatible_filegroup_runfiles_for_data
+    incompatible_fix_package_group_reporoot_syntax
+    incompatible_locations_prefers_executable
+    incompatible_make_thinlto_command_lines_standalone
+    incompatible_merge_genfiles_directory
+    incompatible_modify_execution_info_additive
+    incompatible_no_attr_license incompatible_no_implicit_file_export
+    incompatible_no_implicit_watch_label incompatible_no_rule_outputs_param
+    incompatible_objc_alwayslink_by_default
+    incompatible_package_group_has_public_syntax
+    incompatible_python_disallow_native_rules
+    incompatible_remote_local_fallback_for_remote_cache
+    incompatible_remove_legacy_whole_archive
+    incompatible_repo_env_ignores_action_env
+    incompatible_require_ctx_in_configure_features
+    incompatible_resolve_select_keys_eagerly
+    incompatible_run_shell_command_string
+    incompatible_simplify_unconditional_selects_in_rule_attrs
+    incompatible_stop_exporting_build_file_path
+    incompatible_stop_exporting_language_modules
+    incompatible_strict_action_env incompatible_strip_executable_safely
+    incompatible_target_cpu_from_platform
+    incompatible_unambiguous_label_stringification
+    incompatible_use_cc_configure_from_rules_cc
+    incompatible_use_new_cgroup_implementation
+    incompatible_validate_top_level_header_inclusions incremental_dexing
+    instrument_test_targets interface_shared_objects
+    internal_spawn_scheduler ios_memleaks java_deps java_header_compilation
+    keep_going keep_state_after_build legacy_important_outputs
+    legacy_whole_archive materialize_param_files objc_debug_with_
+    objc_enable_binary_stripping objc_generate_linkmap
+    objc_use_dotd_pruning omit_run_args
+    one_version_enforcement_on_java_tests portable_paths preemptible
+    print_relative_test_log_paths process_headers_in_dependencies
+    progress_in_terminal_title proto_profile quiet
+    record_full_profiler_data redirect_local_instrumentation_output_writes
+    remote_accept_cached remote_cache_async remote_cache_compression
+    remote_local_fallback remote_upload_local_results
+    remote_verify_downloads repository_disable_download
+    reuse_sandbox_directories run run_in_cwd run_validations
+    runs_per_test_detects_flakes sandbox_debug
+    sandbox_default_allow_network sandbox_enable_loopback_device
+    sandbox_explicit_pseudoterminal sandbox_fake_hostname
+    sandbox_fake_username save_temps share_native_deps
+    show_loading_progress show_progress show_timestamps
+    shutdown_on_low_sys_mem skip_incompatible_explicit_targets slim_profile
+    stamp strict_filesets strict_system_includes subcommands system_rc
+    test_keep_going test_runner_fail_fast test_verbose_timeout_warnings
+    track_incremental_state trim_test_configuration unlimit_coredumps
+    use_ijars use_platforms_in_apple_crosstool_transition
+    use_target_platform_for_tests verbose_failures verbose_test_summary
+    verbose_visibility_errors watchfs windows_enable_symlinks
+    worker_multiplex worker_quit_after_build worker_sandboxing
+    worker_verbose workspace_rc write_command_log
+    zip_undeclared_test_outputs
+)
+
+# Bazel short-flag abbreviations that take a value, in their bare `-x` form
+# (e.g. `-c opt` → `--compilation_mode=opt`, `-j 8` → `--jobs=8`). Like their
+# long counterparts these consume the following argv element. `-x=value`
+# carries its value in one token already and needs no entry here.
+BAZEL_SHORT_VALUE_FLAGS=(
+    -c -j
+)
+
+# Bazel boolean short-flag abbreviations (`-k` keep_going, `-s` subcommands,
+# `-t` cache_test_results). These wrap as a single token, never consuming the
+# next arg.
+BAZEL_SHORT_BOOL_FLAGS=(
+    -k -s -t
+)
+
+# Lookup tables for the membership checks below. We use space-padded strings
+# rather than associative arrays so the wrapper runs on the bash 3.2 that
+# macOS still ships at /bin/bash. The check is O(n) but n is small and bash's
+# `case` pattern match is fast enough that it doesn't show up in any profile.
+#
+# Membership test: `case " $TABLE " in *" $needle "*) hit ;; esac`
+BAZEL_VALUE_FLAGS_STR=" ${BAZEL_VALUE_FLAGS[*]} "
+BAZEL_BOOL_FLAGS_STR=" ${BAZEL_BOOL_FLAGS[*]} "
+BAZEL_SHORT_VALUE_FLAGS_STR=" ${BAZEL_SHORT_VALUE_FLAGS[*]} "
+BAZEL_SHORT_BOOL_FLAGS_STR=" ${BAZEL_SHORT_BOOL_FLAGS[*]} "
+ASPECT_VERBS_WITH_BAZEL_FLAGS_STR=" ${ASPECT_VERBS_WITH_BAZEL_FLAGS[*]} "
+BAZEL_VERBS_STR=" ${BAZEL_VERBS[*]} "
+
+# --- Helpers --------------------------------------------------------------
+
+# Print a grey trace line on stderr showing what the wrapper is about to exec.
+#
+# Usage: trace_exec <category> <argv...>
+#
+# <category> is "aspect" when routing to aspect (the interesting case — the
+# wrapper rewrote something) or "bazel" when forwarding straight to bazel
+# (uninteresting; would be visually noisy on `bazel info`, `bazel query`,
+# etc.). The trace prints by default for the "aspect" category and is
+# suppressed for "bazel" unless ASPECT_WRAPPER_TRACE=1 forces it on.
+#
+# Suppressed entirely when stderr is not a TTY (so $(...) capture and CI
+# logs stay clean), unless ASPECT_WRAPPER_TRACE=1. Always suppressed when
+# ASPECT_WRAPPER_QUIET is set.
+trace_exec() {
+    local category="$1"; shift
+    [[ -n "${ASPECT_WRAPPER_QUIET:-}" ]] && return 0
+    local force="${ASPECT_WRAPPER_TRACE:-}"
+    # Pure bazel forwarding: silent unless explicitly forced.
+    if [[ "$category" == "bazel" && -z "$force" ]]; then
+        return 0
+    fi
+    # Aspect routing: silent under non-TTY stderr unless forced.
+    if [[ -z "$force" && ! -t 2 ]]; then
+        return 0
+    fi
+    local grey="" reset=""
+    if [[ -t 2 || -n "$force" ]]; then
+        grey=$'\033[38;5;244m'
+        reset=$'\033[0m'
+    fi
+    # Quote each arg if it contains anything outside the shell-safe character
+    # set, so the trace line could be copy-pasted back into a terminal.
+    local quoted=""
+    local a stripped
+    for a in "$@"; do
+        # Remove every safe character; whatever remains is "needs quoting".
+        stripped="${a//[A-Za-z0-9._\/=:@,+-]/}"
+        if [[ -z "$a" || -n "$stripped" ]]; then
+            # shellcheck disable=SC2001
+            quoted+=" '$(echo "$a" | sed "s/'/'\\\\''/g")'"
+        else
+            quoted+=" $a"
+        fi
+    done
+    printf '%s[tools/bazel]%s%s\n' "$grey" "$quoted" "$reset" >&2
+}
+
+# Locate the real bazel binary. Bazelisk sets BAZEL_REAL when it execs this
+# wrapper; a direct or aspect-child invocation has no BAZEL_REAL. So prefer
+# BAZEL_REAL, else scan PATH for the next `bazel` that isn't this wrapper.
+resolve_bazel_real() {
+    if [[ -n "${BAZEL_REAL:-}" && -x "$BAZEL_REAL" ]]; then
+        echo "$BAZEL_REAL"
+        return
+    fi
+    local self
+    self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+    local candidate
+    while IFS= read -r candidate; do
+        if [[ "$(cd "$(dirname "$candidate")" && pwd)/$(basename "$candidate")" != "$self" ]]; then
+            echo "$candidate"
+            return
+        fi
+    done < <(type -aP bazel 2>/dev/null || true)
+    echo "ERROR: tools/bazel: cannot find a real bazel binary on PATH (and BAZEL_REAL is unset)" >&2
+    exit 127
+}
+
+contains() {
+    local needle="$1"
+    shift
+    local item
+    for item in "$@"; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+# True when the `aspect` CLI is on PATH. Routing to aspect only matters when
+# it's actually installed; see aspect_missing_hint.
+aspect_on_path() {
+    command -v aspect >/dev/null 2>&1
+}
+
+# Explain that the given command needs the (missing) `aspect` CLI and print
+# install instructions. Leads with *why* so the message isn't a mystery: the
+# presence of this wrapper means `bazel <verb>` is wired to run through aspect.
+#
+# Usage: aspect_missing_hint <verb> [fallback_note]
+aspect_missing_hint() {
+    local verb="$1" fallback_note="${2:-}"
+    cat >&2 <<EOF
+[tools/bazel] \`bazel ${verb}\` runs through the Aspect CLI (\`aspect\`), which is not on your PATH.
+
+  Install it with:
+
+    curl -fsSL https://install.aspect.build | bash
+
+  or see https://docs.aspect.build/cli/install
+EOF
+    [[ -n "$fallback_note" ]] && echo "  $fallback_note" >&2
+    return 0
+}
+
+# Walk a flag list and classify each token into the OUT array. Bazel-native
+# flags (recognized by name in the embedded BAZEL_*_FLAGS lists) are wrapped
+# with WRAPPER_PREFIX (--bazel-flag= or --bazel-startup-flag=); everything
+# else — aspect's own flags, and anything we don't recognize — passes through
+# to aspect unchanged.
+#
+# Usage:  classify_flags <wrapper_prefix> <out_array_name> <args...>
+#
+# Writes the rewritten tokens to the global array named by <out_array_name>
+# (the caller declares it; we append via `eval` because bash 3.2 has no
+# nameref support — see https://wiki.bash-hackers.org/scripting/bashchanges).
+#
+# Behavior per token:
+#   --                                → stop classifying; remainder passes through
+#   non-flag (target, etc.)           → pass through
+#   --name=value / -x=value where name
+#     is a known bazel flag           → push "<prefix><token>"
+#   --name / -x where name is a known
+#     bazel value-taking flag         → consume next token N, push
+#                                       "<prefix>--name=N" (or "<prefix>-x=N")
+#   --name / -x where name is a known
+#     bazel boolean flag (incl. no-)  → push "<prefix><token>"
+#   anything else (aspect/unknown)    → pass through unchanged
+#
+# Append one element to the array named by $1. Bash 3.2 has no namerefs, so
+# the append goes through `eval`; this helper keeps that idiom in one place.
+array_push() {
+    eval "$1+=(\"\$2\")"
+}
+
+classify_flags() {
+    local prefix="$1"
+    local out_name="$2"
+    shift 2
+    local tokens=("$@")
+    local n=${#tokens[@]}
+    local i=0 passthrough=0
+    local t body bare neg
+    while [[ $i -lt $n ]]; do
+        t="${tokens[$i]}"
+        i=$((i + 1))
+
+        # Passthrough mode (after `--`) and non-flags emit verbatim.
+        if [[ $passthrough -eq 1 || "$t" != -* ]]; then
+            array_push "$out_name" "$t"; continue
+        fi
+        if [[ "$t" == "--" ]]; then
+            passthrough=1
+            array_push "$out_name" "$t"; continue
+        fi
+
+        # `bare` is the flag name without leading dashes or =value (keeping the
+        # short `-x` form so short flags match separately). `neg` is the bare
+        # name with a `no` boolean-negation prefix stripped, so `--nokeep_going`
+        # matches the boolean `keep_going`. No bazel flag name starts with `no`,
+        # so stripping never produces a false match.
+        body="${t#--}"
+        bare="${body%%=*}"
+        neg="${bare#no}"
+
+        # Space-form value flag (long or short): consume the next token and glue
+        # with `=` (`--config ci` → `--config=ci`, `-c opt` → `-c=opt`). The
+        # `=value` form already carries its value and falls through to the wrap.
+        if [[ "$body" != *=* && $i -lt $n ]]; then
+            case "$BAZEL_VALUE_FLAGS_STR" in *" $bare "*)
+                array_push "$out_name" "${prefix}--${bare}=${tokens[$i]}"; i=$((i + 1)); continue ;;
+            esac
+            case "$BAZEL_SHORT_VALUE_FLAGS_STR" in *" $bare "*)
+                array_push "$out_name" "${prefix}${bare}=${tokens[$i]}"; i=$((i + 1)); continue ;;
+            esac
+        fi
+
+        # Any other recognized bazel flag — value flag in `=value` form (or with
+        # no value left to consume), boolean (or its `no` negation), or short
+        # flag — wraps as a single token.
+        case "$BAZEL_VALUE_FLAGS_STR$BAZEL_SHORT_VALUE_FLAGS_STR$BAZEL_SHORT_BOOL_FLAGS_STR" in *" $bare "*)
+            array_push "$out_name" "${prefix}${t}"; continue ;;
+        esac
+        case "$BAZEL_BOOL_FLAGS_STR" in *" $bare "* | *" $neg "*)
+            array_push "$out_name" "${prefix}${t}"; continue ;;
+        esac
+
+        # Unrecognized flag: pass through to aspect unchanged.
+        array_push "$out_name" "$t"
+    done
+}
+
+# --- Dispatch -------------------------------------------------------------
+
+BAZEL_REAL_BIN="$(resolve_bazel_real)"
+
+# Skip mode: forward everything straight to vanilla bazel, untouched — no verb
+# parsing, no list checks, no flag rewriting. A total escape hatch for
+# developers who want a 1:1 bazel experience locally; reach for `aspect <verb>`
+# directly when you want the wrapped behavior.
+if [[ -n "${ASPECT_WRAPPER_SKIP:-}" ]]; then
+    trace_exec bazel "$BAZEL_REAL_BIN" "$@"
+    exec "$BAZEL_REAL_BIN" "$@"
+fi
+
+# Verb-disambiguation set: "is this bare token the verb, or the value of a
+# preceding space-separated flag?" Derived from the config lists — bazel
+# verbs plus the aspect verbs we route with rewriting. Best-effort: custom
+# aspect verbs (arbitrary .axl task names) won't appear here, but they don't
+# need to — the fallback below treats any bare token NOT preceded by a
+# value-taking flag as the verb, which covers `bazel mytask …`. The set only
+# breaks the ambiguous `bazel --some_value_flag mytask` case in mytask's
+# favor; without it that custom verb would be mistaken for the flag's value.
+KNOWN_VERBS_STR="${BAZEL_VERBS_STR}${ASPECT_VERBS_WITH_BAZEL_FLAGS_STR}"
+
+# Pre-verb walk. Anything flag-shaped is collected. Bare tokens (no leading
+# `-`) are either the verb or the value of a preceding space-separated flag;
+# we disambiguate by checking KNOWN_VERBS_STR. `--` before any verb is
+# treated as "no verb" — forward the whole thing to bazel verbatim.
+pre_verb=()
+verb=""
+verb_idx=-1
+args=("$@")
+n_args=${#args[@]}
+prev_was_value_taking=0
+i=0
+while [[ $i -lt $n_args ]]; do
+    arg="${args[$i]}"
+    if [[ "$arg" == "--" ]]; then
+        break
+    fi
+    if [[ "$arg" == -* ]]; then
+        pre_verb+=("$arg")
+        # Could this flag consume the next bare token as its value? Only
+        # space-form bazel value flags (long or short) do.
+        body="${arg#--}"
+        name="${body%%=*}"
+        if [[ "$body" == *=* ]]; then
+            prev_was_value_taking=0
+        else
+            case "$BAZEL_VALUE_FLAGS_STR$BAZEL_SHORT_VALUE_FLAGS_STR" in
+                *" $name "*) prev_was_value_taking=1 ;;
+                *) prev_was_value_taking=0 ;;
+            esac
+        fi
+        i=$((i + 1))
+        continue
+    fi
+    # Bare token. If it's a known verb, OR if the previous arg wasn't a
+    # value-taker, treat it as the verb. Otherwise consume it as the
+    # previous flag's value and keep walking.
+    is_known_verb=0
+    case "$KNOWN_VERBS_STR" in
+        *" $arg "*) is_known_verb=1 ;;
+    esac
+    if [[ $is_known_verb -eq 1 || $prev_was_value_taking -eq 0 ]]; then
+        verb="$arg"
+        verb_idx=$i
+        break
+    fi
+    pre_verb+=("$arg")
+    prev_was_value_taking=0
+    i=$((i + 1))
+done
+
+# No verb: forward verbatim to bazel.
+if [[ -z "$verb" ]]; then
+    trace_exec bazel "$BAZEL_REAL_BIN" "$@"
+    exec "$BAZEL_REAL_BIN" "$@"
+fi
+
+# Verb routed to aspect WITH bazel-flag rewriting (the verbs aspect wraps plus
+# the aspect verbs that drive bazel — see ASPECT_VERBS_WITH_BAZEL_FLAGS).
+# Pre-verb bazel flags become --bazel-startup-flag=; post-verb bazel flags
+# become --bazel-flag=.
+if contains "$verb" "${ASPECT_VERBS_WITH_BAZEL_FLAGS[@]}"; then
+    # No aspect on PATH: nudge toward installing it. If the verb is also a real
+    # bazel command (build/test/run/coverage) fall back to vanilla bazel so the
+    # command still runs; otherwise (lint/format/…) bazel can't run it, so stop.
+    if ! aspect_on_path; then
+        if contains "$verb" "${BAZEL_VERBS[@]}"; then
+            aspect_missing_hint "$verb" "Running it through vanilla bazel for now."
+            trace_exec bazel "$BAZEL_REAL_BIN" "$@"
+            exec "$BAZEL_REAL_BIN" "$@"
+        fi
+        aspect_missing_hint "$verb"
+        exit 127
+    fi
+    pre_for_aspect=()
+    if [[ ${#pre_verb[@]} -gt 0 ]]; then
+        classify_flags "--bazel-startup-flag=" pre_for_aspect "${pre_verb[@]}"
+    fi
+    post=("${@:$((verb_idx + 2))}")
+    post_rewritten=()
+    if [[ ${#post[@]} -gt 0 ]]; then
+        classify_flags "--bazel-flag=" post_rewritten "${post[@]}"
+    fi
+    # Aspect accepts --bazel-startup-flag as a POST-verb flag. Move pre-verb
+    # startup-flag forwards into the post-verb position; aspect global flags
+    # (--task-key, --timing, …) stay in front of the verb.
+    #
+    # The `${arr[@]+"${arr[@]}"}` form expands to nothing when the array is
+    # empty without tripping `set -u` on the bash 3.2 that macOS ships.
+    pre_globals=()
+    pre_bazel_starts=()
+    for arg in ${pre_for_aspect[@]+"${pre_for_aspect[@]}"}; do
+        if [[ "$arg" == --bazel-startup-flag=* ]]; then
+            pre_bazel_starts+=("$arg")
+        else
+            pre_globals+=("$arg")
+        fi
+    done
+    export BAZEL_REAL="$BAZEL_REAL_BIN"
+    set -- ${pre_globals[@]+"${pre_globals[@]}"} "$verb" \
+        ${pre_bazel_starts[@]+"${pre_bazel_starts[@]}"} \
+        ${post_rewritten[@]+"${post_rewritten[@]}"}
+    trace_exec aspect aspect "$@"
+    exec aspect "$@"
+fi
+
+# Other bazel verb (query, info, clean, mod, …): vanilla bazel, untouched.
+if contains "$verb" "${BAZEL_VERBS[@]}"; then
+    trace_exec bazel "$BAZEL_REAL_BIN" "$@"
+    exec "$BAZEL_REAL_BIN" "$@"
+fi
+
+# Unknown verb: a custom aspect task (.axl) with an arbitrary name. Route to
+# aspect and forward args verbatim — we don't rewrite bazel flags because the
+# task may define its own flags, and it isn't in ASPECT_VERBS_WITH_BAZEL_FLAGS.
+# Bazel has no such command, so if aspect is missing there's no fallback.
+if ! aspect_on_path; then
+    aspect_missing_hint "$verb"
+    exit 127
+fi
+export BAZEL_REAL="$BAZEL_REAL_BIN"
+trace_exec aspect aspect "$@"
+exec aspect "$@"

--- a/tools/bazel-test.sh
+++ b/tools/bazel-test.sh
@@ -1,0 +1,904 @@
+#!/usr/bin/env bash
+#
+# Tests for tools/bazel. Stubs both aspect and bazel so we can assert exactly
+# what the wrapper exec's. Each stub prints its argv (one arg per line) plus
+# the resolved BAZEL_REAL, which the test then compares against expected.
+#
+# Run: ./tools/bazel-test.sh
+# Run under macOS's bash 3.2 (the wrapper's compatibility floor):
+#   WRAPPER_BASH=/bin/bash ./tools/bazel-test.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$HERE/bazel"
+
+# Build a stub directory containing fake `aspect` and `bazel` binaries.
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+cat > "$STUB_DIR/aspect" <<'EOF'
+#!/usr/bin/env bash
+echo "INVOKED:aspect"
+for a in "$@"; do printf 'ARG:%s\n' "$a"; done
+EOF
+cat > "$STUB_DIR/bazel" <<'EOF'
+#!/usr/bin/env bash
+echo "INVOKED:bazel"
+for a in "$@"; do printf 'ARG:%s\n' "$a"; done
+EOF
+chmod +x "$STUB_DIR/aspect" "$STUB_DIR/bazel"
+
+export BAZEL_REAL="$STUB_DIR/bazel"
+export PATH="$STUB_DIR:$PATH"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+check() {
+    local name="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS  $name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL  $name"
+        echo "  expected:"
+        echo "$expected" | sed 's/^/    /'
+        echo "  actual:"
+        echo "$actual" | sed 's/^/    /'
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES+=("$name")
+    fi
+}
+
+# How to invoke the wrapper. Set WRAPPER_BASH to a specific bash (e.g.
+# /bin/bash, the bash 3.2 macOS ships) to drive the wrapper under that
+# interpreter rather than its own `#!/usr/bin/env bash` shebang — catches
+# 3.2-only regressions like empty-array expansion under `set -u`. Used as an
+# array so it expands to either `<wrapper>` or `<bash> <wrapper>`.
+if [[ -n "${WRAPPER_BASH:-}" ]]; then
+    WRAPPER_CMD=("$WRAPPER_BASH" "$WRAPPER")
+else
+    WRAPPER_CMD=("$WRAPPER")
+fi
+run() {
+    "${WRAPPER_CMD[@]}" "$@" 2>&1
+}
+
+# A PATH dir holding only `bazel` (no `aspect`), to exercise the
+# aspect-not-installed branches. BAZEL_REAL still points at the stub bazel, so
+# resolve_bazel_real succeeds without PATH lookup.
+NO_ASPECT_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR" "$NO_ASPECT_DIR"' EXIT
+cp "$STUB_DIR/bazel" "$NO_ASPECT_DIR/bazel"
+
+# Run the wrapper with `aspect` absent from PATH.
+run_no_aspect() {
+    PATH="$NO_ASPECT_DIR:/usr/bin:/bin" "${WRAPPER_CMD[@]}" "$@" 2>&1
+}
+
+# =====================================================================
+# Section 1: Pure dispatch — verb routing without any flag complexity
+# =====================================================================
+
+check "dispatch: aspect verb 'lint' → aspect" \
+"INVOKED:aspect
+ARG:lint" \
+"$(run lint)"
+
+check "dispatch: aspect verb 'format' with target → aspect" \
+"INVOKED:aspect
+ARG:format
+ARG://some:target" \
+"$(run format //some:target)"
+
+check "dispatch: aspect verb 'delivery' with multi-target → aspect" \
+"INVOKED:aspect
+ARG:delivery
+ARG://a:b
+ARG://c:d" \
+"$(run delivery //a:b //c:d)"
+
+check "dispatch: aspect verb 'configure' → aspect" \
+"INVOKED:aspect
+ARG:configure" \
+"$(run configure)"
+
+check "dispatch: aspect verb 'buildifier' → aspect" \
+"INVOKED:aspect
+ARG:buildifier" \
+"$(run buildifier)"
+
+check "dispatch: bazel verb 'query' stays on bazel" \
+"INVOKED:bazel
+ARG:query
+ARG:deps(//foo)" \
+"$(run query 'deps(//foo)')"
+
+check "dispatch: bazel verb 'cquery' stays on bazel" \
+"INVOKED:bazel
+ARG:cquery
+ARG://..." \
+"$(run cquery //...)"
+
+check "dispatch: bazel verb 'info' stays on bazel" \
+"INVOKED:bazel
+ARG:info
+ARG:workspace" \
+"$(run info workspace)"
+
+check "dispatch: bazel verb 'clean' stays on bazel" \
+"INVOKED:bazel
+ARG:clean
+ARG:--expunge" \
+"$(run clean --expunge)"
+
+check "dispatch: bazel verb 'mod' stays on bazel" \
+"INVOKED:bazel
+ARG:mod
+ARG:graph" \
+"$(run mod graph)"
+
+check "dispatch: no verb at all → bazel" \
+"INVOKED:bazel
+ARG:--version" \
+"$(run --version)"
+
+check "dispatch: bare invocation → bazel" \
+"INVOKED:bazel" \
+"$(run)"
+
+# =====================================================================
+# Section 2: Common verb — bare cases
+# =====================================================================
+
+check "common: build alone → aspect build" \
+"INVOKED:aspect
+ARG:build" \
+"$(run build)"
+
+check "common: build with target → aspect build" \
+"INVOKED:aspect
+ARG:build
+ARG://..." \
+"$(run build //...)"
+
+check "common: test with target → aspect test" \
+"INVOKED:aspect
+ARG:test
+ARG://..." \
+"$(run test //...)"
+
+check "common: run with target → aspect run" \
+"INVOKED:aspect
+ARG:run
+ARG://foo:bin" \
+"$(run run //foo:bin)"
+
+# =====================================================================
+# Section 3: Post-verb flag rewriting — bazel flags
+# =====================================================================
+
+check "post-verb bazel: boolean wrapped (--keep_going)" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--keep_going
+ARG://..." \
+"$(run build --keep_going //...)"
+
+check "post-verb bazel: boolean negation wrapped (--nobuild)" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--nobuild
+ARG://..." \
+"$(run build --nobuild //...)"
+
+check "post-verb bazel: =value form wrapped (--config=ci)" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--config=ci
+ARG://..." \
+"$(run build --config=ci //...)"
+
+check "post-verb bazel: space-value form glued (--config ci)" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--config=ci
+ARG://..." \
+"$(run build --config ci //...)"
+
+check "post-verb bazel: repeated --config space-value" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--config=ci
+ARG:--bazel-flag=--config=remote
+ARG://..." \
+"$(run build --config ci --config remote //...)"
+
+check "post-verb bazel: --jobs with space-value (number)" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--jobs=4
+ARG://..." \
+"$(run build --jobs 4 //...)"
+
+check "post-verb bazel: --jobs with =value" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--jobs=8
+ARG://..." \
+"$(run build --jobs=8 //...)"
+
+check "post-verb bazel: --remote_executor with value containing colons" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--remote_executor=grpc://exec.example.com:443
+ARG://..." \
+"$(run build --remote_executor grpc://exec.example.com:443 //...)"
+
+check "post-verb bazel: --define KEY=VAL" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--define=foo=bar
+ARG://..." \
+"$(run build --define foo=bar //...)"
+
+check "post-verb bazel: --action_env with space-value" \
+"INVOKED:aspect
+ARG:test
+ARG:--bazel-flag=--action_env=HOME=/tmp
+ARG://..." \
+"$(run test --action_env HOME=/tmp //...)"
+
+check "post-verb bazel: --test_arg with =value containing flag-shaped value" \
+"INVOKED:aspect
+ARG:test
+ARG:--bazel-flag=--test_arg=--verbose
+ARG://..." \
+"$(run test --test_arg=--verbose //...)"
+
+check "post-verb bazel: --test_output with space-value" \
+"INVOKED:aspect
+ARG:test
+ARG:--bazel-flag=--test_output=errors
+ARG://..." \
+"$(run test --test_output errors //...)"
+
+check "post-verb bazel: --test_filter with regex value" \
+"INVOKED:aspect
+ARG:test
+ARG:--bazel-flag=--test_filter=^Foo.*Bar$
+ARG://..." \
+"$(run test --test_filter '^Foo.*Bar$' //...)"
+
+check "post-verb bazel: --copt with space-value" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--copt=-O2
+ARG://..." \
+"$(run build --copt -O2 //...)"
+
+check "post-verb bazel: trailing value-taking flag with no value" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--config" \
+"$(run build --config)"
+
+check "post-verb: unknown flag (typo / unlisted) passes through to aspect" \
+"INVOKED:aspect
+ARG:build
+ARG:--keep_goinggg
+ARG://..." \
+"$(run build --keep_goinggg //...)"
+
+# =====================================================================
+# Section 4: Post-verb flag passthrough — aspect flags
+# =====================================================================
+
+check "post-verb aspect: kebab-case --task-key=val passthrough" \
+"INVOKED:aspect
+ARG:build
+ARG:--task-key=mybuild
+ARG://..." \
+"$(run build --task-key=mybuild //...)"
+
+check "post-verb aspect: kebab-case --task-key val (space form) passthrough" \
+"INVOKED:aspect
+ARG:build
+ARG:--task-key
+ARG:mybuild
+ARG://..." \
+"$(run build --task-key mybuild //...)"
+
+check "post-verb aspect: colon-namespaced --artifact-upload:enabled=false" \
+"INVOKED:aspect
+ARG:build
+ARG:--artifact-upload:enabled=false
+ARG://..." \
+"$(run build --artifact-upload:enabled=false //...)"
+
+check "post-verb aspect: colon-namespaced --github-status-checks:mode=always" \
+"INVOKED:aspect
+ARG:build
+ARG:--github-status-checks:mode=always
+ARG://..." \
+"$(run build --github-status-checks:mode=always //...)"
+
+check "post-verb aspect: --timing=summary" \
+"INVOKED:aspect
+ARG:build
+ARG:--timing=summary
+ARG://..." \
+"$(run build --timing=summary //...)"
+
+check "post-verb aspect: --bazel-flag=--foo passthrough (already wrapped)" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--foo
+ARG://..." \
+"$(run build --bazel-flag=--foo //...)"
+
+check "post-verb aspect: --cancel boolean passthrough" \
+"INVOKED:aspect
+ARG:build
+ARG:--cancel
+ARG://..." \
+"$(run build --cancel //...)"
+
+check "post-verb aspect: --coverage (test-only) passthrough" \
+"INVOKED:aspect
+ARG:test
+ARG:--coverage
+ARG://..." \
+"$(run test --coverage //...)"
+
+# =====================================================================
+# Section 5: Mixed aspect + bazel flags
+# =====================================================================
+
+check "mixed: aspect kebab + bazel boolean + bazel =value" \
+"INVOKED:aspect
+ARG:build
+ARG:--task-key=mybuild
+ARG:--bazel-flag=--keep_going
+ARG:--bazel-flag=--config=ci
+ARG://..." \
+"$(run build --task-key=mybuild --keep_going --config=ci //...)"
+
+check "mixed: bazel space-value sandwiched between aspect flags" \
+"INVOKED:aspect
+ARG:build
+ARG:--task-key=mybuild
+ARG:--bazel-flag=--config=ci
+ARG:--timing=summary
+ARG://..." \
+"$(run build --task-key=mybuild --config ci --timing=summary //...)"
+
+check "mixed: many flags in random order" \
+"INVOKED:aspect
+ARG:test
+ARG:--bazel-flag=--keep_going
+ARG:--task-key=t1
+ARG:--bazel-flag=--config=ci
+ARG:--coverage
+ARG:--bazel-flag=--test_output=errors
+ARG://..." \
+"$(run test --keep_going --task-key=t1 --config ci --coverage --test_output errors //...)"
+
+# =====================================================================
+# Section 6: Pre-verb (startup) flag handling
+# =====================================================================
+
+check "pre-verb: bazel startup flag → --bazel-startup-flag= (after verb)" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-startup-flag=--output_base=/tmp/foo
+ARG://..." \
+"$(run --output_base=/tmp/foo build //...)"
+
+check "pre-verb: bazel startup flag space-value → glued and wrapped" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-startup-flag=--output_base=/tmp/foo
+ARG://..." \
+"$(run --output_base /tmp/foo build //...)"
+
+check "pre-verb: aspect global flag (--task-key) before verb → pre-verb aspect" \
+"INVOKED:aspect
+ARG:--task-key=t1
+ARG:build
+ARG://..." \
+"$(run --task-key=t1 build //...)"
+
+check "pre-verb: aspect global flag space-form (--task-key t1)" \
+"INVOKED:aspect
+ARG:--task-key
+ARG:t1
+ARG:build
+ARG://..." \
+"$(run --task-key t1 build //...)"
+
+check "pre-verb: mixed aspect global + bazel startup" \
+"INVOKED:aspect
+ARG:--task-key=t1
+ARG:build
+ARG:--bazel-startup-flag=--output_base=/tmp/x
+ARG://..." \
+"$(run --task-key=t1 --output_base=/tmp/x build //...)"
+
+check "pre-verb: aspect global + bazel startup → bazel startup goes after verb" \
+"INVOKED:aspect
+ARG:--task-key=t1
+ARG:build
+ARG:--bazel-startup-flag=--output_base=/tmp/x
+ARG:--bazel-flag=--keep_going
+ARG://..." \
+"$(run --task-key=t1 --output_base=/tmp/x build --keep_going //...)"
+
+check "pre-verb: aspect verb (lint) with pre-verb aspect global" \
+"INVOKED:aspect
+ARG:--task-key=t1
+ARG:lint" \
+"$(run --task-key=t1 lint)"
+
+check "pre-verb: aspect verb (lint) with pre-verb bazel startup → moved post-verb" \
+"INVOKED:aspect
+ARG:lint
+ARG:--bazel-startup-flag=--output_base=/tmp/x" \
+"$(run --output_base=/tmp/x lint)"
+
+# =====================================================================
+# Section 7: Edge cases — `--`, positionals, hyphen-led targets
+# =====================================================================
+
+check "edge: -- ends flag parsing, positionals untouched" \
+"INVOKED:aspect
+ARG:build
+ARG:--
+ARG://...
+ARG:-//experimental/..." \
+"$(run build -- //... -//experimental/...)"
+
+check "edge: -- with bazel flag before, both after" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--keep_going
+ARG:--
+ARG://...
+ARG:-//experimental/..." \
+"$(run build --keep_going -- //... -//experimental/...)"
+
+check "edge: -- with run args (aspect flags after -- still pass through verbatim)" \
+"INVOKED:aspect
+ARG:run
+ARG://foo:bin
+ARG:--
+ARG:--task-key
+ARG:value
+ARG:--keep_going" \
+"$(run run //foo:bin -- --task-key value --keep_going)"
+
+check "edge: target before any flag" \
+"INVOKED:aspect
+ARG:build
+ARG://...
+ARG:--bazel-flag=--keep_going" \
+"$(run build //... --keep_going)"
+
+check "edge: flag with empty value (--config=)" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--config=
+ARG://..." \
+"$(run build --config= //...)"
+
+check "edge: flag with value containing spaces" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--workspace_status_command=/path/to/cmd arg1
+ARG://..." \
+"$(run build --workspace_status_command '/path/to/cmd arg1' //...)"
+
+check "edge: target with embedded equals sign in label is positional, not flag" \
+"INVOKED:aspect
+ARG:build
+ARG://foo:bar=baz" \
+"$(run build //foo:bar=baz)"
+
+# =====================================================================
+# Section 8: BAZEL_REAL plumbing
+# =====================================================================
+
+# Swap in a stub that also reports BAZEL_REAL so we can assert it.
+cat > "$STUB_DIR/aspect" <<'EOF'
+#!/usr/bin/env bash
+echo "INVOKED:aspect"
+echo "BAZEL_REAL=${BAZEL_REAL:-<unset>}"
+for a in "$@"; do printf 'ARG:%s\n' "$a"; done
+EOF
+
+check "env: BAZEL_REAL forwarded to aspect (aspect verb)" \
+"INVOKED:aspect
+BAZEL_REAL=$STUB_DIR/bazel
+ARG:lint" \
+"$(run lint)"
+
+check "env: BAZEL_REAL forwarded to aspect (common verb)" \
+"INVOKED:aspect
+BAZEL_REAL=$STUB_DIR/bazel
+ARG:build
+ARG://..." \
+"$(run build //...)"
+
+# Anti-inception layer 1: when BAZEL_REAL is UNSET (real bazel execs the
+# wrapper without it), the wrapper resolves bazel via PATH and re-exports it to
+# aspect, so aspect's child bazel uses the real binary instead of re-entering
+# the wrapper. Assert aspect receives a concrete BAZEL_REAL (the stub on PATH),
+# not <unset>.
+check "env: BAZEL_REAL resolved from PATH and forwarded when unset" \
+"INVOKED:aspect
+BAZEL_REAL=$STUB_DIR/bazel
+ARG:build
+ARG://..." \
+"$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" build //... 2>&1)"
+
+# Restore the plain stub so subsequent assertions stay clean.
+cat > "$STUB_DIR/aspect" <<'EOF'
+#!/usr/bin/env bash
+echo "INVOKED:aspect"
+for a in "$@"; do printf 'ARG:%s\n' "$a"; done
+EOF
+
+# =====================================================================
+# Section 9: Trace output (ASPECT_WRAPPER_TRACE / ASPECT_WRAPPER_QUIET)
+# =====================================================================
+
+# Under `$()` capture, stderr-is-not-a-TTY, so trace must be silent by
+# default. Earlier sections already implicitly assert this — if trace
+# bled through, every "$(run ...)" assertion would fail. Just sanity-check.
+check "trace: silent under non-TTY by default (aspect path)" \
+"INVOKED:aspect
+ARG:lint" \
+"$(run lint 2>&1)"
+
+check "trace: silent under non-TTY by default (bazel path)" \
+"INVOKED:bazel
+ARG:query
+ARG:deps(//foo)" \
+"$(run query 'deps(//foo)' 2>&1)"
+
+# Force trace on. Expect the [tools/bazel] line on stderr, then aspect's
+# normal output. Strip ANSI escape sequences so the assertion isn't tied
+# to the exact escape encoding.
+strip_ansi() { sed $'s/\033\\[[0-9;]*m//g'; }
+
+actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" lint 2>&1 | strip_ansi)"
+check "trace: ASPECT_WRAPPER_TRACE=1 prints '[tools/bazel] ...' for aspect route" \
+"[tools/bazel] aspect lint
+INVOKED:aspect
+ARG:lint" \
+"$actual"
+
+actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1 | strip_ansi)"
+check "trace: shows rewritten flags" \
+"[tools/bazel] aspect build --bazel-flag=--keep_going --bazel-flag=--config=ci //...
+INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--keep_going
+ARG:--bazel-flag=--config=ci
+ARG://..." \
+"$actual"
+
+actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" query 'deps(//foo)' 2>&1 | strip_ansi)"
+check "trace: ASPECT_WRAPPER_TRACE=1 also shows bazel-only verb forwarding" \
+"[tools/bazel] $STUB_DIR/bazel query 'deps(//foo)'
+INVOKED:bazel
+ARG:query
+ARG:deps(//foo)" \
+"$actual"
+
+actual="$(ASPECT_WRAPPER_QUIET=1 ASPECT_WRAPPER_TRACE=1 "$WRAPPER" lint 2>&1 | strip_ansi)"
+check "trace: ASPECT_WRAPPER_QUIET=1 wins over TRACE=1" \
+"INVOKED:aspect
+ARG:lint" \
+"$actual"
+
+# =====================================================================
+# Section 10: ASPECT_WRAPPER_SKIP — total bypass, everything → vanilla bazel
+# =====================================================================
+
+check "skip: build forwards straight to bazel" \
+"INVOKED:bazel
+ARG:build
+ARG://..." \
+"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build //... 2>&1)"
+
+check "skip: test forwards straight to bazel" \
+"INVOKED:bazel
+ARG:test
+ARG:--keep_going
+ARG://..." \
+"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" test --keep_going //... 2>&1)"
+
+check "skip: run forwards straight to bazel" \
+"INVOKED:bazel
+ARG:run
+ARG://foo:bin
+ARG:--
+ARG:arg1" \
+"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" run //foo:bin -- arg1 2>&1)"
+
+# Skip is a TOTAL bypass: even aspect verbs go straight to vanilla bazel,
+# untouched. (The user reaches for `aspect <verb>` directly when they want
+# the wrapped behavior.)
+check "skip: aspect verb (lint) also forwards straight to bazel" \
+"INVOKED:bazel
+ARG:lint" \
+"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" lint 2>&1)"
+
+check "skip: aspect verb (format) also forwards straight to bazel" \
+"INVOKED:bazel
+ARG:format
+ARG://..." \
+"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" format //... 2>&1)"
+
+# Custom/unknown verb also bypasses (no aspect routing under skip).
+check "skip: custom verb also forwards straight to bazel" \
+"INVOKED:bazel
+ARG:mytask" \
+"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" mytask 2>&1)"
+
+check "skip: query (bazel-only verb) still goes to bazel" \
+"INVOKED:bazel
+ARG:query
+ARG://..." \
+"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" query //... 2>&1)"
+
+# Skip + flag preservation: bazel sees the raw flags, no --bazel-flag= wrapping.
+check "skip: bazel-native flags pass through unwrapped" \
+"INVOKED:bazel
+ARG:build
+ARG:--keep_going
+ARG:--config=ci
+ARG://..." \
+"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1)"
+
+# Skip + TRACE shows the bazel forward.
+actual="$(ASPECT_WRAPPER_SKIP=1 ASPECT_WRAPPER_TRACE=1 "$WRAPPER" build //... 2>&1 | strip_ansi)"
+check "skip: TRACE=1 shows bazel forward under skip mode" \
+"[tools/bazel] $STUB_DIR/bazel build //...
+INVOKED:bazel
+ARG:build
+ARG://..." \
+"$actual"
+
+# Empty string means unset — make sure we treat "" as no skip.
+check "skip: empty string ASPECT_WRAPPER_SKIP='' is treated as unset" \
+"INVOKED:aspect
+ARG:build
+ARG://..." \
+"$(ASPECT_WRAPPER_SKIP="" "$WRAPPER" build //... 2>&1)"
+
+# =====================================================================
+# Section 11: Anti-inception (ASPECT_CLI_RUNNING bypass)
+# =====================================================================
+#
+# Aspect sets ASPECT_CLI_RUNNING=1 on every child bazel it spawns. The
+# wrapper checks for this BEFORE doing any routing and forwards straight
+# to bazel — otherwise aspect → tools/bazel → aspect → tools/bazel → …
+# recurses forever.
+
+check "inception: ASPECT_CLI_RUNNING=1 + build → straight to bazel" \
+"INVOKED:bazel
+ARG:build
+ARG://..." \
+"$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build //... 2>&1)"
+
+check "inception: ASPECT_CLI_RUNNING=1 + bazel-native flags pass through unwrapped" \
+"INVOKED:bazel
+ARG:build
+ARG:--keep_going
+ARG:--config=ci
+ARG://..." \
+"$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1)"
+
+# Even aspect-only verbs forward to bazel under ASPECT_CLI_RUNNING. Aspect
+# would never spawn `bazel lint`, but if it somehow did we still want the
+# bypass to win — aspect MUST NOT recurse into itself.
+check "inception: ASPECT_CLI_RUNNING=1 wins over aspect-only verbs too" \
+"INVOKED:bazel
+ARG:lint" \
+"$(ASPECT_CLI_RUNNING=1 "$WRAPPER" lint 2>&1)"
+
+check "inception: ASPECT_CLI_RUNNING=1 + info → straight to bazel" \
+"INVOKED:bazel
+ARG:info
+ARG:workspace" \
+"$(ASPECT_CLI_RUNNING=1 "$WRAPPER" info workspace 2>&1)"
+
+# Empty string means unset — wrapper must treat it the same as no env var.
+check "inception: empty ASPECT_CLI_RUNNING='' is treated as unset" \
+"INVOKED:aspect
+ARG:build
+ARG://..." \
+"$(ASPECT_CLI_RUNNING="" "$WRAPPER" build //... 2>&1)"
+
+# Bypass should fire BEFORE the trace logic. Even with TRACE=1, the bypass
+# runs and we get straight bazel — no aspect-route trace line.
+actual="$(ASPECT_CLI_RUNNING=1 ASPECT_WRAPPER_TRACE=1 "$WRAPPER" build //... 2>&1 | strip_ansi)"
+# Bypass exec's bazel directly without calling trace_exec, so TRACE has
+# no effect. This is intentional: in the inception case the trace would
+# fire INSIDE aspect's output stream and confuse the user.
+check "inception: bypass runs before trace, even TRACE=1 is silent" \
+"INVOKED:bazel
+ARG:build
+ARG://..." \
+"$actual"
+
+# =====================================================================
+# Section 12: Bazel short-flag abbreviations that take a value (-c, -j)
+# =====================================================================
+
+check "short: -c opt (space) → --bazel-flag=-c=opt, opt not a target" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=-c=opt
+ARG://..." \
+"$(run build -c opt //...)"
+
+check "short: -j 8 (space) → --bazel-flag=-j=8" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=-j=8
+ARG://..." \
+"$(run build -j 8 //...)"
+
+check "short: -c=opt (already glued) → single token, unchanged" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=-c=opt
+ARG://..." \
+"$(run build -c=opt //...)"
+
+check "short: boolean shorts (-k -s) stay single tokens, don't eat next arg" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=-k
+ARG:--bazel-flag=-s
+ARG://..." \
+"$(run build -k -s //...)"
+
+check "short: -c at end of argv (no value) → passes as single token" \
+"INVOKED:aspect
+ARG:build
+ARG://...
+ARG:--bazel-flag=-c" \
+"$(run build //... -c)"
+
+# =====================================================================
+# Section 13: Aspect-verb bazel-flag forwarding (ASPECT_VERBS_WITH_BAZEL_FLAGS)
+# =====================================================================
+
+check "fwd: format --keep_going → aspect format --bazel-flag=--keep_going" \
+"INVOKED:aspect
+ARG:format
+ARG:--bazel-flag=--keep_going" \
+"$(run format --keep_going)"
+
+check "fwd: lint space-value flag rewritten, aspect flag preserved" \
+"INVOKED:aspect
+ARG:lint
+ARG:--github-lint-comments:enabled=true
+ARG:--bazel-flag=--config=ci" \
+"$(run lint --github-lint-comments:enabled=true --config ci)"
+
+# =====================================================================
+# Section 15: Closed-set model — bazel is the known set, rest → aspect
+# =====================================================================
+
+# Unknown verb (custom .axl task): routes to aspect, args verbatim (no
+# bazel-flag rewriting — not in ASPECT_VERBS_WITH_BAZEL_FLAGS).
+check "model: unknown verb (custom task) → aspect, args verbatim" \
+"INVOKED:aspect
+ARG:mytask
+ARG:--keep_going
+ARG://x" \
+"$(run mytask --keep_going //x)"
+
+# Bazel verb that aspect does NOT wrap → vanilla bazel untouched.
+check "model: bazel verb 'coverage' (not wrapped) → vanilla bazel" \
+"INVOKED:bazel
+ARG:coverage
+ARG://..." \
+"$(run coverage //...)"
+
+# Boolean negation (--no<flag>) is recognized as a bazel flag and wrapped.
+check "model: --nokeep_going recognized as bazel boolean → wrapped" \
+"INVOKED:aspect
+ARG:build
+ARG:--bazel-flag=--nokeep_going
+ARG://..." \
+"$(run build --nokeep_going //...)"
+
+# A flag in no bazel list (aspect feature flag) passes through to aspect.
+check "model: aspect feature flag (colon-namespaced) passes through" \
+"INVOKED:aspect
+ARG:build
+ARG:--artifact-upload:enabled=false
+ARG://..." \
+"$(run build --artifact-upload:enabled=false //...)"
+
+# =====================================================================
+# Section 14: PATH fallback when BAZEL_REAL is unset (type -aP, not zsh)
+# =====================================================================
+
+# With BAZEL_REAL unset, resolve_bazel_real must find the stub bazel on PATH
+# (skipping the wrapper itself). Regression test for the old `command -v -a`
+# zsh-ism that exits non-zero under bash and found nothing.
+check "path: BAZEL_REAL unset → finds real bazel on PATH" \
+"INVOKED:bazel
+ARG:version" \
+"$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" version 2>&1)"
+
+check "path: ASPECT_CLI_RUNNING + BAZEL_REAL unset → finds real bazel on PATH" \
+"INVOKED:bazel
+ARG:build
+ARG://..." \
+"$(env -u BAZEL_REAL ASPECT_CLI_RUNNING=1 "${WRAPPER_CMD[@]}" build //... 2>&1)"
+
+# =====================================================================
+# Section 16: aspect not installed — install hint + graceful fallback
+# =====================================================================
+
+# The verb-specific install hint, mirroring aspect_missing_hint in the wrapper.
+hint() {
+    printf '[tools/bazel] `bazel %s` runs through the Aspect CLI (`aspect`), which is not on your PATH.
+
+  Install it with:
+
+    curl -fsSL https://install.aspect.build | bash
+
+  or see https://docs.aspect.build/cli/install' "$1"
+}
+
+# Verb that is BOTH aspect-wrapped and a real bazel command (build): hint with
+# a fallback note, then run the command on vanilla bazel.
+check "no-aspect: build → install hint then falls back to bazel" \
+"$(hint build)
+  Running it through vanilla bazel for now.
+INVOKED:bazel
+ARG:build
+ARG:--keep_going
+ARG://..." \
+"$(run_no_aspect build --keep_going //...)"
+
+# Aspect-only wrapped verb (lint): bazel can't run it, so hint and stop.
+check "no-aspect: lint (aspect-only) → install hint, no bazel fallback" \
+"$(hint lint)" \
+"$(run_no_aspect lint 2>&1)"
+
+# Custom/unknown verb: aspect-only, hint and stop.
+check "no-aspect: custom verb → install hint, no bazel fallback" \
+"$(hint mytask)" \
+"$(run_no_aspect mytask //x 2>&1)"
+
+# Plain bazel verb: never needs aspect, runs vanilla with no hint.
+check "no-aspect: query (bazel verb) → vanilla bazel, no hint" \
+"INVOKED:bazel
+ARG:query
+ARG://..." \
+"$(run_no_aspect query //...)"
+
+# =====================================================================
+# Summary
+# =====================================================================
+
+echo
+echo "$PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed tests:"
+    printf '  %s\n' "${FAILED_NAMES[@]}"
+fi
+[[ $FAIL -eq 0 ]]

--- a/tools/bazel.md
+++ b/tools/bazel.md
@@ -1,0 +1,150 @@
+# `tools/bazel` wrapper — transparent Aspect routing
+
+A drop-in `tools/bazel` shell script that lets developers keep typing `bazel` while still reaching Aspect-specific functionality (`lint`, `format`, `delivery`, …) and Aspect's value-added wrappers around `build` / `test` / `run`.
+
+This is the **source of truth** for customers who want to adopt Aspect CLI features without forcing their teams to learn a new command name. Copy `tools/bazel` from this repo into your own workspace, adjust the verb lists at the top, commit it, and you're done.
+
+## What it does
+
+The `tools/bazel` hook is a [Bazelisk](https://github.com/bazelbuild/bazelisk) feature — the real `bazel` binary does not look for it. When Bazelisk finds `tools/bazel` in your workspace it execs that script instead of the bazel version it resolved, passing the resolved path as `$BAZEL_REAL`. (So this only works if the `bazel` on your `PATH` is Bazelisk — the standard setup.) This wrapper uses that hook to dispatch each command to the right tool:
+
+| You type | What runs |
+| --- | --- |
+| `bazel build //... --keep_going --config=ci` | `aspect build //... --bazel-flag=--keep_going --bazel-flag=--config=ci` |
+| `bazel build -c opt //...` | `aspect build --bazel-flag=-c=opt //...` |
+| `bazel test //... --test_output errors` | `aspect test //... --bazel-flag=--test_output=errors` |
+| `bazel lint --config=ci //src/...` | `aspect lint --bazel-flag=--config=ci //src/...` |
+| `bazel format --keep_going` | `aspect format --bazel-flag=--keep_going` |
+| `bazel delivery --config=release //...` | `aspect delivery --bazel-flag=--config=release //...` |
+| `bazel query 'deps(//foo)'` | `$BAZEL_REAL query 'deps(//foo)'` (vanilla bazel, unchanged) |
+| `bazel info workspace` | `$BAZEL_REAL info workspace` |
+| `bazel my-custom-task //...` | `aspect my-custom-task //...` (unknown verb → aspect verbatim) |
+
+The interesting case is the verbs aspect wraps (`build` / `test` / `run`) and the aspect verbs that drive Bazel internally (`lint`, `format`, `delivery`, …). The wrapper routes those through `aspect` so you pick up its DX improvements (artifact upload, GitHub PR comments, BES streaming, …), but **bazel-native flags keep working** — they're transparently rewritten as `--bazel-flag=<flag>` so aspect forwards them verbatim to Bazel.
+
+## How verb routing works
+
+The wrapper decides where a command goes from two lists at the top of the script:
+
+- `ASPECT_VERBS_WITH_BAZEL_FLAGS` — verbs routed to `aspect` **with** bazel-flag rewriting (default `build buildifier delivery format gazelle lint run test`).
+- `BAZEL_VERBS` — the closed set of Bazel commands. A verb here that's *not* in the list above (`query`, `info`, `clean`, `mod`, `coverage`, …) goes to vanilla bazel.
+
+The rules, in order (`ASPECT_WRAPPER_SKIP=1` short-circuits all of them — see below):
+
+1. Verb in `ASPECT_VERBS_WITH_BAZEL_FLAGS` → `aspect <verb>` with bazel flags rewritten (see below).
+2. Verb in `BAZEL_VERBS` but not the above (`query`, `info`, `clean`, `mod`, `coverage`, …) → vanilla bazel, untouched.
+3. Any other verb → `aspect <verb>`, args forwarded verbatim. This is how custom `.axl` tasks (arbitrary names) reach aspect; we don't rewrite their flags since they may define their own. **If your custom command accepts `--bazel-flag` / `--bazel-startup-flag`, add it to `ASPECT_VERBS_WITH_BAZEL_FLAGS`** so the wrapper rewrites bazel-native flags for it too (rule 1).
+
+### When `aspect` isn't installed
+
+The wrapper's presence means the org wants devs on aspect, so if a command would route to aspect (rule 1 or 3) but `aspect` isn't on `PATH`, the wrapper prints install instructions:
+
+```
+curl -fsSL https://install.aspect.build | bash
+```
+
+…or see <https://docs.aspect.build/cli/install>. If the verb is also a real Bazel command (`build`/`test`/`run`/`coverage`) the wrapper then falls back to vanilla bazel so the command still runs; for aspect-only verbs (`lint`, `format`, custom tasks) Bazel has nothing to run, so it exits. Plain bazel verbs (rule 2) never need aspect and run regardless.
+
+## How flag rewriting works
+
+Bazel is the closed set. The wrapper classifies each flag against the embedded Bazel flag lists; a flag whose name is in one of them is a Bazel flag, and **everything else** — aspect's own flags and anything unrecognized — passes through to aspect unchanged.
+
+- `BAZEL_VALUE_FLAGS` — Bazel flags that take a value (consume the next token when space-separated). From `bazel help build|test|run|startup_options --long`, **Bazel 9.x**.
+- `BAZEL_BOOL_FLAGS` — Bazel boolean (no-value) flags. The wrapper also matches their `--no…` negations.
+- `BAZEL_SHORT_VALUE_FLAGS` (`-c`, `-j`) / `BAZEL_SHORT_BOOL_FLAGS` (`-k`, `-s`, `-t`) — the short-flag abbreviations, so `bazel build -c opt //...` consumes `opt` instead of leaving it as a stray target.
+
+The rules:
+
+1. A recognized Bazel flag is wrapped: `--keep_going` → `--bazel-flag=--keep_going`; `--config=ci` → `--bazel-flag=--config=ci`; `--config ci` → `--bazel-flag=--config=ci` (next token consumed and glued with `=`); `-c opt` → `--bazel-flag=-c=opt`.
+2. Anything else passes through unchanged: aspect globals (`--task-key`, `--timing`), feature flags (`--artifact-upload:enabled`), and unrecognized flags — including a typo or a brand-new Bazel flag not yet in the lists, which simply goes to aspect until you add it.
+3. After `--`, everything passes through verbatim (positional targets, `run` arguments, etc.).
+4. Flags **before the verb** get the same classification, except Bazel flags wrap as `--bazel-startup-flag=…` (which aspect accepts as a post-verb flag, so they're moved after the verb). Aspect global flags stay in front of the verb.
+
+To refresh the embedded Bazel flag lists when Bazel adds flags. These scrape `bazel help` and aren't aspect- or repo-specific — the output depends only on the Bazel version, so run them against the version you target. Note that in a workspace where this wrapper is on `PATH`, plain `bazel help build` would route through the wrapper; `ASPECT_WRAPPER_SKIP=1` (below) bypasses it so `help` reaches the real bazel. (Outside such a workspace, drop the prefix.)
+
+```sh
+export ASPECT_WRAPPER_SKIP=1  # ensure `bazel help` reaches the real bazel
+
+# Value-taking flags
+for h in build test run startup_options; do bazel help $h --long; done \
+  | grep -oE '^[[:space:]]+--[a-z_][a-z0-9_]*' | grep -vE '\-\-\[no\]' \
+  | sed -E 's/^[[:space:]]*--//' | sort -u
+
+# Boolean flags
+for h in build test run startup_options; do bazel help $h --long; done \
+  | grep -oE '^[[:space:]]+--\[no\][a-z][a-z0-9_]*' \
+  | sed -E 's/^[[:space:]]*--\[no\]//' | sort -u
+```
+
+## Installing in your repo
+
+Grab the script straight from this repo and drop it in your own `tools/` directory, along with this doc so your team has the routing reference:
+
+```sh
+mkdir -p tools
+base=https://raw.githubusercontent.com/aspect-build/aspect-cli/main/tools
+curl -fsSL "$base/bazel" -o tools/bazel
+curl -fsSL "$base/bazel.md" -o tools/bazel.md
+chmod +x tools/bazel
+git add tools/bazel tools/bazel.md
+```
+
+Make sure the `bazel` on your `PATH` is [Bazelisk](https://github.com/bazelbuild/bazelisk) — it's what execs `tools/bazel` (the real bazel binary doesn't). Every Bazelisk release since 2019 honors the hook. No other changes needed.
+
+## Trace output
+
+When the wrapper routes a command **through aspect**, it prints a single grey trace line on stderr beforehand showing the resolved command. This makes the rewrite visible:
+
+```
+[tools/bazel] aspect build --bazel-flag=--keep_going --bazel-flag=--config=ci //...
+→ 🎬 Running `build` task
+…
+```
+
+When the wrapper forwards **straight to bazel** (e.g. `bazel info`, `bazel query`, anything under skip mode below), the trace is silent — that path is uninteresting and would just add noise.
+
+Env vars:
+
+- `ASPECT_WRAPPER_TRACE=1` — print the trace on every exec, including bazel forwarding. Also forces the line on even when stderr is not a TTY (useful for piping debug output to a file).
+- `ASPECT_WRAPPER_QUIET=1` — suppress the trace entirely. Wins over `TRACE`.
+
+The trace is silent under non-TTY stderr by default, so CI logs and command-substitution captures aren't polluted.
+
+## Skip mode — total bypass
+
+Some developers prefer a 1:1 Bazel experience locally and reach for `aspect <verb>` directly when they want the wrapped behavior. Set:
+
+```sh
+export ASPECT_WRAPPER_SKIP=1
+```
+
+…and the wrapper forwards **everything** straight to `$BAZEL_REAL`, untouched — no verb parsing, no list checks, no flag rewriting. It's a complete escape hatch: even aspect-only verbs like `lint` go to vanilla bazel (where they'll error if bazel has no such command — which is the point; you asked for vanilla bazel).
+
+This is per-shell, per-developer. To change routing repo-wide instead, edit the verb lists (e.g. remove `build test run` from `ASPECT_VERBS_WITH_BAZEL_FLAGS` so they fall through to the vanilla-bazel branch).
+
+## How it avoids infinite recursion
+
+When `tools/bazel` routes a verb through `aspect`, aspect then needs to spawn its own child `bazel` to do the actual work. If your `PATH` still has `tools/bazel` first (the normal case), that child `bazel` invocation re-enters the wrapper — which routes it back to `aspect` — which spawns `bazel` again — and so on forever.
+
+The fix: aspect sets `ASPECT_CLI_RUNNING=1` on every child `bazel` it spawns. `tools/bazel` checks for this on entry and forwards straight to the real bazel (`$BAZEL_REAL` if set, else the next `bazel` on `PATH`) without any routing logic. The cycle is broken at the first hop. This matches the pattern Bazelisk uses for `BAZELISK_SKIP_WRAPPER`.
+
+**Customers should never set `ASPECT_CLI_RUNNING` manually** — it's an implementation detail of the aspect ↔ wrapper handshake. If you wrap `aspect-cli` in your own wrapper, propagate the variable through.
+
+## Customizing
+
+Two lists at the top of the script drive every routing decision; edit them in your repo copy:
+
+- `ASPECT_VERBS_WITH_BAZEL_FLAGS` — verbs routed to `aspect` with bazel-flag rewriting. Default: `build buildifier delivery format gazelle lint run test`. Add your own bazel-flag-aware aspect commands (e.g. a custom task that shells out to bazel). (`ASPECT_WRAPPER_SKIP=1` bypasses this entirely — everything goes to vanilla bazel.)
+- `BAZEL_VERBS` — the closed set of Bazel commands. A verb here that's *not* in the list above forwards to vanilla bazel. A verb in *neither* list is treated as a custom aspect task and routed to aspect verbatim. Update this only if Bazel adds a command.
+
+Plus the embedded Bazel flag lists (`BAZEL_VALUE_FLAGS`, `BAZEL_BOOL_FLAGS`, `BAZEL_SHORT_VALUE_FLAGS`, `BAZEL_SHORT_BOOL_FLAGS`) covered above. There is no aspect-flag list — anything not recognized as a Bazel flag passes through to aspect.
+
+## What it deliberately doesn't do
+
+- **It doesn't fetch or pin Bazel.** That's Bazelisk's job. The wrapper just decides which tool to exec.
+- **It doesn't second-guess unknown flags.** A flag not in the embedded Bazel lists passes through to aspect unchanged (rather than being force-wrapped), so a typo or a not-yet-listed flag surfaces wherever it actually belongs.
+- **It doesn't replace `bazel`.** You still install Bazel through Bazelisk (which is what execs this script). The wrapper is purely an in-workspace dispatcher.
+
+## Testing
+
+Run `./tools/bazel-test.sh` (from the repo root) to exercise the wrapper against stubbed `aspect` and `bazel` binaries. Coverage: verb dispatch (aspect-wrapped, plain bazel, custom/unknown verbs), bazel flag wrapping (boolean, boolean `--no` negation, `=value`, space-value, short `-c`/`-j`/`-k`/`-s`), passthrough of aspect and unrecognized flags, aspect-verb bazel-flag forwarding (`format`/`lint`), pre-verb startup-flag classification, edge cases (`--`, hyphen-led targets, empty values, values with spaces), trace behavior, `ASPECT_WRAPPER_SKIP` mode, the `ASPECT_CLI_RUNNING` anti-inception bypass, `BAZEL_REAL` PATH fallback, and the aspect-not-installed install hint + fallback. Add a `check` call when you change behavior. Run `WRAPPER_BASH=/bin/bash ./tools/bazel-test.sh` to exercise the wrapper under macOS's bash 3.2 (its compatibility floor).


### PR DESCRIPTION
Customers who want Aspect CLI features but don't want their developers to learn `aspect` as a new command can drop this `tools/bazel` shell wrapper in their workspace. [Bazelisk](https://github.com/bazelbuild/bazelisk) execs `tools/bazel` when present (the wrapper hook is a Bazelisk feature — the real `bazel` binary doesn't look for it), so it routes each command to the right tool.

| You type | What runs |
| --- | --- |
| `bazel build //... --keep_going --config=ci` | `aspect build //... --bazel-flag=--keep_going --bazel-flag=--config=ci` |
| `bazel build -c opt //...` | `aspect build --bazel-flag=-c=opt //...` |
| `bazel test //... --test_output errors` | `aspect test //... --bazel-flag=--test_output=errors` |
| `bazel lint --config=ci //src/...` | `aspect lint --bazel-flag=--config=ci //src/...` |
| `bazel format --keep_going` | `aspect format --bazel-flag=--keep_going` |
| `bazel query 'deps(//foo)'` / `bazel info` | vanilla bazel, unchanged |
| `bazel my-custom-task //...` | `aspect my-custom-task //...` (custom `.axl` task) |

## Model

Two lists at the top of the script drive routing (edit them in your repo copy):

- **`ASPECT_VERBS_WITH_BAZEL_FLAGS`** → route to `aspect` with bazel-flag rewriting.
- **`BAZEL_VERBS`** → the closed set of Bazel commands.

A verb in `BAZEL_VERBS` but not the first list (`query`, `info`, `clean`, `mod`, …) goes to vanilla bazel untouched. A verb in neither is treated as a custom aspect task and forwarded verbatim.

Flag classification treats **bazel as the closed set**: a flag whose name is in the embedded `BAZEL_*_FLAGS` lists (value, boolean incl. `--no` negations, and the short forms `-c`/`-j`/`-k`/`-s`/`-t`) is wrapped as `--bazel-flag=` (post-verb) or `--bazel-startup-flag=` (pre-verb); space-separated value flags consume the next token and glue with `=`. Every other flag — aspect's own flags and anything unrecognized — passes through to aspect unchanged.

#### `aspect` not installed

If a command would route to aspect but `aspect` isn't on `PATH`, the wrapper prints install instructions (`curl -fsSL https://install.aspect.build | bash`). For a verb that's also a real bazel command (`build`/`test`/`run`/`coverage`) it then falls back to vanilla bazel so the command still runs; for aspect-only verbs (`lint`/`format`/custom tasks) it exits. Plain bazel verbs never need aspect.

#### `ASPECT_WRAPPER_SKIP`

A total escape hatch: forwards **everything** straight to vanilla bazel — no verb parsing, no list checks, no flag rewriting.

#### Anti-inception

When the wrapper routes a verb through aspect, aspect spawns its own child `bazel`. If `tools/bazel` is on PATH that child re-enters the wrapper, looping forever. aspect now sets `ASPECT_CLI_RUNNING=1` on every child bazel it spawns (via a new `bazel_command()` helper at every call site); the wrapper detects it on entry and forwards straight to the real bazel. Same pattern bazelisk uses for `BAZELISK_SKIP_WRAPPER`.

#### Notes

- Wrapper is bash 3.2 compatible (stock macOS `/bin/bash`); the test suite can be run under it with `WRAPPER_BASH=/bin/bash`.
- When `BAZEL_REAL` is unset, the real bazel is found on PATH via `type -aP bazel` (skipping the wrapper itself).
- `ASPECT_WRAPPER_TRACE` / `ASPECT_WRAPPER_QUIET` control the grey trace line.

#### Docs

[`tools/bazel.md`](tools/bazel.md) covers installation (copy both `tools/bazel` and `tools/bazel.md`), the routing model, the aspect-not-installed and skip behaviors, customization, anti-inception, and how to regen the embedded flag lists.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (`tools/bazel.md`)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- New `tools/bazel` reference wrapper lets customers expose Aspect CLI features through the familiar `bazel <verb>` interface, forwarding bazel-native flags (long, `=value`, space-separated, and short `-c`/`-j`) through to Bazel. See [`tools/bazel.md`](tools/bazel.md).
- Aspect now sets `ASPECT_CLI_RUNNING=1` on child `bazel` processes so wrapper scripts can detect they're a child of aspect and skip routing. Customers wrapping `aspect-cli` in their own scripts should propagate this variable through.

### Test plan

- Covered by existing `aspect-cli` unit tests.
- New `tools/bazel-test.sh` (100 checks, run under both bash 5 and macOS bash 3.2) covering verb routing, flag wrapping/passthrough, aspect-verb forwarding, pre-verb startup-flag classification, `ASPECT_WRAPPER_SKIP` total bypass, `ASPECT_CLI_RUNNING` bypass, `BAZEL_REAL` PATH fallback, the aspect-not-installed install hint + fallback, trace output, and edge cases.



