### PR TITLE
feat(run,format): --run-in=<choice> to override the spawned binary cwd

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -60,7 +60,7 @@ buildifier = format.alias(
         # buildifier_binary is a symlink to the raw Go binary; it does not
         # switch to $BUILD_WORKING_DIRECTORY on its own, so we run it in
         # the user's cwd to make relative paths resolve.
-        "run_in_cwd": True,
+        "run_in": "cwd",
         "include_patterns": [
             "**/BUCK",
             "**/BUILD",
@@ -92,21 +92,6 @@ def _buildifier_repro_fix(ctx: TaskContext, info: ReproFixInfo) -> ReproFixSugge
     return repro_fix_replace(
         command = info.command.replace("aspect buildifier", "bazel buildifier", 1),
     )
-
-def _drop_vanilla_bazel_except_build(ctx: TaskContext, info: ReproFixInfo) -> ReproFixSuggestion:
-    """Drop every vanilla-bazel alternate except `build`'s.
-
-    Built-in tasks tack on a vanilla `bazel run <target> ...` next to
-    their `aspect ...` repros/fixes for users without the Aspect CLI on
-    PATH. In this workspace contributors always have either `aspect` or
-    the `tools/bazel` wrapper, so the alternate is noise. Keeping the
-    `build` task's variant lets us continue to dogfood the rendering of
-    that alternate end-to-end. Matches by suggestion-slug suffix so any
-    new vanilla-bazel alternates added later are covered automatically.
-    """
-    if not info.slug.endswith("-vanilla-bazel") or info.task_name == "build":
-        return REPRO_FIX_ACCEPT
-    return REPRO_FIX_REJECT
 
 def _shorten_delivery_local_preview(ctx: TaskContext, info: ReproFixInfo) -> ReproFixSuggestion:
     """Shorten the delivery local-preview description.
@@ -187,7 +172,6 @@ def config(ctx: ConfigContext):
     # buildifier rewrite has nothing to undo on already-renamed entries.
     lifecycle = ctx.traits[TaskLifecycleTrait]
     lifecycle.repro_fix_suggestion.append(_buildifier_repro_fix)
-    lifecycle.repro_fix_suggestion.append(_drop_vanilla_bazel_except_build)
     lifecycle.repro_fix_suggestion.append(_shorten_delivery_local_preview)
 
     # Template snapshot tests — renders bazel_results templates across failure modes.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ buildifier = format.alias(
     defaults = {
         "formatter_target": "@buildifier_prebuilt//buildifier",
         "formatter_args_for_tree_walk": ["-r", "."],
-        "run_in_cwd": True,
+        "run_in": "cwd",
         "include_patterns": [
             "**/BUILD",
             "**/BUILD.bazel",

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -30,8 +30,8 @@ load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
 load("./lib/path_normalize.axl", "normalize_files_for_cwd")
-load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "runnable")
+load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_prefix", "task_cli_path")
+load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
 
@@ -232,8 +232,8 @@ def _append_fix_commands(ctx, data):
          `bazel run <formatter_target> -- <formatter_args> <files>`. Bounded
          at `_BAZEL_ALT_MAX_CHARS`; when the command exceeds that budget,
          `build_bazel_command` wraps it onto multiple lines and truncates the
-         trailing args with a `# +N more` shell-comment marker. `--run_in_cwd`
-         is forwarded when the task ran with it.
+         trailing args with a `# +N more` shell-comment marker. Skipped
+         entirely when the Aspect `tools/bazel` wrapper is in play.
 
     No-op when there are no affected files: nothing to fix, no commands.
     """
@@ -276,18 +276,26 @@ def _append_fix_commands(ctx, data):
             slug = "format-fix-rediscover",
         ))
 
-    bazel_flags = ["--run_in_cwd"] if ctx.args.run_in_cwd else []
-    bazel_run_args = [ctx.args.formatter_target] + list(ctx.args.formatter_args) + affected
-    data["fix_commands"].append(ReproFixCommand(
-        command = prefix + build_bazel_command(
-            "run",
-            bazel_run_args,
-            flags = bazel_flags,
-            max_chars = _BAZEL_ALT_MAX_CHARS,
-        ),
-        description = "vanilla bazel",
-        slug = "format-fix-vanilla-bazel",
-    ))
+    # Vanilla-bazel alternate. Skipped under the Aspect `tools/bazel`
+    # wrapper — there, `bazel run` re-routes through `aspect run`, so
+    # the "vanilla" framing would be misleading.
+    #
+    # Only `--run-in=cwd` maps to a Bazel flag (`--run_in_cwd`); other
+    # modes have no direct Bazel equivalent and are dropped from the
+    # alternate.
+    if not has_tools_bazel_wrapper(ctx):
+        bazel_flags = ["--run_in_cwd"] if ctx.args.run_in == "cwd" else []
+        bazel_run_args = [ctx.args.formatter_target] + list(ctx.args.formatter_args) + affected
+        data["fix_commands"].append(ReproFixCommand(
+            command = prefix + build_bazel_command(
+                "run",
+                bazel_run_args,
+                flags = bazel_flags,
+                max_chars = _BAZEL_ALT_MAX_CHARS,
+            ),
+            description = "vanilla bazel",
+            slug = "format-fix-vanilla-bazel",
+        ))
 
 def _emit_final(ctx, lifecycle, data, exit_code):
     """Emit the terminal task_update for status-check consumers."""
@@ -341,6 +349,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     hc_trait = ctx.traits[HealthCheckTrait]
     lifecycle = ctx.traits[TaskLifecycleTrait]
     ansi = color_enabled(ctx.std)
+
+    # Resolve --run-in up front: a bad value (typo, `git-root` outside
+    # a git repo) must fail before setup_phase opens status surfaces
+    # and before the formatter build spends time.
+    spawn_cwd = resolve_run_in(ctx, ctx.args.run_in)
 
     # Initialize data for status-check emission.
     data = fmt_init_data()
@@ -583,8 +596,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             phase = Phase(name = "format", description = "Format files", emoji = "✨"),
         )
 
-    spawn_cwd = ctx.std.env.current_dir() if ctx.args.run_in_cwd else None
-
     spawn_args = compute_spawn_args(
         ctx.args.formatter_args,
         format_args,
@@ -758,9 +769,18 @@ format = task(
             default = "//tools/format",
             description = "Bazel label of the format_multirun target (or any runnable target) to invoke as the formatter. The target is built first, then run with the changed-file list passed as positional arguments.",
         ),
-        "run_in_cwd": args.boolean(
-            default = False,
-            description = "Spawn the formatter with the current working directory as cwd, rather than the `bazel run` default of `<runfiles_dir>/<workspace>`. Mirrors Bazel's `--run_in_cwd` flag. Set this for formatter targets that do not switch to `$BUILD_WORKSPACE_DIRECTORY` on their own and instead resolve workspace-relative file arguments against the process cwd — for example, `@buildifier_prebuilt//buildifier`, which is a `buildifier_binary` rule (symlink to the raw Go binary, no shell wrapper). Wrapper-based formatters such as `format_multirun` from rules_lint already `cd $BUILD_WORKSPACE_DIRECTORY` on entry, so this flag is a no-op for them. (A truly bare binary — one with no runfiles tree at all — already spawns in cwd because there is no `runfiles_dir/<workspace>` to fall back to.)",
+        "run_in": args.string(
+            default = "",
+            description = RUN_IN_DESCRIPTION + (
+                " Set this for formatter targets that resolve workspace-" +
+                "relative file arguments against the process cwd rather " +
+                "than reading `$BUILD_WORKSPACE_DIRECTORY` — e.g. " +
+                "`@buildifier_prebuilt//buildifier`, a symlink to the raw " +
+                "Go binary with no shell wrapper. Wrapper-based formatters " +
+                "such as `format_multirun` from rules_lint already " +
+                "`cd $BUILD_WORKSPACE_DIRECTORY` on entry and see this as " +
+                "a no-op."
+            ),
         ),
         "formatter_args": args.string_list(
             long = "formatter-arg",

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -197,7 +197,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
-load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_prefix", "task_cli_path")
 load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
@@ -351,7 +351,8 @@ def _append_fix_commands(ctx, data):
       2. Re-discover fallback (only when the dir list was truncated).
       3. Vanilla-bazel alternate — `bazel run <gazelle_target>`. The
          standard gazelle binary runs in fix/update mode by default
-         when invoked via `bazel run`.
+         when invoked via `bazel run`. Skipped entirely when the
+         Aspect `tools/bazel` wrapper is in play.
 
     The primary fix flips to `--severity=info --check-only=false` and
     carries the parent dirs of the affected BUILD files as positionals —
@@ -391,11 +392,15 @@ def _append_fix_commands(ctx, data):
             slug = "gazelle-fix-rediscover",
         ))
 
-    data["fix_commands"].append(ReproFixCommand(
-        command = prefix + build_bazel_command("run", [ctx.args.gazelle_target]),
-        description = "vanilla bazel",
-        slug = "gazelle-fix-vanilla-bazel",
-    ))
+    # Vanilla-bazel alternate. Skipped under the Aspect `tools/bazel`
+    # wrapper — there, `bazel run` re-routes through `aspect run`, so
+    # the "vanilla" framing would be misleading.
+    if not has_tools_bazel_wrapper(ctx):
+        data["fix_commands"].append(ReproFixCommand(
+            command = prefix + build_bazel_command("run", [ctx.args.gazelle_target]),
+            description = "vanilla bazel",
+            slug = "gazelle-fix-vanilla-bazel",
+        ))
 
 def _resolve_check_only(ctx):
     """Resolve `--check-only=auto|true|false` to a bool.

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -421,6 +421,54 @@ def repro_prefix(ctx):
         ctx.std.env.git_root_dir() or ctx.std.env.aspect_root_dir(),
     )
 
+_TOOLS_BAZEL_WRAPPER_MARKER = "aspect-build/tools-bazel-wrapper"
+
+# Hard cap on `tools/bazel`'s on-disk size before we bother reading it.
+# The Aspect wrapper is ~28 KiB; any reasonable fork stays well under
+# 64 KiB. Above this we assume the file isn't an Aspect-shaped wrapper
+# (could be a vendored binary or a megabyte-scale custom script) and
+# skip the read.
+_TOOLS_BAZEL_MAX_PROBE_SIZE = 65536
+
+def has_tools_bazel_wrapper(ctx) -> bool:
+    """True when this workspace ships the Aspect `tools/bazel` wrapper.
+
+    The wrapper routes `bazel <verb>` through `aspect <verb>`, so
+    `bazel run`-flavored vanilla-bazel suggestions are misleading when
+    it's installed (they'd re-enter aspect, not produce a vanilla
+    `bazel run`).
+
+    Two-step detection:
+
+      1. Env var — `ASPECT_BAZEL_WRAPPER_VERSION` is exported by the
+         wrapper itself, so it's already set when aspect was invoked
+         via `bazel <verb>`. Cheap, no I/O.
+      2. File probe — fall back to looking for the marker comment in
+         `<bazel_root>/tools/bazel`. Covers the "CI runs aspect directly
+         but the workspace has the wrapper installed" case: the
+         developer who copies the suggested fix command will be running
+         through the wrapper.
+
+    Stat-capped at `_TOOLS_BAZEL_MAX_PROBE_SIZE` to avoid pulling a
+    vendored binary or megabyte-scale fork into memory just to probe
+    for a header comment.
+
+    Returns False on any failure path (no bazel root, missing file,
+    oversized file, unreadable file, marker absent) — wrapper detection
+    is advisory, not load-bearing, and must never fail the task.
+    """
+    if ctx.std.env.var("ASPECT_BAZEL_WRAPPER_VERSION"):
+        return True
+    bazel_root = ctx.std.env.bazel_root_dir()
+    if not bazel_root:
+        return False
+    path = bazel_root + "/tools/bazel"
+    if not ctx.std.fs.exists(path):
+        return False
+    if ctx.std.fs.metadata(path).size > _TOOLS_BAZEL_MAX_PROBE_SIZE:
+        return False
+    return _TOOLS_BAZEL_WRAPPER_MARKER in ctx.std.fs.try_read_to_string(path)
+
 # ── CLI rendering ─────────────────────────────────────────────────────
 
 def print_repro_and_fix(std, data, status):

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -7,7 +7,7 @@ tests on `Arguments`.
 """
 
 load("./lifecycle.axl", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixCommand", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "repro_fix_replace")
-load("./repro_commands.axl", "build_bazel_command", "explicit_flags", "repro_prefix", "subdir_prefix")
+load("./repro_commands.axl", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "repro_prefix", "subdir_prefix")
 
 def _eq(label, got, want):
     if got != want:
@@ -170,6 +170,97 @@ def _test_repro_prefix_no_git_root_falls_back_to_aspect_root(_ctx):
 def _test_repro_prefix_no_git_root_at_aspect_root(_ctx):
     fake = _fake_env("/project", None, aspect_root = "/project")
     _eq("at aspect_root, no git → empty", repro_prefix(fake), "")
+
+# ---------------------------------------------------------------------------
+# has_tools_bazel_wrapper — env-first, file-marker fallback
+# ---------------------------------------------------------------------------
+
+def _fake_wrapper_ctx(env_var = None, bazel_root = "/repo", files = None):
+    """Build a minimal ctx for has_tools_bazel_wrapper tests.
+
+    `env_var` simulates `ctx.std.env.var("ASPECT_BAZEL_WRAPPER_VERSION")`.
+    `bazel_root` simulates `ctx.std.env.bazel_root_dir()`.
+    `files` is a dict path → (size, contents). A missing path → exists()
+    returns False; size > _TOOLS_BAZEL_MAX_PROBE_SIZE skips the read.
+    `try_read_to_string` mirrors the real API: returns "" on missing
+    rather than raising.
+    """
+    files = files or {}
+    return struct(std = struct(
+        env = struct(
+            var = lambda name: env_var if name == "ASPECT_BAZEL_WRAPPER_VERSION" else None,
+            bazel_root_dir = lambda: bazel_root,
+        ),
+        fs = struct(
+            exists = lambda p: p in files,
+            metadata = lambda p: struct(size = files[p][0]),
+            try_read_to_string = lambda p: files[p][1] if p in files else "",
+        ),
+    ))
+
+_WRAPPER_HEAD = """\
+#!/usr/bin/env bash
+# aspect-build/tools-bazel-wrapper
+#
+# tools/bazel — Bazel wrapper.
+ASPECT_BAZEL_WRAPPER_VERSION="1"
+"""
+
+def _test_wrapper_env_var_short_circuits(_ctx):
+    """When ASPECT_BAZEL_WRAPPER_VERSION is set, no disk I/O needed."""
+    fake = _fake_wrapper_ctx(env_var = "1", bazel_root = "/nonexistent", files = {})
+    _eq("env var set → True (no file probe)", has_tools_bazel_wrapper(fake), True)
+
+def _test_wrapper_file_marker_found(_ctx):
+    """No env var, but the file at <bazel_root>/tools/bazel carries the marker."""
+    fake = _fake_wrapper_ctx(
+        env_var = None,
+        bazel_root = "/repo",
+        files = {"/repo/tools/bazel": (len(_WRAPPER_HEAD), _WRAPPER_HEAD)},
+    )
+    _eq("marker in file → True", has_tools_bazel_wrapper(fake), True)
+
+def _test_wrapper_file_missing(_ctx):
+    """No env var and no tools/bazel → False."""
+    fake = _fake_wrapper_ctx(env_var = None, bazel_root = "/repo", files = {})
+    _eq("no file → False", has_tools_bazel_wrapper(fake), False)
+
+def _test_wrapper_file_without_marker(_ctx):
+    """A homegrown tools/bazel that doesn't carry the Aspect marker → False."""
+    homegrown = "#!/bin/sh\nexec /usr/bin/bazel \"$@\"\n"
+    fake = _fake_wrapper_ctx(
+        env_var = None,
+        bazel_root = "/repo",
+        files = {"/repo/tools/bazel": (len(homegrown), homegrown)},
+    )
+    _eq("homegrown file → False", has_tools_bazel_wrapper(fake), False)
+
+def _test_wrapper_oversized_file_skipped(_ctx):
+    """A megabyte-scale `tools/bazel` is treated as not-our-wrapper without reading it."""
+
+    # We DON'T put valid contents in the dict — read_to_string would have to
+    # be called for this assertion to fail, and it would KeyError. The size
+    # check should short-circuit before that.
+    fake = _fake_wrapper_ctx(
+        env_var = None,
+        bazel_root = "/repo",
+        files = {"/repo/tools/bazel": (10 * 1024 * 1024, None)},
+    )
+    _eq("oversized → False (no read)", has_tools_bazel_wrapper(fake), False)
+
+def _test_wrapper_no_bazel_root(_ctx):
+    """When bazel_root_dir() returns empty (outside a bazel workspace), → False."""
+    fake = _fake_wrapper_ctx(env_var = None, bazel_root = "", files = {})
+    _eq("no bazel root → False", has_tools_bazel_wrapper(fake), False)
+
+def _test_wrapper_empty_file(_ctx):
+    """An empty file (or one that try_read_to_string degraded to '') → False."""
+    fake = _fake_wrapper_ctx(
+        env_var = None,
+        bazel_root = "/repo",
+        files = {"/repo/tools/bazel": (0, "")},
+    )
+    _eq("empty file → False", has_tools_bazel_wrapper(fake), False)
 
 def _test_bazel_build_with_targets(_ctx):
     _eq(
@@ -799,6 +890,13 @@ _UNIT_TESTS = [
     _test_repro_prefix_nested_subdir,
     _test_repro_prefix_no_git_root_falls_back_to_aspect_root,
     _test_repro_prefix_no_git_root_at_aspect_root,
+    _test_wrapper_env_var_short_circuits,
+    _test_wrapper_file_marker_found,
+    _test_wrapper_file_missing,
+    _test_wrapper_file_without_marker,
+    _test_wrapper_oversized_file_skipped,
+    _test_wrapper_no_bazel_root,
+    _test_wrapper_empty_file,
     _test_bazel_build_with_targets,
     _test_bazel_test_with_targets,
     _test_bazel_run_single_target,

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -20,6 +20,66 @@ LOCAL_SPAWN_FLAGS = [
     "--build_runfile_links",
 ]
 
+# Named modes accepted by `--run-in=<choice>` on tasks that spawn a
+# built binary.
+_RUN_IN_NAMED_MODES = ["runfiles", "cwd", "bazel-root", "aspect-root", "git-root"]
+
+# Shared `description=` body for `--run-in`'s task-arg definition. Tasks
+# may concatenate task-specific guidance (e.g. which formatter targets
+# care about cwd) onto the end. Single source of truth so the named-mode
+# set, the path-resolution rules, and `resolve_run_in`'s error message
+# can't drift apart.
+RUN_IN_DESCRIPTION = (
+    "Cwd for the spawned binary. Default (`runfiles` / empty) matches " +
+    "`bazel run`: `<runfiles_dir>/<workspace>`. Named modes: `cwd` " +
+    "(the user's current working directory), `bazel-root` (the dir " +
+    "containing MODULE.bazel), `aspect-root` (the nearest `.aspect/` " +
+    "dir), `git-root` (the nearest `.git/` dir). Paths starting with " +
+    "`/` are taken as absolute; paths starting with `./` or `../` " +
+    "resolve against the user's cwd."
+)
+
+def resolve_run_in(ctx, choice: str) -> str | None:
+    """Resolve `--run-in=<choice>` to an absolute cwd for the spawn.
+
+    Accepts:
+      - "" or "runfiles"  → None (cwd defaults to `<runfiles_dir>/<workspace>`)
+      - "cwd"             → user's current working directory
+      - "bazel-root"      → workspace root (the dir containing MODULE.bazel)
+      - "aspect-root"     → nearest `.aspect/` dir (usually == bazel-root)
+      - "git-root"        → nearest `.git/` dir
+      - "/abs/path"       → absolute path, passed through verbatim
+      - "./rel" or "../rel" → resolved against the user's cwd
+      - anything else     → fail() with the full list of valid choices
+
+    Path resolution is intentionally simple (no `..` collapsing, no `~`
+    expansion); the OS resolves the spawn cwd, and the shell already
+    expands `~` / `$VAR` before the value reaches us.
+
+    Callers should resolve `--run-in` BEFORE opening status surfaces so
+    that a bad value fails fast without orphaning a partially-emitted
+    task lifecycle.
+    """
+    if choice == "" or choice == "runfiles":
+        return None
+    if choice == "cwd":
+        return ctx.std.env.current_dir()
+    if choice == "bazel-root":
+        return ctx.std.env.bazel_root_dir()
+    if choice == "aspect-root":
+        return ctx.std.env.aspect_root_dir()
+    if choice == "git-root":
+        path = ctx.std.env.git_root_dir()
+        if not path:
+            fail("--run-in=git-root: not inside a git repository.")
+        return path
+    if choice.startswith("/"):
+        return choice
+    if choice.startswith("./") or choice.startswith("../"):
+        return ctx.std.env.current_dir() + "/" + choice
+    fail("--run-in: expected one of %s, an absolute path, or a ./relative path; got %r" %
+         (_RUN_IN_NAMED_MODES, choice))
+
 # Pass-2 entrypoint selection: rules that declare
 # ctx.actions.declare_file(ctx.label.name + EXT) produce no no-extension
 # wrapper, so the extensioned file itself is the entrypoint.
@@ -223,11 +283,11 @@ def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture
 
     Working directory defaults to `runfiles_dir/<workspace>` (matching `bazel run`)
     when a runfiles tree is present, falling back to the aspect invocation directory
-    when the target has no runfiles tree. Pass `cwd` explicitly to override — e.g.
-    `format.axl` passes the invocation directory under `--run-in-cwd` so targets
-    that don't switch to `$BUILD_WORKSPACE_DIRECTORY` on their own (such as
-    `@buildifier_prebuilt//buildifier`) resolve workspace-relative arguments
-    against the user's cwd.
+    when the target has no runfiles tree. Pass `cwd` explicitly to override — both
+    `run.axl` and `format.axl` resolve `--run-in=<choice>` via `resolve_run_in()` and
+    forward the result here so targets that don't switch to `$BUILD_WORKSPACE_DIRECTORY`
+    on their own (such as `@buildifier_prebuilt//buildifier`) resolve workspace-relative
+    arguments against the user's cwd.
     """
     effective_cwd = cwd or _runfiles_cwd(state, ep) or ctx.std.env.current_dir()
     cmd = ctx.std.process.command(ep.path) \
@@ -265,7 +325,7 @@ def runnable(ctx, targets: list[str]) -> struct:
           `cwd` defaults to `ep.runfiles_dir/<workspace>` when a runfiles tree
           is present (matching `bazel run`), falling back to the aspect
           invocation directory when there is no runfiles tree. Pass an
-          explicit `cwd` to override — e.g. for `--run-in-cwd` semantics.
+          explicit `cwd` to override — e.g. the resolved value from `--run-in=<choice>`.
     """
     current_package = _current_package(ctx) if ctx else ""
     state = struct(

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,7 +1,7 @@
 """Unit tests for lib/runnable.axl: apparent_label normalization, BES matching,
 entrypoint selection (passes 1–3), and runfiles directory detection."""
 
-load("./runnable.axl", "apparent_label", "runnable")
+load("./runnable.axl", "apparent_label", "resolve_run_in", "runnable")
 
 def _eq(label, got, want):
     if got != want:
@@ -390,6 +390,54 @@ def _test_filesystem_no_runfiles(ctx):
     if ep.runfiles_dir != None:
         fail("fs/no-runfiles: expected runfiles_dir=None (no .runfiles on disk), got %r" % ep.runfiles_dir)
 
+# ---------------------------------------------------------------------------
+# resolve_run_in — `--run-in=<choice>` cwd resolution
+# ---------------------------------------------------------------------------
+
+def _make_env_ctx(cwd = "/user/cwd", bazel_root = "/repo", aspect_root = "/repo", git_root = "/repo"):
+    """Minimal ctx with `std.env.*` dirs for resolve_run_in tests."""
+    return struct(std = struct(env = struct(
+        current_dir = lambda: cwd,
+        bazel_root_dir = lambda: bazel_root,
+        aspect_root_dir = lambda: aspect_root,
+        git_root_dir = lambda: git_root,
+    )))
+
+def _test_run_in_empty_is_none(_ctx):
+    _eq("empty → None (runfiles default)", resolve_run_in(_make_env_ctx(), ""), None)
+
+def _test_run_in_runfiles_is_none(_ctx):
+    _eq("runfiles → None (default)", resolve_run_in(_make_env_ctx(), "runfiles"), None)
+
+def _test_run_in_cwd(_ctx):
+    _eq("cwd → user's cwd", resolve_run_in(_make_env_ctx(cwd = "/here"), "cwd"), "/here")
+
+def _test_run_in_bazel_root(_ctx):
+    _eq("bazel-root", resolve_run_in(_make_env_ctx(bazel_root = "/ws"), "bazel-root"), "/ws")
+
+def _test_run_in_aspect_root(_ctx):
+    _eq("aspect-root", resolve_run_in(_make_env_ctx(aspect_root = "/asp"), "aspect-root"), "/asp")
+
+def _test_run_in_git_root(_ctx):
+    _eq("git-root", resolve_run_in(_make_env_ctx(git_root = "/git"), "git-root"), "/git")
+
+def _test_run_in_absolute_path(_ctx):
+    _eq("/abs/path passthrough", resolve_run_in(_make_env_ctx(), "/abs/path"), "/abs/path")
+
+def _test_run_in_relative_dot(_ctx):
+    _eq(
+        "./sub → resolves against cwd",
+        resolve_run_in(_make_env_ctx(cwd = "/here"), "./sub"),
+        "/here/./sub",
+    )
+
+def _test_run_in_relative_dotdot(_ctx):
+    _eq(
+        "../sub → resolves against cwd",
+        resolve_run_in(_make_env_ctx(cwd = "/here"), "../sub"),
+        "/here/../sub",
+    )
+
 _UNIT_TESTS = [
     _test_local_label_with_colon,
     _test_local_label_without_colon,
@@ -431,6 +479,15 @@ _UNIT_TESTS = [
     _test_filesystem_sh_extension,
     _test_filesystem_bash_extension,
     _test_filesystem_no_runfiles,
+    _test_run_in_empty_is_none,
+    _test_run_in_runfiles_is_none,
+    _test_run_in_cwd,
+    _test_run_in_bazel_root,
+    _test_run_in_aspect_root,
+    _test_run_in_git_root,
+    _test_run_in_absolute_path,
+    _test_run_in_relative_dot,
+    _test_run_in_relative_dotdot,
 ]
 
 def _test_impl(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -9,7 +9,7 @@ load("./lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_bui
 load("./lib/environment.axl", "error")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
-load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
 load("./lib/tips.axl", "tips")
 
 def _terminal_status(data, exit_code):
@@ -65,6 +65,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     target = ctx.args.target[0]
     forward_args = list(ctx.args.run_args)
+
+    # Resolve --run-in up front: a bad value (typo, `git-root` outside
+    # a git repo) must fail before setup_phase opens status surfaces
+    # and before the build spends time.
+    spawn_cwd = resolve_run_in(ctx, ctx.args.run_in)
 
     data = init_data()
 
@@ -144,7 +149,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         phase = Phase(name = "run", description = "Run target", emoji = "🚀"),
     )
 
-    code = r.spawn(entrypoint, forward_args).wait().code
+    code = r.spawn(entrypoint, forward_args, cwd = spawn_cwd).wait().code
     bookend = "Ran %s" % target if code == 0 else "%s exited with code %d" % (target, code)
     return _emit_terminal(ctx, lifecycle, data, code, conclusion_text = bookend)
 
@@ -166,6 +171,18 @@ run = task(
         "bazel_startup_flags": args.string_list(
             description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
             long = "bazel-startup-flag",
+        ),
+        "run_in": args.string(
+            default = "",
+            description = RUN_IN_DESCRIPTION + (
+                " Set this for binaries that resolve workspace-relative " +
+                "file arguments against the process cwd rather than reading " +
+                "`$BUILD_WORKSPACE_DIRECTORY` — e.g. " +
+                "`@buildifier_prebuilt//buildifier`, a symlink to the raw " +
+                "Go binary with no shell wrapper. Wrapper-based binaries " +
+                "that already `cd $BUILD_WORKSPACE_DIRECTORY` on entry see " +
+                "this flag as a no-op."
+            ),
         ),
     } | announce_bazel_args("the build"),
     traits = [


### PR DESCRIPTION
Adds a `--run-in=<choice>` flag to `aspect run` and `aspect format` that overrides the cwd of the spawned binary. Accepts:

| Value | Cwd |
|---|---|
| `runfiles` *(default, also empty)* | `<runfiles_dir>/<workspace>` — matches `bazel run` |
| `cwd` | the user's current working directory |
| `bazel-root` | the dir containing `MODULE.bazel` |
| `aspect-root` | the nearest `.aspect/` dir |
| `git-root` | the nearest `.git/` dir |
| `/abs/path` | absolute path, passed through verbatim |
| `./rel` or `../rel` | resolved against the user's cwd |

Replaces the previous `--run_in_cwd=true` boolean arg on `format`; the new shape covers the same case (`--run-in=cwd`) plus the named-root, absolute-path, and relative-path modes. The buildifier alias in `.aspect/config.axl` updates its `defaults` from `"run_in_cwd": True` to `"run_in": "cwd"`.

`bazel-root` / `aspect-root` / `git-root` resolve to the same path in a typical repo but are kept as distinct named modes so the caller's intent stays explicit. Path resolution is intentionally simple — no `..` collapsing or `~` expansion. Bare strings that aren't named modes and don't start with `/`, `./`, or `../` are rejected with a clear error listing the valid choices.

Both tasks resolve `--run-in` before opening status surfaces so a bad value (typo, `git-root` outside a git repo) fails fast without orphaning a partially-emitted task lifecycle.

`format` and `gazelle` also suppress the vanilla-bazel alternate in their fix-command list when the Aspect `tools/bazel` wrapper is detected. The wrapper routes `bazel run` through `aspect run`, so the "vanilla" framing would be misleading. Detection prefers `ASPECT_BAZEL_WRAPPER_VERSION` (the env var the wrapper exports — no I/O), falling back to a stat-capped probe of `<bazel-root>/tools/bazel` for the marker comment.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes (config-only — see release notes)
- Suggested release notes appear below: yes

### Suggested release notes

- `aspect run --run-in=<choice>` and `aspect format --run-in=<choice>`: new flag overriding the spawned binary's cwd. Accepts `runfiles` (default, matches `bazel run`), `cwd`, `bazel-root`, `aspect-root`, `git-root`, an absolute path, or a `./`/`../` path resolved against the user's cwd. Replaces `aspect format --run_in_cwd=<bool>` — migrate by setting `--run-in=cwd` instead. `format` and `gazelle` also suppress their vanilla-bazel fix-command alternate under the Aspect `tools/bazel` wrapper.

### Test plan

- `aspect dev test-runnable` — 49/49 pass (9 new `resolve_run_in` cases).
- `aspect dev test-repro-commands` — 59/59 pass (7 new `has_tools_bazel_wrapper` cases).
- `aspect dev test-format-template-snapshots` / `test-gazelle-template-snapshots` — clean.
- End-to-end (a `sh_binary` printing `pwd`, run from various dirs):
  - Default → `<runfiles>/_main`
  - `--run-in=cwd` → the user's cwd
  - `--run-in=bazel-root` / `git-root` / `aspect-root` → workspace root
  - `--run-in=/tmp` → `/private/tmp` (macOS canonical form)
  - `--run-in=./examples` from root → `…/aspect-cli/examples`
  - `--run-in=../` from `examples/deliverable` → `…/aspect-cli/examples`
  - `--run-in=cdw` (typo) → fails immediately with the full list of valid choices, before `setup_phase`.
