### PR TITLE
fix(github-status-comments): rehydrate ReproFixCommand records after JSON round-trip

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -60,7 +60,7 @@ load(
     "should_emit_phase_change",
     "usage_footer",
 )
-load("../lib/repro_commands.axl", "ASPECT_CLI_INSTALL_HINT_MARKDOWN", "dedup_and_attribute")
+load("../lib/repro_commands.axl", "ASPECT_CLI_INSTALL_HINT_MARKDOWN", "dedup_and_attribute", "rehydrate_commands")
 load("../lib/result_text.axl", "severity_for_status")
 load("../lib/tar.axl", "bsdtar")
 load(
@@ -878,11 +878,24 @@ def _parse_state(body):
     epoch = decoded.get("last_upsert_epoch_s")
     workflow_runs = decoded.get("workflow_runs")
     entries = decoded.get("entries")
+    parsed_entries = [e for e in entries if type(e) == "dict"] if type(entries) == "list" else []
+
+    # JSON round-trip turns ReproFixCommand records into plain dicts;
+    # rehydrate per-entry so downstream `_collect_repro_fix_rows` can
+    # do record-attribute access (`c.command`, `c.description`). Only
+    # touch keys that are already present so entries written by older
+    # aspect-cli releases (predating the command lists) round-trip
+    # unchanged.
+    for e in parsed_entries:
+        if "repro_commands" in e:
+            e["repro_commands"] = rehydrate_commands(e["repro_commands"])
+        if "fix_commands" in e:
+            e["fix_commands"] = rehydrate_commands(e["fix_commands"])
     return {
         "head_sha": head_sha if type(head_sha) == "string" else "",
         "last_upsert_epoch_s": epoch if type(epoch) == "int" else 0,
         "workflow_runs": [r for r in workflow_runs if type(r) == "dict"] if type(workflow_runs) == "list" else [],
-        "entries": [e for e in entries if type(e) == "dict"] if type(entries) == "list" else [],
+        "entries": parsed_entries,
     }
 
 def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entries, refreshed_other_entries):
@@ -1207,6 +1220,16 @@ def _github_status_comments(ctx: FeatureContext):
             entry = json.try_decode(ctx.std.fs.read_to_string(json_path), None)
             if not entry:
                 continue
+
+            # JSON round-trip turns ReproFixCommand records into plain
+            # dicts; rehydrate them so downstream `_collect_repro_fix_rows`
+            # can do record-attribute access (`c.command`, `c.description`).
+            # Only touch keys that are present so entries from older
+            # aspect-cli releases pass through unchanged.
+            if "repro_commands" in entry:
+                entry["repro_commands"] = rehydrate_commands(entry["repro_commands"])
+            if "fix_commands" in entry:
+                entry["fix_commands"] = rehydrate_commands(entry["fix_commands"])
             cache[aid] = entry
             seen[aname] = entry
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -64,6 +64,7 @@ load(
 )
 load("../lib/bazel_results.axl", "compute_reproducer_command")
 load("../lib/github.axl", "github")
+load("../lib/repro_commands.axl", "rehydrate_commands")
 load("../lib/tips.axl", "tips")
 
 def _eq(label, got, want):
@@ -90,10 +91,21 @@ def _with_commands(data, repro = [], fix = []):
     in scenarios that need to assert the aggregator's repro / fix
     rendering — the producers normally append these at terminal-emit
     time, but the snapshot tests fabricate the artifact-payload
-    shape directly so the inputs are spelled out here."""
+    shape directly so the inputs are spelled out here.
+
+    Runs the dicts through `rehydrate_commands` so the fixture matches
+    what `_list_and_download_workflow_artifacts` hands the renderer
+    after the JSON round-trip — `ReproFixCommand` records, not raw
+    dicts. Without this the renderer would trip on `c.command`
+    record-attribute access.
+    """
     out = dict(data)
-    out["repro_commands"] = [{"command": c, "description": d} for (c, d) in repro]
-    out["fix_commands"] = [{"command": c, "description": d} for (c, d) in fix]
+    out["repro_commands"] = rehydrate_commands(
+        [{"command": c, "description": d, "slug": ""} for (c, d) in repro],
+    )
+    out["fix_commands"] = rehydrate_commands(
+        [{"command": c, "description": d, "slug": ""} for (c, d) in fix],
+    )
     return out
 
 def _body_for(kind, status, data):
@@ -307,12 +319,16 @@ def _entry(
     # Mirror the producer side: if the fixture's `data` doesn't carry
     # repro_commands, synthesize one the way bazel_runner does. Lets
     # existing fixtures exercise the "🔁 Reproduce" section without
-    # spelling out the list shape.
+    # spelling out the list shape. Run the dict through
+    # `rehydrate_commands` so the fixture matches what the production
+    # read path would deliver to the renderer (records, not raw dicts).
     if not data.get("repro_commands"):
         repro, _ = compute_reproducer_command(data, name)
         if repro:
             data = dict(data)
-            data["repro_commands"] = [{"command": repro, "description": ""}]
+            data["repro_commands"] = rehydrate_commands([
+                {"command": repro, "description": "", "slug": ""},
+            ])
     payload = results_subset(
         data,
         elapsed_ms,
@@ -961,6 +977,11 @@ def _check_repro_dedup_consecutive_headings(ctx):
     rendered body should carry the `#### ❌ buildifier (…)` heading
     exactly once under the Fix section, not twice.
     """
+
+    # Entries are shaped like what comes back from `_list_and_download_workflow_artifacts`
+    # after `json.try_decode`: plain dicts (records lost their type on JSON
+    # encode). The real read path rehydrates the command lists at the
+    # boundary; do the same here so we exercise the production code path.
     entries = [
         {
             "name": "buildifier",
@@ -969,13 +990,13 @@ def _check_repro_dedup_consecutive_headings(ctx):
             "kind": "format",
             "status": "failed",
             "elapsed_ms": 1000,
-            "repro_commands": [
-                {"command": "aspect buildifier --severity=fail", "description": ""},
-            ],
-            "fix_commands": [
-                {"command": "aspect buildifier --severity=info BUILD.bazel", "description": ""},
-                {"command": "bazel run --run_in_cwd @buildifier_prebuilt//buildifier -- -r .", "description": "vanilla bazel"},
-            ],
+            "repro_commands": rehydrate_commands([
+                {"command": "aspect buildifier --severity=fail", "description": "", "slug": "format-repro"},
+            ]),
+            "fix_commands": rehydrate_commands([
+                {"command": "aspect buildifier --severity=info BUILD.bazel", "description": "", "slug": "format-fix"},
+                {"command": "bazel run --run_in_cwd @buildifier_prebuilt//buildifier -- -r .", "description": "vanilla bazel", "slug": "format-fix-vanilla-bazel"},
+            ]),
         },
     ]
     prepared = prepare_for_render(entries)

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -469,6 +469,49 @@ def has_tools_bazel_wrapper(ctx) -> bool:
         return False
     return _TOOLS_BAZEL_WRAPPER_MARKER in ctx.std.fs.try_read_to_string(path)
 
+def rehydrate_commands(commands):
+    """Normalize a `repro_commands` / `fix_commands` list to
+    `[ReproFixCommand, ...]`.
+
+    Producers write `ReproFixCommand` records into the lists, but the
+    GitHub PR-comment publisher round-trips those lists through JSON
+    (per-task artifacts + the in-comment state block). After
+    `json.decode` each entry is a plain dict, which then fails
+    record-attribute access (`c.command`) downstream. Call this at the
+    deserialization boundary to convert the dicts back to records.
+
+    Idempotent: entries that are already records pass through
+    unchanged, so it's safe to apply this on every read without
+    knowing whether a particular list has been round-tripped.
+
+    Schema-tolerant: drops entries that aren't dicts or records, and
+    falls back to `""` for missing optional fields (`description`,
+    `slug`) so a state block written by an older aspect-cli release
+    (predating the `slug` field) still round-trips cleanly. Entries
+    that lack the required `command` field are also dropped.
+
+    `None` / empty input → `[]`.
+    """
+    if not commands:
+        return []
+    out = []
+    for c in commands:
+        if type(c) == "record":
+            out.append(c)
+            continue
+        if type(c) != "dict":
+            continue
+        cmd = c.get("command")
+        if type(cmd) != "string" or not cmd:
+            continue
+        out.append(ReproFixCommand(
+            command = cmd,
+            description = c.get("description") or "",
+            slug = c.get("slug") or "",
+            _hooked = bool(c.get("_hooked", False)),
+        ))
+    return out
+
 # ── CLI rendering ─────────────────────────────────────────────────────
 
 def print_repro_and_fix(std, data, status):

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -7,7 +7,7 @@ tests on `Arguments`.
 """
 
 load("./lifecycle.axl", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixCommand", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "repro_fix_replace")
-load("./repro_commands.axl", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "repro_prefix", "subdir_prefix")
+load("./repro_commands.axl", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "rehydrate_commands", "repro_prefix", "subdir_prefix")
 
 def _eq(label, got, want):
     if got != want:
@@ -171,7 +171,6 @@ def _test_repro_prefix_no_git_root_at_aspect_root(_ctx):
     fake = _fake_env("/project", None, aspect_root = "/project")
     _eq("at aspect_root, no git → empty", repro_prefix(fake), "")
 
-# ---------------------------------------------------------------------------
 # has_tools_bazel_wrapper — env-first, file-marker fallback
 # ---------------------------------------------------------------------------
 
@@ -261,6 +260,75 @@ def _test_wrapper_empty_file(_ctx):
         files = {"/repo/tools/bazel": (0, "")},
     )
     _eq("empty file → False", has_tools_bazel_wrapper(fake), False)
+
+# ---------------------------------------------------------------------------
+# rehydrate_commands — JSON round-trip recovery for repro/fix lists
+# ---------------------------------------------------------------------------
+
+def _test_rehydrate_dicts_become_records(_ctx):
+    out = rehydrate_commands([
+        {"command": "aspect lint", "description": "", "slug": "lint-repro"},
+        {"command": "aspect lint --fix", "description": "vanilla bazel", "slug": "lint-fix"},
+    ])
+    _eq("two entries rehydrated", len(out), 2)
+    _eq("type[0]", type(out[0]), "record")
+    _eq("command[0]", out[0].command, "aspect lint")
+    _eq("slug[1]", out[1].slug, "lint-fix")
+    _eq("description[1]", out[1].description, "vanilla bazel")
+
+def _test_rehydrate_passthrough_records(_ctx):
+    """Already-record entries pass through unchanged (idempotence)."""
+    rec = ReproFixCommand(command = "aspect build", slug = "build-repro")
+    out = rehydrate_commands([rec])
+    _eq("record passthrough preserves identity", out[0], rec)
+
+def _test_rehydrate_mixed_dicts_and_records(_ctx):
+    rec = ReproFixCommand(command = "aspect run //x", slug = "x-fix")
+    out = rehydrate_commands([rec, {"command": "aspect run //y", "slug": "y-fix"}])
+    _eq("mixed input length", len(out), 2)
+    _eq("mixed[0] is the record", out[0].command, "aspect run //x")
+    _eq("mixed[1] rehydrated", out[1].command, "aspect run //y")
+
+def _test_rehydrate_empty_inputs(_ctx):
+    _eq("None → []", rehydrate_commands(None), [])
+    _eq("empty list → []", rehydrate_commands([]), [])
+
+def _test_rehydrate_drops_non_dict_non_record(_ctx):
+    """Garbage entries (string, int, None) are dropped, valid ones kept."""
+    out = rehydrate_commands([
+        None,
+        "not-a-command",
+        42,
+        {"command": "aspect lint", "slug": "lint-fix"},
+    ])
+    _eq("only the valid dict survives", len(out), 1)
+    _eq("survivor command", out[0].command, "aspect lint")
+
+def _test_rehydrate_drops_missing_command(_ctx):
+    """Dicts without a usable `command` field are dropped."""
+    out = rehydrate_commands([
+        {"command": "", "slug": "lint-fix"},
+        {"slug": "lint-fix"},
+        {"command": None, "slug": "lint-fix"},
+        {"command": "aspect lint --fix", "slug": "lint-fix"},
+    ])
+    _eq("only the well-formed dict survives", len(out), 1)
+    _eq("survivor command", out[0].command, "aspect lint --fix")
+
+def _test_rehydrate_defaults_missing_optional_fields(_ctx):
+    """Legacy state-block entries (predating the slug field) still round-trip."""
+    out = rehydrate_commands([{"command": "aspect lint"}])
+    _eq("legacy entry survives", len(out), 1)
+    _eq("missing description defaults to ''", out[0].description, "")
+    _eq("missing slug defaults to ''", out[0].slug, "")
+    _eq("missing _hooked defaults to False", out[0]._hooked, False)
+
+def _test_rehydrate_preserves_hooked_flag(_ctx):
+    """`_hooked = True` from a serialized state block must survive
+    rehydration so dispatch_task_update doesn't re-run user hooks on
+    already-hooked entries."""
+    out = rehydrate_commands([{"command": "aspect lint", "slug": "lint-fix", "_hooked": True}])
+    _eq("_hooked carried through", out[0]._hooked, True)
 
 def _test_bazel_build_with_targets(_ctx):
     _eq(
@@ -897,6 +965,14 @@ _UNIT_TESTS = [
     _test_wrapper_oversized_file_skipped,
     _test_wrapper_no_bazel_root,
     _test_wrapper_empty_file,
+    _test_rehydrate_dicts_become_records,
+    _test_rehydrate_passthrough_records,
+    _test_rehydrate_mixed_dicts_and_records,
+    _test_rehydrate_empty_inputs,
+    _test_rehydrate_drops_non_dict_non_record,
+    _test_rehydrate_drops_missing_command,
+    _test_rehydrate_defaults_missing_optional_fields,
+    _test_rehydrate_preserves_hooked_flag,
     _test_bazel_build_with_targets,
     _test_bazel_test_with_targets,
     _test_bazel_run_single_target,


### PR DESCRIPTION
`aspect build` (or any task running with the `GithubStatusComments` feature enabled) crashed inside `_collect_repro_fix_rows` while rendering the PR-comment body:

```
error: Object of type `dict` has no attribute `command`
  --> feature/github_status_comments.axl:641:21
```

Producers append `ReproFixCommand` records to `data["repro_commands"]` / `data["fix_commands"]`, but the GHSC publisher round-trips entries through JSON twice — once when uploading the per-task artifact and again when reading sibling entries back from the artifact zip, plus the cross-workflow state block embedded in the comment body. JSON has no record type, so after `json.try_decode` each entry was a plain dict, and the downstream `c.command` / `c.description` record-attribute access tripped.

Fix: add `rehydrate_commands(commands)` in `lib/repro_commands.axl` that converts a list of dicts (or already-records) back to `[ReproFixCommand, ...]`. Idempotent (record entries pass through) and schema-tolerant (drops malformed entries, defaults `description` / `slug` to `""` for legacy state-block payloads that predate those fields). Called at the two deserialization boundaries in `github_status_comments.axl` — `_list_and_download_workflow_artifacts` (per-task artifact JSON) and `_parse_state` (in-comment state block).

PR-comment test fixtures (`_with_commands` + the inline-synthesized repro in the payload builder) now run their hand-built dict lists through `rehydrate_commands` too, matching what the production read path delivers to the renderer.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fix a crash in the GitHub PR-comment aggregator (`feature/github_status_comments.axl`) when rendering repro / fix command sections — entries read back from the per-task artifact JSON or the comment-body state block are now rehydrated into `ReproFixCommand` records before downstream attribute access. Affected any task running with `GithubStatusComments` enabled.

### Test plan

- `aspect dev test-repro-commands` — 60/60 pass (8 new `rehydrate_commands` cases: dicts→records, record passthrough, mixed lists, empty input, garbage dropped, missing `command` dropped, optional-field defaults, `_hooked` preserved).
- `aspect dev test-pr-comment-snapshots` — 20/20 scenarios render without error. The previously-failing `_check_repro_dedup_consecutive_headings` now passes.
- `aspect dev test-bk-annotation-snapshots` — 22/22 pass (BK doesn't round-trip, so it was unaffected; verified untouched).
- `aspect dev test-template-snapshots` — 18/18 pass.