### PR TITLE
Dim the bazel-announce INFO lines

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -174,6 +174,22 @@ def config(ctx: ConfigContext):
     lifecycle.repro_fix_suggestion.append(_buildifier_repro_fix)
     lifecycle.repro_fix_suggestion.append(_shorten_delivery_local_preview)
 
+    # Announce the resolved Bazel version on every task that supports it.
+    ctx.tasks["build"].args.announce_bazel_version = "true"
+    ctx.tasks["buildifier"].args.announce_bazel_version = "true"
+    ctx.tasks["format"].args.announce_bazel_version = "true"
+    ctx.tasks["gazelle"].args.announce_bazel_version = "true"
+    ctx.tasks["lint"].args.announce_bazel_version = "true"
+    ctx.tasks["test"].args.announce_bazel_version = "true"
+
+    # Announce the spawned Bazel command on every task that supports it.
+    ctx.tasks["build"].args.announce_bazel_command = "true"
+    ctx.tasks["buildifier"].args.announce_bazel_command = "true"
+    ctx.tasks["format"].args.announce_bazel_command = "true"
+    ctx.tasks["gazelle"].args.announce_bazel_command = "true"
+    ctx.tasks["lint"].args.announce_bazel_command = "true"
+    ctx.tasks["test"].args.announce_bazel_command = "true"
+
     # Template snapshot tests — renders bazel_results templates across failure modes.
     # Run with: aspect test-template-snapshots
     ctx.tasks.add(template_snapshot_tests)

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -576,8 +576,14 @@ def _repro_header(ansi, label):
     return "\x1b[1m" + label + "\x1b[0m" if ansi else label
 
 def _install_hint_line(ansi):
-    """Dim-formatted install hint printed under each repro/fix block."""
-    return ("\x1b[2m" + ASPECT_CLI_INSTALL_HINT + "\x1b[0m") if ansi else ASPECT_CLI_INSTALL_HINT
+    """Grey-formatted install hint printed under each repro/fix block.
+
+    Uses 256-color grey (`38;5;244`) rather than SGR 2 (faint): GitHub
+    Actions' log viewer silently drops SGR 2, and `color_enabled` is
+    true under GHA, so the hint would render at full weight on CI even
+    though the styling was applied.
+    """
+    return ("\x1b[38;5;244m" + ASPECT_CLI_INSTALL_HINT + "\x1b[0m") if ansi else ASPECT_CLI_INSTALL_HINT
 
 def _print_repro_entry(ansi, entry):
     """Print one `ReproFixCommand` entry as a fenced code block.
@@ -586,17 +592,18 @@ def _print_repro_entry(ansi, entry):
     printed flush-left, so the copy-paste region is unambiguous and can
     be selected without stripping leading whitespace.
 
-    Description renders as a dim `# <description>` shell-comment line
+    Description renders as a grey `# <description>` shell-comment line
     ABOVE the command — copy-paste still runs the command (bash ignores
     `#` lines), and the comment reads as a header explaining what's
-    coming.
+    coming. See `_install_hint_line` for why we use 256-color grey
+    instead of SGR 2 (faint).
     """
     if not entry.command:
         return
     print("```")
     if entry.description:
         comment = "# " + entry.description
-        print(("\x1b[2m" + comment + "\x1b[0m") if ansi else comment)
+        print(("\x1b[38;5;244m" + comment + "\x1b[0m") if ansi else comment)
     for line in entry.command.split("\n"):
         print(line)
     print("```")

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -628,14 +628,33 @@ fn payload_discriminant(p: &axl_proto::build_event_stream::build_event::Payload)
 /// invocation. Gated by the `--announce-bazel-version` / `--announce-bazel-command`
 /// task flags, resolved in AXL and passed through as `announce`.
 ///
-/// Plain (unstyled) to match Bazel's own `INFO:` output, which interleaves
-/// with these lines.
+/// Styled with ANSI dim so the long `INFO: Spawning:` line reads as
+/// background context next to bazel's own (undimmed) `INFO:` output. Falls
+/// back to plain text when stderr isn't a TTY and we're not on a recognized
+/// CI host — matching the gate used elsewhere in the runtime (see
+/// `multi_phase::running_verb_color`).
 fn announce_spawn(announce: AnnounceSpawn, version: Option<&semver::Version>, cmd: &Command) {
+    let (dim, reset) = dim_style();
     if announce.version {
-        eprintln!("INFO: {}", version_line(version));
+        eprintln!("{dim}INFO: {}{reset}", version_line(version));
     }
     if announce.command {
-        eprintln!("INFO: Spawning: {}", render_command(cmd));
+        eprintln!("{dim}INFO: Spawning: {}{reset}", render_command(cmd));
+    }
+}
+
+/// Return `(dim_prefix, reset)` ANSI escape pair for the announce lines.
+///
+/// Empty strings when stderr isn't a TTY and we're not on a recognized CI
+/// host, so file-captured / piped output stays plain. CI hosts (GitHub
+/// Actions, Buildkite, …) render ANSI in their log viewers even though
+/// stderr is a non-TTY pipe — same heuristic as `running_verb_color`.
+fn dim_style() -> (&'static str, &'static str) {
+    use std::io::IsTerminal;
+    if std::io::stderr().is_terminal() || crate::ci::on_recognized_ci() {
+        ("\x1b[2m", "\x1b[0m")
+    } else {
+        ("", "")
     }
 }
 

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -628,31 +628,37 @@ fn payload_discriminant(p: &axl_proto::build_event_stream::build_event::Payload)
 /// invocation. Gated by the `--announce-bazel-version` / `--announce-bazel-command`
 /// task flags, resolved in AXL and passed through as `announce`.
 ///
-/// Styled with ANSI dim so the long `INFO: Spawning:` line reads as
-/// background context next to bazel's own (undimmed) `INFO:` output. Falls
-/// back to plain text when stderr isn't a TTY and we're not on a recognized
-/// CI host — matching the gate used elsewhere in the runtime (see
+/// Styled in grey so the long `INFO: Spawning:` line reads as background
+/// context next to bazel's own (undimmed) `INFO:` output. Falls back to
+/// plain text when stderr isn't a TTY and we're not on a recognized CI host
+/// — matching the gate used elsewhere in the runtime (see
 /// `multi_phase::running_verb_color`).
 fn announce_spawn(announce: AnnounceSpawn, version: Option<&semver::Version>, cmd: &Command) {
-    let (dim, reset) = dim_style();
+    let (grey, reset) = grey_style();
     if announce.version {
-        eprintln!("{dim}INFO: {}{reset}", version_line(version));
+        eprintln!("{grey}INFO: {}{reset}", version_line(version));
     }
     if announce.command {
-        eprintln!("{dim}INFO: Spawning: {}{reset}", render_command(cmd));
+        eprintln!("{grey}INFO: Spawning: {}{reset}", render_command(cmd));
     }
 }
 
-/// Return `(dim_prefix, reset)` ANSI escape pair for the announce lines.
+/// Return `(grey_prefix, reset)` ANSI escape pair for the announce lines.
 ///
 /// Empty strings when stderr isn't a TTY and we're not on a recognized CI
 /// host, so file-captured / piped output stays plain. CI hosts (GitHub
 /// Actions, Buildkite, …) render ANSI in their log viewers even though
 /// stderr is a non-TTY pipe — same heuristic as `running_verb_color`.
-fn dim_style() -> (&'static str, &'static str) {
+///
+/// Uses 256-color grey (`38;5;244`) rather than SGR 2 (faint): GitHub
+/// Actions' log viewer silently drops SGR 2, which is the bug the original
+/// implementation hit. 256-color escapes are rendered by GHA, Buildkite,
+/// and every TTY we ship to, and match the grey `tools/bazel` itself uses
+/// for its `[tools/bazel]` trace line.
+fn grey_style() -> (&'static str, &'static str) {
     use std::io::IsTerminal;
     if std::io::stderr().is_terminal() || crate::ci::on_recognized_ci() {
-        ("\x1b[2m", "\x1b[0m")
+        ("\x1b[38;5;244m", "\x1b[0m")
     } else {
         ("", "")
     }

--- a/crates/bazelrc/src/lib.rs
+++ b/crates/bazelrc/src/lib.rs
@@ -251,8 +251,13 @@ impl BazelRC {
         home: Option<&Path>,
         redact: impl Fn(&str) -> String,
     ) -> String {
+        // `d` uses 256-color grey rather than SGR 2 (faint) because GitHub
+        // Actions' log viewer silently drops SGR 2 — the section keys would
+        // render at full weight on GHA even though the gate fired. Matches
+        // the styling aspect-cli's runtime announce lines and `tools/bazel`
+        // already use for grey output.
         let (b, d, y, r) = if ansi {
-            ("\x1b[1m", "\x1b[2m", "\x1b[33m", "\x1b[0m")
+            ("\x1b[1m", "\x1b[38;5;244m", "\x1b[33m", "\x1b[0m")
         } else {
             ("", "", "", "")
         };


### PR DESCRIPTION
Dim the `INFO: Bazel <version>` and `INFO: Spawning: <cmd>` lines that
the runtime emits before every `bazel build`/`test` spawn. The lines
get long — especially `Spawning:` with every default-override flag
listed — and they crowd out Bazel's own `INFO:` output. Wrapping them
in ANSI dim (SGR 2) makes them read as background context while
Bazel's own emitted INFO lines stay at normal weight.

Plain text when stderr isn't a TTY and we're not on a recognized CI
host — same gate `multi_phase::running_verb_color` uses, so file
captures and piped output stay clean.

The second commit turns both announce flags on in this repo's own
`.aspect/config.axl` so we exercise the styling on every local run,
not just under CI.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

The `INFO: Bazel …` / `INFO: Spawning: …` lines emitted by
`--announce-bazel-version` / `--announce-bazel-command` are now styled
with ANSI dim so they sit visually behind Bazel's own `INFO:` output.

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  Run any Bazel-spawning task with `--announce-bazel-version=true
  --announce-bazel-command=true` (or rely on this repo's
  `.aspect/config.axl` now that both flags are on) and confirm the
  two announce lines render dim while Bazel's own `INFO:` lines stay
  at normal weight. Pipe stderr to a file and confirm the saved
  output has no ANSI escapes.
