### PR TITLE
feat(bazel): capture Bazel stderr through a processing pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "hyperlocal",
  "include_dir",
  "keyring",
+ "libc",
  "liquid",
  "liquid-core",
  "md-5",
@@ -370,6 +371,7 @@ dependencies = [
  "prost",
  "psl",
  "rand 0.8.5",
+ "regex",
  "reqwest",
  "semver",
  "serde",
@@ -1193,7 +1195,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1312,7 +1314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3284,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.216"
+version = "2.1.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9826c2fe4dade07e9da1af2e18427257877bc8bc27aa810f6fbb52d907a480cc"
+checksum = "f558d33d882cb296fb65dbe0246b98b90e761fbe00c552701d2030eb5bbce63a"
 dependencies = [
  "psl-types",
 ]
@@ -3693,7 +3695,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3897,7 +3899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4517,7 +4519,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5481,7 +5483,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5591,15 +5593,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/crates/aspect-cli/src/builtins/aspect/bazel.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazel.axl
@@ -77,6 +77,13 @@ BazelTrait = trait(
     # each task's impl for lint/delivery.
     task_flags = attr(list[typing.Callable[[TaskContext], list[str]]], default = [], description = "Hooks returning additional flags; called with TaskContext at invocation time"),
 
+    # When True, the Bazel child's stderr is captured by the runtime, run
+    # through its output processing pipeline, and forwarded to the real stderr
+    # instead of being inherited directly. Uses a plain pipe in non-TTY
+    # contexts and a PTY interactively so the live progress UI is preserved.
+    # Default off → stderr is inherited and behavior is unchanged.
+    capture_output = attr(bool, default = False, description = "Capture the Bazel child's stderr, run it through the output processing pipeline, and forward it to the real stderr (instead of inheriting it directly)"),
+
     # Lifecycle hooks — lists of callables; callers close over their own state
     build_start = attr(list[typing.Callable[[TaskContext], None]], default = [], description = "Hooks called once before the Bazel invocation starts"),
     build_event = attr(list[typing.Callable[[TaskContext, dict], None]], default = [], description = "Hooks called for each Build Event Protocol event received during the build"),

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -276,7 +276,23 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     # forwarded as a flag rather than expanded to argv (the flag exists
     # to bypass OS command-line length limits). These are defaults the
     # user can still override via --bazel-flag=...
-    base_flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))]
+    #
+    # With output capture on, the child's stderr goes to a runtime-owned
+    # pipe/PTY (see `output_processor` below), so `--isatty` must match that
+    # captured fd rather than the parent's stdout: a PTY (TTY stderr) renders
+    # the curses UI (--isatty=1); a plain pipe gets clean lines
+    # (--isatty=0 --curses=no). With capture off, derive --isatty from the
+    # parent's stdout as before — the child inherits the terminal directly.
+    output_processor = None
+    if bazel_trait.capture_output:
+        capture_is_tty = ctx.std.io.stderr.is_tty
+        output_processor = bazel.output.processor(tty = capture_is_tty)
+        if capture_is_tty:
+            base_flags = ["--isatty=1"]
+        else:
+            base_flags = ["--isatty=0", "--curses=no"]
+    else:
+        base_flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))]
 
     # `--deployment <name>` wires the deployment's advertised endpoints:
     # --remote_cache / --remote_executor as base flags (user --bazel-flag still
@@ -402,6 +418,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
             invocation = ctx.bazel.test(
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
+                output = output_processor,
                 announce_version = announce_version,
                 announce_command = announce_command,
                 flags = invocation_flags,
@@ -411,6 +428,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
             invocation = ctx.bazel.build(
                 build_events = build_events,
                 execution_log = bazel_trait.execution_log_sinks or False,
+                output = output_processor,
                 announce_version = announce_version,
                 announce_command = announce_command,
                 flags = invocation_flags,

--- a/crates/axl-runtime/Cargo.toml
+++ b/crates/axl-runtime/Cargo.toml
@@ -37,7 +37,9 @@ http-body-util = "0.1.3"
 url = "2.5.4"
 zstd = "0.13.3"
 
-nix = { version = "0.30.1", features = ["fs", "signal"] }
+nix = { version = "0.30.1", features = ["fs", "signal", "term"] }
+libc = "0.2"
+regex = "1.11.3"
 wasmi = "0.51.0"
 wasmi_wasi = "0.51.0"
 

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -34,6 +34,7 @@ use axl_proto::build_event_stream::BuildEvent;
 use crate::engine::r#async::rt::AsyncRuntime;
 
 use super::iter::ExecutionLogIterator;
+use super::iter::OutputEventIterator;
 use super::iter::WorkspaceEventIterator;
 use super::sink::execlog::ExecLogSink;
 use super::sink::grpc;
@@ -43,6 +44,10 @@ use super::stream::BuildEventStream;
 use super::stream::ExecLogStream;
 use super::stream::Subscriber;
 use super::stream::WorkspaceEventStream;
+use super::stream::output::LineProcessor;
+use super::stream::processors::{
+    CollapseRepeats, LineMatcher, MatchResponder, OutputSignals, PendingMatch,
+};
 
 /// Convert a Starlark `Writable` handle to a `std::process::Stdio` for use
 /// as a child's stdio slot.
@@ -616,6 +621,140 @@ pub(crate) fn build_event_iter_methods(registry: &mut MethodsBuilder) {
     }
 }
 
+/// How the captured stderr fd is allocated for a build.
+///
+/// `Pipe` is a plain anonymous pipe for non-TTY contexts (CI, redirected
+/// output): Bazel emits clean newline-terminated lines. `Pty` allocates a
+/// pseudo-terminal so Bazel keeps its live curses UI, forwarded near-verbatim.
+/// The mode is chosen when the processor is constructed (see
+/// `bazel.output.processor`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureMode {
+    Pipe,
+    Pty,
+}
+
+/// Starlark handle passed as `ctx.bazel.build(output = ...)` to enable stderr
+/// capture + forwarding. Created via `bazel.output.processor(...)`; carries
+/// only configuration (patterns are pre-compiled regexes), so one handle can
+/// be reused across retry attempts — each `Build::spawn` builds a fresh
+/// pipeline and signal state from it.
+///
+/// `Build::spawn` reads the capture mode to allocate the child's stderr and
+/// assembles the processing chain from the remaining fields (see
+/// `super::stream::processors`): observer `LineMatcher` stages first (so they
+/// see every record as Bazel wrote it), then the `MatchResponder` (which may
+/// rewrite records), then `CollapseRepeats`.
+#[derive(Clone, Debug, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
+#[display("<bazel.output.OutputProcessor>")]
+pub struct OutputProcessor {
+    #[allocative(skip)]
+    mode: CaptureMode,
+    /// Fold runs of identical lines into one + a repeat-count annotation.
+    collapse_repeats: bool,
+    /// `(id, regex)` observer patterns; hits are recorded on `OutputSignals`
+    /// and exposed via `build.output_matches()`.
+    #[allocative(skip)]
+    match_patterns: Vec<(String, regex::Regex)>,
+    /// Regexes that latch `OutputSignals::fatal` (exposed via
+    /// `build.output_fatal` / `output_fatal_line`).
+    #[allocative(skip)]
+    fatal_patterns: Vec<(String, regex::Regex)>,
+    /// `(id, regex)` interactive patterns: a matching line is held until the
+    /// consumer of `build.output_events()` answers keep/replace/drop, or
+    /// `respond_timeout` fires (fail-open: original line forwards).
+    #[allocative(skip)]
+    respond_patterns: Vec<(String, regex::Regex)>,
+    #[allocative(skip)]
+    respond_timeout: std::time::Duration,
+}
+
+impl OutputProcessor {
+    pub fn new(
+        mode: CaptureMode,
+        collapse_repeats: bool,
+        match_patterns: Vec<(String, regex::Regex)>,
+        fatal_patterns: Vec<(String, regex::Regex)>,
+        respond_patterns: Vec<(String, regex::Regex)>,
+        respond_timeout: std::time::Duration,
+    ) -> Self {
+        Self {
+            mode,
+            collapse_repeats,
+            match_patterns,
+            fatal_patterns,
+            respond_patterns,
+            respond_timeout,
+        }
+    }
+
+    pub fn mode(&self) -> CaptureMode {
+        self.mode
+    }
+
+    /// Assemble the per-invocation pipeline, its shared signal state, and —
+    /// when `respond_patterns` are configured — the receiver
+    /// `build.output_events()` hands to the consumer.
+    fn build_pipeline(
+        &self,
+    ) -> (
+        Vec<Box<dyn LineProcessor>>,
+        Arc<OutputSignals>,
+        Option<std::sync::mpsc::Receiver<PendingMatch>>,
+    ) {
+        let signals = Arc::new(OutputSignals::default());
+        let mut chain: Vec<Box<dyn LineProcessor>> = vec![];
+        if !self.fatal_patterns.is_empty() {
+            let s = signals.clone();
+            chain.push(Box::new(LineMatcher::new(
+                self.fatal_patterns.clone(),
+                Box::new(move |_id, line| s.set_fatal(line)),
+            )));
+        }
+        if !self.match_patterns.is_empty() {
+            let s = signals.clone();
+            chain.push(Box::new(LineMatcher::new(
+                self.match_patterns.clone(),
+                Box::new(move |id, line| s.record_match(id, line)),
+            )));
+        }
+        let events = if self.respond_patterns.is_empty() {
+            None
+        } else {
+            let (tx, rx) = std::sync::mpsc::channel();
+            chain.push(Box::new(MatchResponder::new(
+                self.respond_patterns.clone(),
+                tx,
+                self.respond_timeout,
+            )));
+            Some(rx)
+        };
+        if self.collapse_repeats {
+            chain.push(Box::new(CollapseRepeats::new()));
+        }
+        (chain, signals, events)
+    }
+}
+
+impl<'v> AllocValue<'v> for OutputProcessor {
+    fn alloc_value(self, heap: Heap<'v>) -> Value<'v> {
+        heap.alloc_complex_no_freeze(self)
+    }
+}
+
+impl<'v> UnpackValue<'v> for OutputProcessor {
+    type Error = anyhow::Error;
+    fn unpack_value_impl(value: Value<'v>) -> Result<Option<Self>, Self::Error> {
+        let v = value
+            .downcast_ref_err::<OutputProcessor>()
+            .into_anyhow_result()?;
+        Ok(Some(v.clone()))
+    }
+}
+
+#[starlark_value(type = "bazel.output.OutputProcessor")]
+impl<'v> values::StarlarkValue<'v> for OutputProcessor {}
+
 fn matches_kinds(event: &BuildEvent, kinds: Option<&Arc<HashSet<i32>>>) -> bool {
     let Some(kinds) = kinds else {
         return true;
@@ -753,6 +892,26 @@ pub struct Build {
     #[allocative(skip)]
     execlog_stream: RefCell<Option<ExecLogStream>>,
 
+    /// Captured-stderr forwarder, present only when the build was spawned with
+    /// `output = bazel.output.processor(...)`. Joined in `wait()` after the
+    /// child is reaped so all forwarded stderr is flushed before the task
+    /// prints its terminal summary.
+    #[allocative(skip)]
+    output_stream: RefCell<Option<super::stream::OutputStream>>,
+
+    /// Shared state the capture pipeline's matcher stages feed (fatal flag,
+    /// match hits); backs the `output_fatal` / `output_fatal_line` attributes
+    /// and `output_matches()`. `None` when capture is off.
+    #[allocative(skip)]
+    output_signals: Option<Arc<OutputSignals>>,
+
+    /// Held-line events from the pipeline's `MatchResponder`, present only
+    /// when `respond_patterns` were configured. Taken (single-use) by
+    /// `output_events()`; a matched line stays held until the consumer
+    /// responds or the responder's fail-open timeout fires.
+    #[allocative(skip)]
+    output_events: RefCell<Option<std::sync::mpsc::Receiver<PendingMatch>>>,
+
     /// Shared UUID every gRPC sink indexes this invocation under. Minted
     /// before bazel emits `build_started` so forwarders can start
     /// immediately; distinct from Bazel's `build_started.uuid`.
@@ -792,6 +951,7 @@ impl Build {
         startup_flags: Vec<String>,
         stdout: Stdio,
         stderr: Stdio,
+        output: Option<OutputProcessor>,
         directory: Option<String>,
         announce: AnnounceSpawn,
         rt: AsyncRuntime,
@@ -893,12 +1053,49 @@ impl Build {
         announce_spawn(announce, version.as_ref(), &cmd);
 
         cmd.stdout(stdout);
-        cmd.stderr(stderr);
+        // When capturing, the child's stderr goes to a runtime-owned pipe/PTY
+        // instead of the resolved `stderr` Stdio; the `OutputStream` started
+        // after spawn reads, processes, and forwards it to the real stderr.
+        let mut capture = match &output {
+            Some(p) => {
+                let (child_stderr, capture) = super::capture::Capture::open(p.mode())?;
+                cmd.stderr(child_stderr);
+                Some(capture)
+            }
+            None => {
+                cmd.stderr(stderr);
+                None
+            }
+        };
         cmd.stdin(Stdio::null());
 
         let child = cmd
             .spawn()
             .map_err(|e| io::Error::other(format!("failed to spawn bazel: {e}")))?;
+
+        // Start forwarding captured stderr now that the child holds the write
+        // end. Drop the parent's PTY-slave copy first (release_after_spawn) so
+        // the master read can observe EOF when the child exits — otherwise the
+        // forwarder thread would hang forever in `wait()`.
+        //
+        // The forwarder writes to the real stderr on its own thread. Any
+        // aspect-cli stderr written on the main thread while the build runs
+        // (e.g. status lines) races it on a separate handle, so callers that
+        // capture output should route their own stderr elsewhere for the
+        // build's duration.
+        let (output_stream, output_signals, output_events) = match capture.take() {
+            Some(mut c) => {
+                c.release_after_spawn();
+                let (chain, signals, events) = output
+                    .as_ref()
+                    .expect("capture is only allocated when output is set")
+                    .build_pipeline();
+                let stream =
+                    super::stream::OutputStream::spawn(c.reader, Box::new(std::io::stderr()), chain);
+                (Some(stream), Some(signals), events)
+            }
+            None => (None, None, None),
+        };
 
         // Register the bazel client with the live-subprocess registry so
         // aspect-cli's OS-signal handler can forward SIGINT to it on
@@ -989,6 +1186,9 @@ impl Build {
             build_event_stream: RefCell::new(build_event_stream),
             workspace_event_stream: RefCell::new(workspace_event_stream),
             execlog_stream: RefCell::new(execlog_stream),
+            output_stream: RefCell::new(output_stream),
+            output_signals,
+            output_events: RefCell::new(output_events),
             sink_invocation_id: RefCell::new(sink_invocation_id),
             live_guard: RefCell::new(Some(live_guard)),
             span: RefCell::new(span),
@@ -1018,12 +1218,43 @@ impl<'v> values::StarlarkValue<'v> for Build {
                 let id = self.sink_invocation_id.borrow();
                 Some(heap.alloc_str(id.as_deref().unwrap_or("")).to_value())
             }
+            // Whether a fatal_pattern from `bazel.output.processor(...)`
+            // matched a captured stderr line. False when capture is off.
+            "output_fatal" => Some(heap.alloc(
+                self.output_signals
+                    .as_ref()
+                    .is_some_and(|s| s.fatal()),
+            )),
+            // The first fatal line matched, or None.
+            "output_fatal_line" => {
+                let line = self.output_signals.as_ref().and_then(|s| s.fatal_line());
+                Some(match line {
+                    Some(l) => heap.alloc_str(&l).to_value(),
+                    None => values::Value::new_none(),
+                })
+            }
+            // Millis of captured-stderr silence (since the last byte, or since
+            // spawn if none arrived). 0 when capture is off or after `wait()`
+            // has drained the stream — poll it mid-build, alongside child
+            // liveness, to detect a hung invocation.
+            "output_idle_ms" => {
+                let idle = self
+                    .output_stream
+                    .borrow()
+                    .as_ref()
+                    .map(|s| s.idle_ms())
+                    .unwrap_or(0);
+                Some(heap.alloc(idle.min(i32::MAX as u64) as i32))
+            }
             _ => None,
         }
     }
 
     fn has_attr(&self, attribute: &str, _heap: values::Heap<'v>) -> bool {
-        matches!(attribute, "sink_invocation_id")
+        matches!(
+            attribute,
+            "sink_invocation_id" | "output_fatal" | "output_fatal_line" | "output_idle_ms"
+        )
     }
 }
 
@@ -1051,6 +1282,37 @@ pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
         ))?;
 
         Ok(WorkspaceEventIterator::new(event_stream.receiver()))
+    }
+
+    /// The held-line event stream for this build's `respond_patterns`
+    /// (see `bazel.output.processor`). Single-use: the first call takes the
+    /// stream; drain it with `try_pop()` during the build and answer each
+    /// event with `keep()` / `replace(text)` / `drop()`. A matched line is
+    /// not forwarded to the terminal until answered (or the fail-open
+    /// timeout forwards the original), so drain promptly.
+    fn output_events<'v>(this: values::Value<'v>) -> anyhow::Result<OutputEventIterator> {
+        let build = this.downcast_ref_err::<Build>().into_anyhow_result()?;
+        let recv = build.output_events.borrow_mut().take().ok_or_else(|| {
+            anyhow::anyhow!(
+                "output_events() is single-use and requires `output = \
+                 bazel.output.processor(respond_patterns = {{...}})` on the build"
+            )
+        })?;
+        Ok(OutputEventIterator::new(recv))
+    }
+
+    /// Snapshot of `(id, line)` hits for the `match_patterns` configured on
+    /// this build's `bazel.output.processor(...)`. Safe to call during the
+    /// build (hits so far) or after `wait()` (all hits). Empty when capture
+    /// is off or nothing matched. At most 1024 hits are recorded per
+    /// invocation; lines are truncated to 2048 bytes.
+    fn output_matches<'v>(this: values::Value<'v>) -> anyhow::Result<Vec<(String, String)>> {
+        let build = this.downcast_ref_err::<Build>().into_anyhow_result()?;
+        Ok(build
+            .output_signals
+            .as_ref()
+            .map(|s| s.matches())
+            .unwrap_or_default())
     }
 
     fn try_wait<'v>(this: values::Value<'v>) -> anyhow::Result<NoneOr<BuildStatus>> {
@@ -1124,6 +1386,18 @@ pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
             }
         };
 
+        // Drain the captured-stderr forwarder. The child has exited (reaped
+        // above), so its stderr write end is closed and the reader reaches
+        // EOF; joining here guarantees all forwarded stderr is flushed before
+        // the caller (`_emit_terminal`) prints the task's terminal summary.
+        let output_stream = build.output_stream.take();
+        if let Some(mut output_stream) = output_stream {
+            match output_stream.join() {
+                Ok(_) => {}
+                Err(err) => anyhow::bail!("output stream thread error: {}", err),
+            }
+        };
+
         // Drop the span to end the trace
         drop(build.span.replace(tracing::Span::none()));
 
@@ -1138,6 +1412,83 @@ pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
 mod tests {
     //! End-to-end coverage of `ctx.bazel.build` via the `basil` fake-bazel
     //! binary, selected per-test via `--scenario=<name>`.
+
+    /// `OutputProcessor::build_pipeline` assembles matcher stages before the
+    /// collapser, so matchers see every record — including the repeats the
+    /// collapser folds away.
+    #[test]
+    fn output_pipeline_matchers_see_collapsed_repeats() {
+        use crate::engine::bazel::stream::OutputStream;
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct SharedSink(Arc<Mutex<Vec<u8>>>);
+        impl Write for SharedSink {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let rx = |p: &str| regex::Regex::new(p).unwrap();
+        let processor = super::OutputProcessor::new(
+            super::CaptureMode::Pipe,
+            true,
+            vec![("warn".to_string(), rx("^WARNING:"))],
+            vec![(
+                "Server terminated abruptly".to_string(),
+                rx("Server terminated abruptly"),
+            )],
+            vec![("secret".to_string(), rx("password"))],
+            std::time::Duration::from_secs(5),
+        );
+        let (chain, signals, events) = processor.build_pipeline();
+
+        // Consumer thread standing in for AXL: rewrite the matched line.
+        let events = events.expect("respond_patterns configured");
+        let consumer = std::thread::spawn(move || {
+            for ev in events {
+                let reply = ev.reply.clone();
+                let _ = reply.send(super::super::stream::processors::Verdict::Replace(
+                    b"(password elided)".to_vec(),
+                ));
+            }
+        });
+
+        let input = b"WARNING: flaky\nWARNING: flaky\nWARNING: flaky\npassword=hunter2\nServer terminated abruptly\n";
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let mut stream = OutputStream::spawn(
+            Box::new(std::io::Cursor::new(input.to_vec())),
+            Box::new(SharedSink(sink.clone())),
+            chain,
+        );
+        stream.join().unwrap();
+        consumer.join().unwrap();
+
+        // Forwarded output: repeats collapsed, matched line replaced by the
+        // consumer's verdict before display.
+        let out = String::from_utf8(sink.lock().unwrap().clone()).unwrap();
+        assert_eq!(
+            out,
+            "WARNING: flaky\n(last line repeated 2 more times)\n(password elided)\nServer terminated abruptly\n"
+        );
+
+        // Matchers ran before the collapser: every repeat was a hit.
+        let hits = signals.matches();
+        assert_eq!(hits.len(), 3);
+        assert!(hits.iter().all(|(id, _)| id == "warn"));
+
+        // The fatal pattern latched with its line.
+        assert!(signals.fatal());
+        assert_eq!(
+            signals.fatal_line().as_deref(),
+            Some("Server terminated abruptly")
+        );
+    }
 
     /// Iter handle subscribed pre-spawn receives every event from a clean
     /// build, even on the warm-daemon path that drops late subscribers.
@@ -1168,6 +1519,94 @@ def _impl(ctx):
     if started != 1: return 2
     if finished != 1: return 3
     if other != 0: return 4
+    return 0
+
+Test = task(implementation = _impl)
+"#,
+        )
+        .with_fake_bazel()
+        .run_task(0)
+        .expect("run_task");
+
+        assert_eq!(exit, Some(0));
+    }
+
+    /// The captured-output Starlark surface end-to-end against a real spawn:
+    /// `bazel.output.processor(...)` arg unpacking, `output=` on
+    /// `ctx.bazel.build`, and the `output_*` attributes / `output_matches()`.
+    /// basil emits nothing on stderr in the success scenario, so signals stay
+    /// at their defaults — the point is the plumbing, not the matching (the
+    /// pipeline itself is covered by `output_pipeline_matchers_see_collapsed_repeats`).
+    #[test]
+    fn output_processor_starlark_surface() {
+        let exit = crate::test::eval(
+            r#"
+def _impl(ctx):
+    processor = bazel.output.processor(
+        tty = False,
+        collapse_repeats = True,
+        match_patterns = {"warn": "WARNING:"},
+        fatal_patterns = ["Server terminated abruptly"],
+    )
+    build = ctx.bazel.build(
+        flags = ["--scenario=success"],
+        output = processor,
+    )
+    status = build.wait()
+    if not status.success: return 1
+    if build.output_fatal: return 2
+    if build.output_fatal_line != None: return 3
+    if build.output_matches() != []: return 4
+    if build.output_idle_ms < 0: return 5
+    return 0
+
+Test = task(implementation = _impl)
+"#,
+        )
+        .with_fake_bazel()
+        .run_task(0)
+        .expect("run_task");
+
+        assert_eq!(exit, Some(0));
+    }
+
+    /// The interactive respond/replace flow end-to-end from Starlark: basil
+    /// emits console lines on stderr; AXL drains `output_events()`, replaces
+    /// the credential line and keeps the rest; observer patterns record hits.
+    /// The blocking `for` over the iterator also proves the stream closes
+    /// (and the loop exits) when the capture pipeline ends.
+    #[test]
+    fn output_events_respond_and_replace() {
+        let exit = crate::test::eval(
+            r#"
+def _impl(ctx):
+    processor = bazel.output.processor(
+        tty = False,
+        match_patterns = {"warn": "^WARNING:"},
+        respond_patterns = {"secret": "password"},
+    )
+    build = ctx.bazel.build(
+        flags = ["--scenario=stderr_chatter"],
+        output = processor,
+    )
+    events = build.output_events()
+    replaced = 0
+    kept = 0
+    for ev in events:
+        if ev.id == "secret":
+            ev.replace("(password elided)")
+            replaced += 1
+        else:
+            ev.keep()
+            kept += 1
+    status = build.wait()
+    if not status.success: return 1
+    if replaced != 1: return 2
+    if kept != 0: return 3
+    matches = build.output_matches()
+    if len(matches) != 1: return 4
+    if matches[0][0] != "warn": return 5
+    if build.output_fatal: return 6
     return 0
 
 Test = task(implementation = _impl)

--- a/crates/axl-runtime/src/engine/bazel/capture.rs
+++ b/crates/axl-runtime/src/engine/bazel/capture.rs
@@ -1,0 +1,311 @@
+//! Allocate the captured-stderr fd for a Bazel invocation.
+//!
+//! When a build is spawned with `output = bazel.output.processor(...)`, the
+//! child's stderr must go to a fd the runtime controls instead of being
+//! inherited, so [`super::stream::OutputStream`] can read, process, and forward
+//! it. Two modes:
+//!
+//! - [`CaptureMode::Pipe`] — a plain anonymous pipe. Used in non-TTY contexts;
+//!   Bazel emits clean newline-terminated lines.
+//! - [`CaptureMode::Pty`] — a pseudo-terminal. The slave becomes the child's
+//!   stderr; we read the master. Bazel keeps its live curses UI. Unix-only;
+//!   callers fall back to `Pipe` on platforms without `openpty`.
+//!
+//! # The slave-drop discipline (PTY)
+//!
+//! The parent MUST drop its copy of the PTY slave fd right after spawning the
+//! child, or the master read never sees EOF and the forwarder thread hangs
+//! forever. [`Capture`] holds the slave in `parent_slave` precisely so the
+//! caller can drop it (via [`Capture::release_after_spawn`]) at the right
+//! moment — after `cmd.spawn()` has dup'd it into the child.
+
+use std::io::Read;
+use std::process::Stdio;
+
+use super::build::CaptureMode;
+
+/// The parent's side of a captured invocation: the read end the forwarder
+/// consumes, and (PTY only) the retained slave fd.
+///
+/// The child's stderr `Stdio` is returned separately by [`Capture::open`] so
+/// the caller moves it straight into the `Command` and this handle owns only
+/// what the parent keeps.
+pub struct Capture {
+    /// The read end the `OutputStream` reads from.
+    pub reader: Box<dyn Read + Send>,
+    /// PTY slave fd retained by the parent; dropped after spawn so the master
+    /// can observe EOF. `None` for the pipe path.
+    parent_slave: Option<std::fs::File>,
+}
+
+impl Capture {
+    /// Drop the parent's retained slave fd (no-op for the pipe path). Call
+    /// immediately after `cmd.spawn()` so the master can observe EOF once the
+    /// child exits.
+    pub fn release_after_spawn(&mut self) {
+        self.parent_slave = None;
+    }
+
+    /// Allocate the capture fds for `mode`, returning the child's stderr
+    /// `Stdio` alongside the parent-side handle. Falls back to a pipe if PTY
+    /// allocation isn't available on this platform or fails.
+    pub fn open(mode: CaptureMode) -> std::io::Result<(Stdio, Capture)> {
+        match mode {
+            CaptureMode::Pipe => open_pipe(),
+            CaptureMode::Pty => match open_pty() {
+                Ok(c) => Ok(c),
+                Err(e) => {
+                    crate::trace!("PTY capture unavailable ({e}); falling back to pipe");
+                    open_pipe()
+                }
+            },
+        }
+    }
+}
+
+/// Anonymous pipe: the child writes the write end (its stderr), we read the
+/// read end.
+///
+/// Both ends are opened `O_CLOEXEC` so a concurrent `fork`+`exec` on another
+/// thread can't leak the write end into an unrelated child — a leaked writer
+/// would keep the read end from ever seeing EOF, hanging the forwarder. The
+/// child's own stderr is set up by `Command`'s `Stdio` dup, which re-clears
+/// CLOEXEC on fd 2, so the child still inherits it correctly.
+#[cfg(unix)]
+fn open_pipe() -> std::io::Result<(Stdio, Capture)> {
+    use std::os::fd::FromRawFd;
+
+    // `pipe(2)` (not `pipe2`, which macOS lacks) + explicit CLOEXEC on both
+    // ends. CLOEXEC keeps a concurrent `fork`+`exec` on another thread from
+    // leaking the writer into an unrelated child — a leaked writer would keep
+    // the reader from ever seeing EOF, hanging the forwarder. `Command`'s
+    // `Stdio` dup re-clears CLOEXEC on the child's fd 2, so the Bazel child
+    // still inherits its stderr.
+    let mut fds = [0_i32; 2];
+    // SAFETY: `pipe` writes two valid fds into `fds` on success; each is
+    // wrapped in an owning `File` exactly once below.
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let reader = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let writer = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+    set_cloexec(&reader)?;
+    set_cloexec(&writer)?;
+    Ok((
+        Stdio::from(writer),
+        Capture {
+            reader: Box::new(reader),
+            parent_slave: None,
+        },
+    ))
+}
+
+#[cfg(not(unix))]
+fn open_pipe() -> std::io::Result<(Stdio, Capture)> {
+    Err(std::io::Error::other(
+        "output capture is only supported on Unix",
+    ))
+}
+
+/// Allocate a PTY, returning the master as the reader and the slave as the
+/// child's stderr. The slave is dup'd: one copy goes to the child (via the
+/// `Stdio`), one is retained in `parent_slave` to be dropped after spawn.
+///
+/// All three fds are `O_CLOEXEC`. The master and the parent's retained slave
+/// must not leak into any child. The slave handed to the child is `CLOEXEC`
+/// too — `Command` re-clears it on fd 2 via the `Stdio` dup, so the Bazel
+/// child still gets it, but a concurrent `fork`+`exec` on another thread can't
+/// leak it into an unrelated child (which would keep the master from ever
+/// seeing EOF and hang the forwarder).
+#[cfg(unix)]
+fn open_pty() -> std::io::Result<(Stdio, Capture)> {
+    use nix::pty::openpty;
+    use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+
+    // Seed the slave winsize from the real terminal so Bazel wraps at the
+    // right width; best-effort (ignored if stderr isn't a terminal).
+    let winsize = current_winsize();
+    let pty = openpty(winsize.as_ref(), None).map_err(std::io::Error::from)?;
+    let master: OwnedFd = pty.master;
+    let slave: OwnedFd = pty.slave;
+
+    set_cloexec(&master)?;
+    set_cloexec(&slave)?;
+
+    // Two owning handles to the slave: one becomes the child's stderr Stdio,
+    // one is retained so the parent can hold the slave open until just after
+    // spawn (then drop it so the master observes EOF on child exit).
+    let slave_for_child = slave.try_clone()?; // inherits CLOEXEC
+    let child_stderr = unsafe { Stdio::from_raw_fd(slave_for_child.into_raw_fd()) };
+    let parent_slave = unsafe { std::fs::File::from_raw_fd(slave.into_raw_fd()) };
+    let reader = unsafe { std::fs::File::from_raw_fd(master.into_raw_fd()) };
+
+    Ok((
+        child_stderr,
+        Capture {
+            reader: Box::new(reader),
+            parent_slave: Some(parent_slave),
+        },
+    ))
+}
+
+#[cfg(not(unix))]
+fn open_pty() -> std::io::Result<(Stdio, Capture)> {
+    Err(std::io::Error::other("PTY capture is only supported on Unix"))
+}
+
+#[cfg(unix)]
+fn set_cloexec<F: std::os::fd::AsFd>(fd: &F) -> std::io::Result<()> {
+    use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+    let raw = fcntl(fd, FcntlArg::F_GETFD).map_err(std::io::Error::from)?;
+    let mut flags = FdFlag::from_bits_truncate(raw);
+    flags.insert(FdFlag::FD_CLOEXEC);
+    fcntl(fd, FcntlArg::F_SETFD(flags)).map_err(std::io::Error::from)?;
+    Ok(())
+}
+
+/// The current terminal's window size, read from the real stderr. `None` when
+/// stderr isn't a terminal (the PTY then uses the kernel default).
+#[cfg(unix)]
+fn current_winsize() -> Option<nix::pty::Winsize> {
+    use std::io::IsTerminal;
+    use std::os::fd::AsRawFd;
+    let stderr = std::io::stderr();
+    if !stderr.is_terminal() {
+        return None;
+    }
+    let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+    // SAFETY: TIOCGWINSZ writes a `winsize` through the pointer; we pass a
+    // valid stack slot and check the return code.
+    let rc = unsafe { libc::ioctl(stderr.as_raw_fd(), libc::TIOCGWINSZ, &mut ws) };
+    if rc != 0 {
+        return None;
+    }
+    Some(nix::pty::Winsize {
+        ws_row: ws.ws_row,
+        ws_col: ws.ws_col,
+        ws_xpixel: ws.ws_xpixel,
+        ws_ypixel: ws.ws_ypixel,
+    })
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::engine::bazel::stream::OutputStream;
+    use std::io::Write;
+    use std::process::Command;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct SharedSink(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedSink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// End-to-end through the real capture machinery + `OutputStream`: open a
+    /// capture, spawn a child whose stderr is the captured fd, forward to a
+    /// sink, and assert the forwarder drains everything and terminates (no
+    /// hang). This exercises the slave-drop / EOF / EIO discipline that the
+    /// `Cursor`-based `OutputStream` unit tests can't.
+    fn round_trip(mode: CaptureMode) {
+        let (child_stderr, mut capture) = Capture::open(mode).expect("open capture");
+
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("printf 'err line 1\\nerr line 2\\n' 1>&2")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(child_stderr)
+            .spawn()
+            .expect("spawn child");
+
+        // The #1 PTY mistake: the parent must drop its slave copy so the
+        // master read observes EOF. (No-op for the pipe path.)
+        capture.release_after_spawn();
+
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let mut stream = OutputStream::spawn(
+            capture.reader,
+            Box::new(SharedSink(sink.clone())),
+            vec![],
+        );
+
+        child.wait().expect("child wait");
+        // join() must return — if the slave/EOF handling were wrong this hangs.
+        stream.join().expect("stream join");
+
+        let out = String::from_utf8_lossy(&sink.lock().unwrap()).into_owned();
+        assert!(out.contains("err line 1"), "missing line 1 in {out:?}");
+        assert!(out.contains("err line 2"), "missing line 2 in {out:?}");
+    }
+
+    #[test]
+    fn pipe_round_trip() {
+        round_trip(CaptureMode::Pipe);
+    }
+
+    #[test]
+    fn pty_round_trip() {
+        round_trip(CaptureMode::Pty);
+    }
+
+    /// An unrelated child spawned while the capture is open must NOT inherit
+    /// the captured fd. Without `CLOEXEC` on the pipe/PTY ends, a long-lived
+    /// interposer would keep the write end open and the forwarder would never
+    /// see EOF after the real child exits — hanging `join()` forever.
+    ///
+    /// Here `sleep 30` inherits the parent's fds (default `Command` stdio). The
+    /// real child then writes and exits; the forwarder must terminate promptly
+    /// despite the sleep still running.
+    fn cloexec_no_hang(mode: CaptureMode) {
+        let (child_stderr, mut capture) = Capture::open(mode).expect("open capture");
+
+        // Interposer spawned AFTER the capture fds exist, BEFORE the real
+        // child — the exact window in which a non-CLOEXEC fd would leak.
+        let mut interposer = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn interposer");
+
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("printf 'done\\n' 1>&2")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(child_stderr)
+            .spawn()
+            .expect("spawn child");
+        capture.release_after_spawn();
+
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let mut stream =
+            OutputStream::spawn(capture.reader, Box::new(SharedSink(sink.clone())), vec![]);
+
+        child.wait().expect("child wait");
+        // Terminates only because the interposer did NOT inherit the write end.
+        stream.join().expect("stream join");
+        let _ = interposer.kill();
+        let _ = interposer.wait();
+
+        let out = String::from_utf8_lossy(&sink.lock().unwrap()).into_owned();
+        assert!(out.contains("done"), "missing forwarded output in {out:?}");
+    }
+
+    #[test]
+    fn pipe_cloexec_no_hang() {
+        cloexec_no_hang(CaptureMode::Pipe);
+    }
+
+    #[test]
+    fn pty_cloexec_no_hang() {
+        cloexec_no_hang(CaptureMode::Pty);
+    }
+}

--- a/crates/axl-runtime/src/engine/bazel/iter/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/iter/mod.rs
@@ -1,5 +1,7 @@
 mod execlog;
+mod output;
 mod workspace_event;
 
 pub use execlog::ExecutionLogIterator;
+pub use output::{OutputEventIterator, OutputMatch};
 pub use workspace_event::WorkspaceEventIterator;

--- a/crates/axl-runtime/src/engine/bazel/iter/output.rs
+++ b/crates/axl-runtime/src/engine/bazel/iter/output.rs
@@ -1,0 +1,209 @@
+//! Starlark surface for the captured-output respond/replace flow.
+//!
+//! `build.output_events()` returns an [`OutputEventIterator`] over
+//! [`OutputMatch`] events, one per captured line that matched a
+//! `respond_patterns` regex. The line is **held** — not yet forwarded to the
+//! terminal — until the event is answered with `keep()`, `replace(text)`, or
+//! `drop()`, or the processor's fail-open timeout forwards the original.
+//! Drain with `try_pop()` from a tick loop (or `for` to block):
+//!
+//! ```python
+//! events = build.output_events()
+//! for _tick in sleep_iter(50):
+//!     ev = events.try_pop()
+//!     if ev:
+//!         ev.replace("(elided)") if "secret" in ev.line else ev.keep()
+//!     if events.done:
+//!         break
+//! ```
+
+use std::cell::{Cell, RefCell};
+use std::sync::mpsc;
+
+use allocative::Allocative;
+use derive_more::Display;
+use starlark::StarlarkResultExt;
+use starlark::environment::Methods;
+use starlark::environment::MethodsBuilder;
+use starlark::environment::MethodsStatic;
+use starlark::starlark_module;
+use starlark::values;
+use starlark::values::AllocValue;
+use starlark::values::Heap;
+use starlark::values::NoSerialize;
+use starlark::values::ProvidesStaticType;
+use starlark::values::Trace;
+use starlark::values::ValueLike;
+use starlark::values::none::{NoneOr, NoneType};
+use starlark::values::starlark_value;
+
+use crate::engine::bazel::stream::processors::{PendingMatch, Verdict};
+
+/// A captured line held for a verdict. Answer exactly once with `keep()`,
+/// `replace(text)`, or `drop()`; an unanswered event fails open (the original
+/// line forwards after the processor's timeout).
+#[derive(Debug, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
+#[display("<bazel.output.OutputMatch id={id}>")]
+pub struct OutputMatch {
+    id: String,
+    line: String,
+    #[allocative(skip)]
+    reply: RefCell<Option<mpsc::SyncSender<Verdict>>>,
+}
+
+impl OutputMatch {
+    fn respond(&self, verdict: Verdict) -> anyhow::Result<()> {
+        let sender = self.reply.borrow_mut().take().ok_or_else(|| {
+            anyhow::anyhow!("this OutputMatch was already responded to; respond exactly once")
+        })?;
+        // The reader may have timed out and moved on — a closed channel is
+        // not an error, the verdict is simply too late to apply.
+        let _ = sender.send(verdict);
+        Ok(())
+    }
+}
+
+impl<'v> AllocValue<'v> for OutputMatch {
+    fn alloc_value(self, heap: Heap<'v>) -> values::Value<'v> {
+        heap.alloc_complex_no_freeze(self)
+    }
+}
+
+#[starlark_value(type = "bazel.output.OutputMatch")]
+impl<'v> values::StarlarkValue<'v> for OutputMatch {
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(output_match_methods)
+    }
+
+    fn get_attr(&self, attribute: &str, heap: Heap<'v>) -> Option<values::Value<'v>> {
+        match attribute {
+            "id" => Some(heap.alloc_str(&self.id).to_value()),
+            "line" => Some(heap.alloc_str(&self.line).to_value()),
+            _ => None,
+        }
+    }
+
+    fn has_attr(&self, attribute: &str, _heap: Heap<'v>) -> bool {
+        matches!(attribute, "id" | "line")
+    }
+}
+
+#[starlark_module]
+fn output_match_methods(registry: &mut MethodsBuilder) {
+    /// Release the held line unchanged.
+    fn keep<'v>(this: values::Value<'v>) -> anyhow::Result<NoneType> {
+        let ev = this.downcast_ref_err::<OutputMatch>().into_anyhow_result()?;
+        ev.respond(Verdict::Keep)?;
+        Ok(NoneType)
+    }
+
+    /// Forward `text` in place of the held line (its original `\n`/`\r`
+    /// boundary is preserved; embedded newlines in `text` are allowed).
+    fn replace<'v>(
+        this: values::Value<'v>,
+        #[starlark(require = pos)] text: &str,
+    ) -> anyhow::Result<NoneType> {
+        let ev = this.downcast_ref_err::<OutputMatch>().into_anyhow_result()?;
+        ev.respond(Verdict::Replace(text.as_bytes().to_vec()))?;
+        Ok(NoneType)
+    }
+
+    /// Suppress the held line entirely (boundary included).
+    fn drop<'v>(this: values::Value<'v>) -> anyhow::Result<NoneType> {
+        let ev = this.downcast_ref_err::<OutputMatch>().into_anyhow_result()?;
+        ev.respond(Verdict::Drop)?;
+        Ok(NoneType)
+    }
+}
+
+/// Iterator over [`OutputMatch`] events. Single-use handle returned by
+/// `build.output_events()`. `try_pop()` is the non-blocking drain for tick
+/// loops; `for` iteration blocks until the stream closes.
+#[derive(Debug, ProvidesStaticType, Display, Trace, NoSerialize, Allocative)]
+#[display("<bazel.output.OutputEventIterator>")]
+pub struct OutputEventIterator {
+    #[allocative(skip)]
+    recv: RefCell<mpsc::Receiver<PendingMatch>>,
+    #[allocative(skip)]
+    done: Cell<bool>,
+}
+
+impl OutputEventIterator {
+    pub fn new(recv: mpsc::Receiver<PendingMatch>) -> Self {
+        Self {
+            recv: RefCell::new(recv),
+            done: Cell::new(false),
+        }
+    }
+}
+
+fn to_match(p: PendingMatch) -> OutputMatch {
+    OutputMatch {
+        id: p.id,
+        line: p.line,
+        reply: RefCell::new(Some(p.reply)),
+    }
+}
+
+impl<'v> AllocValue<'v> for OutputEventIterator {
+    fn alloc_value(self, heap: Heap<'v>) -> values::Value<'v> {
+        heap.alloc_complex_no_freeze(self)
+    }
+}
+
+#[starlark_module]
+fn output_event_iterator_methods(registry: &mut MethodsBuilder) {
+    /// Non-blocking pop: the next held-line event, or `None` when nothing is
+    /// pending (or the stream has closed — check `done`).
+    fn try_pop<'v>(this: values::Value<'v>) -> anyhow::Result<NoneOr<OutputMatch>> {
+        let iter = this
+            .downcast_ref_err::<OutputEventIterator>()
+            .into_anyhow_result()?;
+        match iter.recv.borrow().try_recv() {
+            Ok(p) => Ok(NoneOr::Other(to_match(p))),
+            Err(mpsc::TryRecvError::Empty) => Ok(NoneOr::None),
+            Err(mpsc::TryRecvError::Disconnected) => {
+                iter.done.set(true);
+                Ok(NoneOr::None)
+            }
+        }
+    }
+}
+
+#[starlark_value(type = "bazel.output.OutputEventIterator")]
+impl<'v> values::StarlarkValue<'v> for OutputEventIterator {
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(output_event_iterator_methods)
+    }
+
+    fn get_attr(&self, attribute: &str, heap: Heap<'v>) -> Option<values::Value<'v>> {
+        match attribute {
+            // True once the capture stream has ended and no more events can
+            // arrive (set after a `try_pop` observes the disconnect).
+            "done" => Some(heap.alloc(self.done.get())),
+            _ => None,
+        }
+    }
+
+    fn has_attr(&self, attribute: &str, _heap: Heap<'v>) -> bool {
+        matches!(attribute, "done")
+    }
+
+    unsafe fn iterate(&self, me: values::Value<'v>, _heap: Heap<'v>) -> starlark::Result<values::Value<'v>> {
+        Ok(me)
+    }
+
+    unsafe fn iter_next(&self, _index: usize, heap: Heap<'v>) -> Option<values::Value<'v>> {
+        match self.recv.borrow().recv() {
+            Ok(p) => Some(to_match(p).alloc_value(heap)),
+            Err(_) => {
+                self.done.set(true);
+                None
+            }
+        }
+    }
+
+    unsafe fn iter_stop(&self) {}
+}

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -36,6 +36,7 @@ use axl_types::stream::Writable;
 mod aspect;
 mod build;
 mod cancel;
+mod capture;
 mod health_check;
 mod info;
 mod iter;
@@ -437,6 +438,11 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     /// * `stdio` - Shorthand: set both `stdout` and `stderr` from a single
     ///   `Stdio` bundle (typically `ctx.std.io`). Cannot be combined with
     ///   `stdout`/`stderr`.
+    /// * `output` - An `OutputProcessor` from `bazel.output.processor(...)`.
+    ///   When set, the child's stderr is captured by the runtime, run through
+    ///   the output processing pipeline, and forwarded to the real stderr
+    ///   (overriding the resolved `stderr` slot). Omit (the default) to leave
+    ///   stderr handling to `stderr`/`stdio`/inherit.
     /// * `directory` - Working directory for the Bazel invocation; selects
     ///   the workspace / server (used for git-worktree execution).
     /// * `announce_version` - Print an `INFO: Bazel <version>` line before
@@ -492,6 +498,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named)] stdout: Option<NoneOr<Writable>>,
         #[starlark(require = named)] stderr: Option<NoneOr<Writable>>,
         #[starlark(require = named, default = NoneOr::None)] stdio: NoneOr<StdStdio>,
+        #[starlark(require = named, default = NoneOr::None)] output: NoneOr<build::OutputProcessor>,
         #[starlark(require = named, default = NoneOr::None)] directory: NoneOr<String>,
         #[starlark(require = named, default = false)] announce_version: bool,
         #[starlark(require = named, default = false)] announce_command: bool,
@@ -523,6 +530,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             resolved_startup_flags,
             stdout,
             stderr,
+            output.into_option(),
             directory.into_option(),
             build::AnnounceSpawn {
                 version: announce_version,
@@ -559,6 +567,11 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     /// * `stdio` - Shorthand: set both `stdout` and `stderr` from a single
     ///   `Stdio` bundle (typically `ctx.std.io`). Cannot be combined with
     ///   `stdout`/`stderr`.
+    /// * `output` - An `OutputProcessor` from `bazel.output.processor(...)`.
+    ///   When set, the child's stderr is captured by the runtime, run through
+    ///   the output processing pipeline, and forwarded to the real stderr
+    ///   (overriding the resolved `stderr` slot). Omit (the default) to leave
+    ///   stderr handling to `stderr`/`stdio`/inherit.
     /// * `directory` - Working directory for the Bazel invocation; selects
     ///   the workspace / server (used for git-worktree execution).
     /// * `announce_version` - Print an `INFO: Bazel <version>` line before
@@ -612,6 +625,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named)] stdout: Option<NoneOr<Writable>>,
         #[starlark(require = named)] stderr: Option<NoneOr<Writable>>,
         #[starlark(require = named, default = NoneOr::None)] stdio: NoneOr<StdStdio>,
+        #[starlark(require = named, default = NoneOr::None)] output: NoneOr<build::OutputProcessor>,
         #[starlark(require = named, default = NoneOr::None)] directory: NoneOr<String>,
         #[starlark(require = named, default = false)] announce_version: bool,
         #[starlark(require = named, default = false)] announce_command: bool,
@@ -643,6 +657,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             resolved_startup_flags,
             stdout,
             stderr,
+            output.into_option(),
             directory.into_option(),
             build::AnnounceSpawn {
                 version: announce_version,
@@ -1183,6 +1198,139 @@ fn parse_event_kind<'v>(value: values::Value<'v>) -> anyhow::Result<i32> {
 }
 
 #[starlark_module]
+fn register_output(globals: &mut GlobalsBuilder) {
+    /// Create a captured-output processor. Pass it as
+    /// `ctx.bazel.build(output = bazel.output.processor(...))` to capture the
+    /// child's stderr, run it through the processing pipeline, and forward it
+    /// to the real stderr instead of letting Bazel write the terminal directly.
+    ///
+    /// # Arguments
+    /// * `tty` - Whether the destination stderr is an interactive terminal.
+    ///   `True` → allocate a PTY so Bazel keeps its live curses progress UI
+    ///   (bytes forwarded near-verbatim). `False` → a plain pipe, so Bazel
+    ///   emits clean newline-terminated lines. Defaults to auto-detecting the
+    ///   real stderr, but a caller that also sets Bazel flags should pass an
+    ///   explicit value so the one decision drives both.
+    /// * `collapse_repeats` - Fold runs of consecutive identical lines into
+    ///   the first occurrence plus a `(last line repeated N more times)`
+    ///   annotation. Meant for the pipe (non-TTY) mode, where Bazel emits
+    ///   line-oriented output.
+    /// * `match_patterns` - `{id: regex}` observer patterns matched against
+    ///   every captured line. Hits are recorded and readable — during or after
+    ///   the build — via `build.output_matches()` as `(id, line)` tuples
+    ///   (capped at 1024 hits; lines truncated to 2048 bytes). Drive hooks
+    ///   and features from these, e.g. in a `bazel_attempt_end` handler.
+    /// * `fatal_patterns` - Regexes that, when matched, latch
+    ///   `build.output_fatal` and record the first such line in
+    ///   `build.output_fatal_line` — the health signal for reacting to a
+    ///   wedged server (cancel the invocation, mark the runner unhealthy).
+    ///   `build.output_idle_ms` complements this for silence-based stall
+    ///   detection.
+    /// * `respond_patterns` - `{id: regex}` interactive patterns. A matching
+    ///   line is **held** — not yet shown to the user — and surfaced as an
+    ///   event on `build.output_events()`; answer it with `keep()`,
+    ///   `replace(text)`, or `drop()` to control what is forwarded. Output
+    ///   order is preserved (everything behind the held line waits), so
+    ///   drain the events promptly from your build loop. An unanswered event
+    ///   fails open after `respond_timeout_ms`: the original line forwards.
+    /// * `respond_timeout_ms` - Fail-open deadline per held line
+    ///   (default 1000). A slow or absent consumer delays matched lines by at
+    ///   most this much and never wedges the build.
+    ///
+    /// All patterns are [regex](https://docs.rs/regex) syntax and are
+    /// compiled here — an invalid pattern errors at construction.
+    ///
+    /// The caller must set `--isatty` / `--curses` on the Bazel invocation to
+    /// match: `--isatty=1` for a PTY, `--isatty=0 --curses=no` for a pipe
+    /// (see `bazel_runner.axl`).
+    ///
+    /// **Example**
+    ///
+    /// ```python
+    /// processor = bazel.output.processor(
+    ///     tty = ctx.std.io.stderr.is_tty,
+    ///     collapse_repeats = True,
+    ///     match_patterns = {"oom": r"java\.lang\.OutOfMemoryError"},
+    ///     fatal_patterns = [r"Server terminated abruptly"],
+    ///     respond_patterns = {"cred": r"password|token"},
+    /// )
+    /// build = ctx.bazel.build("//...", output = processor, flags = ["--isatty=0", "--curses=no"])
+    /// events = build.output_events()
+    /// for _tick in sleep_iter(50):
+    ///     ev = events.try_pop()
+    ///     if ev:
+    ///         ev.replace("(credential elided)")  # or ev.keep() / ev.drop()
+    ///     if events.done:
+    ///         break
+    /// status = build.wait()
+    /// if build.output_fatal:
+    ///     print("bazel server died: " + (build.output_fatal_line or ""))
+    /// for id, line in build.output_matches():
+    ///     print("matched " + id + ": " + line)
+    /// ```
+    #[starlark(as_type = build::OutputProcessor)]
+    fn processor(
+        #[starlark(require = named, default = NoneOr::None)] tty: NoneOr<bool>,
+        #[starlark(require = named, default = false)] collapse_repeats: bool,
+        #[starlark(require = named, default = UnpackDictEntries::default())]
+        match_patterns: UnpackDictEntries<String, String>,
+        #[starlark(require = named, default = UnpackList::default())] fatal_patterns: UnpackList<
+            String,
+        >,
+        #[starlark(require = named, default = UnpackDictEntries::default())]
+        respond_patterns: UnpackDictEntries<String, String>,
+        #[starlark(require = named, default = 1000)] respond_timeout_ms: i32,
+    ) -> anyhow::Result<build::OutputProcessor> {
+        use std::io::IsTerminal;
+        let is_tty = match tty {
+            NoneOr::Other(b) => b,
+            NoneOr::None => std::io::stderr().is_terminal(),
+        };
+        let mode = if is_tty {
+            build::CaptureMode::Pty
+        } else {
+            build::CaptureMode::Pipe
+        };
+        if respond_timeout_ms <= 0 {
+            anyhow::bail!("respond_timeout_ms must be > 0, got {respond_timeout_ms}");
+        }
+        let compile = |(id, pattern): (String, String)| -> anyhow::Result<(String, regex::Regex)> {
+            let re = regex::Regex::new(&pattern)
+                .map_err(|e| anyhow::anyhow!("invalid regex for '{id}': {e}"))?;
+            Ok((id, re))
+        };
+        Ok(build::OutputProcessor::new(
+            mode,
+            collapse_repeats,
+            match_patterns
+                .entries
+                .into_iter()
+                .map(compile)
+                .collect::<anyhow::Result<Vec<_>>>()?,
+            fatal_patterns
+                .items
+                .into_iter()
+                .map(|p| compile((p.clone(), p)))
+                .collect::<anyhow::Result<Vec<_>>>()?,
+            respond_patterns
+                .entries
+                .into_iter()
+                .map(compile)
+                .collect::<anyhow::Result<Vec<_>>>()?,
+            std::time::Duration::from_millis(respond_timeout_ms as u64),
+        ))
+    }
+}
+
+#[starlark_module]
+fn register_output_types(globals: &mut GlobalsBuilder) {
+    const OutputProcessor: StarlarkValueAsType<build::OutputProcessor> = StarlarkValueAsType::new();
+    const OutputMatch: StarlarkValueAsType<iter::OutputMatch> = StarlarkValueAsType::new();
+    const OutputEventIterator: StarlarkValueAsType<iter::OutputEventIterator> =
+        StarlarkValueAsType::new();
+}
+
+#[starlark_module]
 fn register_execlog_sinks(globals: &mut GlobalsBuilder) {
     #[starlark(as_type = sink::execlog::ExecLogSink)]
     fn file(
@@ -1248,6 +1396,11 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
 
     globals.namespace("build_events", |globals| {
         register_build_events(globals);
+    });
+
+    globals.namespace("output", |globals| {
+        register_output_types(globals);
+        register_output(globals);
     });
 
     globals.namespace("execution_log", |globals| {

--- a/crates/axl-runtime/src/engine/bazel/stream/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/mod.rs
@@ -1,6 +1,8 @@
 pub mod broadcaster;
 pub mod build_event;
 pub mod execlog;
+pub mod output;
+pub mod processors;
 pub mod redaction;
 mod util;
 pub mod workspace_event;
@@ -8,4 +10,5 @@ pub mod workspace_event;
 pub use broadcaster::Subscriber;
 pub use build_event::BuildEventStream;
 pub use execlog::ExecLogStream;
+pub use output::OutputStream;
 pub use workspace_event::WorkspaceEventStream;

--- a/crates/axl-runtime/src/engine/bazel/stream/output.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/output.rs
@@ -1,0 +1,457 @@
+//! Captured-output stream: read the Bazel child's stderr, run each record
+//! through an extensible processing pipeline, and forward the surviving bytes
+//! to the parent's real stderr.
+//!
+//! # Why this exists
+//!
+//! By default the Bazel child inherits the parent's stderr fd
+//! (`Stdio::inherit()`), so its output reaches the terminal untouched and we
+//! can't pre-process it. When a task opts into output capture, `Build::spawn`
+//! hands the child a captured fd (a pipe in non-TTY contexts, a PTY master's
+//! slave in interactive ones) and starts an `OutputStream` over the read end.
+//!
+//! # Design
+//!
+//! This mirrors [`super::build_event::BuildEventStream`]: a single dedicated
+//! reader thread, owned by the `Build`, joined inside `Build::wait`. Unlike the
+//! BES path it does **not** fan out through the unbounded
+//! [`super::broadcaster::Broadcaster`] — that clones per subscriber into
+//! unbounded buffers, a memory hazard for a high-volume byte stream. Instead
+//! the reader forwards straight to the parent stderr with a blocking `write`,
+//! so a slow terminal back-pressures the kernel pipe/PTY buffer and ultimately
+//! Bazel itself, bounding memory for free.
+//!
+//! # Record splitting and snappiness
+//!
+//! Bazel's curses progress UI rewrites in place with bare `\r` (carriage
+//! return, no newline). Splitting only on `\n` would buffer the whole progress
+//! region until a real newline arrived, freezing the live UI. So the loop
+//! treats both `\r` and `\n` as record boundaries, and flushes the forward
+//! writer once per `read()` syscall (not per newline — `LineWriter` would
+//! reintroduce the freeze). The kernel already batches bytes into one read, so
+//! a per-read flush is cheap and keeps output snappy.
+//!
+//! # Processing pipeline
+//!
+//! Each record passes through an ordered [`LineProcessor`] chain before it is
+//! forwarded; an empty chain forwards every record verbatim. A stage can
+//! transform a record, drop it (with its boundary), or hold state across
+//! records and flush it at end-of-stream via [`LineProcessor::finish`].
+//! Built-in stages live in [`super::processors`]: repeated-line collapsing
+//! and pattern matching for hooks and health signals.
+
+use std::io::ErrorKind;
+use std::io::Read;
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::Instant;
+
+use thiserror::Error;
+
+/// Read buffer size per `read()` syscall. One read's worth of bytes is the
+/// natural flush boundary (see module docs).
+const READ_BUF_SIZE: usize = 8 * 1024;
+
+/// Hard cap on the in-flight incomplete record. A pathological producer that
+/// never emits `\r`/`\n` would otherwise grow `carry` without bound; past this
+/// we force-flush the partial bytes so memory stays bounded.
+const MAX_CARRY_BYTES: usize = 1024 * 1024;
+
+#[derive(Error, Debug)]
+pub enum OutputStreamError {
+    #[error("io error: {0}")]
+    IO(#[from] std::io::Error),
+}
+
+/// A single processing stage applied to each output record before it is
+/// forwarded.
+///
+/// A `record` is the bytes between two boundaries, *excluding* the boundary
+/// byte itself (`\r` or `\n`), so processors operate on logical-line content.
+/// Stages run on the reader thread — they must never block, or forwarding
+/// stalls.
+pub trait LineProcessor: Send {
+    /// Transform one record. `Some(bytes)` forwards those bytes followed by
+    /// the record's original boundary; the bytes may differ from the input
+    /// and may contain embedded newlines (e.g. an annotation line prepended
+    /// to the record). `None` drops the record *and* its boundary — return
+    /// `Some(vec![])` instead to keep a blank line.
+    fn process(&mut self, record: &[u8]) -> Option<Vec<u8>>;
+
+    /// Called once at end-of-stream; any returned bytes are forwarded as-is
+    /// (include trailing newlines as needed). Lets a stateful stage flush
+    /// held state, e.g. a pending repeat count.
+    fn finish(&mut self) -> Option<Vec<u8>> {
+        None
+    }
+}
+
+#[derive(Debug)]
+pub struct OutputStream {
+    /// Reader thread handle, in an `Option` so `join()` can `take()` it
+    /// without consuming `self`.
+    handle: Option<JoinHandle<Result<(), OutputStreamError>>>,
+
+    /// When the stream started, paired with `last_activity_ms` to answer
+    /// [`OutputStream::idle_ms`].
+    started: Instant,
+
+    /// Millis-since-start of the last read that returned bytes. The reader
+    /// bumps it on every such read; `idle_ms()` derives silence duration from
+    /// it so a caller can detect a stalled invocation (child alive, no output).
+    last_activity_ms: Arc<AtomicU64>,
+}
+
+impl OutputStream {
+    /// Spawn the reader/forwarder thread.
+    ///
+    /// `reader` is the read end of the captured stderr (a pipe or a PTY master).
+    /// `forward` is the parent's real stderr. `processors` is the per-record
+    /// pipeline; an empty list forwards every record verbatim.
+    ///
+    /// The thread runs until the reader reaches EOF — on Unix a pipe returns a
+    /// 0-length read when the write end closes, while a PTY master returns
+    /// `EIO` once the child closes the slave; both are treated as clean
+    /// end-of-stream. The parent must drop its copy of the captured fd /
+    /// PTY slave after spawning the child, or this read never terminates.
+    pub fn spawn(
+        mut reader: Box<dyn Read + Send>,
+        mut forward: Box<dyn Write + Send>,
+        mut processors: Vec<Box<dyn LineProcessor>>,
+    ) -> OutputStream {
+        let started = Instant::now();
+        let last_activity_ms = Arc::new(AtomicU64::new(0));
+        let thread_activity = last_activity_ms.clone();
+
+        let handle = thread::spawn(move || -> Result<(), OutputStreamError> {
+            let start = Instant::now();
+            let mut buf = [0u8; READ_BUF_SIZE];
+            let mut carry: Vec<u8> = Vec::with_capacity(READ_BUF_SIZE);
+
+            loop {
+                let n = match reader.read(&mut buf) {
+                    Ok(0) => break, // clean EOF (pipe write end closed)
+                    Ok(n) => n,
+                    // PTY master read after the child closes the slave returns
+                    // EIO on Linux — that is end-of-stream, not an error.
+                    Err(e) if is_pty_eof(&e) => break,
+                    Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                    Err(e) => {
+                        // Flush whatever we have, then surface the error.
+                        let _ = flush_carry(&mut carry, &mut processors, &mut forward);
+                        let _ = forward.flush();
+                        return Err(OutputStreamError::IO(e));
+                    }
+                };
+
+                thread_activity.store(start.elapsed().as_millis() as u64, Ordering::Relaxed);
+
+                carry.extend_from_slice(&buf[..n]);
+                process_carry(&mut carry, &mut processors, &mut forward)?;
+
+                // Bound the incomplete-record buffer: a producer that never
+                // emits a boundary byte must not grow `carry` unboundedly.
+                // Flush it as a record through the pipeline (not raw) so a
+                // processor sees the same byte stream it would for a normal
+                // record.
+                if carry.len() > MAX_CARRY_BYTES {
+                    flush_carry(&mut carry, &mut processors, &mut forward)?;
+                }
+
+                // Flush once per read so the `\r`-driven progress UI stays live.
+                forward.flush()?;
+            }
+
+            // Drain the trailing partial record (output with no final
+            // newline), then let each stage flush any held state.
+            flush_carry(&mut carry, &mut processors, &mut forward)?;
+            for p in processors.iter_mut() {
+                if let Some(out) = p.finish() {
+                    forward.write_all(&out)?;
+                }
+            }
+            forward.flush()?;
+            Ok(())
+        });
+
+        OutputStream {
+            handle: Some(handle),
+            started,
+            last_activity_ms,
+        }
+    }
+
+    /// Millis since the last read that returned bytes (since stream start if
+    /// none have arrived). A caller polling this alongside child liveness can
+    /// detect a hung invocation.
+    pub fn idle_ms(&self) -> u64 {
+        let elapsed = self.started.elapsed().as_millis() as u64;
+        elapsed.saturating_sub(self.last_activity_ms.load(Ordering::Relaxed))
+    }
+
+    /// Wait for the reader thread to finish (after the child's captured fd has
+    /// reached EOF). Called from `Build::wait` after `child.wait()`.
+    pub fn join(&mut self) -> Result<(), OutputStreamError> {
+        if let Some(handle) = self.handle.take() {
+            match handle.join() {
+                Ok(result) => result,
+                Err(_) => Err(OutputStreamError::IO(std::io::Error::other(
+                    "output stream thread panicked",
+                ))),
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Split complete records (terminated by `\r` or `\n`) out of `carry`, run each
+/// through the pipeline, and forward the survivors plus their boundary byte
+/// (a dropped record drops its boundary too). Leaves the trailing incomplete
+/// record in `carry`.
+fn process_carry(
+    carry: &mut Vec<u8>,
+    processors: &mut [Box<dyn LineProcessor>],
+    forward: &mut Box<dyn Write + Send>,
+) -> Result<(), OutputStreamError> {
+    let mut start = 0;
+    let mut i = 0;
+    while i < carry.len() {
+        let b = carry[i];
+        if b == b'\n' || b == b'\r' {
+            let record = &carry[start..i];
+            if emit_record(record, processors, forward)? {
+                forward.write_all(&[b])?;
+            }
+            i += 1;
+            start = i;
+        } else {
+            i += 1;
+        }
+    }
+    if start > 0 {
+        carry.drain(..start);
+    }
+    Ok(())
+}
+
+/// Emit the buffered incomplete record (no boundary byte) through the pipeline
+/// and clear `carry`. Used at EOF and when `carry` exceeds its size cap.
+fn flush_carry(
+    carry: &mut Vec<u8>,
+    processors: &mut [Box<dyn LineProcessor>],
+    forward: &mut Box<dyn Write + Send>,
+) -> Result<(), OutputStreamError> {
+    if !carry.is_empty() {
+        emit_record(carry, processors, forward)?;
+        carry.clear();
+    }
+    Ok(())
+}
+
+/// Run one record through the processor chain and forward the result,
+/// returning whether the record survived (`false` = some stage dropped it,
+/// so its boundary byte must be suppressed too). With an empty chain the
+/// record is forwarded verbatim.
+fn emit_record(
+    record: &[u8],
+    processors: &mut [Box<dyn LineProcessor>],
+    forward: &mut Box<dyn Write + Send>,
+) -> Result<bool, OutputStreamError> {
+    if processors.is_empty() {
+        forward.write_all(record)?;
+        return Ok(true);
+    }
+    let mut current = record.to_vec();
+    for p in processors.iter_mut() {
+        match p.process(&current) {
+            Some(out) => current = out,
+            None => return Ok(false),
+        }
+    }
+    forward.write_all(&current)?;
+    Ok(true)
+}
+
+/// Whether an error reading a captured fd should be treated as end-of-stream.
+/// A PTY master read after the child closes the slave returns `EIO` on Linux;
+/// macOS typically returns a 0-length read instead (handled by the `Ok(0)`
+/// arm). We treat any `EIO` as EOF, accepting that a genuine mid-stream I/O
+/// error would drop the tail rather than surface — the expected PTY teardown
+/// path dominates.
+#[cfg(unix)]
+fn is_pty_eof(e: &std::io::Error) -> bool {
+    e.raw_os_error() == Some(libc::EIO)
+}
+
+#[cfg(not(unix))]
+fn is_pty_eof(_e: &std::io::Error) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// A `Write` sink that records everything written, shared with the test
+    /// thread via `Arc<Mutex<…>>`.
+    #[derive(Clone)]
+    struct SharedSink(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedSink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Feed `input` through a fresh `OutputStream` with the given `processors`
+    /// and return everything forwarded.
+    fn run_with(input: &[u8], processors: Vec<Box<dyn LineProcessor>>) -> Vec<u8> {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let reader = std::io::Cursor::new(input.to_vec());
+        let mut stream =
+            OutputStream::spawn(Box::new(reader), Box::new(SharedSink(sink.clone())), processors);
+        stream.join().unwrap();
+        let out = sink.lock().unwrap().clone();
+        out
+    }
+
+    fn run(input: &[u8]) -> Vec<u8> {
+        run_with(input, vec![])
+    }
+
+    #[test]
+    fn passthrough_newline_delimited() {
+        let input = b"line one\nline two\nline three\n";
+        assert_eq!(run(input), input);
+    }
+
+    #[test]
+    fn passthrough_preserves_carriage_returns() {
+        // The curses-style progress stream: bare \r, no newline.
+        let input = b"[1 / 9] Building\r[2 / 9] Building\r[3 / 9] Building\r";
+        assert_eq!(run(input), input);
+    }
+
+    #[test]
+    fn flushes_trailing_partial_record() {
+        // No trailing newline — must still be forwarded.
+        let input = b"no trailing newline";
+        assert_eq!(run(input), input);
+    }
+
+    #[test]
+    fn mixed_cr_lf() {
+        let input = b"progress\rprogress\rdone\n";
+        assert_eq!(run(input), input);
+    }
+
+    #[test]
+    fn empty_input_eof() {
+        assert_eq!(run(b""), b"");
+    }
+
+    #[test]
+    fn carry_cap_force_flushes_giant_line() {
+        // A record larger than MAX_CARRY_BYTES with no boundary must still be
+        // forwarded in full (in chunks), never dropped or grown unbounded.
+        let big = vec![b'x'; MAX_CARRY_BYTES + 4096];
+        assert_eq!(run(&big), big);
+    }
+
+    /// A processor that drops records equal to the immediately-previous one,
+    /// exercising the `None`-drops-a-record path of the pipeline.
+    struct ConsecutiveDedup {
+        prev: Option<Vec<u8>>,
+    }
+
+    impl LineProcessor for ConsecutiveDedup {
+        fn process(&mut self, record: &[u8]) -> Option<Vec<u8>> {
+            if self.prev.as_deref() == Some(record) {
+                return None;
+            }
+            self.prev = Some(record.to_vec());
+            Some(record.to_vec())
+        }
+    }
+
+    #[test]
+    fn processor_can_drop_records() {
+        // Second "a" record dropped along with its newline boundary.
+        let out = run_with(b"a\na\nb\n", vec![Box::new(ConsecutiveDedup { prev: None })]);
+        assert_eq!(out, b"a\nb\n");
+    }
+
+    #[test]
+    fn empty_output_keeps_blank_line() {
+        // Some(vec![]) blanks the record but keeps its boundary.
+        struct Blank;
+        impl LineProcessor for Blank {
+            fn process(&mut self, _record: &[u8]) -> Option<Vec<u8>> {
+                Some(vec![])
+            }
+        }
+        assert_eq!(run_with(b"a\nb\n", vec![Box::new(Blank)]), b"\n\n");
+    }
+
+    #[test]
+    fn finish_flushes_held_state_at_eof() {
+        // A stage that swallows every record and emits a summary on finish.
+        struct CountOnly {
+            n: usize,
+        }
+        impl LineProcessor for CountOnly {
+            fn process(&mut self, _record: &[u8]) -> Option<Vec<u8>> {
+                self.n += 1;
+                None
+            }
+            fn finish(&mut self) -> Option<Vec<u8>> {
+                Some(format!("{} lines\n", self.n).into_bytes())
+            }
+        }
+        let out = run_with(b"a\nb\nc\n", vec![Box::new(CountOnly { n: 0 })]);
+        assert_eq!(out, b"3 lines\n");
+    }
+
+    /// A processor that rewrites the record bytes (uppercases), exercising the
+    /// `Some(transformed)` path.
+    struct Upcase;
+    impl LineProcessor for Upcase {
+        fn process(&mut self, record: &[u8]) -> Option<Vec<u8>> {
+            Some(record.to_ascii_uppercase())
+        }
+    }
+
+    #[test]
+    fn processor_can_transform_records() {
+        let out = run_with(b"hi\nthere\n", vec![Box::new(Upcase)]);
+        assert_eq!(out, b"HI\nTHERE\n");
+    }
+
+    #[test]
+    fn processor_chain_runs_in_order() {
+        // Upcase then drop-consecutive: "a\nA\n" upcases to two "A" records, the
+        // second of which the dedup stage (seeing the upcased bytes) collapses.
+        let out = run_with(
+            b"a\nA\nb\n",
+            vec![Box::new(Upcase), Box::new(ConsecutiveDedup { prev: None })],
+        );
+        assert_eq!(out, b"A\nB\n");
+    }
+
+    #[test]
+    fn carry_cap_flush_runs_through_pipeline() {
+        // A >cap record with no boundary is flushed mid-stream; it must still
+        // pass through the processor (here, uppercased), not be forwarded raw.
+        let big = vec![b'x'; MAX_CARRY_BYTES + 4096];
+        let out = run_with(&big, vec![Box::new(Upcase)]);
+        assert_eq!(out, big.to_ascii_uppercase());
+    }
+}

--- a/crates/axl-runtime/src/engine/bazel/stream/processors.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/processors.rs
@@ -1,0 +1,461 @@
+//! Built-in [`LineProcessor`] stages for the captured-output pipeline.
+//!
+//! Four capabilities, chained by `Build::spawn` as: observers
+//! ([`LineMatcher`]) first so they see every record, then the responder
+//! ([`MatchResponder`]) which may rewrite records, then [`CollapseRepeats`]
+//! which dedups whatever the earlier stages produced:
+//!
+//! - **Noise reduction** — [`CollapseRepeats`] folds runs of identical lines
+//!   into the first occurrence plus a `(last line repeated N more times)`
+//!   annotation. Intended for the pipe (non-TTY) capture mode where Bazel
+//!   emits clean line-oriented output.
+//! - **Pattern-driven hooks** — [`LineMatcher`] scans each record against
+//!   configured regexes and invokes a callback per hit, forwarding the
+//!   record unchanged. What the callback does is the caller's business.
+//! - **Health signals** — [`OutputSignals`] is the shared state a
+//!   [`LineMatcher`] callback typically feeds: a fatal flag + first fatal
+//!   line, and a bounded list of match hits. `Build` exposes it to Starlark
+//!   (`output_fatal`, `output_fatal_line`, `output_matches()`) so tasks can
+//!   react — e.g. cancel a wedged invocation or mark a runner unhealthy.
+//! - **Interactive respond/replace** — [`MatchResponder`] holds a matching
+//!   record, ships it to a consumer (AXL) as a [`PendingMatch`], and blocks
+//!   forwarding until a [`Verdict`] arrives or the timeout fires. This is
+//!   what lets AXL rewrite or suppress a line *before* the user sees it;
+//!   see the type docs for the ordering and fail-open contract.
+//!
+//! All stages run on the reader thread; `LineMatcher`/`CollapseRepeats` work
+//! is bounded and non-blocking (the `OutputSignals` mutexes are only ever
+//! held briefly), while `MatchResponder` blocks by design — bounded by its
+//! timeout — only on records that match.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use regex::Regex;
+
+use super::output::LineProcessor;
+
+/// Cap on recorded match hits; further hits still fire callbacks/flags but are
+/// not stored, so a pathological pattern can't grow memory unboundedly.
+const MAX_RECORDED_MATCHES: usize = 1024;
+
+/// Cap on the stored copy of a matched/fatal line.
+const MAX_RECORDED_LINE_BYTES: usize = 2048;
+
+/// Collapse runs of consecutive identical records into the first occurrence
+/// plus an annotation carrying the repeat count.
+///
+/// The first occurrence is forwarded immediately (streaming — never held
+/// back). Each repeat is dropped and counted; when a different record arrives
+/// the annotation is prepended to it, and a run still open at end-of-stream is
+/// flushed via `finish`.
+#[derive(Default)]
+pub struct CollapseRepeats {
+    prev: Option<Vec<u8>>,
+    repeats: u64,
+}
+
+impl CollapseRepeats {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn annotation(&self) -> Vec<u8> {
+        let s = if self.repeats == 1 { "" } else { "s" };
+        format!("(last line repeated {} more time{s})", self.repeats).into_bytes()
+    }
+}
+
+impl LineProcessor for CollapseRepeats {
+    fn process(&mut self, record: &[u8]) -> Option<Vec<u8>> {
+        if self.prev.as_deref() == Some(record) {
+            self.repeats += 1;
+            return None;
+        }
+        let mut out = Vec::with_capacity(record.len());
+        if self.repeats > 0 {
+            out.extend_from_slice(&self.annotation());
+            out.push(b'\n');
+            self.repeats = 0;
+        }
+        self.prev = Some(record.to_vec());
+        out.extend_from_slice(record);
+        Some(out)
+    }
+
+    fn finish(&mut self) -> Option<Vec<u8>> {
+        if self.repeats == 0 {
+            return None;
+        }
+        let mut out = self.annotation();
+        out.push(b'\n');
+        Some(out)
+    }
+}
+
+/// Callback fired by [`LineMatcher`] per pattern hit, with `(id, line)`.
+pub type MatchCallback = Box<dyn FnMut(&str, &str) + Send>;
+
+/// Scan each record against configured `(id, regex)` patterns and fire
+/// `on_match(id, line)` per hit, forwarding the record unchanged.
+///
+/// Patterns are pre-compiled [`Regex`]es, so per-record cost is linear scans
+/// that can't stall forwarding. The callback runs on the reader thread and
+/// must not block.
+pub struct LineMatcher {
+    patterns: Vec<(String, Regex)>,
+    on_match: MatchCallback,
+}
+
+impl LineMatcher {
+    pub fn new(patterns: Vec<(String, Regex)>, on_match: MatchCallback) -> Self {
+        Self { patterns, on_match }
+    }
+}
+
+impl LineProcessor for LineMatcher {
+    fn process(&mut self, record: &[u8]) -> Option<Vec<u8>> {
+        if !self.patterns.is_empty() {
+            let line = String::from_utf8_lossy(record);
+            for (id, regex) in &self.patterns {
+                if regex.is_match(&line) {
+                    (self.on_match)(id, &line);
+                }
+            }
+        }
+        Some(record.to_vec())
+    }
+}
+
+/// A consumer's decision on a [`PendingMatch`].
+#[derive(Debug)]
+pub enum Verdict {
+    /// Forward the record unchanged.
+    Keep,
+    /// Forward these bytes instead (the original boundary is preserved).
+    Replace(Vec<u8>),
+    /// Suppress the record and its boundary.
+    Drop,
+}
+
+/// A matched record awaiting a consumer's [`Verdict`]. Sending on `reply`
+/// releases the held record; dropping the reply sender (or never answering)
+/// fails open — the original record forwards once the responder times out.
+pub struct PendingMatch {
+    pub id: String,
+    pub line: String,
+    pub reply: mpsc::SyncSender<Verdict>,
+}
+
+/// Hold each record that matches an `(id, regex)` pattern until a consumer
+/// (AXL, draining `build.output_events()`) delivers a [`Verdict`], then
+/// forward accordingly. Non-matching records flow through untouched.
+///
+/// **Ordering:** while a verdict is pending, the reader thread is blocked, so
+/// every subsequent record waits behind the held one — output order is always
+/// preserved, and Bazel is back-pressured by the kernel pipe/PTY buffer. This
+/// hold is what makes replace-before-display possible.
+///
+/// **Fail-open:** if no verdict arrives within `timeout` (consumer busy), or
+/// the event is dropped unanswered, or nothing ever drains the events channel
+/// (receiver gone), the original record forwards unchanged. A misbehaving
+/// consumer can slow matched lines down, never wedge the build.
+pub struct MatchResponder {
+    patterns: Vec<(String, Regex)>,
+    events: mpsc::Sender<PendingMatch>,
+    timeout: Duration,
+}
+
+impl MatchResponder {
+    /// `events` is the channel the consumer drains; one `PendingMatch` is in
+    /// flight at a time (the reader blocks on its reply before matching the
+    /// next record).
+    pub fn new(
+        patterns: Vec<(String, Regex)>,
+        events: mpsc::Sender<PendingMatch>,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            patterns,
+            events,
+            timeout,
+        }
+    }
+}
+
+impl LineProcessor for MatchResponder {
+    fn process(&mut self, record: &[u8]) -> Option<Vec<u8>> {
+        let line = String::from_utf8_lossy(record);
+        let id = match self.patterns.iter().find(|(_, r)| r.is_match(&line)) {
+            Some((id, _)) => id.clone(),
+            None => return Some(record.to_vec()),
+        };
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        let pending = PendingMatch {
+            id,
+            line: line.into_owned(),
+            reply: reply_tx,
+        };
+        if self.events.send(pending).is_err() {
+            // No consumer (receiver dropped) — fail open immediately.
+            return Some(record.to_vec());
+        }
+        match reply_rx.recv_timeout(self.timeout) {
+            Ok(Verdict::Keep) => Some(record.to_vec()),
+            Ok(Verdict::Replace(bytes)) => Some(bytes),
+            Ok(Verdict::Drop) => None,
+            // Timeout, or the event was dropped unanswered — fail open.
+            Err(_) => Some(record.to_vec()),
+        }
+    }
+}
+
+/// Shared state fed by [`LineMatcher`] callbacks and read by the `Build`
+/// handle (and through it, Starlark) while the invocation runs or after it
+/// finishes.
+///
+/// `fatal` latches on the first fatal-pattern hit and keeps that line;
+/// `matches` accumulates `(id, line)` hits up to [`MAX_RECORDED_MATCHES`].
+/// All access is lock-brief and thread-safe.
+#[derive(Debug, Default)]
+pub struct OutputSignals {
+    fatal: AtomicBool,
+    fatal_line: Mutex<Option<String>>,
+    matches: Mutex<Vec<(String, String)>>,
+}
+
+impl OutputSignals {
+    /// Latch the fatal flag; the first fatal line wins.
+    pub fn set_fatal(&self, line: &str) {
+        if !self.fatal.swap(true, Ordering::SeqCst) {
+            *self.fatal_line.lock().unwrap() = Some(truncate(line));
+        }
+    }
+
+    pub fn fatal(&self) -> bool {
+        self.fatal.load(Ordering::SeqCst)
+    }
+
+    pub fn fatal_line(&self) -> Option<String> {
+        self.fatal_line.lock().unwrap().clone()
+    }
+
+    /// Record a match hit; hits past [`MAX_RECORDED_MATCHES`] are dropped.
+    pub fn record_match(&self, id: &str, line: &str) {
+        let mut matches = self.matches.lock().unwrap();
+        if matches.len() < MAX_RECORDED_MATCHES {
+            matches.push((id.to_string(), truncate(line)));
+        }
+    }
+
+    /// Snapshot of the recorded `(id, line)` hits so far.
+    pub fn matches(&self) -> Vec<(String, String)> {
+        self.matches.lock().unwrap().clone()
+    }
+}
+
+/// Bound the stored copy of a line, respecting char boundaries.
+fn truncate(line: &str) -> String {
+    if line.len() <= MAX_RECORDED_LINE_BYTES {
+        return line.to_string();
+    }
+    let mut end = MAX_RECORDED_LINE_BYTES;
+    while !line.is_char_boundary(end) {
+        end -= 1;
+    }
+    line[..end].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn feed(p: &mut dyn LineProcessor, records: &[&[u8]]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for r in records {
+            if let Some(bytes) = p.process(r) {
+                out.extend_from_slice(&bytes);
+                out.push(b'\n');
+            }
+        }
+        if let Some(bytes) = p.finish() {
+            out.extend_from_slice(&bytes);
+        }
+        out
+    }
+
+    #[test]
+    fn collapse_repeats_basic() {
+        let mut p = CollapseRepeats::new();
+        let out = feed(&mut p, &[b"a", b"a", b"a", b"b"]);
+        assert_eq!(out, b"a\n(last line repeated 2 more times)\nb\n");
+    }
+
+    #[test]
+    fn collapse_repeats_no_repeats_is_passthrough() {
+        let mut p = CollapseRepeats::new();
+        assert_eq!(feed(&mut p, &[b"a", b"b", b"c"]), b"a\nb\nc\n");
+    }
+
+    #[test]
+    fn collapse_repeats_flushes_trailing_run_on_finish() {
+        let mut p = CollapseRepeats::new();
+        let out = feed(&mut p, &[b"x", b"x", b"x"]);
+        assert_eq!(out, b"x\n(last line repeated 2 more times)\n");
+    }
+
+    #[test]
+    fn collapse_repeats_multiple_runs() {
+        let mut p = CollapseRepeats::new();
+        let out = feed(&mut p, &[b"a", b"a", b"b", b"b", b"b", b"a"]);
+        assert_eq!(
+            out,
+            b"a\n(last line repeated 1 more time)\nb\n(last line repeated 2 more times)\na\n"
+                .to_vec()
+        );
+    }
+
+    fn rx(pattern: &str) -> Regex {
+        Regex::new(pattern).unwrap()
+    }
+
+    #[test]
+    fn line_matcher_fires_per_hit_and_forwards_unchanged() {
+        let hits = Arc::new(Mutex::new(Vec::new()));
+        let sink = hits.clone();
+        let mut p = LineMatcher::new(
+            vec![
+                ("oom".to_string(), rx(r"OutOfMemory")),
+                ("warn".to_string(), rx(r"^WARNING:")),
+            ],
+            Box::new(move |id, line| sink.lock().unwrap().push((id.to_string(), line.to_string()))),
+        );
+        let out = feed(
+            &mut p,
+            &[
+                b"INFO: ok",
+                b"java.lang.OutOfMemoryError: heap",
+                b"WARNING: deprecated",
+            ],
+        );
+        assert_eq!(
+            out,
+            b"INFO: ok\njava.lang.OutOfMemoryError: heap\nWARNING: deprecated\n"
+        );
+        let hits = hits.lock().unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].0, "oom");
+        assert_eq!(hits[1].0, "warn");
+    }
+
+    #[test]
+    fn responder_verdicts_apply() {
+        let (events_tx, events_rx) = mpsc::channel();
+        // Consumer thread: keep INFO lines, rewrite WARNINGs, drop DEBUGs.
+        let consumer = std::thread::spawn(move || {
+            for ev in events_rx {
+                let PendingMatch { id, reply, .. } = ev;
+                let verdict = match id.as_str() {
+                    "warn" => Verdict::Replace(b"warning elided".to_vec()),
+                    "debug" => Verdict::Drop,
+                    _ => Verdict::Keep,
+                };
+                let _ = reply.send(verdict);
+            }
+        });
+
+        let mut p = MatchResponder::new(
+            vec![
+                ("info".to_string(), rx(r"^INFO:")),
+                ("warn".to_string(), rx(r"^WARNING:")),
+                ("debug".to_string(), rx(r"^DEBUG:")),
+            ],
+            events_tx,
+            Duration::from_secs(5),
+        );
+        let out = feed(
+            &mut p,
+            &[b"INFO: ok", b"WARNING: noisy", b"DEBUG: spam", b"plain"],
+        );
+        assert_eq!(out, b"INFO: ok\nwarning elided\nplain\n");
+        drop(p); // disconnects the events channel so the consumer loop exits
+        consumer.join().unwrap();
+    }
+
+    #[test]
+    fn responder_fails_open_on_timeout() {
+        let (events_tx, events_rx) = mpsc::channel();
+        // Consumer receives but never answers.
+        let _keep_alive = events_rx;
+        let mut p = MatchResponder::new(
+            vec![("m".to_string(), rx("match"))],
+            events_tx,
+            Duration::from_millis(50),
+        );
+        assert_eq!(feed(&mut p, &[b"match me"]), b"match me\n");
+    }
+
+    #[test]
+    fn responder_fails_open_with_no_consumer() {
+        let (events_tx, events_rx) = mpsc::channel::<PendingMatch>();
+        drop(events_rx);
+        let mut p = MatchResponder::new(
+            vec![("m".to_string(), rx("match"))],
+            events_tx,
+            Duration::from_secs(30), // must not wait this long
+        );
+        let start = std::time::Instant::now();
+        assert_eq!(feed(&mut p, &[b"match me"]), b"match me\n");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[test]
+    fn responder_fails_open_when_event_dropped_unanswered() {
+        let (events_tx, events_rx) = mpsc::channel();
+        let consumer = std::thread::spawn(move || {
+            for ev in events_rx {
+                drop(ev); // reply sender dropped without a verdict
+            }
+        });
+        let mut p = MatchResponder::new(
+            vec![("m".to_string(), rx("match"))],
+            events_tx,
+            Duration::from_secs(30), // disconnect must release before this
+        );
+        let start = std::time::Instant::now();
+        assert_eq!(feed(&mut p, &[b"match me"]), b"match me\n");
+        assert!(start.elapsed() < Duration::from_secs(5));
+        drop(p);
+        consumer.join().unwrap();
+    }
+
+    #[test]
+    fn signals_fatal_latches_first_line() {
+        let s = OutputSignals::default();
+        assert!(!s.fatal());
+        s.set_fatal("first failure");
+        s.set_fatal("second failure");
+        assert!(s.fatal());
+        assert_eq!(s.fatal_line().as_deref(), Some("first failure"));
+    }
+
+    #[test]
+    fn signals_matches_capped() {
+        let s = OutputSignals::default();
+        for i in 0..(MAX_RECORDED_MATCHES + 10) {
+            s.record_match("id", &format!("line {i}"));
+        }
+        assert_eq!(s.matches().len(), MAX_RECORDED_MATCHES);
+    }
+
+    #[test]
+    fn truncate_respects_char_boundary() {
+        let long = "é".repeat(MAX_RECORDED_LINE_BYTES); // 2 bytes per char
+        let t = truncate(&long);
+        assert!(t.len() <= MAX_RECORDED_LINE_BYTES);
+        assert!(t.chars().all(|c| c == 'é'));
+    }
+}

--- a/crates/basil/src/main.rs
+++ b/crates/basil/src/main.rs
@@ -92,6 +92,10 @@ fn run_build(args: &[String]) {
         find_flag_value(args, "--scenario").unwrap_or_else(|| "success".to_string());
     let s = scenario(&scenario_name);
 
+    for line in s.stderr_lines {
+        eprintln!("{line}");
+    }
+
     if let Some(path) = bes_path {
         write_scenario(&path, &s);
     }
@@ -161,6 +165,9 @@ struct Scenario {
     open_delay: Duration,
     attempts: Vec<Vec<BuildEvent>>,
     exit: ExitBehavior,
+    /// Lines printed to stderr before the BEP write, for tests exercising
+    /// the captured-output pipeline (real bazel writes its console to stderr).
+    stderr_lines: &'static [&'static str],
 }
 
 fn write_scenario(path: &str, scenario: &Scenario) {
@@ -198,6 +205,22 @@ fn scenario(name: &str) -> Scenario {
             open_delay: Duration::from_millis(50),
             attempts: vec![vec![build_started(), build_finished(0, true)]],
             exit: ExitBehavior::Code(0),
+            stderr_lines: &[],
+        },
+
+        // Like `success`, but emits console lines on stderr first — drives
+        // the captured-output pipeline tests (match/fatal/respond patterns
+        // against real child stderr).
+        "stderr_chatter" => Scenario {
+            open_delay: Duration::from_millis(50),
+            attempts: vec![vec![build_started(), build_finished(0, true)]],
+            exit: ExitBehavior::Code(0),
+            stderr_lines: &[
+                "INFO: Analyzed 1 target",
+                "WARNING: deprecated flag used",
+                "password=hunter2 leaked",
+                "INFO: Build completed successfully",
+            ],
         },
 
         // Regression for aspect-build/aspect-cli#1060: a single attempt with
@@ -212,6 +235,7 @@ fn scenario(name: &str) -> Scenario {
             open_delay: Duration::ZERO,
             attempts: vec![vec![build_started(), build_finished(39, true)]],
             exit: ExitBehavior::Code(0),
+            stderr_lines: &[],
         },
 
         // Reference scenario: REMOTE_CACHE_EVICTED followed by a successful
@@ -225,6 +249,7 @@ fn scenario(name: &str) -> Scenario {
                 vec![build_started(), build_finished(0, true)],
             ],
             exit: ExitBehavior::Code(0),
+            stderr_lines: &[],
         },
 
         // Like `success`, but basil exits with code 2 (a genuine Bazel
@@ -235,6 +260,7 @@ fn scenario(name: &str) -> Scenario {
             open_delay: Duration::ZERO,
             attempts: vec![vec![build_started(), build_finished(2, true)]],
             exit: ExitBehavior::Code(2),
+            stderr_lines: &[],
         },
 
         // Like `success`, but basil is killed by SIGKILL after the event
@@ -248,6 +274,7 @@ fn scenario(name: &str) -> Scenario {
             // SIGKILL: signal 9 on every Unix. Hard-coded to avoid a
             // libc dep for a single constant.
             exit: ExitBehavior::Signal(9),
+            stderr_lines: &[],
         },
 
         other => {


### PR DESCRIPTION
When a task sets `BazelTrait.capture_output`, the Bazel child's stderr is captured by the runtime, run through a processing pipeline, and forwarded to the real stderr — instead of being inherited straight to the terminal, which left no chance to pre-process it.

**Off by default.** With `capture_output` unset, stderr stays `Stdio::inherit()` and behavior is unchanged.

### How it works

- **Capture mode** — when capture is on, `bazel_runner.axl` picks the fd to match the destination stderr and sets Bazel's flags accordingly:
  - stderr is an interactive TTY → a **PTY** (`--isatty=1`), so Bazel keeps its live curses progress UI; bytes are forwarded near-verbatim.
  - otherwise (CI, redirected) → a **plain pipe** (`--isatty=0 --curses=no`), so Bazel emits clean newline-terminated lines.
- **Reader/forwarder** (`stream/output.rs`) — a dedicated thread reads the captured fd, splits records on `\r` and `\n` (so the `\r`-driven progress UI stays live), runs each through an ordered `LineProcessor` chain, and writes to the real stderr with a per-read flush. Single producer→consumer with a blocking write, so a slow terminal back-pressures the kernel buffer and ultimately Bazel — bounding memory without an unbounded queue. A stage can transform a record, drop it (with its boundary), or hold state and flush it at end-of-stream via `finish()`.
- **Lifecycle** — the fds are `O_CLOEXEC` so a concurrent `fork`+`exec` can't leak the write end (which would hang the forwarder); the PTY slave is dropped right after spawn so the master sees EOF; the stream is joined in `Build::wait` after the child is reaped, so all stderr flushes before the task's terminal summary.

### Built-in processors (`stream/processors.rs`)

All patterns are regex, compiled at `processor(...)` construction (invalid patterns error there).

- **Noise reduction** — `collapse_repeats` folds runs of consecutive identical lines into the first occurrence plus a `(last line repeated N more times)` annotation.
- **Pattern observers** — `match_patterns = {id: regex}` records hits, readable from Starlark via `build.output_matches()` (during or after the build; capped at 1024 hits, lines truncated to 2048 bytes) — the input for hooks and features, e.g. a `bazel_attempt_end` handler.
- **Health/liveness signals** — `fatal_patterns` latch `build.output_fatal` / `build.output_fatal_line` (e.g. a dead-server message), and `build.output_idle_ms` reports captured-output silence for stall detection.
- **Interactive respond/replace** — `respond_patterns = {id: regex}`: a matching line is **held before display** and surfaced on `build.output_events()`; AXL answers each event with `keep()`, `replace(text)`, or `drop()`, deciding what the user sees. Output order is always preserved (everything behind the held line waits, back-pressured by the kernel buffer). Fail-open by design: an unanswered event forwards the original line after `respond_timeout_ms` (default 1000) — a slow or absent consumer can delay matched lines, never wedge the build.

```python
processor = bazel.output.processor(
    tty = ctx.std.io.stderr.is_tty,
    collapse_repeats = True,
    match_patterns = {"oom": r"java\.lang\.OutOfMemoryError"},
    fatal_patterns = [r"Server terminated abruptly"],
    respond_patterns = {"cred": r"password|token"},
)
build = ctx.bazel.build("//...", output = processor, flags = ["--isatty=0", "--curses=no"])

events = build.output_events()
for _tick in sleep_iter(50):
    ev = events.try_pop()
    if ev:
        ev.replace("(credential elided)")  # or ev.keep() / ev.drop()
    if events.done:
        break

status = build.wait()
if build.output_fatal:
    print("bazel server died: " + (build.output_fatal_line or ""))
for id, line in build.output_matches():
    print("matched " + id + ": " + line)
```

Chain order: observer matchers first (they see every line as Bazel wrote it, including repeats), then the responder (may rewrite), then the collapser (dedups the final stream).

### Alternatives considered

**"Bazel can already write output to a file — why build this?"** A file (or the BEP `progress` events, which also carry console text) gives a *copy* of the output for later; this feature is an *interceptor* for the output the user is watching:

- **Modifying what the user sees** (dedup, respond/replace) requires sitting between Bazel and the terminal. With a file, the raw output still reaches the user (inherit + tee), or nothing does and we'd have to re-render Bazel's curses UI from a log — a terminal emulator, far more machinery than a pass-through pipe/PTY.
- **The live progress UI** — pointing stderr at a file makes it non-TTY and Bazel drops its interactive UI. PTY interposition preserves it, and is the standard tool (`script(1)`, `ssh`, `tmux` do exactly this).
- **Real-time reaction and liveness** — a pipe gives blocking reads, EOF-on-death, and back-pressure for free; files need tail/poll loops, size tracking, and cleanup, and have no death semantics. BEP progress events are batched/async (`fully_async` upload mode) and can themselves stall when the server wedges (#1060); the raw stderr fd is the most primitive, most trustworthy "is it alive" channel.
- The mechanism itself is small and precedented: `Stdio::piped()` instead of `Stdio::inherit()` plus a forwarding thread — the same shape as the existing BES FIFO reader and `ctx.std.process` piped spawns.

---

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: yes (Starlark API docstrings on `ctx.bazel.build/.test`, `bazel.output.processor`, `output_events`/`output_matches`, and `BazelTrait.capture_output`)
- Breaking change: no
- Suggested release notes appear below: no

### Test plan

- New Rust tests: `OutputStream` record splitting / CR-LF / partial-line / carry-cap / drop-with-boundary / `finish()`-at-EOF; `processors.rs` unit tests (collapse runs + trailing-run flush, regex matcher hits, responder keep/replace/drop verdicts, fail-open on timeout / no consumer / event dropped unanswered, fatal latch, match cap, truncation); a pipeline integration test proving observer→responder→collapser ordering with a live replace; Starlark eval tests against fake-bazel — `processor(...)` args + `output_*` attrs, and a full respond/replace loop over `output_events()` (new `stderr_chatter` basil scenario); end-to-end `capture.rs` round-trips through a real subprocess for both pipe and PTY, plus CLOEXEC no-hang regression tests.
- Covered by existing test cases: full AXL suite passes; no-opt-in build verified byte-unchanged.
- Manual testing: `capture_output` build of a real target with stderr redirected (pipe path) and under a PTY (`script`) — output forwarded, exit 0, no hang; flags confirmed via `ASPECT_DEBUG=1`.
