### PR TITLE
tools/bazel: surface ASPECT_WRAPPER_SKIP + docs link when shadowing bazel

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -11,6 +11,22 @@
 # functionality through the `aspect` CLI without forcing developers to learn
 # a new command name.
 #
+# Docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
+#
+# Surprised that `bazel build` / `bazel test` runs through `aspect`?
+# Two ways to opt out, in increasing permanence:
+#
+#   1. Per-invocation:  ASPECT_WRAPPER_SKIP=1 bazel <verb> …
+#      Forwards everything straight to vanilla bazel, this run only. The
+#      same hint appears on the grey `[tools/bazel] …` trace line when the
+#      wrapper is about to shadow a real bazel verb.
+#
+#   2. Workspace-wide:  remove the verb (e.g. `build`, `test`) from
+#      ASPECT_VERBS_WITH_BAZEL_FLAGS below in your vendored copy of this
+#      script. Aspect-only verbs (lint/format/custom .axl tasks) keep
+#      routing through aspect; the listed bazel verbs go straight to
+#      vanilla bazel. No env var needed.
+#
 # The marker comment above (`# aspect-build/tools-bazel-wrapper`) and the
 # ASPECT_BAZEL_WRAPPER_VERSION variable below identify this file as the
 # canonical Aspect-shipped wrapper. Aspect detects them to know that in
@@ -533,9 +549,13 @@ BAZEL_VERBS_STR=" ${BAZEL_VERBS[*]} "
 
 # --- Helpers --------------------------------------------------------------
 
+# Source-of-truth docs link, appended to every aspect-route trace so the
+# user can read about the routing rules without grepping the wrapper.
+ASPECT_WRAPPER_DOCS_URL="https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md"
+
 # Print a grey trace line on stderr showing what the wrapper is about to exec.
 #
-# Usage: trace_exec <category> <argv...>
+# Usage: trace_exec <category> <shadow> <argv...>
 #
 # <category> is "aspect" when routing to aspect (the interesting case — the
 # wrapper rewrote something) or "bazel" when forwarding straight to bazel
@@ -543,12 +563,24 @@ BAZEL_VERBS_STR=" ${BAZEL_VERBS[*]} "
 # etc.). The trace prints by default for the "aspect" category and is
 # suppressed for "bazel" unless ASPECT_WRAPPER_TRACE=1 forces it on.
 #
+# <shadow> is "shadow" when this invocation is shadowing a real bazel verb
+# (e.g. `build`/`test` — verbs in both ASPECT_VERBS_WITH_BAZEL_FLAGS and
+# BAZEL_VERBS), and "" otherwise. Shadowing is the surprising case — the
+# user typed something bazel could run, and we routed it through aspect.
+# When set, the trace line gets a suffix nudging the user toward
+# `ASPECT_WRAPPER_SKIP=1` (one-shot bypass) so they know how to opt out;
+# the docs link covers the longer-lived alternative of editing
+# ASPECT_VERBS_WITH_BAZEL_FLAGS in their copy of the wrapper.
+#
+# Every aspect-route trace ends with `— docs: <url>` so the routing rules
+# are one click away regardless of whether the verb shadows bazel.
+#
 # Suppressed entirely when stderr is not a TTY (so $(...) capture and CI
 # logs stay clean), unless ASPECT_WRAPPER_TRACE=1. Always suppressed when
 # ASPECT_WRAPPER_QUIET is set.
 trace_exec() {
-    local category="$1"
-    shift
+    local category="$1" shadow="$2"
+    shift 2
     [[ -n "${ASPECT_WRAPPER_QUIET:-}" ]] && return 0
     local force="${ASPECT_WRAPPER_TRACE:-}"
     # Pure bazel forwarding: silent unless explicitly forced.
@@ -578,7 +610,17 @@ trace_exec() {
             quoted+=" $a"
         fi
     done
-    printf '%s[tools/bazel]%s%s\n' "$grey" "$quoted" "$reset" >&2
+    # Suffix only on aspect routing: bazel forwards are already vanilla and
+    # don't need an opt-out hint. Shadow nudges go first (most actionable);
+    # the docs link is always last.
+    local suffix=""
+    if [[ "$category" == "aspect" ]]; then
+        if [[ "$shadow" == "shadow" ]]; then
+            suffix+=" — set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\`"
+        fi
+        suffix+=" — docs: $ASPECT_WRAPPER_DOCS_URL"
+    fi
+    printf '%s[tools/bazel]%s%s%s\n' "$grey" "$quoted" "$suffix" "$reset" >&2
 }
 
 # Locate the real bazel binary. Bazelisk sets BAZEL_REAL when it execs this
@@ -746,7 +788,7 @@ BAZEL_REAL_BIN="$(resolve_bazel_real)"
 # developers who want a 1:1 bazel experience locally; reach for `aspect <verb>`
 # directly when you want the wrapped behavior.
 if [[ -n "${ASPECT_WRAPPER_SKIP:-}" ]]; then
-    trace_exec bazel "$BAZEL_REAL_BIN" "$@"
+    trace_exec bazel "" "$BAZEL_REAL_BIN" "$@"
     exec "$BAZEL_REAL_BIN" "$@"
 fi
 
@@ -812,7 +854,7 @@ done
 
 # No verb: forward verbatim to bazel.
 if [[ -z "$verb" ]]; then
-    trace_exec bazel "$BAZEL_REAL_BIN" "$@"
+    trace_exec bazel "" "$BAZEL_REAL_BIN" "$@"
     exec "$BAZEL_REAL_BIN" "$@"
 fi
 
@@ -827,7 +869,7 @@ if contains "$verb" "${ASPECT_VERBS_WITH_BAZEL_FLAGS[@]}"; then
     if ! aspect_on_path; then
         if contains "$verb" "${BAZEL_VERBS[@]}"; then
             aspect_missing_hint "$verb" "Running it through vanilla bazel for now."
-            trace_exec bazel "$BAZEL_REAL_BIN" "$@"
+            trace_exec bazel "" "$BAZEL_REAL_BIN" "$@"
             exec "$BAZEL_REAL_BIN" "$@"
         fi
         aspect_missing_hint "$verb"
@@ -861,13 +903,20 @@ if contains "$verb" "${ASPECT_VERBS_WITH_BAZEL_FLAGS[@]}"; then
     set -- ${pre_globals[@]+"${pre_globals[@]}"} "$verb" \
         ${pre_bazel_starts[@]+"${pre_bazel_starts[@]}"} \
         ${post_rewritten[@]+"${post_rewritten[@]}"}
-    trace_exec aspect aspect "$@"
+    # A verb in both lists (build/test/…) shadows bazel — what the user typed
+    # is a real bazel command and we're routing it through aspect anyway. The
+    # trace nudges toward ASPECT_WRAPPER_SKIP=1 in that case.
+    shadow=""
+    if contains "$verb" "${BAZEL_VERBS[@]}"; then
+        shadow="shadow"
+    fi
+    trace_exec aspect "$shadow" aspect "$@"
     exec aspect "$@"
 fi
 
 # Other bazel verb (query, info, clean, mod, …): vanilla bazel, untouched.
 if contains "$verb" "${BAZEL_VERBS[@]}"; then
-    trace_exec bazel "$BAZEL_REAL_BIN" "$@"
+    trace_exec bazel "" "$BAZEL_REAL_BIN" "$@"
     exec "$BAZEL_REAL_BIN" "$@"
 fi
 
@@ -880,5 +929,6 @@ if ! aspect_on_path; then
     exit 127
 fi
 export BAZEL_REAL="$BAZEL_REAL_BIN"
-trace_exec aspect aspect "$@"
+# Custom .axl tasks never shadow bazel: bazel has no such command.
+trace_exec aspect "" aspect "$@"
 exec aspect "$@"

--- a/tools/bazel-test.sh
+++ b/tools/bazel-test.sh
@@ -16,12 +16,12 @@ WRAPPER="$HERE/bazel"
 STUB_DIR="$(mktemp -d)"
 trap 'rm -rf "$STUB_DIR"' EXIT
 
-cat > "$STUB_DIR/aspect" <<'EOF'
+cat >"$STUB_DIR/aspect" <<'EOF'
 #!/usr/bin/env bash
 echo "INVOKED:aspect"
 for a in "$@"; do printf 'ARG:%s\n' "$a"; done
 EOF
-cat > "$STUB_DIR/bazel" <<'EOF'
+cat >"$STUB_DIR/bazel" <<'EOF'
 #!/usr/bin/env bash
 echo "INVOKED:bazel"
 for a in "$@"; do printf 'ARG:%s\n' "$a"; done
@@ -84,300 +84,300 @@ run_no_aspect() {
 # =====================================================================
 
 check "dispatch: aspect verb 'lint' → aspect" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:lint" \
-"$(run lint)"
+    "$(run lint)"
 
 check "dispatch: aspect verb 'format' with target → aspect" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:format
 ARG://some:target" \
-"$(run format //some:target)"
+    "$(run format //some:target)"
 
 check "dispatch: aspect verb 'delivery' with multi-target → aspect" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:delivery
 ARG://a:b
 ARG://c:d" \
-"$(run delivery //a:b //c:d)"
+    "$(run delivery //a:b //c:d)"
 
 check "dispatch: aspect verb 'configure' → aspect" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:configure" \
-"$(run configure)"
+    "$(run configure)"
 
 check "dispatch: aspect verb 'buildifier' → aspect" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:buildifier" \
-"$(run buildifier)"
+    "$(run buildifier)"
 
 check "dispatch: bazel verb 'query' stays on bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:query
 ARG:deps(//foo)" \
-"$(run query 'deps(//foo)')"
+    "$(run query 'deps(//foo)')"
 
 check "dispatch: bazel verb 'cquery' stays on bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:cquery
 ARG://..." \
-"$(run cquery //...)"
+    "$(run cquery //...)"
 
 check "dispatch: bazel verb 'info' stays on bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:info
 ARG:workspace" \
-"$(run info workspace)"
+    "$(run info workspace)"
 
 check "dispatch: bazel verb 'clean' stays on bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:clean
 ARG:--expunge" \
-"$(run clean --expunge)"
+    "$(run clean --expunge)"
 
 check "dispatch: bazel verb 'mod' stays on bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:mod
 ARG:graph" \
-"$(run mod graph)"
+    "$(run mod graph)"
 
 check "dispatch: no verb at all → bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:--version" \
-"$(run --version)"
+    "$(run --version)"
 
 check "dispatch: bare invocation → bazel" \
-"INVOKED:bazel" \
-"$(run)"
+    "INVOKED:bazel" \
+    "$(run)"
 
 # =====================================================================
 # Section 2: Common verb — bare cases
 # =====================================================================
 
 check "common: build alone → aspect build" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build" \
-"$(run build)"
+    "$(run build)"
 
 check "common: build with target → aspect build" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG://..." \
-"$(run build //...)"
+    "$(run build //...)"
 
 check "common: test with target → aspect test" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:test
 ARG://..." \
-"$(run test //...)"
+    "$(run test //...)"
 
 check "common: run with target → bazel run (not yet wrapped by aspect)" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:run
 ARG://foo:bin" \
-"$(run run //foo:bin)"
+    "$(run run //foo:bin)"
 
 # =====================================================================
 # Section 3: Post-verb flag rewriting — bazel flags
 # =====================================================================
 
 check "post-verb bazel: boolean wrapped (--keep_going)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--keep_going
 ARG://..." \
-"$(run build --keep_going //...)"
+    "$(run build --keep_going //...)"
 
 check "post-verb bazel: boolean negation wrapped (--nobuild)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--nobuild
 ARG://..." \
-"$(run build --nobuild //...)"
+    "$(run build --nobuild //...)"
 
 check "post-verb bazel: =value form wrapped (--config=ci)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--config=ci
 ARG://..." \
-"$(run build --config=ci //...)"
+    "$(run build --config=ci //...)"
 
 check "post-verb bazel: space-value form glued (--config ci)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--config=ci
 ARG://..." \
-"$(run build --config ci //...)"
+    "$(run build --config ci //...)"
 
 check "post-verb bazel: repeated --config space-value" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--config=ci
 ARG:--bazel-flag=--config=remote
 ARG://..." \
-"$(run build --config ci --config remote //...)"
+    "$(run build --config ci --config remote //...)"
 
 check "post-verb bazel: --jobs with space-value (number)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--jobs=4
 ARG://..." \
-"$(run build --jobs 4 //...)"
+    "$(run build --jobs 4 //...)"
 
 check "post-verb bazel: --jobs with =value" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--jobs=8
 ARG://..." \
-"$(run build --jobs=8 //...)"
+    "$(run build --jobs=8 //...)"
 
 check "post-verb bazel: --remote_executor with value containing colons" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--remote_executor=grpc://exec.example.com:443
 ARG://..." \
-"$(run build --remote_executor grpc://exec.example.com:443 //...)"
+    "$(run build --remote_executor grpc://exec.example.com:443 //...)"
 
 check "post-verb bazel: --define KEY=VAL" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--define=foo=bar
 ARG://..." \
-"$(run build --define foo=bar //...)"
+    "$(run build --define foo=bar //...)"
 
 check "post-verb bazel: --action_env with space-value" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:test
 ARG:--bazel-flag=--action_env=HOME=/tmp
 ARG://..." \
-"$(run test --action_env HOME=/tmp //...)"
+    "$(run test --action_env HOME=/tmp //...)"
 
 check "post-verb bazel: --test_arg with =value containing flag-shaped value" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:test
 ARG:--bazel-flag=--test_arg=--verbose
 ARG://..." \
-"$(run test --test_arg=--verbose //...)"
+    "$(run test --test_arg=--verbose //...)"
 
 check "post-verb bazel: --test_output with space-value" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:test
 ARG:--bazel-flag=--test_output=errors
 ARG://..." \
-"$(run test --test_output errors //...)"
+    "$(run test --test_output errors //...)"
 
 check "post-verb bazel: --test_filter with regex value" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:test
 ARG:--bazel-flag=--test_filter=^Foo.*Bar$
 ARG://..." \
-"$(run test --test_filter '^Foo.*Bar$' //...)"
+    "$(run test --test_filter '^Foo.*Bar$' //...)"
 
 check "post-verb bazel: --copt with space-value" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--copt=-O2
 ARG://..." \
-"$(run build --copt -O2 //...)"
+    "$(run build --copt -O2 //...)"
 
 check "post-verb bazel: trailing value-taking flag with no value" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--config" \
-"$(run build --config)"
+    "$(run build --config)"
 
 check "post-verb: unknown flag (typo / unlisted) passes through to aspect" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--keep_goinggg
 ARG://..." \
-"$(run build --keep_goinggg //...)"
+    "$(run build --keep_goinggg //...)"
 
 # =====================================================================
 # Section 4: Post-verb flag passthrough — aspect flags
 # =====================================================================
 
 check "post-verb aspect: kebab-case --task-key=val passthrough" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--task-key=mybuild
 ARG://..." \
-"$(run build --task-key=mybuild //...)"
+    "$(run build --task-key=mybuild //...)"
 
 check "post-verb aspect: kebab-case --task-key val (space form) passthrough" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--task-key
 ARG:mybuild
 ARG://..." \
-"$(run build --task-key mybuild //...)"
+    "$(run build --task-key mybuild //...)"
 
 check "post-verb aspect: colon-namespaced --artifact-upload:enabled=false" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--artifact-upload:enabled=false
 ARG://..." \
-"$(run build --artifact-upload:enabled=false //...)"
+    "$(run build --artifact-upload:enabled=false //...)"
 
 check "post-verb aspect: colon-namespaced --github-status-checks:mode=always" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--github-status-checks:mode=always
 ARG://..." \
-"$(run build --github-status-checks:mode=always //...)"
+    "$(run build --github-status-checks:mode=always //...)"
 
 check "post-verb aspect: --timing=summary" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--timing=summary
 ARG://..." \
-"$(run build --timing=summary //...)"
+    "$(run build --timing=summary //...)"
 
 check "post-verb aspect: --bazel-flag=--foo passthrough (already wrapped)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--foo
 ARG://..." \
-"$(run build --bazel-flag=--foo //...)"
+    "$(run build --bazel-flag=--foo //...)"
 
 check "post-verb aspect: --cancel boolean passthrough" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--cancel
 ARG://..." \
-"$(run build --cancel //...)"
+    "$(run build --cancel //...)"
 
 check "post-verb aspect: --coverage (test-only) passthrough" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:test
 ARG:--coverage
 ARG://..." \
-"$(run test --coverage //...)"
+    "$(run test --coverage //...)"
 
 # =====================================================================
 # Section 5: Mixed aspect + bazel flags
 # =====================================================================
 
 check "mixed: aspect kebab + bazel boolean + bazel =value" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--task-key=mybuild
 ARG:--bazel-flag=--keep_going
 ARG:--bazel-flag=--config=ci
 ARG://..." \
-"$(run build --task-key=mybuild --keep_going --config=ci //...)"
+    "$(run build --task-key=mybuild --keep_going --config=ci //...)"
 
 check "mixed: bazel space-value sandwiched between aspect flags" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--task-key=mybuild
 ARG:--bazel-flag=--config=ci
 ARG:--timing=summary
 ARG://..." \
-"$(run build --task-key=mybuild --config ci --timing=summary //...)"
+    "$(run build --task-key=mybuild --config ci --timing=summary //...)"
 
 check "mixed: many flags in random order" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:test
 ARG:--bazel-flag=--keep_going
 ARG:--task-key=t1
@@ -385,134 +385,134 @@ ARG:--bazel-flag=--config=ci
 ARG:--coverage
 ARG:--bazel-flag=--test_output=errors
 ARG://..." \
-"$(run test --keep_going --task-key=t1 --config ci --coverage --test_output errors //...)"
+    "$(run test --keep_going --task-key=t1 --config ci --coverage --test_output errors //...)"
 
 # =====================================================================
 # Section 6: Pre-verb (startup) flag handling
 # =====================================================================
 
 check "pre-verb: bazel startup flag → --bazel-startup-flag= (after verb)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-startup-flag=--output_base=/tmp/foo
 ARG://..." \
-"$(run --output_base=/tmp/foo build //...)"
+    "$(run --output_base=/tmp/foo build //...)"
 
 check "pre-verb: bazel startup flag space-value → glued and wrapped" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-startup-flag=--output_base=/tmp/foo
 ARG://..." \
-"$(run --output_base /tmp/foo build //...)"
+    "$(run --output_base /tmp/foo build //...)"
 
 check "pre-verb: aspect global flag (--task-key) before verb → pre-verb aspect" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:--task-key=t1
 ARG:build
 ARG://..." \
-"$(run --task-key=t1 build //...)"
+    "$(run --task-key=t1 build //...)"
 
 check "pre-verb: aspect global flag space-form (--task-key t1)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:--task-key
 ARG:t1
 ARG:build
 ARG://..." \
-"$(run --task-key t1 build //...)"
+    "$(run --task-key t1 build //...)"
 
 check "pre-verb: mixed aspect global + bazel startup" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:--task-key=t1
 ARG:build
 ARG:--bazel-startup-flag=--output_base=/tmp/x
 ARG://..." \
-"$(run --task-key=t1 --output_base=/tmp/x build //...)"
+    "$(run --task-key=t1 --output_base=/tmp/x build //...)"
 
 check "pre-verb: aspect global + bazel startup → bazel startup goes after verb" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:--task-key=t1
 ARG:build
 ARG:--bazel-startup-flag=--output_base=/tmp/x
 ARG:--bazel-flag=--keep_going
 ARG://..." \
-"$(run --task-key=t1 --output_base=/tmp/x build --keep_going //...)"
+    "$(run --task-key=t1 --output_base=/tmp/x build --keep_going //...)"
 
 check "pre-verb: aspect verb (lint) with pre-verb aspect global" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:--task-key=t1
 ARG:lint" \
-"$(run --task-key=t1 lint)"
+    "$(run --task-key=t1 lint)"
 
 check "pre-verb: aspect verb (lint) with pre-verb bazel startup → moved post-verb" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:lint
 ARG:--bazel-startup-flag=--output_base=/tmp/x" \
-"$(run --output_base=/tmp/x lint)"
+    "$(run --output_base=/tmp/x lint)"
 
 # =====================================================================
 # Section 7: Edge cases — `--`, positionals, hyphen-led targets
 # =====================================================================
 
 check "edge: -- ends flag parsing, positionals untouched" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--
 ARG://...
 ARG:-//experimental/..." \
-"$(run build -- //... -//experimental/...)"
+    "$(run build -- //... -//experimental/...)"
 
 check "edge: -- with bazel flag before, both after" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--keep_going
 ARG:--
 ARG://...
 ARG:-//experimental/..." \
-"$(run build --keep_going -- //... -//experimental/...)"
+    "$(run build --keep_going -- //... -//experimental/...)"
 
 check "edge: -- with run args (run forwards verbatim to bazel)" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:run
 ARG://foo:bin
 ARG:--
 ARG:--task-key
 ARG:value
 ARG:--keep_going" \
-"$(run run //foo:bin -- --task-key value --keep_going)"
+    "$(run run //foo:bin -- --task-key value --keep_going)"
 
 check "edge: target before any flag" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG://...
 ARG:--bazel-flag=--keep_going" \
-"$(run build //... --keep_going)"
+    "$(run build //... --keep_going)"
 
 check "edge: flag with empty value (--config=)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--config=
 ARG://..." \
-"$(run build --config= //...)"
+    "$(run build --config= //...)"
 
 check "edge: flag with value containing spaces" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--workspace_status_command=/path/to/cmd arg1
 ARG://..." \
-"$(run build --workspace_status_command '/path/to/cmd arg1' //...)"
+    "$(run build --workspace_status_command '/path/to/cmd arg1' //...)"
 
 check "edge: target with embedded equals sign in label is positional, not flag" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG://foo:bar=baz" \
-"$(run build //foo:bar=baz)"
+    "$(run build //foo:bar=baz)"
 
 # =====================================================================
 # Section 8: BAZEL_REAL plumbing
 # =====================================================================
 
 # Swap in a stub that also reports BAZEL_REAL so we can assert it.
-cat > "$STUB_DIR/aspect" <<'EOF'
+cat >"$STUB_DIR/aspect" <<'EOF'
 #!/usr/bin/env bash
 echo "INVOKED:aspect"
 echo "BAZEL_REAL=${BAZEL_REAL:-<unset>}"
@@ -520,17 +520,17 @@ for a in "$@"; do printf 'ARG:%s\n' "$a"; done
 EOF
 
 check "env: BAZEL_REAL forwarded to aspect (aspect verb)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 BAZEL_REAL=$STUB_DIR/bazel
 ARG:lint" \
-"$(run lint)"
+    "$(run lint)"
 
 check "env: BAZEL_REAL forwarded to aspect (common verb)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 BAZEL_REAL=$STUB_DIR/bazel
 ARG:build
 ARG://..." \
-"$(run build //...)"
+    "$(run build //...)"
 
 # Anti-inception layer 1: when BAZEL_REAL is UNSET (real bazel execs the
 # wrapper without it), the wrapper resolves bazel via PATH and re-exports it to
@@ -538,14 +538,14 @@ ARG://..." \
 # the wrapper. Assert aspect receives a concrete BAZEL_REAL (the stub on PATH),
 # not <unset>.
 check "env: BAZEL_REAL resolved from PATH and forwarded when unset" \
-"INVOKED:aspect
+    "INVOKED:aspect
 BAZEL_REAL=$STUB_DIR/bazel
 ARG:build
 ARG://..." \
-"$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" build //... 2>&1)"
+    "$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" build //... 2>&1)"
 
 # Restore the plain stub so subsequent assertions stay clean.
-cat > "$STUB_DIR/aspect" <<'EOF'
+cat >"$STUB_DIR/aspect" <<'EOF'
 #!/usr/bin/env bash
 echo "INVOKED:aspect"
 for a in "$@"; do printf 'ARG:%s\n' "$a"; done
@@ -559,127 +559,149 @@ EOF
 # default. Earlier sections already implicitly assert this — if trace
 # bled through, every "$(run ...)" assertion would fail. Just sanity-check.
 check "trace: silent under non-TTY by default (aspect path)" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:lint" \
-"$(run lint 2>&1)"
+    "$(run lint 2>&1)"
 
 check "trace: silent under non-TTY by default (bazel path)" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:query
 ARG:deps(//foo)" \
-"$(run query 'deps(//foo)' 2>&1)"
+    "$(run query 'deps(//foo)' 2>&1)"
 
 # Force trace on. Expect the [tools/bazel] line on stderr, then aspect's
 # normal output. Strip ANSI escape sequences so the assertion isn't tied
 # to the exact escape encoding.
 strip_ansi() { sed $'s/\033\\[[0-9;]*m//g'; }
 
+# Aspect-only verb (lint) — no shadowing of bazel, so the trace gets the
+# docs suffix but NOT the ASPECT_WRAPPER_SKIP nudge.
 actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" lint 2>&1 | strip_ansi)"
 check "trace: ASPECT_WRAPPER_TRACE=1 prints '[tools/bazel] ...' for aspect route" \
-"[tools/bazel] aspect lint
+    "[tools/bazel] aspect lint — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
 INVOKED:aspect
 ARG:lint" \
-"$actual"
+    "$actual"
 
+# Shadowing verb (build) — `build` is also a real bazel command, so the
+# trace gets the ASPECT_WRAPPER_SKIP nudge AND the docs link.
 actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1 | strip_ansi)"
-check "trace: shows rewritten flags" \
-"[tools/bazel] aspect build --bazel-flag=--keep_going --bazel-flag=--config=ci //...
+check "trace: shows rewritten flags + shadow nudge + docs" \
+    "[tools/bazel] aspect build --bazel-flag=--keep_going --bazel-flag=--config=ci //... — set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\` — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
 INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--keep_going
 ARG:--bazel-flag=--config=ci
 ARG://..." \
-"$actual"
+    "$actual"
 
 actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" query 'deps(//foo)' 2>&1 | strip_ansi)"
 check "trace: ASPECT_WRAPPER_TRACE=1 also shows bazel-only verb forwarding" \
-"[tools/bazel] $STUB_DIR/bazel query 'deps(//foo)'
+    "[tools/bazel] $STUB_DIR/bazel query 'deps(//foo)'
 INVOKED:bazel
 ARG:query
 ARG:deps(//foo)" \
-"$actual"
+    "$actual"
+
+# Shadowing test verb gets the same SKIP nudge as build.
+actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" test //... 2>&1 | strip_ansi)"
+check "trace: shadow nudge fires on 'test' too (verb in both lists)" \
+    "[tools/bazel] aspect test //... — set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\` — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
+INVOKED:aspect
+ARG:test
+ARG://..." \
+    "$actual"
+
+# Custom .axl task (unknown verb) routes to aspect but does NOT shadow bazel —
+# only the docs suffix, no SKIP nudge.
+actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" mytask 2>&1 | strip_ansi)"
+check "trace: custom .axl verb gets docs link, no shadow nudge" \
+    "[tools/bazel] aspect mytask — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
+INVOKED:aspect
+ARG:mytask" \
+    "$actual"
 
 actual="$(ASPECT_WRAPPER_QUIET=1 ASPECT_WRAPPER_TRACE=1 "$WRAPPER" lint 2>&1 | strip_ansi)"
 check "trace: ASPECT_WRAPPER_QUIET=1 wins over TRACE=1" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:lint" \
-"$actual"
+    "$actual"
 
 # =====================================================================
 # Section 10: ASPECT_WRAPPER_SKIP — total bypass, everything → vanilla bazel
 # =====================================================================
 
 check "skip: build forwards straight to bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:build
 ARG://..." \
-"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build //... 2>&1)"
 
 check "skip: test forwards straight to bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:test
 ARG:--keep_going
 ARG://..." \
-"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" test --keep_going //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" test --keep_going //... 2>&1)"
 
 check "skip: run forwards straight to bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:run
 ARG://foo:bin
 ARG:--
 ARG:arg1" \
-"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" run //foo:bin -- arg1 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" run //foo:bin -- arg1 2>&1)"
 
 # Skip is a TOTAL bypass: even aspect verbs go straight to vanilla bazel,
 # untouched. (The user reaches for `aspect <verb>` directly when they want
 # the wrapped behavior.)
 check "skip: aspect verb (lint) also forwards straight to bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:lint" \
-"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" lint 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" lint 2>&1)"
 
 check "skip: aspect verb (format) also forwards straight to bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:format
 ARG://..." \
-"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" format //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" format //... 2>&1)"
 
 # Custom/unknown verb also bypasses (no aspect routing under skip).
 check "skip: custom verb also forwards straight to bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:mytask" \
-"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" mytask 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" mytask 2>&1)"
 
 check "skip: query (bazel-only verb) still goes to bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:query
 ARG://..." \
-"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" query //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" query //... 2>&1)"
 
 # Skip + flag preservation: bazel sees the raw flags, no --bazel-flag= wrapping.
 check "skip: bazel-native flags pass through unwrapped" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:build
 ARG:--keep_going
 ARG:--config=ci
 ARG://..." \
-"$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1)"
 
 # Skip + TRACE shows the bazel forward.
 actual="$(ASPECT_WRAPPER_SKIP=1 ASPECT_WRAPPER_TRACE=1 "$WRAPPER" build //... 2>&1 | strip_ansi)"
 check "skip: TRACE=1 shows bazel forward under skip mode" \
-"[tools/bazel] $STUB_DIR/bazel build //...
+    "[tools/bazel] $STUB_DIR/bazel build //...
 INVOKED:bazel
 ARG:build
 ARG://..." \
-"$actual"
+    "$actual"
 
 # Empty string means unset — make sure we treat "" as no skip.
 check "skip: empty string ASPECT_WRAPPER_SKIP='' is treated as unset" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG://..." \
-"$(ASPECT_WRAPPER_SKIP="" "$WRAPPER" build //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP="" "$WRAPPER" build //... 2>&1)"
 
 # =====================================================================
 # Section 11: Anti-inception (ASPECT_CLI_RUNNING bypass)
@@ -691,39 +713,39 @@ ARG://..." \
 # recurses forever.
 
 check "inception: ASPECT_CLI_RUNNING=1 + build → straight to bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:build
 ARG://..." \
-"$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build //... 2>&1)"
+    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build //... 2>&1)"
 
 check "inception: ASPECT_CLI_RUNNING=1 + bazel-native flags pass through unwrapped" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:build
 ARG:--keep_going
 ARG:--config=ci
 ARG://..." \
-"$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1)"
+    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1)"
 
 # Even aspect-only verbs forward to bazel under ASPECT_CLI_RUNNING. Aspect
 # would never spawn `bazel lint`, but if it somehow did we still want the
 # bypass to win — aspect MUST NOT recurse into itself.
 check "inception: ASPECT_CLI_RUNNING=1 wins over aspect-only verbs too" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:lint" \
-"$(ASPECT_CLI_RUNNING=1 "$WRAPPER" lint 2>&1)"
+    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" lint 2>&1)"
 
 check "inception: ASPECT_CLI_RUNNING=1 + info → straight to bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:info
 ARG:workspace" \
-"$(ASPECT_CLI_RUNNING=1 "$WRAPPER" info workspace 2>&1)"
+    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" info workspace 2>&1)"
 
 # Empty string means unset — wrapper must treat it the same as no env var.
 check "inception: empty ASPECT_CLI_RUNNING='' is treated as unset" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG://..." \
-"$(ASPECT_CLI_RUNNING="" "$WRAPPER" build //... 2>&1)"
+    "$(ASPECT_CLI_RUNNING="" "$WRAPPER" build //... 2>&1)"
 
 # Bypass should fire BEFORE the trace logic. Even with TRACE=1, the bypass
 # runs and we get straight bazel — no aspect-route trace line.
@@ -732,67 +754,67 @@ actual="$(ASPECT_CLI_RUNNING=1 ASPECT_WRAPPER_TRACE=1 "$WRAPPER" build //... 2>&
 # no effect. This is intentional: in the inception case the trace would
 # fire INSIDE aspect's output stream and confuse the user.
 check "inception: bypass runs before trace, even TRACE=1 is silent" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:build
 ARG://..." \
-"$actual"
+    "$actual"
 
 # =====================================================================
 # Section 12: Bazel short-flag abbreviations that take a value (-c, -j)
 # =====================================================================
 
 check "short: -c opt (space) → --bazel-flag=-c=opt, opt not a target" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=-c=opt
 ARG://..." \
-"$(run build -c opt //...)"
+    "$(run build -c opt //...)"
 
 check "short: -j 8 (space) → --bazel-flag=-j=8" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=-j=8
 ARG://..." \
-"$(run build -j 8 //...)"
+    "$(run build -j 8 //...)"
 
 check "short: -c=opt (already glued) → single token, unchanged" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=-c=opt
 ARG://..." \
-"$(run build -c=opt //...)"
+    "$(run build -c=opt //...)"
 
 check "short: boolean shorts (-k -s) stay single tokens, don't eat next arg" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=-k
 ARG:--bazel-flag=-s
 ARG://..." \
-"$(run build -k -s //...)"
+    "$(run build -k -s //...)"
 
 check "short: -c at end of argv (no value) → passes as single token" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG://...
 ARG:--bazel-flag=-c" \
-"$(run build //... -c)"
+    "$(run build //... -c)"
 
 # =====================================================================
 # Section 13: Aspect-verb bazel-flag forwarding (ASPECT_VERBS_WITH_BAZEL_FLAGS)
 # =====================================================================
 
 check "fwd: format --keep_going → aspect format --bazel-flag=--keep_going" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:format
 ARG:--bazel-flag=--keep_going" \
-"$(run format --keep_going)"
+    "$(run format --keep_going)"
 
 check "fwd: lint space-value flag rewritten, aspect flag preserved" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:lint
 ARG:--github-lint-comments:enabled=true
 ARG:--bazel-flag=--config=ci" \
-"$(run lint --github-lint-comments:enabled=true --config ci)"
+    "$(run lint --github-lint-comments:enabled=true --config ci)"
 
 # =====================================================================
 # Section 15: Closed-set model — bazel is the known set, rest → aspect
@@ -801,34 +823,34 @@ ARG:--bazel-flag=--config=ci" \
 # Unknown verb (custom .axl task): routes to aspect, args verbatim (no
 # bazel-flag rewriting — not in ASPECT_VERBS_WITH_BAZEL_FLAGS).
 check "model: unknown verb (custom task) → aspect, args verbatim" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:mytask
 ARG:--keep_going
 ARG://x" \
-"$(run mytask --keep_going //x)"
+    "$(run mytask --keep_going //x)"
 
 # Bazel verb that aspect does NOT wrap → vanilla bazel untouched.
 check "model: bazel verb 'coverage' (not wrapped) → vanilla bazel" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:coverage
 ARG://..." \
-"$(run coverage //...)"
+    "$(run coverage //...)"
 
 # Boolean negation (--no<flag>) is recognized as a bazel flag and wrapped.
 check "model: --nokeep_going recognized as bazel boolean → wrapped" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--bazel-flag=--nokeep_going
 ARG://..." \
-"$(run build --nokeep_going //...)"
+    "$(run build --nokeep_going //...)"
 
 # A flag in no bazel list (aspect feature flag) passes through to aspect.
 check "model: aspect feature flag (colon-namespaced) passes through" \
-"INVOKED:aspect
+    "INVOKED:aspect
 ARG:build
 ARG:--artifact-upload:enabled=false
 ARG://..." \
-"$(run build --artifact-upload:enabled=false //...)"
+    "$(run build --artifact-upload:enabled=false //...)"
 
 # =====================================================================
 # Section 14: PATH fallback when BAZEL_REAL is unset (type -aP, not zsh)
@@ -838,15 +860,15 @@ ARG://..." \
 # (skipping the wrapper itself). Regression test for the old `command -v -a`
 # zsh-ism that exits non-zero under bash and found nothing.
 check "path: BAZEL_REAL unset → finds real bazel on PATH" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:version" \
-"$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" version 2>&1)"
+    "$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" version 2>&1)"
 
 check "path: ASPECT_CLI_RUNNING + BAZEL_REAL unset → finds real bazel on PATH" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:build
 ARG://..." \
-"$(env -u BAZEL_REAL ASPECT_CLI_RUNNING=1 "${WRAPPER_CMD[@]}" build //... 2>&1)"
+    "$(env -u BAZEL_REAL ASPECT_CLI_RUNNING=1 "${WRAPPER_CMD[@]}" build //... 2>&1)"
 
 # =====================================================================
 # Section 16: aspect not installed — install hint + graceful fallback
@@ -866,30 +888,30 @@ hint() {
 # Verb that is BOTH aspect-wrapped and a real bazel command (build): hint with
 # a fallback note, then run the command on vanilla bazel.
 check "no-aspect: build → install hint then falls back to bazel" \
-"$(hint build)
+    "$(hint build)
   Running it through vanilla bazel for now.
 INVOKED:bazel
 ARG:build
 ARG:--keep_going
 ARG://..." \
-"$(run_no_aspect build --keep_going //...)"
+    "$(run_no_aspect build --keep_going //...)"
 
 # Aspect-only wrapped verb (lint): bazel can't run it, so hint and stop.
 check "no-aspect: lint (aspect-only) → install hint, no bazel fallback" \
-"$(hint lint)" \
-"$(run_no_aspect lint 2>&1)"
+    "$(hint lint)" \
+    "$(run_no_aspect lint 2>&1)"
 
 # Custom/unknown verb: aspect-only, hint and stop.
 check "no-aspect: custom verb → install hint, no bazel fallback" \
-"$(hint mytask)" \
-"$(run_no_aspect mytask //x 2>&1)"
+    "$(hint mytask)" \
+    "$(run_no_aspect mytask //x 2>&1)"
 
 # Plain bazel verb: never needs aspect, runs vanilla with no hint.
 check "no-aspect: query (bazel verb) → vanilla bazel, no hint" \
-"INVOKED:bazel
+    "INVOKED:bazel
 ARG:query
 ARG://..." \
-"$(run_no_aspect query //...)"
+    "$(run_no_aspect query //...)"
 
 # =====================================================================
 # Summary


### PR DESCRIPTION
The `tools/bazel` wrapper transparently routes some bazel verbs
(`build`, `test`, …) through `aspect`. That's normally what you want,
but when someone is first seeing the behavior — or hits a case where
they want the underlying bazel directly — they need to know how to
opt out, fast.

This PR makes the escape hatches discoverable from the trace line and
the script header:

- **Shadowing trace suffix.** When the wrapper routes a verb that's
  also a real bazel command (`build`, `test`, `coverage` after
  customization, etc.) through `aspect`, the grey
  `[tools/bazel] aspect …` trace line now ends with
  `— set ASPECT_WRAPPER_SKIP=1 to skip the forward to ``aspect`` —
  docs: …/tools/bazel.md`. Aspect-only verbs (`lint`, `format`,
  custom `.axl` tasks) get just the docs link — `ASPECT_WRAPPER_SKIP`
  wouldn't help there because bazel can't run those verbs.

- **Header comment.** A new "Surprised that `bazel build` runs through
  `aspect`?" block sits right under the script summary, calling out
  both escape hatches in increasing permanence: the per-invocation
  env var, and the workspace-wide option of removing the verb from
  `ASPECT_VERBS_WITH_BAZEL_FLAGS`. The docs URL gets a prominent slot
  up top too.

Tests cover the new suffix on `build` (shadowing), `test` (shadowing),
`lint` (aspect-only), and `mytask` (custom .axl) — both bash 5.x and
the bash 3.2 compatibility floor.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
  (`tools/bazel.md` already documents both opt-outs; the wrapper now
  links to it)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`tools/bazel`: the grey `[tools/bazel] …` trace now ends with
`— set ASPECT_WRAPPER_SKIP=1 to skip the forward to ``aspect``` when
the wrapper is routing a verb that's also a real bazel command, plus a
link to `tools/bazel.md` on every aspect-route trace. The script's
header comment gains a prominent "Surprised that `bazel build` runs
through `aspect`?" block listing both escape hatches.

### Test plan

- Covered by existing test cases (`tools/bazel-test.sh`, plus four new
  cases targeting the new suffix).
- New test cases added.
