### PR TITLE
tools/bazel: always print the aspect-route trace to stderr

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -1,18 +1,14 @@
 name: CI - Workflows
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
 permissions:
   id-token: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-
 # The Dash0 OTLP endpoint and bearer token feed `.aspect/config.axl`'s `ctx.telemetry.exporters.add(...)`
 # call, which dogfoods the trace.event/trace.log pipeline against a real backend.
 # Both are no-ops if a secret isn't configured (unset env var = empty string,
@@ -21,7 +17,6 @@ env:
   DASH0_ENDPOINT: ${{ secrets.DASH0_ENDPOINT }}
   DASH0_TOKEN: ${{ secrets.DASH0_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   # Pure-bash unit tests for the tools/bazel wrapper. No aspect, no bazel, no
   # pre-build — runs on a stock ephemeral runner in seconds and guards the
@@ -33,7 +28,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: tools/bazel wrapper tests
         run: ./tools/bazel-test.sh
-
   pre-build:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     timeout-minutes: 30
@@ -61,7 +55,6 @@ jobs:
           path: target/ci/aspect-cli
           retention-days: 1
           if-no-files-found: error
-
   # Kick off ci-workflows-delivery.yaml as its OWN workflow run, immediately
   # after pre-build. We dispatch via the API (rather than a reusable
   # `uses:` call) on purpose: a reusable workflow nests its jobs inside this
@@ -105,7 +98,6 @@ jobs:
             --field "prebuild_run_id=${{ github.run_id }}" \
             --field "pr_number=${PR_NUMBER}" \
             --field "head_sha=${HEAD_SHA}"
-
   # Dedicated buildifier-only step that runs in parallel with format-task.
   # Models the legacy Rosetta `buildifier` task using a Starlark-only
   # `format_multirun` target — see https://docs.aspect.build/cli/migration/buildifier.
@@ -126,7 +118,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Buildifier Task
         run: aspect buildifier --task-key buildifier-gha
-
   buildifier-debug-task:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -140,7 +131,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Buildifier Task (ASPECT_DEBUG=1)
         run: ASPECT_DEBUG=1 aspect buildifier --task-key buildifier-gha-debug
-
   format-task:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -153,8 +143,7 @@ jobs:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Format Task
-        run: aspect format --task-key format-gha
-
+        run: bazel format --task-key format-gha
   format-debug-task:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -167,8 +156,7 @@ jobs:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Format Task (ASPECT_DEBUG=1)
-        run: ASPECT_DEBUG=1 aspect format --task-key format-gha-debug
-
+        run: ASPECT_DEBUG=1 bazel format --task-key format-gha-debug
   gazelle-task:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -182,7 +170,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Gazelle Task
         run: aspect gazelle --task-key gazelle-gha
-
   gazelle-debug-task:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -196,7 +183,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Gazelle Task (ASPECT_DEBUG=1)
         run: ASPECT_DEBUG=1 aspect gazelle --task-key gazelle-gha-debug
-
   gazelle-from-source-task:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -215,7 +201,6 @@ jobs:
       # lld can't accept Go's non-PIC relocations on x86_64.
       - name: Gazelle Task — from-source
         run: aspect gazelle --gazelle-target=//tools/gazelle:gazelle_from_source --bazel-flag=--config=pure_go --task-key gazelle-from-source-gha
-
   gazelle-from-source-debug-task:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -229,7 +214,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Gazelle Task — from-source (ASPECT_DEBUG=1)
         run: ASPECT_DEBUG=1 aspect gazelle --gazelle-target=//tools/gazelle:gazelle_from_source --bazel-flag=--config=pure_go --task-key gazelle-from-source-gha-debug
-
   lint-task:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -243,7 +227,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Lint Task
         run: aspect lint --task-key lint-gha
-
   lint-debug-task:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -257,7 +240,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Lint Task (ASPECT_DEBUG=1)
         run: ASPECT_DEBUG=1 aspect lint --task-key lint-gha-debug
-
   build-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
@@ -270,7 +252,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task
         run: aspect build --task-key build-gha
-
   build-debug-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
@@ -283,7 +264,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task (ASPECT_DEBUG=1)
         run: ASPECT_DEBUG=1 aspect build --task-key build-gha-debug
-
   test-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
@@ -296,7 +276,6 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test Task
         run: aspect test --task-key test-gha
-
   test-debug-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -251,7 +251,7 @@ jobs:
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task
-        run: aspect build --task-key build-gha
+        run: bazel build --task-key build-gha
   build-debug-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
@@ -263,7 +263,7 @@ jobs:
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task (ASPECT_DEBUG=1)
-        run: ASPECT_DEBUG=1 aspect build --task-key build-gha-debug
+        run: ASPECT_DEBUG=1 bazel build --task-key build-gha-debug
   test-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]

--- a/tools/bazel
+++ b/tools/bazel
@@ -81,12 +81,13 @@
 #                            A total escape hatch for a 1:1 vanilla-bazel
 #                            experience; reach for `aspect <verb>` directly when
 #                            you want the wrapped behavior.
-#   ASPECT_WRAPPER_TRACE=1   Always print the resolved command (in grey, on
-#                            stderr), even when forwarding straight to bazel.
-#                            By default the trace prints only when routing
-#                            to aspect, since plain bazel forwarding is
-#                            uninteresting.
-#   ASPECT_WRAPPER_QUIET=1   Suppress the trace line entirely.
+#   ASPECT_WRAPPER_TRACE=1   Also print the resolved command when forwarding
+#                            straight to bazel. The aspect-route trace already
+#                            prints unconditionally (in grey on a TTY, plain
+#                            text otherwise, always on stderr); plain bazel
+#                            forwarding stays silent unless TRACE forces it on.
+#   ASPECT_WRAPPER_QUIET=1   Suppress the trace line entirely (wins over
+#                            ASPECT_WRAPPER_TRACE).
 #
 # Implicit env var (set by aspect, not by users):
 #   ASPECT_CLI_RUNNING=1     Aspect sets this on every child bazel it spawns.
@@ -553,6 +554,19 @@ BAZEL_VERBS_STR=" ${BAZEL_VERBS[*]} "
 # user can read about the routing rules without grepping the wrapper.
 ASPECT_WRAPPER_DOCS_URL="https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md"
 
+# True on any recognized CI host. Mirrors the runtime's `on_recognized_ci`
+# (crates/axl-runtime/src/ci.rs) so the wrapper and aspect-cli agree on
+# what "on CI" means. Presence — not truthiness — is what counts: GHA
+# sometimes exports `CI=` (empty), and that still marks a CI host.
+on_recognized_ci() {
+    [[ -n "${CI+x}" ]] && return 0
+    [[ -n "${BUILDKITE+x}" ]] && return 0
+    [[ -n "${GITHUB_ACTIONS+x}" ]] && return 0
+    [[ -n "${CIRCLECI+x}" ]] && return 0
+    [[ -n "${GITLAB_CI+x}" ]] && return 0
+    return 1
+}
+
 # Print a grey trace line on stderr showing what the wrapper is about to exec.
 #
 # Usage: trace_exec <category> <shadow> <argv...>
@@ -560,8 +574,8 @@ ASPECT_WRAPPER_DOCS_URL="https://github.com/aspect-build/aspect-cli/blob/main/to
 # <category> is "aspect" when routing to aspect (the interesting case — the
 # wrapper rewrote something) or "bazel" when forwarding straight to bazel
 # (uninteresting; would be visually noisy on `bazel info`, `bazel query`,
-# etc.). The trace prints by default for the "aspect" category and is
-# suppressed for "bazel" unless ASPECT_WRAPPER_TRACE=1 forces it on.
+# etc.). The "aspect" category always prints (unless ASPECT_WRAPPER_QUIET);
+# the "bazel" category is silent unless ASPECT_WRAPPER_TRACE=1 forces it on.
 #
 # <shadow> is "shadow" when this invocation is shadowing a real bazel verb
 # (e.g. `build`/`test` — verbs in both ASPECT_VERBS_WITH_BAZEL_FLAGS and
@@ -575,9 +589,21 @@ ASPECT_WRAPPER_DOCS_URL="https://github.com/aspect-build/aspect-cli/blob/main/to
 # Every aspect-route trace ends with `— docs: <url>` so the routing rules
 # are one click away regardless of whether the verb shadows bazel.
 #
-# Suppressed entirely when stderr is not a TTY (so $(...) capture and CI
-# logs stay clean), unless ASPECT_WRAPPER_TRACE=1. Always suppressed when
-# ASPECT_WRAPPER_QUIET is set.
+# Visibility rules:
+#
+#   aspect category (routing to / shadowing aspect — the interesting case):
+#     - always print, exclusively to stderr, regardless of TTY or CI. The
+#       wrapper rewrote/shadowed a command and the user should see it.
+#     - ASPECT_WRAPPER_QUIET → silent (the only mute).
+#
+#   bazel category (plain forwarding — uninteresting, would be noisy on
+#   `bazel info`, `bazel query`, …):
+#     - silent unless ASPECT_WRAPPER_TRACE=1 forces it on.
+#     - ASPECT_WRAPPER_QUIET → silent (wins over TRACE).
+#
+# ANSI grey wraps the line only on a TTY (or when forced / on CI, where logs
+# render color); a non-TTY stderr gets plain text, so a script capturing
+# stderr never sees escape bytes.
 trace_exec() {
     local category="$1" shadow="$2"
     shift 2
@@ -587,12 +613,17 @@ trace_exec() {
     if [[ "$category" == "bazel" && -z "$force" ]]; then
         return 0
     fi
-    # Aspect routing: silent under non-TTY stderr unless forced.
-    if [[ -z "$force" && ! -t 2 ]]; then
-        return 0
-    fi
+    # Aspect routing always prints (we're shadowing/rewriting a command, which
+    # the user should see). The only mute is ASPECT_WRAPPER_QUIET, handled
+    # above. The trace goes exclusively to stderr, so capturing the command's
+    # stdout never picks it up.
+    local on_ci=0
+    on_recognized_ci && on_ci=1
+    # ANSI grey only when stderr is a TTY (or forced / on CI, where logs render
+    # color). A non-TTY stderr gets plain text — no escape bytes — so a script
+    # that captures stderr sees clean output.
     local grey="" reset=""
-    if [[ -t 2 || -n "$force" ]]; then
+    if [[ -t 2 || -n "$force" || $on_ci -eq 1 ]]; then
         grey=$'\033[38;5;244m'
         reset=$'\033[0m'
     fi

--- a/tools/bazel
+++ b/tools/bazel
@@ -555,9 +555,9 @@ BAZEL_VERBS_STR=" ${BAZEL_VERBS[*]} "
 ASPECT_WRAPPER_DOCS_URL="https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md"
 
 # True on any recognized CI host. Mirrors the runtime's `on_recognized_ci`
-# (crates/axl-runtime/src/ci.rs) so the wrapper and aspect-cli agree on
-# what "on CI" means. Presence — not truthiness — is what counts: GHA
-# sometimes exports `CI=` (empty), and that still marks a CI host.
+# (crates/axl-runtime/src/ci.rs). Used to grey the trace in CI logs, which
+# render ANSI color despite having no TTY. Presence — not truthiness — is
+# what counts: GHA sometimes exports `CI=` (empty), and that still counts.
 on_recognized_ci() {
     [[ -n "${CI+x}" ]] && return 0
     [[ -n "${BUILDKITE+x}" ]] && return 0
@@ -567,7 +567,8 @@ on_recognized_ci() {
     return 1
 }
 
-# Print a grey trace line on stderr showing what the wrapper is about to exec.
+# Print a trace line on stderr showing what the wrapper is about to exec
+# (grey on a color-capable destination, plain text otherwise).
 #
 # Usage: trace_exec <category> <shadow> <argv...>
 #
@@ -613,15 +614,10 @@ trace_exec() {
     if [[ "$category" == "bazel" && -z "$force" ]]; then
         return 0
     fi
-    # Aspect routing always prints (we're shadowing/rewriting a command, which
-    # the user should see). The only mute is ASPECT_WRAPPER_QUIET, handled
-    # above. The trace goes exclusively to stderr, so capturing the command's
-    # stdout never picks it up.
+    # Aspect routing always prints (handled by falling through to here). Grey
+    # only when the output renders color: a TTY, or forced / on CI.
     local on_ci=0
     on_recognized_ci && on_ci=1
-    # ANSI grey only when stderr is a TTY (or forced / on CI, where logs render
-    # color). A non-TTY stderr gets plain text — no escape bytes — so a script
-    # that captures stderr sees clean output.
     local grey="" reset=""
     if [[ -t 2 || -n "$force" || $on_ci -eq 1 ]]; then
         grey=$'\033[38;5;244m'

--- a/tools/bazel-test.sh
+++ b/tools/bazel-test.sh
@@ -31,6 +31,13 @@ chmod +x "$STUB_DIR/aspect" "$STUB_DIR/bazel"
 export BAZEL_REAL="$STUB_DIR/bazel"
 export PATH="$STUB_DIR:$PATH"
 
+# Clear every CI marker the wrapper detects, so the default test run sees
+# the documented "no TTY, no CI" environment. Section 9 sets them back per
+# case to exercise the CI-detection branch explicitly. Without this, the
+# whole suite would behave differently when run on GHA (CI=true) than
+# locally — every $(run …) assertion would have the trace line bleed in.
+unset CI BUILDKITE GITHUB_ACTIONS CIRCLECI GITLAB_CI
+
 PASS=0
 FAIL=0
 FAILED_NAMES=()
@@ -621,10 +628,51 @@ INVOKED:aspect
 ARG:mytask" \
     "$actual"
 
+# Recognized CI host: the aspect-route trace fires WITHOUT
+# ASPECT_WRAPPER_TRACE=1, so the SKIP nudge / docs link is discoverable in
+# CI logs (where surprised developers most often see the routing).
+for marker in CI BUILDKITE GITHUB_ACTIONS CIRCLECI GITLAB_CI; do
+    actual="$(env "$marker=1" "$WRAPPER" build //... 2>&1 | strip_ansi)"
+    check "trace: aspect route prints on CI (marker=$marker, no TRACE)" \
+        "[tools/bazel] aspect build //... — set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\` — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
+INVOKED:aspect
+ARG:build
+ARG://..." \
+        "$actual"
+done
+
+# Presence — not truthiness — is what counts: GHA sometimes exports empty
+# CI markers and the wrapper must still detect them.
+actual="$(env CI= "$WRAPPER" build //... 2>&1 | strip_ansi)"
+check "trace: aspect route prints on CI even when marker is empty (CI=)" \
+    "[tools/bazel] aspect build //... — set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\` — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
+INVOKED:aspect
+ARG:build
+ARG://..." \
+    "$actual"
+
+# Bazel-only verb forwarding stays silent on CI by default — the trace
+# only kicks in for aspect-routed verbs. Pure bazel forwarding still
+# requires ASPECT_WRAPPER_TRACE=1.
+actual="$(env CI=1 "$WRAPPER" query 'deps(//foo)' 2>&1 | strip_ansi)"
+check "trace: bazel-only verb stays silent on CI without TRACE" \
+    "INVOKED:bazel
+ARG:query
+ARG:deps(//foo)" \
+    "$actual"
+
 actual="$(ASPECT_WRAPPER_QUIET=1 ASPECT_WRAPPER_TRACE=1 "$WRAPPER" lint 2>&1 | strip_ansi)"
 check "trace: ASPECT_WRAPPER_QUIET=1 wins over TRACE=1" \
     "INVOKED:aspect
 ARG:lint" \
+    "$actual"
+
+# QUIET also wins over CI detection.
+actual="$(env CI=1 ASPECT_WRAPPER_QUIET=1 "$WRAPPER" build //... 2>&1 | strip_ansi)"
+check "trace: ASPECT_WRAPPER_QUIET=1 wins over CI detection" \
+    "INVOKED:aspect
+ARG:build
+ARG://..." \
     "$actual"
 
 # =====================================================================

--- a/tools/bazel-test.sh
+++ b/tools/bazel-test.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
 # Tests for tools/bazel. Stubs both aspect and bazel so we can assert exactly
-# what the wrapper exec's. Each stub prints its argv (one arg per line) plus
-# the resolved BAZEL_REAL, which the test then compares against expected.
+# what the wrapper exec's: each stub prints its argv, one `ARG:<value>` per
+# line, prefixed with `INVOKED:<name>`. Dispatch/flag assertions capture the
+# stub's stdout (via run()); trace assertions capture stderr (Section 9).
 #
 # Run: ./tools/bazel-test.sh
 # Run under macOS's bash 3.2 (the wrapper's compatibility floor):
@@ -31,11 +32,10 @@ chmod +x "$STUB_DIR/aspect" "$STUB_DIR/bazel"
 export BAZEL_REAL="$STUB_DIR/bazel"
 export PATH="$STUB_DIR:$PATH"
 
-# Clear every CI marker the wrapper detects, so the default test run sees
-# the documented "no TTY, no CI" environment. Section 9 sets them back per
-# case to exercise the CI-detection branch explicitly. Without this, the
-# whole suite would behave differently when run on GHA (CI=true) than
-# locally — every $(run …) assertion would have the trace line bleed in.
+# Clear every CI marker the wrapper detects, so the suite has a known "no TTY,
+# no CI" baseline regardless of where it runs. Section 9 sets markers back per
+# case to exercise CI coloring. Without this, the trace's color tests would see
+# grey when the suite itself runs on GHA (CI=true) and fail.
 unset CI BUILDKITE GITHUB_ACTIONS CIRCLECI GITLAB_CI
 
 PASS=0
@@ -70,8 +70,14 @@ if [[ -n "${WRAPPER_BASH:-}" ]]; then
 else
     WRAPPER_CMD=("$WRAPPER")
 fi
+
+# Capture only the wrapper's stdout — i.e. the stub's report of what got
+# exec'd. The trace line goes to stderr (and the aspect route now always
+# traces), so dropping stderr both keeps these dispatch assertions trace-proof
+# AND verifies the wrapper never leaks anything but the exec to stdout. Trace
+# assertions live in their own section and capture stderr explicitly.
 run() {
-    "${WRAPPER_CMD[@]}" "$@" 2>&1
+    "${WRAPPER_CMD[@]}" "$@" 2>/dev/null
 }
 
 # A PATH dir holding only `bazel` (no `aspect`), to exercise the
@@ -81,7 +87,9 @@ NO_ASPECT_DIR="$(mktemp -d)"
 trap 'rm -rf "$STUB_DIR" "$NO_ASPECT_DIR"' EXIT
 cp "$STUB_DIR/bazel" "$NO_ASPECT_DIR/bazel"
 
-# Run the wrapper with `aspect` absent from PATH.
+# Run the wrapper with `aspect` absent from PATH. Merges stderr into stdout
+# (unlike run()) because these cases assert the stderr install hint and the
+# stdout bazel-fallback output together, in order.
 run_no_aspect() {
     PATH="$NO_ASPECT_DIR:/usr/bin:/bin" "${WRAPPER_CMD[@]}" "$@" 2>&1
 }
@@ -549,7 +557,7 @@ check "env: BAZEL_REAL resolved from PATH and forwarded when unset" \
 BAZEL_REAL=$STUB_DIR/bazel
 ARG:build
 ARG://..." \
-    "$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" build //... 2>&1)"
+    "$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" build //... 2>/dev/null)"
 
 # Restore the plain stub so subsequent assertions stay clean.
 cat >"$STUB_DIR/aspect" <<'EOF'
@@ -561,119 +569,100 @@ EOF
 # =====================================================================
 # Section 9: Trace output (ASPECT_WRAPPER_TRACE / ASPECT_WRAPPER_QUIET)
 # =====================================================================
+#
+# The trace goes to stderr; the sections above capture only stdout via run(),
+# so they're immune to it. Here we capture stderr explicitly to assert the
+# trace itself — content via trace() (ANSI stripped, so assertions don't pin
+# the escape encoding) and color via raw_trace() (escapes kept).
 
-# Under `$()` capture, stderr-is-not-a-TTY, so trace must be silent by
-# default. Earlier sections already implicitly assert this — if trace
-# bled through, every "$(run ...)" assertion would fail. Just sanity-check.
-check "trace: silent under non-TTY by default (aspect path)" \
-    "INVOKED:aspect
-ARG:lint" \
-    "$(run lint 2>&1)"
-
-check "trace: silent under non-TTY by default (bazel path)" \
-    "INVOKED:bazel
-ARG:query
-ARG:deps(//foo)" \
-    "$(run query 'deps(//foo)' 2>&1)"
-
-# Force trace on. Expect the [tools/bazel] line on stderr, then aspect's
-# normal output. Strip ANSI escape sequences so the assertion isn't tied
-# to the exact escape encoding.
 strip_ansi() { sed $'s/\033\\[[0-9;]*m//g'; }
 
-# Aspect-only verb (lint) — no shadowing of bazel, so the trace gets the
-# docs suffix but NOT the ASPECT_WRAPPER_SKIP nudge.
-actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" lint 2>&1 | strip_ansi)"
-check "trace: ASPECT_WRAPPER_TRACE=1 prints '[tools/bazel] ...' for aspect route" \
-    "[tools/bazel] aspect lint — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
-INVOKED:aspect
-ARG:lint" \
-    "$actual"
+# Run the wrapper, returning its stderr only (the trace line). The
+# `2>&1 >/dev/null` order is deliberate: dup stderr onto the pipe's stdout,
+# THEN send the real stdout to /dev/null, so only stderr survives. raw_trace
+# keeps ANSI escapes for the color assertions; trace strips them for content.
+# shellcheck disable=SC2069  # order is intentional (stderr-only capture)
+raw_trace() { "${WRAPPER_CMD[@]}" "$@" 2>&1 >/dev/null; }
+trace() { raw_trace "$@" | strip_ansi; }
 
-# Shadowing verb (build) — `build` is also a real bazel command, so the
-# trace gets the ASPECT_WRAPPER_SKIP nudge AND the docs link.
-actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1 | strip_ansi)"
-check "trace: shows rewritten flags + shadow nudge + docs" \
-    "[tools/bazel] aspect build --bazel-flag=--keep_going --bazel-flag=--config=ci //... — set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\` — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
-INVOKED:aspect
-ARG:build
-ARG:--bazel-flag=--keep_going
-ARG:--bazel-flag=--config=ci
-ARG://..." \
-    "$actual"
+DOCS="docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md"
+SKIP_NUDGE="set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\`"
 
-actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" query 'deps(//foo)' 2>&1 | strip_ansi)"
-check "trace: ASPECT_WRAPPER_TRACE=1 also shows bazel-only verb forwarding" \
-    "[tools/bazel] $STUB_DIR/bazel query 'deps(//foo)'
-INVOKED:bazel
-ARG:query
-ARG:deps(//foo)" \
-    "$actual"
+# --- Aspect route: always traces, even under non-TTY with no CI / TRACE. ---
 
-# Shadowing test verb gets the same SKIP nudge as build.
-actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" test //... 2>&1 | strip_ansi)"
+# Aspect-only verb (lint): docs suffix, but no SKIP nudge (bazel has no lint).
+check "trace: aspect-only verb traces by default (non-TTY), docs but no nudge" \
+    "[tools/bazel] aspect lint — $DOCS" \
+    "$(trace lint)"
+
+# Shadowing verb (build): also a real bazel command, so the SKIP nudge fires.
+# Also asserts bazel flags are shown rewritten in the trace.
+check "trace: shadowing verb shows rewritten flags + SKIP nudge + docs" \
+    "[tools/bazel] aspect build --bazel-flag=--keep_going --bazel-flag=--config=ci //... — $SKIP_NUDGE — $DOCS" \
+    "$(trace build --keep_going --config=ci //...)"
+
 check "trace: shadow nudge fires on 'test' too (verb in both lists)" \
-    "[tools/bazel] aspect test //... — set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\` — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
-INVOKED:aspect
-ARG:test
-ARG://..." \
-    "$actual"
+    "[tools/bazel] aspect test //... — $SKIP_NUDGE — $DOCS" \
+    "$(trace test //...)"
 
-# Custom .axl task (unknown verb) routes to aspect but does NOT shadow bazel —
-# only the docs suffix, no SKIP nudge.
-actual="$(ASPECT_WRAPPER_TRACE=1 "$WRAPPER" mytask 2>&1 | strip_ansi)"
+# Custom .axl task (unknown verb): routes to aspect, no shadow (bazel has no
+# such command) → docs suffix, no SKIP nudge.
 check "trace: custom .axl verb gets docs link, no shadow nudge" \
-    "[tools/bazel] aspect mytask — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
-INVOKED:aspect
-ARG:mytask" \
-    "$actual"
+    "[tools/bazel] aspect mytask — $DOCS" \
+    "$(trace mytask)"
 
-# Recognized CI host: the aspect-route trace fires WITHOUT
-# ASPECT_WRAPPER_TRACE=1, so the SKIP nudge / docs link is discoverable in
-# CI logs (where surprised developers most often see the routing).
-for marker in CI BUILDKITE GITHUB_ACTIONS CIRCLECI GITLAB_CI; do
-    actual="$(env "$marker=1" "$WRAPPER" build //... 2>&1 | strip_ansi)"
-    check "trace: aspect route prints on CI (marker=$marker, no TRACE)" \
-        "[tools/bazel] aspect build //... — set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\` — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
-INVOKED:aspect
-ARG:build
-ARG://..." \
-        "$actual"
-done
+# --- Bazel route: silent by default; ASPECT_WRAPPER_TRACE=1 forces it on. ---
 
-# Presence — not truthiness — is what counts: GHA sometimes exports empty
-# CI markers and the wrapper must still detect them.
-actual="$(env CI= "$WRAPPER" build //... 2>&1 | strip_ansi)"
-check "trace: aspect route prints on CI even when marker is empty (CI=)" \
-    "[tools/bazel] aspect build //... — set ASPECT_WRAPPER_SKIP=1 to skip the forward to \`aspect\` — docs: https://github.com/aspect-build/aspect-cli/blob/main/tools/bazel.md
-INVOKED:aspect
-ARG:build
-ARG://..." \
-    "$actual"
+check "trace: bazel-only verb silent by default" \
+    "" \
+    "$(trace query 'deps(//foo)')"
 
-# Bazel-only verb forwarding stays silent on CI by default — the trace
-# only kicks in for aspect-routed verbs. Pure bazel forwarding still
-# requires ASPECT_WRAPPER_TRACE=1.
-actual="$(env CI=1 "$WRAPPER" query 'deps(//foo)' 2>&1 | strip_ansi)"
+check "trace: ASPECT_WRAPPER_TRACE=1 surfaces bazel forwarding (no suffix)" \
+    "[tools/bazel] $STUB_DIR/bazel query 'deps(//foo)'" \
+    "$(ASPECT_WRAPPER_TRACE=1 trace query 'deps(//foo)')"
+
+# CI markers don't change bazel-route visibility — only TRACE does.
 check "trace: bazel-only verb stays silent on CI without TRACE" \
-    "INVOKED:bazel
-ARG:query
-ARG:deps(//foo)" \
-    "$actual"
+    "" \
+    "$(CI=1 trace query 'deps(//foo)')"
 
-actual="$(ASPECT_WRAPPER_QUIET=1 ASPECT_WRAPPER_TRACE=1 "$WRAPPER" lint 2>&1 | strip_ansi)"
-check "trace: ASPECT_WRAPPER_QUIET=1 wins over TRACE=1" \
-    "INVOKED:aspect
-ARG:lint" \
-    "$actual"
+# --- ASPECT_WRAPPER_QUIET: the only mute, wins over everything. ---
 
-# QUIET also wins over CI detection.
-actual="$(env CI=1 ASPECT_WRAPPER_QUIET=1 "$WRAPPER" build //... 2>&1 | strip_ansi)"
-check "trace: ASPECT_WRAPPER_QUIET=1 wins over CI detection" \
-    "INVOKED:aspect
-ARG:build
-ARG://..." \
-    "$actual"
+check "trace: ASPECT_WRAPPER_QUIET=1 silences aspect route" \
+    "" \
+    "$(ASPECT_WRAPPER_QUIET=1 trace lint)"
+
+check "trace: ASPECT_WRAPPER_QUIET=1 wins over TRACE=1 (bazel route)" \
+    "" \
+    "$(ASPECT_WRAPPER_QUIET=1 ASPECT_WRAPPER_TRACE=1 trace query 'deps(//foo)')"
+
+check "trace: ASPECT_WRAPPER_QUIET=1 wins over CI" \
+    "" \
+    "$(CI=1 ASPECT_WRAPPER_QUIET=1 trace build //...)"
+
+# --- Color: grey on a color-capable destination, plain text otherwise. ---
+#
+# Look for the SGR grey escape in raw_trace's output. Non-TTY with no CI /
+# TRACE → plain text; CI or TRACE → grey.
+GREY=$'\033[38;5;244m'
+
+case "$(raw_trace lint)" in
+*"$GREY"*) plain=0 ;;
+*) plain=1 ;;
+esac
+check "trace: aspect route is plain text (no ANSI) under non-TTY, no CI" "1" "$plain"
+
+case "$(CI=1 raw_trace build //...)" in
+*"$GREY"*) grey=1 ;;
+*) grey=0 ;;
+esac
+check "trace: aspect route is grey on CI" "1" "$grey"
+
+case "$(ASPECT_WRAPPER_TRACE=1 raw_trace query 'deps(//foo)')" in
+*"$GREY"*) grey=1 ;;
+*) grey=0 ;;
+esac
+check "trace: bazel route is grey when TRACE forces it on" "1" "$grey"
 
 # =====================================================================
 # Section 10: ASPECT_WRAPPER_SKIP — total bypass, everything → vanilla bazel
@@ -683,14 +672,14 @@ check "skip: build forwards straight to bazel" \
     "INVOKED:bazel
 ARG:build
 ARG://..." \
-    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build //... 2>/dev/null)"
 
 check "skip: test forwards straight to bazel" \
     "INVOKED:bazel
 ARG:test
 ARG:--keep_going
 ARG://..." \
-    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" test --keep_going //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" test --keep_going //... 2>/dev/null)"
 
 check "skip: run forwards straight to bazel" \
     "INVOKED:bazel
@@ -698,7 +687,7 @@ ARG:run
 ARG://foo:bin
 ARG:--
 ARG:arg1" \
-    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" run //foo:bin -- arg1 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" run //foo:bin -- arg1 2>/dev/null)"
 
 # Skip is a TOTAL bypass: even aspect verbs go straight to vanilla bazel,
 # untouched. (The user reaches for `aspect <verb>` directly when they want
@@ -706,25 +695,25 @@ ARG:arg1" \
 check "skip: aspect verb (lint) also forwards straight to bazel" \
     "INVOKED:bazel
 ARG:lint" \
-    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" lint 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" lint 2>/dev/null)"
 
 check "skip: aspect verb (format) also forwards straight to bazel" \
     "INVOKED:bazel
 ARG:format
 ARG://..." \
-    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" format //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" format //... 2>/dev/null)"
 
 # Custom/unknown verb also bypasses (no aspect routing under skip).
 check "skip: custom verb also forwards straight to bazel" \
     "INVOKED:bazel
 ARG:mytask" \
-    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" mytask 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" mytask 2>/dev/null)"
 
 check "skip: query (bazel-only verb) still goes to bazel" \
     "INVOKED:bazel
 ARG:query
 ARG://..." \
-    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" query //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" query //... 2>/dev/null)"
 
 # Skip + flag preservation: bazel sees the raw flags, no --bazel-flag= wrapping.
 check "skip: bazel-native flags pass through unwrapped" \
@@ -733,7 +722,7 @@ ARG:build
 ARG:--keep_going
 ARG:--config=ci
 ARG://..." \
-    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP=1 "$WRAPPER" build --keep_going --config=ci //... 2>/dev/null)"
 
 # Skip + TRACE shows the bazel forward.
 actual="$(ASPECT_WRAPPER_SKIP=1 ASPECT_WRAPPER_TRACE=1 "$WRAPPER" build //... 2>&1 | strip_ansi)"
@@ -749,7 +738,7 @@ check "skip: empty string ASPECT_WRAPPER_SKIP='' is treated as unset" \
     "INVOKED:aspect
 ARG:build
 ARG://..." \
-    "$(ASPECT_WRAPPER_SKIP="" "$WRAPPER" build //... 2>&1)"
+    "$(ASPECT_WRAPPER_SKIP="" "$WRAPPER" build //... 2>/dev/null)"
 
 # =====================================================================
 # Section 11: Anti-inception (ASPECT_CLI_RUNNING bypass)
@@ -764,7 +753,7 @@ check "inception: ASPECT_CLI_RUNNING=1 + build → straight to bazel" \
     "INVOKED:bazel
 ARG:build
 ARG://..." \
-    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build //... 2>&1)"
+    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build //... 2>/dev/null)"
 
 check "inception: ASPECT_CLI_RUNNING=1 + bazel-native flags pass through unwrapped" \
     "INVOKED:bazel
@@ -772,7 +761,7 @@ ARG:build
 ARG:--keep_going
 ARG:--config=ci
 ARG://..." \
-    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build --keep_going --config=ci //... 2>&1)"
+    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" build --keep_going --config=ci //... 2>/dev/null)"
 
 # Even aspect-only verbs forward to bazel under ASPECT_CLI_RUNNING. Aspect
 # would never spawn `bazel lint`, but if it somehow did we still want the
@@ -780,20 +769,20 @@ ARG://..." \
 check "inception: ASPECT_CLI_RUNNING=1 wins over aspect-only verbs too" \
     "INVOKED:bazel
 ARG:lint" \
-    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" lint 2>&1)"
+    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" lint 2>/dev/null)"
 
 check "inception: ASPECT_CLI_RUNNING=1 + info → straight to bazel" \
     "INVOKED:bazel
 ARG:info
 ARG:workspace" \
-    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" info workspace 2>&1)"
+    "$(ASPECT_CLI_RUNNING=1 "$WRAPPER" info workspace 2>/dev/null)"
 
 # Empty string means unset — wrapper must treat it the same as no env var.
 check "inception: empty ASPECT_CLI_RUNNING='' is treated as unset" \
     "INVOKED:aspect
 ARG:build
 ARG://..." \
-    "$(ASPECT_CLI_RUNNING="" "$WRAPPER" build //... 2>&1)"
+    "$(ASPECT_CLI_RUNNING="" "$WRAPPER" build //... 2>/dev/null)"
 
 # Bypass should fire BEFORE the trace logic. Even with TRACE=1, the bypass
 # runs and we get straight bazel — no aspect-route trace line.
@@ -910,13 +899,13 @@ ARG://..." \
 check "path: BAZEL_REAL unset → finds real bazel on PATH" \
     "INVOKED:bazel
 ARG:version" \
-    "$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" version 2>&1)"
+    "$(env -u BAZEL_REAL "${WRAPPER_CMD[@]}" version 2>/dev/null)"
 
 check "path: ASPECT_CLI_RUNNING + BAZEL_REAL unset → finds real bazel on PATH" \
     "INVOKED:bazel
 ARG:build
 ARG://..." \
-    "$(env -u BAZEL_REAL ASPECT_CLI_RUNNING=1 "${WRAPPER_CMD[@]}" build //... 2>&1)"
+    "$(env -u BAZEL_REAL ASPECT_CLI_RUNNING=1 "${WRAPPER_CMD[@]}" build //... 2>/dev/null)"
 
 # =====================================================================
 # Section 16: aspect not installed — install hint + graceful fallback
@@ -947,12 +936,12 @@ ARG://..." \
 # Aspect-only wrapped verb (lint): bazel can't run it, so hint and stop.
 check "no-aspect: lint (aspect-only) → install hint, no bazel fallback" \
     "$(hint lint)" \
-    "$(run_no_aspect lint 2>&1)"
+    "$(run_no_aspect lint)"
 
 # Custom/unknown verb: aspect-only, hint and stop.
 check "no-aspect: custom verb → install hint, no bazel fallback" \
     "$(hint mytask)" \
-    "$(run_no_aspect mytask //x 2>&1)"
+    "$(run_no_aspect mytask //x)"
 
 # Plain bazel verb: never needs aspect, runs vanilla with no hint.
 check "no-aspect: query (bazel verb) → vanilla bazel, no hint" \


### PR DESCRIPTION
The `tools/bazel` wrapper routes `bazel build`/`test`/`lint`/… through
the `aspect` CLI. Two guarantees must be met:

1. **The wrapper must never write to stdout.** Only the final
   `exec` to `aspect`/`bazel` should produce stdout, so a script that
   captures `$(bazel …)` gets exactly the command's output and nothing
   from the wrapper.

2. **Routing to `aspect` should always be visible.** The grey
   `[tools/bazel] aspect …` trace — carrying the `ASPECT_WRAPPER_SKIP=1`
   opt-out hint and docs link — previously only fired on a TTY (or with
   `ASPECT_WRAPPER_TRACE=1`), so a developer whose `bazel build` was
   silently shadowed by `aspect` in a non-TTY context had no hint.

This makes the trace contract explicit and tests it:

- **Aspect route always traces**, exclusively on stderr, regardless of
  TTY or CI. `ASPECT_WRAPPER_QUIET=1` is the only mute.
- **Bazel forwarding stays silent** unless `ASPECT_WRAPPER_TRACE=1`
  forces it on (`ASPECT_WRAPPER_QUIET=1` wins).
- The line is grey only on a color-capable destination — a TTY, or a
  recognized CI host (GHA/Buildkite/CircleCI/GitLab/`CI=…`, presence not
  truthiness, mirroring [`crates/axl-runtime/src/ci.rs`](crates/axl-runtime/src/ci.rs)).
  A non-TTY stderr gets plain text, so captured stderr carries no escape
  bytes.

The `tools/bazel-test.sh` suite now separates streams: dispatch/flag
assertions capture stdout only (which also proves the wrapper leaks
nothing but the exec to stdout), while the trace section captures
stderr. CI dogfoods the wrapper by running the two `format` jobs as
`bazel format`.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
  (env-var block and `trace_exec` docs in the wrapper header)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`tools/bazel`: the `[tools/bazel] aspect …` trace now prints on every
invocation routed to `aspect` (on stderr), not just on a TTY — so the
`ASPECT_WRAPPER_SKIP=1` opt-out hint and docs link are always visible,
including in CI logs. It is greyed on a TTY or recognized CI host and
plain text otherwise. `ASPECT_WRAPPER_QUIET=1` suppresses it entirely;
plain `bazel` forwarding stays silent unless `ASPECT_WRAPPER_TRACE=1`.

### Test plan

- New test cases added in [`tools/bazel-test.sh`](tools/bazel-test.sh):
  aspect route always traces (non-TTY), shadow/docs suffixes, bazel-route
  silence, `ASPECT_WRAPPER_QUIET` precedence, and grey-vs-plain coloring.
- 107/107 pass under both the default bash and the bash 3.2 floor
  (`WRAPPER_BASH=/bin/bash ./tools/bazel-test.sh`).
