### PR TITLE
Let users override --remote_download_outputs for spawn tasks

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -118,7 +118,7 @@ load("@aspect//lib/github.axl", "detect_commit_sha")
 load("@aspect//lib/health_check.axl", "HealthCheckTrait")
 load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "apparent_label", "runnable")
+load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "apparent_label", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
 load("@aspect//lib/tips.axl", "tips")
 load("@std//time.axl", "sleep_iter", "time")
@@ -914,14 +914,31 @@ def _delivery_impl(ctx):
             phase = Phase(name = "download", description = "Download runfiles", emoji = "📥"),
         )
 
-        # release_bazel_flags sit between expanded_flags and the trailing
-        # spawn-required flags so release-only values (e.g. --stamp) win
-        # over --config=X expansion. The trailing block is appended LAST
-        # and overrides everything — must take effect for the delivery
-        # spawn to succeed.
+        # Phase 3 flag composition:
+        #   expanded_flags          — phase 1/2 setup (carries the `=minimal`
+        #                             base from setup_phase, plus user/rc flags).
+        #                             The trailing `=minimal` is intentional
+        #                             for phase 1/2 (sha computation, never
+        #                             downloads outputs), but phase 3 needs to
+        #                             reassert `=toplevel` over it.
+        #   LOCAL_SPAWN_BASE_FLAGS  — restores `--remote_download_outputs=toplevel`
+        #                             as the phase-3 default, overriding the
+        #                             `=minimal` from expanded_flags. Placed
+        #                             BEFORE release_bazel_flags so a user who
+        #                             needs `=all` (e.g. older bazel version or
+        #                             misbehaving rule set) can pass
+        #                             `--release-bazel-flag=--remote_download_outputs=all`
+        #                             and win.
+        #   release_bazel_flags     — release-only user flags (e.g. --stamp);
+        #                             last user-controlled win before the
+        #                             mandatory trailing block.
+        #   LOCAL_SPAWN_FLAGS       — mandatory spawn flags; appended LAST so
+        #                             they win over everything — without them
+        #                             the spawn fails (BES upload strategy,
+        #                             runfile links).
         # --noremote_upload_local_results: release artifacts shouldn't
         #     pollute the shared remote cache (delivery-specific).
-        phase3_flags = list(expanded_flags) + list(ctx.args.release_bazel_flags) + LOCAL_SPAWN_FLAGS + [
+        phase3_flags = list(expanded_flags) + LOCAL_SPAWN_BASE_FLAGS + list(ctx.args.release_bazel_flags) + LOCAL_SPAWN_FLAGS + [
             "--noremote_upload_local_results",
         ]
         _t_download = time.monotonic()

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -232,7 +232,8 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
         "--inject_repository=aspect_delivery=" + repo_dir,
     ]
 
-    phase1_flags = bazel_flags + ["--nokeep_state_after_build"]
+    # Force `=minimal`: phase 1 reads outputs via BES, never from disk.
+    phase1_flags = bazel_flags + ["--nokeep_state_after_build", "--remote_download_outputs=minimal"]
     _t_phase1 = time.monotonic()
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
@@ -374,11 +375,14 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     )
     _t_phase2 = time.monotonic()
     log_path = _GRPC_LOG_PATH.format(ctx.task.key)
+
+    # Force `=minimal`: phase 2 reads digests from the gRPC log, not disk.
     phase2_flags = bazel_flags + aspect_flags + [
         "--remote_executor=" + remote_executor_uri,
         "--experimental_remote_require_cached",
         "--remote_grpc_log=" + log_path,
         "--keep_going",
+        "--remote_download_outputs=minimal",
     ]
 
     # Redirect stderr to a log file: require-cached failures on first
@@ -652,9 +656,6 @@ def _delivery_impl(ctx):
     # The single pre-task setup phase (status surface, rc parse, health
     # checks); returns expanded_flags (a failed health check fails the task
     # inside setup_phase). phase1/2/3_flags layer on top later.
-    # --remote_download_outputs=minimal is mandatory for phases 1/2 (we never
-    # download outputs while computing shas); phase 3 appends
-    # ctx.args.release_bazel_flags for release-only flags like --stamp.
     expanded_flags = setup_phase(
         ctx,
         lifecycle,
@@ -664,7 +665,6 @@ def _delivery_impl(ctx):
         hc_trait,
         bazel_trait,
         "build",
-        bazel_base_flags = ["--remote_download_outputs=minimal"],
     )
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
@@ -914,31 +914,16 @@ def _delivery_impl(ctx):
             phase = Phase(name = "download", description = "Download runfiles", emoji = "📥"),
         )
 
-        # Phase 3 flag composition:
-        #   expanded_flags          — phase 1/2 setup (carries the `=minimal`
-        #                             base from setup_phase, plus user/rc flags).
-        #                             The trailing `=minimal` is intentional
-        #                             for phase 1/2 (sha computation, never
-        #                             downloads outputs), but phase 3 needs to
-        #                             reassert `=toplevel` over it.
-        #   LOCAL_SPAWN_BASE_FLAGS  — restores `--remote_download_outputs=toplevel`
-        #                             as the phase-3 default, overriding the
-        #                             `=minimal` from expanded_flags. Placed
-        #                             BEFORE release_bazel_flags so a user who
-        #                             needs `=all` (e.g. older bazel version or
-        #                             misbehaving rule set) can pass
-        #                             `--release-bazel-flag=--remote_download_outputs=all`
-        #                             and win.
-        #   release_bazel_flags     — release-only user flags (e.g. --stamp);
-        #                             last user-controlled win before the
-        #                             mandatory trailing block.
-        #   LOCAL_SPAWN_FLAGS       — mandatory spawn flags; appended LAST so
-        #                             they win over everything — without them
-        #                             the spawn fails (BES upload strategy,
-        #                             runfile links).
-        # --noremote_upload_local_results: release artifacts shouldn't
-        #     pollute the shared remote cache (delivery-specific).
-        phase3_flags = list(expanded_flags) + LOCAL_SPAWN_BASE_FLAGS + list(ctx.args.release_bazel_flags) + LOCAL_SPAWN_FLAGS + [
+        # Phase 3 flag order (last-wins):
+        #   LOCAL_SPAWN_BASE_FLAGS  — default `--remote_download_outputs=toplevel`;
+        #                             first so user/rc overrides win.
+        #   expanded_flags          — user `--bazel-flag` / rc settings.
+        #   release_bazel_flags     — release-only flags via `--release-bazel-flag`
+        #                             (e.g. `--stamp`).
+        #   LOCAL_SPAWN_FLAGS       — mandatory; last so nothing can flip them.
+        #   --noremote_upload_local_results — release artifacts shouldn't pollute
+        #                             the shared remote cache (delivery-specific).
+        phase3_flags = LOCAL_SPAWN_BASE_FLAGS + list(expanded_flags) + list(ctx.args.release_bazel_flags) + LOCAL_SPAWN_FLAGS + [
             "--noremote_upload_local_results",
         ]
         _t_download = time.monotonic()

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -31,7 +31,7 @@ load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskL
 load("./lib/path_glob.axl", "match_any")
 load("./lib/path_normalize.axl", "normalize_files_for_cwd")
 load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
 
@@ -366,7 +366,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # The single pre-task setup phase (status surface, rc parse, health
     # checks); returns the resolved flags (a failed health check fails the task
     # inside setup_phase).
-    flags = setup_phase(ctx, lifecycle, ctx.args.formatter_target, "format_results", data, hc_trait, bazel_trait)
+    flags = setup_phase(ctx, lifecycle, ctx.args.formatter_target, "format_results", data, hc_trait, bazel_trait, bazel_base_flags = LOCAL_SPAWN_BASE_FLAGS)
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
     flags.extend(LOCAL_SPAWN_FLAGS)

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -198,7 +198,7 @@ load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
 load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
 
@@ -585,7 +585,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # The single pre-task setup phase (status surface, rc parse, health
     # checks); returns the resolved flags (a failed health check fails the task
     # inside setup_phase).
-    flags = setup_phase(ctx, lifecycle, ctx.args.gazelle_target, "gazelle_results", data, hc_trait, bazel_trait)
+    flags = setup_phase(ctx, lifecycle, ctx.args.gazelle_target, "gazelle_results", data, hc_trait, bazel_trait, bazel_base_flags = LOCAL_SPAWN_BASE_FLAGS)
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
     # Resolve effective dirs before the bazel build phase: gazelle

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
@@ -190,8 +190,7 @@ def setup_bazel_command(ctx, command, bazel_trait, base_flags = []):
       bazel_trait: `BazelTrait` instance from `ctx.traits`.
       base_flags: task-injected defaults the user can override via
         `--bazel-flag=...` (last-wins after rc expansion). Examples:
-        build/test's `--isatty=...`, lint's `--aspects=...`,
-        delivery's `--remote_download_outputs=minimal`.
+        lint's `--aspects=...`, spawn tasks' `--remote_download_outputs=toplevel`.
 
     Requires the task to declare `bazel_startup_flags`, `bazel_flags`,
     and `announce_bazel_rc` CLI args.

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -2,15 +2,13 @@ _DEFAULT_WORKSPACE_NAME = "_main"
 
 # Mandatory Bazel flags for a task that immediately spawns the built binary
 # (format, gazelle, run, delivery phase 3). Append these LAST so they win
-# over any rc or trait flag that would flip them — user .bazelrc can carry
-# `common:ci --nobuild_runfile_links` which would otherwise ENOENT the
-# spawn. These are non-negotiable: the spawn cannot work without them.
+# over any user rc / `--bazel-flag` value that would flip them: the spawn
+# cannot work without them.
 #
-#   --experimental_build_event_upload_strategy=local: have BES report
-#       artifacts as local file:// paths so we can locate the binary
-#       on disk to spawn it. With the remote strategy, BES reports
-#       bytestream:// URIs, which aren't on-disk paths.
-#   --build_runfile_links: lay down the runfiles tree so the binary's
+#   --experimental_build_event_upload_strategy=local: BES reports artifacts
+#       as local file:// paths so we can locate the binary on disk;
+#       the remote strategy yields bytestream:// URIs, which aren't paths.
+#   --build_runfile_links: materializes the runfiles tree so the binary's
 #       wrappers and data deps resolve at runtime.
 LOCAL_SPAWN_FLAGS = [
     "--experimental_build_event_upload_strategy=local",
@@ -19,11 +17,12 @@ LOCAL_SPAWN_FLAGS = [
 
 # Default `--remote_download_outputs` value for a task that immediately
 # spawns the built binary. Inject these via the `bazel_base_flags` path
-# (i.e. BEFORE user flags / rc expansion) so a user who needs the wider
-# `=all` setting — e.g. older version or bazel or misbehaving rule set —
-# can override on the command line or in their `.bazelrc`. `=toplevel`
-# is the minimum that materializes the binary itself on disk so we can
-# spawn it; `=minimal` would leave it remote and break the spawn.
+# (i.e. BEFORE user flags / rc expansion) so a user who needs `=all` —
+# e.g. an older Bazel version or a misbehaving rule set that won't run
+# without dependency outputs materialized — can override via the command
+# line or `.bazelrc`. `=toplevel` is the minimum that puts the binary
+# itself on disk so we can spawn it; `=minimal` would leave it remote
+# and break the spawn.
 LOCAL_SPAWN_BASE_FLAGS = [
     "--remote_download_outputs=toplevel",
 ]

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -1,23 +1,31 @@
 _DEFAULT_WORKSPACE_NAME = "_main"
 
-# Bazel flags required for a task that immediately spawns the built binary
+# Mandatory Bazel flags for a task that immediately spawns the built binary
 # (format, gazelle, run, delivery phase 3). Append these LAST so they win
 # over any rc or trait flag that would flip them — user .bazelrc can carry
-# `common:-ci --remote_download_outputs=minimal --nobuild_runfile_links`
-# which would otherwise ENOENT the spawn.
+# `common:ci --nobuild_runfile_links` which would otherwise ENOENT the
+# spawn. These are non-negotiable: the spawn cannot work without them.
 #
 #   --experimental_build_event_upload_strategy=local: have BES report
 #       artifacts as local file:// paths so we can locate the binary
 #       on disk to spawn it. With the remote strategy, BES reports
 #       bytestream:// URIs, which aren't on-disk paths.
-#   --remote_download_outputs=toplevel: materialize the binary itself on
-#       disk so we can spawn it.
 #   --build_runfile_links: lay down the runfiles tree so the binary's
 #       wrappers and data deps resolve at runtime.
 LOCAL_SPAWN_FLAGS = [
     "--experimental_build_event_upload_strategy=local",
-    "--remote_download_outputs=toplevel",
     "--build_runfile_links",
+]
+
+# Default `--remote_download_outputs` value for a task that immediately
+# spawns the built binary. Inject these via the `bazel_base_flags` path
+# (i.e. BEFORE user flags / rc expansion) so a user who needs the wider
+# `=all` setting — e.g. older version or bazel or misbehaving rule set —
+# can override on the command line or in their `.bazelrc`. `=toplevel`
+# is the minimum that materializes the binary itself on disk so we can
+# spawn it; `=minimal` would leave it remote and break the spawn.
+LOCAL_SPAWN_BASE_FLAGS = [
+    "--remote_download_outputs=toplevel",
 ]
 
 # Named modes accepted by `--run-in=<choice>` on tasks that spawn a

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -9,7 +9,7 @@ load("./lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_bui
 load("./lib/environment.axl", "error")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
-load("./lib/runnable.axl", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
 load("./lib/tips.axl", "tips")
 
 def _terminal_status(data, exit_code):
@@ -79,7 +79,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # ultimately invokes `ctx.bazel.build`, which spawns a literal `bazel
     # build`. The `run:` rc section can contain options Bazel's `build` command
     # rejects as unrecognized (e.g. `--script_path`).
-    flags = setup_phase(ctx, lifecycle, target, "bazel_results", data, hc_trait, bazel_trait, "build")
+    flags = setup_phase(ctx, lifecycle, target, "bazel_results", data, hc_trait, bazel_trait, "build", bazel_base_flags = LOCAL_SPAWN_BASE_FLAGS)
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
     flags.extend(LOCAL_SPAWN_FLAGS)


### PR DESCRIPTION
`LOCAL_SPAWN_FLAGS` (used by `run`, `format`, `gazelle`, and delivery phase 3) was appended LAST in every callsite, forcing `--remote_download_outputs=toplevel` even when a user genuinely needed `=all` — e.g. an older Bazel version or a misbehaving rule set that won't run without dependency outputs materialized.

Split into two constants in [lib/runnable.axl](crates/aspect-cli/src/builtins/aspect/lib/runnable.axl):

- `LOCAL_SPAWN_FLAGS` — mandatory (`--experimental_build_event_upload_strategy=local`, `--build_runfile_links`); still appended LAST so a stray `--nobuild_runfile_links` in a user `.bazelrc` can't ENOENT the spawn.
- `LOCAL_SPAWN_BASE_FLAGS` — default `--remote_download_outputs=toplevel`; injected BEFORE user flags so any `--bazel-flag` / `.bazelrc` / `--release-bazel-flag` (delivery) override wins.

Delivery phases 1 and 2 used to inject `--remote_download_outputs=minimal` via `setup_phase`'s `bazel_base_flags`, which leaked the value into `expanded_flags` and complicated phase 3's override story. Phases 1/2 now force `=minimal` directly on their own flag lists (they only read BES + the gRPC log, never on-disk outputs), so `expanded_flags` carries only user/rc settings and phase 3's override semantics match the other spawn tasks.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- `aspect run`, `aspect format`, `aspect configure`, and `aspect delivery` no longer force `--remote_download_outputs=toplevel`. Users who need `=all` can set it via `--bazel-flag=--remote_download_outputs=all`, `.bazelrc`, or (delivery only) `--release-bazel-flag=...`.

### Test plan

- Covered by existing test cases
