### PR TITLE
Add per-tip identity, surface, and combine controls + tip_suggestion hook

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -32,7 +32,7 @@ load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
 load("../lib/rate_limit.axl", "usage_footer")
 load("../lib/result_text.axl", "severity_for_status")
-load("../lib/tips.axl", "collect_tips_sorted")
+load("../lib/tips.axl", "SURFACE_BUILDKITE_ANNOTATIONS", "collect_tips_sorted")
 
 # ─── Style selection ──────────────────────────────────────────────────────────
 
@@ -317,7 +317,7 @@ def _buildkite_annotations(ctx: FeatureContext):
             ctx,
             data,
             status,
-            make_render_ctx(_state, tips = collect_tips_sorted(ctx), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
+            make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_BUILDKITE_ANNOTATIONS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             _make_links(data),
             None,
             None,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -65,7 +65,7 @@ load(
     "should_emit_phase_change",
     "usage_footer",
 )
-load("../lib/tips.axl", "collect_tips_sorted")
+load("../lib/tips.axl", "SURFACE_GITHUB_STATUS_CHECKS", "collect_tips_sorted")
 load("../lint.axl", "LintTrait")
 
 # The previous `GitHubStatusChecksTrait` (templates, metadata_keys) was
@@ -231,7 +231,7 @@ def _github_status_checks(ctx: FeatureContext):
             ctx,
             initial_renderer.init(),
             "running",
-            make_render_ctx(_state, tips = collect_tips_sorted(ctx), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
+            make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITHUB_STATUS_CHECKS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             dict(_ci_links_base),
             templates,
             metadata_keys,
@@ -487,7 +487,7 @@ def _github_status_checks(ctx: FeatureContext):
             ctx,
             data,
             status,
-            make_render_ctx(_state, tips = collect_tips_sorted(ctx), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
+            make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITHUB_STATUS_CHECKS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             _make_links(data),
             templates,
             metadata_keys,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -65,12 +65,14 @@ load("../lib/result_text.axl", "severity_for_status")
 load("../lib/tar.axl", "bsdtar")
 load(
     "../lib/tips.axl",
+    "SURFACE_GITHUB_PR_SUMMARY",
     "TIP_IMPORTANT",
     "TIP_TEMPLATE_JINJA2",
     "TIP_WARNING",
     "collect_tips_sorted",
     "decorate_tip",
     "severity_rank",
+    "tip_shows_on",
     "tip_to_payload",
 )
 
@@ -682,15 +684,78 @@ def _is_must_show(severity):
     and warning signals degraded behavior."""
     return severity == TIP_IMPORTANT or severity == TIP_WARNING
 
-def _collect_tip_rows(ctx, entries):
-    """Walk every entry's `tips` list, dedup by id, attribute by task
-    key, sort by severity, then apply the rendering caps.
+def _ordered_unique(values):
+    """First-seen-order dedup of a list (no set; preserves order)."""
+    out = []
+    for v in values:
+        if v and v not in out:
+            out.append(v)
+    return out
 
-    Dedup is by `id`. Pre-rendered tips (RAW/FORMAT) take the first
-    seen `title` / `body`. JINJA2 tips union each accumulator's values
-    across tasks (preserving first-seen order) and re-render so the
-    comment surfaces the full cross-task picture (e.g. every scope +
-    endpoint contributed by every task that hit the path).
+def _combine_across(ctx, contributors):
+    """Collapse a same-`(id, key)` group into one row, unioning across tasks.
+
+    `contributors` is a list of `(tip, task_key)`. JINJA2 `accumulate`
+    fields are unioned across tasks (first-seen order) and re-rendered
+    against `vars` + the merged lists, so the row surfaces the full
+    cross-task set. Pre-rendered title/body follow newest-wins: the row
+    starts from the last contributor. Attribution is every contributing
+    task."""
+    tips_ = [t for t, _ in contributors]
+    row = dict(tips_[-1])
+    merged = {}
+    for t in tips_:
+        for name, values in (t.get("accumulate") or {}).items():
+            merged[name] = _ordered_unique(merged.get(name, []) + list(values or []))
+    if row.get("type") == TIP_TEMPLATE_JINJA2 and merged:
+        row["accumulate"] = merged
+        data = dict(row.get("vars") or {})
+        data.update(merged)
+        if row.get("title_template"):
+            row["title"] = ctx.template.jinja2(row["title_template"], data = data)
+        if row.get("body_template"):
+            row["body"] = ctx.template.jinja2(row["body_template"], data = data)
+    row["_task_keys"] = _ordered_unique([k for _, k in contributors])
+    return row
+
+def _latest(contributors):
+    """Collapse a same-`(id, key)` group into one row, no cross-task
+    accumulation. `contributors` is `(tip, task_key)` in task order.
+
+    When every task rendered identical `(title, body)`, the row keeps that
+    content attributed to all of them — so N tasks emitting the same tip
+    read as one row crediting all N. When content diverges, the latest
+    task's content wins, attributed to that task."""
+    distinct = _ordered_unique([(t.get("title", ""), t.get("body", "")) for t, _ in contributors])
+    if len(distinct) == 1:
+        row = dict(contributors[0][0])
+        row["_task_keys"] = _ordered_unique([k for _, k in contributors])
+        return row
+    tip, task_key = contributors[-1]
+    row = dict(tip)
+    row["_task_keys"] = [task_key] if task_key else []
+    return row
+
+def _collect_tip_rows(ctx, entries):
+    """Group every entry's `tips` by `(id, key)`, combine each group into
+    a PR-summary row, attribute by task key, sort by severity, then apply
+    the rendering caps.
+
+    Eligibility: a tip is a rollup candidate only when its `surfaces`
+    allowlist is empty (all surfaces) or contains `SURFACE_GITHUB_PR_SUMMARY`.
+    The per-task producer already filtered with
+    `collect_tips_sorted(ctx, surface = SURFACE_GITHUB_PR_SUMMARY)`, so this is a
+    defensive re-assertion.
+
+    Each `(id, key)` group combines per `combine_across_tasks` (True if
+    any contributor sets it):
+
+      - True  — one row unioning the `accumulate` fields across every
+        task (`_combine_across`), attributed to all of them.
+      - False — one row (`_latest`): identical content across tasks is
+        attributed to all of them; divergent content takes the latest
+        task's. Distinct subjects belong under distinct `key`s, which
+        group separately here.
 
     Render caps:
       - `TIP_IMPORTANT` and `TIP_WARNING` always surface.
@@ -700,45 +765,28 @@ def _collect_tip_rows(ctx, entries):
 
     Returns rows in `decorate_tip` shape plus `task_keys` (sorted) for
     the attribution footer."""
-    by_id = {}
+    groups = {}
     insertion_order = []
     for e in entries:
         task_key = e.get("key", "") or e.get("name", "")
         for tip in e.get("tips", []) or []:
-            id_ = tip.get("id", "")
-            if not id_:
+            if not tip.get("id"):
                 continue
-            if id_ not in by_id:
-                row = dict(tip)
-                row["accumulators"] = {
-                    name: list(values or [])
-                    for name, values in (tip.get("accumulators") or {}).items()
-                }
-                row["_task_keys"] = []
-                by_id[id_] = row
-                insertion_order.append(id_)
-            else:
-                row = by_id[id_]
-                for name, values in (tip.get("accumulators") or {}).items():
-                    current = row["accumulators"].get(name, [])
-                    for v in values or []:
-                        if v not in current:
-                            current = current + [v]
-                    row["accumulators"][name] = current
-            if task_key and task_key not in by_id[id_]["_task_keys"]:
-                by_id[id_]["_task_keys"].append(task_key)
+            if not tip_shows_on(tip, SURFACE_GITHUB_PR_SUMMARY):
+                continue
+            identity = (tip["id"], tip.get("key", ""))
+            if identity not in groups:
+                groups[identity] = []
+                insertion_order.append(identity)
+            groups[identity].append((tip, task_key))
 
-    for row in by_id.values():
-        if row.get("type") == TIP_TEMPLATE_JINJA2 and row["accumulators"]:
-            if row.get("title_template"):
-                row["title"] = ctx.template.jinja2(row["title_template"], data = row["accumulators"])
-            if row.get("body_template"):
-                row["body"] = ctx.template.jinja2(row["body_template"], data = row["accumulators"])
+    rows = []
+    for identity in insertion_order:
+        contributors = groups[identity]
+        combine = any([t.get("combine_across_tasks") for t, _ in contributors])
+        rows.append(_combine_across(ctx, contributors) if combine else _latest(contributors))
 
-    rows = sorted(
-        [by_id[id_] for id_ in insertion_order],
-        key = lambda r: severity_rank(r.get("severity")),
-    )
+    rows = sorted(rows, key = lambda r: severity_rank(r.get("severity")))
     must_show, subordinate = [], []
     for r in rows:
         (must_show if _is_must_show(r.get("severity")) else subordinate).append(r)
@@ -1082,7 +1130,7 @@ def _github_status_comments(ctx: FeatureContext):
             "run_attempt": run_attempt,
             "status": _state.get("_status", "running"),
             "ci_run_url": link_url,
-            "tips": [tip_to_payload(t) for t in collect_tips_sorted(ctx)],
+            "tips": [tip_to_payload(t) for t in collect_tips_sorted(ctx, surface = SURFACE_GITHUB_PR_SUMMARY)],
             "rate_limit_observations": export_observations(ctx),
             "last_pr_comment_upsert_epoch_s": _state.get("_last_pr_comment_upsert_epoch_s", 0),
             # Cross-workflow merge tags. `head_sha` lets `_merge_state`

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -367,8 +367,8 @@ def _check_collect_tip_rows(ctx):
     and the multi-accumulator JINJA2 re-render logic without going
     through the full snapshot pipeline."""
 
-    # Dedup + attribution: same id surfaced by two tasks merges into
-    # one row with both task keys in alphabetical order.
+    # Dedup + attribution: same (id, key) with identical content from two
+    # tasks merges into one row with both task keys in alphabetical order.
     rows = collect_tip_rows(ctx, [
         {"key": "lint-task", "tips": [
             {"id": "x", "severity": "suggestion", "title": "T", "body": "B"},
@@ -424,13 +424,10 @@ def _check_collect_tip_rows(ctx):
     if "tips" not in by_id["s"]["silence_hint"] or "silence" not in by_id["s"]["silence_hint"]:
         fail("collect_tip_rows: suggestion row must reference the tips silence knob in silence_hint")
 
-    # Multi-accumulator cross-task merge: two tasks each emit the
-    # `add-github-token-scope` JINJA2 tip with distinct scopes and
-    # endpoints. The merged row carries the union of each
-    # accumulator (preserving first-seen order across tasks), and
-    # the title + body are re-rendered via Jinja2 so the surfaced
-    # text reflects the merged accumulator state (pluralized title,
-    # full endpoint list in the body).
+    # combine_across_tasks: two tasks emit the `add-github-token-scope`
+    # JINJA2 tip with distinct scopes/endpoints. The combined row unions
+    # each `accumulate` field across tasks (first-seen order) and
+    # re-renders title + body (pluralized title, full endpoint list).
     title_tmpl = "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %}"
     body_tmpl = "{{ endpoints|length }} calls fell back:\n{% for e in endpoints %}- {{ e }}\n{% endfor %}"
     rows = collect_tip_rows(ctx, [
@@ -440,9 +437,10 @@ def _check_collect_tip_rows(ctx):
             "title": "Grant `actions: read`",
             "body": "...",
             "type": "jinja2",
+            "combine_across_tasks": True,
             "title_template": title_tmpl,
             "body_template": body_tmpl,
-            "accumulators": {"scopes": ["actions: read"], "endpoints": ["/a/jobs"]},
+            "accumulate": {"scopes": ["actions: read"], "endpoints": ["/a/jobs"]},
         }]},
         {"key": "test-task", "tips": [{
             "id": "add-github-token-scope",
@@ -450,21 +448,102 @@ def _check_collect_tip_rows(ctx):
             "title": "Grant `pull-requests: read`",
             "body": "...",
             "type": "jinja2",
+            "combine_across_tasks": True,
             "title_template": title_tmpl,
             "body_template": body_tmpl,
-            "accumulators": {"scopes": ["pull-requests: read"], "endpoints": ["/b/files", "/c/files"]},
+            "accumulate": {"scopes": ["pull-requests: read"], "endpoints": ["/b/files", "/c/files"]},
         }]},
     ])
     if len(rows) != 1:
-        fail("multi-accumulator merge: expected 1 row, got %d" % len(rows))
+        fail("combine: expected 1 row, got %d" % len(rows))
     if "2 scopes" not in rows[0]["title"]:
-        fail("multi-accumulator merge: title not re-rendered with plural form: %r" % rows[0]["title"])
+        fail("combine: title not re-rendered with plural form: %r" % rows[0]["title"])
     if "/a/jobs" not in rows[0]["body_quoted"] or "/b/files" not in rows[0]["body_quoted"] or "/c/files" not in rows[0]["body_quoted"]:
-        fail("multi-accumulator merge: body missing an endpoint: %r" % rows[0]["body_quoted"])
+        fail("combine: body missing an endpoint: %r" % rows[0]["body_quoted"])
     if "3 calls" not in rows[0]["body_quoted"]:
-        fail("multi-accumulator merge: body not re-rendered with merged count: %r" % rows[0]["body_quoted"])
+        fail("combine: body not re-rendered with merged count: %r" % rows[0]["body_quoted"])
     if rows[0]["task_keys"] != ["build-task", "test-task"]:
-        fail("multi-accumulator merge: task_keys merge wrong: %r" % rows[0]["task_keys"])
+        fail("combine: task_keys merge wrong: %r" % rows[0]["task_keys"])
+
+    # ── Surface gate + (id, key) grouping + combine vs latest ─────────
+
+    # Surface gate: a tip whose `surfaces` omits the PR summary is
+    # dropped from the rollup even though it reached the aggregator.
+    rows = collect_tip_rows(ctx, [
+        {"key": "build-task", "tips": [{
+            "id": "task-only-tip",
+            "severity": "info",
+            "title": "Only on task screens",
+            "body": "...",
+            "type": "raw",
+            "surfaces": ["cli", "github-status-checks"],
+        }]},
+    ])
+    if len(rows) != 0:
+        fail("surface gate: tip excluding github-pr-summary must be dropped, got %d rows" % len(rows))
+
+    # An empty `surfaces` list means all surfaces — eligible for the rollup.
+    rows = collect_tip_rows(ctx, [
+        {"key": "build-task", "tips": [{"id": "everywhere-tip", "severity": "info", "title": "Everywhere", "body": "b", "type": "raw", "surfaces": []}]},
+    ])
+    if len(rows) != 1:
+        fail("surface gate: empty surfaces must be eligible, got %d rows" % len(rows))
+
+    # combine=False (default), identical content across tasks → one row
+    # attributed to both.
+    rows = collect_tip_rows(ctx, [
+        {"key": "build-task", "tips": [{"id": "static", "severity": "info", "title": "Same", "body": "Same body", "type": "raw"}]},
+        {"key": "test-task", "tips": [{"id": "static", "severity": "info", "title": "Same", "body": "Same body", "type": "raw"}]},
+    ])
+    if len(rows) != 1:
+        fail("latest-identical: expected 1 row, got %d" % len(rows))
+    if rows[0]["task_keys"] != ["build-task", "test-task"]:
+        fail("latest-identical: expected both task keys, got %r" % rows[0]["task_keys"])
+
+    # combine=False, divergent content across tasks → latest task's
+    # content wins, attributed to that task.
+    rows = collect_tip_rows(ctx, [
+        {"key": "build-task", "tips": [{"id": "dyn", "severity": "info", "title": "Built //a", "body": "b1", "type": "raw"}]},
+        {"key": "test-task", "tips": [{"id": "dyn", "severity": "info", "title": "Built //b", "body": "b2", "type": "raw"}]},
+    ])
+    if len(rows) != 1:
+        fail("latest-divergent: expected 1 row, got %d" % len(rows))
+    if rows[0]["title"] != "Built //b" or rows[0]["task_keys"] != ["test-task"]:
+        fail("latest-divergent: expected latest task to win, got title=%r keys=%r" % (rows[0]["title"], rows[0]["task_keys"]))
+
+    # Distinct `key` under the same `id` → separate rows, each attributed
+    # to its own task. (The "same tip, different subjects" use case.)
+    rows = collect_tip_rows(ctx, [
+        {"key": "build-task", "tips": [{"id": "flaky", "key": "//a", "severity": "warning", "title": "Flaky //a", "body": "b", "type": "raw"}]},
+        {"key": "test-task", "tips": [{"id": "flaky", "key": "//b", "severity": "warning", "title": "Flaky //b", "body": "b", "type": "raw"}]},
+    ])
+    if len(rows) != 2:
+        fail("distinct-key: expected 2 rows, got %d" % len(rows))
+    by_title = {r["title"]: r for r in rows}
+    if by_title["Flaky //a"]["task_keys"] != ["build-task"]:
+        fail("distinct-key: //a mis-attributed: %r" % by_title["Flaky //a"]["task_keys"])
+    if by_title["Flaky //b"]["task_keys"] != ["test-task"]:
+        fail("distinct-key: //b mis-attributed: %r" % by_title["Flaky //b"]["task_keys"])
+
+    # combine=False: same id, same key, different content from two tasks
+    # collapses to ONE row (latest), not two — distinctness needs a key.
+    rows = collect_tip_rows(ctx, [
+        {"key": "build-task", "tips": [{"id": "nokey", "severity": "info", "title": "Built //a", "body": "b1", "type": "raw"}]},
+        {"key": "test-task", "tips": [{"id": "nokey", "severity": "info", "title": "Built //b", "body": "b2", "type": "raw"}]},
+    ])
+    if len(rows) != 1:
+        fail("no-key-collapse: same (id, '') must be one row, got %d" % len(rows))
+
+    # combine=True if ANY contributor opts in: the group merges into one
+    # row even when another contributor left it False.
+    rows = collect_tip_rows(ctx, [
+        {"key": "build-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "title_template": "T", "body_template": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["a"]}}]},
+        {"key": "test-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "combine_across_tasks": True, "title_template": "T", "body_template": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["b"]}}]},
+    ])
+    if len(rows) != 1 or rows[0]["task_keys"] != ["build-task", "test-task"]:
+        fail("combine-any: a single combine_across_tasks contributor must merge the group, got %r" % rows)
+    if "a" not in rows[0]["body_quoted"] or "b" not in rows[0]["body_quoted"]:
+        fail("combine-any: scopes not unioned across tasks: %r" % rows[0]["body_quoted"])
 
 def _check_dedup_by_run_attempt():
     """Functional assertions for `_dedup_by_run_attempt` — collapse

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -87,7 +87,7 @@ load(
     "effective_throttle_factor",
     "should_emit_phase_change",
 )
-load("../lib/tips.axl", "collect_tips_sorted")
+load("../lib/tips.axl", "SURFACE_GITLAB_COMMIT_STATUSES", "collect_tips_sorted")
 
 _LOG = feature_logger("GitLab commit statuses")
 
@@ -299,7 +299,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             ctx,
             initial_renderer.init(),
             "running",
-            make_render_ctx(_state, tips = collect_tips_sorted(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
+            make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITLAB_COMMIT_STATUSES), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             initial_links,
             templates,
             metadata_keys,
@@ -373,7 +373,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             ctx,
             data,
             status,
-            make_render_ctx(_state, tips = collect_tips_sorted(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
+            make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITLAB_COMMIT_STATUSES), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             links,
             templates,
             metadata_keys,

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -2030,7 +2030,7 @@ def _resolve_current_job_url(ctx, token, owner, repo, run_id, fallback_token = N
     fallback_class = BUCKET_ENV if token_class == BUCKET_APP else BUCKET_APP
     success, status_code, body = _do_request(ctx, "GET", url, token, quiet_4xx_auth = has_fallback, token_class = token_class)
     if (not success) and has_fallback and _is_4xx_auth(status_code):
-        _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN_SCOPE, accumulators = {
+        _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN_SCOPE, accumulate = {
             "scopes": "actions: read",
             "endpoints": "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
         })
@@ -2091,7 +2091,7 @@ def list_pull_request_files(ctx, token, owner, repo, pull_number, fallback_token
         has_fallback = page == 1 and fallback_token and fallback_token != token
         success, status_code, body = _do_request(ctx, "GET", url, active_token, quiet_4xx_auth = has_fallback, token_class = active_class)
         if (not success) and has_fallback and _is_4xx_auth(status_code):
-            _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN_SCOPE, accumulators = {
+            _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN_SCOPE, accumulate = {
                 "scopes": "pull-requests: read",
                 "endpoints": "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
             })

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -9,12 +9,13 @@ logs for WARNs or read docs to discover improvements.
 
 `add_tip(ctx, id, severity, ...)` — adds a tip to the trait. Accepts
 either pre-rendered `title` + `body` (for `TIP_TEMPLATE_RAW` /
-`TIP_TEMPLATE_FORMAT` tips) or `title_template` + `body_template` +
-`accumulators` (for `TIP_TEMPLATE_JINJA2` tips, see below). Dedup
-by `id`: first add wins for pre-rendered tips; JINJA2 tips merge new
-accumulator values into the stored tip and re-render.
+`TIP_TEMPLATE_FORMAT` tips) or `title_template` + `body_template`
+(for `TIP_TEMPLATE_JINJA2` tips) rendered against `vars` (fixed scalars)
+and `accumulate` (list-valued fields). A tip is identified by `(id, key)`
+— see "Tip identity".
 
-`emit_tip(ctx, template, vars=None, accumulators=None, id_suffix="", task_keys=None)`
+`emit_tip(ctx, template, key=None, vars=None, accumulate=None,
+id_suffix="", task_keys=None, surfaces=None, combine_across_tasks=None)`
 — renders a tip template, then calls `add_tip`. Used by built-in
 producers (so their templates are overridable; see "Customization"
 below) and by user task code wanting parameterised tips.
@@ -22,38 +23,50 @@ below) and by user task code wanting parameterised tips.
 Tip templates are dicts of the shape:
 
     {
-        "id":        str,         # stable dedup key; vars are NOT interpolated here
+        "id":        str,         # stable kind + silence key — see "Tip identity"
+        "key":       str?,        # optional (id, key) discriminator — see "Tip identity"
         "severity":  str,         # TIP_IMPORTANT / TIP_WARNING / TIP_SUGGESTION / TIP_INFO
         "title":     str,         # short headline; interpolated per `type`
         "body":      str,         # markdown body; interpolated per `type`
         "type":      str,         # TIP_TEMPLATE_RAW / TIP_TEMPLATE_FORMAT (default) / TIP_TEMPLATE_JINJA2
         "task_keys": list[str]?,  # optional glob list — see "Task-key scoping" below
+        "surfaces":  list[str]?,  # optional surface allowlist — see "Surface allowlist" below
+        "combine_across_tasks": bool?,  # cross-task PR-summary union — see "Cross-task accumulation"
     }
 
 # Template types
 
 The `type` field selects the interpolation engine for `title` / `body`:
 
-  - `TIP_TEMPLATE_RAW`    — no interpolation; `vars` ignored.
+  - `TIP_TEMPLATE_RAW`    — no interpolation; `vars` / `accumulate` ignored.
   - `TIP_TEMPLATE_FORMAT` — Starlark `str.format(**vars)` — `{name}`
                             placeholders replaced from `vars`. Default.
-  - `TIP_TEMPLATE_JINJA2` — Jinja2 source rendered against the tip's
-                            `accumulators` dict (each name maps to a
-                            list). Re-rendered every time `accumulators`
-                            change so the surfaced strings always
-                            reflect the merged state.
+  - `TIP_TEMPLATE_JINJA2` — Jinja2 source rendered against `vars`
+                            (scalars) plus `accumulate` (each name a
+                            deduped + sorted list). Re-rendered whenever
+                            `accumulate` grows, so the surfaced strings
+                            always reflect the merged state.
 
 # Customization
 
 Built-in tip templates are exported as module-level constants
 (e.g. `TIP_ADD_GITHUB_TOKEN`). User task / config code can:
 
-  a) Add custom tips via `add_tip` or `emit_tip` with arbitrary
-     templates of their own.
-  b) Preempt a built-in tip by calling `add_tip` with that built-in
-     tip's id BEFORE the framework emits — dedup-by-id makes the
-     user's version win.
-  c) Silence any non-important tip (built-in or custom) by appending
+  a) Add custom tips via `add_tip` or `emit_tip` from any code with a
+     `TaskContext`. To add a tip at task start from `.aspect/config.axl`,
+     register a `task_update` handler and emit on the first update (the
+     Setup-phase emit) — see the example below.
+  b) Override a built-in tip's content by calling `add_tip` with that
+     built-in tip's `(id, key)` — a re-emit replaces the stored tip, so
+     a user emit AFTER the framework's wins.
+  c) Accept / reject / rewrite any tip (built-in or custom) by
+     registering a `tip_suggestion` hook on `TipsTrait`. It fires on
+     every `add_tip`, receives a `TipInfo`, and returns a `TipSuggestion`
+     (`TIP_ACCEPT` / `TIP_REJECT` / `tip_replace(...)`). Use it to veto a
+     tip id, downgrade a severity, or re-scope `surfaces` — the same
+     accept/reject/replace shape as the `repro_fix_suggestion` hook. See
+     `apply_tip_suggestion_hooks`.
+  d) Silence any non-important tip (built-in or custom) by appending
      its id to the `Tips` feature's `silence` arg from
      `.aspect/config.axl`, or by passing `--tips:silence=<id>` on the
      command line. `add_tip` short-circuits on a match so the tip
@@ -63,19 +76,25 @@ Built-in tip templates are exported as module-level constants
      that breaks key features, so a silence entry for an important id
      is a no-op.
 
-The tip subsystem is owned by the `Tips` feature (co-located below in
-this file). Configure it from `.aspect/config.axl`:
+Example — add a tip at task start and veto another, from `.aspect/config.axl`:
 
-    # In .aspect/config.axl
+    _seen = {}  # per-id once-flag so the tip is added on the first update only
+
+    def _add_docs_tip(ctx, update):
+        if not _seen.get(ctx.task.key):
+            _seen[ctx.task.key] = True
+            add_tip(ctx, id = "internal-docs", severity = TIP_INFO,
+                    title = "Lint docs", body = "See https://wiki/lint",
+                    task_keys = ["lint-*"])
+
+    def _veto_tip(ctx, info):
+        return TIP_REJECT if info.id == "add-github-token" else TIP_ACCEPT
+
     def config(ctx):
+        ctx.traits[TaskLifecycleTrait].task_update.append(_add_docs_tip)
+        ctx.traits[TipsTrait].tip_suggestion.append(_veto_tip)
+        # or just silence by id:
         ctx.features["tips"].args.silence.append("add-github-token")
-        ctx.features["tips"].args.seed.append({
-            "id": "internal-docs-reminder",
-            "severity": TIP_INFO,
-            "title": "Internal docs link for lint failures",
-            "body": "See https://wiki.example/lint for triage notes.",
-            "task_keys": ["lint-*"],
-        })
 
 Or on the command line: `--tips:silence=add-github-token`.
 
@@ -87,10 +106,11 @@ don't need to probe for the feature — the data flow just goes quiet.
 
 # Surface rendering
 
-`collect_tips_sorted(ctx)` returns tips sorted by severity (most
-urgent first), stable within a bucket by insertion order. Renderers
-(check-run summary template, PR comment aggregator) call it and
-display the result.
+`collect_tips_sorted(ctx, surface = ...)` returns tips sorted by
+severity (most urgent first), stable within a bucket by insertion
+order, filtered to those allowed on `surface` (see "Surface
+allowlist"). Renderers (check-run summary template, PR comment
+aggregator) call it with their own surface id and display the result.
 
 # Severity ordering (highest → lowest urgency)
 
@@ -154,13 +174,193 @@ TIP_TEMPLATE_JINJA2 = "jinja2"
 
 _VALID_TEMPLATE_TYPES = [TIP_TEMPLATE_RAW, TIP_TEMPLATE_FORMAT, TIP_TEMPLATE_JINJA2]
 
+# ── Surface allowlist ────────────────────────────────────────────────
+#
+# Each tip carries a `surfaces` list naming the status surfaces it is
+# allowed to render on. The surface identifiers below name every place a
+# tip can appear today. A tip with an empty / unset `surfaces` list shows
+# everywhere (`SURFACE_ALL`) — the back-compatible default, so existing
+# producers need no change.
+#
+# Each rendering surface filters by passing its own identifier to
+# `collect_tips_sorted(ctx, surface = ...)` (and the CLI print path checks
+# `SURFACE_CLI` inside `add_tip`); a tip whose `surfaces` list omits that
+# identifier is skipped for that surface only.
+#
+# Names are intentionally verbose and host-qualified — they're
+# customer-facing (set in `.aspect/config.axl`), and leave room for
+# sibling surfaces on the same host (e.g. a future GitLab MR note or
+# Buildkite PR comment) without ambiguity.
+#
+#   SURFACE_CLI                    the terminal `TIP:` block printed on emit
+#   SURFACE_GITHUB_STATUS_CHECKS   GitHub check-run summary (GithubStatusChecks)
+#   SURFACE_BUILDKITE_ANNOTATIONS  Buildkite annotation (BuildkiteAnnotations)
+#   SURFACE_GITLAB_COMMIT_STATUSES GitLab commit-status description (GitlabCommitStatuses)
+#   SURFACE_GITHUB_PR_SUMMARY      the cross-task GitHub PR summary comment
+#                                  (GithubStatusComments) — the only
+#                                  *aggregate* surface, where same-`(id, key)`
+#                                  tips from sibling tasks combine. See
+#                                  "Cross-task accumulation".
+SURFACE_CLI = "cli"
+SURFACE_GITHUB_STATUS_CHECKS = "github-status-checks"
+SURFACE_BUILDKITE_ANNOTATIONS = "buildkite-annotations"
+SURFACE_GITLAB_COMMIT_STATUSES = "gitlab-commit-statuses"
+SURFACE_GITHUB_PR_SUMMARY = "github-pr-summary"
+
+# Per-task status screens — every surface bound to a single task's own
+# render. Excludes the aggregate PR summary. A tip that's only meaningful
+# in the context of the one task that emitted it (dynamic, per-invocation
+# detail) should set `surfaces = TASK_SCREENS` so it never lands in the
+# cross-task rollup.
+TASK_SCREENS = [SURFACE_CLI, SURFACE_GITHUB_STATUS_CHECKS, SURFACE_BUILDKITE_ANNOTATIONS, SURFACE_GITLAB_COMMIT_STATUSES]
+
+# The aggregate screen(s) — just the PR summary today, named as a list so
+# `surfaces = AGGREGATE_SCREENS` reads symmetrically with `TASK_SCREENS`
+# for a tip that should ONLY appear in the rollup.
+AGGREGATE_SCREENS = [SURFACE_GITHUB_PR_SUMMARY]
+
+# Every surface. The default for a tip that doesn't restrict itself.
+SURFACE_ALL = TASK_SCREENS + AGGREGATE_SCREENS
+
+_VALID_SURFACES = SURFACE_ALL
+
+def tip_shows_on(tip, surface):
+    """True iff `tip` is allowed to render on `surface`.
+
+    Empty / missing `surfaces` means "all surfaces" (back-compat). A
+    non-empty list is an allowlist: the tip renders on `surface` only when
+    the list contains it. `surface = None` (the unfiltered collect) always
+    passes — callers that don't name a surface get every tip, as before.
+    """
+    if surface == None:
+        return True
+    allowed = tip.get("surfaces") or []
+    if not allowed:
+        return True
+    return surface in allowed
+
+# ── Tip identity: (id, key) ──────────────────────────────────────────
+#
+# A tip is identified by the pair `(id, key)`:
+#
+#   id  — the tip kind + silence key. `--tips:silence=<id>` (and the
+#         `silence` feature arg) match on `id`, so silencing one id
+#         covers every `key` under it.
+#   key — optional discriminator (default ""). Two tips with the same
+#         `id` but different `key` are DISTINCT: they coexist on a task's
+#         surface and as separate rows in the PR summary. Use it for "same
+#         tip kind, different subject" — e.g. one `flaky-test` tip per
+#         failing target, all silenceable with `--tips:silence=flaky-test`.
+#
+# Within a task, re-emitting the same `(id, key)` REPLACES the stored tip
+# (last content wins); `accumulate` fields ride along, unioned (deduped +
+# sorted) onto the prior. Across tasks in the PR summary, same-`(id, key)`
+# tips combine per `combine_across_tasks` (below).
+
+# ── Cross-task accumulation ──────────────────────────────────────────
+#
+# `combine_across_tasks` (bool, default False) controls how same-(id,
+# key) tips from different tasks combine in the PR summary rollup:
+#
+#   False (default) — each task stands alone; if several share an
+#                     (id, key), the latest task's rendered content wins
+#                     (one row). `accumulate` fields are NOT unioned
+#                     across tasks.
+#   True            — `accumulate` fields are unioned across every
+#                     contributing task (deduped + sorted) and the tip is
+#                     re-rendered, surfacing the full cross-task set (e.g.
+#                     every scope every task was missing). One row.
+#
+# Eligibility for the rollup at all is governed by `surfaces` — a tip
+# whose `surfaces` omits `SURFACE_GITHUB_PR_SUMMARY` (e.g. `TASK_SCREENS`) never
+# enters the rollup regardless of this flag.
+
+# ── tip_suggestion hook records ──────────────────────────────────────
+#
+# A `tip_suggestion` hook (registered on the public `TipsTrait` below)
+# fires on every `add_tip` / `emit_tip`, letting `config.axl` accept /
+# reject / rewrite any tip — the same accept/reject/replace shape as the
+# `repro_fix_suggestion` hook on `TaskLifecycleTrait`.
+
+# Verdict action: `accept` keeps the tip, `reject` drops it (never enters
+# storage / surfaces), `replace` overrides the fields set on the returned
+# `TipSuggestion`.
+TipAction = enum("accept", "reject", "replace")
+
+# Metadata passed to each `tip_suggestion` hook alongside `ctx`. Carries
+# the tip's identity + content + policy fields so the hook can scope by
+# `id` / `key` / `severity` / `type` and rewrite any of them. Fires on
+# every `add_tip`, including each accumulate re-emit.
+TipInfo = record(
+    # Task identity — joined `<group...> <name>` path plus its parts, for
+    # hooks that scope by task (e.g. only adjust tips on `aspect lint`).
+    task_path = field(str),
+    task_name = field(str),
+    task_group = field(list[str]),
+
+    # The tip about to be stored. `id` / `key` are the identity (see "Tip
+    # identity"); `severity` is a TIP_* value; `type` is the template
+    # kind; `surfaces` / `combine_across_tasks` are the policy fields.
+    #
+    # `title` / `body` are the pre-rendered strings for RAW / FORMAT tips.
+    # For a JINJA2 tip they are EMPTY — the templates aren't rendered
+    # until the tip is stored, after this hook runs — so scope JINJA2
+    # tips by `id` / `key` / `type`, not by rendered text.
+    id = field(str),
+    key = field(str),
+    severity = field(str),
+    title = field(str),
+    body = field(str),
+    type = field(str),
+    surfaces = field(list[str], default = []),
+    combine_across_tasks = field(bool),
+)
+
+# Verdict returned by every `tip_suggestion` hook. `action` is required.
+# The remaining fields are consulted only on `action == "replace"`; each
+# left `None` keeps the tip's current value, so a hook can retag just the
+# `severity` (or just the `surfaces`) without restating the rest. A
+# `replace` with every field `None` is a no-op (equivalent to accept).
+TipSuggestion = record(
+    action = field(TipAction),
+    severity = field(str | None, default = None),
+    title = field(str | None, default = None),
+    body = field(str | None, default = None),
+    surfaces = field(list[str] | None, default = None),
+    combine_across_tasks = field(bool | None, default = None),
+)
+
+# Shared singletons for the no-argument verdicts so hooks read as
+# `return TIP_ACCEPT`. Use `tip_replace(...)` for the replace verdict.
+TIP_ACCEPT = TipSuggestion(action = TipAction("accept"))
+TIP_REJECT = TipSuggestion(action = TipAction("reject"))
+
+def tip_replace(
+        severity: str | None = None,
+        title: str | None = None,
+        body: str | None = None,
+        surfaces: list[str] | None = None,
+        combine_across_tasks: bool | None = None) -> TipSuggestion:
+    """Build a `replace` `TipSuggestion`. Omitted fields keep the tip's
+    current value. See `TipSuggestion` for field semantics."""
+    return TipSuggestion(
+        action = TipAction("replace"),
+        severity = severity,
+        title = title,
+        body = body,
+        surfaces = surfaces,
+        combine_across_tasks = combine_across_tasks,
+    )
+
 # ── Private trait — owner-feature implementation detail ────────────
 #
-# Pre-rendered tips carry `{id, severity, title, body, type, task_keys}`;
-# JINJA2 tips additionally carry `title_template`, `body_template`, and
-# `accumulators` (dict<name, list<value>>) so `add_tip` can re-render
-# on each accumulation event. Dedup by `id`; ids in the silence list
-# are dropped on `add_tip` (unless severity is TIP_IMPORTANT).
+# Every stored tip carries `{id, key, severity, title, body, type,
+# task_keys, surfaces, combine_across_tasks}`; JINJA2 tips additionally
+# carry `title_template`, `body_template`, `vars`, and `accumulate`
+# (dict<name, list<value>>) so `add_tip` can re-render on accumulation.
+# A same-`(id, key)` re-emit replaces the stored tip (accumulate fields
+# union onto the prior); ids in the silence list are dropped on `add_tip`
+# (unless severity is TIP_IMPORTANT).
 #
 # When the `Tips` feature isn't loaded (user set `enabled = False` or
 # the framework didn't enable it), the trait callable defaults are
@@ -169,10 +369,11 @@ _VALID_TEMPLATE_TYPES = [TIP_TEMPLATE_RAW, TIP_TEMPLATE_FORMAT, TIP_TEMPLATE_JIN
 # and the disabled state propagates as zero output.
 
 _TipsTrait = trait(
-    # Add a constructed tip dict. The owner's closure handles dedup,
-    # jinja2 accumulator merge / re-render, silence-list checks, and
-    # the terminal-print side effect. Takes ctx for jinja2 rendering
-    # (`ctx.template.jinja2`) and the print path (`ctx.std`).
+    # Add a constructed tip dict. The owner's closure handles the
+    # silence-list check, the `tip_suggestion` hook chain, the
+    # (id, key) replace-with-accumulate dedup, and the terminal-print side
+    # effect. Takes ctx for jinja2 rendering (`ctx.template.jinja2`) and
+    # the print path (`ctx.std`).
     add = attr(typing.Callable[[TaskContext, dict], None], default = lambda ctx, t: None),
 
     # Return the raw, insertion-ordered list of stored tip dicts.
@@ -184,6 +385,20 @@ _TipsTrait = trait(
     _reset = attr(typing.Callable[[], None], default = lambda: None),
     _set_silenced = attr(typing.Callable[[list], None], default = lambda ids: None),
     _set_auto_print = attr(typing.Callable[[bool], None], default = lambda v: None),
+)
+
+# Public trait carrying the user `tip_suggestion` hook list. Separate
+# from `_TipsTrait` (whose `add` / `collect` callables are internal) so
+# users only see the hook surface. Tasks include it via `tips.TRAITS`;
+# users register from `.aspect/config.axl`:
+#
+#     ctx.traits[TipsTrait].tip_suggestion.append(my_hook)
+#
+# Each hook is `(ctx: TaskContext, info: TipInfo) -> TipSuggestion`, run
+# on every `add_tip` by `apply_tip_suggestion_hooks`. See that helper and
+# the "tip_suggestion hook records" section above.
+TipsTrait = trait(
+    tip_suggestion = attr(list[typing.Callable[[TaskContext, TipInfo], TipSuggestion]], default = []),
 )
 
 # ── Built-in tip templates ───────────────────────────────────────────
@@ -269,12 +484,16 @@ TIP_ADD_ASPECT_API_TOKEN_CIRCLECI = _aspect_api_token_tip(
     "job env.",
 )
 
-# One tip per task accumulating both the missing scopes and the API
-# endpoints that fell back. Pluralization + per-scope snippet lines
-# are driven by Jinja2 on the merged accumulator state.
+# One tip accumulating both the missing scopes and the API endpoints
+# that fell back. Pluralization + per-scope snippet lines are driven by
+# Jinja2 on the merged `accumulate` state. Each fallback event re-emits
+# with new scopes/endpoints that union into the running total within a
+# task; `combine_across_tasks` unions the combined set across every task
+# into one PR-summary row.
 TIP_ADD_GITHUB_TOKEN_SCOPE = {
     "id": "add-github-token-scope",
     "severity": TIP_WARNING,
+    "combine_across_tasks": True,
     "title": "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %} to the job-scoped `GITHUB_TOKEN`",
     "body": """aspect-cli made {{ endpoints|length }} supporting API {{ "call" if endpoints|length == 1 else "calls" }} that needed {{ "a scope" if scopes|length == 1 else "scopes" }} the job-scoped `GITHUB_TOKEN` lacks; {{ "the call" if endpoints|length == 1 else "the calls" }} fell back to the Aspect Workflows GitHub App token. Granting {{ "this scope" if scopes|length == 1 else "these scopes" }} keeps the {{ "call" if endpoints|length == 1 else "calls" }} on the job-scoped token and reduces App quota usage.
 
@@ -327,99 +546,124 @@ def add_tip(
         ctx,
         id,
         severity,
+        key = "",
         task_keys = None,
         title = "",
         body = "",
         type_ = TIP_TEMPLATE_RAW,
         title_template = "",
         body_template = "",
-        accumulators = None):
+        vars = None,
+        accumulate = None,
+        surfaces = None,
+        combine_across_tasks = False):
     """Add a tip to the task's tip storage and print a `TIP:` block to
     the terminal (subject to the owner feature's `auto_print` arg).
 
-    No-op if `id` is in the silence list AND `severity != TIP_IMPORTANT`
-    (important tips can't be silenced — see "Severity ordering" in the
-    module docstring). Users seed the silence list via the `Tips`
-    feature's `silence` arg in `.aspect/config.axl`:
-
-        def config(ctx):
-            ctx.features["tips"].args.silence.append("add-github-token")
+    A tip is identified by `(id, key)` — see the "Tip identity" section
+    in the module docstring. Re-emitting the same `(id, key)` within a
+    task replaces the stored content; `accumulate` fields ride along,
+    unioned (deduped + sorted) onto the prior. A different `key` is a
+    distinct tip. Silencing is always by `id`: no-op if `id` is in the
+    silence list AND `severity != TIP_IMPORTANT`.
 
     Two storage shapes:
 
       - Pre-rendered tips (`type_ == TIP_TEMPLATE_RAW` / `_FORMAT`):
-        `title` and `body` are the final strings to surface. No
-        accumulators. Dedup-by-id is silent (first add wins).
+        `title` / `body` are the final strings to surface.
 
-      - Jinja2 tips (`type_ == TIP_TEMPLATE_JINJA2`):
-        `title_template` and `body_template` are stored as Jinja2
-        source. `accumulators` is a dict<name, value> for the initial
-        emit. The framework converts each value to a single-entry list
-        and re-renders title + body with the accumulators as
-        `dict<name, list<value>>`. On every subsequent emit with the
-        same id, the new accumulator values get unioned into the
-        stored lists (skipping duplicates), the title and body are
-        re-rendered, and the terminal re-prints so each accumulation
-        event surfaces in the log. Plain dedups (no accumulator
-        change) stay silent.
+      - Jinja2 tips (`type_ == TIP_TEMPLATE_JINJA2`): `title_template` /
+        `body_template` are rendered against `vars` (fixed scalars) plus
+        `accumulate` (each a deduped + sorted list). The rendered strings
+        are stored alongside the inputs so a re-emit (within-task
+        accumulate) or cross-task union can re-render.
+
+    `vars` are fixed scalars: interpolated via `str.format` for
+    `TIP_TEMPLATE_FORMAT`, exposed as scalars to `TIP_TEMPLATE_JINJA2`
+    templates, ignored for `TIP_TEMPLATE_RAW`. `accumulate` fields are
+    list-valued (a template sees `{{ name }}` as a list) and union on
+    re-emit and, when `combine_across_tasks`, across tasks. A name
+    appearing in both `vars` and `accumulate` is an error.
 
     `task_keys` is an optional list of glob patterns; when set, the
     renderer only shows the tip on tasks whose key matches one of the
     patterns. When unset / empty, the tip shows on the task it was
     emitted into. The terminal print fires regardless of `task_keys`.
 
+    `surfaces` is an optional allowlist of surface identifiers
+    (`SURFACE_CLI` / `SURFACE_GITHUB_STATUS_CHECKS` /
+    `SURFACE_BUILDKITE_ANNOTATIONS` / `SURFACE_GITLAB_COMMIT_STATUSES` /
+    `SURFACE_GITHUB_PR_SUMMARY`, or the `TASK_SCREENS` / `AGGREGATE_SCREENS`
+    shorthands) controlling which status screens may render the tip. When
+    unset / empty the tip shows everywhere (`SURFACE_ALL`). See the
+    "Surface allowlist" section. The terminal print is gated on
+    `SURFACE_CLI`; omit `SURFACE_GITHUB_PR_SUMMARY` to keep the tip off the
+    cross-task rollup.
+
+    `combine_across_tasks` governs how same-`(id, key)` tips from
+    sibling tasks combine in the PR summary — see the "Cross-task
+    accumulation" section.
+
     No-op overall when the `Tips` feature is disabled — the trait's
     `add` callable falls back to its null-object default.
     """
     if severity not in _SEVERITY_ORDER:
         fail("unknown tip severity %r; valid: %s" % (severity, ", ".join(_SEVERITY_ORDER.keys())))
+    surfaces_list = list(surfaces) if surfaces else []
+    for s in surfaces_list:
+        if s not in _VALID_SURFACES:
+            fail("unknown tip surface %r; valid: %s" % (s, ", ".join(_VALID_SURFACES)))
+    vars = dict(vars or {})
+    accumulate = dict(accumulate or {})
+    collision = [name for name in accumulate if name in vars]
+    if collision:
+        fail("tip %r: %r set in both vars and accumulate" % (id, collision))
     is_jinja2 = type_ == TIP_TEMPLATE_JINJA2
-    if is_jinja2 and not [v for v in (accumulators or {}).values() if v]:
-        fail("TIP_TEMPLATE_JINJA2 tip %r requires at least one non-empty accumulator value" % id)
+    if is_jinja2 and not ([v for v in accumulate.values() if v] or [v for v in vars.values() if v]):
+        fail("TIP_TEMPLATE_JINJA2 tip %r requires at least one non-empty `vars` or `accumulate` value" % id)
 
+    common = {
+        "id": id,
+        "key": key,
+        "severity": severity,
+        "task_keys": list(task_keys) if task_keys else [],
+        "type": type_,
+        "surfaces": surfaces_list,
+        "combine_across_tasks": combine_across_tasks,
+    }
     if is_jinja2:
-        tip = {
-            "id": id,
-            "severity": severity,
-            "task_keys": list(task_keys) if task_keys else [],
-            "type": TIP_TEMPLATE_JINJA2,
-            "title_template": title_template,
-            "body_template": body_template,
-            "accumulators": dict(accumulators or {}),
-        }
+        tip = dict(common, title_template = title_template, body_template = body_template, vars = vars, accumulate = accumulate)
     else:
-        tip = {
-            "id": id,
-            "severity": severity,
-            "title": title,
-            "body": body,
-            "task_keys": list(task_keys) if task_keys else [],
-            "type": type_,
-        }
+        tip = dict(common, title = title, body = body)
     ctx.traits[_TipsTrait].add(ctx, tip)
 
-def emit_tip(ctx, template, vars = None, accumulators = None, id_suffix = "", task_keys = None):
+def emit_tip(ctx, template, key = None, vars = None, accumulate = None, id_suffix = "", task_keys = None, surfaces = None, combine_across_tasks = None):
     """Render a tip template and add it via `add_tip`.
 
     Args:
-      template:      dict — see module docstring for shape.
-      vars:          dict — `{name: value}` interpolated into title /
-                     body when `template.type == TIP_TEMPLATE_FORMAT`.
-                     Ignored for `TIP_TEMPLATE_RAW` and
-                     `TIP_TEMPLATE_JINJA2` (the latter takes its
-                     data from `accumulators` instead).
-      accumulators:  dict — `{name: value}` for
-                     `TIP_TEMPLATE_JINJA2` tips. Each value becomes
-                     the first entry of a per-name accumulator list
-                     on first emit; subsequent emits union new
-                     values into the existing lists. The body /
-                     title templates see each accumulator as a list
-                     and can iterate / pluralize on it.
+      template:      dict — see module docstring for shape. May carry
+                     optional `key`, `surfaces`, and
+                     `combine_across_tasks` keys, used as defaults
+                     when the same-named args below are unset.
+      key:           optional `(id, key)` discriminator overriding the
+                     template's `key`. See the "Tip identity" section.
+      vars:          dict — fixed scalars. `str.format`-interpolated into
+                     title / body for `TIP_TEMPLATE_FORMAT`; exposed as
+                     scalars to `TIP_TEMPLATE_JINJA2` templates; ignored
+                     for `TIP_TEMPLATE_RAW`.
+      accumulate:    dict — list-valued fields for `TIP_TEMPLATE_JINJA2`
+                     tips. A template sees `{{ name }}` as a deduped +
+                     sorted list; values union on re-emit and, when
+                     `combine_across_tasks`, across tasks.
       id_suffix:     optional kebab-case suffix appended to
                      `template.id`.
       task_keys:     optional list of glob patterns overriding the
-                     template's `task_keys` (or supplying it if
-                     absent).
+                     template's `task_keys` (or supplying it if absent).
+      surfaces:      optional surface allowlist overriding the template's
+                     `surfaces`. See the "Surface allowlist" section.
+      combine_across_tasks: optional bool overriding the template's
+                     value (default False). See the "Cross-task
+                     accumulation" section.
     """
     type_ = template.get("type", TIP_TEMPLATE_FORMAT)
     if type_ not in _VALID_TEMPLATE_TYPES:
@@ -427,17 +671,24 @@ def emit_tip(ctx, template, vars = None, accumulators = None, id_suffix = "", ta
     id = template["id"]
     if id_suffix:
         id = id + "-" + id_suffix
+    resolved_key = key if key != None else template.get("key", "")
     resolved_task_keys = task_keys if task_keys != None else template.get("task_keys")
+    resolved_surfaces = surfaces if surfaces != None else template.get("surfaces")
+    resolved_across = combine_across_tasks if combine_across_tasks != None else template.get("combine_across_tasks", False)
     if type_ == TIP_TEMPLATE_JINJA2:
         add_tip(
             ctx,
             id = id,
+            key = resolved_key,
             severity = template["severity"],
             task_keys = resolved_task_keys,
             type_ = TIP_TEMPLATE_JINJA2,
             title_template = template["title"],
             body_template = template["body"],
-            accumulators = accumulators or {},
+            vars = vars,
+            accumulate = accumulate,
+            surfaces = resolved_surfaces,
+            combine_across_tasks = resolved_across,
         )
         return
     title = template["title"]
@@ -448,16 +699,20 @@ def emit_tip(ctx, template, vars = None, accumulators = None, id_suffix = "", ta
     add_tip(
         ctx,
         id = id,
+        key = resolved_key,
         severity = template["severity"],
         task_keys = resolved_task_keys,
         title = title,
         body = body,
         type_ = type_,
+        surfaces = resolved_surfaces,
+        combine_across_tasks = resolved_across,
     )
 
-def collect_tips_sorted(ctx, limit = None):
+def collect_tips_sorted(ctx, limit = None, surface = None):
     """Return the current tips list filtered by `task_keys` (when set)
-    against `ctx.task.key`, then sorted by severity (highest urgency
+    against `ctx.task.key` and by `surface` (when set) against each tip's
+    `surfaces` allowlist, then sorted by severity (highest urgency
     first); the sort is stable, so insertion order is preserved
     within a severity bucket.
 
@@ -465,6 +720,13 @@ def collect_tips_sorted(ctx, limit = None):
     scoped to the task they were emitted into. Tips with `task_keys`
     apply only on tasks whose key matches one of the glob patterns
     (e.g. `["lint-*"]`, `["*"]`).
+
+    `surface` is the calling surface's identifier (e.g.
+    `SURFACE_GITHUB_STATUS_CHECKS`, `SURFACE_GITHUB_PR_SUMMARY`). When set, a tip
+    is dropped unless its `surfaces` allowlist is empty (all surfaces) or
+    contains `surface`. When `None` (the default), no surface filtering is
+    applied — every tip passes, preserving the pre-surface behavior for
+    callers that don't name a surface. See `tip_shows_on`.
 
     Pass `limit` to cap the result for space-constrained surfaces
     (e.g. PR comment summary).
@@ -474,6 +736,8 @@ def collect_tips_sorted(ctx, limit = None):
     for t in ctx.traits[_TipsTrait].collect():
         patterns = t.get("task_keys") or []
         if patterns and not match_any(patterns, task_key):
+            continue
+        if not tip_shows_on(t, surface):
             continue
         filtered.append(t)
     out = sorted(filtered, key = lambda t: severity_rank(t.get("severity")))
@@ -514,18 +778,28 @@ def silence_hint_line(id, severity):
 def tip_to_payload(t):
     """Project a stored tip dict into the render-only field subset
     that crosses the per-task artifact boundary (PR-comment
-    aggregation pipeline). JINJA2 fields are preserved so the
-    cross-task merge in `_collect_tip_rows` can re-render against
-    the unioned accumulator state."""
+    aggregation pipeline). JINJA2 fields (`vars`, `accumulate`, the
+    templates) are preserved so the cross-task merge in
+    `_collect_tip_rows` can re-render against the unioned state.
+
+    `key` is carried so the aggregator groups by `(id, key)`;
+    `combine_across_tasks` so it knows whether to union accumulators
+    across tasks; `surfaces` so it can re-assert the `SURFACE_GITHUB_PR_SUMMARY`
+    gate defensively even though the producer already filtered with
+    `collect_tips_sorted(ctx, surface = SURFACE_GITHUB_PR_SUMMARY)`."""
     return {
         "id": t.get("id", ""),
+        "key": t.get("key", ""),
         "severity": t.get("severity", ""),
         "title": t.get("title", ""),
         "body": t.get("body", ""),
         "type": t.get("type", ""),
         "title_template": t.get("title_template", ""),
         "body_template": t.get("body_template", ""),
-        "accumulators": t.get("accumulators", {}) or {},
+        "vars": dict(t.get("vars") or {}),
+        "accumulate": t.get("accumulate", {}) or {},
+        "surfaces": list(t.get("surfaces") or []),
+        "combine_across_tasks": t.get("combine_across_tasks", False),
     }
 
 def decorate_tip(t):
@@ -568,9 +842,9 @@ _TERMINAL_TIP_COLOR = {
 }
 
 def _print_tip(std, id, severity, title, body):
-    """Print a tip block to the terminal — called from `add_tip` on each
-    first add and (for `TIP_TEMPLATE_JINJA2` tips) on each accumulator
-    change.
+    """Print a tip block to the terminal — called from `add_tip` whenever
+    a tip's stored content changes (first add, a re-emit replace, or an
+    accumulate re-render).
 
     Header line is `<emoji> <LABEL>: <title>`, rendered bold throughout.
     The `<emoji> <LABEL>:` segment is colored by severity (red / yellow
@@ -627,73 +901,140 @@ def blockquote_body(body):
             out.append("> " + line)
     return "\n".join(out)
 
+# ── tip_suggestion hook application ──────────────────────────────────
+
+def apply_tip_suggestion_hooks(ctx: TaskContext, tip: dict) -> dict | None:
+    """Run `tip` through every `TipsTrait.tip_suggestion` handler.
+
+    Returns the post-chain tip dict (with any `replace` overrides
+    applied), or `None` when a handler rejected it. Handlers run in
+    registration order; a `reject` short-circuits. No-op pass-through
+    when no handlers are registered (the common case).
+
+    Called by `_tips_impl._add` on every `add_tip`, including each
+    accumulate re-emit. For a JINJA2 tip the hook runs before the
+    templates are rendered, so `info.title` / `info.body` are empty and a
+    `replace` of `title` / `body` has no effect (the stored values come
+    from rendering the templates); scope JINJA2 tips by `id` / `key` /
+    `type` and rewrite policy fields (`severity` / `surfaces` /
+    `combine_across_tasks`) instead.
+    """
+    handlers = ctx.traits[TipsTrait].tip_suggestion
+    if not handlers:
+        return tip
+
+    out = dict(tip)
+    info_base = {
+        "task_path": " ".join(list(ctx.task.group) + [ctx.task.name]),
+        "task_name": ctx.task.name,
+        "task_group": list(ctx.task.group),
+    }
+    for handler in handlers:
+        info = TipInfo(
+            id = out["id"],
+            key = out.get("key", ""),
+            severity = out["severity"],
+            title = out.get("title", ""),
+            body = out.get("body", ""),
+            type = out.get("type", ""),
+            surfaces = list(out.get("surfaces") or []),
+            combine_across_tasks = out.get("combine_across_tasks", False),
+            **info_base
+        )
+        verdict = handler(ctx, info)
+        action = verdict.action.value
+        if action == "reject":
+            return None
+        if action == "replace":
+            if verdict.severity != None:
+                out["severity"] = verdict.severity
+            if verdict.title != None:
+                out["title"] = verdict.title
+            if verdict.body != None:
+                out["body"] = verdict.body
+            if verdict.surfaces != None:
+                out["surfaces"] = list(verdict.surfaces)
+            if verdict.combine_across_tasks != None:
+                out["combine_across_tasks"] = verdict.combine_across_tasks
+    return out
+
 # ── Owner feature — co-located with the trait so it can bind closures ─
 
 def _tips_impl(ctx):
     """Owner feature impl. Holds the per-task tip list and silence list
-    in closure state; reads `silence` / `seed` / `auto_print` from
-    feature args at bind time so user configuration in .aspect/config.axl
-    or via `--tips:*` command-line flags propagates."""
+    in closure state; reads `silence` / `auto_print` from feature args at
+    bind time so user configuration in .aspect/config.axl or via
+    `--tips:*` command-line flags propagates."""
     state = []
 
     # `args.custom(...)` returns None at runtime when unset, even when
     # the declaration has `default = []` (same quirk used elsewhere with
     # `args.custom(dict, ...)`). Coalesce defensively.
     silenced = list(ctx.args.silence or [])
-    seed_list = list(ctx.args.seed or [])
     auto_print = [ctx.args.auto_print]  # boxed so test seam can mutate
 
-    # Pre-seed from feature args. Idempotent dedup-by-id with framework
-    # `add_tip` calls — first add wins (or accumulator-merge for jinja2).
-    for t in seed_list:
-        if not any([existing.get("id") == t.get("id") for existing in state]):
-            state.append(dict(t))
+    def _render_jinja2(call_ctx, tip, accumulate):
+        """Render `tip`'s templates against `vars` (scalars) + `accumulate`
+        (dict<name, list>) and return the stored tip with the rendered
+        title/body and the merged `accumulate` recorded."""
+        data = dict(tip.get("vars") or {})
+        data.update(accumulate)
+        stored = dict(tip)
+        stored["accumulate"] = accumulate
+        stored["title"] = call_ctx.template.jinja2(tip["title_template"], data = data)
+        stored["body"] = call_ctx.template.jinja2(tip["body_template"], data = data)
+        return stored
+
+    def _store(call_ctx, tip):
+        """Materialize a freshly-emitted `tip` into its stored form. For
+        JINJA2 tips this seeds each `accumulate` value into a single-entry
+        list and renders; pre-rendered tips store as-is."""
+        if tip.get("type") == TIP_TEMPLATE_JINJA2:
+            seeded = {name: [value] for name, value in tip["accumulate"].items() if value}
+            return _render_jinja2(call_ctx, tip, seeded)
+        return dict(tip)
+
+    def _emit_print(call_ctx, stored):
+        """Print the stored tip to the terminal, gated on auto_print and
+        the tip's SURFACE_CLI allowlist."""
+        if auto_print[0] and tip_shows_on(stored, SURFACE_CLI):
+            _print_tip(call_ctx.std, stored["id"], stored["severity"], stored["title"], stored["body"])
 
     def _add(call_ctx, tip):
-        id = tip["id"]
-        severity = tip["severity"]
-        if severity != TIP_IMPORTANT and id in silenced:
+        if tip["severity"] != TIP_IMPORTANT and tip["id"] in silenced:
             return
-        is_jinja2 = tip.get("type") == TIP_TEMPLATE_JINJA2
 
+        # Run the tip through the user `tip_suggestion` hook chain. A
+        # reject drops it; a replace returns the rewritten dict.
+        tip = apply_tip_suggestion_hooks(call_ctx, tip)
+        if tip == None:
+            return
+
+        identity = (tip["id"], tip.get("key", ""))
         for i, existing in enumerate(state):
-            if existing.get("id") != id:
+            if (existing["id"], existing.get("key", "")) != identity:
                 continue
-            if not is_jinja2:
-                return
-            merged, changed = _merge_accumulators(existing.get("accumulators", {}), tip.get("accumulators"))
-            if not changed:
-                return
-            stored_severity = existing.get("severity", severity)
-            rendered_title = call_ctx.template.jinja2(existing["title_template"], data = merged)
-            rendered_body = call_ctx.template.jinja2(existing["body_template"], data = merged)
-            updated = dict(existing)
-            updated["title"] = rendered_title
-            updated["body"] = rendered_body
-            updated["accumulators"] = merged
-            state[i] = updated
-            if auto_print[0]:
-                _print_tip(call_ctx.std, id, stored_severity, rendered_title, rendered_body)
+
+            # Re-emit of the same (id, key): replace the stored tip, but
+            # union any `accumulate` fields onto the prior so the running
+            # total carries across emits.
+            if tip.get("type") == TIP_TEMPLATE_JINJA2:
+                merged, _ = _merge_accumulators(existing.get("accumulate", {}), tip["accumulate"])
+                refreshed = _render_jinja2(call_ctx, tip, merged)
+            else:
+                refreshed = _store(call_ctx, tip)
+
+            # Re-print only when the rendered content actually changed, so
+            # a no-op re-emit (e.g. a streaming progress loop) stays quiet.
+            changed = (refreshed["title"], refreshed["body"]) != (existing.get("title"), existing.get("body"))
+            state[i] = refreshed
+            if changed:
+                _emit_print(call_ctx, refreshed)
             return
 
-        if is_jinja2:
-            seeded = {name: [value] for name, value in tip["accumulators"].items() if value}
-            stored = {
-                "id": id,
-                "severity": severity,
-                "title": call_ctx.template.jinja2(tip["title_template"], data = seeded),
-                "body": call_ctx.template.jinja2(tip["body_template"], data = seeded),
-                "task_keys": list(tip.get("task_keys") or []),
-                "type": TIP_TEMPLATE_JINJA2,
-                "title_template": tip["title_template"],
-                "body_template": tip["body_template"],
-                "accumulators": seeded,
-            }
-        else:
-            stored = dict(tip)
+        stored = _store(call_ctx, tip)
         state.append(stored)
-        if auto_print[0]:
-            _print_tip(call_ctx.std, id, severity, stored["title"], stored["body"])
+        _emit_print(call_ctx, stored)
 
     def _collect():
         return list(state)
@@ -732,11 +1073,6 @@ Tips = feature(
             default = [],
             description = "Tip ids to suppress for this task. Important tips (severity=important) ignore this list — they signal key-feature breakages. Append from config: `ctx.features[\"tips\"].args.silence.append(\"<id>\")`. Pass on CLI: `--tips:silence=<id>` (repeat for multiple).",
         ),
-        "seed": args.custom(
-            list,
-            default = [],
-            description = "Pre-seed list of tip dicts to register at task start. Each entry must have {id, severity, title, body, type?, task_keys?}. Useful for user-defined tips scoped to specific tasks via `task_keys` globs. Append from config: `ctx.features[\"tips\"].args.seed.append({...})`.",
-        ),
         "auto_print": args.boolean(
             default = True,
             description = "Print tips to the terminal on emit. Set False to suppress the `TIP:` blocks (tips still surface on rendered check-runs / PR comments).",
@@ -759,5 +1095,5 @@ tips = struct(
     _inspect_for_test = lambda ctx: ctx.traits[_TipsTrait].collect(),
     _set_silenced_for_test = lambda ctx, ids: ctx.traits[_TipsTrait]._set_silenced(ids),
     _set_auto_print_for_test = lambda ctx, v: ctx.traits[_TipsTrait]._set_auto_print(v),
-    TRAITS = [_TipsTrait],
+    TRAITS = [_TipsTrait, TipsTrait],
 )

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -1,12 +1,24 @@
 """Tests for `lib/tips.axl`.
 
 Covers the tip framework primitives directly:
-  - `add_tip` — fully-rendered emission + dedup-by-id + severity guard
-                + `silenced_tips` short-circuit.
-  - `emit_tip` — template render + vars interpolation + id_suffix +
+  - `add_tip` — fully-rendered emission + `(id, key)` identity (re-emit
+                replaces; distinct `key` coexists) + within-task
+                `accumulate` union + severity guard + `silenced_tips`
+                short-circuit (by `id`, across keys).
+  - `emit_tip` — template render + `vars` interpolation + id_suffix +
                  type validation + task_keys propagation + silence.
   - `collect_tips_sorted` — severity ordering, insertion-order stability,
-                            task_keys glob filter, limit.
+                            task_keys glob filter, limit, surface allowlist.
+  - `surfaces` / `combine_across_tasks` — storage + defaults on `add_tip`,
+                            `emit_tip` template-vs-arg precedence, the
+                            `tip_shows_on` predicate, the per-surface
+                            collect filter, and `tip_to_payload` carrying
+                            them across the artifact boundary. (Cross-task
+                            combination itself is covered in
+                            `github_status_comments_test.axl`.)
+  - `tip_suggestion` hook — accept / reject (incl. scoped-by-id and
+                            chain short-circuit) / replace, via a hook
+                            registered on `TipsTrait`.
   - `severity_emoji`, `severity_label`.
   - `blockquote_body` — the line-prefix transform applied to tip bodies
                         so they render as Markdown blockquotes.
@@ -24,6 +36,12 @@ Run with:
 
 load(
     "./tips.axl",
+    "SURFACE_BUILDKITE_ANNOTATIONS",
+    "SURFACE_CLI",
+    "SURFACE_GITHUB_PR_SUMMARY",
+    "SURFACE_GITHUB_STATUS_CHECKS",
+    "TASK_SCREENS",
+    "TIP_ACCEPT",
     "TIP_ADD_ASPECT_API_TOKEN_BUILDKITE",
     "TIP_ADD_ASPECT_API_TOKEN_CIRCLECI",
     "TIP_ADD_ASPECT_API_TOKEN_GHA",
@@ -32,11 +50,13 @@ load(
     "TIP_ADD_ID_TOKEN_PERMISSION",
     "TIP_IMPORTANT",
     "TIP_INFO",
+    "TIP_REJECT",
     "TIP_SUGGESTION",
     "TIP_TEMPLATE_FORMAT",
     "TIP_TEMPLATE_JINJA2",
     "TIP_TEMPLATE_RAW",
     "TIP_WARNING",
+    "TipsTrait",
     "add_tip",
     "blockquote_body",
     "collect_tips_sorted",
@@ -47,6 +67,8 @@ load(
     "severity_rank",
     "silence_hint_line",
     "strip_code_fences",
+    "tip_replace",
+    "tip_shows_on",
     "tip_to_payload",
     "tips",
 )
@@ -76,13 +98,36 @@ def _test_add_tip_basic(ctx):
     _eq("add_tip basic — ids in insertion order", _ids(tips._inspect_for_test(ctx)), ["a", "b"])
 
 def _test_add_tip_dedup(ctx):
+    """A re-emit of the same `(id, key)` within a task replaces the stored
+    tip (last-wins), so a task can revise a tip it made earlier."""
     _reset(ctx)
     add_tip(ctx, id = "a", severity = TIP_INFO, title = "first", body = "first body")
     add_tip(ctx, id = "a", severity = TIP_WARNING, title = "second", body = "second body")
     stored = tips._inspect_for_test(ctx)
     _eq("dedup — count is 1", len(stored), 1)
-    _eq("dedup — first add wins (title)", stored[0]["title"], "first")
-    _eq("dedup — first add wins (severity)", stored[0]["severity"], TIP_INFO)
+    _eq("dedup — last emit wins (title)", stored[0]["title"], "second")
+    _eq("dedup — last emit wins (body)", stored[0]["body"], "second body")
+    _eq("dedup — last emit wins (severity)", stored[0]["severity"], TIP_WARNING)
+
+def _test_key_distinct(ctx):
+    """Same `id`, different `key` → distinct tips that coexist. Silencing
+    by `id` removes the whole family regardless of key."""
+    _reset(ctx)
+    add_tip(ctx, id = "flaky", key = "//a", severity = TIP_WARNING, title = "Flaky //a", body = "b")
+    add_tip(ctx, id = "flaky", key = "//b", severity = TIP_WARNING, title = "Flaky //b", body = "b")
+    add_tip(ctx, id = "flaky", key = "//a", severity = TIP_WARNING, title = "Flaky //a (again)", body = "b")
+    stored = tips._inspect_for_test(ctx)
+    _eq("key — two distinct tips coexist", len(stored), 2)
+    by_key = {t["key"]: t for t in stored}
+    _eq("key — //a re-emit replaced", by_key["//a"]["title"], "Flaky //a (again)")
+    _eq("key — //b untouched", by_key["//b"]["title"], "Flaky //b")
+
+    # Silence by id covers every key.
+    _reset(ctx)
+    tips._set_silenced_for_test(ctx, ["flaky"])
+    add_tip(ctx, id = "flaky", key = "//a", severity = TIP_WARNING, title = "T", body = "b")
+    add_tip(ctx, id = "flaky", key = "//b", severity = TIP_WARNING, title = "T", body = "b")
+    _eq("key — silence by id covers all keys", tips._inspect_for_test(ctx), [])
 
 def _test_silenced_tips_short_circuits_add_tip(ctx):
     _reset(ctx)
@@ -206,127 +251,100 @@ _JINJA2_TEMPLATE = {
     "type": TIP_TEMPLATE_JINJA2,
 }
 
-def _test_jinja2_first_emit_seeds_accumulators(ctx):
-    """First emit of a JINJA2 tip seeds each accumulator with the
+def _test_jinja2_first_emit_seeds_accumulate(ctx):
+    """First emit of a JINJA2 tip seeds each `accumulate` field with the
     initial value as a single-entry list, renders title + body, and
-    stores both the templates and the dict<name, list> for later
-    re-render on merge."""
+    retains the templates for later re-render on merge."""
     _reset(ctx)
-    emit_tip(
-        ctx,
-        _JINJA2_TEMPLATE,
-        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
-    )
+    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
     stored = tips._inspect_for_test(ctx)
     _eq("jinja2 first-emit — single tip", len(stored), 1)
     _eq("jinja2 first-emit — type recorded", stored[0]["type"], TIP_TEMPLATE_JINJA2)
     _eq(
-        "jinja2 first-emit — accumulators seeded as lists",
-        stored[0]["accumulators"],
+        "jinja2 first-emit — accumulate seeded as lists",
+        stored[0]["accumulate"],
         {"scopes": ["actions: read"], "endpoints": ["/jobs"]},
     )
     if "actions: read" not in stored[0]["title"]:
         fail("jinja2 first-emit — title missing scope: %r" % stored[0]["title"])
     if "/jobs" not in stored[0]["body"]:
         fail("jinja2 first-emit — body missing endpoint: %r" % stored[0]["body"])
+    if not stored[0].get("title_template") or not stored[0].get("body_template"):
+        fail("jinja2 first-emit — templates not retained")
 
-    # Templates retained for later re-render on accumulator merge.
-    if not stored[0].get("title_template"):
-        fail("jinja2 first-emit — title_template not retained")
-    if not stored[0].get("body_template"):
-        fail("jinja2 first-emit — body_template not retained")
-
-def _test_jinja2_dedup_merges_new_values(ctx):
-    """Second emit with new accumulator values: dedup on id, union
-    each accumulator (preserving insertion order), re-render title +
-    body so the merged state is what's stored."""
+def _test_jinja2_reemit_merges_new_values(ctx):
+    """A same-`(id, key)` re-emit unions each `accumulate` field
+    (preserving insertion order) and re-renders against the merged
+    state."""
     _reset(ctx)
-    emit_tip(
-        ctx,
-        _JINJA2_TEMPLATE,
-        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
-    )
-    emit_tip(
-        ctx,
-        _JINJA2_TEMPLATE,
-        accumulators = {"scopes": "pull-requests: read", "endpoints": "/files"},
-    )
+    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
+    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "pull-requests: read", "endpoints": "/files"})
     stored = tips._inspect_for_test(ctx)
-    _eq("jinja2 dedup — still single tip", len(stored), 1)
-    _eq(
-        "jinja2 dedup — scopes unioned in order",
-        stored[0]["accumulators"]["scopes"],
-        ["actions: read", "pull-requests: read"],
-    )
-    _eq(
-        "jinja2 dedup — endpoints unioned in order",
-        stored[0]["accumulators"]["endpoints"],
-        ["/jobs", "/files"],
-    )
-
-    # Title plural form now applies (2 scopes).
+    _eq("jinja2 reemit — still single tip", len(stored), 1)
+    _eq("jinja2 reemit — scopes unioned in order", stored[0]["accumulate"]["scopes"], ["actions: read", "pull-requests: read"])
+    _eq("jinja2 reemit — endpoints unioned in order", stored[0]["accumulate"]["endpoints"], ["/jobs", "/files"])
     if "2 scopes" not in stored[0]["title"]:
-        fail("jinja2 dedup — title not re-rendered with plural form: %r" % stored[0]["title"])
+        fail("jinja2 reemit — title not re-rendered plural: %r" % stored[0]["title"])
+    if "2 calls" not in stored[0]["body"] or "/jobs" not in stored[0]["body"] or "/files" not in stored[0]["body"]:
+        fail("jinja2 reemit — body not re-rendered with both endpoints: %r" % stored[0]["body"])
 
-    # Body lists both endpoints with plural noun.
-    if "/jobs" not in stored[0]["body"] or "/files" not in stored[0]["body"]:
-        fail("jinja2 dedup — body missing one endpoint: %r" % stored[0]["body"])
-    if "2 calls" not in stored[0]["body"]:
-        fail("jinja2 dedup — body not re-rendered with plural form: %r" % stored[0]["body"])
-
-def _test_jinja2_dedup_skips_duplicate_values(ctx):
-    """Re-emitting the same accumulator values is a no-op — no
-    duplicate list entries, no re-render."""
+def _test_jinja2_reemit_skips_duplicate_values(ctx):
+    """Re-emitting the same `accumulate` values is a no-op — no duplicate
+    list entries."""
     _reset(ctx)
-    emit_tip(
-        ctx,
-        _JINJA2_TEMPLATE,
-        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
-    )
-    emit_tip(
-        ctx,
-        _JINJA2_TEMPLATE,
-        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
-    )
+    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
+    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
     tip = tips._inspect_for_test(ctx)[0]
-    _eq(
-        "jinja2 dedup — duplicate scope skipped",
-        tip["accumulators"]["scopes"],
-        ["actions: read"],
-    )
-    _eq(
-        "jinja2 dedup — duplicate endpoint skipped",
-        tip["accumulators"]["endpoints"],
-        ["/jobs"],
-    )
+    _eq("jinja2 reemit — duplicate scope skipped", tip["accumulate"]["scopes"], ["actions: read"])
+    _eq("jinja2 reemit — duplicate endpoint skipped", tip["accumulate"]["endpoints"], ["/jobs"])
 
 def _test_jinja2_partial_overlap_appends_only_new(ctx):
-    """Second emit sharing one accumulator value with the first only
-    appends the new value to the differing accumulator. Confirms the
-    per-name union is independent (scopes can dedup while endpoints
-    accumulate)."""
+    """A re-emit sharing one value only appends the new value to the
+    differing field — per-name union is independent."""
     _reset(ctx)
-    emit_tip(
-        ctx,
-        _JINJA2_TEMPLATE,
-        accumulators = {"scopes": "actions: read", "endpoints": "/jobs"},
-    )
-    emit_tip(
-        ctx,
-        _JINJA2_TEMPLATE,
-        accumulators = {"scopes": "actions: read", "endpoints": "/runs"},
-    )
+    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
+    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/runs"})
     tip = tips._inspect_for_test(ctx)[0]
-    _eq(
-        "jinja2 partial overlap — scopes deduped",
-        tip["accumulators"]["scopes"],
-        ["actions: read"],
-    )
-    _eq(
-        "jinja2 partial overlap — endpoints both retained",
-        tip["accumulators"]["endpoints"],
-        ["/jobs", "/runs"],
-    )
+    _eq("jinja2 partial overlap — scopes deduped", tip["accumulate"]["scopes"], ["actions: read"])
+    _eq("jinja2 partial overlap — endpoints both retained", tip["accumulate"]["endpoints"], ["/jobs", "/runs"])
+
+def _test_jinja2_vars_and_accumulate(ctx):
+    """`vars` are fixed scalars (template sees them un-listed, last-wins);
+    `accumulate` fields are lists that union. A name in both is an error
+    (not exercised here — `fail()` aborts the run)."""
+    template = {
+        "id": "mixed",
+        "severity": TIP_INFO,
+        "type": TIP_TEMPLATE_JINJA2,
+        "title": "{{ repo }}: {{ scopes|length }} scopes",
+        "body": "{% for s in scopes %}- {{ s }}\n{% endfor %}",
+    }
+    _reset(ctx)
+    emit_tip(ctx, template, vars = {"repo": "acme/web"}, accumulate = {"scopes": "actions: read"})
+    emit_tip(ctx, template, vars = {"repo": "acme/web"}, accumulate = {"scopes": "pulls: read"})
+    tip = tips._inspect_for_test(ctx)[0]
+    _eq("jinja2 vars — fixed scalar stored un-listed", tip["vars"], {"repo": "acme/web"})
+    _eq("jinja2 vars — accumulate unioned", tip["accumulate"]["scopes"], ["actions: read", "pulls: read"])
+    if "acme/web: 2 scopes" not in tip["title"]:
+        fail("jinja2 vars — title mixes scalar + list wrong: %r" % tip["title"])
+
+    # A JINJA2 tip driven only by `vars` (no accumulate) is valid, and a
+    # re-emit with a changed var takes effect (last-wins).
+    vars_only = {"id": "vo", "severity": TIP_INFO, "type": TIP_TEMPLATE_JINJA2, "title": "{{ n }}", "body": "b"}
+    _reset(ctx)
+    emit_tip(ctx, vars_only, vars = {"n": "first"})
+    emit_tip(ctx, vars_only, vars = {"n": "second"})
+    tip = tips._inspect_for_test(ctx)[0]
+    _eq("jinja2 vars-only — re-emit var change wins", tip["title"], "second")
+
+def _test_combine_across_tasks_stored(ctx):
+    """`add_tip` stores `combine_across_tasks`, defaulting to False."""
+    _reset(ctx)
+    add_tip(ctx, id = "a", severity = TIP_INFO, title = "T", body = "B")
+    add_tip(ctx, id = "b", severity = TIP_INFO, title = "T", body = "B", combine_across_tasks = True)
+    stored = {t["id"]: t for t in tips._inspect_for_test(ctx)}
+    _eq("combine — default False", stored["a"]["combine_across_tasks"], False)
+    _eq("combine — explicit True stored", stored["b"]["combine_across_tasks"], True)
 
 def _test_collect_sorted_by_severity(ctx):
     _reset(ctx)
@@ -475,7 +493,7 @@ def _test_builtin_insufficient_scope_renders(ctx):
     emit_tip(
         ctx,
         TIP_ADD_GITHUB_TOKEN_SCOPE,
-        accumulators = {
+        accumulate = {
             "scopes": "pull-requests: read",
             "endpoints": "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
         },
@@ -488,10 +506,10 @@ def _test_builtin_insufficient_scope_renders(ctx):
         fail("scope tip — title missing scope: %r" % tip["title"])
     if "GET /repos/{owner}/{repo}/pulls/{pull_number}/files" not in tip["body"]:
         fail("scope tip — body missing endpoint: %r" % tip["body"])
-    _eq("scope tip — scopes accumulated", tip["accumulators"]["scopes"], ["pull-requests: read"])
+    _eq("scope tip — scopes accumulated", tip["accumulate"]["scopes"], ["pull-requests: read"])
     _eq(
         "scope tip — endpoints accumulated",
-        tip["accumulators"]["endpoints"],
+        tip["accumulate"]["endpoints"],
         ["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"],
     )
 
@@ -499,7 +517,7 @@ def _test_builtin_insufficient_scope_renders(ctx):
     emit_tip(
         ctx,
         TIP_ADD_GITHUB_TOKEN_SCOPE,
-        accumulators = {
+        accumulate = {
             "scopes": "actions: read",
             "endpoints": "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
         },
@@ -508,12 +526,12 @@ def _test_builtin_insufficient_scope_renders(ctx):
     merged = tips._inspect_for_test(ctx)[0]
     _eq(
         "scope tip — both scopes unioned",
-        merged["accumulators"]["scopes"],
+        merged["accumulate"]["scopes"],
         ["pull-requests: read", "actions: read"],
     )
     _eq(
         "scope tip — both endpoints unioned",
-        merged["accumulators"]["endpoints"],
+        merged["accumulate"]["endpoints"],
         [
             "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
             "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
@@ -553,30 +571,180 @@ def _test_tip_to_payload(ctx):
     than at the downstream JINJA2 re-render."""
     stored = {
         "id": "x",
+        "key": "//a",
         "severity": TIP_WARNING,
         "title": "Title",
         "body": "Body",
         "type": TIP_TEMPLATE_JINJA2,
         "title_template": "T",
         "body_template": "B",
-        "accumulators": {"scopes": ["actions: read"]},
+        "vars": {"repo": "acme/web"},
+        "accumulate": {"scopes": ["actions: read"]},
         "task_keys": ["lint-*"],  # producer-side filter; payload omits this
     }
     payload = tip_to_payload(stored)
     _eq("tip_to_payload — id", payload["id"], "x")
+    _eq("tip_to_payload — key", payload["key"], "//a")
     _eq("tip_to_payload — severity", payload["severity"], TIP_WARNING)
     _eq("tip_to_payload — title", payload["title"], "Title")
     _eq("tip_to_payload — body", payload["body"], "Body")
     _eq("tip_to_payload — type", payload["type"], TIP_TEMPLATE_JINJA2)
     _eq("tip_to_payload — title_template", payload["title_template"], "T")
     _eq("tip_to_payload — body_template", payload["body_template"], "B")
-    _eq("tip_to_payload — accumulators", payload["accumulators"], {"scopes": ["actions: read"]})
+    _eq("tip_to_payload — vars", payload["vars"], {"repo": "acme/web"})
+    _eq("tip_to_payload — accumulate", payload["accumulate"], {"scopes": ["actions: read"]})
     if "task_keys" in payload:
         fail("tip_to_payload — task_keys (producer-side filter) must NOT cross the artifact boundary")
 
-    # Empty accumulators normalize to {} rather than None.
+    _eq("tip_to_payload — surfaces carried", payload.get("surfaces"), [])
+    _eq("tip_to_payload — combine_across_tasks defaults False", payload.get("combine_across_tasks"), False)
+
+    # Empty accumulate normalizes to {} rather than None.
     minimal = tip_to_payload({"id": "y", "severity": TIP_INFO, "title": "T", "body": "B"})
-    _eq("tip_to_payload — missing accumulators → empty dict", minimal["accumulators"], {})
+    _eq("tip_to_payload — missing accumulate → empty dict", minimal["accumulate"], {})
+
+    # surfaces + combine_across_tasks carried verbatim when present.
+    full = tip_to_payload({
+        "id": "z",
+        "severity": TIP_INFO,
+        "title": "T",
+        "body": "B",
+        "surfaces": [SURFACE_GITHUB_STATUS_CHECKS, SURFACE_BUILDKITE_ANNOTATIONS],
+        "combine_across_tasks": True,
+    })
+    _eq("tip_to_payload — surfaces verbatim", full["surfaces"], [SURFACE_GITHUB_STATUS_CHECKS, SURFACE_BUILDKITE_ANNOTATIONS])
+    _eq("tip_to_payload — combine_across_tasks verbatim", full["combine_across_tasks"], True)
+
+def _test_surfaces_and_combine_stored(ctx):
+    """`add_tip` stores the `surfaces` allowlist + `combine_across_tasks`
+    flag, defaulting `surfaces` to all (empty list) and combine to
+    False."""
+    _reset(ctx)
+    add_tip(ctx, id = "a", severity = TIP_INFO, title = "T", body = "B", surfaces = [SURFACE_GITHUB_STATUS_CHECKS, SURFACE_BUILDKITE_ANNOTATIONS], combine_across_tasks = True)
+    add_tip(ctx, id = "b", severity = TIP_INFO, title = "T", body = "B")  # defaults
+    stored = {t["id"]: t for t in tips._inspect_for_test(ctx)}
+    _eq("surfaces — explicit list stored", stored["a"]["surfaces"], [SURFACE_GITHUB_STATUS_CHECKS, SURFACE_BUILDKITE_ANNOTATIONS])
+    _eq("combine — explicit True stored", stored["a"]["combine_across_tasks"], True)
+    _eq("surfaces — default empty (all)", stored["b"]["surfaces"], [])
+    _eq("combine — default False", stored["b"]["combine_across_tasks"], False)
+
+    # Category shorthand stores as a plain list.
+    _reset(ctx)
+    add_tip(ctx, id = "c", severity = TIP_INFO, title = "T", body = "B", surfaces = TASK_SCREENS)
+    stored = {t["id"]: t for t in tips._inspect_for_test(ctx)}
+    _eq("surfaces — TASK_SCREENS shorthand", stored["c"]["surfaces"], TASK_SCREENS)
+    if SURFACE_GITHUB_PR_SUMMARY in stored["c"]["surfaces"]:
+        fail("surfaces — TASK_SCREENS must not include the PR summary")
+
+def _test_collect_filters_by_surface(ctx):
+    """`collect_tips_sorted(ctx, surface = ...)` drops tips whose
+    allowlist excludes the named surface; an empty allowlist passes
+    everywhere; `surface = None` applies no filter."""
+    _reset(ctx)
+    add_tip(ctx, id = "everywhere", severity = TIP_INFO, title = "T", body = "B")  # all
+    add_tip(ctx, id = "ghsc-only", severity = TIP_INFO, title = "T", body = "B", surfaces = [SURFACE_GITHUB_STATUS_CHECKS])
+    add_tip(ctx, id = "pr-only", severity = TIP_INFO, title = "T", body = "B", surfaces = [SURFACE_GITHUB_PR_SUMMARY])
+
+    _eq("surface filter — GHSC", sorted(_ids(collect_tips_sorted(ctx, surface = SURFACE_GITHUB_STATUS_CHECKS))), ["everywhere", "ghsc-only"])
+    _eq("surface filter — PR summary", sorted(_ids(collect_tips_sorted(ctx, surface = SURFACE_GITHUB_PR_SUMMARY))), ["everywhere", "pr-only"])
+    _eq("surface filter — BK (only the unrestricted one)", _ids(collect_tips_sorted(ctx, surface = SURFACE_BUILDKITE_ANNOTATIONS)), ["everywhere"])
+    _eq("surface filter — None applies no filter", sorted(_ids(collect_tips_sorted(ctx))), ["everywhere", "ghsc-only", "pr-only"])
+
+def _test_tip_shows_on(ctx):
+    """`tip_shows_on` — the surface-allowlist predicate shared by the
+    collect filter, the CLI-print gate, and the PR-summary aggregator."""
+    _eq("shows_on — empty allowlist shows everywhere", tip_shows_on({"surfaces": []}, SURFACE_BUILDKITE_ANNOTATIONS), True)
+    _eq("shows_on — missing allowlist shows everywhere", tip_shows_on({}, SURFACE_GITHUB_STATUS_CHECKS), True)
+    _eq("shows_on — listed surface shows", tip_shows_on({"surfaces": [SURFACE_GITHUB_STATUS_CHECKS]}, SURFACE_GITHUB_STATUS_CHECKS), True)
+    _eq("shows_on — unlisted surface hidden", tip_shows_on({"surfaces": [SURFACE_GITHUB_STATUS_CHECKS]}, SURFACE_BUILDKITE_ANNOTATIONS), False)
+    _eq("shows_on — surface=None always shows", tip_shows_on({"surfaces": [SURFACE_GITHUB_STATUS_CHECKS]}, None), True)
+
+def _test_emit_tip_key_surfaces_combine(ctx):
+    """`emit_tip` reads `key` / `surfaces` / `combine_across_tasks` from
+    the template, and the explicit args override the template's values."""
+    template = {
+        "id": "t",
+        "key": "tmpl-key",
+        "severity": TIP_INFO,
+        "title": "T",
+        "body": "B",
+        "type": TIP_TEMPLATE_RAW,
+        "surfaces": [SURFACE_GITHUB_STATUS_CHECKS],
+        "combine_across_tasks": True,
+    }
+
+    _reset(ctx)
+    emit_tip(ctx, template)
+    stored = tips._inspect_for_test(ctx)[0]
+    _eq("emit — key from template", stored["key"], "tmpl-key")
+    _eq("emit — surfaces from template", stored["surfaces"], [SURFACE_GITHUB_STATUS_CHECKS])
+    _eq("emit — combine from template", stored["combine_across_tasks"], True)
+
+    _reset(ctx)
+    emit_tip(ctx, template, key = "arg-key", surfaces = [SURFACE_BUILDKITE_ANNOTATIONS], combine_across_tasks = False)
+    stored = tips._inspect_for_test(ctx)[0]
+    _eq("emit — key arg overrides template", stored["key"], "arg-key")
+    _eq("emit — surfaces arg overrides template", stored["surfaces"], [SURFACE_BUILDKITE_ANNOTATIONS])
+    _eq("emit — combine arg overrides template", stored["combine_across_tasks"], False)
+
+def _test_tip_suggestion_hook(ctx):
+    """A `tip_suggestion` hook on `TipsTrait` fires per `add_tip` and can
+    accept / reject / replace the tip before it reaches storage."""
+    hooks = ctx.traits[TipsTrait].tip_suggestion
+
+    def with_hook(hook, body):
+        # Register `hook`, run `body`, then pop it so subtests don't leak.
+        hooks.append(hook)
+        body()
+        hooks.pop()
+
+    # accept — tip passes through unchanged.
+    _reset(ctx)
+    with_hook(lambda c, info: TIP_ACCEPT, lambda: add_tip(ctx, id = "a", severity = TIP_INFO, title = "T", body = "B"))
+    _eq("hook accept — tip stored", _ids(tips._inspect_for_test(ctx)), ["a"])
+
+    # reject — tip never enters storage.
+    _reset(ctx)
+    with_hook(lambda c, info: TIP_REJECT, lambda: add_tip(ctx, id = "a", severity = TIP_INFO, title = "T", body = "B"))
+    _eq("hook reject — tip dropped", tips._inspect_for_test(ctx), [])
+
+    # reject scoped by id — only the matching id is dropped.
+    _reset(ctx)
+
+    def _reject_b(c, info):
+        return TIP_REJECT if info.id == "b" else TIP_ACCEPT
+
+    def _emit_two():
+        add_tip(ctx, id = "a", severity = TIP_INFO, title = "T", body = "B")
+        add_tip(ctx, id = "b", severity = TIP_INFO, title = "T", body = "B")
+
+    with_hook(_reject_b, _emit_two)
+    _eq("hook reject-by-id — only b dropped", _ids(tips._inspect_for_test(ctx)), ["a"])
+
+    # replace — override severity + surfaces, leave the rest.
+    _reset(ctx)
+
+    def _downgrade(c, info):
+        return tip_replace(severity = TIP_INFO, surfaces = [SURFACE_GITHUB_STATUS_CHECKS])
+
+    with_hook(_downgrade, lambda: add_tip(ctx, id = "a", severity = TIP_WARNING, title = "T", body = "B"))
+    stored = tips._inspect_for_test(ctx)[0]
+    _eq("hook replace — severity overridden", stored["severity"], TIP_INFO)
+    _eq("hook replace — surfaces overridden", stored["surfaces"], [SURFACE_GITHUB_STATUS_CHECKS])
+    _eq("hook replace — title untouched", stored["title"], "T")
+
+    # chaining — a reject short-circuits a later accept.
+    _reset(ctx)
+
+    def _record(c, info):
+        return TIP_ACCEPT
+
+    hooks.append(lambda c, info: TIP_REJECT)
+    hooks.append(_record)
+    add_tip(ctx, id = "a", severity = TIP_INFO, title = "T", body = "B")
+    hooks.pop()
+    hooks.pop()
+    _eq("hook chain — reject short-circuits", tips._inspect_for_test(ctx), [])
 
 def _test_decorate_tip(ctx):
     """`decorate_tip` projects a stored tip into the render shape both
@@ -633,6 +801,7 @@ def _test_auto_print_flag(ctx):
 def _test_impl(ctx):
     _test_add_tip_basic(ctx)
     _test_add_tip_dedup(ctx)
+    _test_key_distinct(ctx)
     _test_silenced_tips_short_circuits_add_tip(ctx)
     _test_silenced_tips_blocks_emit_tip(ctx)
     _test_important_tips_cannot_be_silenced(ctx)
@@ -642,10 +811,12 @@ def _test_impl(ctx):
     _test_emit_tip_default_type_is_format(ctx)
     _test_emit_tip_id_suffix(ctx)
     _test_emit_tip_task_keys_override(ctx)
-    _test_jinja2_first_emit_seeds_accumulators(ctx)
-    _test_jinja2_dedup_merges_new_values(ctx)
-    _test_jinja2_dedup_skips_duplicate_values(ctx)
+    _test_jinja2_first_emit_seeds_accumulate(ctx)
+    _test_jinja2_reemit_merges_new_values(ctx)
+    _test_jinja2_reemit_skips_duplicate_values(ctx)
     _test_jinja2_partial_overlap_appends_only_new(ctx)
+    _test_jinja2_vars_and_accumulate(ctx)
+    _test_combine_across_tasks_stored(ctx)
     _test_collect_sorted_by_severity(ctx)
     _test_collect_task_keys_filter(ctx)
     _test_collect_limit(ctx)
@@ -658,9 +829,14 @@ def _test_impl(ctx):
     _test_silence_hint_line(ctx)
     _test_decorate_tip(ctx)
     _test_tip_to_payload(ctx)
+    _test_surfaces_and_combine_stored(ctx)
+    _test_collect_filters_by_surface(ctx)
+    _test_tip_shows_on(ctx)
+    _test_emit_tip_key_surfaces_combine(ctx)
+    _test_tip_suggestion_hook(ctx)
     _test_strip_code_fences(ctx)
     _test_auto_print_flag(ctx)
-    print("tips.axl: OK (29 sections)")
+    print("tips.axl: OK (38 sections)")
     return 0
 
 tips_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/traits.axl
+++ b/crates/aspect-cli/src/builtins/aspect/traits.axl
@@ -17,7 +17,13 @@ files can load the full trait set with a single import:
          "ReproFixInfo",
          "ReproFixSuggestion",
          "TaskUpdate",
-         "repro_fix_replace")
+         "TipInfo",
+         "TipSuggestion",
+         "TipsTrait",
+         "TIP_ACCEPT",
+         "TIP_REJECT",
+         "repro_fix_replace",
+         "tip_replace")
 
 Internal modules should load directly from the owning module — this
 facade is purely a user-facing convenience.
@@ -45,6 +51,16 @@ load(
     _TaskUpdate = "TaskUpdate",
     _repro_fix_replace = "repro_fix_replace",
 )
+load(
+    "./lib/tips.axl",
+    _TIP_ACCEPT = "TIP_ACCEPT",
+    _TIP_REJECT = "TIP_REJECT",
+    _TipAction = "TipAction",
+    _TipInfo = "TipInfo",
+    _TipSuggestion = "TipSuggestion",
+    _TipsTrait = "TipsTrait",
+    _tip_replace = "tip_replace",
+)
 load("./lint.axl", _LintTrait = "LintTrait")
 
 BazelTrait = _BazelTrait
@@ -58,6 +74,13 @@ ReproFixCommand = _ReproFixCommand
 ReproFixCommandKind = _ReproFixCommandKind
 ReproFixInfo = _ReproFixInfo
 ReproFixSuggestion = _ReproFixSuggestion
+TIP_ACCEPT = _TIP_ACCEPT
+TIP_REJECT = _TIP_REJECT
 TaskLifecycleTrait = _TaskLifecycleTrait
 TaskUpdate = _TaskUpdate
+TipAction = _TipAction
+TipInfo = _TipInfo
+TipSuggestion = _TipSuggestion
+TipsTrait = _TipsTrait
 repro_fix_replace = _repro_fix_replace
+tip_replace = _tip_replace


### PR DESCRIPTION
Adds per-tip control over **identity**, **which status screens a tip renders on**, and **how same-tips from different tasks combine in the PR summary**, plus a hook to intercept tip creation.

## Identity — `(id, key)`

A tip is identified by `(id, key)`:

- `id` — the tip kind + silence key. `--tips:silence=<id>` (and the `silence` feature arg) match on `id`, so silencing one id covers every key under it.
- `key` — optional discriminator (default `""`). Same `id`, different `key` ⇒ distinct tips that coexist on a task's surface and as separate PR-summary rows. Use it for "same tip kind, different subject" (e.g. one `flaky-test` tip per failing target, all silenceable with `--tips:silence=flaky-test`).

A re-emit of the same `(id, key)` within a task replaces the stored tip; `accumulate` fields union (deduped + sorted) onto the prior.

## Inputs — `vars` vs `accumulate`

- `vars` — fixed scalars: `str.format`-interpolated for `TIP_TEMPLATE_FORMAT`, exposed as scalars to `TIP_TEMPLATE_JINJA2` templates.
- `accumulate` — list-valued JINJA2 fields: a template sees `{{ name }}` as a deduped + sorted list; values union on re-emit and (when `combine_across_tasks`) across tasks.

A name set in both is an error.

## Surfaces

A `surfaces` allowlist names the screens a tip may render on: `SURFACE_CLI`, `SURFACE_GITHUB_STATUS_CHECKS`, `SURFACE_BUILDKITE_ANNOTATIONS`, `SURFACE_GITLAB_COMMIT_STATUSES`, `SURFACE_GITHUB_PR_SUMMARY` (or the `TASK_SCREENS` / `AGGREGATE_SCREENS` / `SURFACE_ALL` shorthands; empty ⇒ all). `collect_tips_sorted(ctx, surface=…)` filters via the shared `tip_shows_on` predicate; the CLI print is gated on `SURFACE_CLI`. Omitting `SURFACE_GITHUB_PR_SUMMARY` keeps a tip off the cross-task rollup.

## Cross-task combination — `combine_across_tasks`

For same-`(id, key)` tips from sibling tasks in the PR summary:

- `True` — union the `accumulate` fields across every task into one row (e.g. every scope every task was missing).
- `False` (default) — one row with the latest task's content (identical content across tasks is attributed to all of them).

The built-in `add-github-token-scope` tip sets `combine_across_tasks` to union scopes/endpoints across tasks.

## `tip_suggestion` hook

A `TipsTrait.tip_suggestion` hook fires on every `add_tip`, receives a `TipInfo`, and returns `TIP_ACCEPT` / `TIP_REJECT` / `tip_replace(...)` — letting `config.axl` veto or rewrite any tip (suppress an id, downgrade a severity, re-scope `surfaces`). Same accept/reject/replace shape as the existing `repro_fix_suggestion` hook.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no

### Suggested release notes

- Tips gain `(id, key)` identity (distinct `key`s coexist; silencing is by `id`), a `surfaces` allowlist controlling which status screens render a tip, a `combine_across_tasks` flag controlling cross-task PR-summary union, separate `vars` (fixed) / `accumulate` (list-valued) template inputs, and a `tip_suggestion` hook on `TipsTrait` to accept / reject / rewrite any tip from `.aspect/config.axl`.

### Test plan

- New / updated test cases:
  - `tips_test.axl` — `(id, key)` identity (re-emit replaces; distinct key coexists; silence-by-id across keys); within-task `accumulate` union (seed / merge / dedup / partial-overlap); `vars` + `accumulate` mix and vars-only JINJA2 re-emit; `surfaces` / `combine_across_tasks` storage + defaults; `emit_tip` template-vs-arg precedence; `tip_shows_on`; per-surface collect filter; `tip_to_payload`; the `tip_suggestion` hook (accept / reject / reject-by-id / replace / chain short-circuit).
  - `github_status_comments_test.axl` — surface gate; `(id, key)` grouping; `combine_across_tasks` union; latest-wins (identical → all tasks, divergent → latest); distinct-key separate rows; combine-if-any-contributor-opts-in.
- Covered by existing test cases: tips / PR-comment / Buildkite-annotation / bazel-results / lint / format / gazelle / delivery / GitLab suites pass.

