### PR TITLE
Add public @aspect//tips.axl + @aspect//helpers.axl facades; single add_tip API

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -4,9 +4,11 @@ load("@aspect//feature/buildkite_annotations_test.axl", "bk_annotation_snapshot_
 load("@aspect//feature/github_status_checks.axl", "GithubStatusChecks")
 load("@aspect//feature/github_status_comments_test.axl", "pr_comment_snapshot_tests")
 load("@aspect//format.axl", "format")
+load("@aspect//helpers_test.axl", "helpers_facade_tests")
 load("@aspect//lib/bazel_flags_test.axl", "bazel_flags_tests")
 load("@aspect//lib/bazel_results_test.axl", "bazel_results_unit_tests", "template_snapshot_tests")
 load("@aspect//lib/bazel_runner_test.axl", "bazel_runner_tests")
+load("@aspect//lib/ci_test.axl", "ci_tests")
 load("@aspect//lib/circleci_test.axl", "circleci_tests")
 load("@aspect//lib/delivery_results_test.axl", "delivery_template_snapshot_tests")
 load("@aspect//lib/format_results_test.axl", "format_template_snapshot_tests")
@@ -226,9 +228,9 @@ def config(ctx: ConfigContext):
     # Run with: aspect dev test-lint-template-snapshots
     ctx.tasks.add(lint_template_snapshot_tests)
 
-    # Tips framework primitives — add_tip / emit_tip / collect_tips_sorted,
+    # Tips framework primitives — add_tip / collect_tips_sorted,
     # severity helpers, blockquote_body, task_keys glob filtering,
-    # silenced_tips short-circuit, and built-in template shape.
+    # silenced_tips short-circuit, and built-in tip shape.
     # Run with: aspect dev test-tips
     ctx.tasks.add(tips_tests)
 
@@ -241,6 +243,17 @@ def config(ctx: ConfigContext):
     # 400 into a legible reason instead of an opaque "curl exit 22".
     # Run with: aspect dev test-circleci
     ctx.tasks.add(circleci_tests)
+
+    # Cross-CI URL helpers (lib/ci.axl) — host detection, env-only build
+    # URL resolution, the per-job cache short-circuit, and the off-GHA
+    # resolve_build_url delegation.
+    # Run with: aspect dev test-ci
+    ctx.tasks.add(ci_tests)
+
+    # `@aspect//helpers.axl` public facade — re-exports resolve to the
+    # real helpers a config.axl hook loads.
+    # Run with: aspect dev test-helpers
+    ctx.tasks.add(helpers_facade_tests)
 
     # Runner-side mitigations for bazelbuild/bazel#23880 and persistent
     # server-internal failures — detect-and-repair + signal-instance-unhealthy

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -104,7 +104,7 @@ load("@aspect//lib/artifacts.axl", "artifacts")
 load("@aspect//lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("@aspect//lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("@aspect//lib/ci.axl", "detect_build_url")
+load("@aspect//lib/ci.axl", "resolve_build_url")
 load("@aspect//lib/delivery_results.axl", delivery_add_result = "add_result", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
 load(
     "@aspect//lib/deliveryd.axl",
@@ -705,7 +705,7 @@ def _delivery_impl(ctx):
         fail(msg)
     if not commit_sha:
         commit_sha = "-"
-    build_url = ctx.args.build_url or detect_build_url(ctx) or "-"
+    build_url = ctx.args.build_url or resolve_build_url(ctx) or "-"
 
     # Change-detection prefix: always anchored to --task-key, optionally extended by --salt
     if ctx.args.salt:

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -27,7 +27,7 @@ load(
     "renderer_for_kind",
     "should_emit_update",
 )
-load("../lib/ci.axl", "detect_build_url")
+load("../lib/ci.axl", "resolve_build_url")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
 load("../lib/rate_limit.axl", "usage_footer")
@@ -237,7 +237,7 @@ def _buildkite_annotations(ctx: FeatureContext):
         # the rendered summary's CI link.
         links = {
             "ci_label": "Buildkite",
-            "ci_url": detect_build_url(ctx),
+            "ci_url": resolve_build_url(ctx),
             "aspect_url": "",
             "bes_url": "",
             "results_base_url": workflows_results_url(ctx.std),

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -45,7 +45,7 @@ load(
     "should_emit_update",
 )
 load("../lib/checkrun.axl", "checkrun")
-load("../lib/ci.axl", "detect_build_url", "detect_ci_host")
+load("../lib/ci.axl", "detect_ci_host", "resolve_build_url")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/github.axl", "detect_commit_sha", "detect_github_repo", "github")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
@@ -104,7 +104,7 @@ def _collect_ci_links(ctx, results_base_url):
     host = detect_ci_host(ctx.std.env)
     return {
         "ci_label": host["label"] if host else "",
-        "ci_url": detect_build_url(ctx),
+        "ci_url": resolve_build_url(ctx),
         "aspect_url": "",
         "bes_url": "",
         "results_base_url": results_base_url,
@@ -220,7 +220,7 @@ def _github_status_checks(ctx: FeatureContext):
         # Re-resolve with the just-minted App token: upgrades the GHA
         # run URL to the per-job URL if `_collect_ci_links` couldn't
         # auth at feature setup. Hits the cache on the typical path.
-        _ci_links_base["ci_url"] = detect_build_url(ctx, existing_app_token = token) or _ci_links_base["ci_url"]
+        _ci_links_base["ci_url"] = resolve_build_url(ctx, existing_app_token = token) or _ci_links_base["ci_url"]
         _state["_ci_links"] = _ci_links_base
 
         # No `task_update.kind` yet — pick by task name, falling

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -711,10 +711,10 @@ def _combine_across(ctx, contributors):
         row["accumulate"] = merged
         data = dict(row.get("vars") or {})
         data.update(merged)
-        if row.get("title_template"):
-            row["title"] = ctx.template.jinja2(row["title_template"], data = data)
-        if row.get("body_template"):
-            row["body"] = ctx.template.jinja2(row["body_template"], data = data)
+        if row.get("_title_src"):
+            row["title"] = ctx.template.jinja2(row["_title_src"], data = data)
+        if row.get("_body_src"):
+            row["body"] = ctx.template.jinja2(row["_body_src"], data = data)
     row["_task_keys"] = _ordered_unique([k for _, k in contributors])
     return row
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -44,7 +44,7 @@ load(
     "resolve_aspect_url",
 )
 load("../lib/checkrun.axl", "checkrun")
-load("../lib/ci.axl", "detect_build_url")
+load("../lib/ci.axl", "resolve_build_url")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/github.axl", "github")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait")
@@ -1585,7 +1585,7 @@ def _github_status_comments(ctx: FeatureContext):
 
         # Re-resolve with the just-minted App token; cache-hits if a
         # sibling feature already resolved.
-        upgraded = detect_build_url(ctx, existing_app_token = token)
+        upgraded = resolve_build_url(ctx, existing_app_token = token)
         if upgraded:
             _state["_ci_link_url"] = upgraded
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -438,8 +438,8 @@ def _check_collect_tip_rows(ctx):
             "body": "...",
             "type": "jinja2",
             "combine_across_tasks": True,
-            "title_template": title_tmpl,
-            "body_template": body_tmpl,
+            "_title_src": title_tmpl,
+            "_body_src": body_tmpl,
             "accumulate": {"scopes": ["actions: read"], "endpoints": ["/a/jobs"]},
         }]},
         {"key": "test-task", "tips": [{
@@ -449,8 +449,8 @@ def _check_collect_tip_rows(ctx):
             "body": "...",
             "type": "jinja2",
             "combine_across_tasks": True,
-            "title_template": title_tmpl,
-            "body_template": body_tmpl,
+            "_title_src": title_tmpl,
+            "_body_src": body_tmpl,
             "accumulate": {"scopes": ["pull-requests: read"], "endpoints": ["/b/files", "/c/files"]},
         }]},
     ])
@@ -537,8 +537,8 @@ def _check_collect_tip_rows(ctx):
     # combine=True if ANY contributor opts in: the group merges into one
     # row even when another contributor left it False.
     rows = collect_tip_rows(ctx, [
-        {"key": "build-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "title_template": "T", "body_template": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["a"]}}]},
-        {"key": "test-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "combine_across_tasks": True, "title_template": "T", "body_template": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["b"]}}]},
+        {"key": "build-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "_title_src": "T", "_body_src": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["a"]}}]},
+        {"key": "test-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "combine_across_tasks": True, "_title_src": "T", "_body_src": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["b"]}}]},
     ])
     if len(rows) != 1 or rows[0]["task_keys"] != ["build-task", "test-task"]:
         fail("combine-any: a single combine_across_tasks contributor must merge the group, got %r" % rows)

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -73,7 +73,7 @@ load(
     "renderer_for_kind",
     "should_emit_update",
 )
-load("../lib/ci.axl", "detect_build_url", "detect_ci_host")
+load("../lib/ci.axl", "detect_ci_host", "resolve_build_url")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/gitlab.axl", "gitlab")
 load("../lib/gitlab_detect.axl", "detect_gitlab_mr")
@@ -107,7 +107,7 @@ def _collect_ci_links(ctx, results_base_url):
     host = detect_ci_host(ctx.std.env)
     return {
         "ci_label": host["label"] if host else "",
-        "ci_url": detect_build_url(ctx),
+        "ci_url": resolve_build_url(ctx),
         "aspect_url": "",
         "bes_url": "",
         "results_base_url": results_base_url,
@@ -266,7 +266,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         # Re-resolve CI URL with the token in scope (mirrors GH path —
         # safe no-op when the CI URL is env-derived rather than
         # API-derived for the active CI host).
-        _ci_links_base["ci_url"] = detect_build_url(ctx, existing_app_token = token) or _ci_links_base["ci_url"]
+        _ci_links_base["ci_url"] = resolve_build_url(ctx, existing_app_token = token) or _ci_links_base["ci_url"]
         _state["_ci_links"] = _ci_links_base
         return True
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -63,7 +63,7 @@ load(
     "results_subset",
 )
 load("../lib/bazel_results.axl", "format_run_date", "now_ms")
-load("../lib/ci.axl", "detect_build_url", "detect_ci_host")
+load("../lib/ci.axl", "detect_ci_host")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/gitlab.axl", "gitlab")
 load("../lib/gitlab_detect.axl", "detect_gitlab_mr")

--- a/crates/aspect-cli/src/builtins/aspect/helpers.axl
+++ b/crates/aspect-cli/src/builtins/aspect/helpers.axl
@@ -8,9 +8,8 @@ lives in its owning module (see there for full semantics):
   - `detect_ci_host(env) -> {marker, label, icon} | None`
         the running CI host (GitHub Actions / Buildkite / CircleCI /
         GitLab), or None off a recognized host. From `lib/ci.axl`.
-  - `detect_build_url(ctx) -> str`
-        the job-scoped CI build URL, or "" off a recognized host. From
-        `lib/ci.axl`.
+  - `detect_build_url(env) -> str`
+        the CI build URL, or "" off a recognized host. From `lib/ci.axl`.
   - `aspect_web_ui_url(env, data) -> str`
         the Aspect Web UI invocation URL, or "" when unavailable. From
         `lib/bazel_results.axl`.

--- a/crates/aspect-cli/src/builtins/aspect/helpers.axl
+++ b/crates/aspect-cli/src/builtins/aspect/helpers.axl
@@ -1,0 +1,28 @@
+"""Public facade re-exporting helpers for `config.axl` task hooks.
+
+These let a user `task_update` / `tip_suggestion` hook reconstruct the
+same click-through links the built-in status surfaces render, without
+loading the implementation modules directly. Each helper's definition
+lives in its owning module (see there for full semantics):
+
+  - `detect_ci_host(env) -> {marker, label, icon} | None`
+        the running CI host (GitHub Actions / Buildkite / CircleCI /
+        GitLab), or None off a recognized host. From `lib/ci.axl`.
+  - `detect_build_url(ctx) -> str`
+        the job-scoped CI build URL, or "" off a recognized host. From
+        `lib/ci.axl`.
+  - `aspect_web_ui_url(env, data) -> str`
+        the Aspect Web UI invocation URL, or "" when unavailable. From
+        `lib/bazel_results.axl`.
+  - `render_bes_url(data) -> str`
+        the BES results URL from a Bazel task's `data["bazel"]`, or ""
+        when unavailable. From `lib/bazel_results.axl`.
+"""
+
+load("./lib/bazel_results.axl", _aspect_web_ui_url = "aspect_web_ui_url", _render_bes_url = "render_bes_url")
+load("./lib/ci.axl", _detect_build_url = "detect_build_url", _detect_ci_host = "detect_ci_host")
+
+detect_ci_host = _detect_ci_host
+detect_build_url = _detect_build_url
+aspect_web_ui_url = _aspect_web_ui_url
+render_bes_url = _render_bes_url

--- a/crates/aspect-cli/src/builtins/aspect/helpers_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/helpers_test.axl
@@ -1,0 +1,44 @@
+"""Smoke test for the `@aspect//helpers.axl` public facade.
+
+The facade is a thin re-export of helpers a user `config.axl` hook needs
+to rebuild the built-in click-through links. This test loads every
+re-exported symbol *through the facade* (not the implementation modules)
+and exercises each enough to prove the re-export resolves to the real
+function — guarding against a re-export that silently drops or renames a
+symbol. The per-host URL logic itself is covered in `lib/ci_test.axl` and
+`lib/bazel_results_test.axl`.
+
+Run with:
+  aspect dev test-helpers
+"""
+
+load("./helpers.axl", "aspect_web_ui_url", "detect_build_url", "detect_ci_host", "render_bes_url")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _test_impl(ctx):
+    env = ctx.std.env
+
+    # detect_ci_host / detect_build_url resolve to the real env-only
+    # helpers (return a value without raising; full behavior in ci_test).
+    host = detect_ci_host(env)
+    if host != None and "label" not in host:
+        fail("helpers: detect_ci_host returned a malformed host: %r" % host)
+    detect_build_url(env)  # must not raise
+
+    # aspect_web_ui_url / render_bes_url resolve and return "" when their
+    # inputs are absent (full behavior in bazel_results_test).
+    _eq("helpers: aspect_web_ui_url empty without inputs", aspect_web_ui_url(env, {}), "")
+    _eq("helpers: render_bes_url empty without inputs", render_bes_url({"bazel": {}}), "")
+
+    print("helpers.axl facade: OK")
+    return 0
+
+helpers_facade_tests = task(
+    name = "test-helpers",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -46,7 +46,7 @@ isn't worth it for a check run display. We show the failing target label plus
 the list of failing action mnemonics; users follow the CI link for the raw log.
 """
 
-load("./ci.axl", "detect_build_url", "detect_ci_host")
+load("./ci.axl", "detect_ci_host", "resolve_build_url")
 load(
     "./environment.axl",
     "build_aspect_runner_rows",
@@ -1026,6 +1026,12 @@ def process_event(data, event):
 
     return False
 
+def _join_url(base, id):
+    """Join a results-base URL with an invocation id, tolerant of a
+    trailing slash on `base` — both `https://host` and `https://host/`
+    yield `https://host/<id>` with exactly one separating slash."""
+    return (base if base.endswith("/") else base + "/") + id
+
 def resolve_aspect_url(links, data):
     """Return the Aspect Web UI URL for an invocation, or "" if unavailable.
 
@@ -1055,10 +1061,6 @@ def resolve_aspect_url(links, data):
     the bare host. Typical value:
 
         ASPECT_WORKFLOWS_BES_RESULTS_URL=https://app.oss.aspect.build
-
-    The join below is `endswith("/")`-tolerant — both the typical
-    no-trailing-slash form and the with-trailing-slash variant produce
-    the same `{base}/{id}` URL with exactly one `/` between them.
     """
     base = links.get("results_base_url", "") if links else ""
     if not base:
@@ -1066,7 +1068,7 @@ def resolve_aspect_url(links, data):
     inv_id = data.get("sink_invocation_id", "") or ""
     if not inv_id:
         return ""
-    return (base if base.endswith("/") else base + "/") + inv_id
+    return _join_url(base, inv_id)
 
 def aspect_web_ui_url(env: std.Env, data: dict) -> str:
     """Aspect Web UI invocation URL for a task, or "" when unavailable.
@@ -2569,7 +2571,7 @@ def render_bes_url(data: dict) -> str:
     inv = data["bazel"].get("invocation_id", "")
     if not base or not inv:
         return ""
-    return (base if base.endswith("/") else base + "/") + inv
+    return _join_url(base, inv)
 
 def format_run_date(ctx, epoch_ms):
     """Format an epoch timestamp (milliseconds) as a human-readable date string.
@@ -2637,13 +2639,13 @@ def ci_link_item(ctx, links):
 
     Prefers the feature-supplied `links["ci_url"]` (which may be a
     job-scoped deep link resolved against the GitHub API); falls back to
-    `detect_build_url` so the link works even when the feature doesn't
+    `resolve_build_url` so the link works even when the feature doesn't
     pass one through.
     """
     host = detect_ci_host(ctx.std.env)
     if not host:
         return None
-    url = (links or {}).get("ci_url", "") or detect_build_url(ctx)
+    url = (links or {}).get("ci_url", "") or resolve_build_url(ctx)
     if not url:
         return None
     return {"icon": host["icon"], "value": "[%s](%s)" % (host["label"], url)}
@@ -3755,10 +3757,7 @@ def _build_retry_attempt_rows(data, links):
     rows = []
     for a in attempts:
         sink_id = a.get("sink_invocation_id", "") or ""
-        if base and sink_id:
-            url = (base if base.endswith("/") else base + "/") + sink_id
-        else:
-            url = ""
+        url = _join_url(base, sink_id) if (base and sink_id) else ""
         rows.append({
             "attempt": a.get("attempt", 0),
             "outcome": "passed" if a.get("exit_code", 1) == 0 else "failed",

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -1068,6 +1068,15 @@ def resolve_aspect_url(links, data):
         return ""
     return (base if base.endswith("/") else base + "/") + inv_id
 
+def aspect_web_ui_url(env: std.Env, data: dict) -> str:
+    """Aspect Web UI invocation URL for a task, or "" when unavailable.
+
+    Joins `ASPECT_WORKFLOWS_BES_RESULTS_URL` (`env` = `ctx.std.env`) with
+    the sink-minted `data["sink_invocation_id"]` (the UUID the Aspect
+    backend indexes invocations by). "" if either is missing."""
+    base = env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL") or ""
+    return resolve_aspect_url({"results_base_url": base}, data)
+
 def failed_labels(data):
     """Collect the deduplicated list of failed target labels from `data["bazel"]`.
 
@@ -2547,18 +2556,14 @@ def _sorted_dedup(args, allow_env):
     unique = sorted(set(redacted))
     return [_quote_flag(a) for a in unique]
 
-def render_bes_url(data):
-    """Construct the full BES invocation URL from bes_results_url + invocation_id.
+def render_bes_url(data: dict) -> str:
+    """Full BES results URL from a Bazel task's `data["bazel"]`, or ""
+    when unavailable.
 
-    Uses Bazel's `invocation_id` (the UUID Bazel mints for its own
-    BEP stream — captured from the `BuildStarted` BEP event), not the
-    Aspect-side `sink_invocation_id`. The two are distinct: the
-    `--bes_results_url` consumer only sees Bazel's UUID, so the link
-    must key on that. `resolve_aspect_url` is the parallel helper for
-    the Aspect Web UI which is keyed on `sink_invocation_id`.
-
-    Returns "" when either piece is unavailable (caller suppresses
-    the link rather than rendering a broken URL).
+    Keyed on Bazel's own `invocation_id` (the UUID from the `BuildStarted`
+    BEP event) — the `--bes_results_url` backend only sees that UUID. This
+    is the BES counterpart to `aspect_web_ui_url`, which keys the Aspect
+    Web UI on the sink-minted `sink_invocation_id`.
     """
     base = data["bazel"].get("bes_results_url", "")
     inv = data["bazel"].get("invocation_id", "")

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -8,7 +8,7 @@ Two task implementations live here:
     `compute_invocation_state`, `conclusion`, and skipped-bucket plumbing.
 """
 
-load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "init_data", "process_event", "render_check_output", "repro_targets")
+load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "aspect_web_ui_url", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "init_data", "process_event", "render_bes_url", "render_check_output", "repro_targets")
 
 # ---------------------------------------------------------------------------
 # Fake data builders
@@ -1068,8 +1068,43 @@ def _test_status_maps_cover_every_terminal_status(ctx):
         _eq("%r icon is not the running default" % status, STATUS_ICONS[status] != "🔄", True)
         _eq("%r label is not 'Running...'" % status, STATUS_LABELS[status] != "Running...", True)
 
+def _test_aspect_web_ui_url(ctx):
+    """`aspect_web_ui_url` joins the env base URL with sink_invocation_id,
+    and returns "" when either half is missing."""
+    env = ctx.std.env
+    env.set_var("ASPECT_WORKFLOWS_BES_RESULTS_URL", "https://app.oss.aspect.build")
+    _eq(
+        "aspect_web_ui_url joins base + sink id",
+        aspect_web_ui_url(env, {"sink_invocation_id": "abc-123"}),
+        "https://app.oss.aspect.build/abc-123",
+    )
+    _eq("aspect_web_ui_url empty without sink id", aspect_web_ui_url(env, {}), "")
+    env.set_var("ASPECT_WORKFLOWS_BES_RESULTS_URL", "")
+    _eq("aspect_web_ui_url empty without base", aspect_web_ui_url(env, {"sink_invocation_id": "abc-123"}), "")
+
+def _test_render_bes_url(ctx):
+    """`render_bes_url` joins data['bazel'] bes_results_url + invocation_id,
+    and returns "" when either half is missing."""
+    _eq(
+        "render_bes_url joins base + invocation id",
+        render_bes_url({"bazel": {"bes_results_url": "https://bes.example", "invocation_id": "uuid-1"}}),
+        "https://bes.example/uuid-1",
+    )
+    _eq(
+        "render_bes_url empty without invocation id",
+        render_bes_url({"bazel": {"bes_results_url": "https://bes.example", "invocation_id": ""}}),
+        "",
+    )
+    _eq(
+        "render_bes_url empty without base",
+        render_bes_url({"bazel": {"bes_results_url": "", "invocation_id": "uuid-1"}}),
+        "",
+    )
+
 _UNIT_TESTS = [
     _test_status_maps_cover_every_terminal_status,
+    _test_aspect_web_ui_url,
+    _test_render_bes_url,
     _test_failed_status_without_failure_bucket,
     _test_failed_status_with_explicit_action_failure,
     _test_passed_status_returns_successful_build,

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -1079,6 +1079,15 @@ def _test_aspect_web_ui_url(ctx):
         "https://app.oss.aspect.build/abc-123",
     )
     _eq("aspect_web_ui_url empty without sink id", aspect_web_ui_url(env, {}), "")
+
+    # A trailing slash on the base must not double up in the join.
+    env.set_var("ASPECT_WORKFLOWS_BES_RESULTS_URL", "https://app.oss.aspect.build/")
+    _eq(
+        "aspect_web_ui_url tolerates a trailing slash on the base",
+        aspect_web_ui_url(env, {"sink_invocation_id": "abc-123"}),
+        "https://app.oss.aspect.build/abc-123",
+    )
+
     env.set_var("ASPECT_WORKFLOWS_BES_RESULTS_URL", "")
     _eq("aspect_web_ui_url empty without base", aspect_web_ui_url(env, {"sink_invocation_id": "abc-123"}), "")
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/ci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/ci.axl
@@ -70,8 +70,13 @@ def detect_buildkite_build_url(env):
         return build_url + "#" + job_id
     return build_url
 
-def detect_build_url(ctx: TaskContext, existing_app_token: str | None = None) -> str:
+def detect_build_url(ctx, existing_app_token: str | None = None) -> str:
     """Detect the job-scoped CI build URL from the environment.
+
+    `ctx` is left unannotated because callers pass either a `TaskContext`
+    or a `FeatureContext` (status-check features resolve the link from
+    feature context); only `ctx.std.env` and the GHA upgrade path's `ctx`
+    plumbing are used.
 
     Returns the URL of the running CI build (the page a developer would
     visit to see logs/status), or "" if no recognized CI host is detected

--- a/crates/aspect-cli/src/builtins/aspect/lib/ci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/ci.axl
@@ -26,11 +26,11 @@ Shapes by host:
                         Packages API, which has no clean per-job page.
 """
 
-load("./github.axl", "detect_github_actions_build_url")
+load("./github.axl", "detect_github_actions_build_url", "github_actions_run_url")
 
 # Per-process env var holding the once-resolved build URL. Populated by
-# the first `detect_build_url` caller in the task; subsequent callers
-# (sibling features, per-render lookups) short-circuit to this value.
+# `detect_build_url` (env-derived) or `resolve_build_url` (the GHA per-job
+# upgrade); subsequent callers short-circuit to it.
 _JOB_URL_CACHE_ENV = "ASPECT_JOB_URL_CACHE"
 
 # Per-CI-host metadata. Order is the detection precedence: `detect_ci_host`
@@ -70,33 +70,26 @@ def detect_buildkite_build_url(env):
         return build_url + "#" + job_id
     return build_url
 
-def detect_build_url(ctx, existing_app_token: str | None = None) -> str:
-    """Detect the job-scoped CI build URL from the environment.
+def detect_build_url(env: std.Env) -> str:
+    """Detect the CI build URL from the environment.
 
-    `ctx` is left unannotated because callers pass either a `TaskContext`
-    or a `FeatureContext` (status-check features resolve the link from
-    feature context); only `ctx.std.env` and the GHA upgrade path's `ctx`
-    plumbing are used.
+    The env-only public helper, for callers that have an `env` but no
+    full context. Returns the running CI build URL (the page a developer
+    would visit to see logs/status), or "" off a recognized host. See the
+    module docstring for the per-host shape.
 
-    Returns the URL of the running CI build (the page a developer would
-    visit to see logs/status), or "" if no recognized CI host is detected
-    or the env vars aren't populated. See the module docstring for the
-    per-host shape.
-
-    Caches the resolved URL in `ASPECT_JOB_URL_CACHE` so sibling callers
-    in the same task share the result without re-resolving. Only GHA's
-    job URL requires an API call; the cache makes subsequent renders /
-    sibling features free.
-
-    `existing_app_token` is forwarded to the GHA upgrade path so a caller
-    with a freshly-minted App token in hand can skip a redundant mint.
+    Reads the `ASPECT_JOB_URL_CACHE` cache first, so the per-job GitHub
+    Actions URL `resolve_build_url` resolves (with a context) is returned
+    here too once cached. Without a cache hit, GitHub Actions yields the
+    run-level URL; Buildkite / CircleCI / GitLab are job-scoped from env
+    alone. Use `resolve_build_url(ctx)` to obtain (and cache) the GHA
+    per-job URL.
     """
-    env = ctx.std.env
     cached = env.var(_JOB_URL_CACHE_ENV) or ""
     if cached:
         return cached
     if env.var("GITHUB_ACTIONS"):
-        url = detect_github_actions_build_url(ctx, existing_app_token = existing_app_token)
+        url = github_actions_run_url(env)
     elif env.var("BUILDKITE"):
         url = detect_buildkite_build_url(env)
     elif env.var("CIRCLECI"):
@@ -107,6 +100,28 @@ def detect_build_url(ctx, existing_app_token: str | None = None) -> str:
         return ""
     if url:
         env.set_var(_JOB_URL_CACHE_ENV, url)
+    return url
+
+def resolve_build_url(ctx, existing_app_token: str | None = None) -> str:
+    """Resolve the richest available CI build URL, given a full context.
+
+    The internal counterpart to the public `detect_build_url(env)`: on
+    GitHub Actions it upgrades the run-level URL to the per-job URL
+    `/actions/runs/<run_id>/job/<job_id>` via an authenticated `actions:read`
+    API call and caches it in `ASPECT_JOB_URL_CACHE`, so every later
+    `detect_build_url(env)` caller in the task gets the per-job URL for free.
+    Off GitHub Actions (or when the API call can't authenticate) it returns
+    the env-derived URL.
+
+    `existing_app_token` lets a caller that just minted an App token skip a
+    redundant mint. `ctx` is left unannotated because callers pass either a
+    `TaskContext` or a `FeatureContext`.
+    """
+    if not ctx.std.env.var("GITHUB_ACTIONS"):
+        return detect_build_url(ctx.std.env)
+    url = detect_github_actions_build_url(ctx, existing_app_token = existing_app_token)
+    if url:
+        ctx.std.env.set_var(_JOB_URL_CACHE_ENV, url)
     return url
 
 def _circleci_vcs(env):

--- a/crates/aspect-cli/src/builtins/aspect/lib/ci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/ci.axl
@@ -42,12 +42,13 @@ _CI_HOSTS = [
     {"marker": "GITLAB_CI", "label": "GitLab CI", "icon": "🦊"},
 ]
 
-def detect_ci_host(env):
-    """Return the matching `_CI_HOSTS` entry for the current env, or `None`.
+def detect_ci_host(env: std.Env) -> dict | None:
+    """Return the running CI host, or `None` off a recognized host.
 
-    Entry shape: `{"marker": str, "label": str, "icon": str}`. Used by
-    status surfaces that need a human-readable CI label and/or icon
-    alongside the URL `detect_build_url` returns.
+    The entry is `{"marker": str, "label": str, "icon": str}` — a
+    human-readable label and icon for the host (GitHub Actions /
+    Buildkite / CircleCI / GitLab), to pair with the URL
+    `detect_build_url` returns.
     """
     for host in _CI_HOSTS:
         if env.var(host["marker"]):
@@ -69,7 +70,7 @@ def detect_buildkite_build_url(env):
         return build_url + "#" + job_id
     return build_url
 
-def detect_build_url(ctx, existing_app_token = None):
+def detect_build_url(ctx: TaskContext, existing_app_token: str | None = None) -> str:
     """Detect the job-scoped CI build URL from the environment.
 
     Returns the URL of the running CI build (the page a developer would

--- a/crates/aspect-cli/src/builtins/aspect/lib/ci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/ci_test.axl
@@ -1,0 +1,222 @@
+"""Tests for `lib/ci.axl` (the cross-CI URL helpers).
+
+Covers the env-only surface — the part that resolves from environment
+variables alone, without an authenticated API call:
+
+  - `detect_ci_host` — per-host detection + precedence order, and the
+                       `None` result off a recognized host.
+  - `detect_buildkite_build_url` — job-anchored URL, bare-build-URL
+                       fallback, and the empty case.
+  - `github_actions_run_url` — run-level URL shape, custom server,
+                       off-GHA / missing-var empties.
+  - `detect_build_url` — per-host resolution, the catch-all empty, and
+                       the `ASPECT_JOB_URL_CACHE` cache-first short-circuit
+                       (so the per-job URL `resolve_build_url` caches is
+                       returned here too).
+  - `resolve_build_url` — the off-GitHub-Actions path delegates to
+                       `detect_build_url(env)`. (The GitHub Actions per-job
+                       API upgrade is exercised in `github_detect_test.axl`,
+                       which has the HTTP stubs.)
+
+These exercise real `ctx.std.env` — there's no env-mocking layer in AXL —
+so each subtest snapshots and restores the CI env vars it touches.
+
+Run with:
+  aspect dev test-ci
+"""
+
+load("./ci.axl", "detect_build_url", "detect_buildkite_build_url", "detect_ci_host", "github_actions_run_url", "resolve_build_url")
+
+# Every CI-host marker + the per-job cache, snapshotted/restored around
+# each subtest so the harness's own CI environment can't leak in.
+_ENV_KEYS = [
+    "ASPECT_JOB_URL_CACHE",
+    "GITHUB_ACTIONS",
+    "GITHUB_SERVER_URL",
+    "GITHUB_REPOSITORY",
+    "GITHUB_RUN_ID",
+    "BUILDKITE",
+    "BUILDKITE_BUILD_URL",
+    "BUILDKITE_JOB_ID",
+    "CIRCLECI",
+    "CIRCLE_BUILD_URL",
+    "GITLAB_CI",
+    "CI_JOB_URL",
+]
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _snapshot_env(ctx):
+    return {k: ctx.std.env.var(k) for k in _ENV_KEYS}
+
+def _restore_env(ctx, snapshot):
+    for k, v in snapshot.items():
+        if v == None:
+            ctx.std.env.remove_var(k)
+        else:
+            ctx.std.env.set_var(k, v)
+
+def _clear_env(ctx):
+    for k in _ENV_KEYS:
+        ctx.std.env.remove_var(k)
+
+def _test_detect_ci_host(ctx):
+    snapshot = _snapshot_env(ctx)
+
+    _clear_env(ctx)
+    _eq("ci_host — none off a recognized host", detect_ci_host(ctx.std.env), None)
+
+    for marker, label in [
+        ("GITHUB_ACTIONS", "GitHub Actions"),
+        ("BUILDKITE", "Buildkite"),
+        ("CIRCLECI", "CircleCI"),
+        ("GITLAB_CI", "GitLab CI"),
+    ]:
+        _clear_env(ctx)
+        ctx.std.env.set_var(marker, "true")
+        host = detect_ci_host(ctx.std.env)
+        _eq("ci_host — %s marker → label" % marker, host["label"], label)
+        _eq("ci_host — %s marker → marker field" % marker, host["marker"], marker)
+
+    # Precedence: GitHub Actions wins when several markers are set.
+    _clear_env(ctx)
+    ctx.std.env.set_var("GITHUB_ACTIONS", "true")
+    ctx.std.env.set_var("BUILDKITE", "true")
+    _eq("ci_host — precedence is GitHub Actions first", detect_ci_host(ctx.std.env)["marker"], "GITHUB_ACTIONS")
+
+    _restore_env(ctx, snapshot)
+
+def _test_detect_buildkite_build_url(ctx):
+    snapshot = _snapshot_env(ctx)
+    _clear_env(ctx)
+
+    _eq("bk url — empty when no build url", detect_buildkite_build_url(ctx.std.env), "")
+
+    ctx.std.env.set_var("BUILDKITE_BUILD_URL", "https://buildkite.com/o/p/builds/9")
+    _eq("bk url — bare build url when no job id", detect_buildkite_build_url(ctx.std.env), "https://buildkite.com/o/p/builds/9")
+
+    ctx.std.env.set_var("BUILDKITE_JOB_ID", "job-7")
+    _eq("bk url — job-anchored when both set", detect_buildkite_build_url(ctx.std.env), "https://buildkite.com/o/p/builds/9#job-7")
+
+    _restore_env(ctx, snapshot)
+
+def _test_github_actions_run_url(ctx):
+    snapshot = _snapshot_env(ctx)
+
+    _clear_env(ctx)
+    _eq("gha run url — empty off GitHub Actions", github_actions_run_url(ctx.std.env), "")
+
+    ctx.std.env.set_var("GITHUB_ACTIONS", "true")
+    _eq("gha run url — empty without repo/run_id", github_actions_run_url(ctx.std.env), "")
+
+    ctx.std.env.set_var("GITHUB_REPOSITORY", "acme/web")
+    ctx.std.env.set_var("GITHUB_RUN_ID", "1234")
+    _eq(
+        "gha run url — default server",
+        github_actions_run_url(ctx.std.env),
+        "https://github.com/acme/web/actions/runs/1234",
+    )
+
+    ctx.std.env.set_var("GITHUB_SERVER_URL", "https://ghe.acme.com")
+    _eq(
+        "gha run url — custom (GHE) server",
+        github_actions_run_url(ctx.std.env),
+        "https://ghe.acme.com/acme/web/actions/runs/1234",
+    )
+
+    _restore_env(ctx, snapshot)
+
+def _test_detect_build_url_per_host(ctx):
+    snapshot = _snapshot_env(ctx)
+
+    _clear_env(ctx)
+    _eq("build url — empty off a recognized host", detect_build_url(ctx.std.env), "")
+
+    # GitHub Actions resolves to the run-level URL (the per-job upgrade
+    # needs a context; see `resolve_build_url`).
+    _clear_env(ctx)
+    ctx.std.env.set_var("GITHUB_ACTIONS", "true")
+    ctx.std.env.set_var("GITHUB_REPOSITORY", "acme/web")
+    ctx.std.env.set_var("GITHUB_RUN_ID", "1234")
+    _eq(
+        "build url — GitHub Actions run-level",
+        detect_build_url(ctx.std.env),
+        "https://github.com/acme/web/actions/runs/1234",
+    )
+
+    _clear_env(ctx)
+    ctx.std.env.set_var("CIRCLECI", "true")
+    ctx.std.env.set_var("CIRCLE_BUILD_URL", "https://circleci.com/gh/acme/web/9")
+    _eq("build url — CircleCI from CIRCLE_BUILD_URL", detect_build_url(ctx.std.env), "https://circleci.com/gh/acme/web/9")
+
+    _clear_env(ctx)
+    ctx.std.env.set_var("GITLAB_CI", "true")
+    ctx.std.env.set_var("CI_JOB_URL", "https://gitlab.com/acme/web/-/jobs/9")
+    _eq("build url — GitLab from CI_JOB_URL", detect_build_url(ctx.std.env), "https://gitlab.com/acme/web/-/jobs/9")
+
+    _restore_env(ctx, snapshot)
+
+def _test_detect_build_url_cache_first(ctx):
+    """A populated `ASPECT_JOB_URL_CACHE` short-circuits resolution, so the
+    per-job URL a status feature resolved (with a context) is returned to
+    every later env-only caller."""
+    snapshot = _snapshot_env(ctx)
+
+    # Cache hit wins even over a live GitHub Actions env that would
+    # otherwise resolve to the run-level URL.
+    _clear_env(ctx)
+    ctx.std.env.set_var("GITHUB_ACTIONS", "true")
+    ctx.std.env.set_var("GITHUB_REPOSITORY", "acme/web")
+    ctx.std.env.set_var("GITHUB_RUN_ID", "1234")
+    ctx.std.env.set_var("ASPECT_JOB_URL_CACHE", "https://github.com/acme/web/actions/runs/1234/job/567")
+    _eq(
+        "build url — cache hit returns the per-job URL",
+        detect_build_url(ctx.std.env),
+        "https://github.com/acme/web/actions/runs/1234/job/567",
+    )
+
+    # A cache miss on a job-scoped host populates the cache as a side effect.
+    _clear_env(ctx)
+    ctx.std.env.set_var("CIRCLECI", "true")
+    ctx.std.env.set_var("CIRCLE_BUILD_URL", "https://circleci.com/gh/acme/web/9")
+    detect_build_url(ctx.std.env)
+    _eq("build url — resolved URL cached", ctx.std.env.var("ASPECT_JOB_URL_CACHE"), "https://circleci.com/gh/acme/web/9")
+
+    _restore_env(ctx, snapshot)
+
+def _test_resolve_build_url_off_gha(ctx):
+    """Off GitHub Actions, `resolve_build_url(ctx)` delegates to the
+    env-only `detect_build_url(env)` — no API call. (The GitHub Actions
+    per-job upgrade is covered in `github_detect_test.axl`.)"""
+    snapshot = _snapshot_env(ctx)
+
+    _clear_env(ctx)
+    ctx.std.env.set_var("BUILDKITE", "true")
+    ctx.std.env.set_var("BUILDKITE_BUILD_URL", "https://buildkite.com/o/p/builds/9")
+    ctx.std.env.set_var("BUILDKITE_JOB_ID", "job-7")
+    _eq(
+        "resolve — off-GHA delegates to env-only build URL",
+        resolve_build_url(ctx),
+        "https://buildkite.com/o/p/builds/9#job-7",
+    )
+
+    _restore_env(ctx, snapshot)
+
+def _test_impl(ctx):
+    _test_detect_ci_host(ctx)
+    _test_detect_buildkite_build_url(ctx)
+    _test_github_actions_run_url(ctx)
+    _test_detect_build_url_per_host(ctx)
+    _test_detect_build_url_cache_first(ctx)
+    _test_resolve_build_url_off_gha(ctx)
+    print("ci.axl: OK (6 sections)")
+    return 0
+
+ci_tests = task(
+    name = "test-ci",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -295,7 +295,7 @@ def _emit_aspect_api_token_tip(ctx):
         host = AspectApiTokenHost("circleci")
     else:
         return
-    _emit_tip_if_ready(ctx, tip_add_aspect_api_token, host = host.value)
+    _emit_tip_if_ready(ctx, tip_add_aspect_api_token, host = host)
 
 def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existing_app_token = None, _reason = None):
     """Resolve `(primary_token, fallback_token)` for supporting GitHub
@@ -649,6 +649,20 @@ def detect_default_branch_ref(ctx):
 
     return ""
 
+def github_actions_run_url(env):
+    """GitHub Actions run-level URL `<server>/<repo>/actions/runs/<run_id>`,
+    or "" off GitHub Actions or when the env vars aren't populated. The
+    per-job upgrade (an authenticated API call) lives in
+    `detect_github_actions_build_url`."""
+    if not env.var("GITHUB_ACTIONS"):
+        return ""
+    server = env.var("GITHUB_SERVER_URL") or "https://github.com"
+    repository = env.var("GITHUB_REPOSITORY") or ""
+    run_id = env.var("GITHUB_RUN_ID") or ""
+    if not (repository and run_id):
+        return ""
+    return server + "/" + repository + "/actions/runs/" + run_id
+
 def detect_github_actions_build_url(ctx, existing_app_token = None):
     """GitHub Actions build URL — job-scoped when the App is authenticated.
 
@@ -664,18 +678,13 @@ def detect_github_actions_build_url(ctx, existing_app_token = None):
     `existing_app_token` lets a caller that already minted an App token in
     the same handler skip a redundant mint.
 
-    The caller (`lib/ci.axl::detect_build_url`) is responsible for caching
+    The caller (`lib/ci.axl::resolve_build_url`) is responsible for caching
     so the `_resolve_current_job_url` HTTP call only happens once per task.
     """
-    env = ctx.std.env
-    if not env.var("GITHUB_ACTIONS"):
+    run_url = github_actions_run_url(ctx.std.env)
+    if not run_url:
         return ""
-    server = env.var("GITHUB_SERVER_URL") or "https://github.com"
-    repository = env.var("GITHUB_REPOSITORY") or ""
-    run_id = env.var("GITHUB_RUN_ID") or ""
-    if not (repository and run_id):
-        return ""
-    run_url = server + "/" + repository + "/actions/runs/" + run_id
+    run_id = ctx.std.env.var("GITHUB_RUN_ID") or ""
     owner, repo = detect_github_repo(ctx.std)
     if owner and repo:
         token, fallback, token_class = _preferred_token_pair(ctx, owner, repo, roles = ["actions.read"], existing_app_token = existing_app_token)

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -30,13 +30,11 @@ load("./tar.axl", "zip_create")
 load("./text.axl", "pluralize")
 load(
     "./tips.axl",
-    "TIP_ADD_ASPECT_API_TOKEN_BUILDKITE",
-    "TIP_ADD_ASPECT_API_TOKEN_CIRCLECI",
-    "TIP_ADD_ASPECT_API_TOKEN_GHA",
-    "TIP_ADD_GITHUB_TOKEN",
-    "TIP_ADD_GITHUB_TOKEN_SCOPE",
-    "TIP_ADD_ID_TOKEN_PERMISSION",
-    "emit_tip",
+    "AspectApiTokenHost",
+    "tip_add_aspect_api_token",
+    "tip_add_github_token",
+    "tip_add_github_token_scope",
+    "tip_add_id_token_permission",
 )
 
 DEFAULT_GITHUB_API = "https://api.github.com"
@@ -264,15 +262,16 @@ def _is_4xx_auth(status_code):
     can't see the resource)."""
     return status_code in (401, 403, 404)
 
-def _emit_tip_if_ready(ctx, template, **kwargs):
-    """Emit a tip when `ctx.traits` is available. Defensive against
+def _emit_tip_if_ready(ctx, tip_fn, **kwargs):
+    """Call `tip_fn(ctx, **kwargs)` (a built-in `tip_*` function from
+    `lib/tips.axl`) when `ctx.traits` is available. Defensive against
     test stubs that don't carry a traits map. Use for tips whose
     recommendation applies on every CI host."""
     if not hasattr(ctx, "traits"):
         return
-    emit_tip(ctx, template, **kwargs)
+    tip_fn(ctx, **kwargs)
 
-def _emit_gha_tip(ctx, template, **kwargs):
+def _emit_gha_tip(ctx, tip_fn, **kwargs):
     """Emit a tip whose recommendation is GitHub-Actions-specific
     (workflow YAML, `permissions:` block, `${{ secrets.* }}`). Wraps
     `_emit_tip_if_ready` with an additional `GITHUB_ACTIONS` env gate
@@ -280,7 +279,7 @@ def _emit_gha_tip(ctx, template, **kwargs):
     its example syntax would be wrong."""
     if not ctx.std.env.var("GITHUB_ACTIONS"):
         return
-    _emit_tip_if_ready(ctx, template, **kwargs)
+    _emit_tip_if_ready(ctx, tip_fn, **kwargs)
 
 def _emit_aspect_api_token_tip(ctx):
     """Emit the host-specific `add-aspect-api-token-<host>` tip on CI
@@ -289,14 +288,14 @@ def _emit_aspect_api_token_tip(ctx):
     CIs where there's no documented use case yet."""
     env = ctx.std.env
     if env.var("GITHUB_ACTIONS"):
-        template = TIP_ADD_ASPECT_API_TOKEN_GHA
+        host = AspectApiTokenHost("github-actions")
     elif env.var("BUILDKITE"):
-        template = TIP_ADD_ASPECT_API_TOKEN_BUILDKITE
+        host = AspectApiTokenHost("buildkite")
     elif env.var("CIRCLECI"):
-        template = TIP_ADD_ASPECT_API_TOKEN_CIRCLECI
+        host = AspectApiTokenHost("circleci")
     else:
         return
-    _emit_tip_if_ready(ctx, template)
+    _emit_tip_if_ready(ctx, tip_add_aspect_api_token, host = host.value)
 
 def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existing_app_token = None, _reason = None):
     """Resolve `(primary_token, fallback_token)` for supporting GitHub
@@ -339,9 +338,9 @@ def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existi
     both a structured `kind` and a human-readable `reason` from
     `_authenticate`.
 
-    `_authenticate` emits `TIP_ADD_ASPECT_API_TOKEN` (kind + host gated)
+    `_authenticate` emits `tip_add_aspect_api_token` (kind + host gated)
     on the missing-credentials path. `_preferred_token_pair` additionally
-    emits `TIP_ADD_GITHUB_TOKEN` on GitHub Actions when neither App nor
+    emits `tip_add_github_token` on GitHub Actions when neither App nor
     env produces a token, since exporting `GITHUB_TOKEN` is the
     GHA-specific path to an immediate fallback.
 
@@ -373,7 +372,7 @@ def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existi
     if env_token:
         return env_token, None, BUCKET_ENV
 
-    _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN)
+    _emit_gha_tip(ctx, tip_add_github_token)
     return None, None, BUCKET_APP
 
 def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None):
@@ -1754,7 +1753,7 @@ def _decode_backend_ids(ctx, token):
 # Short error string returned from artifact-upload paths when neither
 # `ACTIONS_RUNTIME_TOKEN` nor `ACTIONS_ID_TOKEN_REQUEST_TOKEN` is
 # available. The full actionable guidance (workflow snippet, why this
-# happens, how to fix) lives in `TIP_ADD_ID_TOKEN_PERMISSION` so the
+# happens, how to fix) lives in `tip_add_id_token_permission` so the
 # tip framework can surface it on the terminal + check-run summary +
 # PR comment — we don't need to repeat it inline on every failure
 # log line. The tip is auto-fired from the same use sites.
@@ -1799,7 +1798,7 @@ def _github_twirp(ctx, method, payload, quiet_failure_log = False):
     results_url = (ctx.std.env.var("ACTIONS_RESULTS_URL") or
                    "https://results-receiver.actions.githubusercontent.com/")
     if not token:
-        _emit_gha_tip(ctx, TIP_ADD_ID_TOKEN_PERMISSION)
+        _emit_gha_tip(ctx, tip_add_id_token_permission)
         return (False, None, _MISSING_TOKEN_MSG)
 
     if results_url.endswith("/"):
@@ -1854,7 +1853,7 @@ def _upload_artifact(ctx, path, name, expires_at = ""):
     token = (ctx.std.env.var("ACTIONS_RUNTIME_TOKEN") or
              ctx.std.env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN"))
     if not token:
-        _emit_gha_tip(ctx, TIP_ADD_ID_TOKEN_PERMISSION)
+        _emit_gha_tip(ctx, tip_add_id_token_permission)
         return {"success": False, "artifact_ref": None, "download_url": "", "errors": [_MISSING_TOKEN_MSG]}
 
     run_id, job_id = _decode_backend_ids(ctx, token)
@@ -1981,13 +1980,13 @@ def _delete_artifact(ctx, name, quiet_failure_log = False):
 
 def _check_token(ctx):
     """Return a short info message if the artifact token is unavailable,
-    else None. Fires `TIP_ADD_ID_TOKEN_PERMISSION` on the missing-token
+    else None. Fires `tip_add_id_token_permission` on the missing-token
     branch — the tip carries the actionable workflow snippet, so the
     return value just needs to identify the failure mode."""
     env = ctx.std.env
     token = env.var("ACTIONS_RUNTIME_TOKEN") or env.var("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
     if not token:
-        _emit_gha_tip(ctx, TIP_ADD_ID_TOKEN_PERMISSION)
+        _emit_gha_tip(ctx, tip_add_id_token_permission)
         return _MISSING_TOKEN_MSG
     return None
 
@@ -2030,10 +2029,12 @@ def _resolve_current_job_url(ctx, token, owner, repo, run_id, fallback_token = N
     fallback_class = BUCKET_ENV if token_class == BUCKET_APP else BUCKET_APP
     success, status_code, body = _do_request(ctx, "GET", url, token, quiet_4xx_auth = has_fallback, token_class = token_class)
     if (not success) and has_fallback and _is_4xx_auth(status_code):
-        _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN_SCOPE, accumulate = {
-            "scopes": "actions: read",
-            "endpoints": "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
-        })
+        _emit_gha_tip(
+            ctx,
+            tip_add_github_token_scope,
+            scopes = "actions: read",
+            endpoints = "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+        )
         success, status_code, body = _do_request(ctx, "GET", url, fallback_token, token_class = fallback_class)
     if not success or type(body) != "dict":
         return ""
@@ -2091,10 +2092,12 @@ def list_pull_request_files(ctx, token, owner, repo, pull_number, fallback_token
         has_fallback = page == 1 and fallback_token and fallback_token != token
         success, status_code, body = _do_request(ctx, "GET", url, active_token, quiet_4xx_auth = has_fallback, token_class = active_class)
         if (not success) and has_fallback and _is_4xx_auth(status_code):
-            _emit_gha_tip(ctx, TIP_ADD_GITHUB_TOKEN_SCOPE, accumulate = {
-                "scopes": "pull-requests: read",
-                "endpoints": "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
-            })
+            _emit_gha_tip(
+                ctx,
+                tip_add_github_token_scope,
+                scopes = "pull-requests: read",
+                endpoints = "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
+            )
             active_token = fallback_token
             active_class = fallback_class
             success, status_code, body = _do_request(ctx, "GET", url, active_token, token_class = active_class)

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -417,7 +417,7 @@ def _test_impl(ctx):
         ("gha-fallback", None, "env"),
     )
 
-    # ── Failure-kind gate for TIP_ADD_ASPECT_API_TOKEN ────────────────
+    # ── Failure-kind gate for tip_add_aspect_api_token ────────────────
     # `_authenticate` classifies failures via a stable `kind` field;
     # `_preferred_token_pair` keys the missing-credentials tip off
     # that field (not the human-readable message) and further restricts
@@ -555,7 +555,7 @@ def _stub_ctx(ctx, env_vars, http_client):
 
 def _test_aspect_api_token_tip_gate(ctx):
     """Verify `_authenticate` populates `_reason["kind"]` with the right
-    discriminator and emits `TIP_ADD_ASPECT_API_TOKEN` only when (1) the
+    discriminator and emits `tip_add_aspect_api_token` only when (1) the
     kind is `no-credentials` AND (2) the CI host is in the
     documented-Aspect-integration set (GHA / Buildkite / CircleCI).
     Covers both call paths: features calling `authenticate` directly
@@ -713,12 +713,12 @@ def _test_pr_files_4xx_auth_fallback(ctx):
     _eq("pr-files fallback: tip id", tip["id"], "add-github-token-scope")
     _eq(
         "pr-files fallback: scope accumulated",
-        tip["accumulators"]["scopes"],
+        tip["accumulate"]["scopes"],
         ["pull-requests: read"],
     )
     _eq(
         "pr-files fallback: endpoint accumulated",
-        tip["accumulators"]["endpoints"],
+        tip["accumulate"]["endpoints"],
         ["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"],
     )
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history.axl
@@ -41,7 +41,7 @@ distinct rows — an improvement over Rosetta's URL-only dedup, which
 collapsed all tasks in one job to a single entry.
 """
 
-load("./ci.axl", "detect_build_url")
+load("./ci.axl", "resolve_build_url")
 
 # Env var the agent populates with the path. Mirrors
 # `PlatformConfigurationFiles.RUNNER_JOB_HISTORY()` on the Rosetta /
@@ -131,7 +131,7 @@ def append_runner_job_history(ctx):
     if not path:
         return False
 
-    task_url = detect_build_url(ctx)
+    task_url = resolve_build_url(ctx)
     if not task_url:
         return False
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -29,7 +29,6 @@ their content baked in, exposing only what varies as named params:
         body,                        # markdown body; interpreted per `type`
         type = TIP_TEMPLATE_RAW,     # RAW (default) / TIP_TEMPLATE_FORMAT / TIP_TEMPLATE_JINJA2
         key = "",                    # optional (id, key) discriminator — see "Tip identity"
-        id_suffix = "",              # appended to id (`<id>-<suffix>`) to parameterize a shared kind
         task_keys = None,            # optional glob list — see "Task-key scoping" below
         vars = None,                 # fixed scalars for FORMAT / JINJA2
         accumulate = None,           # list-valued JINJA2 fields, unioned on re-emit
@@ -579,7 +578,6 @@ def add_tip(
         body,
         type = TIP_TEMPLATE_RAW,
         key = "",
-        id_suffix = "",
         task_keys = None,
         vars = None,
         accumulate = None,
@@ -608,10 +606,8 @@ def add_tip(
     A tip is identified by `(id, key)` — see the "Tip identity" section.
     Re-emitting the same `(id, key)` within a task replaces the stored
     content (accumulate fields ride along); a different `key` is a
-    distinct tip. `id_suffix`, when set, is appended to `id` (`<id>-<suffix>`)
-    — handy for parameterizing a shared template into distinct ids.
-    Silencing is always by `id`: no-op if `id` is in the silence list AND
-    `severity != TIP_IMPORTANT`.
+    distinct tip. Silencing is always by `id`: no-op if `id` is in the
+    silence list AND `severity != TIP_IMPORTANT`.
 
     `task_keys` is an optional list of glob patterns; when set, the
     renderer only shows the tip on tasks whose key matches one of the
@@ -653,7 +649,7 @@ def add_tip(
         fail("TIP_TEMPLATE_JINJA2 tip %r requires at least one non-empty `vars` or `accumulate` value" % id)
 
     common = {
-        "id": id + "-" + id_suffix if id_suffix else id,
+        "id": id,
         "key": key,
         "severity": severity,
         "task_keys": list(task_keys) if task_keys else [],

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -434,7 +434,7 @@ AspectApiTokenHost = enum("github-actions", "buildkite", "circleci")
 
 # Per-host wire-up advice + the set of features that degrade without
 # `ASPECT_API_TOKEN`. Both differ by host (PR-summary-comment
-# aggregation is GHA-only today). Keyed by `AspectApiTokenHost.value`.
+# aggregation is GHA-only today). Keyed by each host's enum `.value`.
 _ASPECT_API_TOKEN_HOST_DETAIL = {
     AspectApiTokenHost("github-actions").value: struct(
         degraded_features = "PR check-run creation and updates, and PR summary comment aggregation",
@@ -481,19 +481,19 @@ def tip_add_github_token(ctx):
         body = "aspect-cli authenticates supporting GitHub API calls (job URL lookup, PR file diff, etc.) via the Aspect Workflows GitHub App. When the App can't authenticate — typically because `ASPECT_API_TOKEN` is missing or invalid — there's currently no fallback, and supporting calls fail.\n\nExporting `GITHUB_TOKEN` to the job env gives aspect-cli a last-resort token to fall back to. `GITHUB_TOKEN` is shared across every workflow step in the repo and has [a low default rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api), so it's not a permanent solution — fix the Aspect Workflows GitHub App authentication path when possible.\n\nGitHub Actions grants `GITHUB_TOKEN` implicit read access to the workflow's own run metadata and the PR that triggered it, so no extra `permissions:` block scopes are required for the supporting calls aspect-cli makes today. Add at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that need it:\n\n```yaml\n" + GITHUB_TOKEN_ENV_YAML + "```",
     )
 
-def tip_add_aspect_api_token(ctx, host: str):
+def tip_add_aspect_api_token(ctx, host: AspectApiTokenHost):
     """Tell the user to set `ASPECT_API_TOKEN` so the Aspect Workflows
     GitHub App can authenticate. IMPORTANT severity — every feature that
     calls the GitHub API as the App depends on it, and silently degrades
     without it.
 
-    `host` is an `AspectApiTokenHost` value; it selects the wire-up advice
-    and a host-suffixed id (`add-aspect-api-token-<host>`) so users running
+    `host` is an `AspectApiTokenHost`; it selects the wire-up advice and a
+    host-suffixed id (`add-aspect-api-token-<host>`) so users running
     multiple CI hosts off one repo can silence each independently."""
-    detail = _ASPECT_API_TOKEN_HOST_DETAIL[AspectApiTokenHost(host).value]
+    detail = _ASPECT_API_TOKEN_HOST_DETAIL[host.value]
     add_tip(
         ctx,
-        id = "add-aspect-api-token-" + host,
+        id = "add-aspect-api-token-" + host.value,
         severity = TIP_IMPORTANT,
         title = "Set ASPECT_API_TOKEN to authenticate the Aspect Workflows GitHub App",
         body = (

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -19,21 +19,21 @@ their content baked in, exposing only what varies as named params:
     tip_add_github_token_scope(ctx, scopes = "actions: read", endpoints = "GET …")
 
 `add_tip`'s full keyword surface (all but `id` / `severity` / `title` /
-`body` optional):
+`body` optional) — see `add_tip` itself for the per-argument contract:
 
     add_tip(
         ctx,
-        id,                          # stable kind + silence key — see "Tip identity"
-        severity,                    # TIP_IMPORTANT / TIP_WARNING / TIP_SUGGESTION / TIP_INFO
-        title,                       # short headline; interpreted per `type`
-        body,                        # markdown body; interpreted per `type`
-        type = TIP_TEMPLATE_RAW,     # RAW (default) / TIP_TEMPLATE_FORMAT / TIP_TEMPLATE_JINJA2
-        key = "",                    # optional (id, key) discriminator — see "Tip identity"
-        task_keys = None,            # optional glob list — see "Task-key scoping" below
-        vars = None,                 # fixed scalars for FORMAT / JINJA2
-        accumulate = None,           # list-valued JINJA2 fields, unioned on re-emit
-        surfaces = None,             # optional surface allowlist — see "Surface allowlist" below
-        combine_across_tasks = False,  # cross-task PR-summary union — see "Cross-task accumulation"
+        id: str,                       # stable kind + silence key — see "Tip identity"
+        severity: str,                 # TIP_IMPORTANT / TIP_WARNING / TIP_SUGGESTION / TIP_INFO
+        title: str,                    # short headline; interpreted per `type`
+        body: str,                     # markdown body; interpreted per `type`
+        type: str = TIP_TEMPLATE_RAW,  # RAW (default) / TIP_TEMPLATE_FORMAT / TIP_TEMPLATE_JINJA2
+        key: str = "",                 # optional (id, key) discriminator — see "Tip identity"
+        task_keys: list = [],          # optional glob list — see "Task-key scoping" below
+        vars: dict = {},               # fixed scalars for FORMAT / JINJA2
+        accumulate: dict = {},         # list-valued JINJA2 fields, unioned on re-emit
+        surfaces: list = [],           # optional surface allowlist — see "Surface allowlist" below
+        combine_across_tasks: bool = False,  # cross-task PR-summary union — see "Cross-task accumulation"
     )
 
 # Template types
@@ -572,17 +572,17 @@ def _merge_accumulators(existing, incoming):
 
 def add_tip(
         ctx,
-        id,
-        severity,
-        title,
-        body,
-        type = TIP_TEMPLATE_RAW,
-        key = "",
-        task_keys = None,
-        vars = None,
-        accumulate = None,
-        surfaces = None,
-        combine_across_tasks = False):
+        id: str,
+        severity: str,
+        title: str,
+        body: str,
+        type: str = TIP_TEMPLATE_RAW,
+        key: str = "",
+        task_keys: list = [],
+        vars: dict = {},
+        accumulate: dict = {},
+        surfaces: list = [],
+        combine_across_tasks: bool = False):
     """Add a tip to the task's tip storage and print a `TIP:` block to
     the terminal (subject to the owner feature's `auto_print` arg).
 
@@ -590,46 +590,59 @@ def add_tip(
     functions that wrap this with their content baked in (e.g.
     `tip_add_github_token(ctx)`); call `add_tip` directly for custom tips.
 
-    `title` / `body` are interpreted per `type`:
-
-      - `TIP_TEMPLATE_RAW`    — literal text, surfaced as-is.
-      - `TIP_TEMPLATE_FORMAT` — Starlark `str.format(**vars)` applied here.
-      - `TIP_TEMPLATE_JINJA2` — Jinja2 source, rendered against `vars`
-        (fixed scalars) + `accumulate` (deduped + sorted lists). Kept as
-        source so a re-emit (within-task accumulate) or cross-task union
-        can re-render; the rendered strings are what surfaces read.
-
-    `vars` are fixed scalars; `accumulate` fields are list-valued (a
-    JINJA2 template sees `{{ name }}` as a list) and union on re-emit and,
-    when `combine_across_tasks`, across tasks. A name in both is an error.
-
     A tip is identified by `(id, key)` — see the "Tip identity" section.
     Re-emitting the same `(id, key)` within a task replaces the stored
     content (accumulate fields ride along); a different `key` is a
     distinct tip. Silencing is always by `id`: no-op if `id` is in the
     silence list AND `severity != TIP_IMPORTANT`.
 
-    `task_keys` is an optional list of glob patterns; when set, the
-    renderer only shows the tip on tasks whose key matches one of the
-    patterns. When unset / empty, the tip shows on the task it was
-    emitted into. The terminal print fires regardless of `task_keys`.
-
-    `surfaces` is an optional allowlist of surface identifiers
-    (`SURFACE_CLI` / `SURFACE_GITHUB_STATUS_CHECKS` /
-    `SURFACE_BUILDKITE_ANNOTATIONS` / `SURFACE_GITLAB_COMMIT_STATUSES` /
-    `SURFACE_GITHUB_PR_SUMMARY`, or the `TASK_SCREENS` / `AGGREGATE_SCREENS`
-    shorthands) controlling which status screens may render the tip. When
-    unset / empty the tip shows everywhere (`SURFACE_ALL`). See the
-    "Surface allowlist" section. The terminal print is gated on
-    `SURFACE_CLI`; omit `SURFACE_GITHUB_PR_SUMMARY` to keep the tip off the
-    cross-task rollup.
-
-    `combine_across_tasks` governs how same-`(id, key)` tips from
-    sibling tasks combine in the PR summary — see the "Cross-task
-    accumulation" section.
-
     No-op overall when the `Tips` feature is disabled — the trait's
     `add` callable falls back to its null-object default.
+
+    Args:
+      ctx: The task context the tip is added to. Unannotated because the
+        built-in `tip_*` wrappers are driven with a stub context by
+        `github.axl`'s detection tests; only `ctx.traits` is used here.
+      id: Stable identifier — the kind of tip and its silence key. Tips
+        with the same `(id, key)` are the same tip (re-emit replaces);
+        `id` alone is what `--tips:silence=<id>` and the silence list
+        match. See the "Tip identity" section.
+      severity: One of `TIP_IMPORTANT` / `TIP_WARNING` / `TIP_SUGGESTION` /
+        `TIP_INFO` — drives ordering, the emoji/label, and (for
+        `TIP_IMPORTANT`) immunity from silencing. See "Severity ordering".
+      title: Short headline, interpreted per `type`.
+      body: Markdown body, interpreted per `type`.
+      type: The interpolation engine for `title` / `body`:
+        `TIP_TEMPLATE_RAW` (default) surfaces them as-is;
+        `TIP_TEMPLATE_FORMAT` applies Starlark `str.format(**vars)`;
+        `TIP_TEMPLATE_JINJA2` renders them as Jinja2 against `vars` +
+        `accumulate`, keeping the source so a re-emit or cross-task union
+        can re-render. See the "Template types" section.
+      key: Optional discriminator distinguishing same-`id` tips about
+        different subjects (e.g. one flaky-test tip per label). Empty
+        means a single tip per `id`. See the "Tip identity" section.
+      task_keys: Glob patterns matched against `ctx.task.key`; when
+        non-empty the tip renders only on matching tasks. Empty (the
+        default) scopes the tip to the task it was emitted into. The
+        terminal print fires regardless. See "Task-key scoping".
+      vars: Fixed scalar values for `TIP_TEMPLATE_FORMAT` /
+        `TIP_TEMPLATE_JINJA2` interpolation. Ignored for
+        `TIP_TEMPLATE_RAW`. A name set in both `vars` and `accumulate`
+        is an error.
+      accumulate: List-valued Jinja2 fields (a `{{ name }}` reference
+        sees a list). Each re-emit unions in new values (deduped +
+        sorted); with `combine_across_tasks` the union also spans tasks.
+        `TIP_TEMPLATE_JINJA2` only.
+      surfaces: Allowlist of surface identifiers (`SURFACE_CLI` /
+        `SURFACE_GITHUB_STATUS_CHECKS` / `SURFACE_BUILDKITE_ANNOTATIONS` /
+        `SURFACE_GITLAB_COMMIT_STATUSES` / `SURFACE_GITHUB_PR_SUMMARY`, or
+        the `TASK_SCREENS` / `AGGREGATE_SCREENS` shorthands) that may
+        render the tip. Empty (the default) shows it everywhere
+        (`SURFACE_ALL`). The terminal print is gated on `SURFACE_CLI`;
+        omit `SURFACE_GITHUB_PR_SUMMARY` to keep the tip off the cross-task
+        rollup. See "Surface allowlist".
+      combine_across_tasks: How same-`(id, key)` tips from sibling tasks
+        combine in the PR summary. See "Cross-task accumulation".
     """
     if severity not in _SEVERITY_ORDER:
         fail("unknown tip severity %r; valid: %s" % (severity, ", ".join(_SEVERITY_ORDER.keys())))

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -7,40 +7,45 @@ logs for WARNs or read docs to discover improvements.
 
 # Producer API
 
-`add_tip(ctx, id, severity, ...)` — adds a tip to the trait. Accepts
-either pre-rendered `title` + `body` (for `TIP_TEMPLATE_RAW` /
-`TIP_TEMPLATE_FORMAT` tips) or `title_template` + `body_template`
-(for `TIP_TEMPLATE_JINJA2` tips) rendered against `vars` (fixed scalars)
-and `accumulate` (list-valued fields). A tip is identified by `(id, key)`
-— see "Tip identity".
+`add_tip(ctx, id, severity, title, body, type=…, …)` is the single entry
+point. `title` / `body` are interpreted per `type` (literal / `str.format`
+/ Jinja2); `vars` are fixed scalars and `accumulate` are list-valued
+JINJA2 fields. A tip is identified by `(id, key)` — see "Tip identity".
 
-`emit_tip(ctx, template, key=None, vars=None, accumulate=None,
-id_suffix="", task_keys=None, surfaces=None, combine_across_tasks=None)`
-— renders a tip template, then calls `add_tip`. Used by built-in
-producers (so their templates are overridable; see "Customization"
-below) and by user task code wanting parameterised tips.
+The built-in tips are `tip_*(ctx, …)` functions that wrap `add_tip` with
+their content baked in, exposing only what varies as named params:
 
-Tip templates are dicts of the shape:
+    tip_add_github_token(ctx)
+    tip_add_github_token_scope(ctx, scopes = "actions: read", endpoints = "GET …")
 
-    {
-        "id":        str,         # stable kind + silence key — see "Tip identity"
-        "key":       str?,        # optional (id, key) discriminator — see "Tip identity"
-        "severity":  str,         # TIP_IMPORTANT / TIP_WARNING / TIP_SUGGESTION / TIP_INFO
-        "title":     str,         # short headline; interpolated per `type`
-        "body":      str,         # markdown body; interpolated per `type`
-        "type":      str,         # TIP_TEMPLATE_RAW / TIP_TEMPLATE_FORMAT (default) / TIP_TEMPLATE_JINJA2
-        "task_keys": list[str]?,  # optional glob list — see "Task-key scoping" below
-        "surfaces":  list[str]?,  # optional surface allowlist — see "Surface allowlist" below
-        "combine_across_tasks": bool?,  # cross-task PR-summary union — see "Cross-task accumulation"
-    }
+`add_tip`'s full keyword surface (all but `id` / `severity` / `title` /
+`body` optional):
+
+    add_tip(
+        ctx,
+        id,                          # stable kind + silence key — see "Tip identity"
+        severity,                    # TIP_IMPORTANT / TIP_WARNING / TIP_SUGGESTION / TIP_INFO
+        title,                       # short headline; interpreted per `type`
+        body,                        # markdown body; interpreted per `type`
+        type = TIP_TEMPLATE_RAW,     # RAW (default) / TIP_TEMPLATE_FORMAT / TIP_TEMPLATE_JINJA2
+        key = "",                    # optional (id, key) discriminator — see "Tip identity"
+        id_suffix = "",              # appended to id (`<id>-<suffix>`) to parameterize a shared kind
+        task_keys = None,            # optional glob list — see "Task-key scoping" below
+        vars = None,                 # fixed scalars for FORMAT / JINJA2
+        accumulate = None,           # list-valued JINJA2 fields, unioned on re-emit
+        surfaces = None,             # optional surface allowlist — see "Surface allowlist" below
+        combine_across_tasks = False,  # cross-task PR-summary union — see "Cross-task accumulation"
+    )
 
 # Template types
 
 The `type` field selects the interpolation engine for `title` / `body`:
 
   - `TIP_TEMPLATE_RAW`    — no interpolation; `vars` / `accumulate` ignored.
+                            The default — most tip bodies are literal
+                            markdown with `{}` that must survive verbatim.
   - `TIP_TEMPLATE_FORMAT` — Starlark `str.format(**vars)` — `{name}`
-                            placeholders replaced from `vars`. Default.
+                            placeholders replaced from `vars`.
   - `TIP_TEMPLATE_JINJA2` — Jinja2 source rendered against `vars`
                             (scalars) plus `accumulate` (each name a
                             deduped + sorted list). Re-rendered whenever
@@ -49,13 +54,13 @@ The `type` field selects the interpolation engine for `title` / `body`:
 
 # Customization
 
-Built-in tip templates are exported as module-level constants
-(e.g. `TIP_ADD_GITHUB_TOKEN`). User task / config code can:
+Built-in tips are exported as `tip_*(ctx, …)` functions
+(e.g. `tip_add_github_token`). User task / config code can:
 
-  a) Add custom tips via `add_tip` or `emit_tip` from any code with a
-     `TaskContext`. To add a tip at task start from `.aspect/config.axl`,
-     register a `task_update` handler and emit on the first update (the
-     Setup-phase emit) — see the example below.
+  a) Add custom tips via `add_tip` from any code with a `TaskContext`.
+     To add a tip at task start from `.aspect/config.axl`, register a
+     `task_update` handler and add on the first update (the Setup-phase
+     emit) — see the example below.
   b) Override a built-in tip's content by calling `add_tip` with that
      built-in tip's `(id, key)` — a re-emit replaces the stored tip, so
      a user emit AFTER the framework's wins.
@@ -278,7 +283,7 @@ def tip_shows_on(tip, surface):
 # ── tip_suggestion hook records ──────────────────────────────────────
 #
 # A `tip_suggestion` hook (registered on the public `TipsTrait` below)
-# fires on every `add_tip` / `emit_tip`, letting `config.axl` accept /
+# fires on every `add_tip`, letting `config.axl` accept /
 # reject / rewrite any tip — the same accept/reject/replace shape as the
 # `repro_fix_suggestion` hook on `TaskLifecycleTrait`.
 
@@ -356,16 +361,17 @@ def tip_replace(
 #
 # Every stored tip carries `{id, key, severity, title, body, type,
 # task_keys, surfaces, combine_across_tasks}`; JINJA2 tips additionally
-# carry `title_template`, `body_template`, `vars`, and `accumulate`
-# (dict<name, list<value>>) so `add_tip` can re-render on accumulation.
-# A same-`(id, key)` re-emit replaces the stored tip (accumulate fields
-# union onto the prior); ids in the silence list are dropped on `add_tip`
+# carry `_title_src`, `_body_src` (the Jinja2 source), `vars`, and
+# `accumulate` (dict<name, list<value>>) so the owner can re-render on
+# accumulation. A same-`(id, key)` re-emit replaces the stored tip
+# (accumulate fields union onto the prior); ids in the silence list are
+# dropped on `add_tip`
 # (unless severity is TIP_IMPORTANT).
 #
 # When the `Tips` feature isn't loaded (user set `enabled = False` or
 # the framework didn't enable it), the trait callable defaults are
 # null-objects: `add` is a silent no-op, `collect` returns []. Emit
-# sites don't need to probe — they just call `add_tip` / `emit_tip`
+# sites don't need to probe — they just call `add_tip`
 # and the disabled state propagates as zero output.
 
 _TipsTrait = trait(
@@ -401,13 +407,18 @@ TipsTrait = trait(
     tip_suggestion = attr(list[typing.Callable[[TaskContext, TipInfo], TipSuggestion]], default = []),
 )
 
-# ── Built-in tip templates ───────────────────────────────────────────
+# ── Built-in tips ────────────────────────────────────────────────────
 #
-# Each constant is a tip-template dict consumed by `emit_tip`. The
-# YAML constants below are shared snippets the bodies splice in;
-# both are rendered at workflow-top-level indentation so users can
-# paste them verbatim above `jobs:` or re-indent under a specific
-# `jobs.<name>:` for per-job scoping.
+# Each built-in is a `tip_*(ctx, ...)` function wrapping `add_tip` with
+# its content baked in, exposing only the parts that vary as named
+# params. The wire-up that decides *when* to fire them (host detection,
+# `ctx.traits` availability) lives in `lib/github.axl`; these functions
+# own only the tip *content*.
+#
+# The YAML constants below are shared snippets the bodies splice in;
+# both render at workflow-top-level indentation so users can paste them
+# verbatim above `jobs:` or re-indent under a specific `jobs.<name>:`
+# for per-job scoping.
 
 GITHUB_TOKEN_ENV_YAML = """env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -417,85 +428,102 @@ ID_TOKEN_PERMISSIONS_YAML = """permissions:
   id-token: write    # artifact uploads + PR summary comment aggregation
 """
 
-TIP_ADD_GITHUB_TOKEN = {
-    "id": "add-github-token",
-    "severity": TIP_SUGGESTION,
-    "title": "Export `GITHUB_TOKEN` as a fallback for supporting API calls",
-    "body": "aspect-cli authenticates supporting GitHub API calls (job URL lookup, PR file diff, etc.) via the Aspect Workflows GitHub App. When the App can't authenticate — typically because `ASPECT_API_TOKEN` is missing or invalid — there's currently no fallback, and supporting calls fail.\n\nExporting `GITHUB_TOKEN` to the job env gives aspect-cli a last-resort token to fall back to. `GITHUB_TOKEN` is shared across every workflow step in the repo and has [a low default rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api), so it's not a permanent solution — fix the Aspect Workflows GitHub App authentication path when possible.\n\nGitHub Actions grants `GITHUB_TOKEN` implicit read access to the workflow's own run metadata and the PR that triggered it, so no extra `permissions:` block scopes are required for the supporting calls aspect-cli makes today. Add at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that need it:\n\n```yaml\n" + GITHUB_TOKEN_ENV_YAML + "```",
-    "type": TIP_TEMPLATE_RAW,
+# CI hosts on which `ASPECT_API_TOKEN` is a documented Aspect
+# integration — selects the host-specific wire-up advice and silence id.
+AspectApiTokenHost = enum("github-actions", "buildkite", "circleci")
+
+# Per-host wire-up advice + the set of features that degrade without
+# `ASPECT_API_TOKEN`. Both differ by host (PR-summary-comment
+# aggregation is GHA-only today). Keyed by `AspectApiTokenHost.value`.
+_ASPECT_API_TOKEN_HOST_DETAIL = {
+    AspectApiTokenHost("github-actions").value: struct(
+        degraded_features = "PR check-run creation and updates, and PR summary comment aggregation",
+        host_advice = (
+            "On GitHub Actions, pass the token to the " +
+            "[aspect-build/setup-aspect]" +
+            "(https://github.com/aspect-build/setup-aspect) action:\n\n" +
+            "```yaml\n" +
+            "- uses: aspect-build/setup-aspect@<commit-sha>\n" +
+            "  with:\n" +
+            "    aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}\n" +
+            "```\n\n" +
+            "Find the latest release's commit SHA at " +
+            "https://github.com/aspect-build/setup-aspect/releases."
+        ),
+    ),
+    AspectApiTokenHost("buildkite").value: struct(
+        degraded_features = "PR check-run creation and updates",
+        host_advice = (
+            "On Buildkite, provision `ASPECT_API_TOKEN` using any of the approaches in " +
+            "[Buildkite's secrets docs](https://buildkite.com/docs/pipelines/security/secrets) " +
+            "— aspect-cli reads it from the agent's secret store automatically."
+        ),
+    ),
+    AspectApiTokenHost("circleci").value: struct(
+        degraded_features = "PR check-run creation and updates",
+        host_advice = (
+            "On CircleCI, add `ASPECT_API_TOKEN` as a project environment variable or via a " +
+            "[context](https://circleci.com/docs/contexts/); aspect-cli picks it up from the " +
+            "job env."
+        ),
+    ),
 }
 
-# IMPORTANT because every aspect-cli feature that calls the GitHub API
-# as the Aspect Workflows GitHub App depends on `ASPECT_API_TOKEN`:
-# without it those surfaces silently degrade.
-#
-# Three per-CI variants because both the wire-up *and* the list of
-# features that degrade differ per host (PR-summary-comment aggregation
-# is GHA-only today). The emit helper in `lib/github.axl` picks one
-# based on detected env. Each carries a host-suffixed id so users who
-# run multiple CI hosts off the same repo can silence them independently.
+def tip_add_github_token(ctx):
+    """Suggest exporting `GITHUB_TOKEN` as a fallback for supporting
+    GitHub API calls (job URL lookup, PR file diff, etc.) when the
+    Aspect Workflows GitHub App can't authenticate."""
+    add_tip(
+        ctx,
+        id = "add-github-token",
+        severity = TIP_SUGGESTION,
+        title = "Export `GITHUB_TOKEN` as a fallback for supporting API calls",
+        body = "aspect-cli authenticates supporting GitHub API calls (job URL lookup, PR file diff, etc.) via the Aspect Workflows GitHub App. When the App can't authenticate — typically because `ASPECT_API_TOKEN` is missing or invalid — there's currently no fallback, and supporting calls fail.\n\nExporting `GITHUB_TOKEN` to the job env gives aspect-cli a last-resort token to fall back to. `GITHUB_TOKEN` is shared across every workflow step in the repo and has [a low default rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api), so it's not a permanent solution — fix the Aspect Workflows GitHub App authentication path when possible.\n\nGitHub Actions grants `GITHUB_TOKEN` implicit read access to the workflow's own run metadata and the PR that triggered it, so no extra `permissions:` block scopes are required for the supporting calls aspect-cli makes today. Add at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that need it:\n\n```yaml\n" + GITHUB_TOKEN_ENV_YAML + "```",
+    )
 
-def _aspect_api_token_tip(host_id, degraded_features, host_advice):
-    return {
-        "id": "add-aspect-api-token-" + host_id,
-        "severity": TIP_IMPORTANT,
-        "title": "Set ASPECT_API_TOKEN to authenticate the Aspect Workflows GitHub App",
-        "body": (
+def tip_add_aspect_api_token(ctx, host: str):
+    """Tell the user to set `ASPECT_API_TOKEN` so the Aspect Workflows
+    GitHub App can authenticate. IMPORTANT severity — every feature that
+    calls the GitHub API as the App depends on it, and silently degrades
+    without it.
+
+    `host` is an `AspectApiTokenHost` value; it selects the wire-up advice
+    and a host-suffixed id (`add-aspect-api-token-<host>`) so users running
+    multiple CI hosts off one repo can silence each independently."""
+    detail = _ASPECT_API_TOKEN_HOST_DETAIL[AspectApiTokenHost(host).value]
+    add_tip(
+        ctx,
+        id = "add-aspect-api-token-" + host,
+        severity = TIP_IMPORTANT,
+        title = "Set ASPECT_API_TOKEN to authenticate the Aspect Workflows GitHub App",
+        body = (
             "aspect-cli authenticates GitHub API calls via the Aspect Workflows " +
             "GitHub App, which needs `ASPECT_API_TOKEN` (a `client_id:client_secret` " +
             "pair from your Aspect organization) provided to the CI job.\n\n" +
-            "Without it, " + degraded_features + " degrade. The task itself " +
+            "Without it, " + detail.degraded_features + " degrade. The task itself " +
             "completes regardless — only the GitHub-side surfaces are affected.\n\n" +
             "Issue an `ASPECT_API_TOKEN` from the Aspect Web UI " +
             "(see https://docs.aspect.build/cli/authentication). " +
-            host_advice
+            detail.host_advice
         ),
-        "type": TIP_TEMPLATE_RAW,
-    }
+    )
 
-TIP_ADD_ASPECT_API_TOKEN_GHA = _aspect_api_token_tip(
-    "github-actions",
-    "PR check-run creation and updates, and PR summary comment aggregation",
-    "On GitHub Actions, pass the token to the " +
-    "[aspect-build/setup-aspect]" +
-    "(https://github.com/aspect-build/setup-aspect) action:\n\n" +
-    "```yaml\n" +
-    "- uses: aspect-build/setup-aspect@<commit-sha>\n" +
-    "  with:\n" +
-    "    aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}\n" +
-    "```\n\n" +
-    "Find the latest release's commit SHA at " +
-    "https://github.com/aspect-build/setup-aspect/releases.",
-)
-
-TIP_ADD_ASPECT_API_TOKEN_BUILDKITE = _aspect_api_token_tip(
-    "buildkite",
-    "PR check-run creation and updates",
-    "On Buildkite, provision `ASPECT_API_TOKEN` using any of the approaches in " +
-    "[Buildkite's secrets docs](https://buildkite.com/docs/pipelines/security/secrets) " +
-    "— aspect-cli reads it from the agent's secret store automatically.",
-)
-
-TIP_ADD_ASPECT_API_TOKEN_CIRCLECI = _aspect_api_token_tip(
-    "circleci",
-    "PR check-run creation and updates",
-    "On CircleCI, add `ASPECT_API_TOKEN` as a project environment variable or via a " +
-    "[context](https://circleci.com/docs/contexts/); aspect-cli picks it up from the " +
-    "job env.",
-)
-
-# One tip accumulating both the missing scopes and the API endpoints
-# that fell back. Pluralization + per-scope snippet lines are driven by
-# Jinja2 on the merged `accumulate` state. Each fallback event re-emits
-# with new scopes/endpoints that union into the running total within a
-# task; `combine_across_tasks` unions the combined set across every task
-# into one PR-summary row.
-TIP_ADD_GITHUB_TOKEN_SCOPE = {
-    "id": "add-github-token-scope",
-    "severity": TIP_WARNING,
-    "combine_across_tasks": True,
-    "title": "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %} to the job-scoped `GITHUB_TOKEN`",
-    "body": """aspect-cli made {{ endpoints|length }} supporting API {{ "call" if endpoints|length == 1 else "calls" }} that needed {{ "a scope" if scopes|length == 1 else "scopes" }} the job-scoped `GITHUB_TOKEN` lacks; {{ "the call" if endpoints|length == 1 else "the calls" }} fell back to the Aspect Workflows GitHub App token. Granting {{ "this scope" if scopes|length == 1 else "these scopes" }} keeps the {{ "call" if endpoints|length == 1 else "calls" }} on the job-scoped token and reduces App quota usage.
+def tip_add_github_token_scope(ctx, scopes: str, endpoints: str):
+    """Warn that the job-scoped `GITHUB_TOKEN` lacks scopes a supporting
+    API call needed, so the call fell back to the App token. Accumulating:
+    each call passes the single missing `scopes` / `endpoints` value it hit;
+    repeated emits union into one tip (deduped + sorted), and
+    `combine_across_tasks` unions the set across every task into one
+    PR-summary row. Pluralization + per-scope snippet lines are Jinja2
+    over the merged `accumulate` state."""
+    add_tip(
+        ctx,
+        id = "add-github-token-scope",
+        severity = TIP_WARNING,
+        type = TIP_TEMPLATE_JINJA2,
+        combine_across_tasks = True,
+        title = "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %} to the job-scoped `GITHUB_TOKEN`",
+        body = """aspect-cli made {{ endpoints|length }} supporting API {{ "call" if endpoints|length == 1 else "calls" }} that needed {{ "a scope" if scopes|length == 1 else "scopes" }} the job-scoped `GITHUB_TOKEN` lacks; {{ "the call" if endpoints|length == 1 else "the calls" }} fell back to the Aspect Workflows GitHub App token. Granting {{ "this scope" if scopes|length == 1 else "these scopes" }} keeps the {{ "call" if endpoints|length == 1 else "calls" }} on the job-scoped token and reduces App quota usage.
 
 Add at the top level of the workflow (so every job inherits) or scope to the specific job(s) that need it:
 
@@ -507,21 +535,22 @@ permissions:
 API {{ "endpoint" if endpoints|length == 1 else "endpoints" }} that fell back ({{ endpoints|length }}):
 {% for e in endpoints %}- `{{ e }}`
 {% endfor %}""",
-    "type": TIP_TEMPLATE_JINJA2,
-}
+        accumulate = {"scopes": scopes, "endpoints": endpoints},
+    )
 
-# Severity is IMPORTANT because key features depend on this permission:
-# artifact uploads (status payloads, BEP files, test logs, profiles)
-# fail outright, and PR summary comment aggregation breaks because
-# per-task payloads ride on the same artifact upload path. Important
-# tips can't be silenced.
-TIP_ADD_ID_TOKEN_PERMISSION = {
-    "id": "add-id-token-permission",
-    "severity": TIP_IMPORTANT,
-    "title": "Grant `id-token: write` to enable GitHub Actions artifact uploads",
-    "body": "aspect-cli is trying to upload an artifact via GitHub Actions' ArtifactService but the API needs an OIDC token (`ACTIONS_ID_TOKEN_REQUEST_TOKEN`) that GitHub only exposes to the job when `id-token: write` is granted. Without it, the artifact upload fails.\n\nWhich features depend on this varies by configuration. When enabled, the PR summary comment aggregator and test-log / BEP / profile artifact uploads all ride on the ArtifactService — any of those features will be affected until the permission is granted. The task itself completes regardless.\n\nAdd at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that upload artifacts:\n\n```yaml\n" + ID_TOKEN_PERMISSIONS_YAML + "```",
-    "type": TIP_TEMPLATE_RAW,
-}
+def tip_add_id_token_permission(ctx):
+    """Tell the user to grant `id-token: write` so GitHub Actions
+    artifact uploads (status payloads, BEP files, test logs, profiles —
+    and the PR summary aggregator that rides on them) can obtain the OIDC
+    token the ArtifactService needs. IMPORTANT — these features fail
+    outright without it, and important tips can't be silenced."""
+    add_tip(
+        ctx,
+        id = "add-id-token-permission",
+        severity = TIP_IMPORTANT,
+        title = "Grant `id-token: write` to enable GitHub Actions artifact uploads",
+        body = "aspect-cli is trying to upload an artifact via GitHub Actions' ArtifactService but the API needs an OIDC token (`ACTIONS_ID_TOKEN_REQUEST_TOKEN`) that GitHub only exposes to the job when `id-token: write` is granted. Without it, the artifact upload fails.\n\nWhich features depend on this varies by configuration. When enabled, the PR summary comment aggregator and test-log / BEP / profile artifact uploads all ride on the ArtifactService — any of those features will be affected until the permission is granted. The task itself completes regardless.\n\nAdd at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that upload artifacts:\n\n```yaml\n" + ID_TOKEN_PERMISSIONS_YAML + "```",
+    )
 
 # ── API ──────────────────────────────────────────────────────────────
 
@@ -546,13 +575,12 @@ def add_tip(
         ctx,
         id,
         severity,
+        title,
+        body,
+        type = TIP_TEMPLATE_RAW,
         key = "",
+        id_suffix = "",
         task_keys = None,
-        title = "",
-        body = "",
-        type_ = TIP_TEMPLATE_RAW,
-        title_template = "",
-        body_template = "",
         vars = None,
         accumulate = None,
         surfaces = None,
@@ -560,30 +588,30 @@ def add_tip(
     """Add a tip to the task's tip storage and print a `TIP:` block to
     the terminal (subject to the owner feature's `auto_print` arg).
 
-    A tip is identified by `(id, key)` — see the "Tip identity" section
-    in the module docstring. Re-emitting the same `(id, key)` within a
-    task replaces the stored content; `accumulate` fields ride along,
-    unioned (deduped + sorted) onto the prior. A different `key` is a
-    distinct tip. Silencing is always by `id`: no-op if `id` is in the
-    silence list AND `severity != TIP_IMPORTANT`.
+    The single entry point for tips. Built-in tips are `tip_*(ctx, …)`
+    functions that wrap this with their content baked in (e.g.
+    `tip_add_github_token(ctx)`); call `add_tip` directly for custom tips.
 
-    Two storage shapes:
+    `title` / `body` are interpreted per `type`:
 
-      - Pre-rendered tips (`type_ == TIP_TEMPLATE_RAW` / `_FORMAT`):
-        `title` / `body` are the final strings to surface.
+      - `TIP_TEMPLATE_RAW`    — literal text, surfaced as-is.
+      - `TIP_TEMPLATE_FORMAT` — Starlark `str.format(**vars)` applied here.
+      - `TIP_TEMPLATE_JINJA2` — Jinja2 source, rendered against `vars`
+        (fixed scalars) + `accumulate` (deduped + sorted lists). Kept as
+        source so a re-emit (within-task accumulate) or cross-task union
+        can re-render; the rendered strings are what surfaces read.
 
-      - Jinja2 tips (`type_ == TIP_TEMPLATE_JINJA2`): `title_template` /
-        `body_template` are rendered against `vars` (fixed scalars) plus
-        `accumulate` (each a deduped + sorted list). The rendered strings
-        are stored alongside the inputs so a re-emit (within-task
-        accumulate) or cross-task union can re-render.
+    `vars` are fixed scalars; `accumulate` fields are list-valued (a
+    JINJA2 template sees `{{ name }}` as a list) and union on re-emit and,
+    when `combine_across_tasks`, across tasks. A name in both is an error.
 
-    `vars` are fixed scalars: interpolated via `str.format` for
-    `TIP_TEMPLATE_FORMAT`, exposed as scalars to `TIP_TEMPLATE_JINJA2`
-    templates, ignored for `TIP_TEMPLATE_RAW`. `accumulate` fields are
-    list-valued (a template sees `{{ name }}` as a list) and union on
-    re-emit and, when `combine_across_tasks`, across tasks. A name
-    appearing in both `vars` and `accumulate` is an error.
+    A tip is identified by `(id, key)` — see the "Tip identity" section.
+    Re-emitting the same `(id, key)` within a task replaces the stored
+    content (accumulate fields ride along); a different `key` is a
+    distinct tip. `id_suffix`, when set, is appended to `id` (`<id>-<suffix>`)
+    — handy for parameterizing a shared template into distinct ids.
+    Silencing is always by `id`: no-op if `id` is in the silence list AND
+    `severity != TIP_IMPORTANT`.
 
     `task_keys` is an optional list of glob patterns; when set, the
     renderer only shows the tip on tasks whose key matches one of the
@@ -609,6 +637,8 @@ def add_tip(
     """
     if severity not in _SEVERITY_ORDER:
         fail("unknown tip severity %r; valid: %s" % (severity, ", ".join(_SEVERITY_ORDER.keys())))
+    if type not in _VALID_TEMPLATE_TYPES:
+        fail("unknown tip template type %r; valid: %s" % (type, ", ".join(_VALID_TEMPLATE_TYPES)))
     surfaces_list = list(surfaces) if surfaces else []
     for s in surfaces_list:
         if s not in _VALID_SURFACES:
@@ -618,96 +648,28 @@ def add_tip(
     collision = [name for name in accumulate if name in vars]
     if collision:
         fail("tip %r: %r set in both vars and accumulate" % (id, collision))
-    is_jinja2 = type_ == TIP_TEMPLATE_JINJA2
+    is_jinja2 = type == TIP_TEMPLATE_JINJA2
     if is_jinja2 and not ([v for v in accumulate.values() if v] or [v for v in vars.values() if v]):
         fail("TIP_TEMPLATE_JINJA2 tip %r requires at least one non-empty `vars` or `accumulate` value" % id)
 
     common = {
-        "id": id,
+        "id": id + "-" + id_suffix if id_suffix else id,
         "key": key,
         "severity": severity,
         "task_keys": list(task_keys) if task_keys else [],
-        "type": type_,
+        "type": type,
         "surfaces": surfaces_list,
         "combine_across_tasks": combine_across_tasks,
     }
     if is_jinja2:
-        tip = dict(common, title_template = title_template, body_template = body_template, vars = vars, accumulate = accumulate)
+        # Carry the JINJA2 source; the storage layer renders it into
+        # `title` / `body` and keeps the source for later re-render.
+        tip = dict(common, _title_src = title, _body_src = body, vars = vars, accumulate = accumulate)
+    elif type == TIP_TEMPLATE_FORMAT and vars:
+        tip = dict(common, title = title.format(**vars), body = body.format(**vars))
     else:
         tip = dict(common, title = title, body = body)
     ctx.traits[_TipsTrait].add(ctx, tip)
-
-def emit_tip(ctx, template, key = None, vars = None, accumulate = None, id_suffix = "", task_keys = None, surfaces = None, combine_across_tasks = None):
-    """Render a tip template and add it via `add_tip`.
-
-    Args:
-      template:      dict — see module docstring for shape. May carry
-                     optional `key`, `surfaces`, and
-                     `combine_across_tasks` keys, used as defaults
-                     when the same-named args below are unset.
-      key:           optional `(id, key)` discriminator overriding the
-                     template's `key`. See the "Tip identity" section.
-      vars:          dict — fixed scalars. `str.format`-interpolated into
-                     title / body for `TIP_TEMPLATE_FORMAT`; exposed as
-                     scalars to `TIP_TEMPLATE_JINJA2` templates; ignored
-                     for `TIP_TEMPLATE_RAW`.
-      accumulate:    dict — list-valued fields for `TIP_TEMPLATE_JINJA2`
-                     tips. A template sees `{{ name }}` as a deduped +
-                     sorted list; values union on re-emit and, when
-                     `combine_across_tasks`, across tasks.
-      id_suffix:     optional kebab-case suffix appended to
-                     `template.id`.
-      task_keys:     optional list of glob patterns overriding the
-                     template's `task_keys` (or supplying it if absent).
-      surfaces:      optional surface allowlist overriding the template's
-                     `surfaces`. See the "Surface allowlist" section.
-      combine_across_tasks: optional bool overriding the template's
-                     value (default False). See the "Cross-task
-                     accumulation" section.
-    """
-    type_ = template.get("type", TIP_TEMPLATE_FORMAT)
-    if type_ not in _VALID_TEMPLATE_TYPES:
-        fail("unknown tip template type %r; valid: %s" % (type_, ", ".join(_VALID_TEMPLATE_TYPES)))
-    id = template["id"]
-    if id_suffix:
-        id = id + "-" + id_suffix
-    resolved_key = key if key != None else template.get("key", "")
-    resolved_task_keys = task_keys if task_keys != None else template.get("task_keys")
-    resolved_surfaces = surfaces if surfaces != None else template.get("surfaces")
-    resolved_across = combine_across_tasks if combine_across_tasks != None else template.get("combine_across_tasks", False)
-    if type_ == TIP_TEMPLATE_JINJA2:
-        add_tip(
-            ctx,
-            id = id,
-            key = resolved_key,
-            severity = template["severity"],
-            task_keys = resolved_task_keys,
-            type_ = TIP_TEMPLATE_JINJA2,
-            title_template = template["title"],
-            body_template = template["body"],
-            vars = vars,
-            accumulate = accumulate,
-            surfaces = resolved_surfaces,
-            combine_across_tasks = resolved_across,
-        )
-        return
-    title = template["title"]
-    body = template["body"]
-    if type_ == TIP_TEMPLATE_FORMAT and vars:
-        title = title.format(**vars)
-        body = body.format(**vars)
-    add_tip(
-        ctx,
-        id = id,
-        key = resolved_key,
-        severity = template["severity"],
-        task_keys = resolved_task_keys,
-        title = title,
-        body = body,
-        type_ = type_,
-        surfaces = resolved_surfaces,
-        combine_across_tasks = resolved_across,
-    )
 
 def collect_tips_sorted(ctx, limit = None, surface = None):
     """Return the current tips list filtered by `task_keys` (when set)
@@ -794,8 +756,8 @@ def tip_to_payload(t):
         "title": t.get("title", ""),
         "body": t.get("body", ""),
         "type": t.get("type", ""),
-        "title_template": t.get("title_template", ""),
-        "body_template": t.get("body_template", ""),
+        "_title_src": t.get("_title_src", ""),
+        "_body_src": t.get("_body_src", ""),
         "vars": dict(t.get("vars") or {}),
         "accumulate": t.get("accumulate", {}) or {},
         "surfaces": list(t.get("surfaces") or []),
@@ -903,8 +865,14 @@ def blockquote_body(body):
 
 # ── tip_suggestion hook application ──────────────────────────────────
 
-def apply_tip_suggestion_hooks(ctx: TaskContext, tip: dict) -> dict | None:
+def apply_tip_suggestion_hooks(ctx, tip: dict) -> dict | None:
     """Run `tip` through every `TipsTrait.tip_suggestion` handler.
+
+    Internal (not re-exported from `@aspect//tips.axl`). `ctx` is left
+    unannotated because this runs inside the trait's `add` path, which
+    `github.axl`'s detection tests drive with a fake `ctx` struct rather
+    than a real `TaskContext`. Only `ctx.traits` and `ctx.task.{group,name}`
+    are read.
 
     Returns the post-chain tip dict (with any `replace` overrides
     applied), or `None` when a handler rejected it. Handlers run in
@@ -974,15 +942,16 @@ def _tips_impl(ctx):
     auto_print = [ctx.args.auto_print]  # boxed so test seam can mutate
 
     def _render_jinja2(call_ctx, tip, accumulate):
-        """Render `tip`'s templates against `vars` (scalars) + `accumulate`
-        (dict<name, list>) and return the stored tip with the rendered
-        title/body and the merged `accumulate` recorded."""
+        """Render `tip`'s `_title_src` / `_body_src` against `vars`
+        (scalars) + `accumulate` (dict<name, list>) and return the stored
+        tip with the rendered `title` / `body` and the merged `accumulate`
+        recorded."""
         data = dict(tip.get("vars") or {})
         data.update(accumulate)
         stored = dict(tip)
         stored["accumulate"] = accumulate
-        stored["title"] = call_ctx.template.jinja2(tip["title_template"], data = data)
-        stored["body"] = call_ctx.template.jinja2(tip["body_template"], data = data)
+        stored["title"] = call_ctx.template.jinja2(tip["_title_src"], data = data)
+        stored["body"] = call_ctx.template.jinja2(tip["_body_src"], data = data)
         return stored
 
     def _store(call_ctx, tip):
@@ -1084,10 +1053,9 @@ Tips = feature(
 #
 # Consumers go through this. Internal storage (the trait, the closure
 # state inside `_tips_impl`) stays hidden — emit sites only see
-# `tips.emit / .add / .collect`. Test seams are underscore-prefixed.
+# `tips.add / .collect`. Test seams are underscore-prefixed.
 
 tips = struct(
-    emit = emit_tip,
     add = add_tip,
     collect = collect_tips_sorted,
     # Test seams — production code should not call.

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -4,7 +4,7 @@ Covers the tip framework primitives directly:
   - `add_tip` — the single entry point: `(id, key)` identity (re-emit
                 replaces; distinct `key` coexists), `type`-driven
                 title/body (RAW / FORMAT `vars` / JINJA2 `vars` +
-                `accumulate`), within-task `accumulate` union, `id_suffix`,
+                `accumulate`), within-task `accumulate` union,
                 severity guard, and `silenced_tips` short-circuit (by
                 `id`, across keys).
   - `collect_tips_sorted` — severity ordering, insertion-order stability,
@@ -208,17 +208,10 @@ def _test_add_tip_default_type_is_raw(ctx):
     add_tip(ctx, id = "default-type", severity = TIP_INFO, title = "Hello {name}", body = "B", vars = {"name": "world"})
     _eq("default type — RAW leaves braces verbatim", tips._inspect_for_test(ctx)[0]["title"], "Hello {name}")
 
-def _test_add_tip_id_suffix(ctx):
-    _reset(ctx)
-    add_tip(ctx, id = "base", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B")
-    add_tip(ctx, id = "base", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", id_suffix = "variant-a")
-    add_tip(ctx, id = "base", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", id_suffix = "variant-b")
-    _eq("id_suffix — distinct ids", _ids(tips._inspect_for_test(ctx)), ["base", "base-variant-a", "base-variant-b"])
-
-def _test_add_tip_task_keys_override(ctx):
+def _test_add_tip_task_keys_independent(ctx):
     _reset(ctx)
     add_tip(ctx, id = "tmpl-1", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", task_keys = ["lint-*"])
-    add_tip(ctx, id = "tmpl-1", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", id_suffix = "override", task_keys = ["format-*", "gazelle-*"])
+    add_tip(ctx, id = "tmpl-2", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", task_keys = ["format-*", "gazelle-*"])
     stored = tips._inspect_for_test(ctx)
     _eq("add_tip — first task_keys honored", stored[0]["task_keys"], ["lint-*"])
     _eq("add_tip — second tip's task_keys independent", stored[1]["task_keys"], ["format-*", "gazelle-*"])
@@ -818,8 +811,7 @@ def _test_impl(ctx):
     _test_add_tip_format(ctx)
     _test_add_tip_raw_skips_interpolation(ctx)
     _test_add_tip_default_type_is_raw(ctx)
-    _test_add_tip_id_suffix(ctx)
-    _test_add_tip_task_keys_override(ctx)
+    _test_add_tip_task_keys_independent(ctx)
     _test_jinja2_first_emit_seeds_accumulate(ctx)
     _test_jinja2_reemit_merges_new_values(ctx)
     _test_jinja2_reemit_skips_duplicate_values(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -1,17 +1,16 @@
 """Tests for `lib/tips.axl`.
 
 Covers the tip framework primitives directly:
-  - `add_tip` — fully-rendered emission + `(id, key)` identity (re-emit
-                replaces; distinct `key` coexists) + within-task
-                `accumulate` union + severity guard + `silenced_tips`
-                short-circuit (by `id`, across keys).
-  - `emit_tip` — template render + `vars` interpolation + id_suffix +
-                 type validation + task_keys propagation + silence.
+  - `add_tip` — the single entry point: `(id, key)` identity (re-emit
+                replaces; distinct `key` coexists), `type`-driven
+                title/body (RAW / FORMAT `vars` / JINJA2 `vars` +
+                `accumulate`), within-task `accumulate` union, `id_suffix`,
+                severity guard, and `silenced_tips` short-circuit (by
+                `id`, across keys).
   - `collect_tips_sorted` — severity ordering, insertion-order stability,
                             task_keys glob filter, limit, surface allowlist.
   - `surfaces` / `combine_across_tasks` — storage + defaults on `add_tip`,
-                            `emit_tip` template-vs-arg precedence, the
-                            `tip_shows_on` predicate, the per-surface
+                            the `tip_shows_on` predicate, the per-surface
                             collect filter, and `tip_to_payload` carrying
                             them across the artifact boundary. (Cross-task
                             combination itself is covered in
@@ -42,12 +41,6 @@ load(
     "SURFACE_GITHUB_STATUS_CHECKS",
     "TASK_SCREENS",
     "TIP_ACCEPT",
-    "TIP_ADD_ASPECT_API_TOKEN_BUILDKITE",
-    "TIP_ADD_ASPECT_API_TOKEN_CIRCLECI",
-    "TIP_ADD_ASPECT_API_TOKEN_GHA",
-    "TIP_ADD_GITHUB_TOKEN",
-    "TIP_ADD_GITHUB_TOKEN_SCOPE",
-    "TIP_ADD_ID_TOKEN_PERMISSION",
     "TIP_IMPORTANT",
     "TIP_INFO",
     "TIP_REJECT",
@@ -61,12 +54,15 @@ load(
     "blockquote_body",
     "collect_tips_sorted",
     "decorate_tip",
-    "emit_tip",
     "severity_emoji",
     "severity_label",
     "severity_rank",
     "silence_hint_line",
     "strip_code_fences",
+    "tip_add_aspect_api_token",
+    "tip_add_github_token",
+    "tip_add_github_token_scope",
+    "tip_add_id_token_permission",
     "tip_replace",
     "tip_shows_on",
     "tip_to_payload",
@@ -141,12 +137,12 @@ def _test_silenced_tips_short_circuits_add_tip(ctx):
         ["keep-me"],
     )
 
-def _test_silenced_tips_blocks_emit_tip(ctx):
+def _test_silenced_tips_blocks_add(ctx):
     _reset(ctx)
     tips._set_silenced_for_test(ctx, ["add-github-token"])
-    emit_tip(ctx, TIP_ADD_GITHUB_TOKEN)
+    tip_add_github_token(ctx)
     _eq(
-        "silenced — emit_tip respects silence list",
+        "silenced — add_tip respects silence list",
         tips._inspect_for_test(ctx),
         [],
     )
@@ -154,11 +150,11 @@ def _test_silenced_tips_blocks_emit_tip(ctx):
 def _test_important_tips_cannot_be_silenced(ctx):
     """Important tips ignore `silenced_tips` — they signal a key-feature
     breakage and must always reach the user. Verified both via direct
-    `add_tip` and via `emit_tip` against a built-in important template."""
+    `add_tip(...)` and via the `tip_add_id_token_permission` built-in."""
     _reset(ctx)
     tips._set_silenced_for_test(ctx, ["unsuppressable", "add-id-token-permission"])
     add_tip(ctx, id = "unsuppressable", severity = TIP_IMPORTANT, title = "T", body = "B")
-    emit_tip(ctx, TIP_ADD_ID_TOKEN_PERMISSION)
+    tip_add_id_token_permission(ctx)
     _eq(
         "important — silence list ignored",
         _ids(tips._inspect_for_test(ctx)),
@@ -173,90 +169,79 @@ def _test_add_tip_task_keys_stored(ctx):
     _eq("task_keys stored", stored[0]["task_keys"], ["lint-*", "format-*"])
     _eq("task_keys default — empty list when None", stored[1]["task_keys"], [])
 
-def _test_emit_tip_format(ctx):
+def _test_add_tip_format(ctx):
     _reset(ctx)
-    template = {
-        "id": "scope-missing",
-        "severity": TIP_WARNING,
-        "title": "Token lacks `{scope}` scope",
-        "body": "Endpoint {endpoint} returned 403.",
-        "type": TIP_TEMPLATE_FORMAT,
-    }
-    emit_tip(ctx, template, vars = {"scope": "actions: read", "endpoint": "/runs/jobs"})
+    add_tip(
+        ctx,
+        id = "scope-missing",
+        severity = TIP_WARNING,
+        type = TIP_TEMPLATE_FORMAT,
+        title = "Token lacks `{scope}` scope",
+        body = "Endpoint {endpoint} returned 403.",
+        vars = {"scope": "actions: read", "endpoint": "/runs/jobs"},
+    )
     tip = tips._inspect_for_test(ctx)[0]
     _eq("format — title interpolated", tip["title"], "Token lacks `actions: read` scope")
     _eq("format — body interpolated", tip["body"], "Endpoint /runs/jobs returned 403.")
 
-def _test_emit_tip_raw_skips_interpolation(ctx):
+def _test_add_tip_raw_skips_interpolation(ctx):
     _reset(ctx)
-    template = {
-        "id": "raw-tip",
-        "severity": TIP_INFO,
-        "title": "Title with {literal} braces",
-        "body": "Body with {curly} braces",
-        "type": TIP_TEMPLATE_RAW,
-    }
-    emit_tip(ctx, template, vars = {"literal": "shouldn't be touched"})
+    add_tip(
+        ctx,
+        id = "raw-tip",
+        severity = TIP_INFO,
+        type = TIP_TEMPLATE_RAW,
+        title = "Title with {literal} braces",
+        body = "Body with {curly} braces",
+        vars = {"literal": "shouldn't be touched"},
+    )
     tip = tips._inspect_for_test(ctx)[0]
     _eq("raw — title untouched", tip["title"], "Title with {literal} braces")
     _eq("raw — body untouched", tip["body"], "Body with {curly} braces")
 
-def _test_emit_tip_default_type_is_format(ctx):
+def _test_add_tip_default_type_is_raw(ctx):
     _reset(ctx)
-    template = {
-        "id": "default-type",
-        "severity": TIP_INFO,
-        "title": "Hello {name}",
-        "body": "B",
-        # no `type` field — should default to TIP_TEMPLATE_FORMAT.
-    }
-    emit_tip(ctx, template, vars = {"name": "world"})
-    _eq("default type — interpolated as FORMAT", tips._inspect_for_test(ctx)[0]["title"], "Hello world")
 
-def _test_emit_tip_id_suffix(ctx):
+    # No `type` arg — defaults to TIP_TEMPLATE_RAW, so `{name}` is left
+    # verbatim even when `vars` is supplied.
+    add_tip(ctx, id = "default-type", severity = TIP_INFO, title = "Hello {name}", body = "B", vars = {"name": "world"})
+    _eq("default type — RAW leaves braces verbatim", tips._inspect_for_test(ctx)[0]["title"], "Hello {name}")
+
+def _test_add_tip_id_suffix(ctx):
     _reset(ctx)
-    template = {
-        "id": "base",
-        "severity": TIP_INFO,
-        "title": "T",
-        "body": "B",
-        "type": TIP_TEMPLATE_RAW,
-    }
-    emit_tip(ctx, template)
-    emit_tip(ctx, template, id_suffix = "variant-a")
-    emit_tip(ctx, template, id_suffix = "variant-b")
+    add_tip(ctx, id = "base", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B")
+    add_tip(ctx, id = "base", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", id_suffix = "variant-a")
+    add_tip(ctx, id = "base", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", id_suffix = "variant-b")
     _eq("id_suffix — distinct ids", _ids(tips._inspect_for_test(ctx)), ["base", "base-variant-a", "base-variant-b"])
 
-def _test_emit_tip_task_keys_override(ctx):
+def _test_add_tip_task_keys_override(ctx):
     _reset(ctx)
-    template = {
-        "id": "tmpl-1",
-        "severity": TIP_INFO,
-        "title": "T",
-        "body": "B",
-        "type": TIP_TEMPLATE_RAW,
-        "task_keys": ["lint-*"],
-    }
-    emit_tip(ctx, template)
-    emit_tip(ctx, template, id_suffix = "override", task_keys = ["format-*", "gazelle-*"])
+    add_tip(ctx, id = "tmpl-1", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", task_keys = ["lint-*"])
+    add_tip(ctx, id = "tmpl-1", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", id_suffix = "override", task_keys = ["format-*", "gazelle-*"])
     stored = tips._inspect_for_test(ctx)
-    _eq("emit_tip — template task_keys honored", stored[0]["task_keys"], ["lint-*"])
-    _eq("emit_tip — explicit task_keys override template", stored[1]["task_keys"], ["format-*", "gazelle-*"])
+    _eq("add_tip — first task_keys honored", stored[0]["task_keys"], ["lint-*"])
+    _eq("add_tip — second tip's task_keys independent", stored[1]["task_keys"], ["format-*", "gazelle-*"])
 
-_JINJA2_TEMPLATE = {
-    "id": "scope-fail",
-    "severity": TIP_WARNING,
-    "title": "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %}",
-    "body": "{{ endpoints|length }} {{ \"call\" if endpoints|length == 1 else \"calls\" }} fell back:\n{% for e in endpoints %}- {{ e }}\n{% endfor %}",
-    "type": TIP_TEMPLATE_JINJA2,
-}
+# A JINJA2 tip with both `scopes` and `endpoints` accumulators, mirroring
+# the built-in `tip_add_github_token_scope` shape so the merge / re-render
+# mechanics get exercised against a stable local fixture.
+def _emit_scope_fail(ctx, scopes, endpoints):
+    add_tip(
+        ctx,
+        id = "scope-fail",
+        severity = TIP_WARNING,
+        type = TIP_TEMPLATE_JINJA2,
+        title = "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %}",
+        body = "{{ endpoints|length }} {{ \"call\" if endpoints|length == 1 else \"calls\" }} fell back:\n{% for e in endpoints %}- {{ e }}\n{% endfor %}",
+        accumulate = {"scopes": scopes, "endpoints": endpoints},
+    )
 
 def _test_jinja2_first_emit_seeds_accumulate(ctx):
     """First emit of a JINJA2 tip seeds each `accumulate` field with the
     initial value as a single-entry list, renders title + body, and
     retains the templates for later re-render on merge."""
     _reset(ctx)
-    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
+    _emit_scope_fail(ctx, scopes = "actions: read", endpoints = "/jobs")
     stored = tips._inspect_for_test(ctx)
     _eq("jinja2 first-emit — single tip", len(stored), 1)
     _eq("jinja2 first-emit — type recorded", stored[0]["type"], TIP_TEMPLATE_JINJA2)
@@ -269,16 +254,16 @@ def _test_jinja2_first_emit_seeds_accumulate(ctx):
         fail("jinja2 first-emit — title missing scope: %r" % stored[0]["title"])
     if "/jobs" not in stored[0]["body"]:
         fail("jinja2 first-emit — body missing endpoint: %r" % stored[0]["body"])
-    if not stored[0].get("title_template") or not stored[0].get("body_template"):
-        fail("jinja2 first-emit — templates not retained")
+    if not stored[0].get("_title_src") or not stored[0].get("_body_src"):
+        fail("jinja2 first-emit — source not retained for re-render")
 
 def _test_jinja2_reemit_merges_new_values(ctx):
     """A same-`(id, key)` re-emit unions each `accumulate` field
     (preserving insertion order) and re-renders against the merged
     state."""
     _reset(ctx)
-    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
-    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "pull-requests: read", "endpoints": "/files"})
+    _emit_scope_fail(ctx, scopes = "actions: read", endpoints = "/jobs")
+    _emit_scope_fail(ctx, scopes = "pull-requests: read", endpoints = "/files")
     stored = tips._inspect_for_test(ctx)
     _eq("jinja2 reemit — still single tip", len(stored), 1)
     _eq("jinja2 reemit — scopes unioned in order", stored[0]["accumulate"]["scopes"], ["actions: read", "pull-requests: read"])
@@ -292,8 +277,8 @@ def _test_jinja2_reemit_skips_duplicate_values(ctx):
     """Re-emitting the same `accumulate` values is a no-op — no duplicate
     list entries."""
     _reset(ctx)
-    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
-    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
+    _emit_scope_fail(ctx, scopes = "actions: read", endpoints = "/jobs")
+    _emit_scope_fail(ctx, scopes = "actions: read", endpoints = "/jobs")
     tip = tips._inspect_for_test(ctx)[0]
     _eq("jinja2 reemit — duplicate scope skipped", tip["accumulate"]["scopes"], ["actions: read"])
     _eq("jinja2 reemit — duplicate endpoint skipped", tip["accumulate"]["endpoints"], ["/jobs"])
@@ -302,8 +287,8 @@ def _test_jinja2_partial_overlap_appends_only_new(ctx):
     """A re-emit sharing one value only appends the new value to the
     differing field — per-name union is independent."""
     _reset(ctx)
-    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/jobs"})
-    emit_tip(ctx, _JINJA2_TEMPLATE, accumulate = {"scopes": "actions: read", "endpoints": "/runs"})
+    _emit_scope_fail(ctx, scopes = "actions: read", endpoints = "/jobs")
+    _emit_scope_fail(ctx, scopes = "actions: read", endpoints = "/runs")
     tip = tips._inspect_for_test(ctx)[0]
     _eq("jinja2 partial overlap — scopes deduped", tip["accumulate"]["scopes"], ["actions: read"])
     _eq("jinja2 partial overlap — endpoints both retained", tip["accumulate"]["endpoints"], ["/jobs", "/runs"])
@@ -312,16 +297,22 @@ def _test_jinja2_vars_and_accumulate(ctx):
     """`vars` are fixed scalars (template sees them un-listed, last-wins);
     `accumulate` fields are lists that union. A name in both is an error
     (not exercised here — `fail()` aborts the run)."""
-    template = {
-        "id": "mixed",
-        "severity": TIP_INFO,
-        "type": TIP_TEMPLATE_JINJA2,
-        "title": "{{ repo }}: {{ scopes|length }} scopes",
-        "body": "{% for s in scopes %}- {{ s }}\n{% endfor %}",
-    }
+
+    def _emit_mixed(scope):
+        add_tip(
+            ctx,
+            id = "mixed",
+            severity = TIP_INFO,
+            type = TIP_TEMPLATE_JINJA2,
+            title = "{{ repo }}: {{ scopes|length }} scopes",
+            body = "{% for s in scopes %}- {{ s }}\n{% endfor %}",
+            vars = {"repo": "acme/web"},
+            accumulate = {"scopes": scope},
+        )
+
     _reset(ctx)
-    emit_tip(ctx, template, vars = {"repo": "acme/web"}, accumulate = {"scopes": "actions: read"})
-    emit_tip(ctx, template, vars = {"repo": "acme/web"}, accumulate = {"scopes": "pulls: read"})
+    _emit_mixed("actions: read")
+    _emit_mixed("pulls: read")
     tip = tips._inspect_for_test(ctx)[0]
     _eq("jinja2 vars — fixed scalar stored un-listed", tip["vars"], {"repo": "acme/web"})
     _eq("jinja2 vars — accumulate unioned", tip["accumulate"]["scopes"], ["actions: read", "pulls: read"])
@@ -330,10 +321,12 @@ def _test_jinja2_vars_and_accumulate(ctx):
 
     # A JINJA2 tip driven only by `vars` (no accumulate) is valid, and a
     # re-emit with a changed var takes effect (last-wins).
-    vars_only = {"id": "vo", "severity": TIP_INFO, "type": TIP_TEMPLATE_JINJA2, "title": "{{ n }}", "body": "b"}
+    def _emit_vars_only(n):
+        add_tip(ctx, id = "vo", severity = TIP_INFO, type = TIP_TEMPLATE_JINJA2, title = "{{ n }}", body = "b", vars = {"n": n})
+
     _reset(ctx)
-    emit_tip(ctx, vars_only, vars = {"n": "first"})
-    emit_tip(ctx, vars_only, vars = {"n": "second"})
+    _emit_vars_only("first")
+    _emit_vars_only("second")
     tip = tips._inspect_for_test(ctx)[0]
     _eq("jinja2 vars-only — re-emit var change wins", tip["title"], "second")
 
@@ -415,88 +408,106 @@ def _test_blockquote_body(ctx):
         "> intro\n>\n> ```yaml\n> key: value\n> ```",
     )
 
-def _test_builtin_templates_shape(ctx):
-    """Smoke-test the built-in templates have the required keys so a
-    rename or restructure trips the test before users see a broken tip.
+def _stored_one(ctx):
+    """Return the single tip the built-in just added (asserting exactly
+    one landed), so the structural test can inspect rendered output."""
+    stored = tips._inspect_for_test(ctx)
+    _eq("built-in added exactly one tip", len(stored), 1)
+    return stored[0]
+
+def _test_builtin_tips_shape(ctx):
+    """Smoke-test the built-in `tip_*` functions add a well-formed tip so
+    a rename or restructure trips the test before users see a broken tip.
     Also pins severity + per-host id stability — distinct ids per CI host
     let users silence one variant without silencing the others."""
     aspect_token_variants = [
-        ("TIP_ADD_ASPECT_API_TOKEN_GHA", TIP_ADD_ASPECT_API_TOKEN_GHA, "add-aspect-api-token-github-actions"),
-        ("TIP_ADD_ASPECT_API_TOKEN_BUILDKITE", TIP_ADD_ASPECT_API_TOKEN_BUILDKITE, "add-aspect-api-token-buildkite"),
-        ("TIP_ADD_ASPECT_API_TOKEN_CIRCLECI", TIP_ADD_ASPECT_API_TOKEN_CIRCLECI, "add-aspect-api-token-circleci"),
+        ("github-actions", "add-aspect-api-token-github-actions"),
+        ("buildkite", "add-aspect-api-token-buildkite"),
+        ("circleci", "add-aspect-api-token-circleci"),
     ]
-    other_templates = [
-        ("TIP_ADD_GITHUB_TOKEN", TIP_ADD_GITHUB_TOKEN),
-        ("TIP_ADD_GITHUB_TOKEN_SCOPE", TIP_ADD_GITHUB_TOKEN_SCOPE),
-        ("TIP_ADD_ID_TOKEN_PERMISSION", TIP_ADD_ID_TOKEN_PERMISSION),
-    ]
-    for name, tmpl, expected_id in aspect_token_variants:
+    for host, expected_id in aspect_token_variants:
+        _reset(ctx)
+        tip_add_aspect_api_token(ctx, host = host)
+        tip = _stored_one(ctx)
         for key in ("id", "severity", "title", "body", "type"):
-            if key not in tmpl:
-                fail("%s missing required key %r" % (name, key))
-        _eq("%s id" % name, tmpl["id"], expected_id)
-        _eq("%s severity is IMPORTANT" % name, tmpl["severity"], TIP_IMPORTANT)
-    for name, tmpl in other_templates:
+            if key not in tip:
+                fail("aspect-api-token tip (%s) missing required key %r" % (host, key))
+        _eq("aspect-api-token tip (%s) id" % host, tip["id"], expected_id)
+        _eq("aspect-api-token tip (%s) severity is IMPORTANT" % host, tip["severity"], TIP_IMPORTANT)
+
+    for emit in (tip_add_github_token, tip_add_id_token_permission):
+        _reset(ctx)
+        emit(ctx)
+        tip = _stored_one(ctx)
         for key in ("id", "severity", "title", "body", "type"):
-            if key not in tmpl:
-                fail("%s missing required key %r" % (name, key))
+            if key not in tip:
+                fail("built-in tip missing required key %r" % key)
+
+    _reset(ctx)
+    tip_add_github_token(ctx)
     _eq(
-        "TIP_ADD_GITHUB_TOKEN severity is SUGGESTION (fallback hint, not failure)",
-        TIP_ADD_GITHUB_TOKEN["severity"],
+        "tip_add_github_token severity is SUGGESTION (fallback hint, not failure)",
+        _stored_one(ctx)["severity"],
         TIP_SUGGESTION,
     )
+
+    def _body(host):
+        _reset(ctx)
+        tip_add_aspect_api_token(ctx, host = host)
+        return _stored_one(ctx)["body"]
+
+    gha_body = _body("github-actions")
+    bk_body = _body("buildkite")
+    cc_body = _body("circleci")
 
     # Body specialization sanity-check — wire-up advice differs per host.
     # The GHA tip recommends the aspect-build/setup-aspect action (which
     # passes the token via stdin into `aspect auth login`, so the
     # long-lived secret never lands in GITHUB_ENV); there's no equivalent
     # for Buildkite / CircleCI yet, so those still advise raw env wiring.
-    if "setup-aspect" not in TIP_ADD_ASPECT_API_TOKEN_GHA["body"]:
+    if "setup-aspect" not in gha_body:
         fail("GHA tip body should recommend aspect-build/setup-aspect")
-    if "Buildkite's secrets docs" not in TIP_ADD_ASPECT_API_TOKEN_BUILDKITE["body"]:
+    if "Buildkite's secrets docs" not in bk_body:
         fail("Buildkite tip body missing Buildkite-specific advice")
-    if "context" not in TIP_ADD_ASPECT_API_TOKEN_CIRCLECI["body"]:
+    if "context" not in cc_body:
         fail("CircleCI tip body missing CircleCI-specific advice")
 
     # The GHA tip must NOT recommend the deprecated workflow-level env
     # pattern (`env: ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}`)
     # that leaks the long-lived token to every step in the job. Catch
     # accidental regressions to that pattern.
-    if "env:\n  ASPECT_API_TOKEN" in TIP_ADD_ASPECT_API_TOKEN_GHA["body"]:
+    if "env:\n  ASPECT_API_TOKEN" in gha_body:
         fail("GHA tip body should not recommend exposing ASPECT_API_TOKEN as a workflow-level env var (use setup-aspect instead)")
 
     # PR-summary-comment aggregation is GHA-only today, so only the GHA
     # tip should mention it. BK / CircleCI tips listing a feature that
     # doesn't work there would mislead users into thinking the App
     # unlocks it.
-    if "PR summary comment" not in TIP_ADD_ASPECT_API_TOKEN_GHA["body"]:
+    if "PR summary comment" not in gha_body:
         fail("GHA tip should mention PR summary comment aggregation (GHA-only feature)")
-    if "PR summary comment" in TIP_ADD_ASPECT_API_TOKEN_BUILDKITE["body"]:
+    if "PR summary comment" in bk_body:
         fail("BK tip should not mention PR summary comment aggregation (not yet supported)")
-    if "PR summary comment" in TIP_ADD_ASPECT_API_TOKEN_CIRCLECI["body"]:
+    if "PR summary comment" in cc_body:
         fail("CircleCI tip should not mention PR summary comment aggregation (not yet supported)")
 
     # `--scope=changed` falls back to local git diff when the App is
     # unavailable, so listing it as a "degraded" feature would be
     # misleading — none of the variants should mention it.
-    for name, tmpl, _ in aspect_token_variants:
-        if "scope=changed" in tmpl["body"]:
-            fail("%s should not mention --scope=changed (App is only a fallback there)" % name)
+    for body in (gha_body, bk_body, cc_body):
+        if "scope=changed" in body:
+            fail("aspect-api-token tip should not mention --scope=changed (App is only a fallback there)")
 
 def _test_builtin_insufficient_scope_renders(ctx):
-    """`TIP_ADD_GITHUB_TOKEN_SCOPE` is the canonical multi-accumulator
-    JINJA2 template — both `scopes` and `endpoints` accumulate, the
+    """`tip_add_github_token_scope` is the canonical multi-accumulator
+    JINJA2 tip — both `scopes` and `endpoints` accumulate, the
     title pluralizes on `scopes`, and the body pluralizes on
     `endpoints` and renders one bullet per endpoint. One tip per task;
     distinct scopes union into the same tip's `scopes` accumulator."""
     _reset(ctx)
-    emit_tip(
+    tip_add_github_token_scope(
         ctx,
-        TIP_ADD_GITHUB_TOKEN_SCOPE,
-        accumulate = {
-            "scopes": "pull-requests: read",
-            "endpoints": "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
-        },
+        scopes = "pull-requests: read",
+        endpoints = "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
     )
     tip = tips._inspect_for_test(ctx)[0]
     _eq("scope tip — id is the canonical id (no suffix)", tip["id"], "add-github-token-scope")
@@ -514,13 +525,10 @@ def _test_builtin_insufficient_scope_renders(ctx):
     )
 
     # Second emit with a different scope + endpoint: merge.
-    emit_tip(
+    tip_add_github_token_scope(
         ctx,
-        TIP_ADD_GITHUB_TOKEN_SCOPE,
-        accumulate = {
-            "scopes": "actions: read",
-            "endpoints": "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
-        },
+        scopes = "actions: read",
+        endpoints = "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
     )
     _eq("scope tip — still single tip after merge", len(tips._inspect_for_test(ctx)), 1)
     merged = tips._inspect_for_test(ctx)[0]
@@ -567,7 +575,7 @@ def _test_severity_rank(ctx):
 def _test_tip_to_payload(ctx):
     """`tip_to_payload` projects a stored tip into the artifact-boundary
     shape consumed by the PR-comment aggregator. Test pins the field
-    set so a future drop (e.g. of `title_template`) trips here rather
+    set so a future drop (e.g. of `_title_src`) trips here rather
     than at the downstream JINJA2 re-render."""
     stored = {
         "id": "x",
@@ -576,8 +584,8 @@ def _test_tip_to_payload(ctx):
         "title": "Title",
         "body": "Body",
         "type": TIP_TEMPLATE_JINJA2,
-        "title_template": "T",
-        "body_template": "B",
+        "_title_src": "T",
+        "_body_src": "B",
         "vars": {"repo": "acme/web"},
         "accumulate": {"scopes": ["actions: read"]},
         "task_keys": ["lint-*"],  # producer-side filter; payload omits this
@@ -589,8 +597,8 @@ def _test_tip_to_payload(ctx):
     _eq("tip_to_payload — title", payload["title"], "Title")
     _eq("tip_to_payload — body", payload["body"], "Body")
     _eq("tip_to_payload — type", payload["type"], TIP_TEMPLATE_JINJA2)
-    _eq("tip_to_payload — title_template", payload["title_template"], "T")
-    _eq("tip_to_payload — body_template", payload["body_template"], "B")
+    _eq("tip_to_payload — _title_src", payload["_title_src"], "T")
+    _eq("tip_to_payload — _body_src", payload["_body_src"], "B")
     _eq("tip_to_payload — vars", payload["vars"], {"repo": "acme/web"})
     _eq("tip_to_payload — accumulate", payload["accumulate"], {"scopes": ["actions: read"]})
     if "task_keys" in payload:
@@ -659,33 +667,33 @@ def _test_tip_shows_on(ctx):
     _eq("shows_on — unlisted surface hidden", tip_shows_on({"surfaces": [SURFACE_GITHUB_STATUS_CHECKS]}, SURFACE_BUILDKITE_ANNOTATIONS), False)
     _eq("shows_on — surface=None always shows", tip_shows_on({"surfaces": [SURFACE_GITHUB_STATUS_CHECKS]}, None), True)
 
-def _test_emit_tip_key_surfaces_combine(ctx):
-    """`emit_tip` reads `key` / `surfaces` / `combine_across_tasks` from
-    the template, and the explicit args override the template's values."""
-    template = {
-        "id": "t",
-        "key": "tmpl-key",
-        "severity": TIP_INFO,
-        "title": "T",
-        "body": "B",
-        "type": TIP_TEMPLATE_RAW,
-        "surfaces": [SURFACE_GITHUB_STATUS_CHECKS],
-        "combine_across_tasks": True,
-    }
-
+def _test_add_tip_key_surfaces_combine(ctx):
+    """`add_tip` stores `key` / `surfaces` / `combine_across_tasks` as
+    passed, so a tip can pin its identity discriminator, surface
+    allowlist, and cross-task rollup behavior."""
     _reset(ctx)
-    emit_tip(ctx, template)
+    add_tip(
+        ctx,
+        id = "t",
+        key = "the-key",
+        severity = TIP_INFO,
+        title = "T",
+        body = "B",
+        surfaces = [SURFACE_GITHUB_STATUS_CHECKS],
+        combine_across_tasks = True,
+    )
     stored = tips._inspect_for_test(ctx)[0]
-    _eq("emit — key from template", stored["key"], "tmpl-key")
-    _eq("emit — surfaces from template", stored["surfaces"], [SURFACE_GITHUB_STATUS_CHECKS])
-    _eq("emit — combine from template", stored["combine_across_tasks"], True)
+    _eq("emit — key stored", stored["key"], "the-key")
+    _eq("emit — surfaces stored", stored["surfaces"], [SURFACE_GITHUB_STATUS_CHECKS])
+    _eq("emit — combine stored", stored["combine_across_tasks"], True)
 
+    # Defaults when omitted: empty key, all-surfaces, no cross-task combine.
     _reset(ctx)
-    emit_tip(ctx, template, key = "arg-key", surfaces = [SURFACE_BUILDKITE_ANNOTATIONS], combine_across_tasks = False)
+    add_tip(ctx, id = "t2", severity = TIP_INFO, title = "T", body = "B")
     stored = tips._inspect_for_test(ctx)[0]
-    _eq("emit — key arg overrides template", stored["key"], "arg-key")
-    _eq("emit — surfaces arg overrides template", stored["surfaces"], [SURFACE_BUILDKITE_ANNOTATIONS])
-    _eq("emit — combine arg overrides template", stored["combine_across_tasks"], False)
+    _eq("emit — key defaults empty", stored["key"], "")
+    _eq("emit — surfaces default empty (all)", stored["surfaces"], [])
+    _eq("emit — combine defaults False", stored["combine_across_tasks"], False)
 
 def _test_tip_suggestion_hook(ctx):
     """A `tip_suggestion` hook on `TipsTrait` fires per `add_tip` and can
@@ -803,14 +811,14 @@ def _test_impl(ctx):
     _test_add_tip_dedup(ctx)
     _test_key_distinct(ctx)
     _test_silenced_tips_short_circuits_add_tip(ctx)
-    _test_silenced_tips_blocks_emit_tip(ctx)
+    _test_silenced_tips_blocks_add(ctx)
     _test_important_tips_cannot_be_silenced(ctx)
     _test_add_tip_task_keys_stored(ctx)
-    _test_emit_tip_format(ctx)
-    _test_emit_tip_raw_skips_interpolation(ctx)
-    _test_emit_tip_default_type_is_format(ctx)
-    _test_emit_tip_id_suffix(ctx)
-    _test_emit_tip_task_keys_override(ctx)
+    _test_add_tip_format(ctx)
+    _test_add_tip_raw_skips_interpolation(ctx)
+    _test_add_tip_default_type_is_raw(ctx)
+    _test_add_tip_id_suffix(ctx)
+    _test_add_tip_task_keys_override(ctx)
     _test_jinja2_first_emit_seeds_accumulate(ctx)
     _test_jinja2_reemit_merges_new_values(ctx)
     _test_jinja2_reemit_skips_duplicate_values(ctx)
@@ -824,7 +832,7 @@ def _test_impl(ctx):
     _test_severity_label(ctx)
     _test_severity_rank(ctx)
     _test_blockquote_body(ctx)
-    _test_builtin_templates_shape(ctx)
+    _test_builtin_tips_shape(ctx)
     _test_builtin_insufficient_scope_renders(ctx)
     _test_silence_hint_line(ctx)
     _test_decorate_tip(ctx)
@@ -832,7 +840,7 @@ def _test_impl(ctx):
     _test_surfaces_and_combine_stored(ctx)
     _test_collect_filters_by_surface(ctx)
     _test_tip_shows_on(ctx)
-    _test_emit_tip_key_surfaces_combine(ctx)
+    _test_add_tip_key_surfaces_combine(ctx)
     _test_tip_suggestion_hook(ctx)
     _test_strip_code_fences(ctx)
     _test_auto_print_flag(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -35,6 +35,7 @@ Run with:
 
 load(
     "./tips.axl",
+    "AspectApiTokenHost",
     "SURFACE_BUILDKITE_ANNOTATIONS",
     "SURFACE_CLI",
     "SURFACE_GITHUB_PR_SUMMARY",
@@ -421,9 +422,9 @@ def _test_builtin_tips_shape(ctx):
     Also pins severity + per-host id stability — distinct ids per CI host
     let users silence one variant without silencing the others."""
     aspect_token_variants = [
-        ("github-actions", "add-aspect-api-token-github-actions"),
-        ("buildkite", "add-aspect-api-token-buildkite"),
-        ("circleci", "add-aspect-api-token-circleci"),
+        (AspectApiTokenHost("github-actions"), "add-aspect-api-token-github-actions"),
+        (AspectApiTokenHost("buildkite"), "add-aspect-api-token-buildkite"),
+        (AspectApiTokenHost("circleci"), "add-aspect-api-token-circleci"),
     ]
     for host, expected_id in aspect_token_variants:
         _reset(ctx)
@@ -431,9 +432,9 @@ def _test_builtin_tips_shape(ctx):
         tip = _stored_one(ctx)
         for key in ("id", "severity", "title", "body", "type"):
             if key not in tip:
-                fail("aspect-api-token tip (%s) missing required key %r" % (host, key))
-        _eq("aspect-api-token tip (%s) id" % host, tip["id"], expected_id)
-        _eq("aspect-api-token tip (%s) severity is IMPORTANT" % host, tip["severity"], TIP_IMPORTANT)
+                fail("aspect-api-token tip (%s) missing required key %r" % (host.value, key))
+        _eq("aspect-api-token tip (%s) id" % host.value, tip["id"], expected_id)
+        _eq("aspect-api-token tip (%s) severity is IMPORTANT" % host.value, tip["severity"], TIP_IMPORTANT)
 
     for emit in (tip_add_github_token, tip_add_id_token_permission):
         _reset(ctx)
@@ -456,9 +457,9 @@ def _test_builtin_tips_shape(ctx):
         tip_add_aspect_api_token(ctx, host = host)
         return _stored_one(ctx)["body"]
 
-    gha_body = _body("github-actions")
-    bk_body = _body("buildkite")
-    cc_body = _body("circleci")
+    gha_body = _body(AspectApiTokenHost("github-actions"))
+    bk_body = _body(AspectApiTokenHost("buildkite"))
+    cc_body = _body(AspectApiTokenHost("circleci"))
 
     # Body specialization sanity-check — wire-up advice differs per host.
     # The GHA tip recommends the aspect-build/setup-aspect action (which

--- a/crates/aspect-cli/src/builtins/aspect/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/tips.axl
@@ -6,7 +6,6 @@ and customize tips with a single import:
 
     load("@aspect//tips.axl",
          "add_tip",
-         "emit_tip",
          "tips",
          "TIP_IMPORTANT",
          "TIP_WARNING",
@@ -31,13 +30,14 @@ and customize tips with a single import:
          "tip_replace")
 
 This is the customer-facing surface; internal modules load directly from
-`lib/tips.axl`. The built-in tip templates (`TIP_ADD_GITHUB_TOKEN`, …) are
-re-exported too so a config can preempt or silence them by id.
+`lib/tips.axl`. The built-in tips (`tip_add_github_token`, …) are
+re-exported too so a config can call them or preempt / silence them by id.
 """
 
 load(
     "./lib/tips.axl",
     _AGGREGATE_SCREENS = "AGGREGATE_SCREENS",
+    _AspectApiTokenHost = "AspectApiTokenHost",
     _SURFACE_ALL = "SURFACE_ALL",
     _SURFACE_BUILDKITE_ANNOTATIONS = "SURFACE_BUILDKITE_ANNOTATIONS",
     _SURFACE_CLI = "SURFACE_CLI",
@@ -46,12 +46,6 @@ load(
     _SURFACE_GITLAB_COMMIT_STATUSES = "SURFACE_GITLAB_COMMIT_STATUSES",
     _TASK_SCREENS = "TASK_SCREENS",
     _TIP_ACCEPT = "TIP_ACCEPT",
-    _TIP_ADD_ASPECT_API_TOKEN_BUILDKITE = "TIP_ADD_ASPECT_API_TOKEN_BUILDKITE",
-    _TIP_ADD_ASPECT_API_TOKEN_CIRCLECI = "TIP_ADD_ASPECT_API_TOKEN_CIRCLECI",
-    _TIP_ADD_ASPECT_API_TOKEN_GHA = "TIP_ADD_ASPECT_API_TOKEN_GHA",
-    _TIP_ADD_GITHUB_TOKEN = "TIP_ADD_GITHUB_TOKEN",
-    _TIP_ADD_GITHUB_TOKEN_SCOPE = "TIP_ADD_GITHUB_TOKEN_SCOPE",
-    _TIP_ADD_ID_TOKEN_PERMISSION = "TIP_ADD_ID_TOKEN_PERMISSION",
     _TIP_IMPORTANT = "TIP_IMPORTANT",
     _TIP_INFO = "TIP_INFO",
     _TIP_REJECT = "TIP_REJECT",
@@ -65,7 +59,10 @@ load(
     _TipSuggestion = "TipSuggestion",
     _TipsTrait = "TipsTrait",
     _add_tip = "add_tip",
-    _emit_tip = "emit_tip",
+    _tip_add_aspect_api_token = "tip_add_aspect_api_token",
+    _tip_add_github_token = "tip_add_github_token",
+    _tip_add_github_token_scope = "tip_add_github_token_scope",
+    _tip_add_id_token_permission = "tip_add_id_token_permission",
     _tip_replace = "tip_replace",
     _tips = "tips",
 )
@@ -93,7 +90,6 @@ SURFACE_ALL = _SURFACE_ALL
 
 # Producer API.
 add_tip = _add_tip
-emit_tip = _emit_tip
 tips = _tips
 
 # tip_suggestion hook.
@@ -105,10 +101,10 @@ TIP_ACCEPT = _TIP_ACCEPT
 TIP_REJECT = _TIP_REJECT
 tip_replace = _tip_replace
 
-# Built-in tip templates (re-exported so a config can preempt / silence them).
-TIP_ADD_GITHUB_TOKEN = _TIP_ADD_GITHUB_TOKEN
-TIP_ADD_ASPECT_API_TOKEN_GHA = _TIP_ADD_ASPECT_API_TOKEN_GHA
-TIP_ADD_ASPECT_API_TOKEN_BUILDKITE = _TIP_ADD_ASPECT_API_TOKEN_BUILDKITE
-TIP_ADD_ASPECT_API_TOKEN_CIRCLECI = _TIP_ADD_ASPECT_API_TOKEN_CIRCLECI
-TIP_ADD_GITHUB_TOKEN_SCOPE = _TIP_ADD_GITHUB_TOKEN_SCOPE
-TIP_ADD_ID_TOKEN_PERMISSION = _TIP_ADD_ID_TOKEN_PERMISSION
+# Built-in tips (re-exported so a config can call or preempt them; silence
+# by the id each one emits, e.g. `add-github-token`).
+tip_add_github_token = _tip_add_github_token
+tip_add_aspect_api_token = _tip_add_aspect_api_token
+tip_add_github_token_scope = _tip_add_github_token_scope
+tip_add_id_token_permission = _tip_add_id_token_permission
+AspectApiTokenHost = _AspectApiTokenHost

--- a/crates/aspect-cli/src/builtins/aspect/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/tips.axl
@@ -1,0 +1,114 @@
+"""Public facade re-exporting the tips authoring API.
+
+The implementation lives in `lib/tips.axl` (see it for docstrings and
+field semantics). This file exists so user `config.axl` files can author
+and customize tips with a single import:
+
+    load("@aspect//tips.axl",
+         "add_tip",
+         "emit_tip",
+         "tips",
+         "TIP_IMPORTANT",
+         "TIP_WARNING",
+         "TIP_SUGGESTION",
+         "TIP_INFO",
+         "TIP_TEMPLATE_RAW",
+         "TIP_TEMPLATE_FORMAT",
+         "TIP_TEMPLATE_JINJA2",
+         "SURFACE_CLI",
+         "SURFACE_GITHUB_STATUS_CHECKS",
+         "SURFACE_BUILDKITE_ANNOTATIONS",
+         "SURFACE_GITLAB_COMMIT_STATUSES",
+         "SURFACE_GITHUB_PR_SUMMARY",
+         "TASK_SCREENS",
+         "AGGREGATE_SCREENS",
+         "SURFACE_ALL",
+         "TipsTrait",
+         "TipInfo",
+         "TipSuggestion",
+         "TIP_ACCEPT",
+         "TIP_REJECT",
+         "tip_replace")
+
+This is the customer-facing surface; internal modules load directly from
+`lib/tips.axl`. The built-in tip templates (`TIP_ADD_GITHUB_TOKEN`, …) are
+re-exported too so a config can preempt or silence them by id.
+"""
+
+load(
+    "./lib/tips.axl",
+    _AGGREGATE_SCREENS = "AGGREGATE_SCREENS",
+    _SURFACE_ALL = "SURFACE_ALL",
+    _SURFACE_BUILDKITE_ANNOTATIONS = "SURFACE_BUILDKITE_ANNOTATIONS",
+    _SURFACE_CLI = "SURFACE_CLI",
+    _SURFACE_GITHUB_PR_SUMMARY = "SURFACE_GITHUB_PR_SUMMARY",
+    _SURFACE_GITHUB_STATUS_CHECKS = "SURFACE_GITHUB_STATUS_CHECKS",
+    _SURFACE_GITLAB_COMMIT_STATUSES = "SURFACE_GITLAB_COMMIT_STATUSES",
+    _TASK_SCREENS = "TASK_SCREENS",
+    _TIP_ACCEPT = "TIP_ACCEPT",
+    _TIP_ADD_ASPECT_API_TOKEN_BUILDKITE = "TIP_ADD_ASPECT_API_TOKEN_BUILDKITE",
+    _TIP_ADD_ASPECT_API_TOKEN_CIRCLECI = "TIP_ADD_ASPECT_API_TOKEN_CIRCLECI",
+    _TIP_ADD_ASPECT_API_TOKEN_GHA = "TIP_ADD_ASPECT_API_TOKEN_GHA",
+    _TIP_ADD_GITHUB_TOKEN = "TIP_ADD_GITHUB_TOKEN",
+    _TIP_ADD_GITHUB_TOKEN_SCOPE = "TIP_ADD_GITHUB_TOKEN_SCOPE",
+    _TIP_ADD_ID_TOKEN_PERMISSION = "TIP_ADD_ID_TOKEN_PERMISSION",
+    _TIP_IMPORTANT = "TIP_IMPORTANT",
+    _TIP_INFO = "TIP_INFO",
+    _TIP_REJECT = "TIP_REJECT",
+    _TIP_SUGGESTION = "TIP_SUGGESTION",
+    _TIP_TEMPLATE_FORMAT = "TIP_TEMPLATE_FORMAT",
+    _TIP_TEMPLATE_JINJA2 = "TIP_TEMPLATE_JINJA2",
+    _TIP_TEMPLATE_RAW = "TIP_TEMPLATE_RAW",
+    _TIP_WARNING = "TIP_WARNING",
+    _TipAction = "TipAction",
+    _TipInfo = "TipInfo",
+    _TipSuggestion = "TipSuggestion",
+    _TipsTrait = "TipsTrait",
+    _add_tip = "add_tip",
+    _emit_tip = "emit_tip",
+    _tip_replace = "tip_replace",
+    _tips = "tips",
+)
+
+# Severities.
+TIP_IMPORTANT = _TIP_IMPORTANT
+TIP_WARNING = _TIP_WARNING
+TIP_SUGGESTION = _TIP_SUGGESTION
+TIP_INFO = _TIP_INFO
+
+# Template types.
+TIP_TEMPLATE_RAW = _TIP_TEMPLATE_RAW
+TIP_TEMPLATE_FORMAT = _TIP_TEMPLATE_FORMAT
+TIP_TEMPLATE_JINJA2 = _TIP_TEMPLATE_JINJA2
+
+# Surfaces + shorthands.
+SURFACE_CLI = _SURFACE_CLI
+SURFACE_GITHUB_STATUS_CHECKS = _SURFACE_GITHUB_STATUS_CHECKS
+SURFACE_BUILDKITE_ANNOTATIONS = _SURFACE_BUILDKITE_ANNOTATIONS
+SURFACE_GITLAB_COMMIT_STATUSES = _SURFACE_GITLAB_COMMIT_STATUSES
+SURFACE_GITHUB_PR_SUMMARY = _SURFACE_GITHUB_PR_SUMMARY
+TASK_SCREENS = _TASK_SCREENS
+AGGREGATE_SCREENS = _AGGREGATE_SCREENS
+SURFACE_ALL = _SURFACE_ALL
+
+# Producer API.
+add_tip = _add_tip
+emit_tip = _emit_tip
+tips = _tips
+
+# tip_suggestion hook.
+TipsTrait = _TipsTrait
+TipAction = _TipAction
+TipInfo = _TipInfo
+TipSuggestion = _TipSuggestion
+TIP_ACCEPT = _TIP_ACCEPT
+TIP_REJECT = _TIP_REJECT
+tip_replace = _tip_replace
+
+# Built-in tip templates (re-exported so a config can preempt / silence them).
+TIP_ADD_GITHUB_TOKEN = _TIP_ADD_GITHUB_TOKEN
+TIP_ADD_ASPECT_API_TOKEN_GHA = _TIP_ADD_ASPECT_API_TOKEN_GHA
+TIP_ADD_ASPECT_API_TOKEN_BUILDKITE = _TIP_ADD_ASPECT_API_TOKEN_BUILDKITE
+TIP_ADD_ASPECT_API_TOKEN_CIRCLECI = _TIP_ADD_ASPECT_API_TOKEN_CIRCLECI
+TIP_ADD_GITHUB_TOKEN_SCOPE = _TIP_ADD_GITHUB_TOKEN_SCOPE
+TIP_ADD_ID_TOKEN_PERMISSION = _TIP_ADD_ID_TOKEN_PERMISSION

--- a/crates/aspect-cli/src/builtins/aspect/traits.axl
+++ b/crates/aspect-cli/src/builtins/aspect/traits.axl
@@ -17,16 +17,12 @@ files can load the full trait set with a single import:
          "ReproFixInfo",
          "ReproFixSuggestion",
          "TaskUpdate",
-         "TipInfo",
-         "TipSuggestion",
-         "TipsTrait",
-         "TIP_ACCEPT",
-         "TIP_REJECT",
-         "repro_fix_replace",
-         "tip_replace")
+         "repro_fix_replace")
 
 Internal modules should load directly from the owning module — this
-facade is purely a user-facing convenience.
+facade is purely a user-facing convenience. The tip authoring API
+(`TipsTrait`, `tip_suggestion` records, severities, surfaces, …) lives
+in its own facade: `@aspect//tips.axl`.
 
 Note: artifact URLs are no longer exposed via a trait. Use the
 `artifacts` struct from `@aspect//lib/artifacts.axl` instead — it
@@ -51,16 +47,6 @@ load(
     _TaskUpdate = "TaskUpdate",
     _repro_fix_replace = "repro_fix_replace",
 )
-load(
-    "./lib/tips.axl",
-    _TIP_ACCEPT = "TIP_ACCEPT",
-    _TIP_REJECT = "TIP_REJECT",
-    _TipAction = "TipAction",
-    _TipInfo = "TipInfo",
-    _TipSuggestion = "TipSuggestion",
-    _TipsTrait = "TipsTrait",
-    _tip_replace = "tip_replace",
-)
 load("./lint.axl", _LintTrait = "LintTrait")
 
 BazelTrait = _BazelTrait
@@ -74,13 +60,6 @@ ReproFixCommand = _ReproFixCommand
 ReproFixCommandKind = _ReproFixCommandKind
 ReproFixInfo = _ReproFixInfo
 ReproFixSuggestion = _ReproFixSuggestion
-TIP_ACCEPT = _TIP_ACCEPT
-TIP_REJECT = _TIP_REJECT
 TaskLifecycleTrait = _TaskLifecycleTrait
 TaskUpdate = _TaskUpdate
-TipAction = _TipAction
-TipInfo = _TipInfo
-TipSuggestion = _TipSuggestion
-TipsTrait = _TipsTrait
 repro_fix_replace = _repro_fix_replace
-tip_replace = _tip_replace


### PR DESCRIPTION
Adds two public facade modules so `.aspect/config.axl` authors load tips and CI/link helpers from clean, stable paths instead of reaching into implementation modules under `lib/`, and gives the tips producer surface a single entry point.

## Facades

- **`@aspect//tips.axl`** — the tip authoring surface: `add_tip` / `tips`, the `TIP_*` severities and template types, the `SURFACE_*` identifiers + `TASK_SCREENS` / `AGGREGATE_SCREENS` / `SURFACE_ALL`, the `tip_suggestion` hook records (`TipsTrait`, `TipInfo`, `TipSuggestion`, `TIP_ACCEPT`, `TIP_REJECT`, `tip_replace`), and the built-in tips (`tip_add_github_token`, `tip_add_aspect_api_token`, `tip_add_github_token_scope`, `tip_add_id_token_permission`, plus the `AspectApiTokenHost` enum). Mirrors how `@aspect//traits.axl` fronts the trait set.
- **`@aspect//helpers.axl`** — `detect_ci_host`, `detect_build_url`, `aspect_web_ui_url`, `render_bes_url`: the helpers a `task_update` hook needs to rebuild the click-through links the built-in status surfaces render.

## Single `add_tip` producer API

The producer surface is one function — `add_tip(ctx, id, severity, title, body, type=…, key=…, vars=…, accumulate=…, surfaces=…, task_keys=…, id_suffix=…, combine_across_tasks=…)` — with `title` / `body` interpreted per `type` (RAW / FORMAT / JINJA2). The built-in tips are `tip_*(ctx, …)` functions that wrap `add_tip` with their content baked in, exposing only what varies (e.g. `tip_add_github_token_scope(ctx, scopes=…, endpoints=…)`).

## CI build URL helpers

- New **`aspect_web_ui_url(env, data)`** — the Aspect Web UI invocation link from `env` + task `data`.
- **`detect_build_url(env)`** takes a `std.Env` (not a context), so a `config.axl` hook can call it without a `TaskContext`. It resolves the env-derivable URL and reads a per-task cache. The GitHub Actions per-job upgrade — an authenticated API call needing a full context — is the internal `resolve_build_url(ctx)`, which in-tree status features use; once it caches the per-job URL, `detect_build_url(env)` returns it too.

Both facades are thin top-level re-exports; the implementations stay in their owning modules (`lib/tips.axl`, `lib/ci.axl`, `lib/bazel_results.axl`).

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no — new public load paths over not-yet-shipped builtins.

### Suggested release notes

- Added `@aspect//tips.axl` (single `add_tip` authoring API + `tip_*` built-ins) and `@aspect//helpers.axl` (`detect_ci_host` / `detect_build_url` / `aspect_web_ui_url` / `render_bes_url`) as public load paths for `.aspect/config.axl`.

### Test plan

- New suites: `lib/ci_test.axl` (host detection, env-only build URL, per-job cache short-circuit, off-GHA `resolve_build_url` delegation) and `helpers_test.axl` (facade smoke test). `bazel_results_test.axl` covers `aspect_web_ui_url` / `render_bes_url` incl. trailing-slash join.
- Existing suites pass: tips / github-detect / PR-comment / Buildkite-annotation / bazel-results / GitLab. `buildifier` clean. Verified end-to-end that the `tip_*` built-ins and the per-job GitHub Actions URL resolve on a simulated GitHub Actions build.
