### PR TITLE
fix(github-status-comments): evict superseded workflow-run slots so re-runs don't duplicate task rows

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -408,25 +408,23 @@ def _dedup_by_run_attempt(entries):
     )
 
 def _dedup_for_display(entries):
-    """Collapse entries that share a `(job, name, key)` identity across
-    different `workflow_run_id`s to the one from the newest run (by
-    `workflow_run_id`, then `run_attempt`).
+    """Collapse exact-duplicate rows — same `(workflow_run_id, job,
+    name, key)` — to the highest `run_attempt`, for the render path.
 
-    Defense-in-depth on the render path: `_merge_state` already evicts
-    superseded slots (`_live_sibling_runs`), so in steady state each
-    logical task appears once. This guards against a future slot
-    leak — or a snapshot row outliving its eviction by one cycle —
-    visibly duplicating a row. Operates on the display copy only; the
-    persisted state block keeps per-run_id granularity for the
-    snapshot-fallback merge.
-
-    Same-named jobs across genuinely-parallel workflows collapse here,
-    but that matches the one-row-per-task contract — the row reflects
-    the most recent run."""
+    Defense-in-depth: `_merge_state` keeps one live run per
+    `workflow_name` (`_live_runs`) and sources each run's entries from a
+    single place, so in steady state every row is already unique. This
+    guards against a snapshot that briefly carries two rows for the same
+    task within one run_id (e.g. an artifact-listing eventual-
+    consistency blip). `workflow_run_id` is part of the identity so rows
+    from genuinely-distinct concurrent workflows that happen to share a
+    `(job, name, key)` are preserved — collapsing those would drop a
+    real workflow's row. Operates on the display copy only; the
+    persisted state block is untouched."""
     return _collapse_by(
         entries,
-        lambda e: (e.get("job", ""), e.get("name", ""), e.get("key", "")),
-        lambda e: (_run_id_sort_key(e.get("workflow_run_id", "")), _run_attempt_int(e)),
+        lambda e: (e.get("workflow_run_id", ""), e.get("job", ""), e.get("name", ""), e.get("key", "")),
+        _run_attempt_int,
     )
 
 def _should_quiet_delete_log(last_upload_at, now):
@@ -990,34 +988,38 @@ def _parse_state(body):
         "entries": parsed_entries,
     }
 
-def _live_sibling_runs(workflow_runs, my_run_id, my_workflow_name):
-    """Filter `workflow_runs` (the comment's existing slots) down to the
-    live run per sibling workflow, dropping this writer's own slot and
-    any run a newer run of the same workflow has superseded.
+def _live_runs(workflow_runs, my_run_id, my_workflow_name):
+    """Reduce the comment's `workflow_runs` slots — plus this writer's
+    own run as a candidate — to the live run per `workflow_name`.
 
     A workflow re-triggered on the same head SHA keeps its
     `GITHUB_WORKFLOW` name but gets a fresh `GITHUB_RUN_ID`. Left in
     place, the stale slot lingers (its artifacts expire → frozen
     snapshot fallback), duplicating every task in that workflow on the
     rendered comment. For each named workflow only the newest `run_id`
-    survives. This writer's slot — matched on either `my_run_id` (so an
-    out-of-band-renamed slot at our run_id doesn't double up) or
-    `my_workflow_name` (a prior run of our own workflow) — is dropped so
-    the caller can re-add it as the live run.
+    survives.
 
-    Slots with an empty `workflow_name` are passed through untouched
-    (unless they match `my_run_id`) — they can't be matched to a newer
-    run reliably, so each keeps its own identity."""
+    This writer's own run competes in the contest like any other slot.
+    It does NOT win by fiat: in a re-run race the older run is still
+    executing and publishing, so if a newer run of our name already
+    holds the slot, that newer slot wins and ours is dropped (it would
+    otherwise resurrect stale rows over the newer run's). Any existing
+    slot at `my_run_id` (e.g. one whose `workflow_name` was renamed
+    out of band) is replaced by our current identity.
+
+    Slots with an empty `workflow_name` are passed through untouched —
+    they can't be matched to a newer run reliably, so each keeps its
+    own identity. If our own run has no name (GITHUB_WORKFLOW unset),
+    our candidate is one of these and is always kept."""
+    candidates = [r for r in workflow_runs if str(r.get("run_id", "")) != str(my_run_id)]
+    candidates.append({"run_id": str(my_run_id), "workflow_name": my_workflow_name})
+
     newest_by_name = {}
     passthrough = []
-    for r in workflow_runs:
-        if str(r.get("run_id", "")) == str(my_run_id):
-            continue
+    for r in candidates:
         name = r.get("workflow_name", "") or ""
         if not name:
             passthrough.append(r)
-            continue
-        if name == my_workflow_name:
             continue
         cur = newest_by_name.get(name)
         if cur == None or _run_id_sort_key(r.get("run_id", "")) > _run_id_sort_key(cur.get("run_id", "")):
@@ -1033,8 +1035,9 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
         writer overlays its own slot, preserving sibling-workflow slots
         unchanged. Writes are slot-independent → no cross-workflow data
         race. A workflow re-triggered on the same head SHA supersedes
-        its prior slot (`_live_sibling_runs`) so stale runs don't
-        accumulate as duplicate task rows.
+        its prior slot (`_live_runs`) so stale runs don't accumulate as
+        duplicate task rows; a still-running older run that lost the
+        contest contributes nothing rather than resurrecting its rows.
       * `entries` is the full per-task snapshot, kept for two reasons:
         (a) fallback when a sibling workflow's artifacts are unreachable
         (TTL expiry, transient API error); (b) terminal-state
@@ -1062,11 +1065,12 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
 
     existing_runs = (existing_state or {}).get("workflow_runs", []) or []
 
-    # Keep one live slot per sibling workflow (evicting runs superseded
-    # by a re-trigger on the same head SHA), then add our own slot back
-    # as the live run for our name. See `_live_sibling_runs`.
-    other_runs = _live_sibling_runs(existing_runs, my_run_id, my_workflow_name)
-    workflow_runs = other_runs + [{"run_id": str(my_run_id), "workflow_name": my_workflow_name}]
+    # Reduce to the live run per workflow_name (evicting runs superseded
+    # by a re-trigger on the same head SHA), with our own run competing
+    # as a candidate. We only own the slot for our name if we won the
+    # contest; in a re-run race a newer run of our name wins and we
+    # contribute nothing this cycle. See `_live_runs`.
+    workflow_runs = _live_runs(existing_runs, my_run_id, my_workflow_name)
 
     # Per-task union of refreshed entries with the comment's prior
     # snapshot. Refresh wins per `(name, key)`; snapshot fills any
@@ -1080,9 +1084,13 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
         rid = str(e.get("workflow_run_id", ""))
         snapshot_by_run.setdefault(rid, []).append(e)
 
-    entries = list(my_entries)
-    for r in other_runs:
+    entries = []
+    for r in workflow_runs:
         rid = str(r.get("run_id", ""))
+        if rid == str(my_run_id):
+            # Our own authoritative entries — only if we won our slot.
+            entries.extend(my_entries)
+            continue
         snapshot = snapshot_by_run.get(rid, [])
         refreshed = refreshed_other_entries.get(rid)
         if refreshed == None:
@@ -1096,9 +1104,10 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
 
     # Deterministic ordering so the serialized state block is byte-stable
     # across writers. Without this, publish ownership alternating between
-    # workflows would flip the order on each cycle (`others + [mine]`
-    # depends on which writer "mine" is), and `stable_body`'s
-    # unchanged-content short-circuit in `_publish` would never fire.
+    # workflows would flip the slot/row order on each cycle (`_live_runs`
+    # iteration order depends on which writer "mine" is), and
+    # `stable_body`'s unchanged-content short-circuit in `_publish` would
+    # never fire.
     workflow_runs = sorted(workflow_runs, key = lambda r: str(r.get("run_id", "")))
     entries = sorted(entries, key = lambda e: (
         str(e.get("workflow_run_id", "")),
@@ -1584,11 +1593,9 @@ def _github_status_comments(ctx: FeatureContext):
 
         new_state = _merge_state(parsed, head_sha, run_id, workflow_name, raw_entries, refreshed_others)
 
-        # Render from a logical-identity-deduped view so a leaked or
-        # one-cycle-stale duplicate slot can't surface the same task
-        # twice. The persisted `new_state["entries"]` keeps per-run_id
-        # granularity for the snapshot-fallback merge — only the display
-        # copy collapses.
+        # Drop exact-duplicate rows before rendering (defense-in-depth;
+        # `_merge_state` already produces unique rows). The persisted
+        # `new_state["entries"]` is untouched.
         prepared = _prepare_for_render(_dedup_for_display(new_state["entries"]))
         sections = _bucket_entries(prepared)
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -379,6 +379,18 @@ def _collapse_by(entries, key_of, rank_of):
             best[k] = e
     return list(best.values())
 
+def _union_entries_by_name_key(primary, fallback):
+    """Concatenate `primary` with the `fallback` entries whose
+    `(name, key)` isn't already in `primary`. Primary wins per task;
+    fallback fills the gaps. Order: all of `primary`, then the surviving
+    fallback rows in their original order."""
+    primary_keys = {(e.get("name", ""), e.get("key", "")): True for e in primary}
+    return list(primary) + [
+        e
+        for e in fallback
+        if (e.get("name", ""), e.get("key", "")) not in primary_keys
+    ]
+
 def _dedup_by_run_attempt(entries):
     """Collapse entries that share a `(name, key, job)` identity to the
     one with the highest `run_attempt`.
@@ -1072,13 +1084,11 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
     # contribute nothing this cycle. See `_live_runs`.
     workflow_runs = _live_runs(existing_runs, my_run_id, my_workflow_name)
 
-    # Per-task union of refreshed entries with the comment's prior
-    # snapshot. Refresh wins per `(name, key)`; snapshot fills any
-    # tasks the refresh didn't return. Mitigates artifact-listing
-    # eventual consistency: a partial refresh that's briefly missing
-    # some task's artifact would otherwise drop that row this cycle
-    # and re-add it next cycle when the listing converges, causing
-    # visible "entry count flips" thrashing on the comment.
+    # Index the comment's prior per-task snapshot by run_id. It backfills
+    # tasks a sibling-workflow refresh didn't return this cycle (see the
+    # union below) — a partial refresh under artifact-listing eventual
+    # consistency would otherwise drop a row this cycle and re-add it the
+    # next, thrashing the visible entry count.
     snapshot_by_run = {}
     for e in ((existing_state or {}).get("entries", []) or []):
         rid = str(e.get("workflow_run_id", ""))
@@ -1088,19 +1098,15 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
     for r in workflow_runs:
         rid = str(r.get("run_id", ""))
         if rid == str(my_run_id):
-            # Our own authoritative entries — only if we won our slot.
+            # Our own authoritative entries (only present when we won our slot).
             entries.extend(my_entries)
             continue
         snapshot = snapshot_by_run.get(rid, [])
         refreshed = refreshed_other_entries.get(rid)
         if refreshed == None:
             entries.extend(snapshot)
-            continue
-        entries.extend(refreshed)
-        refreshed_keys = {(e.get("name", ""), e.get("key", "")): True for e in refreshed}
-        for e in snapshot:
-            if (e.get("name", ""), e.get("key", "")) not in refreshed_keys:
-                entries.append(e)
+        else:
+            entries.extend(_union_entries_by_name_key(refreshed, snapshot))
 
     # Deterministic ordering so the serialized state block is byte-stable
     # across writers. Without this, publish ownership alternating between

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -355,6 +355,30 @@ def _run_attempt_int(entry):
         return 1
     return int(raw)
 
+def _run_id_sort_key(run_id):
+    """Order GitHub Actions run_ids oldest-to-newest. Run_ids are
+    monotonically increasing integers per repo, so a larger value is the
+    more recent run. `(0, int)` for numeric ids; `(1, str)` for anything
+    non-numeric (defensive — a hand-edited slot sorts after all numeric
+    ids and compares by string)."""
+    s = str(run_id or "")
+    if s.isdigit():
+        return (0, int(s))
+    return (1, s)
+
+def _collapse_by(entries, key_of, rank_of):
+    """Collapse entries sharing a `key_of(entry)` identity to the single
+    entry with the greatest `rank_of(entry)`. Ties keep the first seen,
+    so callers that pre-sort can rely on stable first-wins behavior.
+    Returns the survivors in arbitrary order."""
+    best = {}
+    for e in entries:
+        k = key_of(e)
+        cur = best.get(k)
+        if cur == None or rank_of(e) > rank_of(cur):
+            best[k] = e
+    return list(best.values())
+
 def _dedup_by_run_attempt(entries):
     """Collapse entries that share a `(name, key, job)` identity to the
     one with the highest `run_attempt`.
@@ -371,50 +395,39 @@ def _dedup_by_run_attempt(entries):
     because they're legitimately distinct entries — `job` is part of
     the dedup key.
 
-    Tiebreak on equal `run_attempt`: the first entry to land in
-    `by_logical` wins. Callers feeding entries newest-first (e.g.
-    `_collect_sibling_entries`'s newest-id-first artifact sort) get
-    the newest-by-upstream-ordering as the tiebreaker — sufficient
-    for the only realistic tie scenario (two same-name artifacts on
-    the same attempt left over from a delete-race)."""
-    by_logical = {}
-    for e in entries:
-        key = (e.get("name", ""), e.get("key", ""), e.get("job", ""))
-        existing = by_logical.get(key)
-        if existing == None or _run_attempt_int(e) > _run_attempt_int(existing):
-            by_logical[key] = e
-    return list(by_logical.values())
+    Tiebreak on equal `run_attempt`: the first entry seen wins. Callers
+    feeding entries newest-first (e.g. `_collect_sibling_entries`'s
+    newest-id-first artifact sort) get the newest-by-upstream-ordering
+    as the tiebreaker — sufficient for the only realistic tie (two
+    same-name artifacts on the same attempt left over from a
+    delete-race)."""
+    return _collapse_by(
+        entries,
+        lambda e: (e.get("name", ""), e.get("key", ""), e.get("job", "")),
+        _run_attempt_int,
+    )
 
 def _dedup_for_display(entries):
     """Collapse entries that share a `(job, name, key)` identity across
-    DIFFERENT `workflow_run_id`s down to the one from the newest run.
+    different `workflow_run_id`s to the one from the newest run (by
+    `workflow_run_id`, then `run_attempt`).
 
-    Defense-in-depth against stale cross-workflow slots: `_merge_state`
-    evicts superseded slots (`_newest_run_per_workflow`), so in steady
-    state each logical task appears once. This guards the render path
-    so any future slot leak — or a snapshot row that outlived its
-    eviction by one cycle — can't visibly duplicate a row. Operates on
-    the display copy only; the persisted state block keeps per-run_id
-    granularity for the snapshot-fallback merge.
+    Defense-in-depth on the render path: `_merge_state` already evicts
+    superseded slots (`_live_sibling_runs`), so in steady state each
+    logical task appears once. This guards against a future slot
+    leak — or a snapshot row outliving its eviction by one cycle —
+    visibly duplicating a row. Operates on the display copy only; the
+    persisted state block keeps per-run_id granularity for the
+    snapshot-fallback merge.
 
-    Newest wins by `workflow_run_id` (monotonic per repo), then by
-    `run_attempt`. Distinct concurrent workflows produce distinct
-    `(job, ...)` only when their job names differ; same-named jobs in
-    genuinely-parallel workflows would collapse here, but that's the
-    intended one-row-per-task contract — the row reflects the most
-    recent run."""
-    by_logical = {}
-    for e in entries:
-        key = (e.get("job", ""), e.get("name", ""), e.get("key", ""))
-        existing = by_logical.get(key)
-        if existing == None:
-            by_logical[key] = e
-            continue
-        rank_new = (_run_id_sort_key(e.get("workflow_run_id", "")), _run_attempt_int(e))
-        rank_old = (_run_id_sort_key(existing.get("workflow_run_id", "")), _run_attempt_int(existing))
-        if rank_new > rank_old:
-            by_logical[key] = e
-    return list(by_logical.values())
+    Same-named jobs across genuinely-parallel workflows collapse here,
+    but that matches the one-row-per-task contract — the row reflects
+    the most recent run."""
+    return _collapse_by(
+        entries,
+        lambda e: (e.get("job", ""), e.get("name", ""), e.get("key", "")),
+        lambda e: (_run_id_sort_key(e.get("workflow_run_id", "")), _run_attempt_int(e)),
+    )
 
 def _should_quiet_delete_log(last_upload_at, now):
     """Decide whether a `DeleteArtifact` failure on a pre-upload cleanup
@@ -977,53 +990,39 @@ def _parse_state(body):
         "entries": parsed_entries,
     }
 
-def _run_id_sort_key(run_id):
-    """Sort key that orders GitHub Actions run_ids newest-last.
-
-    Run_ids are monotonically increasing integers per repo, so a larger
-    value is the more recent run. Returns `(0, int)` for numeric ids and
-    `(1, str)` for anything non-numeric (defensive — a hand-edited or
-    malformed slot sorts after all numeric ids and compares by string)."""
-    s = str(run_id or "")
-    if s.isdigit():
-        return (0, int(s))
-    return (1, s)
-
-def _newest_run_per_workflow(workflow_runs, my_run_id, my_workflow_name):
-    """Collapse `workflow_runs` slots to the newest `run_id` per
-    `workflow_name`, evicting slots superseded by a more recent run of
-    the same workflow on the same PR head.
+def _live_sibling_runs(workflow_runs, my_run_id, my_workflow_name):
+    """Filter `workflow_runs` (the comment's existing slots) down to the
+    live run per sibling workflow, dropping this writer's own slot and
+    any run a newer run of the same workflow has superseded.
 
     A workflow re-triggered on the same head SHA keeps its
-    `GITHUB_WORKFLOW` name but gets a fresh `GITHUB_RUN_ID`. Without
-    eviction the stale slot lingers (artifacts expire → frozen snapshot
-    fallback), duplicating every task in that workflow on the rendered
-    comment. Our own run (`my_run_id` / `my_workflow_name`) participates
-    in the contest so a stale prior run of our OWN workflow is dropped
-    too — the caller re-appends our slot afterward.
+    `GITHUB_WORKFLOW` name but gets a fresh `GITHUB_RUN_ID`. Left in
+    place, the stale slot lingers (its artifacts expire → frozen
+    snapshot fallback), duplicating every task in that workflow on the
+    rendered comment. For each named workflow only the newest `run_id`
+    survives. This writer's slot — matched on either `my_run_id` (so an
+    out-of-band-renamed slot at our run_id doesn't double up) or
+    `my_workflow_name` (a prior run of our own workflow) — is dropped so
+    the caller can re-add it as the live run.
 
     Slots with an empty `workflow_name` are passed through untouched
-    (can't be matched to a newer run reliably); each keeps its own
-    identity. Within a name, ties on `run_id` keep the first seen."""
-    contenders = list(workflow_runs)
-    contenders.append({"run_id": str(my_run_id), "workflow_name": my_workflow_name})
-
+    (unless they match `my_run_id`) — they can't be matched to a newer
+    run reliably, so each keeps its own identity."""
     newest_by_name = {}
     passthrough = []
-    for r in contenders:
+    for r in workflow_runs:
+        if str(r.get("run_id", "")) == str(my_run_id):
+            continue
         name = r.get("workflow_name", "") or ""
         if not name:
             passthrough.append(r)
             continue
+        if name == my_workflow_name:
+            continue
         cur = newest_by_name.get(name)
         if cur == None or _run_id_sort_key(r.get("run_id", "")) > _run_id_sort_key(cur.get("run_id", "")):
             newest_by_name[name] = r
-
-    # Exclude the synthetic self-slot we appended; the caller owns
-    # re-appending it (with the authoritative workflow_name).
-    kept = [r for r in (list(newest_by_name.values()) + passthrough)
-            if str(r.get("run_id", "")) != str(my_run_id)]
-    return kept
+    return list(newest_by_name.values()) + passthrough
 
 def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entries, refreshed_other_entries):
     """Build the new state block to write to the comment.
@@ -1034,7 +1033,7 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
         writer overlays its own slot, preserving sibling-workflow slots
         unchanged. Writes are slot-independent → no cross-workflow data
         race. A workflow re-triggered on the same head SHA supersedes
-        its prior slot (`_newest_run_per_workflow`) so stale runs don't
+        its prior slot (`_live_sibling_runs`) so stale runs don't
         accumulate as duplicate task rows.
       * `entries` is the full per-task snapshot, kept for two reasons:
         (a) fallback when a sibling workflow's artifacts are unreachable
@@ -1063,20 +1062,10 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
 
     existing_runs = (existing_state or {}).get("workflow_runs", []) or []
 
-    # Evict superseded slots. A workflow re-triggered on the same PR head
-    # SHA (re-run, repeated `synchronize` that lands on the same commit,
-    # etc.) gets a fresh `GITHUB_RUN_ID` but the same `GITHUB_WORKFLOW`
-    # name. The old run's slot would otherwise persist in the comment
-    # state forever (its artifacts expire, so it falls back to a frozen
-    # snapshot), rendering a phantom duplicate of every task in that
-    # workflow. Keep only the newest `run_id` per `workflow_name` —
-    # run_ids are monotonically increasing per repo, so the lexically/
-    # numerically largest is the live run. Slots feeding into this from
-    # the comment exclude our own (`my_run_id`); our slot is appended
-    # after, so a stale prior run of OUR OWN workflow is dropped too.
-    existing_runs = _newest_run_per_workflow(existing_runs, my_run_id, my_workflow_name)
-
-    other_runs = [r for r in existing_runs if str(r.get("run_id", "")) != str(my_run_id)]
+    # Keep one live slot per sibling workflow (evicting runs superseded
+    # by a re-trigger on the same head SHA), then add our own slot back
+    # as the live run for our name. See `_live_sibling_runs`.
+    other_runs = _live_sibling_runs(existing_runs, my_run_id, my_workflow_name)
     workflow_runs = other_runs + [{"run_id": str(my_run_id), "workflow_name": my_workflow_name}]
 
     # Per-task union of refreshed entries with the comment's prior

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -385,6 +385,37 @@ def _dedup_by_run_attempt(entries):
             by_logical[key] = e
     return list(by_logical.values())
 
+def _dedup_for_display(entries):
+    """Collapse entries that share a `(job, name, key)` identity across
+    DIFFERENT `workflow_run_id`s down to the one from the newest run.
+
+    Defense-in-depth against stale cross-workflow slots: `_merge_state`
+    evicts superseded slots (`_newest_run_per_workflow`), so in steady
+    state each logical task appears once. This guards the render path
+    so any future slot leak — or a snapshot row that outlived its
+    eviction by one cycle — can't visibly duplicate a row. Operates on
+    the display copy only; the persisted state block keeps per-run_id
+    granularity for the snapshot-fallback merge.
+
+    Newest wins by `workflow_run_id` (monotonic per repo), then by
+    `run_attempt`. Distinct concurrent workflows produce distinct
+    `(job, ...)` only when their job names differ; same-named jobs in
+    genuinely-parallel workflows would collapse here, but that's the
+    intended one-row-per-task contract — the row reflects the most
+    recent run."""
+    by_logical = {}
+    for e in entries:
+        key = (e.get("job", ""), e.get("name", ""), e.get("key", ""))
+        existing = by_logical.get(key)
+        if existing == None:
+            by_logical[key] = e
+            continue
+        rank_new = (_run_id_sort_key(e.get("workflow_run_id", "")), _run_attempt_int(e))
+        rank_old = (_run_id_sort_key(existing.get("workflow_run_id", "")), _run_attempt_int(existing))
+        if rank_new > rank_old:
+            by_logical[key] = e
+    return list(by_logical.values())
+
 def _should_quiet_delete_log(last_upload_at, now):
     """Decide whether a `DeleteArtifact` failure on a pre-upload cleanup
     should log at INFO (`True`) or WARN (`False`).
@@ -946,14 +977,65 @@ def _parse_state(body):
         "entries": parsed_entries,
     }
 
+def _run_id_sort_key(run_id):
+    """Sort key that orders GitHub Actions run_ids newest-last.
+
+    Run_ids are monotonically increasing integers per repo, so a larger
+    value is the more recent run. Returns `(0, int)` for numeric ids and
+    `(1, str)` for anything non-numeric (defensive — a hand-edited or
+    malformed slot sorts after all numeric ids and compares by string)."""
+    s = str(run_id or "")
+    if s.isdigit():
+        return (0, int(s))
+    return (1, s)
+
+def _newest_run_per_workflow(workflow_runs, my_run_id, my_workflow_name):
+    """Collapse `workflow_runs` slots to the newest `run_id` per
+    `workflow_name`, evicting slots superseded by a more recent run of
+    the same workflow on the same PR head.
+
+    A workflow re-triggered on the same head SHA keeps its
+    `GITHUB_WORKFLOW` name but gets a fresh `GITHUB_RUN_ID`. Without
+    eviction the stale slot lingers (artifacts expire → frozen snapshot
+    fallback), duplicating every task in that workflow on the rendered
+    comment. Our own run (`my_run_id` / `my_workflow_name`) participates
+    in the contest so a stale prior run of our OWN workflow is dropped
+    too — the caller re-appends our slot afterward.
+
+    Slots with an empty `workflow_name` are passed through untouched
+    (can't be matched to a newer run reliably); each keeps its own
+    identity. Within a name, ties on `run_id` keep the first seen."""
+    contenders = list(workflow_runs)
+    contenders.append({"run_id": str(my_run_id), "workflow_name": my_workflow_name})
+
+    newest_by_name = {}
+    passthrough = []
+    for r in contenders:
+        name = r.get("workflow_name", "") or ""
+        if not name:
+            passthrough.append(r)
+            continue
+        cur = newest_by_name.get(name)
+        if cur == None or _run_id_sort_key(r.get("run_id", "")) > _run_id_sort_key(cur.get("run_id", "")):
+            newest_by_name[name] = r
+
+    # Exclude the synthetic self-slot we appended; the caller owns
+    # re-appending it (with the authoritative workflow_name).
+    kept = [r for r in (list(newest_by_name.values()) + passthrough)
+            if str(r.get("run_id", "")) != str(my_run_id)]
+    return kept
+
 def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entries, refreshed_other_entries):
     """Build the new state block to write to the comment.
 
     The hybrid cross-workflow model:
       * `workflow_runs` is the list of `{run_id, workflow_name}` slots —
-        one per workflow active on this PR. Each writer overlays its own
-        slot, preserving sibling-workflow slots unchanged. Writes are
-        slot-independent → no cross-workflow data race.
+        the newest `run_id` per `workflow_name` active on this PR. Each
+        writer overlays its own slot, preserving sibling-workflow slots
+        unchanged. Writes are slot-independent → no cross-workflow data
+        race. A workflow re-triggered on the same head SHA supersedes
+        its prior slot (`_newest_run_per_workflow`) so stale runs don't
+        accumulate as duplicate task rows.
       * `entries` is the full per-task snapshot, kept for two reasons:
         (a) fallback when a sibling workflow's artifacts are unreachable
         (TTL expiry, transient API error); (b) terminal-state
@@ -980,6 +1062,20 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
         existing_state = None
 
     existing_runs = (existing_state or {}).get("workflow_runs", []) or []
+
+    # Evict superseded slots. A workflow re-triggered on the same PR head
+    # SHA (re-run, repeated `synchronize` that lands on the same commit,
+    # etc.) gets a fresh `GITHUB_RUN_ID` but the same `GITHUB_WORKFLOW`
+    # name. The old run's slot would otherwise persist in the comment
+    # state forever (its artifacts expire, so it falls back to a frozen
+    # snapshot), rendering a phantom duplicate of every task in that
+    # workflow. Keep only the newest `run_id` per `workflow_name` —
+    # run_ids are monotonically increasing per repo, so the lexically/
+    # numerically largest is the live run. Slots feeding into this from
+    # the comment exclude our own (`my_run_id`); our slot is appended
+    # after, so a stale prior run of OUR OWN workflow is dropped too.
+    existing_runs = _newest_run_per_workflow(existing_runs, my_run_id, my_workflow_name)
+
     other_runs = [r for r in existing_runs if str(r.get("run_id", "")) != str(my_run_id)]
     workflow_runs = other_runs + [{"run_id": str(my_run_id), "workflow_name": my_workflow_name}]
 
@@ -1498,7 +1594,13 @@ def _github_status_comments(ctx: FeatureContext):
                     refreshed_others[other_run_id] = other_entries
 
         new_state = _merge_state(parsed, head_sha, run_id, workflow_name, raw_entries, refreshed_others)
-        prepared = _prepare_for_render(new_state["entries"])
+
+        # Render from a logical-identity-deduped view so a leaked or
+        # one-cycle-stale duplicate slot can't surface the same task
+        # twice. The persisted `new_state["entries"]` keeps per-run_id
+        # granularity for the snapshot-fallback merge — only the display
+        # copy collapses.
+        prepared = _prepare_for_render(_dedup_for_display(new_state["entries"]))
         sections = _bucket_entries(prepared)
 
         # Earliest start across all sibling tasks (own + cross-workflow)
@@ -1718,6 +1820,10 @@ def bucket_entries(entries):
 def dedup_by_run_attempt(entries):
     """Public test hook; see `_dedup_by_run_attempt`."""
     return _dedup_by_run_attempt(entries)
+
+def dedup_for_display(entries):
+    """Public test hook; see `_dedup_for_display`."""
+    return _dedup_for_display(entries)
 
 def should_quiet_delete_log(last_upload_at, now):
     """Public test hook; see `_should_quiet_delete_log`."""

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -1039,6 +1039,31 @@ def _check_merge_state_evicts_superseded_sibling_run():
     run_ids_with_lint = [e["workflow_run_id"] for e in new["entries"] if e["name"] == "lint"]
     _eq("merge — only newest sibling lint row kept", run_ids_with_lint, ["700"])
 
+def _check_merge_state_losing_rerun_does_not_resurrect():
+    """Rerun race: a newer run (999) of our workflow already published
+    its slot, and we are the OLDER run (100) still executing. We must
+    NOT evict the newer slot and reinstate our own — that would
+    resurrect stale rows. We lose the contest, contribute nothing, and
+    the newer run's slot + rows survive."""
+    existing = {
+        "head_sha": "abc",
+        "workflow_runs": [
+            {"run_id": "999", "workflow_name": "ci-gha"},
+        ],
+        "entries": [
+            {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "999", "status": "running"},
+        ],
+    }
+
+    # We are the older run 100; our entries are stale.
+    my_entries = [{"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "status": "passed"}]
+    new = merge_state(existing, "abc", "100", "ci-gha", my_entries, {})
+
+    rids = [r["run_id"] for r in new["workflow_runs"]]
+    _eq("merge — losing rerun keeps only the newer slot", rids, ["999"])
+    run_ids = sorted([e["workflow_run_id"] for e in new["entries"]])
+    _eq("merge — losing rerun contributes no rows of its own", run_ids, ["999"])
+
 def _check_merge_state_keeps_empty_workflow_name_slots():
     """Slots with an empty `workflow_name` (e.g. older aspect-cli
     writers that didn't stamp it) can't be matched to a newer run, so
@@ -1055,17 +1080,18 @@ def _check_merge_state_keeps_empty_workflow_name_slots():
     rids = sorted([r["run_id"] for r in new["workflow_runs"]])
     _eq("merge — empty-name slots both kept", rids, ["100", "200", "999"])
 
-def _check_dedup_for_display_collapses_stale_duplicates():
-    """`_dedup_for_display` collapses a `(job, name, key)` that appears
-    under two `workflow_run_id`s to the newest run's row — the render
-    path's defense against a leaked/one-cycle-stale duplicate slot."""
+def _check_dedup_for_display_collapses_exact_duplicates():
+    """`_dedup_for_display` collapses an exact-duplicate row — same
+    `(workflow_run_id, job, name, key)` — to the higher `run_attempt`,
+    guarding against a snapshot that briefly carries two rows for one
+    task within a single run_id."""
     out = dedup_for_display([
-        {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "status": "passed"},
-        {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "999", "status": "running"},
+        {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "run_attempt": "1", "status": "running"},
+        {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "run_attempt": "2", "status": "passed"},
     ])
     if len(out) != 1:
         fail("dedup_for_display: expected 1 row, got %d: %r" % (len(out), out))
-    _eq("dedup_for_display — newest run_id wins", out[0]["status"], "running")
+    _eq("dedup_for_display — higher run_attempt wins", out[0]["status"], "passed")
 
 def _check_dedup_for_display_keeps_distinct_jobs():
     """Distinct `job` values are legitimately separate rows (matrix
@@ -1077,17 +1103,16 @@ def _check_dedup_for_display_keeps_distinct_jobs():
     ])
     _eq("dedup_for_display — distinct jobs kept", len(out), 2)
 
-def _check_dedup_for_display_run_attempt_tiebreak():
-    """Within a single `workflow_run_id`, the higher `run_attempt` wins
-    — same precedence as `_dedup_by_run_attempt`, applied after the
-    run_id comparison."""
+def _check_dedup_for_display_keeps_distinct_workflows():
+    """Two genuinely-concurrent workflows that share a `(job, name,
+    key)` (e.g. a common `test` job in two workflow files) must BOTH
+    render — `workflow_run_id` is part of the display identity, so they
+    are not collapsed into one row."""
     out = dedup_for_display([
-        {"name": "test", "key": "t", "job": "test", "workflow_run_id": "100", "run_attempt": "1", "status": "running"},
-        {"name": "test", "key": "t", "job": "test", "workflow_run_id": "100", "run_attempt": "2", "status": "passed"},
+        {"name": "test", "key": "test", "job": "test", "workflow_run_id": "100", "status": "passed"},
+        {"name": "test", "key": "test", "job": "test", "workflow_run_id": "200", "status": "running"},
     ])
-    if len(out) != 1:
-        fail("dedup_for_display tiebreak: expected 1 row, got %d: %r" % (len(out), out))
-    _eq("dedup_for_display — higher run_attempt wins on equal run_id", out[0]["status"], "passed")
+    _eq("dedup_for_display — distinct workflows both kept", len(out), 2)
 
 def _check_render_body_emits_state_block(ctx):
     """When `state` is set, the rendered body carries an HTML-comment
@@ -1239,10 +1264,11 @@ def _test_impl(ctx):
     _check_merge_state_drops_orphan_snapshot_entries()
     _check_merge_state_evicts_superseded_workflow_run()
     _check_merge_state_evicts_superseded_sibling_run()
+    _check_merge_state_losing_rerun_does_not_resurrect()
     _check_merge_state_keeps_empty_workflow_name_slots()
-    _check_dedup_for_display_collapses_stale_duplicates()
+    _check_dedup_for_display_collapses_exact_duplicates()
     _check_dedup_for_display_keeps_distinct_jobs()
-    _check_dedup_for_display_run_attempt_tiebreak()
+    _check_dedup_for_display_keeps_distinct_workflows()
     _check_merge_state_workflow_runs_sorted()
     _check_merge_state_entries_sorted()
     _check_render_body_emits_state_block(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -31,6 +31,7 @@ load(
     "bucket_entries",
     "collect_tip_rows",
     "dedup_by_run_attempt",
+    "dedup_for_display",
     "lease_held",
     "max_recent_upsert_epoch",
     "merge_state",
@@ -982,6 +983,78 @@ def _check_merge_state_drops_stale_push():
     _eq("merge — stale-push drops slots", new["workflow_runs"], [{"run_id": "100", "workflow_name": "ci-gha"}])
     _eq("merge — stale-push drops entries", new["entries"], my_entries)
 
+def _check_merge_state_evicts_superseded_workflow_run():
+    """A workflow re-triggered on the same PR head SHA gets a fresh
+    `run_id` but the same `workflow_name`. The stale slot (and its
+    snapshot entries) must be evicted in favor of the newest run, or
+    every task in that workflow renders as a phantom duplicate. This is
+    the root cause of the reported cross-comment task duplication."""
+    existing = {
+        "head_sha": "abc",
+        "workflow_runs": [
+            # An older run of the SAME workflow we're now running as.
+            {"run_id": "100", "workflow_name": "ci-gha"},
+            # A genuinely-distinct concurrent workflow — must survive.
+            {"run_id": "500", "workflow_name": "ci-workflows"},
+        ],
+        "entries": [
+            {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "status": "passed"},
+            {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "500", "status": "passed"},
+        ],
+    }
+    # We are a newer run (run_id 999) of "ci-gha".
+    my_entries = [{"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "999", "status": "running"}]
+    new = merge_state(existing, "abc", "999", "ci-gha", my_entries, {})
+
+    rids = sorted([r["run_id"] for r in new["workflow_runs"]])
+    _eq("merge — superseded slot evicted, sibling kept", rids, ["500", "999"])
+
+    # The stale run_id=100 snapshot entry must not survive — only our
+    # live row + the distinct sibling workflow's row.
+    keyed = {(e["name"], e["key"], e.get("workflow_run_id", "")): e for e in new["entries"]}
+    if ("test", "cpu", "100") in keyed:
+        fail("merge — stale superseded entry should be dropped, got %r" % new["entries"])
+    _eq("merge — our live row survives", keyed[("test", "cpu", "999")]["status"], "running")
+    _eq("merge — distinct sibling workflow row survives", keyed[("lint", "lint", "500")]["status"], "passed")
+
+def _check_merge_state_keeps_empty_workflow_name_slots():
+    """Slots with an empty `workflow_name` (e.g. older aspect-cli
+    writers that didn't stamp it) can't be matched to a newer run, so
+    they're passed through untouched rather than collapsed together."""
+    existing = {
+        "head_sha": "abc",
+        "workflow_runs": [
+            {"run_id": "100", "workflow_name": ""},
+            {"run_id": "200", "workflow_name": ""},
+        ],
+        "entries": [],
+    }
+    new = merge_state(existing, "abc", "999", "ci-gha", [], {})
+    rids = sorted([r["run_id"] for r in new["workflow_runs"]])
+    _eq("merge — empty-name slots both kept", rids, ["100", "200", "999"])
+
+def _check_dedup_for_display_collapses_stale_duplicates():
+    """`_dedup_for_display` collapses a `(job, name, key)` that appears
+    under two `workflow_run_id`s to the newest run's row — the render
+    path's defense against a leaked/one-cycle-stale duplicate slot."""
+    out = dedup_for_display([
+        {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "status": "passed"},
+        {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "999", "status": "running"},
+    ])
+    if len(out) != 1:
+        fail("dedup_for_display: expected 1 row, got %d: %r" % (len(out), out))
+    _eq("dedup_for_display — newest run_id wins", out[0]["status"], "running")
+
+def _check_dedup_for_display_keeps_distinct_jobs():
+    """Distinct `job` values are legitimately separate rows (matrix
+    jobs / distinct workflows with different job names) and must not
+    collapse."""
+    out = dedup_for_display([
+        {"name": "test", "key": "t", "job": "test (cpu)", "workflow_run_id": "100"},
+        {"name": "test", "key": "t", "job": "test (gpu)", "workflow_run_id": "100"},
+    ])
+    _eq("dedup_for_display — distinct jobs kept", len(out), 2)
+
 def _check_render_body_emits_state_block(ctx):
     """When `state` is set, the rendered body carries an HTML-comment
     state block whose payload parses back to the state we passed."""
@@ -1130,6 +1203,10 @@ def _test_impl(ctx):
     _check_merge_state_replaces_own_slot()
     _check_merge_state_drops_stale_push()
     _check_merge_state_drops_orphan_snapshot_entries()
+    _check_merge_state_evicts_superseded_workflow_run()
+    _check_merge_state_keeps_empty_workflow_name_slots()
+    _check_dedup_for_display_collapses_stale_duplicates()
+    _check_dedup_for_display_keeps_distinct_jobs()
     _check_merge_state_workflow_runs_sorted()
     _check_merge_state_entries_sorted()
     _check_render_body_emits_state_block(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -1002,6 +1002,7 @@ def _check_merge_state_evicts_superseded_workflow_run():
             {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "500", "status": "passed"},
         ],
     }
+
     # We are a newer run (run_id 999) of "ci-gha".
     my_entries = [{"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "999", "status": "running"}]
     new = merge_state(existing, "abc", "999", "ci-gha", my_entries, {})

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -1017,6 +1017,27 @@ def _check_merge_state_evicts_superseded_workflow_run():
     _eq("merge — our live row survives", keyed[("test", "cpu", "999")]["status"], "running")
     _eq("merge — distinct sibling workflow row survives", keyed[("lint", "lint", "500")]["status"], "passed")
 
+def _check_merge_state_evicts_superseded_sibling_run():
+    """Two slots for the same SIBLING workflow (a re-run of a workflow
+    that isn't ours) collapse to the newest run_id — the eviction isn't
+    limited to our own workflow."""
+    existing = {
+        "head_sha": "abc",
+        "workflow_runs": [
+            {"run_id": "300", "workflow_name": "ci-workflows"},
+            {"run_id": "700", "workflow_name": "ci-workflows"},
+        ],
+        "entries": [
+            {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "300", "status": "running"},
+            {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "700", "status": "passed"},
+        ],
+    }
+    new = merge_state(existing, "abc", "999", "ci-gha", [], {})
+    rids = sorted([r["run_id"] for r in new["workflow_runs"]])
+    _eq("merge — superseded sibling run evicted", rids, ["700", "999"])
+    run_ids_with_lint = [e["workflow_run_id"] for e in new["entries"] if e["name"] == "lint"]
+    _eq("merge — only newest sibling lint row kept", run_ids_with_lint, ["700"])
+
 def _check_merge_state_keeps_empty_workflow_name_slots():
     """Slots with an empty `workflow_name` (e.g. older aspect-cli
     writers that didn't stamp it) can't be matched to a newer run, so
@@ -1054,6 +1075,18 @@ def _check_dedup_for_display_keeps_distinct_jobs():
         {"name": "test", "key": "t", "job": "test (gpu)", "workflow_run_id": "100"},
     ])
     _eq("dedup_for_display — distinct jobs kept", len(out), 2)
+
+def _check_dedup_for_display_run_attempt_tiebreak():
+    """Within a single `workflow_run_id`, the higher `run_attempt` wins
+    — same precedence as `_dedup_by_run_attempt`, applied after the
+    run_id comparison."""
+    out = dedup_for_display([
+        {"name": "test", "key": "t", "job": "test", "workflow_run_id": "100", "run_attempt": "1", "status": "running"},
+        {"name": "test", "key": "t", "job": "test", "workflow_run_id": "100", "run_attempt": "2", "status": "passed"},
+    ])
+    if len(out) != 1:
+        fail("dedup_for_display tiebreak: expected 1 row, got %d: %r" % (len(out), out))
+    _eq("dedup_for_display — higher run_attempt wins on equal run_id", out[0]["status"], "passed")
 
 def _check_render_body_emits_state_block(ctx):
     """When `state` is set, the rendered body carries an HTML-comment
@@ -1204,9 +1237,11 @@ def _test_impl(ctx):
     _check_merge_state_drops_stale_push()
     _check_merge_state_drops_orphan_snapshot_entries()
     _check_merge_state_evicts_superseded_workflow_run()
+    _check_merge_state_evicts_superseded_sibling_run()
     _check_merge_state_keeps_empty_workflow_name_slots()
     _check_dedup_for_display_collapses_stale_duplicates()
     _check_dedup_for_display_keeps_distinct_jobs()
+    _check_dedup_for_display_run_attempt_tiebreak()
     _check_merge_state_workflow_runs_sorted()
     _check_merge_state_entries_sorted()
     _check_render_body_emits_state_block(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -1114,6 +1114,45 @@ def _check_dedup_for_display_keeps_distinct_workflows():
     ])
     _eq("dedup_for_display — distinct workflows both kept", len(out), 2)
 
+def _check_rerun_renders_each_task_once(ctx):
+    """End-to-end regression for the reported duplication: a comment
+    whose state block still carries a stale prior run of our workflow
+    must render each task exactly once after merge + display dedup.
+
+    Drives the full publish-side pipeline a writer uses: merge_state →
+    dedup_for_display → bucket_entries → render_body."""
+    existing = {
+        "head_sha": "abc",
+        "workflow_runs": [{"run_id": "100", "workflow_name": "ci-gha"}],
+        "entries": [
+            {"name": "test", "key": "cpu-test", "job": "test (cpu-test)", "workflow_run_id": "100", "status": "passed"},
+            {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "100", "status": "passed"},
+        ],
+    }
+
+    # We are a newer run (999) of the same workflow with the same tasks.
+    my_entries = [
+        {"name": "test", "key": "cpu-test", "job": "test (cpu-test)", "workflow_run_id": "999", "status": "passed"},
+        {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "999", "status": "passed"},
+    ]
+    new = merge_state(existing, "abc", "999", "ci-gha", my_entries, {})
+
+    prepared = prepare_for_render(dedup_for_display(new["entries"]))
+    sections = bucket_entries(prepared)
+    body = render_body(
+        ctx,
+        MARKER_FMT % 7,
+        prepared,
+        "2026-01-01 00:00:00 UTC",
+        DEFAULT_BODY_TEMPLATE,
+        DEFAULT_STATUS_BADGES,
+        sections,
+        state = new,
+    )
+    _eq("rerun render — 'test (cpu-test)' appears once", body.count("test (cpu-test)"), 1)
+    _eq("rerun render — 'lint' row appears once", body.count("✅ lint"), 1)
+    _eq("rerun render — two task rows total", body.count("<br>💬"), 2)
+
 def _check_render_body_emits_state_block(ctx):
     """When `state` is set, the rendered body carries an HTML-comment
     state block whose payload parses back to the state we passed."""
@@ -1269,6 +1308,7 @@ def _test_impl(ctx):
     _check_dedup_for_display_collapses_exact_duplicates()
     _check_dedup_for_display_keeps_distinct_jobs()
     _check_dedup_for_display_keeps_distinct_workflows()
+    _check_rerun_renders_each_task_once(ctx)
     _check_merge_state_workflow_runs_sorted()
     _check_merge_state_entries_sorted()
     _check_render_body_emits_state_block(ctx)


### PR DESCRIPTION
## Summary

**Issue.** The cross-workflow state block keys its `workflow_runs` slots by `GITHUB_RUN_ID`. A workflow re-triggered on the same PR head SHA — a re-run, or a `synchronize` event landing back on the same commit — keeps its `GITHUB_WORKFLOW` name but gets a new `run_id`. The prior run's slot was never evicted (`head_sha` still matched), so it lingered; its artifacts had expired, so it fell back to a frozen snapshot — rendering a phantom copy of every task in that workflow. Each re-trigger stacked another full set of rows.

**Fix.** `_merge_state` reduces `workflow_runs` to the newest `run_id` per `workflow_name` (`_live_runs`), evicting superseded runs and their snapshot entries. The current run competes in that contest rather than winning by fiat: in a re-run race where an *older* run is still publishing after a newer run has updated the comment, the older run loses and contributes nothing, so it can't resurrect stale rows over the newer run's.

As defense-in-depth, the render path drops exact-duplicate rows (`_dedup_for_display`). Its identity includes `workflow_run_id`, so genuinely-distinct concurrent workflows that share a `(job, name, key)` (e.g. a common `test` job in two workflow files) each keep their row.

The persisted state block retains per-`run_id` granularity for the snapshot-fallback merge; only the display copy collapses.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fixed task duplication on the GitHub PR status comment when a workflow is re-run or re-triggered on the same PR commit.

### Test plan

- New test cases added (`test-pr-comment-snapshots`):
  - `merge_state` eviction: superseded run of our own workflow, of a sibling workflow, the losing-rerun race, and empty-`workflow_name` passthrough.
  - `dedup_for_display`: collapses exact duplicates, keeps distinct jobs, keeps distinct concurrent workflows.
  - End-to-end: a stale-rerun state block renders each task exactly once through merge → display-dedup → render.
- Covered by existing test cases — full `test-pr-comment-snapshots` suite passes.
