### PR TITLE
tips: drop GitLab commit-status surface and unexport built-in tips

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -87,7 +87,6 @@ load(
     "effective_throttle_factor",
     "should_emit_phase_change",
 )
-load("../lib/tips.axl", "SURFACE_GITLAB_COMMIT_STATUSES", "collect_tips_sorted")
 
 _LOG = feature_logger("GitLab commit statuses")
 
@@ -299,7 +298,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             ctx,
             initial_renderer.init(),
             "running",
-            make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITLAB_COMMIT_STATUSES), last_updated_at = format_run_date(ctx, now_ms(ctx))),
+            make_render_ctx(_state, last_updated_at = format_run_date(ctx, now_ms(ctx))),
             initial_links,
             templates,
             metadata_keys,
@@ -373,7 +372,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             ctx,
             data,
             status,
-            make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITLAB_COMMIT_STATUSES), last_updated_at = format_run_date(ctx, now_ms(ctx))),
+            make_render_ctx(_state, last_updated_at = format_run_date(ctx, now_ms(ctx))),
             links,
             templates,
             metadata_keys,

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -127,16 +127,17 @@ _VALID_TEMPLATE_TYPES = [TIP_TEMPLATE_RAW, TIP_TEMPLATE_FORMAT, TIP_TEMPLATE_JIN
 #   SURFACE_CLI                    the terminal `TIP:` block printed on emit
 #   SURFACE_GITHUB_STATUS_CHECKS   GitHub check-run summary (GithubStatusChecks)
 #   SURFACE_BUILDKITE_ANNOTATIONS  Buildkite annotation (BuildkiteAnnotations)
-#   SURFACE_GITLAB_COMMIT_STATUSES GitLab commit-status description (GitlabCommitStatuses)
 #   SURFACE_GITHUB_PR_SUMMARY      the cross-task GitHub PR summary comment
 #                                  (GithubStatusComments) — the only
 #                                  *aggregate* surface, where same-`(id, key)`
 #                                  tips from sibling tasks combine. See
 #                                  "Cross-task accumulation".
+#
+# (GitLab commit statuses are a single short description string with no
+# room to render a tip, so there's no GitLab surface.)
 SURFACE_CLI = "cli"
 SURFACE_GITHUB_STATUS_CHECKS = "github-status-checks"
 SURFACE_BUILDKITE_ANNOTATIONS = "buildkite-annotations"
-SURFACE_GITLAB_COMMIT_STATUSES = "gitlab-commit-statuses"
 SURFACE_GITHUB_PR_SUMMARY = "github-pr-summary"
 
 # Per-task status screens — every surface bound to a single task's own
@@ -144,7 +145,7 @@ SURFACE_GITHUB_PR_SUMMARY = "github-pr-summary"
 # in the context of the one task that emitted it (dynamic, per-invocation
 # detail) should set `surfaces = TASK_SCREENS` so it never lands in the
 # cross-task rollup.
-TASK_SCREENS = [SURFACE_CLI, SURFACE_GITHUB_STATUS_CHECKS, SURFACE_BUILDKITE_ANNOTATIONS, SURFACE_GITLAB_COMMIT_STATUSES]
+TASK_SCREENS = [SURFACE_CLI, SURFACE_GITHUB_STATUS_CHECKS, SURFACE_BUILDKITE_ANNOTATIONS]
 
 # The aggregate screen(s) — just the PR summary today, named as a list so
 # `surfaces = AGGREGATE_SCREENS` reads symmetrically with `TASK_SCREENS`

--- a/crates/aspect-cli/src/builtins/aspect/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/tips.axl
@@ -17,7 +17,6 @@ and customize tips with a single import:
          "SURFACE_CLI",
          "SURFACE_GITHUB_STATUS_CHECKS",
          "SURFACE_BUILDKITE_ANNOTATIONS",
-         "SURFACE_GITLAB_COMMIT_STATUSES",
          "SURFACE_GITHUB_PR_SUMMARY",
          "TASK_SCREENS",
          "AGGREGATE_SCREENS",
@@ -30,20 +29,17 @@ and customize tips with a single import:
          "tip_replace")
 
 This is the customer-facing surface; internal modules load directly from
-`lib/tips.axl`. The built-in tips (`tip_add_github_token`, …) are
-re-exported too so a config can call them or preempt / silence them by id.
+`lib/tips.axl`.
 """
 
 load(
     "./lib/tips.axl",
     _AGGREGATE_SCREENS = "AGGREGATE_SCREENS",
-    _AspectApiTokenHost = "AspectApiTokenHost",
     _SURFACE_ALL = "SURFACE_ALL",
     _SURFACE_BUILDKITE_ANNOTATIONS = "SURFACE_BUILDKITE_ANNOTATIONS",
     _SURFACE_CLI = "SURFACE_CLI",
     _SURFACE_GITHUB_PR_SUMMARY = "SURFACE_GITHUB_PR_SUMMARY",
     _SURFACE_GITHUB_STATUS_CHECKS = "SURFACE_GITHUB_STATUS_CHECKS",
-    _SURFACE_GITLAB_COMMIT_STATUSES = "SURFACE_GITLAB_COMMIT_STATUSES",
     _TASK_SCREENS = "TASK_SCREENS",
     _TIP_ACCEPT = "TIP_ACCEPT",
     _TIP_IMPORTANT = "TIP_IMPORTANT",
@@ -59,10 +55,6 @@ load(
     _TipSuggestion = "TipSuggestion",
     _TipsTrait = "TipsTrait",
     _add_tip = "add_tip",
-    _tip_add_aspect_api_token = "tip_add_aspect_api_token",
-    _tip_add_github_token = "tip_add_github_token",
-    _tip_add_github_token_scope = "tip_add_github_token_scope",
-    _tip_add_id_token_permission = "tip_add_id_token_permission",
     _tip_replace = "tip_replace",
     _tips = "tips",
 )
@@ -82,7 +74,6 @@ TIP_TEMPLATE_JINJA2 = _TIP_TEMPLATE_JINJA2
 SURFACE_CLI = _SURFACE_CLI
 SURFACE_GITHUB_STATUS_CHECKS = _SURFACE_GITHUB_STATUS_CHECKS
 SURFACE_BUILDKITE_ANNOTATIONS = _SURFACE_BUILDKITE_ANNOTATIONS
-SURFACE_GITLAB_COMMIT_STATUSES = _SURFACE_GITLAB_COMMIT_STATUSES
 SURFACE_GITHUB_PR_SUMMARY = _SURFACE_GITHUB_PR_SUMMARY
 TASK_SCREENS = _TASK_SCREENS
 AGGREGATE_SCREENS = _AGGREGATE_SCREENS
@@ -113,9 +104,7 @@ def add_tip(
     """Add a tip to the task's tip storage and print a `TIP:` block to
     the terminal (subject to the owner feature's `auto_print` arg).
 
-    The single entry point for tips. Built-in tips are `tip_*(ctx, …)`
-    functions that wrap this with their content baked in (e.g.
-    `tip_add_github_token(ctx)`); call `add_tip` directly for custom tips.
+    The single entry point for tips.
 
     A tip is identified by `(id, key)`. Re-emitting the same `(id, key)`
     within a task replaces the stored content (accumulate fields ride
@@ -158,8 +147,8 @@ def add_tip(
         `TIP_TEMPLATE_JINJA2` only.
       surfaces: Allowlist of surface identifiers (`SURFACE_CLI` /
         `SURFACE_GITHUB_STATUS_CHECKS` / `SURFACE_BUILDKITE_ANNOTATIONS` /
-        `SURFACE_GITLAB_COMMIT_STATUSES` / `SURFACE_GITHUB_PR_SUMMARY`, or
-        the `TASK_SCREENS` / `AGGREGATE_SCREENS` shorthands) that may
+        `SURFACE_GITHUB_PR_SUMMARY`, or the `TASK_SCREENS` /
+        `AGGREGATE_SCREENS` shorthands) that may
         render the tip. Empty (the default) shows it everywhere
         (`SURFACE_ALL`). The terminal print is gated on `SURFACE_CLI`;
         omit `SURFACE_GITHUB_PR_SUMMARY` to keep the tip off the cross-task
@@ -192,42 +181,3 @@ TipSuggestion = _TipSuggestion
 TIP_ACCEPT = _TIP_ACCEPT
 TIP_REJECT = _TIP_REJECT
 tip_replace = _tip_replace
-
-# Built-in tips (typed pass-throughs to `lib/tips.axl`; a config can call
-# or preempt them, and silence by the id each emits, e.g. `add-github-token`).
-AspectApiTokenHost = _AspectApiTokenHost
-
-def tip_add_github_token(ctx: TaskContext):
-    """Suggest exporting `GITHUB_TOKEN` as a fallback for supporting
-    GitHub API calls (job URL lookup, PR file diff, etc.) when the
-    Aspect Workflows GitHub App can't authenticate."""
-    _tip_add_github_token(ctx)
-
-def tip_add_aspect_api_token(ctx: TaskContext, host: AspectApiTokenHost):
-    """Tell the user to set `ASPECT_API_TOKEN` so the Aspect Workflows
-    GitHub App can authenticate. IMPORTANT severity — every feature that
-    calls the GitHub API as the App depends on it, and silently degrades
-    without it.
-
-    `host` is an `AspectApiTokenHost`; it selects the wire-up advice and a
-    host-suffixed id (`add-aspect-api-token-<host>`) so users running
-    multiple CI hosts off one repo can silence each independently."""
-    _tip_add_aspect_api_token(ctx, host = host)
-
-def tip_add_github_token_scope(ctx: TaskContext, scopes: str, endpoints: str):
-    """Warn that the job-scoped `GITHUB_TOKEN` lacks scopes a supporting
-    API call needed, so the call fell back to the App token. Accumulating:
-    each call passes the single missing `scopes` / `endpoints` value it hit;
-    repeated emits union into one tip (deduped + sorted), and
-    `combine_across_tasks` unions the set across every task into one
-    PR-summary row. Pluralization + per-scope snippet lines are Jinja2
-    over the merged `accumulate` state."""
-    _tip_add_github_token_scope(ctx, scopes = scopes, endpoints = endpoints)
-
-def tip_add_id_token_permission(ctx: TaskContext):
-    """Tell the user to grant `id-token: write` so GitHub Actions
-    artifact uploads (status payloads, BEP files, test logs, profiles —
-    and the PR summary aggregator that rides on them) can obtain the OIDC
-    token the ArtifactService needs. IMPORTANT — these features fail
-    outright without it, and important tips can't be silenced."""
-    _tip_add_id_token_permission(ctx)


### PR DESCRIPTION
Two cleanups to the public tips API surface (`@aspect//tips.axl`).

**Remove `SURFACE_GITLAB_COMMIT_STATUSES`.** A GitLab commit status is a single ~255-char description string with no room to render a tip, so the surface never had a meaningful render target. Drops the constant, removes it from the `TASK_SCREENS` shorthand, and stops `gitlab_commit_statuses.axl` from collecting tips that can't surface.

**Unexport the built-in `tip_*` functions + `AspectApiTokenHost`.** These were re-exported from the public facade, but they're internal — only `github.axl` fires them (loading from `lib/tips.axl` directly), and the public authoring API is `add_tip`. The implementations stay in `lib/tips.axl` untouched; only the facade re-exports are removed.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (the tips guide is updated in a companion docs PR)
- Breaking change (forces users to change their own code or config): no — these symbols shipped in v2026.23.40 but aren't part of the documented authoring API.

### Suggested release notes

- The public `@aspect//tips.axl` no longer exports `SURFACE_GITLAB_COMMIT_STATUSES` (GitLab commit statuses have no tip render room) or the built-in `tip_*` functions (internal; author tips with `add_tip`).

### Test plan

- Covered by existing test cases — `test-tips`, `test-github-detect` (still exercises the built-ins via the lib impls), `test-gitlab-features`, `test-pr-comment-snapshots`, `test-bk-annotation-snapshots`, `test-ci`, `test-helpers` all pass; `buildifier` clean.
