### PR TITLE
tips: drop the unused add_tip(task_keys=…) argument

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -53,18 +53,9 @@ aggregator) call it with their own surface id and display the result.
     TIP_WARNING     — degraded behavior; user should fix to restore full function.
     TIP_SUGGESTION  — improvement opportunity; product works fine without it.
     TIP_INFO        — FYI.
-
-# Task-key scoping
-
-Each tip optionally carries `task_keys` — a list of glob patterns matched
-against `ctx.task.key` at render time. When empty (the default), the tip
-shows on the task it was emitted into and no others. When non-empty,
-the tip shows only on tasks whose key matches one of the patterns.
-`["*"]` shows on every task, `["lint-*"]` on lint variants, etc.
 """
 
 load("./environment.axl", "color_enabled")
-load("./path_glob.axl", "match_any")
 
 # ── Severity constants ───────────────────────────────────────────────
 
@@ -288,7 +279,7 @@ def tip_replace(
 # ── Private trait — owner-feature implementation detail ────────────
 #
 # Every stored tip carries `{id, key, severity, title, body, type,
-# task_keys, surfaces, combine_across_tasks}`; JINJA2 tips additionally
+# surfaces, combine_across_tasks}`; JINJA2 tips additionally
 # carry `_title_src`, `_body_src` (the Jinja2 source), `vars`, and
 # `accumulate` (dict<name, list<value>>) so the owner can re-render on
 # accumulation. A same-`(id, key)` re-emit replaces the stored tip
@@ -311,7 +302,7 @@ _TipsTrait = trait(
     add = attr(typing.Callable[[TaskContext, dict], None], default = lambda ctx, t: None),
 
     # Return the raw, insertion-ordered list of stored tip dicts.
-    # `collect_tips_sorted` filters by task_keys and sorts on top.
+    # `collect_tips_sorted` filters by surface and sorts on top.
     collect = attr(typing.Callable[[], list], default = lambda: []),
 
     # Test seams. Owner feature binds these; production code should
@@ -492,7 +483,6 @@ def add_tip(
         body: str,
         type: str = TIP_TEMPLATE_RAW,
         key: str = "",
-        task_keys: list = [],
         vars: dict = {},
         accumulate: dict = {},
         surfaces: list = [],
@@ -521,7 +511,6 @@ def add_tip(
         "id": id,
         "key": key,
         "severity": severity,
-        "task_keys": list(task_keys) if task_keys else [],
         "type": type,
         "surfaces": surfaces_list,
         "combine_across_tasks": combine_across_tasks,
@@ -537,16 +526,10 @@ def add_tip(
     ctx.traits[_TipsTrait].add(ctx, tip)
 
 def collect_tips_sorted(ctx, limit = None, surface = None):
-    """Return the current tips list filtered by `task_keys` (when set)
-    against `ctx.task.key` and by `surface` (when set) against each tip's
-    `surfaces` allowlist, then sorted by severity (highest urgency
-    first); the sort is stable, so insertion order is preserved
-    within a severity bucket.
-
-    Tips without `task_keys` pass through unconditionally — they're
-    scoped to the task they were emitted into. Tips with `task_keys`
-    apply only on tasks whose key matches one of the glob patterns
-    (e.g. `["lint-*"]`, `["*"]`).
+    """Return the task's tips filtered by `surface` (when set) against each
+    tip's `surfaces` allowlist, then sorted by severity (highest urgency
+    first); the sort is stable, so insertion order is preserved within a
+    severity bucket.
 
     `surface` is the calling surface's identifier (e.g.
     `SURFACE_GITHUB_STATUS_CHECKS`, `SURFACE_GITHUB_PR_SUMMARY`). When set, a tip
@@ -558,15 +541,7 @@ def collect_tips_sorted(ctx, limit = None, surface = None):
     Pass `limit` to cap the result for space-constrained surfaces
     (e.g. PR comment summary).
     """
-    task_key = ctx.task.key
-    filtered = []
-    for t in ctx.traits[_TipsTrait].collect():
-        patterns = t.get("task_keys") or []
-        if patterns and not match_any(patterns, task_key):
-            continue
-        if not tip_shows_on(t, surface):
-            continue
-        filtered.append(t)
+    filtered = [t for t in ctx.traits[_TipsTrait].collect() if tip_shows_on(t, surface)]
     out = sorted(filtered, key = lambda t: severity_rank(t.get("severity")))
     if limit != None and limit >= 0:
         out = out[:limit]

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -8,7 +8,7 @@ Covers the tip framework primitives directly:
                 severity guard, and `silenced_tips` short-circuit (by
                 `id`, across keys).
   - `collect_tips_sorted` — severity ordering, insertion-order stability,
-                            task_keys glob filter, limit, surface allowlist.
+                            limit, surface allowlist.
   - `surfaces` / `combine_across_tasks` — storage + defaults on `add_tip`,
                             the `tip_shows_on` predicate, the per-surface
                             collect filter, and `tip_to_payload` carrying
@@ -162,14 +162,6 @@ def _test_important_tips_cannot_be_silenced(ctx):
         ["unsuppressable", "add-id-token-permission"],
     )
 
-def _test_add_tip_task_keys_stored(ctx):
-    _reset(ctx)
-    add_tip(ctx, id = "a", severity = TIP_INFO, title = "T", body = "B", task_keys = ["lint-*", "format-*"])
-    add_tip(ctx, id = "b", severity = TIP_INFO, title = "T", body = "B")
-    stored = tips._inspect_for_test(ctx)
-    _eq("task_keys stored", stored[0]["task_keys"], ["lint-*", "format-*"])
-    _eq("task_keys default — empty list when None", stored[1]["task_keys"], [])
-
 def _test_add_tip_format(ctx):
     _reset(ctx)
     add_tip(
@@ -207,14 +199,6 @@ def _test_add_tip_default_type_is_raw(ctx):
     # verbatim even when `vars` is supplied.
     add_tip(ctx, id = "default-type", severity = TIP_INFO, title = "Hello {name}", body = "B", vars = {"name": "world"})
     _eq("default type — RAW leaves braces verbatim", tips._inspect_for_test(ctx)[0]["title"], "Hello {name}")
-
-def _test_add_tip_task_keys_independent(ctx):
-    _reset(ctx)
-    add_tip(ctx, id = "tmpl-1", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", task_keys = ["lint-*"])
-    add_tip(ctx, id = "tmpl-2", severity = TIP_INFO, type = TIP_TEMPLATE_RAW, title = "T", body = "B", task_keys = ["format-*", "gazelle-*"])
-    stored = tips._inspect_for_test(ctx)
-    _eq("add_tip — first task_keys honored", stored[0]["task_keys"], ["lint-*"])
-    _eq("add_tip — second tip's task_keys independent", stored[1]["task_keys"], ["format-*", "gazelle-*"])
 
 # A JINJA2 tip with both `scopes` and `endpoints` accumulators, mirroring
 # the built-in `tip_add_github_token_scope` shape so the merge / re-render
@@ -345,24 +329,6 @@ def _test_collect_sorted_by_severity(ctx):
         "sorted — important → warning → suggestion → info; stable within bucket",
         sorted_ids,
         ["important-1", "important-2", "warning-1", "suggestion-1", "info-1"],
-    )
-
-def _test_collect_task_keys_filter(ctx):
-    # Task keys are auto-generated at task instantiation
-    # (`ctx.task.key` looks like a `truthful-ice`-style word pair). The
-    # test can't hardcode the value, so we exercise the filter with
-    # patterns that are deterministic regardless: empty list (current
-    # task), `["*"]` (match all), `["never-match-*"]` (no match), and
-    # one synthesized from the actual `ctx.task.key`.
-    _reset(ctx)
-    add_tip(ctx, id = "empty-keys", severity = TIP_INFO, title = "T", body = "B")
-    add_tip(ctx, id = "match-all", severity = TIP_INFO, title = "T", body = "B", task_keys = ["*"])
-    add_tip(ctx, id = "match-exact", severity = TIP_INFO, title = "T", body = "B", task_keys = [ctx.task.key])
-    add_tip(ctx, id = "never-match", severity = TIP_INFO, title = "T", body = "B", task_keys = ["zzzz-never-match-*"])
-    _eq(
-        "filter — empty + `*` + exact-key pass; mismatched glob skipped",
-        _ids(collect_tips_sorted(ctx)),
-        ["empty-keys", "match-all", "match-exact"],
     )
 
 def _test_collect_limit(ctx):
@@ -582,7 +548,6 @@ def _test_tip_to_payload(ctx):
         "_body_src": "B",
         "vars": {"repo": "acme/web"},
         "accumulate": {"scopes": ["actions: read"]},
-        "task_keys": ["lint-*"],  # producer-side filter; payload omits this
     }
     payload = tip_to_payload(stored)
     _eq("tip_to_payload — id", payload["id"], "x")
@@ -595,8 +560,6 @@ def _test_tip_to_payload(ctx):
     _eq("tip_to_payload — _body_src", payload["_body_src"], "B")
     _eq("tip_to_payload — vars", payload["vars"], {"repo": "acme/web"})
     _eq("tip_to_payload — accumulate", payload["accumulate"], {"scopes": ["actions: read"]})
-    if "task_keys" in payload:
-        fail("tip_to_payload — task_keys (producer-side filter) must NOT cross the artifact boundary")
 
     _eq("tip_to_payload — surfaces carried", payload.get("surfaces"), [])
     _eq("tip_to_payload — combine_across_tasks defaults False", payload.get("combine_across_tasks"), False)
@@ -807,11 +770,9 @@ def _test_impl(ctx):
     _test_silenced_tips_short_circuits_add_tip(ctx)
     _test_silenced_tips_blocks_add(ctx)
     _test_important_tips_cannot_be_silenced(ctx)
-    _test_add_tip_task_keys_stored(ctx)
     _test_add_tip_format(ctx)
     _test_add_tip_raw_skips_interpolation(ctx)
     _test_add_tip_default_type_is_raw(ctx)
-    _test_add_tip_task_keys_independent(ctx)
     _test_jinja2_first_emit_seeds_accumulate(ctx)
     _test_jinja2_reemit_merges_new_values(ctx)
     _test_jinja2_reemit_skips_duplicate_values(ctx)
@@ -819,7 +780,6 @@ def _test_impl(ctx):
     _test_jinja2_vars_and_accumulate(ctx)
     _test_combine_across_tasks_stored(ctx)
     _test_collect_sorted_by_severity(ctx)
-    _test_collect_task_keys_filter(ctx)
     _test_collect_limit(ctx)
     _test_severity_emoji(ctx)
     _test_severity_label(ctx)
@@ -837,7 +797,7 @@ def _test_impl(ctx):
     _test_tip_suggestion_hook(ctx)
     _test_strip_code_fences(ctx)
     _test_auto_print_flag(ctx)
-    print("tips.axl: OK (38 sections)")
+    print("tips.axl: OK (35 sections)")
     return 0
 
 tips_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/tips.axl
@@ -96,7 +96,6 @@ def add_tip(
         body: str,
         type: str = TIP_TEMPLATE_RAW,
         key: str = "",
-        task_keys: list = [],
         vars: dict = {},
         accumulate: dict = {},
         surfaces: list = [],
@@ -133,10 +132,6 @@ def add_tip(
       key: Optional discriminator distinguishing same-`id` tips about
         different subjects (e.g. one flaky-test tip per label). Empty
         means a single tip per `id`.
-      task_keys: Glob patterns matched against `ctx.task.key`; when
-        non-empty the tip renders only on matching tasks. Empty (the
-        default) scopes the tip to the task it was emitted into. The
-        terminal print fires regardless.
       vars: Fixed scalar values for `TIP_TEMPLATE_FORMAT` /
         `TIP_TEMPLATE_JINJA2` interpolation. Ignored for
         `TIP_TEMPLATE_RAW`. A name set in both `vars` and `accumulate`
@@ -164,7 +159,6 @@ def add_tip(
         body = body,
         type = type,
         key = key,
-        task_keys = task_keys,
         vars = vars,
         accumulate = accumulate,
         surfaces = surfaces,


### PR DESCRIPTION
Drops the `task_keys` argument from `add_tip` — it had no legitimate public use.

Tip storage is per-task closure state, so a tip only ever lives in its own emitting task's storage. `add_tip(task_keys=…)` filtered `collect_tips_sorted` against that same task's `ctx.task.key`, so it could only *hide a tip from the very task that emitted it* — never attribute one task's tip to another, which is impossible with per-task storage. No producer set it.

Removes the param, the stored field, the collect-time filter (and its now-unused `match_any` import), and the docstrings/tests.

The PR-summary "Surfaced by" attribution is unaffected: the aggregator derives its own `task_keys` label from the set of tasks that actually contributed a tip, independent of this arg.

Follows the same dead-public-arg cleanup as the earlier `id_suffix` removal.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (the tips guide never documented `task_keys`; the companion docs PR for the guide is already up)
- Breaking change (forces users to change their own code or config): no — `task_keys` shipped in v2026.23.40 but isn't part of the documented authoring API and had no working behavior.

### Suggested release notes

- `add_tip` no longer accepts a `task_keys` argument (it had no effect beyond hiding a tip from its own task).

### Test plan

- Covered by existing test cases — `test-tips`, `test-pr-comment-snapshots` (the "Surfaced by" attribution path), and `test-bazel-results` pass; `buildifier` clean.
