### PR TITLE
fix(change-detection): only trust HEAD^1 on CI-synthesized merge checkouts

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -866,7 +866,15 @@ def _widen_lines(lines, radius):
     out = sorted(out)
     return out
 
-def _head_parents(ctx):
+def _git_cwd(ctx, cwd):
+    """The working directory for the local-git helpers: the caller's
+    explicit `cwd`, or the process current directory when `None`. The
+    explicit override exists so tests can point the helpers at a scratch
+    repo; production calls pass `None`.
+    """
+    return cwd or ctx.std.env.current_dir()
+
+def _head_parents(ctx, cwd = None):
     """Return HEAD's parent SHAs as a list, or `[]` when HEAD is
     unresolvable. `len(result) >= 2` ⇒ HEAD is a merge commit.
 
@@ -887,7 +895,7 @@ def _head_parents(ctx):
     callers treat parents[0] as the base.
     """
     process = ctx.std.process
-    cwd = ctx.std.env.current_dir()
+    cwd = _git_cwd(ctx, cwd)
     out = process.command("git").args(["cat-file", "-p", "HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
     if not out.status.success:
         return []
@@ -902,7 +910,7 @@ def _head_parents(ctx):
             break
     return parents
 
-def _ensure_local_sha(ctx, sha):
+def _ensure_local_sha(ctx, sha, cwd = None):
     """Ensure `sha` is present in the local object store, fetching it
     shallowly from `origin` on-demand. Returns True iff the object is
     available after this call.
@@ -914,7 +922,7 @@ def _ensure_local_sha(ctx, sha):
     accepts arbitrary reachable SHAs via `uploadpack.allowAnySHA1InWant`).
     """
     process = ctx.std.process
-    cwd = ctx.std.env.current_dir()
+    cwd = _git_cwd(ctx, cwd)
     have = process.command("git").args(["cat-file", "-e", sha]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
     if have.status.success:
         return True
@@ -924,7 +932,7 @@ def _ensure_local_sha(ctx, sha):
     recheck = process.command("git").args(["cat-file", "-e", sha]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
     return recheck.status.success
 
-def _resolve_merge_base(ctx, base_ref):
+def _resolve_merge_base(ctx, base_ref, cwd = None):
     """Resolve a diff base SHA for local-git change detection, with
     layered fallbacks. Returns `(sha, source_description)` on success,
     or `("", reason)` when no candidate succeeds.
@@ -962,7 +970,7 @@ def _resolve_merge_base(ctx, base_ref):
          (single-parent now safe because we've confirmed `head_on_base`).
     """
     process = ctx.std.process
-    cwd = ctx.std.env.current_dir()
+    cwd = _git_cwd(ctx, cwd)
 
     head_out = process.command("git").args(["rev-parse", "HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
     head_sha = head_out.stdout.strip() if head_out.status.success else ""
@@ -978,11 +986,11 @@ def _resolve_merge_base(ctx, base_ref):
 
     # HEAD^1 path (step 2 in the docstring): a CI-synthesized merge, or
     # a HEAD merge-base confirmed to be on the base.
-    parents = _head_parents(ctx)
+    parents = _head_parents(ctx, cwd = cwd)
     synthesized = head_is_synthesized_merge(ctx.std, parents)
     if synthesized or (len(parents) >= 1 and head_on_base):
         parent_sha = parents[0]
-        if _ensure_local_sha(ctx, parent_sha):
+        if _ensure_local_sha(ctx, parent_sha, cwd = cwd):
             if synthesized:
                 return parent_sha, "git rev-parse HEAD^1 (CI-synthesized merge commit first parent)"
             return parent_sha, "git rev-parse HEAD^1 (HEAD on %s)" % base_ref
@@ -1003,10 +1011,16 @@ def _resolve_merge_base(ctx, base_ref):
             # single-parent HEAD^1 branch is safe.
             if mb_sha == head_sha and len(parents) >= 1:
                 parent_sha = parents[0]
-                if _ensure_local_sha(ctx, parent_sha):
+                if _ensure_local_sha(ctx, parent_sha, cwd = cwd):
                     return parent_sha, "git rev-parse HEAD^1 (HEAD on %s, confirmed after `git fetch origin %s`)" % (base_ref, remote_ref)
 
     return "", "tried `git merge-base HEAD %s`, `git rev-parse HEAD^1`, and `git fetch --depth=1 origin %s`; none succeeded" % (base_ref, remote_ref)
+
+def resolve_merge_base_for_test(ctx, base_ref, cwd):
+    """Test seam for `_resolve_merge_base` against a scratch repo at
+    `cwd`. Not for production use — callers there go through
+    `detect_changed_files`, which runs in the process working dir."""
+    return _resolve_merge_base(ctx, base_ref, cwd = cwd)
 
 def _try_local_git_diff_from_base_sha(ctx, line_level, base_sha):
     """Run a local `git diff <base_sha>` and return the structured

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -538,6 +538,14 @@ def read_github_event(std):
         return {}
     return json.try_decode(std.fs.read_to_string(event_path), {})
 
+def _pull_request_event_sha(std, side):
+    """`pull_request.<side>.sha` from the GitHub event payload (`side` is
+    "head" or "base"), or `""` when absent. The PR head is the real
+    branch tip; the base is the SHA GitHub merged it onto to synthesize
+    the `refs/pull/<n>/merge` checkout."""
+    pr = read_github_event(std).get("pull_request", {}) or {}
+    return (pr.get(side, {}) or {}).get("sha", "") or ""
+
 def detect_commit_sha(std):
     """Detect commit SHA from CI environment variables.
 
@@ -549,7 +557,7 @@ def detect_commit_sha(std):
     env = std.env
     event_name = env.var("GITHUB_EVENT_NAME") or ""
     if env.var("GITHUB_ACTIONS") and event_name in ("pull_request", "pull_request_target"):
-        head_sha = (read_github_event(std).get("pull_request", {}) or {}).get("head", {}).get("sha", "")
+        head_sha = _pull_request_event_sha(std, "head")
         if head_sha:
             return head_sha
     return (
@@ -614,7 +622,7 @@ def head_is_synthesized_merge(std, parents):
     if env.var("GITHUB_ACTIONS"):
         event_name = env.var("GITHUB_EVENT_NAME") or ""
         if event_name in ("pull_request", "pull_request_target"):
-            base = (read_github_event(std).get("pull_request", {}) or {}).get("base", {}).get("sha", "") or ""
+            base = _pull_request_event_sha(std, "base")
             return base != "" and parents[0] == base
         return event_name == "merge_group"
     return is_gitlab_synthesized_merge_pipeline(std)

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -19,7 +19,7 @@ HTTP failure-handling contract (applies to every helper below):
 load("@std//base64.axl", "base64")
 load("@std//time.axl", "time")
 load("./environment.axl", "color_enabled", "info", "warn")
-load("./gitlab_detect.axl", "detect_gitlab_mr_base_sha")
+load("./gitlab_detect.axl", "detect_gitlab_mr_base_sha", "is_gitlab_synthesized_merge_pipeline")
 load(
     "./rate_limit.axl",
     "BUCKET_APP",
@@ -579,6 +579,46 @@ def detect_merge_group_base_sha(std):
         return ""
     return (read_github_event(std).get("merge_group", {}) or {}).get("base_sha", "") or ""
 
+def head_is_synthesized_merge(std, parents):
+    """True when HEAD is a merge commit the CI host synthesized for this
+    run, so `parents[0]` (from `_head_parents`) is a safe diff base.
+    `parents` is HEAD's parent-SHA list. False for a developer's own
+    merge commit and for any non-synthesized HEAD.
+
+    The trust rule differs by source, because hosts differ in whether
+    the checked-out ref is developer-controllable:
+
+      - GHA `pull_request` / `pull_request_target`: a workflow can point
+        `actions/checkout` at `github.event.pull_request.head.sha`, so
+        the event firing does NOT prove HEAD is the synthesized merge.
+        Confirm against the checkout: `parents[0]` must equal the event's
+        `pull_request.base.sha`. GitHub builds the merge by merging the
+        PR head onto exactly that base, so a genuine synthesized merge
+        matches; a developer's merge (parents[0] = prior branch tip)
+        does not, and falls through to merge-base resolution.
+
+      - GHA `merge_group`: HEAD is the queue's `gh-readonly-queue` ref,
+        which a workflow cannot override, so a ≥2-parent HEAD is always
+        GitHub-made. parents[0] (the speculative base) is NOT compared
+        against `merge_group.base_sha`: that field tracks the target
+        branch tip, while a batched group's first parent is the prior
+        group's HEAD — they legitimately differ.
+
+      - GitLab `merged_result` / `merge_train`: GitLab-controlled refs,
+        likewise not developer-overridable, so a ≥2-parent HEAD is
+        GitLab-made and parents[0] is the base.
+    """
+    if len(parents) < 2:
+        return False
+    env = std.env
+    if env.var("GITHUB_ACTIONS"):
+        event_name = env.var("GITHUB_EVENT_NAME") or ""
+        if event_name in ("pull_request", "pull_request_target"):
+            base = (read_github_event(std).get("pull_request", {}) or {}).get("base", {}).get("sha", "") or ""
+            return base != "" and parents[0] == base
+        return event_name == "merge_group"
+    return is_gitlab_synthesized_merge_pipeline(std)
+
 _CI_BASE_BRANCH_PROBES = [
     # (host_guard_env, target_branch_env). Probed in declaration order;
     # first host whose guard env is truthy AND whose target-branch env
@@ -841,11 +881,10 @@ def _head_parents(ctx):
     (handled by `_try_local_git_diff_from_base_sha` /
     `_ensure_local_sha`) can pull the parent object on demand.
 
-    On a GitHub Actions `pull_request` / `pull_request_target` run,
-    `actions/checkout` checks out the synthesized merge commit at
-    `refs/pull/<n>/merge` — parents[0] is the base branch SHA and
-    parents[1] is the PR head. On a `merge_group` run, HEAD is the
-    queue-synthesized merge commit with the same shape.
+    parents[0] is the base-branch SHA only on CI-synthesized merge
+    checkouts; on a developer's own `git merge <base>` it's the prior
+    branch tip. `head_is_synthesized_merge` distinguishes the two before
+    callers treat parents[0] as the base.
     """
     process = ctx.std.process
     cwd = ctx.std.env.current_dir()
@@ -904,14 +943,16 @@ def _resolve_merge_base(ctx, base_ref):
              multi-commit feature branch to just its tip). Fall through
              but skip the single-parent branch.
       2. HEAD^1 — usable only in topology-confirmed cases:
-           a. HEAD is a merge commit (≥2 parents): parents[0] is the
-              base branch SHA (PR / merge-queue checkout). Safe
-              regardless of `head_on_base` — the merge commit's first
-              parent IS the base by construction.
-           b. HEAD is a single-parent commit AND `head_on_base` is
-              true: HEAD^1 is the previous commit on the branch
-              (push-to-base / squash-merge landing). NOT used when
-              merge-base failed — we'd be guessing the topology.
+           a. `head_is_synthesized_merge`: HEAD is a CI-synthesized
+              merge, so parents[0] is the base — safe regardless of
+              `head_on_base`. A developer's own merge commit is NOT this
+              case (parents[0] is the prior branch tip), so it falls
+              through to step 3's fetch + retry.
+           b. HEAD is on the base branch (`head_on_base` confirmed by
+              step 1): parents[0] is the previous commit on the base
+              (push-to-base / squash-merge landing), for both single-
+              and multi-parent HEADs. NOT used when merge-base failed —
+              we'd be guessing the topology.
          The parent OBJECT may not be local on shallow checkouts;
          `_ensure_local_sha` fetches it on-demand before returning.
       3. `git fetch --depth=1 origin <base_ref>` then retry merge-base
@@ -935,19 +976,15 @@ def _resolve_merge_base(ctx, base_ref):
         if mb_sha == head_sha:
             head_on_base = True
 
+    # HEAD^1 path (step 2 in the docstring): a CI-synthesized merge, or
+    # a HEAD merge-base confirmed to be on the base.
     parents = _head_parents(ctx)
-
-    # Merge commit: parents[0] is the base by construction — safe even
-    # when we couldn't confirm `head_on_base`.
-    # Single-parent: only safe when merge-base CONFIRMED HEAD is on the
-    # base branch. Returning HEAD^1 for an arbitrary single-parent HEAD
-    # (e.g. multi-commit feature branch with origin/<base> not yet
-    # fetched) would under-scope the diff to just the tip commit.
-    if len(parents) >= 2 or (len(parents) >= 1 and head_on_base):
+    synthesized = head_is_synthesized_merge(ctx.std, parents)
+    if synthesized or (len(parents) >= 1 and head_on_base):
         parent_sha = parents[0]
         if _ensure_local_sha(ctx, parent_sha):
-            if len(parents) >= 2:
-                return parent_sha, "git rev-parse HEAD^1 (merge commit first parent)"
+            if synthesized:
+                return parent_sha, "git rev-parse HEAD^1 (CI-synthesized merge commit first parent)"
             return parent_sha, "git rev-parse HEAD^1 (HEAD on %s)" % base_ref
 
     # `git fetch origin <ref>` wants the *remote* ref name. `base_ref`
@@ -1162,13 +1199,15 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
 
     Resolution order (first hit wins):
       1. Caller's explicit `merge_base` SHA → local `git diff`.
-      2. HEAD is a merge commit (≥2 parents) → local diff against
-         HEAD^1. Covers every synthesized-merge-commit checkout: GHA
-         `refs/pull/<n>/merge`, GHA merge_group, GitLab merged_result /
-         merge_train.
+      2. HEAD is a CI-synthesized merge (`head_is_synthesized_merge`:
+         GHA pull_request / pull_request_target, GHA merge_group, GitLab
+         merged_result / merge_train) → local diff against HEAD^1, whose
+         first parent is the base. A developer's own merge commit is
+         rejected (parents[0] is the prior branch tip), so it falls
+         through.
       3. GitLab `detached` MR pipeline → local diff against
-         `CI_MERGE_REQUEST_DIFF_BASE_SHA`. Only fires when step 2
-         missed (HEAD is the source-branch head, not a merge commit).
+         `CI_MERGE_REQUEST_DIFF_BASE_SHA`. Fires when step 2 missed
+         (HEAD is the source-branch head, not a synthesized merge).
       4. `_resolve_merge_base(ctx, base_ref)` → local diff against the
          resolved merge-base. The fallback for everything not covered
          above — Buildkite / CircleCI PR builds (PR head SHA checked
@@ -1243,16 +1282,20 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
             "unscoped": True,
         }
 
-    # (2) merge-commit-first
+    # (2) merge-commit-first — see `head_is_synthesized_merge`. A
+    # developer's own merge is also a 2-parent commit but is rejected
+    # there (parents[0] is the prior branch tip, not the base), so it
+    # falls through to (4)'s merge-base lookup.
     parents = _head_parents(ctx)
-    if len(parents) >= 2:
+    if head_is_synthesized_merge(ctx.std, parents):
         local = _try_local_git_diff_from_base_sha(ctx, line_level, parents[0])
         if local:
-            local["source"] += " (HEAD is a merge commit)"
+            local["source"] += " (HEAD is a CI-synthesized merge commit)"
             return local
 
-    # (3) GitLab `detached` MR pipeline — HEAD isn't a merge commit, so
-    # step 2 skipped; CI_MERGE_REQUEST_DIFF_BASE_SHA is the correct base.
+    # (3) GitLab `detached` MR pipeline — HEAD is the source-branch head
+    # (no synthesized merge), so step 2 skipped; the diff base is
+    # CI_MERGE_REQUEST_DIFF_BASE_SHA.
     gitlab_base = detect_gitlab_mr_base_sha(ctx.std)
     if gitlab_base:
         local = _try_local_git_diff_from_base_sha(ctx, line_level, gitlab_base)

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -1,18 +1,15 @@
-"""Smoke tests for `lib/github.axl` CI-event detection helpers.
+"""Tests for `lib/github.axl` CI change-detection helpers.
 
-Covers the three change-detection event shapes aspect-cli sees in
-GitHub Actions:
-
-  1. GitHub PR (`pull_request` / `pull_request_target`)
-     — `detect_github_pr` returns the PR context;
-       `detect_merge_group_base_sha` returns "".
-  2. Merge queue (`merge_group`)
-     — `detect_merge_group_base_sha` returns `merge_group.base_sha`
-       from the event payload;
-       `detect_github_pr` returns None (no PR ref).
-  3. Landed commit (`push`)
-     — both helpers return empty / None; downstream falls back to
-       local `git diff` against the base branch.
+Covers:
+  - The three CI-event shapes aspect-cli sees on GitHub Actions —
+    `pull_request` / `pull_request_target` (`detect_github_pr` returns
+    the PR context), `merge_group` (`detect_merge_group_base_sha`
+    returns the queue base SHA), and `push` (neither fires; downstream
+    falls back to local `git diff`).
+  - `head_is_synthesized_merge` — the per-source gate that decides
+    whether HEAD's first parent is a safe diff base, including the
+    PR-head-checkout and batched-merge_group cases.
+  - `list_pull_request_files` auth fallback + rate-limit bucketing.
 
 Most cases are env- and event-file-driven, so they stub `std` with a
 fake env (dict-backed) and a fake fs (path → content dict). The
@@ -106,7 +103,7 @@ def _expect_event(label, vars, files, expected):
     _eq(label, got, expected)
 
 def _test_impl(ctx):
-    # ── (1) GitHub PR — pull_request event ──────────────────────────
+    # ── GitHub PR — pull_request event ──────────────────────────────
     # actions/checkout v6 default: synthesized merge commit at
     # refs/pull/N/merge; pull_request.head.sha in event payload is the
     # PR's real head (used for status checks / annotations).
@@ -154,7 +151,7 @@ def _test_impl(ctx):
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     )
 
-    # ── (2) Merge queue — merge_group event ─────────────────────────
+    # ── Merge queue — merge_group event ─────────────────────────────
     # GitHub merges PRs through a queue branch
     # (`gh-readonly-queue/<target>/<sha>`); the event payload exposes
     # `merge_group.base_sha` directly so we don't have to resolve it
@@ -296,7 +293,7 @@ def _test_impl(ctx):
         False,
     )
 
-    # ── (3) Landed commit — push to main ────────────────────────────
+    # ── Landed commit — push to main ────────────────────────────────
     # No PR context, no merge_group payload. Downstream falls back to
     # local `git diff` against `origin/main`.
     push_event_path = "/tmp/event-push.json"
@@ -960,6 +957,7 @@ def _test_resolve_merge_base_integration(ctx):
     diff_base, source = resolve_merge_base_for_test(ctx, "main", repo)
     if "merge-base" not in source:
         fail("developer merge — expected merge-base source, got %r" % source)
+
     # The feature's own files are in scope; HEAD^1 (=c2) would have
     # dropped c1.txt and c2.txt, surfacing only the merged-in b1.txt.
     _eq(

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -14,9 +14,12 @@ GitHub Actions:
      — both helpers return empty / None; downstream falls back to
        local `git diff` against the base branch.
 
-These are env- and event-file-driven, so the tests stub `std` with a
-fake env (dict-backed) and a fake fs (path → content dict). No real
-filesystem, no real subprocesses.
+Most cases are env- and event-file-driven, so they stub `std` with a
+fake env (dict-backed) and a fake fs (path → content dict). The
+`_resolve_merge_base` integration section is the exception: it builds
+real scratch git repos with `git` subprocesses to exercise the
+merge-base / HEAD^1 diff-base resolution end to end (notably the
+developer-merge-commit case behind the reported under-scoping bug).
 
 Run with:
   aspect dev test-github-detect
@@ -31,6 +34,7 @@ load(
     "github",
     "head_is_synthesized_merge",
     "read_github_event",
+    "resolve_merge_base_for_test",
 )
 load(
     "./gitlab_detect.axl",
@@ -551,6 +555,9 @@ def _test_impl(ctx):
     # ── pr_file_is_skipped bucketing decision ─────────────────────────
     _test_pr_file_is_skipped()
 
+    # ── _resolve_merge_base end-to-end against real scratch repos ─────
+    _test_resolve_merge_base_integration(ctx)
+
     print("github_detect.axl smoke: OK")
     return 0
 
@@ -885,6 +892,117 @@ def _test_pr_files_bucket_class_routes_observations(ctx):
     _eq("bucket-class — App `Remaining` matches primary response", app_obs[0][1], 4800)
     _eq("bucket-class — env bucket has the fallback retry's observation", len(env_obs), 1)
     _eq("bucket-class — env `Remaining` matches fallback response", env_obs[0][1], 900)
+
+# ── _resolve_merge_base integration (real git scratch repos) ────────
+# The unit tests above drive the env gate (`head_is_synthesized_merge`)
+# with a fake std; these run `_resolve_merge_base` against repos built
+# with real `git` subprocesses so the merge-base / HEAD^1 topology
+# handling is exercised end to end. Fixed identity + dates keep commit
+# SHAs independent of the wall clock and the host's ~/.gitconfig.
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_AUTHOR_DATE": "2026-01-01T00:00:00",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+    "GIT_COMMITTER_DATE": "2026-01-01T00:00:00",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+}
+
+def _git_ok(ctx, repo, args):
+    cmd = ctx.std.process.command("git").args(args).current_dir(repo)
+    for k, v in _GIT_ENV.items():
+        cmd = cmd.env(k, v)
+    out = cmd.stdout("piped").stderr("piped").spawn().wait_with_output()
+    if not out.status.success:
+        fail("git %s failed in %s: %s" % (" ".join(args), repo, out.stderr.strip()))
+    return out.stdout.strip()
+
+def _commit_file(ctx, repo, name, content, message):
+    ctx.std.fs.write(repo + "/" + name, content)
+    _git_ok(ctx, repo, ["add", name])
+    _git_ok(ctx, repo, ["commit", "-m", message])
+    return _git_ok(ctx, repo, ["rev-parse", "HEAD"])
+
+def _changed_files(ctx, repo, diff_base):
+    """Files in `git diff --name-only <diff_base> HEAD`, sorted — the
+    set lint / format would actually operate on for this diff base."""
+    out = _git_ok(ctx, repo, ["diff", "--name-only", diff_base, "HEAD"])
+    return sorted([f for f in out.split("\n") if f])
+
+def _init_repo(ctx):
+    repo = ctx.std.fs.mkdtemp(prefix = "axl-github-detect-merge-base-test-")
+    _git_ok(ctx, repo, ["init", "-q", "--initial-branch=main"])
+    base_sha = _commit_file(ctx, repo, "base.txt", "base\n", "base")
+    return repo, base_sha
+
+def _test_resolve_merge_base_integration(ctx):
+    # (1) The reported bug: a developer's own merge of the base branch
+    # into a feature branch. main: B0 → B1 (advances after branching).
+    # feature off B0: C1 → C2, then `git merge main` brings B1 in as a
+    # merge commit M. HEAD=M with M^1=C2 (the prior feature tip), so
+    # trusting HEAD^1 diffs C2..M and reports only b1.txt — dropping the
+    # feature's own c1.txt + c2.txt (the bug). The resolved base instead
+    # scopes the whole feature.
+    repo, b0 = _init_repo(ctx)
+    _git_ok(ctx, repo, ["checkout", "-q", "-b", "feature"])
+    _commit_file(ctx, repo, "c1.txt", "c1\n", "c1")
+    c2 = _commit_file(ctx, repo, "c2.txt", "c2\n", "c2")
+    _git_ok(ctx, repo, ["checkout", "-q", "main"])
+    _commit_file(ctx, repo, "b1.txt", "b1\n", "b1")
+    _git_ok(ctx, repo, ["checkout", "-q", "feature"])
+    _git_ok(ctx, repo, ["merge", "-q", "--no-ff", "--no-edit", "main"])
+    parents = _git_ok(ctx, repo, ["rev-list", "--parents", "-n", "1", "HEAD"]).split(" ")
+    if len(parents) != 3:
+        fail("expected HEAD to be a 2-parent merge commit, got parents %r" % parents)
+    _eq("developer merge — HEAD^1 is the prior feature tip (the trap)", parents[1], c2)
+    diff_base, source = resolve_merge_base_for_test(ctx, "main", repo)
+    if "merge-base" not in source:
+        fail("developer merge — expected merge-base source, got %r" % source)
+    # The feature's own files are in scope; HEAD^1 (=c2) would have
+    # dropped c1.txt and c2.txt, surfacing only the merged-in b1.txt.
+    _eq(
+        "developer merge — whole feature in scope (not just merge payload)",
+        _changed_files(ctx, repo, diff_base),
+        ["c1.txt", "c2.txt"],
+    )
+    if diff_base == c2:
+        fail("developer merge — diff base must not be HEAD^1 (would drop pre-merge commits)")
+    ctx.std.fs.remove_dir_all(repo)
+
+    # (2) Linear feature branch (single-parent commits): the diff base is
+    # the fork point B0, so both feature commits are in scope.
+    repo, b0 = _init_repo(ctx)
+    _git_ok(ctx, repo, ["checkout", "-q", "-b", "feature"])
+    _commit_file(ctx, repo, "c1.txt", "c1\n", "c1")
+    _commit_file(ctx, repo, "c2.txt", "c2\n", "c2")
+    diff_base, source = resolve_merge_base_for_test(ctx, "main", repo)
+    _eq("linear branch — diff base is the fork point", diff_base, b0)
+    _eq(
+        "linear branch — both feature commits in scope",
+        _changed_files(ctx, repo, diff_base),
+        ["c1.txt", "c2.txt"],
+    )
+    ctx.std.fs.remove_dir_all(repo)
+
+    # (3) HEAD on the base branch (push-to-base): `git merge-base HEAD
+    # main` == HEAD, so the diff base is the previous commit (HEAD^1) and
+    # the just-landed commit stays in scope.
+    repo, b0 = _init_repo(ctx)
+    b1 = _commit_file(ctx, repo, "b1.txt", "b1\n", "b1")
+    diff_base, source = resolve_merge_base_for_test(ctx, "main", repo)
+    _eq("head-on-base — diff base is the previous commit (HEAD^1)", diff_base, b0)
+    if diff_base == b1:
+        fail("head-on-base — diff base must be HEAD^1, not HEAD itself")
+    if "HEAD on" not in source:
+        fail("head-on-base — expected HEAD-on-base source, got %r" % source)
+    _eq(
+        "head-on-base — landed commit in scope",
+        _changed_files(ctx, repo, diff_base),
+        ["b1.txt"],
+    )
+    ctx.std.fs.remove_dir_all(repo)
 
 github_detect_tests = task(
     name = "test-github-detect",

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -29,6 +29,7 @@ load(
     "detect_github_pr",
     "detect_merge_group_base_sha",
     "github",
+    "head_is_synthesized_merge",
     "read_github_event",
 )
 load(
@@ -86,6 +87,12 @@ def _expect_mg_sha(label, vars, files, expected):
 
 def _expect_commit_sha(label, vars, files, expected):
     got = detect_commit_sha(_fake_std(vars, files))
+    _eq(label, got, expected)
+
+# ── head_is_synthesized_merge ───────────────────────────────────────
+
+def _expect_head_synthesized(label, vars, files, parents, expected):
+    got = head_is_synthesized_merge(_fake_std(vars, files), parents)
     _eq(label, got, expected)
 
 # ── read_github_event ───────────────────────────────────────────────
@@ -177,6 +184,112 @@ def _test_impl(ctx):
         mg_vars,
         mg_files,
         "GITHUB_REF is not a PR merge ref",
+    )
+
+    # ── head_is_synthesized_merge — the gate on trusting parents[0] ──
+    base = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"  # pull_request.base.sha
+    head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # PR head / branch tip
+    prior_tip = "dddddddddddddddddddddddddddddddddddddddd"
+
+    # pull_request: the checked-out ref is developer-overridable, so the
+    # gate is `parents[0] == pull_request.base.sha`, NOT the event alone.
+    _expect_head_synthesized(
+        "pull_request: synthesized merge (parents[0] == base) is trusted",
+        pr_vars,
+        pr_files,
+        [base, head],
+        True,
+    )
+    _expect_head_synthesized(
+        "pull_request_target: synthesized merge is trusted",
+        {
+            "GITHUB_ACTIONS": "true",
+            "GITHUB_EVENT_NAME": "pull_request_target",
+            "GITHUB_EVENT_PATH": pr_event_path,
+        },
+        pr_files,
+        [base, head],
+        True,
+    )
+
+    # The bug this fix targets: a workflow that overrides actions/checkout
+    # `ref:` to github.event.pull_request.head.sha runs the same
+    # pull_request event, but HEAD is the developer's own merge — its
+    # parents[0] is the prior branch tip. GITHUB_REF still says
+    # refs/pull/N/merge, so a ref-based gate would wrongly fire; matching
+    # parents[0] against base.sha correctly rejects it.
+    _expect_head_synthesized(
+        "pull_request: developer merge checked out (parents[0] != base) is rejected",
+        pr_vars,
+        pr_files,
+        [prior_tip, head],
+        False,
+    )
+    _expect_head_synthesized(
+        "single-parent HEAD is never a synthesized merge",
+        pr_vars,
+        pr_files,
+        [base],
+        False,
+    )
+
+    # merge_group: the gh-readonly-queue ref is GitHub-controlled (not
+    # overridable), so a 2-parent HEAD is always trusted — including the
+    # batched case where parents[0] (the prior group's HEAD) differs from
+    # merge_group.base_sha (the target-branch tip).
+    _expect_head_synthesized(
+        "merge_group: 2-parent HEAD is trusted",
+        mg_vars,
+        mg_files,
+        [base, head],
+        True,
+    )
+    _expect_head_synthesized(
+        "merge_group: batched group (parents[0] != base_sha) is still trusted",
+        mg_vars,
+        mg_files,
+        [prior_tip, head],
+        True,
+    )
+
+    # GitLab merged_result / merge_train: GitLab-controlled refs, trusted
+    # on topology; detached checks out the source head (step 3 handles it).
+    _expect_head_synthesized(
+        "GitLab merged_result: 2-parent HEAD is trusted",
+        {"GITLAB_CI": "true", "CI_MERGE_REQUEST_EVENT_TYPE": "merged_result"},
+        {},
+        [base, head],
+        True,
+    )
+    _expect_head_synthesized(
+        "GitLab merge_train: 2-parent HEAD is trusted",
+        {"GITLAB_CI": "true", "CI_MERGE_REQUEST_EVENT_TYPE": "merge_train"},
+        {},
+        [base, head],
+        True,
+    )
+    _expect_head_synthesized(
+        "GitLab detached: 2-parent HEAD is rejected",
+        {"GITLAB_CI": "true", "CI_MERGE_REQUEST_EVENT_TYPE": "detached"},
+        {},
+        [base, head],
+        False,
+    )
+
+    # Non-PR, non-merge contexts never trust a 2-parent HEAD.
+    _expect_head_synthesized(
+        "push build: 2-parent HEAD is rejected",
+        {"GITHUB_ACTIONS": "true", "GITHUB_EVENT_NAME": "push"},
+        {},
+        [base, head],
+        False,
+    )
+    _expect_head_synthesized(
+        "off-CI: 2-parent HEAD is rejected",
+        {},
+        {},
+        [base, head],
+        False,
     )
 
     # ── (3) Landed commit — push to main ────────────────────────────

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect.axl
@@ -148,12 +148,31 @@ def detect_gitlab_mr_base_sha(std):
     target-branch updates beyond this SHA, so `DIFF_BASE_SHA..HEAD`
     over-scopes by those updates. `detect_changed_files` handles this
     by running the merge-commit-first path (HEAD^1) BEFORE consulting
-    this helper — on those pipelines HEAD has ≥2 parents and step 2
-    catches it. On `detached` pipelines (HEAD is the source-branch
-    head, no merge commit) the merge-commit-first path skips and this
-    helper supplies the correct diff base.
+    this helper — `is_gitlab_synthesized_merge_pipeline` flags those
+    pipelines so step 2 diffs against the synthesized merge's first
+    parent. On `detached` pipelines (HEAD is the source-branch head, no
+    synthesized merge) step 2 skips and this helper supplies the diff
+    base.
     """
     env = std.env
     if not env.var("GITLAB_CI"):
         return ""
     return env.var("CI_MERGE_REQUEST_DIFF_BASE_SHA") or ""
+
+def is_gitlab_synthesized_merge_pipeline(std):
+    """True on a GitLab `merged_result` / `merge_train` MR pipeline,
+    where GitLab checks out a synthesized merge commit whose first
+    parent is the base it was built on.
+
+    The GitLab arm of `head_is_synthesized_merge`: these refs are
+    GitLab-controlled (not developer-overridable), so a 2-parent HEAD is
+    GitLab-made and diffing against its first parent is correct.
+    `detached` pipelines check out the source-branch head instead —
+    there a 2-parent HEAD would be the developer's own merge commit
+    (first parent = prior branch tip, not the base), so they're excluded
+    and fall through to `CI_MERGE_REQUEST_DIFF_BASE_SHA`.
+    """
+    env = std.env
+    if not env.var("GITLAB_CI"):
+        return False
+    return (env.var("CI_MERGE_REQUEST_EVENT_TYPE") or "") in ("merged_result", "merge_train")

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect_test.axl
@@ -8,7 +8,7 @@ Run with:
   aspect dev test-gitlab-detect
 """
 
-load("./gitlab_detect.axl", "detect_gitlab_mr")
+load("./gitlab_detect.axl", "detect_gitlab_mr", "is_gitlab_synthesized_merge_pipeline")
 
 def _fake_std(vars):
     """Stub std with an env that resolves `var(name)` against `vars`."""
@@ -191,7 +191,43 @@ def _test_impl(ctx):
         "must be numeric",
     )
 
-    print("gitlab_detect.axl smoke: OK (12 scenarios)")
+    # ── is_gitlab_synthesized_merge_pipeline ────────────────────────────
+    # merged_result / merge_train check out a GitLab-synthesized merge
+    # (HEAD^1 is the base); detached checks out the source-branch head,
+    # where a 2-parent HEAD would be the developer's own merge.
+    _eq(
+        "merged_result is synthesized",
+        is_gitlab_synthesized_merge_pipeline(_fake_std({
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_EVENT_TYPE": "merged_result",
+        })),
+        True,
+    )
+    _eq(
+        "merge_train is synthesized",
+        is_gitlab_synthesized_merge_pipeline(_fake_std({
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_EVENT_TYPE": "merge_train",
+        })),
+        True,
+    )
+    _eq(
+        "detached is not synthesized",
+        is_gitlab_synthesized_merge_pipeline(_fake_std({
+            "GITLAB_CI": "true",
+            "CI_MERGE_REQUEST_EVENT_TYPE": "detached",
+        })),
+        False,
+    )
+    _eq(
+        "not on GitLab CI is not synthesized",
+        is_gitlab_synthesized_merge_pipeline(_fake_std({
+            "CI_MERGE_REQUEST_EVENT_TYPE": "merged_result",
+        })),
+        False,
+    )
+
+    print("gitlab_detect.axl smoke: OK (16 scenarios)")
     return 0
 
 gitlab_detect_tests = task(


### PR DESCRIPTION
The merge-commit-first change-detection path diffed against `parents[0]` for any HEAD with ≥2 parents, assuming `parents[0]` is the base-branch SHA. That holds only for **CI-synthesized** merge commits.

When a developer merges the base branch into their own branch (rather than rebasing) and pushes, HEAD is *their own* merge commit — `parents[0]` is the prior branch tip, not the base. `git diff parents[0]..HEAD` then reports only what the merge dragged in and silently drops every file changed earlier in the branch. A PR with a mis-formatted file committed before such a merge was checked against a base that excluded it, so `aspect format` / `aspect lint` reported clean.

The fix gates the `parents[0]` paths (both `detect_changed_files` step 2 and the `_resolve_merge_base` fallback) on a new `head_is_synthesized_merge`, which applies the correct rule per source — because hosts differ in whether the checked-out ref is developer-controllable:

- **GHA `pull_request` / `pull_request_target`** — a workflow can point `actions/checkout` at `github.event.pull_request.head.sha`, so the event alone doesn't prove HEAD is the synthesized merge (`GITHUB_REF` is `refs/pull/<n>/merge` either way). Confirmed against the actual checkout: `parents[0]` must equal the event's `pull_request.base.sha`.
- **GHA `merge_group` / GitLab `merged_result` / `merge_train`** — host-controlled refs that a workflow cannot override, so a ≥2-parent HEAD is trusted on topology. `parents[0]` is deliberately not compared against `merge_group.base_sha` (that tracks the target-branch tip, while a batched group's first parent is the prior group's HEAD — they legitimately differ).

Non-synthesized merge commits fall through to `git merge-base HEAD origin/<base>`, which resolves the true fork point and scopes the whole branch.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- `aspect format` / `aspect lint` change detection no longer under-scopes when a branch contains a developer-authored merge of the base branch; the full set of changed files in the PR is now checked. Also hardens against workflows that check out the PR head instead of the synthesized merge.

### Test plan

- New unit tests: `head_is_synthesized_merge` across all sources (incl. the PR head-checkout rejection and batched-merge_group cases) and `is_gitlab_synthesized_merge_pipeline`.
- New integration tests (real `git` scratch repos, in `test-github-detect`): `_resolve_merge_base` for the developer-merge case (asserts the whole feature stays in scope vs. HEAD^1 dropping it), the linear-branch case, and the HEAD-on-base case.
- Covered by existing test cases.

