### PR TITLE
fix(runnable): no-op on aborted target_completed BES payloads

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -1,3 +1,5 @@
+load("./bazel_results.axl", "bes_get")
+
 _DEFAULT_WORKSPACE_NAME = "_main"
 
 # Mandatory Bazel flags for a task that immediately spawns the built binary
@@ -174,7 +176,10 @@ def _process_bes(state: struct, event):
     elif event.kind == "target_completed":
         label_key = apparent_label(event.id.label)
         if label_key in state.targets:
-            for og in event.payload.output_group:
+            # A `target_completed` id can carry an `aborted` payload (e.g. the
+            # build was interrupted before the target finished), which has no
+            # `output_group`. Read defensively so an aborted target no-ops.
+            for og in (bes_get(event.payload, "output_group", None) or []):
                 if og.name == "default":
                     state.target_fileset[label_key] = og.file_sets
     elif event.kind == "workspace_config":

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -177,6 +177,24 @@ def _make_target_event(bes_label, set_id):
         ),
     )
 
+def _make_aborted_target_event(bes_label):
+    """A `target_completed`-kinded BES event whose payload is the `aborted`
+    union variant — it lacks `output_group`, matching what Bazel emits when a
+    target is aborted before completing."""
+    return struct(
+        kind = "target_completed",
+        id = struct(label = bes_label),
+        payload = struct(reason = "USER_INTERRUPTED", description = "build interrupted"),
+    )
+
+def _test_bes_aborted_target_no_ops(ctx):
+    """An aborted `target_completed` payload (no `output_group`) must no-op
+    instead of raising AttributeError in _process_bes."""
+    r = runnable(None, ["//tools/format:format"])
+    r.event(_make_aborted_target_event("//tools/format:format"))
+    if r.determine_entrypoint("//tools/format:format") != None:
+        fail("aborted target: expected None entrypoint")
+
 def _test_bes_bzlmod_no_version(ctx):
     """@@module+//pkg:tgt in BES matches @module//pkg:tgt registered target."""
     r = runnable(None, ["@buildifier_prebuilt//buildifier"])
@@ -601,6 +619,7 @@ _UNIT_TESTS = [
     _test_bes_bzlmod_extension_repo,
     _test_bes_local_target,
     _test_bes_unknown_target_returns_none,
+    _test_bes_aborted_target_no_ops,
     _test_no_runfiles_dir_when_ctx_none,
     _test_sh_pass2_selected,
     _test_bash_pass2_selected,


### PR DESCRIPTION
Bazel can deliver a `target_completed`-kinded BES event whose payload is the `aborted` union variant — for example when the build is interrupted before the target finishes. That variant has no `output_group` field, so the unguarded `event.payload.output_group` access in `_process_bes` ([lib/runnable.axl](crates/aspect-cli/src/builtins/aspect/lib/runnable.axl)) raised `Object of type 'aborted' has no attribute 'output_group'` and crashed BES processing mid-delivery.

The fix routes the access through the existing `bes_get` safe-accessor (from `lib/bazel_results.axl`) — the same defensive pattern already used everywhere else BES payloads are read — so an aborted target simply no-ops.

I also audited every direct `.payload.<field>` access across the AXL builtins for this bug shape (reading a payload union field without knowing the variant could be `aborted`). All other sites were already safe: `bazel_results.axl`, `artifacts.axl`, and `circleci_test_results.axl` already route payload reads through `bes_get`; the `workspace_config` handler already uses `getattr` with a default; and the remaining direct accesses are on `named_set_of_files` payloads (never aborted by Bazel) or on `event.id` / exec-log entries rather than the payload union.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Fixed a crash during delivery BES processing (`Object of type 'aborted' has no attribute 'output_group'`) when a target is aborted before completing.

### Test plan

- New test cases added (`_test_bes_aborted_target_no_ops` in `lib/runnable_test.axl`)
- Covered by existing test cases (`aspect dev test-runnable` — 58 tests; `aspect tests axl` — 771 tests)
