### PR TITLE
Bound forwarded list-flags in repro/fix commands

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -23,7 +23,11 @@ parsing the command string).
 `build_aspect_command(subcommand, flags, targets)` is the canonical
 way producers compose the `command` string — handling flag
 normalization, target joining, the `--` separator before targets, and
-length-bounded truncation when the target list is large.
+length-bounded truncation when either the target list or a list-valued
+flag (e.g. a `--gazelle-flag=-exclude=` per untracked file) is large.
+Behavior-changing scalar flags are always retained; only surplus
+list-flag values are dropped, behind a `# +N more <flag> values`
+shell-comment line.
 
 `repro_prefix(ctx)` / `subdir_prefix(cwd, root)` prepend `cd <rel>\n`
 to commands when aspect was called from a subdirectory, so CI failures
@@ -166,21 +170,27 @@ def _build_run_command(targets, flags, max_chars, wrap_at):
 
     Target args are truncated entry-wise (whole tokens, never mid-token) when
     `max_chars` would be exceeded; a `# +N more` shell-comment line indicates
-    the truncation so the command stays copy-paste-runnable.
+    the truncation so the command stays copy-paste-runnable. List-valued flags
+    are length-bounded the same way (see `_budget_flag_parts`); in practice
+    `bazel run` alternates pass a narrow scalar flag set, so flag truncation is
+    rare here, but the discipline matches `_build_command`.
     """
     if not targets:
         return "bazel run"
     label = targets[0]
     target_args = targets[1:]
-    flag_str = _format_flag_parts(flags)
+    flag_str, flag_overflow_notes = _budget_flag_parts(flags, max_chars)
+    overflow_lines = _overflow_comment_lines(flag_overflow_notes)
     head = " ".join(["bazel run"] + flag_str + [_shell_quote(label)])
     if not target_args:
-        return head
+        if not overflow_lines:
+            return head
+        return _join_continued([head] + ["  " + o for o in overflow_lines])
 
     separator = " -- "
     quoted_args = [_shell_quote(a) for a in target_args]
     single_line = head + separator + " ".join(quoted_args)
-    if len(single_line) <= max_chars and len(single_line) <= wrap_at:
+    if len(single_line) <= max_chars and len(single_line) <= wrap_at and not overflow_lines:
         return single_line
 
     used = len(head) + len(separator)
@@ -197,28 +207,122 @@ def _build_run_command(targets, flags, max_chars, wrap_at):
     # `_join_continued` is responsible for the trailing ` \` continuation
     # between lines — don't pre-add it to the head, or the rendered output
     # ends up with `-- \ \` (the literal backslash plus the join's separator).
-    lines = [head + " --"] + ["  " + q for q in included]
+    # Flag-overflow notes go above the `--` so they read as part of the head.
+    lines = [head + " --"] + ["  " + o for o in overflow_lines] + ["  " + q for q in included]
     if omitted > 0:
         lines.append("  # +%d more" % omitted)
     return _join_continued(lines)
 
-def _format_flag_parts(flags):
-    """Render a flag list into shell tokens. See `_build_command` for entry shape."""
-    parts = []
+def _budget_flag_parts(flags, max_chars):
+    """Render `flags` to shell tokens under a `max_chars` budget,
+    dropping list-flag overflow rather than emitting an unbounded wall.
+
+    Background: a list-valued flag entry (`("--gazelle-flag", [v0, v1,
+    …])`) expands to one `--name=v` token per element. When the list
+    is large — e.g. `aspect gazelle` invoked with a `-exclude=` per
+    untracked file — the rendered repro/fix command balloons to
+    hundreds of tokens. The target list has always been length-bounded
+    (see `_build_command`); flags were not. This applies the same
+    discipline to flags.
+
+    What's retained vs. truncated, and why:
+
+      - Single-token entries (bare flags, `("--name", "value")`, plain
+        strings) are ALWAYS retained, regardless of budget. These are
+        the behavior-changing scalars (`--severity`, `--scope`,
+        `--base-ref`, …) — dropping one would change what the command
+        does, defeating the point of a repro. They're few, so they
+        can't be the source of the blow-up.
+      - List-valued entries are the only thing subject to truncation,
+        since they're the only entries that can expand without bound.
+
+    Ordering: list flags are laid down ascending by element count
+    (stable on ties, preserving original relative order). A
+    well-behaved `--scope-all-on-change` with 8 entries thus fills
+    completely before a pathological `--gazelle-flag` with 300
+    entries starts getting clipped — truncation concentrates on the
+    actual offender instead of penalizing small flags that happened to
+    come later in the original order. Element order WITHIN a flag is
+    preserved.
+
+    Returns `(parts, overflow)`:
+      - `parts`: retained shell tokens, scalars first (original order)
+        then list-flag tokens (count-sorted).
+      - `overflow`: list of `(flag_name, dropped_count)` for list flags
+        that were partially or fully clipped, in the order they were
+        laid down. Callers render these as `# +N more <flag> values`
+        shell-comment lines. Empty when nothing was dropped.
+
+    The budget governs only list-flag tokens: scalars are emitted
+    first and their length is subtracted from the budget, so a
+    (pathological) scalar-heavy command still renders every scalar and
+    simply drops all list values. `max_chars` is a soft cap measured in
+    characters of joined token text; truncation is at token boundaries,
+    never mid-token (a single huge element counts as one indivisible
+    token, same as target truncation).
+    """
+    scalars = []
+    list_entries = []
     for f in flags:
         if type(f) == "string":
-            parts.append(f)
+            scalars.append(f)
             continue
         name = f[0]
         value = f[1] if len(f) > 1 else None
-        if value == None:
-            parts.append(name)
-        elif type(value) == "list":
-            for v in value:
-                parts.append("%s=%s" % (name, v))
+        if type(value) == "list":
+            list_entries.append((name, value))
+        elif value == None:
+            scalars.append(name)
         else:
-            parts.append("%s=%s" % (name, value))
-    return parts
+            scalars.append("%s=%s" % (name, value))
+
+    # Scalars are unconditional; charge their width to the budget so
+    # list tokens compete only for what's left.
+    parts = list(scalars)
+    used = 0
+    for s in scalars:
+        used += (1 if used else 0) + len(s)
+
+    # Stable sort ascending by element count: small, well-behaved list
+    # flags render in full before a large one starts getting clipped.
+    indexed = [(len(value), i, name, value) for i, (name, value) in enumerate(list_entries)]
+    ordered = sorted(indexed, key = lambda e: (e[0], e[1]))
+
+    # Lay down list-flag tokens until the budget is hit. Once any flag
+    # is clipped, every flag from that point on is fully dropped — they
+    # were sorted ascending by size, so a larger one can't fit where a
+    # smaller one didn't. `overflowing` flips True at the first clip.
+    overflow = []
+    overflowing = False
+    for _count, _i, name, value in ordered:
+        if overflowing:
+            overflow.append((name, len(value)))
+            continue
+        dropped = 0
+        for elem_idx in range(len(value)):
+            token = "%s=%s" % (name, value[elem_idx])
+            needed = (1 if parts else 0) + len(token)
+            if used + needed > max_chars and parts:
+                dropped = len(value) - elem_idx
+                break
+            parts.append(token)
+            used += needed
+        if dropped > 0:
+            overflow.append((name, dropped))
+            overflowing = True
+
+    return parts, overflow
+
+def _overflow_comment_lines(overflow):
+    """Render `[(flag_name, dropped_count), …]` to `# +N more <flag> values`
+    shell-comment strings. One line per flag so the attribution is exact —
+    a reviewer sees that the dropped tokens were e.g. `--gazelle-flag`
+    excludes, not behavior-changing flags. Empty input → no lines."""
+    lines = []
+    for name, count in overflow:
+        if count > 0:
+            lines.append("# +%d more %s value%s" % (count, name, "" if count == 1 else "s"))
+    return lines
 
 def _build_command(head, flags, targets, max_chars, wrap_at):
     """Compose `<head> <flags...> [-- <targets>]` with shell quoting + wrapping.
@@ -229,9 +333,18 @@ def _build_command(head, flags, targets, max_chars, wrap_at):
                        - `"--name"` — bare flag, no value
                        - `("--name", "value")` — single value
                        - `("--name", ["a", "b"])` — repeated; emits
-                         `--name=a --name=b` in order
-                     Order is preserved end-to-end. Pass an empty list
-                     when there are no flags.
+                         `--name=a --name=b`
+                     Single-token flags (bare + single-value) are
+                     always retained and keep their original relative
+                     order. List-valued flags are length-bounded the
+                     same way targets are: when they'd overflow
+                     `max_chars` the surplus values are dropped behind
+                     a `# +N more <flag> values` shell-comment line.
+                     To make truncation land on the offender rather
+                     than well-behaved flags, list flags are laid down
+                     ascending by element count (stable on ties) — so
+                     output flag order may differ from input order
+                     when truncation kicks in. See `_budget_flag_parts`.
         targets:     list of target patterns. Joined after a leading
                      `--` separator. Truncated entry-wise (whole
                      labels, never mid-label) to keep the total
@@ -240,9 +353,10 @@ def _build_command(head, flags, targets, max_chars, wrap_at):
                      can see the command is incomplete.
                      Pass an empty list for commands that don't take
                      positional targets.
-        max_chars:   soft length cap. When the head + flags already
-                     exceed it, the head still renders and `targets`
-                     collapses to `… +N more`.
+        max_chars:   soft length cap, applied independently to the
+                     flag block and the target block. List-flag values
+                     past the cap collapse to `# +N more <flag> values`;
+                     targets past it collapse to `… +N more`.
         wrap_at:     soft width target. When the composed single-line
                      command exceeds this, switch to a multi-line
                      form: head + flags + ` -- \\` on the first line,
@@ -254,16 +368,19 @@ def _build_command(head, flags, targets, max_chars, wrap_at):
     Returns:
         The composed command string.
     """
-    flag_parts = _format_flag_parts(flags)
+    flag_parts, flag_overflow_notes = _budget_flag_parts(flags, max_chars)
+    overflow_lines = _overflow_comment_lines(flag_overflow_notes)
     head_part = " ".join([head] + flag_parts)
 
     if not targets:
-        if len(head_part) <= wrap_at:
+        if len(head_part) <= wrap_at and not overflow_lines:
             return head_part
 
-        # Flag list alone exceeds wrap_at — wrap each flag onto its
-        # own line. Common on lint with many `--aspect=` entries.
-        return _join_continued([head] + ["  " + fp for fp in flag_parts])
+        # Flag list alone exceeds wrap_at (or some list-flag values
+        # were dropped) — wrap each flag onto its own line and append
+        # the `# +N more` notes. Common on lint with many `--aspect=`
+        # entries or gazelle with many `--gazelle-flag=-exclude=`.
+        return _join_continued([head] + ["  " + fp for fp in flag_parts] + ["  " + o for o in overflow_lines])
 
     separator = " -- "
     used = len(head_part) + len(separator)
@@ -279,23 +396,29 @@ def _build_command(head, flags, targets, max_chars, wrap_at):
         used += needed
 
     if not included:
-        return head_part + separator + "… +%d more" % omitted
+        single = head_part + separator + "… +%d more" % omitted
+        if not overflow_lines:
+            return single
+        return _join_continued([single] + ["  " + o for o in overflow_lines])
 
     single_line = head_part + separator + " ".join(included)
     if omitted > 0:
         single_line += " … +%d more" % omitted
-    if len(single_line) <= wrap_at:
+    if len(single_line) <= wrap_at and not overflow_lines:
         return single_line
 
     # Multi-line. Wrap flags individually too when head + flags
-    # alone overflow. `# … +N more` is a shell comment so the
-    # wrapped block stays copy-paste-runnable.
-    flag_overflow = len(head_part) + len(" -- \\") > wrap_at
+    # alone overflow, or whenever list-flag values were dropped (the
+    # `# +N more` notes need their own lines). `# … +N more` is a
+    # shell comment so the wrapped block stays copy-paste-runnable.
+    flag_overflow = len(head_part) + len(" -- \\") > wrap_at or bool(overflow_lines)
     lines = []
     if flag_overflow:
         lines.append(head)
         for fp in flag_parts:
             lines.append("  " + fp)
+        for o in overflow_lines:
+            lines.append("  " + o)
         lines.append("  --")
     else:
         lines.append(head_part + " --")

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -207,10 +207,16 @@ def _build_run_command(targets, flags, max_chars, wrap_at):
     # `_join_continued` is responsible for the trailing ` \` continuation
     # between lines — don't pre-add it to the head, or the rendered output
     # ends up with `-- \ \` (the literal backslash plus the join's separator).
-    # Flag-overflow notes go above the `--` so they read as part of the head.
-    lines = [head + " --"] + ["  " + o for o in overflow_lines] + ["  " + q for q in included]
+    #
+    # All `# …` markers cluster at the end, after every runnable token: a
+    # comment line terminates the logical command in a pasted shell, so no
+    # target arg may follow one. (`_join_continued` also refuses to put a
+    # trailing `\` on a comment line as a backstop.)
+    lines = [head + " --"] + ["  " + q for q in included]
     if omitted > 0:
         lines.append("  # +%d more" % omitted)
+    for o in overflow_lines:
+        lines.append("  " + o)
     return _join_continued(lines)
 
 def _budget_flag_parts(flags, max_chars):
@@ -409,16 +415,20 @@ def _build_command(head, flags, targets, max_chars, wrap_at):
 
     # Multi-line. Wrap flags individually too when head + flags
     # alone overflow, or whenever list-flag values were dropped (the
-    # `# +N more` notes need their own lines). `# … +N more` is a
-    # shell comment so the wrapped block stays copy-paste-runnable.
+    # `# +N more` notes need their own lines).
+    #
+    # All `# …` markers (dropped flag values AND omitted targets) are
+    # clustered at the very end, after every runnable token. A comment
+    # line terminates the logical command in a pasted shell — anything
+    # after it would run as a separate command — so no `--` or target
+    # may follow a marker. `_join_continued` also refuses to put a
+    # trailing `\` on a comment line as a backstop.
     flag_overflow = len(head_part) + len(" -- \\") > wrap_at or bool(overflow_lines)
     lines = []
     if flag_overflow:
         lines.append(head)
         for fp in flag_parts:
             lines.append("  " + fp)
-        for o in overflow_lines:
-            lines.append("  " + o)
         lines.append("  --")
     else:
         lines.append(head_part + " --")
@@ -426,12 +436,31 @@ def _build_command(head, flags, targets, max_chars, wrap_at):
         lines.append("  " + t)
     if omitted > 0:
         lines.append("  # … +%d more" % omitted)
+    for o in overflow_lines:
+        lines.append("  " + o)
     return _join_continued(lines)
 
 def _join_continued(lines):
-    """Join multi-line shell continuations: all but the last line gain
-    a trailing ` \\`, then `\n` between lines."""
-    return " \\\n".join(lines)
+    """Join `lines` into a multi-line shell continuation: each line but
+    the last gains a trailing ` \\`, joined by `\n`.
+
+    A line whose first non-space character is `#` (a shell comment) is
+    NEVER given a trailing backslash — the `\\` would be swallowed by the
+    comment, silently terminating the logical line so anything after it
+    parses as a separate command. Callers cluster `# +N more …` markers
+    at the end for readability, but this guard makes the join correct
+    regardless of where a comment lands, so a comment can't break the
+    copy-paste repro path.
+    """
+    out = []
+    for i, line in enumerate(lines):
+        last = i == len(lines) - 1
+        is_comment = line.lstrip().startswith("#")
+        if last or is_comment:
+            out.append(line)
+        else:
+            out.append(line + " \\")
+    return "\n".join(out)
 
 def dedup_and_attribute(entries):
     """Collapse `{kind, task_key, command, description}` entries across tasks.

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -454,13 +454,16 @@ def _test_scalars_always_retained_under_truncation(_ctx):
         max_chars = 200,
         wrap_at = 100,
     )
+
     # All three scalars present.
     for needle in ["--severity=info", "--check-only=false", "--scope=changed"]:
         if needle not in got:
             fail("scalar %r dropped under truncation:\n%s" % (needle, got))
+
     # The list flag was clipped, with an attributed comment.
     if "# +" not in got or "--gazelle-flag value" not in got:
         fail("expected `# +N more --gazelle-flag values` note, got:\n%s" % got)
+
     # Not all 60 excludes rendered (some were dropped).
     if got.count("-exclude=dir_") >= 60:
         fail("expected partial inclusion of excludes; all 60 rendered:\n%s" % got)
@@ -482,10 +485,12 @@ def _test_small_list_survives_large_list(_ctx):
         max_chars = 220,
         wrap_at = 100,
     )
+
     # Both small-list values present despite appearing after the big one.
     for needle in ["--scope-all-on-change=BUILD.bazel", "--scope-all-on-change=MODULE.bazel"]:
         if needle not in got:
             fail("small list flag value %r was starved by the large flag:\n%s" % (needle, got))
+
     # The big flag is the one that got clipped.
     if "--gazelle-flag value" not in got:
         fail("expected the large --gazelle-flag to be the clipped one:\n%s" % got)
@@ -535,6 +540,56 @@ def _test_single_value_flag_never_truncated(_ctx):
     )
     if ("--base-ref=" + long_val) not in got:
         fail("single-value flag was truncated (should be retained whole):\n%s" % got)
+
+def _test_overflow_comments_never_carry_continuation(_ctx):
+    """Regression: a command with BOTH overflowing forwarded flags AND
+    targets must keep every `# …` marker AFTER all runnable tokens and
+    must never end a comment line with a trailing ` \\`.
+
+    A `\\` on a comment line is swallowed by the `#`, terminating the
+    logical command — so a `--`/target rendered after the comment would
+    be parsed as a separate shell command, silently breaking the
+    copy-paste repro path. Both `aspect` and `bazel run` shapes."""
+    excludes = ["-exclude=dir_%d/sub/path" % i for i in range(60)]
+
+    for label, got in [
+        ("aspect", build_aspect_command(
+            "gazelle",
+            [("--severity", "info"), ("--gazelle-flag", excludes)],
+            ["tools/go", "services/api"],
+            max_chars = 150,
+            wrap_at = 100,
+        )),
+        ("bazel run", build_bazel_command(
+            "run",
+            ["//tools/gazelle:gazelle", "arg_one", "arg_two"],
+            flags = [("--gazelle-flag", excludes)],
+            max_chars = 150,
+            wrap_at = 100,
+        )),
+    ]:
+        lines = got.split("\n")
+
+        # No comment line ends with a continuation backslash.
+        for line in lines:
+            if line.lstrip().startswith("#") and line.rstrip().endswith("\\"):
+                fail("%s: comment line carries a trailing `\\` (breaks paste):\n%s" % (label, got))
+
+        # Once a comment line appears, no later line may be a runnable
+        # token (a `--` separator or an indented argument). Comments must
+        # be the trailing block.
+        seen_comment = False
+        for line in lines:
+            stripped = line.strip().rstrip("\\").strip()
+            if stripped.startswith("#"):
+                seen_comment = True
+                continue
+            if seen_comment and stripped:
+                fail("%s: runnable token %r appears after a comment marker:\n%s" % (label, stripped, got))
+
+        # Sanity: the test actually exercised the overflow path.
+        if "# +" not in got:
+            fail("%s: expected an overflow marker — test isn't exercising truncation:\n%s" % (label, got))
 
 # ---------------------------------------------------------------------------
 # apply_repro_fix_hooks — user customization hook
@@ -1105,6 +1160,7 @@ _UNIT_TESTS = [
     _test_overflow_note_counts_dropped_values,
     _test_truncation_keeps_command_copy_pasteable,
     _test_single_value_flag_never_truncated,
+    _test_overflow_comments_never_carry_continuation,
     _test_no_handlers_is_noop,
     _test_accept_keeps_entry,
     _test_reject_drops_entry,

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -7,7 +7,7 @@ tests on `Arguments`.
 """
 
 load("./lifecycle.axl", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixCommand", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "repro_fix_replace")
-load("./repro_commands.axl", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "rehydrate_commands", "repro_prefix", "subdir_prefix")
+load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "rehydrate_commands", "repro_prefix", "subdir_prefix")
 
 def _eq(label, got, want):
     if got != want:
@@ -419,6 +419,122 @@ def _test_bazel_run_truncates_long_arg_list(_ctx):
     included_count = got.count("pkg/file_")
     if included_count == 0 or included_count >= 20:
         fail("bazel run truncation: expected partial inclusion (some included, some omitted); included %d/20" % included_count)
+
+# ---------------------------------------------------------------------------
+# Flag truncation — list-valued flags are length-bounded; scalars survive
+# ---------------------------------------------------------------------------
+
+def _test_flags_all_fit_render_verbatim(_ctx):
+    """When everything fits, no reorder and no truncation: scalars and a
+    short list flag render in input order on a single line."""
+    got = build_aspect_command(
+        "gazelle",
+        [("--severity", "fail"), ("--gazelle-flag", ["-exclude=a", "-exclude=b"])],
+        [],
+    )
+    _eq(
+        "short command renders verbatim",
+        got,
+        "aspect gazelle --severity=fail --gazelle-flag=-exclude=a --gazelle-flag=-exclude=b",
+    )
+
+def _test_scalars_always_retained_under_truncation(_ctx):
+    """A huge list flag is clipped, but every scalar survives and the
+    overflow note names the offending flag."""
+    excludes = ["-exclude=dir_%d/sub/path" % i for i in range(60)]
+    got = build_aspect_command(
+        "gazelle",
+        [
+            ("--severity", "info"),
+            ("--check-only", "false"),
+            ("--scope", "changed"),
+            ("--gazelle-flag", excludes),
+        ],
+        [],
+        max_chars = 200,
+        wrap_at = 100,
+    )
+    # All three scalars present.
+    for needle in ["--severity=info", "--check-only=false", "--scope=changed"]:
+        if needle not in got:
+            fail("scalar %r dropped under truncation:\n%s" % (needle, got))
+    # The list flag was clipped, with an attributed comment.
+    if "# +" not in got or "--gazelle-flag value" not in got:
+        fail("expected `# +N more --gazelle-flag values` note, got:\n%s" % got)
+    # Not all 60 excludes rendered (some were dropped).
+    if got.count("-exclude=dir_") >= 60:
+        fail("expected partial inclusion of excludes; all 60 rendered:\n%s" % got)
+
+def _test_small_list_survives_large_list(_ctx):
+    """A well-behaved small list flag renders in full even when a large
+    one (later in input order) overflows — ordering by element count
+    protects the small one."""
+    big = ["-exclude=path_%d/deep/nested/dir" % i for i in range(40)]
+    got = build_aspect_command(
+        "gazelle",
+        [
+            # Large list FIRST in input order — without count-sorting it
+            # would consume the budget and starve the small one.
+            ("--gazelle-flag", big),
+            ("--scope-all-on-change", ["BUILD.bazel", "MODULE.bazel"]),
+        ],
+        [],
+        max_chars = 220,
+        wrap_at = 100,
+    )
+    # Both small-list values present despite appearing after the big one.
+    for needle in ["--scope-all-on-change=BUILD.bazel", "--scope-all-on-change=MODULE.bazel"]:
+        if needle not in got:
+            fail("small list flag value %r was starved by the large flag:\n%s" % (needle, got))
+    # The big flag is the one that got clipped.
+    if "--gazelle-flag value" not in got:
+        fail("expected the large --gazelle-flag to be the clipped one:\n%s" % got)
+
+def _test_overflow_note_counts_dropped_values(_ctx):
+    """The `# +N more` note reports exactly how many values were dropped."""
+    excludes = ["-exclude=val_%d" % i for i in range(30)]
+    got = build_aspect_command(
+        "gazelle",
+        [("--gazelle-flag", excludes)],
+        [],
+        max_chars = 120,
+        wrap_at = 80,
+    )
+    rendered = got.count("--gazelle-flag=-exclude=")
+    dropped = 30 - rendered
+    expected_note = "# +%d more --gazelle-flag values" % dropped
+    if expected_note not in got:
+        fail("expected note %r (rendered %d/30), got:\n%s" % (expected_note, rendered, got))
+
+def _test_truncation_keeps_command_copy_pasteable(_ctx):
+    """Every dropped-value note is a `#` shell comment so the wrapped
+    block stays runnable."""
+    excludes = ["-exclude=dir_%d" % i for i in range(50)]
+    got = build_aspect_command(
+        "gazelle",
+        [("--severity", "info"), ("--gazelle-flag", excludes)],
+        ["tools/go", "services/api"],
+        max_chars = 150,
+        wrap_at = 100,
+    )
+    for line in got.split("\n"):
+        stripped = line.strip().rstrip("\\").strip()
+        if stripped.startswith("+") and not stripped.startswith("#"):
+            fail("overflow marker is not a shell comment (would break paste):\n%s" % got)
+
+def _test_single_value_flag_never_truncated(_ctx):
+    """A single-value (non-list) flag whose value is itself long is a
+    scalar — always retained, never clipped."""
+    long_val = "x" * 300
+    got = build_aspect_command(
+        "gazelle",
+        [("--base-ref", long_val)],
+        [],
+        max_chars = 50,
+        wrap_at = 40,
+    )
+    if ("--base-ref=" + long_val) not in got:
+        fail("single-value flag was truncated (should be retained whole):\n%s" % got)
 
 # ---------------------------------------------------------------------------
 # apply_repro_fix_hooks — user customization hook
@@ -983,6 +1099,12 @@ _UNIT_TESTS = [
     _test_bazel_run_no_targets,
     _test_bazel_run_multiline_continuation_form,
     _test_bazel_run_truncates_long_arg_list,
+    _test_flags_all_fit_render_verbatim,
+    _test_scalars_always_retained_under_truncation,
+    _test_small_list_survives_large_list,
+    _test_overflow_note_counts_dropped_values,
+    _test_truncation_keeps_command_copy_pasteable,
+    _test_single_value_flag_never_truncated,
     _test_no_handlers_is_noop,
     _test_accept_keeps_entry,
     _test_reject_drops_entry,


### PR DESCRIPTION
## Problem

Repro/fix commands re-emit the user's explicit flags so a developer can reproduce CI's exact invocation. List-valued flags (`--gazelle-flag`, `--exclude-pattern`, `--formatter-arg`, …) expand to one shell token per element, and — unlike the positional target list, which has always been length-bounded — the flag list was never capped.

A user's `aspect gazelle` invocation passes one `--gazelle-flag=-exclude=<path>` per untracked file (its ignore-untracked wrapper enumerates `git ls-files --others`). On a large working tree that produced a repro/fix command with **hundreds** of `--gazelle-flag=-exclude=` tokens — a wall of text on the status surface and in the CI log.

## Fix

Bound the flag list the same way the target list already is, in the shared `_build_command` / `_build_run_command` layer so every task benefits (gazelle, format, lint, and the vanilla-bazel alternates).

- **Behavior-changing scalar flags are always retained** — bare flags and single-value flags (`--severity`, `--scope`, `--base-ref`, …) are never dropped; losing one would change what the command does.
- **Only surplus list-flag values are truncated**, behind a `# +N more <flag> values` shell-comment line (per-flag attribution, so a reviewer sees the dropped tokens were e.g. excludes, not meaningful flags). The command stays copy-paste-runnable.
- **List flags are laid down ascending by element count** (stable on ties), so truncation concentrates on the offending flag rather than starving small, well-behaved ones that happened to come later in the original order.

Truncation only engages on the overflow path; commands that already fit render byte-for-byte as before, in original order.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Repro and fix commands no longer render an unbounded wall of forwarded flags. Long list-valued flags (e.g. many `--gazelle-flag=-exclude=` or `--exclude-pattern=` entries) are now truncated with a `# +N more <flag> values` marker, while behavior-changing flags are always preserved.

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce:
  - `aspect dev test-repro-commands` — 73 pass (6 new: all-fits-verbatim, scalars-always-retained, small-list-survives-large-list, count-accurate overflow note, copy-pasteable comment markers, single-value-never-truncated).
