### PR TITLE
fix(delivery): surface Bazel stderr when phase-2 gRPC log is missing

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -1776,6 +1776,7 @@ def test_deliveryd_parse_endpoint(tc: int) -> int:
 
 def test_delivery_should_upload_grpc_log(tc: int) -> int:
     """Coverage for the --upload-grpc-log tristate gating predicate."""
+
     # "true" always uploads, regardless of outcome.
     tc = test_case(tc, delivery_should_upload_grpc_log("true", 0), "upload-grpc-log: true + resolved → upload")
     tc = test_case(tc, delivery_should_upload_grpc_log("true", 3), "upload-grpc-log: true + unresolved → upload")

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -2,7 +2,7 @@
 Exercise axl
 """
 
-load("@aspect//delivery.axl", delivery_fmt_elapsed = "fmt_elapsed")
+load("@aspect//delivery.axl", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_upload_grpc_log = "should_upload_grpc_log")
 load("@aspect//lib/artifacts.axl", "artifact_name")
 load("@aspect//lib/bazel_results.axl", "compute_reproducer_command", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
 load(
@@ -1774,6 +1774,22 @@ def test_deliveryd_parse_endpoint(tc: int) -> int:
 
     return tc
 
+def test_delivery_should_upload_grpc_log(tc: int) -> int:
+    """Coverage for the --upload-grpc-log tristate gating predicate."""
+    # "true" always uploads, regardless of outcome.
+    tc = test_case(tc, delivery_should_upload_grpc_log("true", 0), "upload-grpc-log: true + resolved → upload")
+    tc = test_case(tc, delivery_should_upload_grpc_log("true", 3), "upload-grpc-log: true + unresolved → upload")
+
+    # "false" never uploads.
+    tc = test_case(tc, not delivery_should_upload_grpc_log("false", 0), "upload-grpc-log: false + resolved → skip")
+    tc = test_case(tc, not delivery_should_upload_grpc_log("false", 3), "upload-grpc-log: false + unresolved → skip")
+
+    # "auto" uploads only when a digest went unresolved.
+    tc = test_case(tc, not delivery_should_upload_grpc_log("auto", 0), "upload-grpc-log: auto + resolved → skip")
+    tc = test_case(tc, delivery_should_upload_grpc_log("auto", 1), "upload-grpc-log: auto + unresolved → upload")
+
+    return tc
+
 def test_build_metadata_lib(tc: int) -> int:
     """Coverage for the pure helpers in lib/build_metadata.axl."""
 
@@ -3057,6 +3073,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_parse_git_url_name(tc)
     tc = test_sanitize_filename(tc)
     tc = test_deliveryd_parse_endpoint(tc)
+    tc = test_delivery_should_upload_grpc_log(tc)
     tc = test_build_metadata_lib(tc)
     tc = test_severity_for_status(tc)
     tc = test_gazelle_dir_helpers(tc)

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -513,6 +513,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     if not ctx.std.fs.exists(log_path):
         error(ctx.std, "Phase-2 produced no gRPC log; could not checksum delivery digests. Phase-2 raw log: {}".format(phase2_log_path))
         _dump_bazel_stderr(ctx, phase2_log_path)
+        artifacts.upload_file(ctx, "delivery_phase2_log", "phase2-stderr.log", phase2_log_path)
         return {}, {}, phase2_status.code if phase2_status.code != 0 else 1
 
     log_file = ctx.std.fs.open(log_path)
@@ -533,9 +534,9 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             if mnemonic not in existing:
                 existing.append(mnemonic)
                 misses_by_producer[entry_label] = existing
-    ctx.std.fs.remove_file(log_path)
     _unresolved = len(targets) - len(output_shas)
     if _unresolved == 0:
+        ctx.std.fs.remove_file(log_path)
         print("  Resolved digests for all {} in {}.".format(targets_label, fmt_elapsed(time.monotonic() - _t_phase2)))
     else:
         # Always point at the phase-2 log when anything went unresolved —
@@ -551,6 +552,20 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             phase2_log_path,
         ))
         _dump_bazel_stderr(ctx, phase2_log_path)
+        # Upload the raw diagnostics so an unresolved digest is debuggable
+        # after the fact. The gRPC log is the ground truth (which
+        # GetActionResult missed); the stderr is the human-readable
+        # companion. No-op off-CI; the gRPC log is removed afterward.
+        #
+        # Unlike the exec-log, this phase runs with --remote_download_outputs
+        # =minimal + require-cached, so the log is GetActionResult/FindMissing
+        # Blobs lookups (digests + statuses) — no command lines or action env.
+        # The residual risk is the remote-cache auth token in RPC call
+        # metadata; uploaded unconditionally on failure as an accepted
+        # tradeoff for debuggability (job-artifact access already gates it).
+        artifacts.upload_file(ctx, "delivery_grpc_log", "phase2-grpc.binpb", log_path)
+        artifacts.upload_file(ctx, "delivery_phase2_log", "phase2-stderr.log", phase2_log_path)
+        ctx.std.fs.remove_file(log_path)
 
     # Filter to misses on actions that did NOT declare a remote-cache
     # opt-out — these are real key-drift symptoms (transient or
@@ -1178,6 +1193,7 @@ def _delivery_impl(ctx):
         if status.code != 0:
             error(ctx.std, "Build failed with exit code {}. Phase-3 raw log: {}".format(status.code, phase3_log_path))
             _dump_bazel_stderr(ctx, phase3_log_path)
+            artifacts.upload_file(ctx, "delivery_phase3_log", "phase3-stderr.log", phase3_log_path)
             for label in delivery_targets:
                 delivery_add_result(
                     data,

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1555,7 +1555,7 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
             default = "auto",
             values = ["auto", "true", "false"],
             long = "upload-grpc-log",
-            description = "Whether to upload the phase-2 Bazel gRPC log (--remote_grpc_log) as a CI artifact for debugging change-detection digests. 'auto' (default) uploads only when one or more digests could not be hashed (or phase 2 produced no log). 'true' always uploads it; 'false' never does. The require-cached phase logs only GetActionResult/FindMissingBlobs lookups (digests + statuses) — no command lines or action env — but the gRPC call metadata can carry the remote-cache auth token, so the artifact is gated. Requires the Artifact Upload feature and a recognized CI host; no-op otherwise. Per-phase stderr logs are always uploaded on failure regardless of this flag.",
+            description = "Whether to upload the phase-2 Bazel gRPC log (--remote_grpc_log) as a CI artifact for debugging change-detection digests. 'auto' (default) uploads only when one or more digests could not be hashed. 'true' always uploads it; 'false' never does. (When phase 2 produces no gRPC log at all, there is nothing to upload regardless of this flag — the captured stderr is uploaded instead.) The require-cached phase logs only GetActionResult/FindMissingBlobs lookups (digests + statuses) — no command lines or action env — but the gRPC call metadata can carry the remote-cache auth token, so the artifact is gated. Requires the Artifact Upload feature and a recognized CI host; no-op otherwise. Per-phase stderr logs are always uploaded on failure regardless of this flag.",
         ),
         "manifest_file": args.string(
             default = "",

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -307,15 +307,10 @@ _EXECLOG_PATH = "/tmp/aspect-delivery-execlog-{}.bin"
 # `remote_cacheable` field tells us whether the rule declared the opt-out.
 _DELIVERY_HASH_MNEMONIC = "DeliveryHash"
 
-def _dump_phase2_stderr(ctx, phase2_log_path):
-    """Echo the captured phase-2 Bazel stderr to this process's stderr.
-
-    Phase 2 redirects Bazel's stderr to a file (require-cached misses are
-    noisy-but-expected). When digests go unresolved, that file holds Bazel's
-    own diagnosis — print it verbatim rather than guessing the cause. No-op
-    if the file is absent."""
-    if ctx.std.fs.exists(phase2_log_path):
-        ctx.std.io.stderr.write(ctx.std.fs.read_to_string(phase2_log_path))
+def _dump_bazel_stderr(ctx, log_path):
+    """Echo a phase's captured Bazel stderr to this process's stderr."""
+    if ctx.std.fs.exists(log_path):
+        ctx.std.io.stderr.write(ctx.std.fs.read_to_string(log_path))
 
 def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_flags, remote_executor_uri, ansi, data):
     """Run phase 1 (main build) + phase 2 (digest extraction) and return
@@ -517,7 +512,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     # the captured phase-2 stderr verbatim, which holds Bazel's own reason.
     if not ctx.std.fs.exists(log_path):
         error(ctx.std, "Phase-2 produced no gRPC log; could not checksum delivery digests. Phase-2 raw log: {}".format(phase2_log_path))
-        _dump_phase2_stderr(ctx, phase2_log_path)
+        _dump_bazel_stderr(ctx, phase2_log_path)
         return {}, {}, phase2_status.code if phase2_status.code != 0 else 1
 
     log_file = ctx.std.fs.open(log_path)
@@ -555,7 +550,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             _unresolved,
             phase2_log_path,
         ))
-        _dump_phase2_stderr(ctx, phase2_log_path)
+        _dump_bazel_stderr(ctx, phase2_log_path)
 
     # Filter to misses on actions that did NOT declare a remote-cache
     # opt-out — these are real key-drift symptoms (transient or
@@ -1182,6 +1177,7 @@ def _delivery_impl(ctx):
             dispatch_bazel_build_end(ctx, bazel_trait, status.code)
         if status.code != 0:
             error(ctx.std, "Build failed with exit code {}. Phase-3 raw log: {}".format(status.code, phase3_log_path))
+            _dump_bazel_stderr(ctx, phase3_log_path)
             for label in delivery_targets:
                 delivery_add_result(
                     data,

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -537,7 +537,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     if not ctx.std.fs.exists(log_path):
         error(ctx.std, "Phase-2 produced no gRPC log; could not checksum delivery digests. Phase-2 raw log: {}".format(phase2_log_path))
         _surface_phase_stderr(ctx, 2, phase2_log_path)
-        return {}, {}, phase2_status.code if phase2_status.code != 0 else 1
+        return {}, {}, (phase2_status.code if phase2_status.code != 0 else 1)
 
     log_file = ctx.std.fs.open(log_path)
     for entry in remote.logging.LogEntry().parse_from_delimited(log_file):

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -501,6 +501,16 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     # the producing target (may be a transitive dep, not a deliverable).
     output_shas = {}
     misses_by_producer = {}
+
+    # Bazel only writes `--remote_grpc_log` once it issues remote RPCs; a
+    # phase-2 that fails before then leaves no log. Don't guess why — surface
+    # the captured phase-2 stderr verbatim, which holds Bazel's own reason.
+    if not ctx.std.fs.exists(log_path):
+        error(ctx.std, "Phase-2 produced no gRPC log ({}); could not checksum delivery digests. Bazel stderr follows:".format(log_path))
+        if ctx.std.fs.exists(phase2_log_path):
+            ctx.std.io.stderr.write(ctx.std.fs.read_to_string(phase2_log_path))
+        return {}, {}, phase2_status.code if phase2_status.code != 0 else 1
+
     log_file = ctx.std.fs.open(log_path)
     for entry in remote.logging.LogEntry().parse_from_delimited(log_file):
         if entry.method_name != "build.bazel.remote.execution.v2.ActionCache/GetActionResult":

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -317,6 +317,10 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     `(output_shas, non_hermetic_misses, exit_code)`. Phase 1 BES events
     drive the `data` (delivery_results) metadata; phase 2's gRPC log yields
     the per-target action digests used for change detection.
+
+    On a phase-2 failure or any unresolved digest, the captured Bazel stderr
+    is echoed and uploaded as a CI artifact; the gRPC log is uploaded per
+    `ctx.args.upload_grpc_log` ("auto"/"true"/"false"). Uploads no-op off-CI.
     """
     repo_dir = "/tmp/aspect_delivery_" + ctx.task.key
     _write_aspect_repo(ctx, repo_dir)
@@ -535,6 +539,20 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
                 existing.append(mnemonic)
                 misses_by_producer[entry_label] = existing
     _unresolved = len(targets) - len(output_shas)
+
+    # Upload the phase-2 gRPC log per --upload-grpc-log: "true" always,
+    # "auto" only when a digest went unresolved, "false" never. The log is
+    # the ground truth for which GetActionResult missed. Unlike the
+    # exec-log, this phase runs --remote_download_outputs=minimal +
+    # require-cached, so the log holds only GetActionResult/FindMissingBlobs
+    # lookups (digests + statuses) — no command lines or action env. The
+    # residual risk is the remote-cache auth token in RPC call metadata, so
+    # the upload is gated behind the flag (job-artifact access also gates
+    # who can download it). No-op off-CI.
+    upload_grpc = ctx.args.upload_grpc_log if hasattr(ctx.args, "upload_grpc_log") else "auto"
+    if upload_grpc == "true" or (upload_grpc == "auto" and _unresolved > 0):
+        artifacts.upload_file(ctx, "delivery_grpc_log", "phase2-grpc.binpb", log_path)
+
     if _unresolved == 0:
         ctx.std.fs.remove_file(log_path)
         print("  Resolved digests for all {} in {}.".format(targets_label, fmt_elapsed(time.monotonic() - _t_phase2)))
@@ -552,18 +570,8 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             phase2_log_path,
         ))
         _dump_bazel_stderr(ctx, phase2_log_path)
-        # Upload the raw diagnostics so an unresolved digest is debuggable
-        # after the fact. The gRPC log is the ground truth (which
-        # GetActionResult missed); the stderr is the human-readable
-        # companion. No-op off-CI; the gRPC log is removed afterward.
-        #
-        # Unlike the exec-log, this phase runs with --remote_download_outputs
-        # =minimal + require-cached, so the log is GetActionResult/FindMissing
-        # Blobs lookups (digests + statuses) — no command lines or action env.
-        # The residual risk is the remote-cache auth token in RPC call
-        # metadata; uploaded unconditionally on failure as an accepted
-        # tradeoff for debuggability (job-artifact access already gates it).
-        artifacts.upload_file(ctx, "delivery_grpc_log", "phase2-grpc.binpb", log_path)
+        # The stderr is the human-readable companion to the gRPC log;
+        # always upload it on failure (low-risk, no env/command lines).
         artifacts.upload_file(ctx, "delivery_phase2_log", "phase2-stderr.log", phase2_log_path)
         ctx.std.fs.remove_file(log_path)
 
@@ -1542,6 +1550,12 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         "warn_not_runnable": args.boolean(
             default = False,
             description = "Downgrade a non-runnable deliverable from a hard failure (exit 1) to a warning. A target tagged 'deliverable' whose entrypoint has no runfiles tree fails by default. Set this flag if your repo intentionally tags non-executable targets as deliverable.",
+        ),
+        "upload_grpc_log": args.string(
+            default = "auto",
+            values = ["auto", "true", "false"],
+            long = "upload-grpc-log",
+            description = "Whether to upload the phase-2 Bazel gRPC log (--remote_grpc_log) as a CI artifact for debugging change-detection digests. 'auto' (default) uploads only when one or more digests could not be hashed (or phase 2 produced no log). 'true' always uploads it; 'false' never does. The require-cached phase logs only GetActionResult/FindMissingBlobs lookups (digests + statuses) — no command lines or action env — but the gRPC call metadata can carry the remote-cache auth token, so the artifact is gated. Requires the Artifact Upload feature and a recognized CI host; no-op otherwise. Per-phase stderr logs are always uploaded on failure regardless of this flag.",
         ),
         "manifest_file": args.string(
             default = "",

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -307,10 +307,30 @@ _EXECLOG_PATH = "/tmp/aspect-delivery-execlog-{}.bin"
 # `remote_cacheable` field tells us whether the rule declared the opt-out.
 _DELIVERY_HASH_MNEMONIC = "DeliveryHash"
 
-def _dump_bazel_stderr(ctx, log_path):
-    """Echo a phase's captured Bazel stderr to this process's stderr."""
-    if ctx.std.fs.exists(log_path):
-        ctx.std.io.stderr.write(ctx.std.fs.read_to_string(log_path))
+def should_upload_grpc_log(setting: str, unresolved: int) -> bool:
+    """Resolve the --upload-grpc-log tristate against the phase-2 outcome.
+
+    "true" always uploads, "false" never, "auto" only when a digest went
+    unresolved (`unresolved > 0`). Exported for unit testing."""
+    if setting == "true":
+        return True
+    if setting == "false":
+        return False
+    return unresolved > 0
+
+def _surface_phase_stderr(ctx, phase, log_path):
+    """Echo a failing phase's captured Bazel stderr to the console and upload
+    it as a CI artifact (`delivery_phase{phase}_log`).
+
+    Phases 2 and 3 redirect Bazel's stderr to a file rather than the console
+    (phase-2 require-cached misses are noisy-but-expected). On failure that
+    file holds Bazel's own diagnosis, so echo it verbatim and preserve it as
+    a downloadable artifact. The stderr carries no env/command lines, so it
+    uploads unconditionally. No-op if the file is absent or off-CI."""
+    if not ctx.std.fs.exists(log_path):
+        return
+    ctx.std.io.stderr.write(ctx.std.fs.read_to_string(log_path))
+    artifacts.upload_file(ctx, "delivery_phase{}_log".format(phase), "phase{}-stderr.log".format(phase), log_path)
 
 def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_flags, remote_executor_uri, ansi, data):
     """Run phase 1 (main build) + phase 2 (digest extraction) and return
@@ -512,12 +532,11 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     misses_by_producer = {}
 
     # Bazel only writes `--remote_grpc_log` once it issues remote RPCs; a
-    # phase-2 that fails before then leaves no log. Don't guess why — surface
-    # the captured phase-2 stderr verbatim, which holds Bazel's own reason.
+    # phase-2 that fails before then leaves no log, so there's nothing to
+    # parse — surface the captured stderr (Bazel's own reason) and bail.
     if not ctx.std.fs.exists(log_path):
         error(ctx.std, "Phase-2 produced no gRPC log; could not checksum delivery digests. Phase-2 raw log: {}".format(phase2_log_path))
-        _dump_bazel_stderr(ctx, phase2_log_path)
-        artifacts.upload_file(ctx, "delivery_phase2_log", "phase2-stderr.log", phase2_log_path)
+        _surface_phase_stderr(ctx, 2, phase2_log_path)
         return {}, {}, phase2_status.code if phase2_status.code != 0 else 1
 
     log_file = ctx.std.fs.open(log_path)
@@ -540,28 +559,21 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
                 misses_by_producer[entry_label] = existing
     _unresolved = len(targets) - len(output_shas)
 
-    # Upload the phase-2 gRPC log per --upload-grpc-log: "true" always,
-    # "auto" only when a digest went unresolved, "false" never. The log is
-    # the ground truth for which GetActionResult missed. Unlike the
-    # exec-log, this phase runs --remote_download_outputs=minimal +
-    # require-cached, so the log holds only GetActionResult/FindMissingBlobs
-    # lookups (digests + statuses) — no command lines or action env. The
-    # residual risk is the remote-cache auth token in RPC call metadata, so
-    # the upload is gated behind the flag (job-artifact access also gates
-    # who can download it). No-op off-CI.
+    # Preserve the gRPC log (the ground truth for which GetActionResult
+    # missed) as a CI artifact per --upload-grpc-log; see the flag's
+    # description for the gating rationale. No-op off-CI.
     upload_grpc = ctx.args.upload_grpc_log if hasattr(ctx.args, "upload_grpc_log") else "auto"
-    if upload_grpc == "true" or (upload_grpc == "auto" and _unresolved > 0):
+    if should_upload_grpc_log(upload_grpc, _unresolved):
         artifacts.upload_file(ctx, "delivery_grpc_log", "phase2-grpc.binpb", log_path)
+    ctx.std.fs.remove_file(log_path)
 
     if _unresolved == 0:
-        ctx.std.fs.remove_file(log_path)
         print("  Resolved digests for all {} in {}.".format(targets_label, fmt_elapsed(time.monotonic() - _t_phase2)))
     else:
-        # Always point at the phase-2 log when anything went unresolved —
-        # the gRPC log may contain zero useful entries (auth/network/config
-        # error before any GetActionResult fired), in which case the
-        # per-target row's inline diagnosis can't fire and the log file is
-        # the only diagnostic surface left.
+        # Point at the phase-2 stderr when anything went unresolved: the
+        # gRPC log may hold zero useful entries (an auth/network/config error
+        # before any GetActionResult fired), so the per-target inline
+        # diagnosis can't fire and the stderr is the actionable surface.
         print("  Resolved {} of {} delivery digests in {}; {} could not be hashed. Phase-2 raw log: {}".format(
             len(output_shas),
             len(targets),
@@ -569,11 +581,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             _unresolved,
             phase2_log_path,
         ))
-        _dump_bazel_stderr(ctx, phase2_log_path)
-        # The stderr is the human-readable companion to the gRPC log;
-        # always upload it on failure (low-risk, no env/command lines).
-        artifacts.upload_file(ctx, "delivery_phase2_log", "phase2-stderr.log", phase2_log_path)
-        ctx.std.fs.remove_file(log_path)
+        _surface_phase_stderr(ctx, 2, phase2_log_path)
 
     # Filter to misses on actions that did NOT declare a remote-cache
     # opt-out — these are real key-drift symptoms (transient or
@@ -1200,8 +1208,7 @@ def _delivery_impl(ctx):
             dispatch_bazel_build_end(ctx, bazel_trait, status.code)
         if status.code != 0:
             error(ctx.std, "Build failed with exit code {}. Phase-3 raw log: {}".format(status.code, phase3_log_path))
-            _dump_bazel_stderr(ctx, phase3_log_path)
-            artifacts.upload_file(ctx, "delivery_phase3_log", "phase3-stderr.log", phase3_log_path)
+            _surface_phase_stderr(ctx, 3, phase3_log_path)
             for label in delivery_targets:
                 delivery_add_result(
                     data,

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -307,6 +307,16 @@ _EXECLOG_PATH = "/tmp/aspect-delivery-execlog-{}.bin"
 # `remote_cacheable` field tells us whether the rule declared the opt-out.
 _DELIVERY_HASH_MNEMONIC = "DeliveryHash"
 
+def _dump_phase2_stderr(ctx, phase2_log_path):
+    """Echo the captured phase-2 Bazel stderr to this process's stderr.
+
+    Phase 2 redirects Bazel's stderr to a file (require-cached misses are
+    noisy-but-expected). When digests go unresolved, that file holds Bazel's
+    own diagnosis — print it verbatim rather than guessing the cause. No-op
+    if the file is absent."""
+    if ctx.std.fs.exists(phase2_log_path):
+        ctx.std.io.stderr.write(ctx.std.fs.read_to_string(phase2_log_path))
+
 def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_flags, remote_executor_uri, ansi, data):
     """Run phase 1 (main build) + phase 2 (digest extraction) and return
     `(output_shas, non_hermetic_misses, exit_code)`. Phase 1 BES events
@@ -506,9 +516,8 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     # phase-2 that fails before then leaves no log. Don't guess why — surface
     # the captured phase-2 stderr verbatim, which holds Bazel's own reason.
     if not ctx.std.fs.exists(log_path):
-        error(ctx.std, "Phase-2 produced no gRPC log ({}); could not checksum delivery digests. Bazel stderr follows:".format(log_path))
-        if ctx.std.fs.exists(phase2_log_path):
-            ctx.std.io.stderr.write(ctx.std.fs.read_to_string(phase2_log_path))
+        error(ctx.std, "Phase-2 produced no gRPC log; could not checksum delivery digests. Phase-2 raw log: {}".format(phase2_log_path))
+        _dump_phase2_stderr(ctx, phase2_log_path)
         return {}, {}, phase2_status.code if phase2_status.code != 0 else 1
 
     log_file = ctx.std.fs.open(log_path)
@@ -546,6 +555,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             _unresolved,
             phase2_log_path,
         ))
+        _dump_phase2_stderr(ctx, phase2_log_path)
 
     # Filter to misses on actions that did NOT declare a remote-cache
     # opt-out — these are real key-drift symptoms (transient or


### PR DESCRIPTION
The `delivery` task's phase-2 "checksum" step parses Bazel's `--remote_grpc_log` to extract each target's `DeliveryHash` digest. Bazel only writes that log once it issues remote RPCs, so a phase-2 that fails before then leaves no log file. The code opened the log unconditionally and crashed with a raw `os error 2` Starlark traceback, hiding the captured phase-2 stderr where the real cause lives.

This guards the open and, on any phase-2/phase-3 failure, echoes Bazel's captured stderr and preserves it (plus the phase-2 gRPC log) as CI artifacts for after-the-fact debugging:

- **Missing gRPC log / unresolved digests / phase-3 download failure** now print Bazel's own stderr instead of crashing, and return a non-zero exit so the task fails cleanly.
- The per-phase **stderr** (no env/command lines) is uploaded as a CI artifact on failure.
- The phase-2 **gRPC log** is uploaded per a new `--upload-grpc-log` flag (`auto`/`true`/`false`, default `auto` = on unresolved digests only). It's gated because gRPC call metadata can carry the remote-cache auth token.

All uploads go through the existing Artifact Upload feature and no-op off-CI.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- `delivery` no longer crashes with an internal traceback when phase-2 produces no gRPC log; it prints Bazel's stderr and fails cleanly.
- On a delivery build/checksum failure, Bazel's stderr is uploaded as a CI artifact; the phase-2 gRPC log is uploaded per the new `--upload-grpc-log` flag (`auto`/`true`/`false`, default `auto`).

### Test plan

- New test cases added: `should_upload_grpc_log` tristate gating covered in the AXL self-test suite (`aspect tests axl`).
- Manual testing: run a `delivery` task where phase 2 cannot reach the remote cache/executor. Previously crashed at `delivery.axl` with `os error 2`; now prints `ERROR: Phase-2 produced no gRPC log (...)` followed by Bazel's stderr, uploads the stderr artifact, and exits non-zero.
