### PR TITLE
chore(tips): drop GITHUB_TOKEN fallback tips; point users to the GitHub App

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -238,7 +238,7 @@ def config(ctx: ConfigContext):
 
     # Silence tips — was `ctx.traits[TipsTrait].silenced_tips = [...]`
     # before the tips refactor; now done via the Tips feature's args.
-    # Example: ctx.features["tips"].args.silence.append("add-github-token")
+    # Example: ctx.features["tips"].args.silence.append("some-tip-id")
     # (Left empty — append ids here to suppress specific tips.)
 
     # Add a new task

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -425,15 +425,15 @@ def _check_collect_tip_rows(ctx):
     if "tips" not in by_id["s"]["silence_hint"] or "silence" not in by_id["s"]["silence_hint"]:
         fail("collect_tip_rows: suggestion row must reference the tips silence knob in silence_hint")
 
-    # combine_across_tasks: two tasks emit the `add-github-token-scope`
-    # JINJA2 tip with distinct scopes/endpoints. The combined row unions
-    # each `accumulate` field across tasks (first-seen order) and
-    # re-renders title + body (pluralized title, full endpoint list).
+    # combine_across_tasks: two tasks emit a multi-accumulator JINJA2 tip
+    # with distinct scopes/endpoints. The combined row unions each
+    # `accumulate` field across tasks (first-seen order) and re-renders
+    # title + body (pluralized title, full endpoint list).
     title_tmpl = "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %}"
     body_tmpl = "{{ endpoints|length }} calls fell back:\n{% for e in endpoints %}- {{ e }}\n{% endfor %}"
     rows = collect_tip_rows(ctx, [
         {"key": "build-task", "tips": [{
-            "id": "add-github-token-scope",
+            "id": "sample-scope-tip",
             "severity": "warning",
             "title": "Grant `actions: read`",
             "body": "...",
@@ -444,7 +444,7 @@ def _check_collect_tip_rows(ctx):
             "accumulate": {"scopes": ["actions: read"], "endpoints": ["/a/jobs"]},
         }]},
         {"key": "test-task", "tips": [{
-            "id": "add-github-token-scope",
+            "id": "sample-scope-tip",
             "severity": "warning",
             "title": "Grant `pull-requests: read`",
             "body": "...",
@@ -1904,10 +1904,10 @@ def _test_impl(ctx):
                     make_lint_passed_clean(),
                     16000,
                     tips = [{
-                        "id": "add-github-token",
+                        "id": "sample-suggestion",
                         "severity": "suggestion",
-                        "title": "Export `GITHUB_TOKEN` to free App quota",
-                        "body": "Setting `GITHUB_TOKEN` routes supporting calls through the job-scoped token.",
+                        "title": "A sample suggestion tip",
+                        "body": "Body text for a representative suggestion-severity tip.",
                     }],
                 ),
             ],
@@ -1924,10 +1924,10 @@ def _test_impl(ctx):
                     make_build_passed(),
                     8000,
                     tips = [{
-                        "id": "add-github-token",
+                        "id": "sample-suggestion",
                         "severity": "suggestion",
-                        "title": "Export `GITHUB_TOKEN` to free App quota",
-                        "body": "Setting `GITHUB_TOKEN` routes supporting calls through the job-scoped token.",
+                        "title": "A sample suggestion tip",
+                        "body": "Body text for a representative suggestion-severity tip.",
                     }],
                 ),
                 _entry(
@@ -1939,10 +1939,10 @@ def _test_impl(ctx):
                     make_test_passed_flaky_only(),
                     12000,
                     tips = [{
-                        "id": "add-github-token",
+                        "id": "sample-suggestion",
                         "severity": "suggestion",
-                        "title": "Export `GITHUB_TOKEN` to free App quota",
-                        "body": "Setting `GITHUB_TOKEN` routes supporting calls through the job-scoped token.",
+                        "title": "A sample suggestion tip",
+                        "body": "Body text for a representative suggestion-severity tip.",
                     }],
                 ),
                 _entry(
@@ -1954,10 +1954,10 @@ def _test_impl(ctx):
                     make_lint_passed_clean(),
                     4000,
                     tips = [{
-                        "id": "add-github-token",
+                        "id": "sample-suggestion",
                         "severity": "suggestion",
-                        "title": "Export `GITHUB_TOKEN` to free App quota",
-                        "body": "Setting `GITHUB_TOKEN` routes supporting calls through the job-scoped token.",
+                        "title": "A sample suggestion tip",
+                        "body": "Body text for a representative suggestion-severity tip.",
                     }],
                 ),
             ],

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -32,8 +32,6 @@ load(
     "./tips.axl",
     "AspectApiTokenHost",
     "tip_add_aspect_api_token",
-    "tip_add_github_token",
-    "tip_add_github_token_scope",
     "tip_add_id_token_permission",
 )
 
@@ -339,10 +337,7 @@ def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existi
     `_authenticate`.
 
     `_authenticate` emits `tip_add_aspect_api_token` (kind + host gated)
-    on the missing-credentials path. `_preferred_token_pair` additionally
-    emits `tip_add_github_token` on GitHub Actions when neither App nor
-    env produces a token, since exporting `GITHUB_TOKEN` is the
-    GHA-specific path to an immediate fallback.
+    on the missing-credentials path.
 
     Pass `existing_app_token` when the caller already minted an App
     token earlier in the same handler to avoid a redundant mint.
@@ -372,7 +367,6 @@ def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existi
     if env_token:
         return env_token, None, BUCKET_ENV
 
-    _emit_gha_tip(ctx, tip_add_github_token)
     return None, None, BUCKET_APP
 
 def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None):
@@ -2081,13 +2075,13 @@ def _resolve_current_job_url(ctx, token, owner, repo, run_id, fallback_token = N
     fallback retry below uses the flipped bucket.
 
     When `fallback_token` is supplied AND the primary `token` returns a
-    4xx-auth status (401 / 403 / 404), retries with the fallback and
-    accumulates `actions: read` into the `add-github-token-scope` tip.
-    GitHub's docs list `actions: read` as required for the underlying
-    `GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs` endpoint, but
-    in practice GitHub grants `GITHUB_TOKEN` implicit access to its own
-    workflow run's metadata regardless of the `permissions:` block, so
-    the fallback path is dormant on a normally-configured workflow.
+    4xx-auth status (401 / 403 / 404), retries silently with the
+    fallback. GitHub's docs list `actions: read` as required for the
+    underlying `GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs`
+    endpoint, but in practice GitHub grants `GITHUB_TOKEN` implicit
+    access to its own workflow run's metadata regardless of the
+    `permissions:` block, so the fallback path is dormant on a
+    normally-configured workflow.
     """
     if not token or not owner or not repo or not run_id:
         return ""
@@ -2103,12 +2097,6 @@ def _resolve_current_job_url(ctx, token, owner, repo, run_id, fallback_token = N
     fallback_class = BUCKET_ENV if token_class == BUCKET_APP else BUCKET_APP
     success, status_code, body = _do_request(ctx, "GET", url, token, quiet_4xx_auth = has_fallback, token_class = token_class)
     if (not success) and has_fallback and _is_4xx_auth(status_code):
-        _emit_gha_tip(
-            ctx,
-            tip_add_github_token_scope,
-            scopes = "actions: read",
-            endpoints = "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
-        )
         success, status_code, body = _do_request(ctx, "GET", url, fallback_token, token_class = fallback_class)
     if not success or type(body) != "dict":
         return ""
@@ -2145,9 +2133,8 @@ def list_pull_request_files(ctx, token, owner, repo, pull_number, fallback_token
     bucket is the other one.
 
     When `fallback_token` is supplied AND the primary `token` returns a
-    4xx-auth status on the first page, retries with the fallback and
-    accumulates `pull-requests: read` into the `add-github-token-scope`
-    tip. The fallback only triggers on page 1; if pagination starts
+    4xx-auth status on the first page, retries silently with the
+    fallback. The fallback only triggers on page 1; if pagination starts
     succeeding and then 4xx-auths mid-stream the token is fine and
     something else broke. In practice GitHub grants `GITHUB_TOKEN`
     implicit access to the PR that triggered the workflow regardless
@@ -2166,12 +2153,6 @@ def list_pull_request_files(ctx, token, owner, repo, pull_number, fallback_token
         has_fallback = page == 1 and fallback_token and fallback_token != token
         success, status_code, body = _do_request(ctx, "GET", url, active_token, quiet_4xx_auth = has_fallback, token_class = active_class)
         if (not success) and has_fallback and _is_4xx_auth(status_code):
-            _emit_gha_tip(
-                ctx,
-                tip_add_github_token_scope,
-                scopes = "pull-requests: read",
-                endpoints = "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
-            )
             active_token = fallback_token
             active_class = fallback_class
             success, status_code, body = _do_request(ctx, "GET", url, active_token, token_class = active_class)

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -541,10 +541,9 @@ def _test_impl(ctx):
 
     # ── list_pull_request_files 4xx-auth fallback ─────────────────────
     # When the primary token returns 401 / 403 / 404 on page 1,
-    # `list_pull_request_files` retries with the fallback token and
-    # accumulates the missing scope into the `add-github-token-scope`
-    # tip. With App-primary, env-fallback the fallback is reached only
-    # when the App's installation token unexpectedly 4xx's on a
+    # `list_pull_request_files` retries silently with the fallback token.
+    # With App-primary, env-fallback the fallback is reached only when
+    # the App's installation token unexpectedly 4xx's on a
     # supporting-call endpoint (rare; typically only when the App
     # installation is mid-rotation or scope-pruned).
     _test_pr_files_4xx_auth_fallback(ctx)
@@ -824,20 +823,9 @@ def _test_pr_files_4xx_auth_fallback(ctx):
     _eq("pr-files fallback: 1st call used App token", state["calls"][0]["auth"], "Bearer app-tok")
     _eq("pr-files fallback: 2nd call used env-token fallback", state["calls"][1]["auth"], "Bearer env-tok")
 
-    # Tip emitted with the missing scope + endpoint accumulated.
-    _eq("pr-files fallback: one tip surfaced", len(tips._inspect_for_test(ctx)), 1)
-    tip = tips._inspect_for_test(ctx)[0]
-    _eq("pr-files fallback: tip id", tip["id"], "add-github-token-scope")
-    _eq(
-        "pr-files fallback: scope accumulated",
-        tip["accumulate"]["scopes"],
-        ["pull-requests: read"],
-    )
-    _eq(
-        "pr-files fallback: endpoint accumulated",
-        tip["accumulate"]["endpoints"],
-        ["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"],
-    )
+    # The fallback retry is silent: we no longer advertise the
+    # `GITHUB_TOKEN` scope tip on the 4xx-auth fallback path.
+    _eq("pr-files fallback: no tip surfaced", len(tips._inspect_for_test(ctx)), 0)
 
     # No fallback supplied: same 403 surfaces as a hard failure
     # (no silent --scope=all expansion path because the caller decides).
@@ -850,7 +838,7 @@ def _test_pr_files_4xx_auth_fallback(ctx):
     if result2["success"]:
         fail("pr-files no-fallback: expected success=False on 403 with no fallback, got %r" % result2)
     _eq("pr-files no-fallback: only the primary call ran", len(state2["calls"]), 1)
-    _eq("pr-files no-fallback: no tip emitted (fallback drives the tip)", len(tips._inspect_for_test(ctx)), 0)
+    _eq("pr-files no-fallback: no tip emitted", len(tips._inspect_for_test(ctx)), 0)
 
     _test_pr_files_bucket_class_routes_observations(ctx)
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -388,17 +388,6 @@ _ASPECT_API_TOKEN_HOST_DETAIL = {
     ),
 }
 
-def tip_add_github_token(ctx):
-    """Implementation of `tip_add_github_token`; see the public
-    `@aspect//tips.axl` for the contract."""
-    add_tip(
-        ctx,
-        id = "add-github-token",
-        severity = TIP_SUGGESTION,
-        title = "Export `GITHUB_TOKEN` as a fallback for supporting API calls",
-        body = "aspect-cli authenticates supporting GitHub API calls (job URL lookup, PR file diff, etc.) via the Aspect Workflows GitHub App. When the App can't authenticate — typically because `ASPECT_API_TOKEN` is missing or invalid — there's currently no fallback, and supporting calls fail.\n\nExporting `GITHUB_TOKEN` to the job env gives aspect-cli a last-resort token to fall back to. `GITHUB_TOKEN` is shared across every workflow step in the repo and has [a low default rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api), so it's not a permanent solution — fix the Aspect Workflows GitHub App authentication path when possible.\n\nGitHub Actions grants `GITHUB_TOKEN` implicit read access to the workflow's own run metadata and the PR that triggered it, so no extra `permissions:` block scopes are required for the supporting calls aspect-cli makes today. Add at the top level of the workflow (so every job inherits) or scope it to the specific job(s) that need it:\n\n```yaml\n" + GITHUB_TOKEN_ENV_YAML + "```",
-    )
-
 def tip_add_aspect_api_token(ctx, host: AspectApiTokenHost):
     """Implementation of `tip_add_aspect_api_token`; see the public
     `@aspect//tips.axl` for the contract."""
@@ -418,31 +407,6 @@ def tip_add_aspect_api_token(ctx, host: AspectApiTokenHost):
             "(see https://docs.aspect.build/cli/authentication). " +
             detail.host_advice
         ),
-    )
-
-def tip_add_github_token_scope(ctx, scopes: str, endpoints: str):
-    """Implementation of `tip_add_github_token_scope`; see the public
-    `@aspect//tips.axl` for the contract."""
-    add_tip(
-        ctx,
-        id = "add-github-token-scope",
-        severity = TIP_WARNING,
-        type = TIP_TEMPLATE_JINJA2,
-        combine_across_tasks = True,
-        title = "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %} to the job-scoped `GITHUB_TOKEN`",
-        body = """aspect-cli made {{ endpoints|length }} supporting API {{ "call" if endpoints|length == 1 else "calls" }} that needed {{ "a scope" if scopes|length == 1 else "scopes" }} the job-scoped `GITHUB_TOKEN` lacks; {{ "the call" if endpoints|length == 1 else "the calls" }} fell back to the Aspect Workflows GitHub App token. Granting {{ "this scope" if scopes|length == 1 else "these scopes" }} keeps the {{ "call" if endpoints|length == 1 else "calls" }} on the job-scoped token and reduces App quota usage.
-
-Add at the top level of the workflow (so every job inherits) or scope to the specific job(s) that need it:
-
-```yaml
-permissions:
-{% for s in scopes %}  {{ s }}
-{% endfor %}```
-
-API {{ "endpoint" if endpoints|length == 1 else "endpoints" }} that fell back ({{ endpoints|length }}):
-{% for e in endpoints %}- `{{ e }}`
-{% endfor %}""",
-        accumulate = {"scopes": scopes, "endpoints": endpoints},
     )
 
 def tip_add_id_token_permission(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -61,8 +61,6 @@ load(
     "silence_hint_line",
     "strip_code_fences",
     "tip_add_aspect_api_token",
-    "tip_add_github_token",
-    "tip_add_github_token_scope",
     "tip_add_id_token_permission",
     "tip_replace",
     "tip_shows_on",
@@ -139,9 +137,12 @@ def _test_silenced_tips_short_circuits_add_tip(ctx):
     )
 
 def _test_silenced_tips_blocks_add(ctx):
+    """A non-important tip whose `id` is on the silence list never lands.
+    Mirrors how the suggestion-severity built-ins are gated, without
+    depending on any one built-in."""
     _reset(ctx)
-    tips._set_silenced_for_test(ctx, ["add-github-token"])
-    tip_add_github_token(ctx)
+    tips._set_silenced_for_test(ctx, ["some-suggestion"])
+    add_tip(ctx, id = "some-suggestion", severity = TIP_SUGGESTION, title = "T", body = "B")
     _eq(
         "silenced — add_tip respects silence list",
         tips._inspect_for_test(ctx),
@@ -200,9 +201,10 @@ def _test_add_tip_default_type_is_raw(ctx):
     add_tip(ctx, id = "default-type", severity = TIP_INFO, title = "Hello {name}", body = "B", vars = {"name": "world"})
     _eq("default type — RAW leaves braces verbatim", tips._inspect_for_test(ctx)[0]["title"], "Hello {name}")
 
-# A JINJA2 tip with both `scopes` and `endpoints` accumulators, mirroring
-# the built-in `tip_add_github_token_scope` shape so the merge / re-render
-# mechanics get exercised against a stable local fixture.
+# A JINJA2 tip with both `scopes` and `endpoints` accumulators — a
+# multi-accumulator shape that exercises the merge / re-render mechanics
+# (per-name union, plural title/body rendering) against a stable local
+# fixture, independent of any built-in.
 def _emit_scope_fail(ctx, scopes, endpoints):
     add_tip(
         ctx,
@@ -395,21 +397,12 @@ def _test_builtin_tips_shape(ctx):
         _eq("aspect-api-token tip (%s) id" % host.value, tip["id"], expected_id)
         _eq("aspect-api-token tip (%s) severity is IMPORTANT" % host.value, tip["severity"], TIP_IMPORTANT)
 
-    for emit in (tip_add_github_token, tip_add_id_token_permission):
-        _reset(ctx)
-        emit(ctx)
-        tip = _stored_one(ctx)
-        for key in ("id", "severity", "title", "body", "type"):
-            if key not in tip:
-                fail("built-in tip missing required key %r" % key)
-
     _reset(ctx)
-    tip_add_github_token(ctx)
-    _eq(
-        "tip_add_github_token severity is SUGGESTION (fallback hint, not failure)",
-        _stored_one(ctx)["severity"],
-        TIP_SUGGESTION,
-    )
+    tip_add_id_token_permission(ctx)
+    tip = _stored_one(ctx)
+    for key in ("id", "severity", "title", "body", "type"):
+        if key not in tip:
+            fail("built-in tip missing required key %r" % key)
 
     def _body(host):
         _reset(ctx)
@@ -457,57 +450,6 @@ def _test_builtin_tips_shape(ctx):
         if "scope=changed" in body:
             fail("aspect-api-token tip should not mention --scope=changed (App is only a fallback there)")
 
-def _test_builtin_insufficient_scope_renders(ctx):
-    """`tip_add_github_token_scope` is the canonical multi-accumulator
-    JINJA2 tip — both `scopes` and `endpoints` accumulate, the
-    title pluralizes on `scopes`, and the body pluralizes on
-    `endpoints` and renders one bullet per endpoint. One tip per task;
-    distinct scopes union into the same tip's `scopes` accumulator."""
-    _reset(ctx)
-    tip_add_github_token_scope(
-        ctx,
-        scopes = "pull-requests: read",
-        endpoints = "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
-    )
-    tip = tips._inspect_for_test(ctx)[0]
-    _eq("scope tip — id is the canonical id (no suffix)", tip["id"], "add-github-token-scope")
-    _eq("scope tip — severity is WARNING", tip["severity"], TIP_WARNING)
-    _eq("scope tip — type is JINJA2", tip["type"], TIP_TEMPLATE_JINJA2)
-    if "pull-requests: read" not in tip["title"]:
-        fail("scope tip — title missing scope: %r" % tip["title"])
-    if "GET /repos/{owner}/{repo}/pulls/{pull_number}/files" not in tip["body"]:
-        fail("scope tip — body missing endpoint: %r" % tip["body"])
-    _eq("scope tip — scopes accumulated", tip["accumulate"]["scopes"], ["pull-requests: read"])
-    _eq(
-        "scope tip — endpoints accumulated",
-        tip["accumulate"]["endpoints"],
-        ["GET /repos/{owner}/{repo}/pulls/{pull_number}/files"],
-    )
-
-    # Second emit with a different scope + endpoint: merge.
-    tip_add_github_token_scope(
-        ctx,
-        scopes = "actions: read",
-        endpoints = "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
-    )
-    _eq("scope tip — still single tip after merge", len(tips._inspect_for_test(ctx)), 1)
-    merged = tips._inspect_for_test(ctx)[0]
-    _eq(
-        "scope tip — both scopes unioned",
-        merged["accumulate"]["scopes"],
-        ["pull-requests: read", "actions: read"],
-    )
-    _eq(
-        "scope tip — both endpoints unioned",
-        merged["accumulate"]["endpoints"],
-        [
-            "GET /repos/{owner}/{repo}/pulls/{pull_number}/files",
-            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
-        ],
-    )
-    if "2 scopes" not in merged["title"]:
-        fail("scope tip — merged title not pluralized: %r" % merged["title"])
-
 def _test_silence_hint_line(ctx):
     _eq("silence_hint — empty id", silence_hint_line("", TIP_INFO), "")
     _eq(
@@ -516,8 +458,8 @@ def _test_silence_hint_line(ctx):
         "",
     )
     for sev in (TIP_WARNING, TIP_SUGGESTION, TIP_INFO):
-        line = silence_hint_line("add-github-token", sev)
-        if "add-github-token" not in line:
+        line = silence_hint_line("some-tip", sev)
+        if "some-tip" not in line:
             fail("silence_hint %s: missing tip id: %r" % (sev, line))
         if "tips" not in line or "silence" not in line:
             fail("silence_hint %s: missing tips/silence ref: %r" % (sev, line))
@@ -786,7 +728,6 @@ def _test_impl(ctx):
     _test_severity_rank(ctx)
     _test_blockquote_body(ctx)
     _test_builtin_tips_shape(ctx)
-    _test_builtin_insufficient_scope_renders(ctx)
     _test_silence_hint_line(ctx)
     _test_decorate_tip(ctx)
     _test_tip_to_payload(ctx)
@@ -797,7 +738,7 @@ def _test_impl(ctx):
     _test_tip_suggestion_hook(ctx)
     _test_strip_code_fences(ctx)
     _test_auto_print_flag(ctx)
-    print("tips.axl: OK (35 sections)")
+    print("tips.axl: OK (34 sections)")
     return 0
 
 tips_tests = task(


### PR DESCRIPTION
Removes the `tip_add_github_token` and `tip_add_github_token_scope` built-in tips along with their emit sites in `github.axl`. We'd rather steer users toward the Aspect Workflows GitHub App than advertise the `GITHUB_TOKEN` fallback, which has a low shared rate limit and was only ever intended as a last resort.

The 4xx-auth fallback on the supporting GitHub API calls (job URL lookup, PR file diff) still happens — it just no longer emits a scope-hint tip on that path.

Tests are updated to keep coverage of the underlying behavior without referencing the removed tips:
- `tips_test.axl` — the silence/short-circuit and multi-accumulator JINJA2 merge paths now run against neutral local fixtures rather than the removed built-ins; the redundant built-in scope-tip test is dropped.
- `github_detect_test.axl` — the `list_files` 4xx-auth fallback test still asserts the retry/token/parse behavior, now asserting no tip is surfaced.
- `github_status_comments_test.axl` — snapshot/aggregator fixtures that used the removed tip ids are renamed to neutral sample tips (dedup/attribution/cap coverage unchanged).
- `.aspect/config.axl` — silence-knob example id updated.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Suggested release notes:
- Removed the "Export `GITHUB_TOKEN` as a fallback" and "Grant scopes to the job-scoped `GITHUB_TOKEN`" tips. The recommended path for supporting GitHub API calls is the Aspect Workflows GitHub App; the `GITHUB_TOKEN` fallback still functions but is no longer advertised.

### Test plan

- Covered by existing test cases
- New test cases added

Verified locally:
- `aspect dev test-tips` — OK (34 sections)
- `aspect dev test-github-detect` — OK
- `aspect dev test-pr-comment-snapshots` — OK (20 scenarios)
