### PR TITLE
fix(delivery): surface bazel query failures instead of resolving to 0 targets

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1010,10 +1010,28 @@ def _delivery_impl(ctx):
 
     query_expr = ctx.args.query
     if query_expr:
-        # Echo the query so the resolved set — or a query failure — is
-        # attributable to the expression that produced it.
+        # Open the resolve phase before the query spawns so its progress
+        # line and the bazel spawn disclosure (announce flags below) are
+        # bracketed by the phase. Echoing the query keeps the resolved set
+        # — or a query failure — attributable to the expression.
+        task_update(
+            ctx,
+            lifecycle,
+            _pick_status(data, had_failure = False, terminal = False),
+            ProgressStyles(
+                body = "Querying targets to deliver...",
+                stream = "Querying targets to deliver",
+            ),
+            kind = "delivery_results",
+            data = data,
+            phase = Phase(name = "resolve", description = "Resolve targets to deliver", emoji = "🎯"),
+            subject = query_expr,
+        )
         info(ctx.std, "Running bazel query: {}".format(query_expr))
-        targets = [t.name for t in ctx.bazel.query().raw(query_expr).eval()]
+        targets = [t.name for t in ctx.bazel.query().raw(query_expr).eval(
+            announce_version = announce_version,
+            announce_command = announce_command,
+        )]
         limit = ctx.args.limit
         if limit > 0:
             targets = targets[:limit]

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -92,8 +92,11 @@ Failure modes
                                                     --track-state=true also
                                                     rolls back the recorded
                                                     artifact
-  --query resolves to no targets                  prints "No targets to
+  --query matches no targets                      prints "No targets to
                                                     deliver" and returns 0
+  --query fails (bad expr, BUILD error)           propagates Bazel's stderr
+                                                    and exit code (not a
+                                                    silent empty result)
 
 
 Manifest
@@ -1007,6 +1010,11 @@ def _delivery_impl(ctx):
 
     query_expr = ctx.args.query
     if query_expr:
+        # Echo the query before running it: a long expression that hits a
+        # BUILD/syntax error now fails loudly (see bazel.query().eval),
+        # and printing it first makes clear which query produced the
+        # resolved set — or the error.
+        info(ctx.std, "Running bazel query: {}".format(query_expr))
         targets = [t.name for t in ctx.bazel.query().raw(query_expr).eval()]
         limit = ctx.args.limit
         if limit > 0:

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1055,18 +1055,15 @@ def _delivery_impl(ctx):
             forced_targets.append(tok)
 
     # Setup opened the surface with the *requested* subject (often a query,
-    # so empty here); now that the target set is resolved, record it. It goes
-    # into the data (so the check-run table reflects the actual targets) and
-    # onto the task_update as a refined `subject` so the surface title updates
-    # from the requested subject to the resolved one. `summary_title` caps a
-    # long target list, so the full pattern is fine to pass here.
+    # so empty here); now that the target set is resolved, record it into
+    # `data` (so the check-run table reflects the actual targets) and refine
+    # the surface `subject` from the requested pattern to the resolved label
+    # list. `summary_title` caps a long list, so the full pattern is fine.
     data["target_pattern"] = " ".join(list(targets)) if targets else ""
-
-    # Total target count for the "X/N delivered" running compact. Emit the
-    # resolved set (data + refined subject — the query/requested subject
-    # becomes the concrete label list) without opening a new phase, so it
-    # lands within the resolve phase rather than crossing a boundary.
     data["delivery"]["targets_total"] = len(targets)
+
+    # Emit within the resolve phase (no `phase`, so no boundary or extra
+    # `→` line) — just latches the resolved data and refined subject.
     dispatch_task_update(ctx, lifecycle, TaskUpdate(
         kind = "delivery_results",
         data = data,

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1010,21 +1010,23 @@ def _delivery_impl(ctx):
 
     query_expr = ctx.args.query
     if query_expr:
-        # Open the resolve phase before the query spawns so its progress
-        # line and the bazel spawn disclosure (announce flags below) are
-        # bracketed by the phase. Echoing the query keeps the resolved set
-        # — or a query failure — attributable to the expression.
+        # The Bazel query that selects candidates is its own phase, kept
+        # distinct from the `resolve` phase below (which finalizes the set
+        # and prints the summary) so the two don't collapse into one
+        # phase header. It brackets the query progress line and the bazel
+        # spawn disclosure (announce flags below). Echoing the query keeps
+        # the selected set — or a query failure — attributable to it.
         task_update(
             ctx,
             lifecycle,
             _pick_status(data, had_failure = False, terminal = False),
             ProgressStyles(
-                body = "Querying targets to deliver...",
-                stream = "Querying targets to deliver",
+                body = "Selecting delivery targets via Bazel query...",
+                stream = "Selecting delivery targets via Bazel query",
             ),
             kind = "delivery_results",
             data = data,
-            phase = Phase(name = "resolve", description = "Resolve targets to deliver", emoji = "🎯"),
+            phase = Phase(name = "select", description = "Select delivery targets via Bazel query", emoji = "🔍"),
             subject = query_expr,
         )
         info(ctx.std, "Running bazel query: {}".format(query_expr))

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1010,10 +1010,8 @@ def _delivery_impl(ctx):
 
     query_expr = ctx.args.query
     if query_expr:
-        # Echo the query before running it: a long expression that hits a
-        # BUILD/syntax error now fails loudly (see bazel.query().eval),
-        # and printing it first makes clear which query produced the
-        # resolved set — or the error.
+        # Echo the query so the resolved set — or a query failure — is
+        # attributable to the expression that produced it.
         info(ctx.std, "Running bazel query: {}".format(query_expr))
         targets = [t.name for t in ctx.bazel.query().raw(query_expr).eval()]
         limit = ctx.args.limit

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -51,14 +51,14 @@ Combination matrix
 
 Each cell says whether each pipeline stage runs:
 
-  Combination                                       phase 1/2  phase 3  record  query  run  deliver
-  --mode=selective (default)                            ✓         ✓       ✓      ✓     ✓     ✓
-  --mode=selective --dry-run                            ✓         ✓       ✓      ✓     —     —
+  Combination                                       phase 1/2  phase 3  record  detect  run  deliver
+  --mode=selective (default)                            ✓         ✓       ✓       ✓     ✓     ✓
+  --mode=selective --dry-run                            ✓         ✓       ✓       ✓     —     —
   --mode=selective --track-state=false                  rejected at startup
-  --mode=always                                      ✓         ✓       ✓      —     ✓     ✓
-  --mode=always --dry-run                            ✓         ✓       ✓      —     —     —
-  --mode=always --track-state=false                  —         ✓       —      —     ✓     —
-  --mode=always --dry-run --track-state=false      optional¹   —       —      —     —     —
+  --mode=always                                      ✓         ✓       ✓        —     ✓     ✓
+  --mode=always --dry-run                            ✓         ✓       ✓        —     —     —
+  --mode=always --track-state=false                  —         ✓       —        —     ✓     —
+  --mode=always --dry-run --track-state=false      optional¹   —       —        —     —     —
 
 ¹ Best-effort preview — this is the only combination tolerant of a missing
   remote cache. If a remote cache is configured, action digests are computed
@@ -391,22 +391,12 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
         phase1_execlog_path = _EXECLOG_PATH.format(ctx.task.key)
         phase1_execlog_sinks = list(bazel_trait.execution_log_sinks)
         phase1_execlog_sinks.append(bazel.execution_log.file(path = phase1_execlog_path))
-        build = ctx.bazel.build(
-            flags = phase1_flags,
-            build_events = [events] + build_events,
-            execution_log = phase1_execlog_sinks,
-            announce_version = announce_version,
-            announce_command = announce_command,
-            *targets
-        )
 
-        # Phase 1's sink UUID drives the "✨ Aspect Workflows" link in
-        # the BK annotation / status check. Retries overwrite it.
-        data["sink_invocation_id"] = build.sink_invocation_id
-
-        # Phase 1 inherits the CLI's stdout/stderr (unlike phase 2/3), so
-        # this announce is the only "we're working" signal during the
-        # potentially-minutes-long build.
+        # Advertise the build phase before spawning bazel so the phase
+        # header precedes the spawn disclosure (announce flags below) and
+        # the potentially-minutes-long build output. Phase 1 inherits the
+        # CLI's stdout/stderr (unlike phase 2/3), so this is the only
+        # "we're working" signal during the build.
         targets_label = pluralize(len(targets), "target")
         status = _pick_status(data, had_failure = False, terminal = False)
         if attempt == 0:
@@ -439,6 +429,19 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
                     emoji = "🔨",
                 ),
             )
+
+        build = ctx.bazel.build(
+            flags = phase1_flags,
+            build_events = [events] + build_events,
+            execution_log = phase1_execlog_sinks,
+            announce_version = announce_version,
+            announce_command = announce_command,
+            *targets
+        )
+
+        # Phase 1's sink UUID drives the "✨ Aspect Workflows" link in
+        # the BK annotation / status check. Retries overwrite it.
+        data["sink_invocation_id"] = build.sink_invocation_id
 
         # Tick-driven drain: fires a heartbeat refresh every
         # MIN_HEARTBEAT_INTERVAL_MS even when bazel is silent.
@@ -1139,8 +1142,10 @@ def _delivery_impl(ctx):
             if label in output_shas:
                 deliveryd_record(ctx, endpoint, ci_host, commit_sha, prefix, label, output_shas[label])
 
-    # Query deliveryd. Skipped when --track-state=false (no endpoint) or
-    # in --mode=always (every target is a candidate regardless of state).
+    # Change detection: query deliveryd for prior-delivery state, then
+    # filter below to the targets that actually changed. Skipped when
+    # --track-state=false (no endpoint) or --mode=always (every target is
+    # a candidate regardless of state).
     if track_state and mode != "always":
         status = _pick_status(data, had_failure = False, terminal = False)
         task_update(
@@ -1148,12 +1153,12 @@ def _delivery_impl(ctx):
             lifecycle,
             status,
             ProgressStyles(
-                body = "Checking which targets have already been delivered...",
-                stream = "Checking which targets have already been delivered",
+                body = "Detecting which targets have already been delivered...",
+                stream = "Detecting which targets have already been delivered",
             ),
             kind = "delivery_results",
             data = data,
-            phase = Phase(name = "query", description = "Query delivery state", emoji = "❓"),
+            phase = Phase(name = "detect", description = "Detect already-delivered targets", emoji = "🔬"),
         )
         delivery_state = deliveryd_query(ctx, endpoint, ci_host, commit_sha, prefix)
     else:

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1011,27 +1011,29 @@ def _delivery_impl(ctx):
                            " (Use --mode=always --track-state=false to deliver every target without change detection.)")
             return _emit_final(ctx, lifecycle, data, exit_code = 1)
 
+    # Resolve the delivery set — via a `--query` or from positional
+    # targets — under a single `resolve` phase. The phase update is the
+    # phase's opening bookend, so it's emitted before the query runs (when
+    # there is one); the resolved set is then recorded into `data` within
+    # the same phase and surfaces on the next phase's update.
     query_expr = ctx.args.query
+    task_update(
+        ctx,
+        lifecycle,
+        _pick_status(data, had_failure = False, terminal = False),
+        ProgressStyles(
+            body = "Resolving targets to deliver...",
+            stream = "Resolving targets to deliver",
+        ),
+        kind = "delivery_results",
+        data = data,
+        phase = Phase(name = "resolve", description = "Resolve targets to deliver", emoji = "🎯"),
+        subject = query_expr,
+    )
     if query_expr:
-        # The Bazel query that selects candidates is its own phase, kept
-        # distinct from the `resolve` phase below (which finalizes the set
-        # and prints the summary) so the two don't collapse into one
-        # phase header. It brackets the query progress line and the bazel
-        # spawn disclosure (announce flags below). Echoing the query keeps
-        # the selected set — or a query failure — attributable to it.
-        task_update(
-            ctx,
-            lifecycle,
-            _pick_status(data, had_failure = False, terminal = False),
-            ProgressStyles(
-                body = "Selecting delivery targets via Bazel query...",
-                stream = "Selecting delivery targets via Bazel query",
-            ),
-            kind = "delivery_results",
-            data = data,
-            phase = Phase(name = "select", description = "Select delivery targets via Bazel query", emoji = "🔍"),
-            subject = query_expr,
-        )
+        # Echo the query so the resolved set — or a query failure — is
+        # attributable to it. The spawn disclosure (announce flags) and the
+        # query both fall within the resolve phase opened above.
         info(ctx.std, "Running bazel query: {}".format(query_expr))
         targets = [t.name for t in ctx.bazel.query().raw(query_expr).eval(
             announce_version = announce_version,
@@ -1060,23 +1062,16 @@ def _delivery_impl(ctx):
     # long target list, so the full pattern is fine to pass here.
     data["target_pattern"] = " ".join(list(targets)) if targets else ""
 
-    # Total target count for the "X/N delivered" running compact.
+    # Total target count for the "X/N delivered" running compact. Emit the
+    # resolved set (data + refined subject — the query/requested subject
+    # becomes the concrete label list) without opening a new phase, so it
+    # lands within the resolve phase rather than crossing a boundary.
     data["delivery"]["targets_total"] = len(targets)
-    targets_label = pluralize(len(targets), "target")
-    status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
-        status,
-        ProgressStyles(
-            body = "Resolving {} to deliver...".format(targets_label),
-            stream = "Resolving {} to deliver".format(targets_label),
-        ),
+    dispatch_task_update(ctx, lifecycle, TaskUpdate(
         kind = "delivery_results",
         data = data,
-        phase = Phase(name = "resolve", description = "Resolve targets to deliver", emoji = "🎯"),
         subject = data["target_pattern"],
-    )
+    ))
 
     if not targets:
         info(ctx.std, "No targets to deliver")

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -633,7 +633,11 @@ fn payload_discriminant(p: &axl_proto::build_event_stream::build_event::Payload)
 /// plain text when stderr isn't a TTY and we're not on a recognized CI host
 /// — matching the gate used elsewhere in the runtime (see
 /// `multi_phase::running_verb_color`).
-fn announce_spawn(announce: AnnounceSpawn, version: Option<&semver::Version>, cmd: &Command) {
+pub(super) fn announce_spawn(
+    announce: AnnounceSpawn,
+    version: Option<&semver::Version>,
+    cmd: &Command,
+) {
     let (grey, reset) = grey_style();
     if announce.version {
         eprintln!("{grey}INFO: {}{reset}", version_line(version));

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -175,7 +175,11 @@ impl Query {
         }
     }
 
-    pub fn query(expr: &str, startup_flags: &[String]) -> anyhow::Result<TargetSet> {
+    pub fn query(
+        expr: &str,
+        startup_flags: &[String],
+        announce: super::build::AnnounceSpawn,
+    ) -> anyhow::Result<TargetSet> {
         let mut cmd = super::bazel_command();
         cmd.args(startup_flags);
         cmd.arg("query");
@@ -195,6 +199,20 @@ impl Query {
         cmd.stderr(errfile);
         cmd.stdout(outfile);
         cmd.stdin(Stdio::null());
+
+        // Mirror the build/test spawn disclosure: the version line costs an
+        // extra `bazel info`, so only pay for it when actually announcing.
+        if announce.version || announce.command {
+            let version = if announce.version {
+                super::info::server_info_with_startup_flags(startup_flags)
+                    .ok()
+                    .and_then(|(_pid, version)| version)
+            } else {
+                None
+            };
+            super::build::announce_spawn(announce, version.as_ref(), &cmd);
+        }
+
         // Register with the live-bazel registry so a CI cancel
         // (SIGINT/SIGTERM to aspect-cli) escalates to the bazel
         // client. Large queries can run for many seconds; without
@@ -305,10 +323,25 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     /// expression, BUILD evaluation error, …), rather than returning an
     /// empty target set — a failed query is not the same as one that
     /// matched nothing.
-    fn eval<'v>(this: values::Value<'v>) -> anyhow::Result<TargetSet> {
+    ///
+    /// # Arguments
+    /// * `announce_version` - Print an `INFO: Bazel <version>` line before
+    ///   spawning. Resolved from the `--announce-bazel-version` task flag.
+    /// * `announce_command` - Print an `INFO: Spawning: <command>` line
+    ///   before spawning. Resolved from the `--announce-bazel-command` task
+    ///   flag. Both mirror the `ctx.bazel.build` / `.test` disclosure.
+    fn eval<'v>(
+        this: values::Value<'v>,
+        #[starlark(require = named, default = false)] announce_version: bool,
+        #[starlark(require = named, default = false)] announce_command: bool,
+    ) -> anyhow::Result<TargetSet> {
         let this = this.downcast_ref_err::<Query>().into_anyhow_result()?;
         let expr = this.expr.borrow();
-        Query::query(&expr, &this.startup_flags)
+        let announce = super::build::AnnounceSpawn {
+            version: announce_version,
+            command: announce_command,
+        };
+        Query::query(&expr, &this.startup_flags, announce)
     }
 }
 

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -140,6 +140,24 @@ impl<'v> values::StarlarkValue<'v> for TargetSet {
     }
 }
 
+/// Build the error for a `bazel query` that exited non-zero.
+///
+/// A failed query (bad expression, BUILD evaluation error, …) must not
+/// be mistaken for one that legitimately matched nothing, so the error
+/// carries Bazel's own `stderr` when it's available. `stderr` is
+/// best-effort: it's trimmed and appended only when non-empty, so a
+/// query that died without writing diagnostics still yields a usable
+/// exit-code message.
+fn query_failure_error(expr: &str, exit_code: Option<i32>, stderr: &str) -> anyhow::Error {
+    let stderr = stderr.trim();
+    let detail = if stderr.is_empty() {
+        String::new()
+    } else {
+        format!("\n{stderr}")
+    };
+    anyhow!("bazel query failed with exit code {exit_code:?}: {expr}{detail}")
+}
+
 #[derive(Debug, Display, ProvidesStaticType, Trace, NoSerialize, Allocative)]
 #[display("<bazel.query.Query>")]
 pub struct Query {
@@ -169,12 +187,9 @@ impl Query {
         let _ = fs::remove_file(&errfile_path);
 
         let outfile = File::create(&out)?;
-        // Capture stderr to a file rather than discarding it. A failed
-        // query (syntax error, BUILD evaluation error, etc.) writes its
-        // diagnostics here and exits non-zero; we surface them below so
-        // the failure isn't silently mistaken for an empty result set.
-        // A file (vs. a piped fd read after wait) sidesteps any
-        // pipe-buffer deadlock on a chatty query.
+        // Capture stderr to a file so a failed query's diagnostics can be
+        // surfaced below. A file (rather than a pipe read after wait)
+        // avoids a pipe-buffer deadlock on a chatty query.
         let errfile = File::create(&errfile_path)?;
 
         cmd.stderr(errfile);
@@ -188,26 +203,12 @@ impl Query {
             super::live::spawn_registered(&mut cmd).with_context(|| "failed to spawn bazel")?;
         let status = child.wait()?;
 
-        // A non-zero exit means the query never produced a valid result
-        // — returning an empty `TargetSet` here would make a failed
-        // query indistinguishable from one that legitimately matched
-        // nothing. Surface Bazel's own stderr so the caller sees the
-        // real cause (bad query expression, BUILD error, …).
         if !status.success() {
             let mut stderr = String::new();
             if let Ok(mut f) = File::open(&errfile_path) {
                 let _ = f.read_to_string(&mut stderr);
             }
-            let stderr = stderr.trim();
-            let detail = if stderr.is_empty() {
-                String::new()
-            } else {
-                format!("\n{stderr}")
-            };
-            return Err(anyhow!(
-                "bazel query failed with exit code {:?}: {expr}{detail}",
-                status.code()
-            ));
+            return Err(query_failure_error(expr, status.code(), &stderr));
         }
 
         let mut buf = vec![];
@@ -308,5 +309,34 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
         let this = this.downcast_ref_err::<Query>().into_anyhow_result()?;
         let expr = this.expr.borrow();
         Query::query(&expr, &this.startup_flags)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_failure_error_includes_stderr_when_present() {
+        let err = query_failure_error("kind('x', //...)", Some(2), "ERROR: no such package\n");
+        let msg = format!("{err}");
+        assert!(msg.contains("exit code Some(2)"), "{msg}");
+        assert!(msg.contains("kind('x', //...)"), "{msg}");
+        assert!(msg.contains("ERROR: no such package"), "{msg}");
+    }
+
+    #[test]
+    fn query_failure_error_omits_empty_stderr() {
+        let err = query_failure_error("//...", Some(1), "   \n  ");
+        let msg = format!("{err}");
+        // No dangling separator/newline when there are no diagnostics.
+        assert!(msg.ends_with("//..."), "{msg}");
+    }
+
+    #[test]
+    fn query_failure_error_handles_unknown_exit_code() {
+        // A signal-killed child reports no exit code.
+        let err = query_failure_error("//...", None, "");
+        assert!(format!("{err}").contains("exit code None"));
     }
 }

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -165,10 +165,19 @@ impl Query {
         cmd.arg("--output=streamed_proto");
         let out = temp_dir().join("query.bin");
         let _ = fs::remove_file(&out);
+        let errfile_path = temp_dir().join("query.err");
+        let _ = fs::remove_file(&errfile_path);
 
         let outfile = File::create(&out)?;
+        // Capture stderr to a file rather than discarding it. A failed
+        // query (syntax error, BUILD evaluation error, etc.) writes its
+        // diagnostics here and exits non-zero; we surface them below so
+        // the failure isn't silently mistaken for an empty result set.
+        // A file (vs. a piped fd read after wait) sidesteps any
+        // pipe-buffer deadlock on a chatty query.
+        let errfile = File::create(&errfile_path)?;
 
-        cmd.stderr(Stdio::null());
+        cmd.stderr(errfile);
         cmd.stdout(outfile);
         cmd.stdin(Stdio::null());
         // Register with the live-bazel registry so a CI cancel
@@ -177,7 +186,29 @@ impl Query {
         // registration they'd outlive an aborted aspect-cli.
         let (mut child, _guard) =
             super::live::spawn_registered(&mut cmd).with_context(|| "failed to spawn bazel")?;
-        child.wait()?;
+        let status = child.wait()?;
+
+        // A non-zero exit means the query never produced a valid result
+        // — returning an empty `TargetSet` here would make a failed
+        // query indistinguishable from one that legitimately matched
+        // nothing. Surface Bazel's own stderr so the caller sees the
+        // real cause (bad query expression, BUILD error, …).
+        if !status.success() {
+            let mut stderr = String::new();
+            if let Ok(mut f) = File::open(&errfile_path) {
+                let _ = f.read_to_string(&mut stderr);
+            }
+            let stderr = stderr.trim();
+            let detail = if stderr.is_empty() {
+                String::new()
+            } else {
+                format!("\n{stderr}")
+            };
+            return Err(anyhow!(
+                "bazel query failed with exit code {:?}: {expr}{detail}",
+                status.code()
+            ));
+        }
 
         let mut buf = vec![];
         File::open(&out)?.read_to_end(&mut buf)?;
@@ -268,6 +299,11 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     ///     .kind("source file")
     ///     .eval()
     /// ```
+    ///
+    /// Fails with Bazel's own stderr if the query exits non-zero (bad
+    /// expression, BUILD evaluation error, …), rather than returning an
+    /// empty target set — a failed query is not the same as one that
+    /// matched nothing.
     fn eval<'v>(this: values::Value<'v>) -> anyhow::Result<TargetSet> {
         let this = this.downcast_ref_err::<Query>().into_anyhow_result()?;
         let expr = this.expr.borrow();


### PR DESCRIPTION
`aspect delivery --query '...'` resolved to **0 targets and exited 0 even when the query was failing in Bazel** — the failure was indistinguishable from a query that legitimately matched nothing, with no diagnostics shown.

`Query::query` ([query.rs](crates/axl-runtime/src/engine/bazel/query.rs)) discarded Bazel's stderr (`Stdio::null()`), never checked the child's exit code, and decoded the empty output file into an empty `TargetSet`. So any failing query (bad expression, BUILD evaluation error, …) silently surfaced as "No targets to deliver".

Changes:

- **Surface query failures.** Capture Bazel's stderr, check the exit status, and return an error carrying Bazel's own diagnostics when the query exits non-zero, instead of returning an empty target set.
- **Announce the query spawn.** `ctx.bazel.query().eval(...)` now honors `--announce-bazel-version` / `--announce-bazel-command`, disclosing the Bazel version and command line before spawning — the same `INFO:` lines a build/test spawn prints (reusing the existing `announce_spawn`).
- **Run the query inside the Resolve phase.** Target resolution (the Bazel query, or positional targets) happens under a single `🎯 Resolve` phase whose header is emitted before the query spawns, so the spawn disclosure falls under it.
- **Advertise the build phase before spawning.** The phase-1 build printed its `🔨 Build` header after spawning bazel; the header now precedes the spawn disclosure and build output.
- **Rename the change-detection phase.** The deliveryd state query is change detection — renamed from `query` / "Query delivery state" to `🔬 Detect` / "Detect already-delivered targets".

Example output:

```
→ 🎯 Resolve · Resolving targets to deliver
INFO: Running bazel query: attr(tags, deliverable, //...)
INFO: Bazel 9.0.1
INFO: Spawning: bazel ... query attr(tags, deliverable, //...) --output=streamed_proto

→ 🚚 Deliver · ...
```

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- `aspect delivery --query` now surfaces Bazel's error and exit code when the query fails (bad expression, BUILD evaluation error, etc.) instead of silently resolving to 0 targets. The query runs under the `Resolve` phase, its spawn is disclosed under `--announce-bazel-version` / `--announce-bazel-command` (matching build/test spawns), and the change-detection step is now labeled `Detect`.

### Test plan

- New unit tests for the query-failure error construction (`query_failure_error`)
- Existing `aspect-cli` suite (which loads the `.axl` builtins) passes
- Manual: `aspect delivery --dry-run --query ...` — a valid query runs under `Resolve` and announces its spawn; a malformed query fails with Bazel's `ERROR:` and a non-zero exit (previously printed "No targets to deliver" and exited 0)
