### PR TITLE
fix(artifacts): name the artifact in upload-failure warnings

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
@@ -295,15 +295,19 @@ _gitlab = struct(
 #                  (rolling-replace; GitHub only — others ignore)
 #   download_url — direct download URL for the latest archive (when stable)
 #   label_urls   — {label: {filename: url}} for per-file strategies
-#   _printed_errors — set of error strings already printed (dedup noise)
 
-def _print_upload_error(ctx, group, err):
-    """Print an upload error at most once per group (dedup noisy repeats)."""
-    seen = group.get("_printed_errors") or {}
-    if err not in seen:
-        warn(ctx.std, "Artifact upload error: " + err)
-        seen[err] = True
-        group["_printed_errors"] = seen
+def _print_upload_error(ctx, what, err):
+    """Warn that uploading `what` failed with `err`.
+
+    `what` is the artifact — the archive name for the tar/zip strategies,
+    or the per-file destination for the per-file strategy — so an operator
+    can tell which channel and file hit the failure.
+
+    Emitted inline at each failure rather than summarized at build end: a
+    tail summary can be truncated or never reached when uploads (and the
+    build) are failing.
+    """
+    warn(ctx.std, "Artifact upload failed for %s: %s" % (what, err))
 
 def _build_mtree(entries):
     """Mtree spec for tar/zip create. One file per entry, src → dest."""
@@ -360,7 +364,7 @@ def _upload_archive(ctx, provider, group, entries, name, ext, build_archive, fin
     if not final:
         group["version"] -= 1
     for err in result["errors"]:
-        _print_upload_error(ctx, group, err)
+        _print_upload_error(ctx, artifact, err)
     return False
 
 def _upload_testlogs_tar(ctx, provider, group, entries, name, final = False):
@@ -430,7 +434,8 @@ def _upload_testlogs_per_file(ctx, provider, group, entries, name):
     # re-mints on retry.
     session_cache = group.setdefault("circleci_session", {})
     for entry in new_entries:
-        result = provider.upload_artifact(ctx, entry["src"], name + "/" + entry["dest"], cache = session_cache)
+        dest = name + "/" + entry["dest"]
+        result = provider.upload_artifact(ctx, entry["src"], dest, cache = session_cache)
         if result["success"]:
             url = result.get("download_url", "")
             if url and url.startswith("http"):
@@ -441,7 +446,7 @@ def _upload_testlogs_per_file(ctx, provider, group, entries, name):
             any_success = True
         else:
             for err in result["errors"]:
-                _print_upload_error(ctx, group, err)
+                _print_upload_error(ctx, dest, err)
             break
 
     return any_success


### PR DESCRIPTION
When the artifact uploader hit a failure it logged a bare:

```
WARNING: Artifact upload error: S3 upload HTTP 400 (InvalidRequest)
```

— with no indication of *what* failed to upload. The testlogs archive, an individual per-file testlog, the profile, and the BEP all funnel through the same warning, so an operator can't tell which channel or file failed.

This names the failing artifact in the warning — the archive name for the tar/zip strategies, the per-file destination for the per-file strategy:

```
WARNING: Artifact upload failed for aspect-test-<key>-testlogs.tar.gz: S3 upload HTTP 400 (InvalidRequest)
```

It's provider-agnostic: `_print_upload_error` is reached from the tar (GitLab) and zip (GitHub) archive strategies as well as the per-file strategy (CircleCI). Each failure is emitted inline as it happens, so an operator sees which uploads failed and how widely even when uploads (and the build) are failing and a tail summary would be truncated.

The singleton profile/BEP path already named its artifact via `_upload_file`; this brings the archive and per-file paths in line.

Surfaced by a CircleCI customer log where the anonymous `S3 upload HTTP 400` gave no way to tell which of testlogs / profile / BEP failed — but the gap (and fix) apply to every provider.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Artifact upload failure warnings now name the artifact that failed (`Artifact upload failed for <name>: <error>`) instead of an anonymous `Artifact upload error: ...`, across all CI providers.

### Test plan

- Covered by existing test cases
- Manual testing: `cargo build -p aspect-cli` and `aspect test --help` — the embedded builtins parse and the module evaluates. The change is confined to the warning emitter + its two call sites in `lib/artifacts.axl`, with no behavior change beyond the warning text.
