### PR TITLE
fix(circleci): surface the S3 <Message> in upload-failure detail

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -148,6 +148,19 @@ def session_cache_clear(cache):
     if cache != None and "session" in cache:
         cache.pop("session")
 
+def _s3_extract_element(body, tag):
+    """Pull the text of the first `<tag>…</tag>` from an S3 error body, or ""."""
+    open_tag = "<" + tag + ">"
+    close_tag = "</" + tag + ">"
+    start = body.find(open_tag)
+    if start == -1:
+        return ""
+    start += len(open_tag)
+    end = body.find(close_tag, start)
+    if end == -1:
+        return ""
+    return body[start:end]
+
 def s3_extract_error_code(body):
     """Pull the `<Code>…</Code>` value out of an S3 error response body.
 
@@ -159,30 +172,39 @@ def s3_extract_error_code(body):
     Public (not `_`-prefixed) so `circleci_test.axl` can load it; Starlark
     forbids loading underscore-private symbols.
     """
-    start = body.find("<Code>")
-    if start == -1:
-        return ""
-    start += len("<Code>")
-    end = body.find("</Code>", start)
-    if end == -1:
-        return ""
-    return body[start:end]
+    return _s3_extract_element(body, "Code")
+
+def s3_extract_error_message(body):
+    """Pull the `<Message>…</Message>` value out of an S3 error response body.
+
+    The `<Message>` says *why* the request failed in prose — for a generic
+    `<Code>` like `InvalidRequest` it's the only thing that names the
+    offending header or element (e.g. "The provided 'x-amz-…' header is
+    not signed"). Returns "" when absent. Public so `circleci_test.axl`
+    can load it.
+    """
+    return _s3_extract_element(body, "Message")
 
 def s3_upload_error_detail(http_code, curl_err, body):
     """Build a one-line failure reason from a curl/S3 upload attempt.
 
-    Prefers the HTTP status + parsed S3 `<Code>` ("S3 upload HTTP 400
-    (ExpiredToken)") so an expired credential reads as exactly that. Falls
-    back to curl's stderr for transport-level failures (no HTTP response,
-    `http_code == "000"`).
+    Prefers the HTTP status + parsed S3 `<Code>` and `<Message>` ("S3
+    upload HTTP 400 (InvalidRequest): <message>") so a credential expiry
+    reads as `ExpiredToken` and a malformed request carries S3's prose
+    reason — the only thing that names the offending header/element behind
+    a generic `<Code>`. Falls back to curl's stderr for transport-level
+    failures (no HTTP response, `http_code == "000"`).
 
     Public (not `_`-prefixed) so `circleci_test.axl` can load it.
     """
     code = s3_extract_error_code(body)
+    message = s3_extract_error_message(body)
     if http_code and http_code != "000":
         detail = "S3 upload HTTP " + http_code
         if code:
             detail = detail + " (" + code + ")"
+        if message:
+            detail = detail + ": " + message
         return detail
     if curl_err:
         return "curl transport error: " + curl_err.replace("\n", " ")

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
@@ -6,7 +6,7 @@ S3 error response into a diagnosable failure reason — the part that makes
 an expired-credential `400` legible instead of an opaque "curl exit 22".
 """
 
-load("./circleci.axl", "mark_testcases_skipped", "s3_extract_error_code", "s3_upload_error_detail", "session_cache_clear", "session_cache_get", "session_cache_put", "test_results_object_url")
+load("./circleci.axl", "mark_testcases_skipped", "s3_extract_error_code", "s3_extract_error_message", "s3_upload_error_detail", "session_cache_clear", "session_cache_get", "session_cache_put", "test_results_object_url")
 
 def _eq(label, got, want):
     if got != want:
@@ -35,6 +35,20 @@ def _test_extract_unterminated_code(_ctx):
     _eq("unterminated <Code> → empty", s3_extract_error_code("<Code>ExpiredToken"), "")
 
 # ---------------------------------------------------------------------------
+# s3_extract_error_message — pull <Message>…</Message> out of an S3 error body
+# ---------------------------------------------------------------------------
+
+def _test_extract_message(_ctx):
+    body = "<Error><Code>InvalidRequest</Code><Message>The provided header is not signed.</Message></Error>"
+    _eq("Message extracted", s3_extract_error_message(body), "The provided header is not signed.")
+
+def _test_extract_no_message_element(_ctx):
+    _eq("no <Message> → empty", s3_extract_error_message("<Error><Code>InvalidRequest</Code></Error>"), "")
+
+def _test_extract_unterminated_message(_ctx):
+    _eq("unterminated <Message> → empty", s3_extract_error_message("<Message>oops"), "")
+
+# ---------------------------------------------------------------------------
 # s3_upload_error_detail — build the one-line failure reason
 # ---------------------------------------------------------------------------
 
@@ -44,6 +58,16 @@ def _test_detail_expired_token(_ctx):
         "HTTP 400 + ExpiredToken",
         s3_upload_error_detail("400", "", body),
         "S3 upload HTTP 400 (ExpiredToken)",
+    )
+
+def _test_detail_invalid_request_with_message(_ctx):
+    """The customer case: a generic <Code> carries its <Message> so the
+    operator sees *why* the request was malformed, not just `InvalidRequest`."""
+    body = "<Error><Code>InvalidRequest</Code><Message>The Content-MD5 you specified was invalid.</Message></Error>"
+    _eq(
+        "HTTP 400 + InvalidRequest + message",
+        s3_upload_error_detail("400", "", body),
+        "S3 upload HTTP 400 (InvalidRequest): The Content-MD5 you specified was invalid.",
     )
 
 def _test_detail_http_no_code(_ctx):
@@ -169,7 +193,11 @@ _UNIT_TESTS = [
     _test_extract_no_code_element,
     _test_extract_empty_body,
     _test_extract_unterminated_code,
+    _test_extract_message,
+    _test_extract_no_message_element,
+    _test_extract_unterminated_message,
     _test_detail_expired_token,
+    _test_detail_invalid_request_with_message,
     _test_detail_http_no_code,
     _test_detail_transport_error,
     _test_detail_transport_error_newlines_collapsed,


### PR DESCRIPTION
A CircleCI user enabled the new test-results upload and hit:

```
WARNING: CircleCI test results upload failed: S3 upload HTTP 400 (InvalidRequest)
```

`InvalidRequest` is a generic S3 code — unlike `ExpiredToken` it says nothing about *what* was wrong with the request. S3 returns the actual reason in the `<Message>` element of the error body (e.g. which header/element it rejected), but `s3_upload_error_detail` extracted only `<Code>` and discarded `<Message>`, leaving us guessing.

This extracts `<Message>` alongside `<Code>` and appends it:

```
WARNING: ... S3 upload HTTP 400 (InvalidRequest): <S3's prose reason naming the bad header/element>
```

Implementation: factor the `<Code>` puller into a shared `_s3_extract_element(body, tag)`, add a public `s3_extract_error_message`, and fold the message into `s3_upload_error_detail`. Both the artifact upload path (`_s3_put`) and the test-results path (`_s3_put_object`) share that helper, so both gain the message. The `ExpiredToken`-style output is unchanged when no `<Message>` is present.

This is a diagnostic step: it surfaces the exact S3 reason so we can confirm and fix the underlying test-results 400 (suspected: runner-provided `Key.headers` forwarded on the PUT aren't covered by curl's `--aws-sigv4` signed-headers set). The fix for the upload itself will follow once the message confirms the cause.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- S3 upload failure warnings now include S3's `<Message>` alongside the error code (e.g. `S3 upload HTTP 400 (InvalidRequest): <reason>`), making malformed-request failures diagnosable instead of opaque.

### Test plan

- New test cases added: `s3_extract_error_message` (extraction, missing, unterminated) and `s3_upload_error_detail` with a message (the `InvalidRequest` customer case).
- `aspect dev test-circleci` → `circleci.axl: OK (27 tests)`.
