### PR TITLE
fix(delivery): honor .bazelrc flags in the resolve query

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -473,6 +473,35 @@ def test_conditional_flags(ctx: TaskContext, tc: int) -> int:
 
     return tc
 
+def test_query_flags(ctx: TaskContext, tc: int) -> int:
+    # `bazel query` accepts the same `flags` (incl. version-gated tuples) as
+    # `ctx.bazel.build`, resolving conditionals against the running Bazel
+    # version. Delivery relies on this to forward rc-expanded flags to its
+    # resolve query under `--ignore_all_rc_files`.
+    expr = "//crates/aspect-cli:aspect-cli"
+
+    # Plain flags are passed through.
+    targets1 = [t.name for t in ctx.bazel.query().raw(expr).eval(
+        flags = ["--noimplicit_deps"],
+    )]
+    tc = test_case(tc, expr in targets1, "query with plain flags should resolve the target")
+
+    # An always-matching conditional flag is applied.
+    targets2 = [t.name for t in ctx.bazel.query().raw(expr).eval(
+        flags = [("--noimplicit_deps", ">=1")],
+    )]
+    tc = test_case(tc, expr in targets2, "query with always-matching conditional flag should resolve the target")
+
+    # A never-matching conditional flag is dropped rather than forced onto the
+    # query — an unrecognized flag would otherwise hard-error. This is the
+    # regression guard for version-gated rc flags reaching the resolve query.
+    targets3 = [t.name for t in ctx.bazel.query().raw(expr).eval(
+        flags = ["--noimplicit_deps", ("--ASPECT_NEVER_MATCH_FLAG_XYZ", ">=99999")],
+    )]
+    tc = test_case(tc, expr in targets3, "query with never-matching conditional flag should drop it and still resolve")
+
+    return tc
+
 def test_cancel_invocation(ctx: TaskContext, tc: int) -> int:
     # Test 1: Server-wide cancel_invocation when no build is running
     cancellation3 = ctx.bazel.cancel_invocation()
@@ -3050,6 +3079,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_bazel_info(ctx, tc)
     tc = test_http_get_post(ctx, tc, temp_dir)
     tc = test_conditional_flags(ctx, tc)
+    tc = test_query_flags(ctx, tc)
     tc = test_cancel_invocation(ctx, tc)
     tc = test_template_rendering(ctx, tc)
     tc = test_path_glob(tc)

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1035,7 +1035,18 @@ def _delivery_impl(ctx):
         # attributable to it. The spawn disclosure (announce flags) and the
         # query both fall within the resolve phase opened above.
         info(ctx.std, "Running bazel query: {}".format(query_expr))
+        # The query runs with `--ignore_all_rc_files` on its startup flags
+        # (see lib/bazel_flags.axl), so it sees none of the workspace
+        # `.bazelrc`. Forward the rc-expanded command flags — the same
+        # `expanded_flags` the build phases use — so the query resolves
+        # external repositories the way the build does. Without this an
+        # rc-set `--noenable_bzlmod` / `--enable_workspace` is dropped and
+        # the query fails on repos the build can see. expand_all returns
+        # plain strings or `(value, version-constraint)` tuples; take the
+        # value from the tuple form (cf. the remote-cache scan above).
+        query_flags = [f[0] if type(f) == "tuple" else f for f in expanded_flags]
         targets = [t.name for t in ctx.bazel.query().raw(query_expr).eval(
+            flags = query_flags,
             announce_version = announce_version,
             announce_command = announce_command,
         )]

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1035,18 +1035,15 @@ def _delivery_impl(ctx):
         # attributable to it. The spawn disclosure (announce flags) and the
         # query both fall within the resolve phase opened above.
         info(ctx.std, "Running bazel query: {}".format(query_expr))
-        # The query runs with `--ignore_all_rc_files` on its startup flags
-        # (see lib/bazel_flags.axl), so it sees none of the workspace
-        # `.bazelrc`. Forward the rc-expanded command flags — the same
-        # `expanded_flags` the build phases use — so the query resolves
-        # external repositories the way the build does. Without this an
-        # rc-set `--noenable_bzlmod` / `--enable_workspace` is dropped and
-        # the query fails on repos the build can see. `expanded_flags` may
-        # carry `(flag, version-constraint)` tuples (e.g. from
-        # `try-import`-if-bazel-version); `.eval()` resolves them against the
-        # running Bazel version exactly as `ctx.bazel.build` does, so a flag
-        # gated to a different version is filtered out rather than forced
-        # onto the query.
+
+        # The query carries `--ignore_all_rc_files` (see lib/bazel_flags.axl),
+        # so it reads none of the workspace `.bazelrc`. Forward the same
+        # rc-expanded `expanded_flags` the build phases use, so the query
+        # resolves external repositories the way the build does — otherwise an
+        # rc-set `--noenable_bzlmod` / `--enable_workspace` is dropped and the
+        # query fails on repos the build can see. `.eval()` filters any
+        # version-gated flags against the running Bazel version exactly as
+        # `ctx.bazel.build` does.
         targets = [t.name for t in ctx.bazel.query().raw(query_expr).eval(
             flags = expanded_flags,
             announce_version = announce_version,

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1041,12 +1041,14 @@ def _delivery_impl(ctx):
         # `expanded_flags` the build phases use — so the query resolves
         # external repositories the way the build does. Without this an
         # rc-set `--noenable_bzlmod` / `--enable_workspace` is dropped and
-        # the query fails on repos the build can see. expand_all returns
-        # plain strings or `(value, version-constraint)` tuples; take the
-        # value from the tuple form (cf. the remote-cache scan above).
-        query_flags = [f[0] if type(f) == "tuple" else f for f in expanded_flags]
+        # the query fails on repos the build can see. `expanded_flags` may
+        # carry `(flag, version-constraint)` tuples (e.g. from
+        # `try-import`-if-bazel-version); `.eval()` resolves them against the
+        # running Bazel version exactly as `ctx.bazel.build` does, so a flag
+        # gated to a different version is filtered out rather than forced
+        # onto the query.
         targets = [t.name for t in ctx.bazel.query().raw(query_expr).eval(
-            flags = query_flags,
+            flags = expanded_flags,
             announce_version = announce_version,
             announce_command = announce_command,
         )]

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -141,6 +141,29 @@ fn resolve_flags<'v>(
     Ok(result)
 }
 
+/// Resolve a mixed flag list against the running Bazel version.
+///
+/// Like [`resolve_flags`], but sources the version itself: a `bazel info`
+/// probe is run only when at least one conditional `(flag, constraint)` tuple
+/// is present, so unconditional flag lists never pay for the probe. A
+/// non-release Bazel reports no version, in which case the constraints resolve
+/// against an assumed-latest version (see [`constraint_matches`]).
+///
+/// Shared by every Bazel subcommand that accepts version-gated flags
+/// (`build` / `test` / `query`) so they filter conditional flags identically.
+fn resolve_flags_for_running_bazel<'v>(
+    items: &[Either<values::StringValue<'v>, (values::StringValue<'v>, values::StringValue<'v>)>],
+) -> anyhow::Result<Vec<String>> {
+    let version = if items.iter().any(|f| f.is_right()) {
+        info::server_info()
+            .map_err(|e| anyhow::anyhow!("failed to get Bazel server info: {}", e))?
+            .1
+    } else {
+        None
+    };
+    resolve_flags(items, version.as_ref())
+}
+
 /// Whether a semver `constraint` is satisfied by the running Bazel `version`.
 ///
 /// `version` is `None` when Bazel reports a non-release build (a
@@ -327,17 +350,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             Either::Left(b) => (b, vec![]),
             Either::Right(sinks) => (true, sinks.items),
         };
-        let has_conditional = flags.items.iter().any(|f| f.is_right());
-        // `server_info` returns `None` for the version on a non-release Bazel;
-        // `resolve_flags` then assumes the latest version for conditional flags.
-        let bazel_version = if has_conditional {
-            let (_, version) = info::server_info()
-                .map_err(|e| anyhow::anyhow!("failed to get Bazel server info: {}", e))?;
-            version
-        } else {
-            None
-        };
-        let resolved_flags = resolve_flags(&flags.items, bazel_version.as_ref())?;
+        let resolved_flags = resolve_flags_for_running_bazel(&flags.items)?;
         let resolved_startup_flags = read_startup_flags(this)?;
         let env = Env::from_eval(eval)?;
         let (stdout, stderr) = resolve_stdio(stdio, stdout, stderr)?;
@@ -448,17 +461,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             Either::Left(b) => (b, vec![]),
             Either::Right(sinks) => (true, sinks.items),
         };
-        let has_conditional = flags.items.iter().any(|f| f.is_right());
-        // `server_info` returns `None` for the version on a non-release Bazel;
-        // `resolve_flags` then assumes the latest version for conditional flags.
-        let bazel_version = if has_conditional {
-            let (_, version) = info::server_info()
-                .map_err(|e| anyhow::anyhow!("failed to get Bazel server info: {}", e))?;
-            version
-        } else {
-            None
-        };
-        let resolved_flags = resolve_flags(&flags.items, bazel_version.as_ref())?;
+        let resolved_flags = resolve_flags_for_running_bazel(&flags.items)?;
         let resolved_startup_flags = read_startup_flags(this)?;
         let env = Env::from_eval(eval)?;
         let (stdout, stderr) = resolve_stdio(stdio, stdout, stderr)?;

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -8,6 +8,8 @@ use std::process::Stdio;
 
 use anyhow::Context;
 
+use either::Either;
+
 use allocative::Allocative;
 use anyhow::anyhow;
 use derive_more::Display;
@@ -339,6 +341,12 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     ///   repositories the same way the build does (e.g. an rc-set
     ///   `--noenable_bzlmod` / `--enable_workspace`). Omitting them lets the
     ///   query diverge from the build and fail on repos the build can see.
+    ///   Accepts the same `str | (str, version-constraint)` shape as
+    ///   `ctx.bazel.build` / `.test`: a conditional `(flag, constraint)`
+    ///   tuple is resolved against the running Bazel version and dropped
+    ///   when the constraint does not hold — so a flag gated to a different
+    ///   Bazel version is filtered out here exactly as it would be on the
+    ///   build, rather than being forced onto the query.
     /// * `announce_version` - Print an `INFO: Bazel <version>` line before
     ///   spawning. Resolved from the `--announce-bazel-version` task flag.
     /// * `announce_command` - Print an `INFO: Spawning: <command>` line
@@ -346,18 +354,33 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     ///   flag. Both mirror the `ctx.bazel.build` / `.test` disclosure.
     fn eval<'v>(
         this: values::Value<'v>,
-        #[starlark(require = named, default = UnpackList::default())] flags: UnpackList<String>,
+        #[starlark(require = named, default = UnpackList::default())] flags: UnpackList<
+            Either<values::StringValue<'v>, (values::StringValue<'v>, values::StringValue<'v>)>,
+        >,
         #[starlark(require = named, default = false)] announce_version: bool,
         #[starlark(require = named, default = false)] announce_command: bool,
     ) -> anyhow::Result<TargetSet> {
         let this = this.downcast_ref_err::<Query>().into_anyhow_result()?;
         let expr = this.expr.borrow();
         // Flags passed to `.eval()` win over any carried on the builder, but
-        // fall back to the builder's so the common case still works.
+        // fall back to the builder's so the common case still works. Resolve
+        // conditional `(flag, constraint)` tuples against the running Bazel
+        // version the same way `ctx.bazel.build` does (see `resolve_flags`),
+        // so a version-gated flag is filtered out — not force-applied — on a
+        // mismatch. Only pay for the `bazel info` version probe when a
+        // conditional flag is actually present.
         let flags = if flags.items.is_empty() {
             this.flags.clone()
         } else {
-            flags.items
+            let has_conditional = flags.items.iter().any(|f| f.is_right());
+            let bazel_version = if has_conditional {
+                let (_, version) = super::info::server_info()
+                    .map_err(|e| anyhow!("failed to get Bazel server info: {}", e))?;
+                version
+            } else {
+                None
+            };
+            super::resolve_flags(&flags.items, bazel_version.as_ref())?
         };
         let announce = super::build::AnnounceSpawn {
             version: announce_version,

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -168,8 +168,6 @@ pub struct Query {
     expr: RefCell<String>,
     #[allocative(skip)]
     startup_flags: Vec<String>,
-    #[allocative(skip)]
-    flags: Vec<String>,
 }
 
 impl Query {
@@ -177,7 +175,6 @@ impl Query {
         Self {
             expr: RefCell::new(String::new()),
             startup_flags,
-            flags: vec![],
         }
     }
 
@@ -302,7 +299,6 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
         Ok(Query {
             expr: RefCell::new(expr.as_str().to_string()),
             startup_flags: query.startup_flags.clone(),
-            flags: query.flags.clone(),
         })
     }
 
@@ -342,11 +338,8 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     ///   `--noenable_bzlmod` / `--enable_workspace`). Omitting them lets the
     ///   query diverge from the build and fail on repos the build can see.
     ///   Accepts the same `str | (str, version-constraint)` shape as
-    ///   `ctx.bazel.build` / `.test`: a conditional `(flag, constraint)`
-    ///   tuple is resolved against the running Bazel version and dropped
-    ///   when the constraint does not hold — so a flag gated to a different
-    ///   Bazel version is filtered out here exactly as it would be on the
-    ///   build, rather than being forced onto the query.
+    ///   `ctx.bazel.build` / `.test`; version-gated flags are filtered
+    ///   against the running Bazel version identically.
     /// * `announce_version` - Print an `INFO: Bazel <version>` line before
     ///   spawning. Resolved from the `--announce-bazel-version` task flag.
     /// * `announce_command` - Print an `INFO: Spawning: <command>` line
@@ -362,26 +355,7 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     ) -> anyhow::Result<TargetSet> {
         let this = this.downcast_ref_err::<Query>().into_anyhow_result()?;
         let expr = this.expr.borrow();
-        // Flags passed to `.eval()` win over any carried on the builder, but
-        // fall back to the builder's so the common case still works. Resolve
-        // conditional `(flag, constraint)` tuples against the running Bazel
-        // version the same way `ctx.bazel.build` does (see `resolve_flags`),
-        // so a version-gated flag is filtered out — not force-applied — on a
-        // mismatch. Only pay for the `bazel info` version probe when a
-        // conditional flag is actually present.
-        let flags = if flags.items.is_empty() {
-            this.flags.clone()
-        } else {
-            let has_conditional = flags.items.iter().any(|f| f.is_right());
-            let bazel_version = if has_conditional {
-                let (_, version) = super::info::server_info()
-                    .map_err(|e| anyhow!("failed to get Bazel server info: {}", e))?;
-                version
-            } else {
-                None
-            };
-            super::resolve_flags(&flags.items, bazel_version.as_ref())?
-        };
+        let flags = super::resolve_flags_for_running_bazel(&flags.items)?;
         let announce = super::build::AnnounceSpawn {
             version: announce_version,
             command: announce_command,

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -27,6 +27,7 @@ use starlark::values::NoSerialize;
 use starlark::values::ProvidesStaticType;
 use starlark::values::Trace;
 use starlark::values::ValueLike;
+use starlark::values::list::UnpackList;
 use starlark::values::starlark_value;
 use starlark::values::type_repr::StarlarkTypeRepr;
 
@@ -165,6 +166,8 @@ pub struct Query {
     expr: RefCell<String>,
     #[allocative(skip)]
     startup_flags: Vec<String>,
+    #[allocative(skip)]
+    flags: Vec<String>,
 }
 
 impl Query {
@@ -172,18 +175,21 @@ impl Query {
         Self {
             expr: RefCell::new(String::new()),
             startup_flags,
+            flags: vec![],
         }
     }
 
     pub fn query(
         expr: &str,
         startup_flags: &[String],
+        flags: &[String],
         announce: super::build::AnnounceSpawn,
     ) -> anyhow::Result<TargetSet> {
         let mut cmd = super::bazel_command();
         cmd.args(startup_flags);
         cmd.arg("query");
         cmd.arg(expr);
+        cmd.args(flags);
         cmd.arg("--output=streamed_proto");
         let out = temp_dir().join("query.bin");
         let _ = fs::remove_file(&out);
@@ -294,6 +300,7 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
         Ok(Query {
             expr: RefCell::new(expr.as_str().to_string()),
             startup_flags: query.startup_flags.clone(),
+            flags: query.flags.clone(),
         })
     }
 
@@ -325,6 +332,13 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     /// matched nothing.
     ///
     /// # Arguments
+    /// * `flags` - Command flags to pass to `bazel query` (between the
+    ///   expression and `--output`). Callers that run `query` alongside
+    ///   `build` / `test` under `--ignore_all_rc_files` MUST forward the
+    ///   rc-expanded command flags here, so the query resolves external
+    ///   repositories the same way the build does (e.g. an rc-set
+    ///   `--noenable_bzlmod` / `--enable_workspace`). Omitting them lets the
+    ///   query diverge from the build and fail on repos the build can see.
     /// * `announce_version` - Print an `INFO: Bazel <version>` line before
     ///   spawning. Resolved from the `--announce-bazel-version` task flag.
     /// * `announce_command` - Print an `INFO: Spawning: <command>` line
@@ -332,16 +346,24 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     ///   flag. Both mirror the `ctx.bazel.build` / `.test` disclosure.
     fn eval<'v>(
         this: values::Value<'v>,
+        #[starlark(require = named, default = UnpackList::default())] flags: UnpackList<String>,
         #[starlark(require = named, default = false)] announce_version: bool,
         #[starlark(require = named, default = false)] announce_command: bool,
     ) -> anyhow::Result<TargetSet> {
         let this = this.downcast_ref_err::<Query>().into_anyhow_result()?;
         let expr = this.expr.borrow();
+        // Flags passed to `.eval()` win over any carried on the builder, but
+        // fall back to the builder's so the common case still works.
+        let flags = if flags.items.is_empty() {
+            this.flags.clone()
+        } else {
+            flags.items
+        };
         let announce = super::build::AnnounceSpawn {
             version: announce_version,
             command: announce_command,
         };
-        Query::query(&expr, &this.startup_flags, announce)
+        Query::query(&expr, &this.startup_flags, &flags, announce)
     }
 }
 


### PR DESCRIPTION
`aspect delivery` resolves its delivery set with a `bazel query`. That query runs with `--ignore_all_rc_files` on its startup flags (the CLI resolves the workspace `.bazelrc` once, in `lib/bazel_flags.axl`, rather than letting each spawn re-read it). The build phases honor that contract by passing the rc-expanded command flags to `ctx.bazel.build`, but the resolve query passed none — so it ran with the rc suppressed and nothing re-injected, diverging from how the build sees the repo.

In a workspace whose `.bazelrc` configures external-repository behavior (e.g. `common --noenable_bzlmod` / `--enable_workspace`), the build resolves repositories correctly while the query fails with exit 7 — `No repository visible as '@rules_shell'`, alongside the tell-tale `--enable_bzlmod is set, but no MODULE.bazel file was found` warning.

`ctx.bazel.query().eval()` now accepts a `flags` argument (the same `str | (str, version-constraint)` shape as `ctx.bazel.build` / `.test`) and resolves version-gated flags against the running Bazel version through the shared `resolve_flags_for_running_bazel` helper. Delivery forwards the same `expanded_flags` the build phases use, so query and build resolve the workspace identically — including dropping flags gated to a different Bazel version rather than forcing them onto the query.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Fixed `aspect delivery` failing to resolve its `--query` in workspaces whose `.bazelrc` configures external-repository behavior (e.g. `--noenable_bzlmod` / `--enable_workspace`). The resolve query now honors the same `.bazelrc` flags the delivery build phases do.

### Test plan

- New test cases added: `test_query_flags` exercises `ctx.bazel.query().eval(flags=...)` with plain, always-matching, and never-matching version-gated flags.
- Covered by existing test cases: AXL unit suite, delivery snapshot scenarios, `query` unit tests.
- Manual testing; please provide instructions so we can reproduce:
  - In a Bazel 8 WORKSPACE-only repo with `common --noenable_bzlmod` in `.bazelrc`, run `aspect delivery --query='kind("oci_push", //...)'`. Before this change the resolve query fails with `No repository visible as '@rules_shell'` (exit 7); after it, the query resolves the same targets the build can see.
