### PR TITLE
fix(delivery): stop dumping expected phase-2 stderr on normal misses

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -2,7 +2,7 @@
 Exercise axl
 """
 
-load("@aspect//delivery.axl", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_upload_grpc_log = "should_upload_grpc_log")
+load("@aspect//delivery.axl", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
 load("@aspect//lib/artifacts.axl", "artifact_name")
 load("@aspect//lib/bazel_results.axl", "compute_reproducer_command", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
 load(
@@ -1820,6 +1820,30 @@ def test_delivery_should_upload_grpc_log(tc: int) -> int:
 
     return tc
 
+def test_delivery_should_surface_phase2_stderr(tc: int) -> int:
+    """Coverage for the phase-2 stderr-surfacing predicate.
+
+    Args are `(unexplained_unresolved, getactionresult_count)`. Phase 2 is
+    expected to exit non-zero on first delivery; misses diagnosed per-target
+    (a logged GetActionResult miss) suppress the noisy stderr. It surfaces only
+    when the log was empty, or a digest is missing for an unexplained reason."""
+
+    # Everything explained, log had entries → never surface (the expected,
+    # noisy first-delivery case).
+    tc = test_case(tc, not delivery_should_surface_phase2_stderr(0, 5), "phase2-stderr: all explained + log entries → skip")
+
+    # Empty gRPC log → bazel failed before any remote lookup; stderr is the
+    # only clue, regardless of the unexplained count.
+    tc = test_case(tc, delivery_should_surface_phase2_stderr(0, 0), "phase2-stderr: empty log → surface")
+    tc = test_case(tc, delivery_should_surface_phase2_stderr(2, 0), "phase2-stderr: empty log + unexplained → surface")
+
+    # Log had entries but a digest we expected is missing for an unexplained
+    # reason (e.g. its DeliveryHash lookup came back non-OK) → the per-target
+    # row is generic, so surface the raw stderr.
+    tc = test_case(tc, delivery_should_surface_phase2_stderr(1, 6), "phase2-stderr: unexplained miss + log entries → surface")
+
+    return tc
+
 def test_build_metadata_lib(tc: int) -> int:
     """Coverage for the pure helpers in lib/build_metadata.axl."""
 
@@ -3105,6 +3129,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_sanitize_filename(tc)
     tc = test_deliveryd_parse_endpoint(tc)
     tc = test_delivery_should_upload_grpc_log(tc)
+    tc = test_delivery_should_surface_phase2_stderr(tc)
     tc = test_build_metadata_lib(tc)
     tc = test_severity_for_status(tc)
     tc = test_gazelle_dir_helpers(tc)

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -1821,7 +1821,12 @@ def test_delivery_should_upload_grpc_log(tc: int) -> int:
     return tc
 
 def test_delivery_count_unexplained_unresolved(tc: int) -> int:
-    """Coverage for the unexplained-unresolved tally feeding the stderr gate."""
+    """Coverage for the unexplained-unresolved tally feeding the stderr gate.
+
+    The third arg is `non_hermetic_misses` — the post-opt-out-filter set that
+    drives the per-target WARN row. A target keyed there is explained; an
+    unresolved target absent from it (no surviving miss, or only a declared
+    opt-out, which never reaches this dict) is unexplained."""
 
     a = "//pkg:a"
     b = "//pkg:b"
@@ -1829,24 +1834,40 @@ def test_delivery_count_unexplained_unresolved(tc: int) -> int:
     targets = [a, b, c]
 
     # All resolved → none unexplained.
-    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {a: "h1", b: "h2", c: "h3"}, {}) == 0,
-                   "count_unexplained: all resolved → 0")
+    tc = test_case(
+        tc,
+        delivery_count_unexplained_unresolved(targets, {a: "h1", b: "h2", c: "h3"}, {}) == 0,
+        "count_unexplained: all resolved → 0",
+    )
 
-    # `b` unresolved with a logged miss → explained, not counted.
-    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {a: "h1", c: "h3"}, {b: ["PyWriteBuildData"]}) == 0,
-                   "count_unexplained: unresolved but logged miss → 0")
+    # `b` unresolved but a surviving (non-hermetic) miss explains it → not counted.
+    tc = test_case(
+        tc,
+        delivery_count_unexplained_unresolved(targets, {a: "h1", c: "h3"}, {b: ["PyWriteBuildData"]}) == 0,
+        "count_unexplained: unresolved but explained by surviving miss → 0",
+    )
 
-    # `b` unresolved with no logged miss → unexplained, counted.
-    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {a: "h1", c: "h3"}, {}) == 1,
-                   "count_unexplained: unresolved with no logged miss → 1")
+    # `b` unresolved with no surviving miss → unexplained, counted. (Same shape
+    # as an opt-out-only miss, which is filtered out before reaching this dict.)
+    tc = test_case(
+        tc,
+        delivery_count_unexplained_unresolved(targets, {a: "h1", c: "h3"}, {}) == 1,
+        "count_unexplained: unresolved with no surviving miss → 1",
+    )
 
     # Mixed: `b` explained, `c` unexplained → 1.
-    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {a: "h1"}, {b: ["X"]}) == 1,
-                   "count_unexplained: one explained, one unexplained → 1")
+    tc = test_case(
+        tc,
+        delivery_count_unexplained_unresolved(targets, {a: "h1"}, {b: ["X"]}) == 1,
+        "count_unexplained: one explained, one unexplained → 1",
+    )
 
-    # All unresolved, none logged → all unexplained.
-    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {}, {}) == 3,
-                   "count_unexplained: all unresolved, none logged → 3")
+    # All unresolved, none explained → all unexplained.
+    tc = test_case(
+        tc,
+        delivery_count_unexplained_unresolved(targets, {}, {}) == 3,
+        "count_unexplained: all unresolved, none explained → 3",
+    )
 
     return tc
 

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -2,7 +2,7 @@
 Exercise axl
 """
 
-load("@aspect//delivery.axl", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
+load("@aspect//delivery.axl", delivery_count_unexplained_unresolved = "count_unexplained_unresolved", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
 load("@aspect//lib/artifacts.axl", "artifact_name")
 load("@aspect//lib/bazel_results.axl", "compute_reproducer_command", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
 load(
@@ -1820,6 +1820,36 @@ def test_delivery_should_upload_grpc_log(tc: int) -> int:
 
     return tc
 
+def test_delivery_count_unexplained_unresolved(tc: int) -> int:
+    """Coverage for the unexplained-unresolved tally feeding the stderr gate."""
+
+    a = "//pkg:a"
+    b = "//pkg:b"
+    c = "//pkg:c"
+    targets = [a, b, c]
+
+    # All resolved → none unexplained.
+    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {a: "h1", b: "h2", c: "h3"}, {}) == 0,
+                   "count_unexplained: all resolved → 0")
+
+    # `b` unresolved with a logged miss → explained, not counted.
+    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {a: "h1", c: "h3"}, {b: ["PyWriteBuildData"]}) == 0,
+                   "count_unexplained: unresolved but logged miss → 0")
+
+    # `b` unresolved with no logged miss → unexplained, counted.
+    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {a: "h1", c: "h3"}, {}) == 1,
+                   "count_unexplained: unresolved with no logged miss → 1")
+
+    # Mixed: `b` explained, `c` unexplained → 1.
+    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {a: "h1"}, {b: ["X"]}) == 1,
+                   "count_unexplained: one explained, one unexplained → 1")
+
+    # All unresolved, none logged → all unexplained.
+    tc = test_case(tc, delivery_count_unexplained_unresolved(targets, {}, {}) == 3,
+                   "count_unexplained: all unresolved, none logged → 3")
+
+    return tc
+
 def test_delivery_should_surface_phase2_stderr(tc: int) -> int:
     """Coverage for the phase-2 stderr-surfacing predicate.
 
@@ -3129,6 +3159,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_sanitize_filename(tc)
     tc = test_deliveryd_parse_endpoint(tc)
     tc = test_delivery_should_upload_grpc_log(tc)
+    tc = test_delivery_count_unexplained_unresolved(tc)
     tc = test_delivery_should_surface_phase2_stderr(tc)
     tc = test_build_metadata_lib(tc)
     tc = test_severity_for_status(tc)

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -321,15 +321,40 @@ def should_upload_grpc_log(setting: str, unresolved: int) -> bool:
         return False
     return unresolved > 0
 
+def should_surface_phase2_stderr(unexplained_unresolved: int, getactionresult_count: int) -> bool:
+    """Whether to echo phase-2's captured Bazel stderr to the console.
+
+    Phase 2 is *expected* to exit non-zero on first delivery — its
+    `--experimental_remote_require_cached` build reports the not-yet-cached
+    digests as `ERROR:` lines, which is exactly what the gRPC log captures.
+    Echoing that stderr would drown the user in expected errors, so a target
+    whose miss is explained — diagnosed inline as a non-cacheable upstream
+    action — never triggers it.
+
+    Surface it when either:
+
+    - the gRPC log yielded no GetActionResult entries (`getactionresult_count
+      == 0`): bazel failed before issuing any remote lookup
+      (auth/network/config), so no per-target diagnosis can fire; or
+    - a digest we expected to resolve is missing for an *unexplained* reason
+      (`unexplained_unresolved > 0`): e.g. the DeliveryHash lookup itself came
+      back non-OK. The per-target row falls back to a generic message, so the
+      raw stderr is the actionable surface.
+
+    Exported for unit testing."""
+    return getactionresult_count == 0 or unexplained_unresolved > 0
+
 def _surface_phase_stderr(ctx, phase, log_path):
     """Echo a failing phase's captured Bazel stderr to the console and upload
     it as a CI artifact (`delivery_phase{phase}_log`).
 
     Phases 2 and 3 redirect Bazel's stderr to a file rather than the console
-    (phase-2 require-cached misses are noisy-but-expected). On failure that
-    file holds Bazel's own diagnosis, so echo it verbatim and preserve it as
-    a downloadable artifact. The stderr carries no env/command lines, so it
-    uploads unconditionally. No-op if the file is absent or off-CI."""
+    because phase-2 require-cached misses are noisy-but-expected. Callers gate
+    this to the genuinely-failed cases (the expected misses are diagnosed from
+    the gRPC log instead); when called, the file holds Bazel's own diagnosis,
+    so echo it verbatim and preserve it as a downloadable artifact. The stderr
+    carries no env/command lines, so it uploads unconditionally. No-op if the
+    file is absent or off-CI."""
     if not ctx.std.fs.exists(log_path):
         return
     ctx.std.io.stderr.write(ctx.std.fs.read_to_string(log_path))
@@ -341,9 +366,12 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     drive the `data` (delivery_results) metadata; phase 2's gRPC log yields
     the per-target action digests used for change detection.
 
-    On a phase-2 failure or any unresolved digest, the captured Bazel stderr
-    is echoed and uploaded as a CI artifact; the gRPC log is uploaded per
-    `ctx.args.upload_grpc_log` ("auto"/"true"/"false"). Uploads no-op off-CI.
+    Phase 2 is expected to exit non-zero on first delivery (require-cached
+    reports the not-yet-cached digests), so its stderr is captured to a file
+    and echoed/uploaded only when the per-target rows can't explain the
+    outcome — see `should_surface_phase2_stderr`. The gRPC log itself is
+    uploaded per `ctx.args.upload_grpc_log` ("auto"/"true"/"false"). Uploads
+    no-op off-CI.
     """
     repo_dir = "/tmp/aspect_delivery_" + ctx.task.key
     _write_aspect_repo(ctx, repo_dir)
@@ -546,9 +574,11 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
         return {}, {}, (phase2_status.code if phase2_status.code != 0 else 1)
 
     log_file = ctx.std.fs.open(log_path)
+    getactionresult_count = 0
     for entry in remote.logging.LogEntry().parse_from_delimited(log_file):
         if entry.method_name != "build.bazel.remote.execution.v2.ActionCache/GetActionResult":
             continue
+        getactionresult_count += 1
         trace.log(entry)
         entry_label = apparent_label(entry.metadata.target_id)
         mnemonic = entry.metadata.action_mnemonic
@@ -565,6 +595,18 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
                 misses_by_producer[entry_label] = existing
     _unresolved = len(targets) - len(output_shas)
 
+    # An unresolved target is "explained" when a non-OK GetActionResult for
+    # one of its actions was logged (recorded in misses_by_producer keyed by
+    # the producer's apparent label) — the per-target WARN row then names the
+    # drifting mnemonic. An unresolved target with no such entry (e.g. its
+    # DeliveryHash lookup itself came back non-OK, which isn't recorded as a
+    # miss) is unexplained and only gets a generic message, so stderr is the
+    # actionable surface for it.
+    _unexplained_unresolved = 0
+    for label in targets:
+        if label not in output_shas and apparent_label(label) not in misses_by_producer:
+            _unexplained_unresolved += 1
+
     # Preserve the gRPC log (the ground truth for which GetActionResult
     # missed) as a CI artifact per --upload-grpc-log; see the flag's
     # description for the gating rationale. No-op off-CI.
@@ -576,10 +618,6 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     if _unresolved == 0:
         print("  Resolved digests for all {} in {}.".format(targets_label, fmt_elapsed(time.monotonic() - _t_phase2)))
     else:
-        # Point at the phase-2 stderr when anything went unresolved: the
-        # gRPC log may hold zero useful entries (an auth/network/config error
-        # before any GetActionResult fired), so the per-target inline
-        # diagnosis can't fire and the stderr is the actionable surface.
         print("  Resolved {} of {} delivery digests in {}; {} could not be hashed. Phase-2 raw log: {}".format(
             len(output_shas),
             len(targets),
@@ -587,7 +625,21 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             _unresolved,
             phase2_log_path,
         ))
-        _surface_phase_stderr(ctx, 2, phase2_log_path)
+        # An unresolved digest that's diagnosed per-target below (a logged
+        # miss → WARN row naming the drifting mnemonic) makes the verbose
+        # stderr redundant noise. Surface it only for the cases the per-target
+        # row can't explain — see the helper.
+        if should_surface_phase2_stderr(_unexplained_unresolved, getactionresult_count):
+            # Frame the stderr first: it runs under
+            # `--experimental_remote_require_cached`, so its `Action must be
+            # cached ... but it is not` errors are expected — phase 2 only
+            # reads digests from the gRPC log, it never builds — and are not
+            # themselves the delivery failure.
+            info(ctx.std, "The Bazel errors below are from phase 2's --experimental_remote_require_cached probe" +
+                          " (which reads delivery digests from the remote cache without building); the" +
+                          " \"Action must be cached ... but it is not\" lines are expected. They are shown" +
+                          " because a digest could not be resolved for an unexpected reason.")
+            _surface_phase_stderr(ctx, 2, phase2_log_path)
 
     # Filter to misses on actions that did NOT declare a remote-cache
     # opt-out — these are real key-drift symptoms (transient or

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -321,6 +321,21 @@ def should_upload_grpc_log(setting: str, unresolved: int) -> bool:
         return False
     return unresolved > 0
 
+def count_unexplained_unresolved(targets: list, output_shas: dict, misses_by_producer: dict) -> int:
+    """Count delivery targets whose digest is missing for an unexplained reason.
+
+    A target is unresolved when it has no entry in `output_shas`, and explained
+    when a non-OK GetActionResult was logged against its apparent label (a key
+    in `misses_by_producer`) — a diagnosed cache miss surfaced inline. One with
+    no such entry (e.g. its own DeliveryHash lookup came back non-OK, which the
+    log scan doesn't record as a miss) is unexplained. Exported for unit
+    testing; feeds `should_surface_phase2_stderr`."""
+    return len([
+        label
+        for label in targets
+        if label not in output_shas and apparent_label(label) not in misses_by_producer
+    ])
+
 def should_surface_phase2_stderr(unexplained_unresolved: int, getactionresult_count: int) -> bool:
     """Whether to echo phase-2's captured Bazel stderr to the console.
 
@@ -595,17 +610,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
                 misses_by_producer[entry_label] = existing
     _unresolved = len(targets) - len(output_shas)
 
-    # An unresolved target is "explained" when a non-OK GetActionResult for
-    # one of its actions was logged (recorded in misses_by_producer keyed by
-    # the producer's apparent label) — the per-target WARN row then names the
-    # drifting mnemonic. An unresolved target with no such entry (e.g. its
-    # DeliveryHash lookup itself came back non-OK, which isn't recorded as a
-    # miss) is unexplained and only gets a generic message, so stderr is the
-    # actionable surface for it.
-    _unexplained_unresolved = 0
-    for label in targets:
-        if label not in output_shas and apparent_label(label) not in misses_by_producer:
-            _unexplained_unresolved += 1
+    _unexplained_unresolved = count_unexplained_unresolved(targets, output_shas, misses_by_producer)
 
     # Preserve the gRPC log (the ground truth for which GetActionResult
     # missed) as a CI artifact per --upload-grpc-log; see the flag's
@@ -625,20 +630,13 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
             _unresolved,
             phase2_log_path,
         ))
-        # An unresolved digest that's diagnosed per-target below (a logged
-        # miss → WARN row naming the drifting mnemonic) makes the verbose
-        # stderr redundant noise. Surface it only for the cases the per-target
-        # row can't explain — see the helper.
         if should_surface_phase2_stderr(_unexplained_unresolved, getactionresult_count):
-            # Frame the stderr first: it runs under
-            # `--experimental_remote_require_cached`, so its `Action must be
-            # cached ... but it is not` errors are expected — phase 2 only
-            # reads digests from the gRPC log, it never builds — and are not
-            # themselves the delivery failure.
+            # Frame the stderr so its expected require-cached errors don't read
+            # as the failure.
             info(ctx.std, "The Bazel errors below are from phase 2's --experimental_remote_require_cached probe" +
-                          " (which reads delivery digests from the remote cache without building); the" +
-                          " \"Action must be cached ... but it is not\" lines are expected. They are shown" +
-                          " because a digest could not be resolved for an unexpected reason.")
+                          " (it reads delivery digests from the remote cache without building); the" +
+                          " \"Action must be cached ... but it is not\" lines are expected, and are shown" +
+                          " only because a digest could not be resolved for an unexpected reason.")
             _surface_phase_stderr(ctx, 2, phase2_log_path)
 
     # Filter to misses on actions that did NOT declare a remote-cache

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -321,19 +321,20 @@ def should_upload_grpc_log(setting: str, unresolved: int) -> bool:
         return False
     return unresolved > 0
 
-def count_unexplained_unresolved(targets: list, output_shas: dict, misses_by_producer: dict) -> int:
+def count_unexplained_unresolved(targets: list, output_shas: dict, non_hermetic_misses: dict) -> int:
     """Count delivery targets whose digest is missing for an unexplained reason.
 
     A target is unresolved when it has no entry in `output_shas`, and explained
-    when a non-OK GetActionResult was logged against its apparent label (a key
-    in `misses_by_producer`) — a diagnosed cache miss surfaced inline. One with
-    no such entry (e.g. its own DeliveryHash lookup came back non-OK, which the
-    log scan doesn't record as a miss) is unexplained. Exported for unit
-    testing; feeds `should_surface_phase2_stderr`."""
+    when its apparent label is a key in `non_hermetic_misses` — the same
+    (post opt-out filter) set that produces the per-target mnemonic WARN row.
+    One with no such entry (e.g. its own DeliveryHash lookup came back non-OK,
+    or its only miss was a declared opt-out) gets the generic "not in grpc log"
+    message, so it is unexplained. Exported for unit testing; feeds
+    `should_surface_phase2_stderr`."""
     return len([
         label
         for label in targets
-        if label not in output_shas and apparent_label(label) not in misses_by_producer
+        if label not in output_shas and apparent_label(label) not in non_hermetic_misses
     ])
 
 def should_surface_phase2_stderr(unexplained_unresolved: int, getactionresult_count: int) -> bool:
@@ -610,35 +611,6 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
                 misses_by_producer[entry_label] = existing
     _unresolved = len(targets) - len(output_shas)
 
-    _unexplained_unresolved = count_unexplained_unresolved(targets, output_shas, misses_by_producer)
-
-    # Preserve the gRPC log (the ground truth for which GetActionResult
-    # missed) as a CI artifact per --upload-grpc-log; see the flag's
-    # description for the gating rationale. No-op off-CI.
-    upload_grpc = ctx.args.upload_grpc_log if hasattr(ctx.args, "upload_grpc_log") else "auto"
-    if should_upload_grpc_log(upload_grpc, _unresolved):
-        artifacts.upload_file(ctx, "delivery_grpc_log", "phase2-grpc.binpb", log_path)
-    ctx.std.fs.remove_file(log_path)
-
-    if _unresolved == 0:
-        print("  Resolved digests for all {} in {}.".format(targets_label, fmt_elapsed(time.monotonic() - _t_phase2)))
-    else:
-        print("  Resolved {} of {} delivery digests in {}; {} could not be hashed. Phase-2 raw log: {}".format(
-            len(output_shas),
-            len(targets),
-            fmt_elapsed(time.monotonic() - _t_phase2),
-            _unresolved,
-            phase2_log_path,
-        ))
-        if should_surface_phase2_stderr(_unexplained_unresolved, getactionresult_count):
-            # Frame the stderr so its expected require-cached errors don't read
-            # as the failure.
-            info(ctx.std, "The Bazel errors below are from phase 2's --experimental_remote_require_cached probe" +
-                          " (it reads delivery digests from the remote cache without building); the" +
-                          " \"Action must be cached ... but it is not\" lines are expected, and are shown" +
-                          " only because a digest could not be resolved for an unexpected reason.")
-            _surface_phase_stderr(ctx, 2, phase2_log_path)
-
     # Filter to misses on actions that did NOT declare a remote-cache
     # opt-out — these are real key-drift symptoms (transient or
     # non-hermetic). Caller surfaces them inline on the failed row.
@@ -666,6 +638,40 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
                     continue
                 non_hermetic_misses.setdefault(producer, []).append(m)
     ctx.std.fs.remove_file(phase1_execlog_path)
+
+    # Gate on the same misses that drive the per-target WARN row
+    # (`non_hermetic_misses`, post opt-out filter), not the raw
+    # `misses_by_producer` — a target explained only by a declared opt-out
+    # still gets the generic "not in grpc log" message, so its stderr must
+    # surface.
+    _unexplained_unresolved = count_unexplained_unresolved(targets, output_shas, non_hermetic_misses)
+
+    # Preserve the gRPC log (the ground truth for which GetActionResult
+    # missed) as a CI artifact per --upload-grpc-log; see the flag's
+    # description for the gating rationale. No-op off-CI.
+    upload_grpc = ctx.args.upload_grpc_log if hasattr(ctx.args, "upload_grpc_log") else "auto"
+    if should_upload_grpc_log(upload_grpc, _unresolved):
+        artifacts.upload_file(ctx, "delivery_grpc_log", "phase2-grpc.binpb", log_path)
+    ctx.std.fs.remove_file(log_path)
+
+    if _unresolved == 0:
+        print("  Resolved digests for all {} in {}.".format(targets_label, fmt_elapsed(time.monotonic() - _t_phase2)))
+    else:
+        print("  Resolved {} of {} delivery digests in {}; {} could not be hashed. Phase-2 raw log: {}".format(
+            len(output_shas),
+            len(targets),
+            fmt_elapsed(time.monotonic() - _t_phase2),
+            _unresolved,
+            phase2_log_path,
+        ))
+        if should_surface_phase2_stderr(_unexplained_unresolved, getactionresult_count):
+            # Frame the stderr so its expected require-cached errors don't read
+            # as the failure.
+            info(ctx.std, "The Bazel errors below are from phase 2's --experimental_remote_require_cached probe" +
+                          " (it reads delivery digests from the remote cache without building); the" +
+                          " \"Action must be cached ... but it is not\" lines are expected, and are shown" +
+                          " only because a digest could not be resolved for an unexpected reason.")
+            _surface_phase_stderr(ctx, 2, phase2_log_path)
 
     return output_shas, non_hermetic_misses, 0
 

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -523,7 +523,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
 
     if status.code != 0:
         return {}, {}, status.code
-    print("  Build took {}.".format(fmt_elapsed(time.monotonic() - _t_phase1)))
+    info(ctx.std, "Build took {}.".format(fmt_elapsed(time.monotonic() - _t_phase1)))
 
     # Phase 2. We parse the gRPC log regardless of exit code — a non-zero
     # result usually just means DeliveryHash wasn't cached remotely yet,
@@ -655,9 +655,9 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
     ctx.std.fs.remove_file(log_path)
 
     if _unresolved == 0:
-        print("  Resolved digests for all {} in {}.".format(targets_label, fmt_elapsed(time.monotonic() - _t_phase2)))
+        info(ctx.std, "Resolved digests for all {} in {}.".format(targets_label, fmt_elapsed(time.monotonic() - _t_phase2)))
     else:
-        print("  Resolved {} of {} delivery digests in {}; {} could not be hashed. Phase-2 raw log: {}".format(
+        info(ctx.std, "Resolved {} of {} delivery digests in {}; {} could not be hashed. Phase-2 raw log: {}".format(
             len(output_shas),
             len(targets),
             fmt_elapsed(time.monotonic() - _t_phase2),
@@ -667,11 +667,11 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, bazel_f
         if should_surface_phase2_stderr(_unexplained_unresolved, getactionresult_count):
             # Frame the stderr so its expected require-cached errors don't read
             # as the failure.
-            info(ctx.std, "The Bazel errors below are from phase 2's --experimental_remote_require_cached probe" +
+            _surface_phase_stderr(ctx, 2, phase2_log_path)
+            info(ctx.std, "The Bazel errors above are from phase 2's --experimental_remote_require_cached probe" +
                           " (it reads delivery digests from the remote cache without building); the" +
                           " \"Action must be cached ... but it is not\" lines are expected, and are shown" +
                           " only because a digest could not be resolved for an unexpected reason.")
-            _surface_phase_stderr(ctx, 2, phase2_log_path)
 
     return output_shas, non_hermetic_misses, 0
 
@@ -1159,7 +1159,7 @@ def _delivery_impl(ctx):
     if phase_1_2_runs:
         _t_build = time.monotonic()
         output_shas, non_hermetic_misses, build_code = _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, expanded_flags, remote_cache_uri, ansi, data)
-        print("  Build+checksum total: {}.".format(fmt_elapsed(time.monotonic() - _t_build)))
+        info(ctx.std, "Build+checksum total: {}.".format(fmt_elapsed(time.monotonic() - _t_build)))
 
         for handler in bazel_trait.build_end:
             handler(ctx, build_code)
@@ -1308,7 +1308,7 @@ def _delivery_impl(ctx):
                 )
                 _fire_target_hook(data, delivery_trait, None, label)
             return _emit_final(ctx, lifecycle, data, exit_code = status.code)
-        print("  Download took {}.".format(fmt_elapsed(time.monotonic() - _t_download)))
+        info(ctx.std, "Download took {}.".format(fmt_elapsed(time.monotonic() - _t_download)))
 
     max_par = ctx.args.max_parallelization
     if max_par < 1:


### PR DESCRIPTION
The delivery Checksum phase (phase 2) re-runs the build with `--experimental_remote_require_cached` solely to read each target's `DeliveryHash` action digest from the gRPC log. It is *expected* to exit non-zero on first delivery — bazel emits `Action must be cached due to --experimental_remote_require_cached but it is not` for every digest that isn't cached yet, which is precisely the signal the gRPC log captures.

The phase echoed that entire captured stderr whenever **any** digest went unresolved. But an unresolved digest is the normal case — e.g. a target with a non-hermetic upstream action (`PyWriteBuildData`) that already gets a clear per-target `WARN` row — so the console filled with a wall of expected `ERROR:` lines on top of an already-actionable diagnosis.

Now the captured stderr is surfaced only when the per-target rows can't explain the outcome:

- the gRPC log yielded no `GetActionResult` entries — bazel failed before issuing any remote lookup (auth/network/config), so no per-target diagnosis can fire; or
- a digest we expected is missing for an *unexplained* reason (e.g. its `DeliveryHash` lookup itself came back non-OK), where the per-target row falls back to a generic message.

When stderr is surfaced, a note follows it framing the require-cached errors as expected. Phase 3 (the real delivery build) is unchanged — its non-zero exit is a genuine failure and still surfaces stderr.

The decision is split into two pure helpers — `count_unexplained_unresolved` and `should_surface_phase2_stderr` — both unit-tested.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- `aspect delivery` no longer dumps the expected `--experimental_remote_require_cached` Bazel errors from its checksum phase when a digest is unresolved for an already-diagnosed reason (e.g. a non-hermetic upstream action). The per-target WARN row carries the actionable detail; the raw stderr is shown only when the failure can't be explained per-target, prefixed with a note that the errors are expected.

### Test plan

- New test cases: `test_delivery_count_unexplained_unresolved` (5 cases) and `test_delivery_should_surface_phase2_stderr` (4 cases) cover the tally and the surfacing predicate end to end.
- Covered by existing test cases: AXL unit suite, delivery snapshot scenarios.
