### PR TITLE
fix(circleci): replay the runner's pre-signed test-result PUT instead of re-signing

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -344,7 +344,9 @@ def _delete_artifact(ctx, name):
 # Upload Bazel JUnit XML to CircleCI's runner output test-results API
 # (reverse-engineered from circleci-agent, verified against real CircleCI):
 #   POST /api/v2/output/test-result          {"step_id": N}  -> Key
-#   <Key.method> the gzipped tar to the (relative) S3 Key.location, sigv4-signed
+#   <Key.method> the gzipped tar to the S3 Key.location, replaying
+#     Key.headers verbatim — the Key is already pre-signed by the runner,
+#     so we do NOT re-sign (see `_s3_put_object`).
 #   POST /api/v2/output/test-result/process  {"step_id": N}  -> summary
 # step_id is the agent's internal step index; when unknown we probe for it.
 
@@ -396,19 +398,26 @@ def _resolve_step_id(ctx, session, step_id):
     return None, None
 
 def _s3_put_object(ctx, session, method, url, headers, path):
-    """sigv4 PUT `path` to `url` with the runner's STS creds + Key headers.
-    Returns `(ok, detail)`."""
-    aws_creds = session["aws_creds"]
-    region = session["region"]
+    """Replay the runner's pre-signed upload request: PUT `path` to `url`
+    with `Key.headers` (`headers`) sent verbatim. Returns `(ok, detail)`.
+
+    The CircleCI output service returns a *fully pre-signed* request in the
+    test-result `Key` — `Key.headers` already carries the `Authorization`
+    (sigv4), `x-amz-date`, `x-amz-content-sha256`, and `x-amz-security-token`
+    the runner computed against this exact object. So we must NOT re-sign:
+    curl's `--aws-sigv4` steps aside the moment it sees an explicit
+    `Authorization`, which drops the `x-amz-content-sha256` it would
+    otherwise add and makes S3 reject the request with
+    `400 InvalidRequest: Missing required header ... x-amz-content-sha256`.
+    Replaying the runner's headers as-is (no `--aws-sigv4`, no `--user`, no
+    locally-injected security token) keeps the request the runner signed.
+
+    `session` is unused here (the headers are self-contained) but kept in
+    the signature so the call site mirrors `_s3_put`.
+    """
     curl_args = [
         "--silent",
         "--show-error",
-        "--aws-sigv4",
-        "aws:amz:" + region + ":s3",
-        "--user",
-        aws_creds["AccessKeyID"] + ":" + aws_creds["SecretAccessKey"],
-        "-H",
-        "x-amz-security-token: " + aws_creds["SessionToken"],
         "-T",
         path,
         "-X",

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -1,6 +1,13 @@
-"""CircleCI artifact upload library.
+"""CircleCI runner output upload library.
 
-Uses the CircleCI runner API (Unix socket + HTTP) to upload artifacts to S3.
+Uploads to CircleCI's runner output API (Unix socket + HTTP) over two
+distinct flows that both end in an S3 PUT:
+
+  - Artifacts (`upload_artifact`): the runner returns a bare S3 key and we
+    sign the PUT ourselves with the job-scoped STS credentials.
+  - Test results (`store_test_results`): the runner returns a *pre-signed*
+    request (`Key.method`/`location`/`headers`) that we replay verbatim —
+    see `_s3_put_object`.
 
 Credential lifetime: the runner mints the temporary S3 (STS) credentials
 returned by `/api/v2/output/credentials` with a short TTL (≈10 min) and
@@ -210,6 +217,69 @@ def s3_upload_error_detail(http_code, curl_err, body):
         return "curl transport error: " + curl_err.replace("\n", " ")
     return "curl s3 upload failed"
 
+# Shared `-w` suffix: curl appends the HTTP status as a trailing line so the
+# S3 `<Error>` body (everything before it) stays parseable. No `--fail`, so
+# curl exits 0 on a 4xx and that body lands on stdout for diagnosis.
+_CURL_S3_BASE_ARGS = ["--silent", "--show-error", "-w", "\n%{http_code}"]
+
+def _header_args(headers):
+    """Flatten `{k: v}` into `["-H", "k: v", ...]`; [] when empty/None."""
+    args = []
+    for k, v in (headers or {}).items():
+        args = args + ["-H", k + ": " + v]
+    return args
+
+def s3_sigv4_put_args(region, aws_creds, path, headers = None):
+    """curl args for a self-signed sigv4 PUT (the artifact path mints its own
+    S3 key, so we sign locally). `headers` is an optional `{k: v}` of extra
+    request headers. Public so `circleci_test.axl` can load it.
+    """
+    args = _CURL_S3_BASE_ARGS + [
+        "--aws-sigv4",
+        "aws:amz:" + region + ":s3",
+        "--user",
+        aws_creds["AccessKeyID"] + ":" + aws_creds["SecretAccessKey"],
+        "-H",
+        "x-amz-security-token: " + aws_creds["SessionToken"],
+        "-T",
+        path,
+        "-X",
+        "PUT",
+    ]
+    return args + _header_args(headers)
+
+def s3_replay_put_args(method, path, headers = None):
+    """curl args replaying a pre-signed PUT verbatim — no local signing, just
+    the runner's `Key.headers`. See `_s3_put_object`. Public so
+    `circleci_test.axl` can load it.
+    """
+    return _CURL_S3_BASE_ARGS + ["-T", path, "-X", method] + _header_args(headers)
+
+def _run_s3_put(ctx, curl_args, url):
+    """Spawn `curl <args> <url>` and classify the result.
+
+    Returns `(ok, http_code, body, curl_err)`. `ok` is True only on a 2xx
+    with a clean exit; `body` is the S3 response (the trailing `%{http_code}`
+    line stripped) for error diagnosis.
+    """
+    child = ctx.std.process.command("curl") \
+        .args(curl_args + [url]) \
+        .stdout("piped") \
+        .stderr("piped") \
+        .spawn()
+    out = child.stdout().read_to_string()
+    curl_err = child.stderr().read_to_string().strip()
+    status = child.wait()
+
+    parts = out.rsplit("\n", 1)
+    if len(parts) == 2:
+        body, http_code = parts[0], parts[1].strip()
+    else:
+        body, http_code = "", parts[0].strip()
+
+    ok = status.code == 0 and http_code.startswith("2")
+    return (ok, http_code, body, curl_err)
+
 def _s3_put(ctx, session, path, name):
     """Register the artifact with the runner and PUT it to S3.
 
@@ -233,64 +303,29 @@ def _s3_put(ctx, session, path, name):
     prefix = artifact_resp["prefix"]
     tags = artifact_resp.get("key", {}).get("tags", {})
 
-    s3_key = prefix + "/" + name
-    s3_url = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + s3_key
+    s3_url = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + prefix + "/" + name
 
-    # No `--fail`: let curl exit 0 on a 4xx so the S3 `<Error>` body lands
-    # on stdout for diagnosis. `-w "\n%{http_code}"` appends the status as
-    # the final line; everything before it is the response body.
-    curl_args = [
-        "--silent",
-        "--show-error",
-        "--aws-sigv4",
-        "aws:amz:" + region + ":s3",
-        "--user",
-        aws_creds["AccessKeyID"] + ":" + aws_creds["SecretAccessKey"],
-        "-H",
-        "x-amz-security-token: " + aws_creds["SessionToken"],
-        "-T",
-        path,
-        "-X",
-        "PUT",
-        "-w",
-        "\n%{http_code}",
-    ]
+    extra_headers = {}
     if tags:
-        tag_str = "&".join([k + "=" + v for k, v in tags.items()])
-        curl_args = curl_args + ["-H", "x-amz-tagging: " + tag_str]
-    curl_args = curl_args + [s3_url]
+        extra_headers["x-amz-tagging"] = "&".join([k + "=" + v for k, v in tags.items()])
 
-    child = ctx.std.process.command("curl") \
-        .args(curl_args) \
-        .stdout("piped") \
-        .stderr("piped") \
-        .spawn()
+    ok, http_code, body, curl_err = _run_s3_put(
+        ctx,
+        s3_sigv4_put_args(region, aws_creds, path, extra_headers),
+        s3_url,
+    )
+    if not ok:
+        return (False, s3_upload_error_detail(http_code, curl_err, body), "")
 
-    out = child.stdout().read_to_string()
-    curl_err = child.stderr().read_to_string().strip()
-    status = child.wait()
-
-    # Final line is the `-w` status code; the rest is the S3 response body.
-    parts = out.rsplit("\n", 1)
-    if len(parts) == 2:
-        body = parts[0]
-        http_code = parts[1].strip()
+    # Stable public CircleCI artifact URL so callers can link to individual
+    # files. CIRCLE_WORKFLOW_JOB_ID is always set by the runner; fall back to
+    # the signed S3 URL if it's ever absent.
+    job_id = ctx.std.env.var("CIRCLE_WORKFLOW_JOB_ID") or ""
+    if job_id:
+        download_url = "https://output.circle-artifacts.com/output/job/" + job_id + "/artifacts/0/" + name
     else:
-        body = ""
-        http_code = parts[0].strip()
-
-    if status.code == 0 and http_code.startswith("2"):
-        # Stable public CircleCI artifact URL so callers can link to
-        # individual files. CIRCLE_WORKFLOW_JOB_ID is always set by the
-        # runner; fall back to the signed S3 URL if it's ever absent.
-        job_id = ctx.std.env.var("CIRCLE_WORKFLOW_JOB_ID") or ""
-        if job_id:
-            download_url = "https://output.circle-artifacts.com/output/job/" + job_id + "/artifacts/0/" + name
-        else:
-            download_url = s3_url
-        return (True, "", download_url)
-
-    return (False, s3_upload_error_detail(http_code, curl_err, body), "")
+        download_url = s3_url
+    return (True, "", download_url)
 
 def _upload_artifact(ctx, path, name, cache = None):
     """Upload a file to CircleCI via the runner API and S3.
@@ -397,7 +432,7 @@ def _resolve_step_id(ctx, session, step_id):
             return k, key
     return None, None
 
-def _s3_put_object(ctx, session, method, url, headers, path):
+def _s3_put_object(ctx, method, url, headers, path):
     """Replay the runner's pre-signed upload request: PUT `path` to `url`
     with `Key.headers` (`headers`) sent verbatim. Returns `(ok, detail)`.
 
@@ -411,43 +446,9 @@ def _s3_put_object(ctx, session, method, url, headers, path):
     `400 InvalidRequest: Missing required header ... x-amz-content-sha256`.
     Replaying the runner's headers as-is (no `--aws-sigv4`, no `--user`, no
     locally-injected security token) keeps the request the runner signed.
-
-    `session` is unused here (the headers are self-contained) but kept in
-    the signature so the call site mirrors `_s3_put`.
     """
-    curl_args = [
-        "--silent",
-        "--show-error",
-        "-T",
-        path,
-        "-X",
-        method,
-        "-w",
-        "\n%{http_code}",
-    ]
-    for k, v in (headers or {}).items():
-        curl_args = curl_args + ["-H", k + ": " + v]
-    curl_args = curl_args + [url]
-
-    child = ctx.std.process.command("curl") \
-        .args(curl_args) \
-        .stdout("piped") \
-        .stderr("piped") \
-        .spawn()
-    out = child.stdout().read_to_string()
-    curl_err = child.stderr().read_to_string().strip()
-    status = child.wait()
-
-    # Last line is the `-w` status code; the rest is the body.
-    parts = out.rsplit("\n", 1)
-    if len(parts) == 2:
-        body = parts[0]
-        http_code = parts[1].strip()
-    else:
-        body = ""
-        http_code = parts[0].strip()
-
-    if status.code == 0 and http_code.startswith("2"):
+    ok, http_code, body, curl_err = _run_s3_put(ctx, s3_replay_put_args(method, path, headers), url)
+    if ok:
         return (True, "")
     return (False, s3_upload_error_detail(http_code, curl_err, body))
 
@@ -481,9 +482,10 @@ def _store_test_results(ctx, archive_path, step_id = None, cache = None) -> Test
         return TestResultsUploadResult(success = False, step_id = sid, errors = ["test-result Key had no 'location'"])
 
     url = test_results_object_url(session["bucket"], session["region"], location)
-    ok, detail = _s3_put_object(ctx, session, key.get("method", "PUT"), url, key.get("headers") or {}, archive_path)
+    ok, detail = _s3_put_object(ctx, key.get("method", "PUT"), url, key.get("headers") or {}, archive_path)
     if not ok:
-        # Drop the session so a later call re-mints (handles expired creds).
+        # Drop the session so the next `store_test_results` re-mints a fresh
+        # runner token + Key rather than reusing one we just saw fail.
         session_cache_clear(cache)
         return TestResultsUploadResult(success = False, step_id = sid, errors = [detail])
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
@@ -1,12 +1,13 @@
-"""Unit tests for lib/circleci.axl S3 error parsing.
+"""Unit tests for lib/circleci.axl pure helpers.
 
 The upload flow itself (socket token, runner API, curl PUT) needs live
-runner infrastructure, so these tests cover the pure helpers that turn an
-S3 error response into a diagnosable failure reason — the part that makes
-an expired-credential `400` legible instead of an opaque "curl exit 22".
+runner infrastructure, so these tests cover the pure pieces around it:
+S3 error parsing, the session cache, test-result URL resolution, the
+curl arg builders (what we sign vs. replay verbatim), and JUnit
+skipped-marking.
 """
 
-load("./circleci.axl", "mark_testcases_skipped", "s3_extract_error_code", "s3_extract_error_message", "s3_upload_error_detail", "session_cache_clear", "session_cache_get", "session_cache_put", "test_results_object_url")
+load("./circleci.axl", "mark_testcases_skipped", "s3_extract_error_code", "s3_extract_error_message", "s3_replay_put_args", "s3_sigv4_put_args", "s3_upload_error_detail", "session_cache_clear", "session_cache_get", "session_cache_put", "test_results_object_url")
 
 def _eq(label, got, want):
     if got != want:
@@ -139,14 +140,62 @@ def _test_object_url_relative_key(_ctx):
     )
 
 def _test_object_url_absolute_https_passthrough(_ctx):
-    """An already-absolute https location is returned unchanged (future
-    presigned-URL responses keep working without a code change)."""
+    """An already-absolute https location is returned unchanged (the runner
+    can hand back a full presigned URL instead of a relative key)."""
     url = "https://example.s3.amazonaws.com/key?X-Amz-Signature=abc"
     _eq("https location passthrough", test_results_object_url("b", "r", url), url)
 
 def _test_object_url_absolute_http_passthrough(_ctx):
     url = "http://localhost:9000/bucket/key"
     _eq("http location passthrough", test_results_object_url("b", "r", url), url)
+
+# ---------------------------------------------------------------------------
+# s3 PUT curl arg builders — what we sign vs. what we replay verbatim
+# ---------------------------------------------------------------------------
+
+def _header_value(args, name):
+    """Return the value of the first `-H "name: value"` in `args`, or None."""
+    prefix = name + ": "
+    for i in range(len(args) - 1):
+        if args[i] == "-H" and args[i + 1].startswith(prefix):
+            return args[i + 1][len(prefix):]
+    return None
+
+_FAKE_CREDS = {"AccessKeyID": "AKIA", "SecretAccessKey": "secret", "SessionToken": "tok"}
+
+def _test_sigv4_args_self_sign(_ctx):
+    """The artifact path signs locally: --aws-sigv4 + --user + the session token,
+    PUT of the file."""
+    args = s3_sigv4_put_args("us-west-2", _FAKE_CREDS, "/tmp/a.tar.gz")
+    if "--aws-sigv4" not in args:
+        fail("sigv4 args must include --aws-sigv4: %r" % args)
+    if "--user" not in args:
+        fail("sigv4 args must include --user: %r" % args)
+    _eq("region in the sigv4 scope", args[args.index("--aws-sigv4") + 1], "aws:amz:us-west-2:s3")
+    _eq("session token forwarded", _header_value(args, "x-amz-security-token"), "tok")
+    _eq("PUT of the file", args[args.index("-T") + 1], "/tmp/a.tar.gz")
+
+def _test_sigv4_args_extra_headers(_ctx):
+    args = s3_sigv4_put_args("r", _FAKE_CREDS, "/tmp/a", {"x-amz-tagging": "k=v"})
+    _eq("extra header included", _header_value(args, "x-amz-tagging"), "k=v")
+
+def _test_replay_args_no_local_signing(_ctx):
+    """The test-result path replays the runner's pre-signed request: no
+    --aws-sigv4, no --user, no locally-injected token — only Key.headers."""
+    headers = {"Authorization": "AWS4-HMAC-SHA256 ...", "x-amz-content-sha256": "abc"}
+    args = s3_replay_put_args("PUT", "/tmp/tr.tar.gz", headers)
+    if "--aws-sigv4" in args:
+        fail("replay must NOT re-sign (--aws-sigv4 present): %r" % args)
+    if "--user" in args:
+        fail("replay must NOT pass --user: %r" % args)
+    _eq("no locally-injected security token", _header_value(args, "x-amz-security-token"), None)
+    _eq("runner Authorization forwarded", _header_value(args, "Authorization"), "AWS4-HMAC-SHA256 ...")
+    _eq("runner content-sha256 forwarded", _header_value(args, "x-amz-content-sha256"), "abc")
+
+def _test_replay_args_honors_method(_ctx):
+    """Key.method drives -X (the runner can hand back a non-PUT verb)."""
+    args = s3_replay_put_args("POST", "/tmp/tr.tar.gz", {})
+    _eq("method passed through", args[args.index("-X") + 1], "POST")
 
 # ---------------------------------------------------------------------------
 # mark_testcases_skipped — move cached tests into the "skipped" bucket
@@ -184,6 +233,10 @@ _UNIT_TESTS = [
     _test_object_url_relative_key,
     _test_object_url_absolute_https_passthrough,
     _test_object_url_absolute_http_passthrough,
+    _test_sigv4_args_self_sign,
+    _test_sigv4_args_extra_headers,
+    _test_replay_args_no_local_signing,
+    _test_replay_args_honors_method,
     _test_skip_self_closing,
     _test_skip_with_body,
     _test_skip_multiple,


### PR DESCRIPTION
## Problem

CircleCI test-results uploads failed with:

```
WARNING: CircleCI test results upload failed: S3 upload HTTP 400 (InvalidRequest): Missing required header for this request: x-amz-content-sha256
```

## Root cause

The output-service test-result `Key` is a **fully pre-signed** S3 request: `Key.headers` already carries the `Authorization` (sigv4), `x-amz-date`, `x-amz-content-sha256`, and `x-amz-security-token` the runner computed for that object.

`_s3_put_object` forwarded those headers **and** also passed `--aws-sigv4` / `--user`. curl won't double-sign — seeing an explicit `Authorization`, it disengages `--aws-sigv4` and stops adding `x-amz-content-sha256`, so the request goes out missing that header and S3 rejects it.

## Fix

Replay the runner's pre-signed request verbatim — `Key.method` + url + `Key.headers` — with no local signing or injected security token. The artifact upload path is unaffected: it mints its own S3 key and genuinely self-signs.

The shared S3 PUT plumbing (curl arg construction + spawn/parse/classify) is factored into `s3_sigv4_put_args`, `s3_replay_put_args`, and `_run_s3_put`, so the two flows differ only in whether they sign.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Fixed CircleCI test-results uploads failing with `400 InvalidRequest: Missing required header ... x-amz-content-sha256`. The runner's pre-signed upload request is now replayed verbatim instead of being re-signed locally.

### Test plan

- `aspect dev test-circleci` → `circleci.axl: OK (31 tests)`, including new coverage asserting the artifact PUT signs locally (`--aws-sigv4`/`--user`) while the test-result PUT replays the runner's `Key.headers` with no local signing.
- The PUT itself needs a live runner; verify on a CircleCI runner before relying on it.
