### PR TITLE
fix(circleci): sign the test-result S3 PUT with the STS credentials

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -1,13 +1,15 @@
 """CircleCI runner output upload library.
 
 Uploads to CircleCI's runner output API (Unix socket + HTTP) over two
-distinct flows that both end in an S3 PUT:
+flows that both end in a sigv4-signed S3 PUT using the job-scoped STS
+credentials:
 
-  - Artifacts (`upload_artifact`): the runner returns a bare S3 key and we
-    sign the PUT ourselves with the job-scoped STS credentials.
-  - Test results (`store_test_results`): the runner returns a *pre-signed*
-    request (`Key.method`/`location`/`headers`) that we replay verbatim —
-    see `_s3_put_object`.
+  - Artifacts (`upload_artifact`): the runner returns a bare S3 key.
+  - Test results (`store_test_results`): the runner returns an unsigned
+    upload target (`Key.location` + the `Content-Type` to send).
+
+Neither is pre-signed by the runner; the client signs both — see `_s3_put`
+and `_s3_put_object`.
 
 Credential lifetime: the runner mints the temporary S3 (STS) credentials
 returned by `/api/v2/output/credentials` with a short TTL (≈10 min) and
@@ -230,9 +232,13 @@ def _header_args(headers):
     return args
 
 def s3_sigv4_put_args(region, aws_creds, path, headers = None):
-    """curl args for a self-signed sigv4 PUT (the artifact path mints its own
-    S3 key, so we sign locally). `headers` is an optional `{k: v}` of extra
-    request headers. Public so `circleci_test.axl` can load it.
+    """curl args for a sigv4-signed PUT using the job-scoped STS credentials.
+
+    Both upload flows sign locally — the runner hands back a bare S3 key for
+    artifacts and an unsigned upload target for test results. `headers` is an
+    optional `{k: v}` of extra request headers folded into the signed set
+    (artifact tags, the test-result `Content-Type`). Public so
+    `circleci_test.axl` can load it.
     """
     args = _CURL_S3_BASE_ARGS + [
         "--aws-sigv4",
@@ -248,22 +254,37 @@ def s3_sigv4_put_args(region, aws_creds, path, headers = None):
     ]
     return args + _header_args(headers)
 
-def s3_replay_put_args(method, path, headers = None):
-    """curl args replaying a pre-signed PUT verbatim — no local signing, just
-    the runner's `Key.headers`. See `_s3_put_object`. Public so
-    `circleci_test.axl` can load it.
+def redact_curl_trace(text):
+    """Strip secret-bearing values from curl's `-v` stderr before logging.
+
+    curl `-v` echoes the request as `> Header: value` lines; the
+    `Authorization` and `x-amz-security-token` values are secrets, so keep
+    the header name and elide the value. Other lines pass through. Public so
+    `circleci_test.axl` can assert the redaction.
     """
-    return _CURL_S3_BASE_ARGS + ["-T", path, "-X", method] + _header_args(headers)
+    secret = ("authorization", "x-amz-security-token")
+    out = []
+    for line in text.split("\n"):
+        stripped = line.lstrip("> ").lower()
+        if line.lstrip().startswith(">") and stripped.split(":", 1)[0] in secret:
+            out.append(line.split(":", 1)[0] + ": <redacted>")
+        else:
+            out.append(line)
+    return "\n".join(out)
 
 def _run_s3_put(ctx, curl_args, url):
     """Spawn `curl <args> <url>` and classify the result.
 
     Returns `(ok, http_code, body, curl_err)`. `ok` is True only on a 2xx
     with a clean exit; `body` is the S3 response (the trailing `%{http_code}`
-    line stripped) for error diagnosis.
+    line stripped) for error diagnosis. When `trace.enabled`, runs curl
+    `-v` and logs the (redacted) request/response trace on failure — the
+    sent request headers are what diagnose a signature/`AccessDenied`
+    rejection, since they reveal anything curl added beyond what was signed.
     """
+    args = curl_args + (["-v"] if trace.enabled else [])
     child = ctx.std.process.command("curl") \
-        .args(curl_args + [url]) \
+        .args(args + [url]) \
         .stdout("piped") \
         .stderr("piped") \
         .spawn()
@@ -278,6 +299,8 @@ def _run_s3_put(ctx, curl_args, url):
         body, http_code = "", parts[0].strip()
 
     ok = status.code == 0 and http_code.startswith("2")
+    if not ok and trace.enabled:
+        trace.log("curl PUT failed (http=%s):\n%s" % (http_code, redact_curl_trace(curl_err)))
     return (ok, http_code, body, curl_err)
 
 def _s3_put(ctx, session, path, name):
@@ -379,9 +402,9 @@ def _delete_artifact(ctx, name):
 # Upload Bazel JUnit XML to CircleCI's runner output test-results API
 # (reverse-engineered from circleci-agent, verified against real CircleCI):
 #   POST /api/v2/output/test-result          {"step_id": N}  -> Key
-#   <Key.method> the gzipped tar to the S3 Key.location, replaying
-#     Key.headers verbatim — the Key is already pre-signed by the runner,
-#     so we do NOT re-sign (see `_s3_put_object`).
+#   sigv4-PUT the gzipped tar to the S3 Key.location, sending the
+#     Content-Type from Key.headers (the Key is an unsigned target; we sign
+#     with the STS creds — see `_s3_put_object`).
 #   POST /api/v2/output/test-result/process  {"step_id": N}  -> summary
 # step_id is the agent's internal step index; when unknown we probe for it.
 
@@ -432,22 +455,18 @@ def _resolve_step_id(ctx, session, step_id):
             return k, key
     return None, None
 
-def _s3_put_object(ctx, method, url, headers, path):
-    """Replay the runner's pre-signed upload request: PUT `path` to `url`
-    with `Key.headers` (`headers`) sent verbatim. Returns `(ok, detail)`.
+def _s3_put_object(ctx, session, url, headers, path):
+    """Sign and PUT `path` to the test-result `url`. Returns `(ok, detail)`.
 
-    The CircleCI output service returns a *fully pre-signed* request in the
-    test-result `Key` — `Key.headers` already carries the `Authorization`
-    (sigv4), `x-amz-date`, `x-amz-content-sha256`, and `x-amz-security-token`
-    the runner computed against this exact object. So we must NOT re-sign:
-    curl's `--aws-sigv4` steps aside the moment it sees an explicit
-    `Authorization`, which drops the `x-amz-content-sha256` it would
-    otherwise add and makes S3 reject the request with
-    `400 InvalidRequest: Missing required header ... x-amz-content-sha256`.
-    Replaying the runner's headers as-is (no `--aws-sigv4`, no `--user`, no
-    locally-injected security token) keeps the request the runner signed.
+    The output service's test-result `Key` is an *unsigned* upload target:
+    a bare S3 object key (`Key.location`) plus the `Content-Type` it expects
+    in `Key.headers`. The client signs the PUT itself with the job-scoped STS
+    credentials — the same flow as the artifact path (`_s3_put`) — so we reuse
+    `s3_sigv4_put_args`, folding the runner's headers into the signed set.
     """
-    ok, http_code, body, curl_err = _run_s3_put(ctx, s3_replay_put_args(method, path, headers), url)
+    aws_creds = session["aws_creds"]
+    region = session["region"]
+    ok, http_code, body, curl_err = _run_s3_put(ctx, s3_sigv4_put_args(region, aws_creds, path, headers), url)
     if ok:
         return (True, "")
     return (False, s3_upload_error_detail(http_code, curl_err, body))
@@ -482,7 +501,7 @@ def _store_test_results(ctx, archive_path, step_id = None, cache = None) -> Test
         return TestResultsUploadResult(success = False, step_id = sid, errors = ["test-result Key had no 'location'"])
 
     url = test_results_object_url(session["bucket"], session["region"], location)
-    ok, detail = _s3_put_object(ctx, key.get("method", "PUT"), url, key.get("headers") or {}, archive_path)
+    ok, detail = _s3_put_object(ctx, session, url, key.get("headers") or {}, archive_path)
     if not ok:
         # Drop the session so the next `store_test_results` re-mints a fresh
         # runner token + Key rather than reusing one we just saw fail.

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -277,10 +277,11 @@ def _run_s3_put(ctx, curl_args, url):
 
     Returns `(ok, http_code, body, curl_err)`. `ok` is True only on a 2xx
     with a clean exit; `body` is the S3 response (the trailing `%{http_code}`
-    line stripped) for error diagnosis. When `trace.enabled`, runs curl
-    `-v` and logs the (redacted) request/response trace on failure — the
-    sent request headers are what diagnose a signature/`AccessDenied`
-    rejection, since they reveal anything curl added beyond what was signed.
+    line stripped) for error diagnosis. When `trace.enabled`, runs curl `-v`
+    so the sent request headers — which reveal anything curl added beyond
+    what was signed — show in the trace; `curl_err` is redacted before being
+    returned so a transport-error detail built from it can't leak the SigV4
+    `Authorization` / `x-amz-security-token` that `-v` echoes.
     """
     args = curl_args + (["-v"] if trace.enabled else [])
     child = ctx.std.process.command("curl") \
@@ -289,7 +290,7 @@ def _run_s3_put(ctx, curl_args, url):
         .stderr("piped") \
         .spawn()
     out = child.stdout().read_to_string()
-    curl_err = child.stderr().read_to_string().strip()
+    curl_err = redact_curl_trace(child.stderr().read_to_string().strip())
     status = child.wait()
 
     parts = out.rsplit("\n", 1)
@@ -300,7 +301,7 @@ def _run_s3_put(ctx, curl_args, url):
 
     ok = status.code == 0 and http_code.startswith("2")
     if not ok and trace.enabled:
-        trace.log("curl PUT failed (http=%s):\n%s" % (http_code, redact_curl_trace(curl_err)))
+        trace.log("curl PUT failed (http=%s):\n%s" % (http_code, curl_err))
     return (ok, http_code, body, curl_err)
 
 def _s3_put(ctx, session, path, name):

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
@@ -185,7 +185,8 @@ def _test_sigv4_args_test_result_content_type(_ctx):
     _eq("content-type signed", _header_value(args, "Content-Type"), "application/gzip")
 
 # ---------------------------------------------------------------------------
-# redact_curl_trace — strip secrets from curl -v output before logging
+# redact_curl_trace — strip SigV4 secrets from curl -v output (logged and,
+# on a transport failure, surfaced in the error detail)
 # ---------------------------------------------------------------------------
 
 def _test_redact_curl_trace_elides_secrets(_ctx):
@@ -212,6 +213,24 @@ def _test_redact_curl_trace_elides_secrets(_ctx):
             "< HTTP/1.1 403 Forbidden",
         ]),
     )
+
+def _test_redact_curl_trace_transport_error_no_leak(_ctx):
+    """A transport failure after `-v` emitted the request (http_code "000")
+    builds its detail from curl_err; redacting at the source keeps the SigV4
+    secrets out of that surfaced message."""
+
+    # `-v` echoes the request headers, then curl reports the transport error.
+    raw = "\n".join([
+        "> PUT /k HTTP/1.1",
+        "> Authorization: AWS4-HMAC-SHA256 SECRETAUTH",
+        "> x-amz-security-token: SECRETTOKEN",
+        "* Recv failure: Connection reset by peer",
+    ])
+    detail = s3_upload_error_detail("000", redact_curl_trace(raw), "")
+    if "SECRETAUTH" in detail or "SECRETTOKEN" in detail:
+        fail("transport-error detail leaked a secret: %r" % detail)
+    if "Connection reset by peer" not in detail:
+        fail("transport-error detail dropped the actual error: %r" % detail)
 
 # ---------------------------------------------------------------------------
 # mark_testcases_skipped — move cached tests into the "skipped" bucket
@@ -253,6 +272,7 @@ _UNIT_TESTS = [
     _test_sigv4_args_artifact_tags,
     _test_sigv4_args_test_result_content_type,
     _test_redact_curl_trace_elides_secrets,
+    _test_redact_curl_trace_transport_error_no_leak,
     _test_skip_self_closing,
     _test_skip_with_body,
     _test_skip_multiple,

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
@@ -3,11 +3,10 @@
 The upload flow itself (socket token, runner API, curl PUT) needs live
 runner infrastructure, so these tests cover the pure pieces around it:
 S3 error parsing, the session cache, test-result URL resolution, the
-curl arg builders (what we sign vs. replay verbatim), and JUnit
-skipped-marking.
+sigv4 PUT arg builder, trace redaction, and JUnit skipped-marking.
 """
 
-load("./circleci.axl", "mark_testcases_skipped", "s3_extract_error_code", "s3_extract_error_message", "s3_replay_put_args", "s3_sigv4_put_args", "s3_upload_error_detail", "session_cache_clear", "session_cache_get", "session_cache_put", "test_results_object_url")
+load("./circleci.axl", "mark_testcases_skipped", "redact_curl_trace", "s3_extract_error_code", "s3_extract_error_message", "s3_sigv4_put_args", "s3_upload_error_detail", "session_cache_clear", "session_cache_get", "session_cache_put", "test_results_object_url")
 
 def _eq(label, got, want):
     if got != want:
@@ -140,8 +139,8 @@ def _test_object_url_relative_key(_ctx):
     )
 
 def _test_object_url_absolute_https_passthrough(_ctx):
-    """An already-absolute https location is returned unchanged (the runner
-    can hand back a full presigned URL instead of a relative key)."""
+    """An already-absolute https location is returned unchanged, so a future
+    runner that returns an absolute URL keeps working without a code change."""
     url = "https://example.s3.amazonaws.com/key?X-Amz-Signature=abc"
     _eq("https location passthrough", test_results_object_url("b", "r", url), url)
 
@@ -150,7 +149,7 @@ def _test_object_url_absolute_http_passthrough(_ctx):
     _eq("http location passthrough", test_results_object_url("b", "r", url), url)
 
 # ---------------------------------------------------------------------------
-# s3 PUT curl arg builders — what we sign vs. what we replay verbatim
+# s3_sigv4_put_args — the sigv4-signed PUT both upload flows share
 # ---------------------------------------------------------------------------
 
 def _header_value(args, name):
@@ -164,7 +163,7 @@ def _header_value(args, name):
 _FAKE_CREDS = {"AccessKeyID": "AKIA", "SecretAccessKey": "secret", "SessionToken": "tok"}
 
 def _test_sigv4_args_self_sign(_ctx):
-    """The artifact path signs locally: --aws-sigv4 + --user + the session token,
+    """Both flows sign locally: --aws-sigv4 + --user + the session token,
     PUT of the file."""
     args = s3_sigv4_put_args("us-west-2", _FAKE_CREDS, "/tmp/a.tar.gz")
     if "--aws-sigv4" not in args:
@@ -175,27 +174,44 @@ def _test_sigv4_args_self_sign(_ctx):
     _eq("session token forwarded", _header_value(args, "x-amz-security-token"), "tok")
     _eq("PUT of the file", args[args.index("-T") + 1], "/tmp/a.tar.gz")
 
-def _test_sigv4_args_extra_headers(_ctx):
+def _test_sigv4_args_artifact_tags(_ctx):
+    """The artifact path folds its tag header into the signed set."""
     args = s3_sigv4_put_args("r", _FAKE_CREDS, "/tmp/a", {"x-amz-tagging": "k=v"})
-    _eq("extra header included", _header_value(args, "x-amz-tagging"), "k=v")
+    _eq("tag header included", _header_value(args, "x-amz-tagging"), "k=v")
 
-def _test_replay_args_no_local_signing(_ctx):
-    """The test-result path replays the runner's pre-signed request: no
-    --aws-sigv4, no --user, no locally-injected token — only Key.headers."""
-    headers = {"Authorization": "AWS4-HMAC-SHA256 ...", "x-amz-content-sha256": "abc"}
-    args = s3_replay_put_args("PUT", "/tmp/tr.tar.gz", headers)
-    if "--aws-sigv4" in args:
-        fail("replay must NOT re-sign (--aws-sigv4 present): %r" % args)
-    if "--user" in args:
-        fail("replay must NOT pass --user: %r" % args)
-    _eq("no locally-injected security token", _header_value(args, "x-amz-security-token"), None)
-    _eq("runner Authorization forwarded", _header_value(args, "Authorization"), "AWS4-HMAC-SHA256 ...")
-    _eq("runner content-sha256 forwarded", _header_value(args, "x-amz-content-sha256"), "abc")
+def _test_sigv4_args_test_result_content_type(_ctx):
+    """The test-result path folds the runner's Content-Type into the signed set."""
+    args = s3_sigv4_put_args("r", _FAKE_CREDS, "/tmp/tr.tar.gz", {"Content-Type": "application/gzip"})
+    _eq("content-type signed", _header_value(args, "Content-Type"), "application/gzip")
 
-def _test_replay_args_honors_method(_ctx):
-    """Key.method drives -X (the runner can hand back a non-PUT verb)."""
-    args = s3_replay_put_args("POST", "/tmp/tr.tar.gz", {})
-    _eq("method passed through", args[args.index("-X") + 1], "POST")
+# ---------------------------------------------------------------------------
+# redact_curl_trace — strip secrets from curl -v output before logging
+# ---------------------------------------------------------------------------
+
+def _test_redact_curl_trace_elides_secrets(_ctx):
+    """curl -v request lines for Authorization / security-token keep the
+    header name but drop the value; everything else passes through."""
+    raw = "\n".join([
+        "> PUT /k HTTP/1.1",
+        "> Authorization: AWS4-HMAC-SHA256 SECRETAUTH",
+        "> x-amz-security-token: SECRETTOKEN",
+        "> x-amz-content-sha256: UNSIGNED-PAYLOAD",
+        "< HTTP/1.1 403 Forbidden",
+    ])
+    got = redact_curl_trace(raw)
+    if "SECRETAUTH" in got or "SECRETTOKEN" in got:
+        fail("curl trace leaked a secret: %r" % got)
+    _eq(
+        "redacted trace",
+        got,
+        "\n".join([
+            "> PUT /k HTTP/1.1",
+            "> Authorization: <redacted>",
+            "> x-amz-security-token: <redacted>",
+            "> x-amz-content-sha256: UNSIGNED-PAYLOAD",
+            "< HTTP/1.1 403 Forbidden",
+        ]),
+    )
 
 # ---------------------------------------------------------------------------
 # mark_testcases_skipped — move cached tests into the "skipped" bucket
@@ -234,9 +250,9 @@ _UNIT_TESTS = [
     _test_object_url_absolute_https_passthrough,
     _test_object_url_absolute_http_passthrough,
     _test_sigv4_args_self_sign,
-    _test_sigv4_args_extra_headers,
-    _test_replay_args_no_local_signing,
-    _test_replay_args_honors_method,
+    _test_sigv4_args_artifact_tags,
+    _test_sigv4_args_test_result_content_type,
+    _test_redact_curl_trace_elides_secrets,
     _test_skip_self_closing,
     _test_skip_with_body,
     _test_skip_multiple,


### PR DESCRIPTION
## Problem

CircleCI test-results uploads failed with `403 AccessDenied`, even though artifact uploads — using the same STS credentials — succeeded.

## Root cause

The output service's test-result `Key` is an **unsigned upload target**: a bare S3 object key (`Key.location`) plus the `Content-Type` to send. It is not a pre-signed request. The upload was being sent unsigned, so S3 denied it.

## Fix

Sign the test-result PUT locally with the job-scoped STS credentials — the same flow the artifact upload already uses — folding the runner's `Content-Type` into the signed header set. `_s3_put_object` now shares `s3_sigv4_put_args` with the artifact path.

On a failed PUT, curl's `-v` request/response trace (secrets elided) is logged via `trace.log`, so a future S3 rejection is diagnosable from an `ASPECT_DEBUG=1` run.

## Verified

On a live CircleCI runner: `Uploaded 25 JUnit file(s) to CircleCI test results (step_id=0, 48510 bytes).`

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Fixed CircleCI test-results uploads failing with `403 AccessDenied`. The upload is now signed with the job-scoped STS credentials, matching the artifact upload.

### Test plan

- Verified on a live CircleCI runner — test results upload successfully.
- `aspect dev test-circleci` → `circleci.axl: OK (31 tests)`, covering the sigv4 PUT args (signing flags + session token, and the folded-in `Content-Type` / artifact tags) and the `-v` trace redaction (secrets elided in both the trace log and the transport-error detail).

