### PR TITLE
fix(delivery): expand .bazelrc for the query command, not build

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -500,6 +500,17 @@ def test_query_flags(ctx: TaskContext, tc: int) -> int:
     )]
     tc = test_case(tc, expr in targets3, "query with never-matching conditional flag should drop it and still resolve")
 
+    # A `common`-section option that `query` doesn't recognize (e.g. the
+    # build-only `--show_result`) arrives from rc expansion wrapped as
+    # `--default_override=0:common=…`, which Bazel silently ignores — whereas
+    # the same option passed bare (`--show_result=20`) would hard-error. This
+    # is the regression guard for delivery replaying rc `common` flags onto
+    # its resolve query.
+    targets4 = [t.name for t in ctx.bazel.query().raw(expr).eval(
+        flags = ["--default_override=0:common=--show_result=20"],
+    )]
+    tc = test_case(tc, expr in targets4, "query with common-section override should be silently ignored")
+
     return tc
 
 def test_cancel_invocation(ctx: TaskContext, tc: int) -> int:

--- a/.bazelrc
+++ b/.bazelrc
@@ -28,8 +28,9 @@ common:pure_go --@rules_go//go/config:pure
 
 common --test_output=errors
 
-# Regression fixture for `resolve_query_flags` (lib/bazel_flags.axl): a config
-# defined only under `build:` is invisible to `bazel query` (no `build`
-# ancestor), so the delivery resolve query must drop it rather than fatal with
-# "undefined config". Exercised by bazel_flags_test.axl.
-build:delivery-query-test --show_result=20
+# A `build`-section option that `bazel query` rejects. The live
+# `aspect delivery --query` task on CI runs its resolve query against this
+# repo, so it exercises `resolve_query_flags` (lib/bazel_flags.axl) dropping
+# build-only options from the query expansion. Mirrors the customer rc that
+# surfaced the bug.
+build --show_result=20

--- a/.bazelrc
+++ b/.bazelrc
@@ -27,3 +27,10 @@ common:release --@rules_rust//rust/settings:lto=fat
 common:pure_go --@rules_go//go/config:pure
 
 common --test_output=errors
+
+# A build-only option that `bazel query` rejects: regression coverage for the
+# delivery resolve query, which must expand the rc for `query` (dropping this)
+# rather than forward the build expansion. See lib/bazel_flags.axl
+# `resolve_query_flags`. Mirrors the AssemblyAI DeepLearning repo's
+# convenience.bazelrc that surfaced the bug.
+build --show_result=20

--- a/.bazelrc
+++ b/.bazelrc
@@ -28,13 +28,8 @@ common:pure_go --@rules_go//go/config:pure
 
 common --test_output=errors
 
-# Regression coverage for the delivery resolve query, which expands the rc for
-# the `query` command rather than forwarding the build expansion. See
-# lib/bazel_flags.axl `resolve_query_flags`. A config defined only under
-# `build:` (no `common:`/`query:` section) is invisible to `query`, which has
-# no `build` ancestor — `resolve_query_flags` must drop it rather than let the
-# query fatal with "undefined config". (`bazel/defaults.bazelrc` already
-# carries a `common --show_result=20`, which exercises the build-only-flag side
-# of the fix: it reaches the query wrapped as `--default_override`, which Bazel
-# silently ignores.)
+# Regression fixture for `resolve_query_flags` (lib/bazel_flags.axl): a config
+# defined only under `build:` is invisible to `bazel query` (no `build`
+# ancestor), so the delivery resolve query must drop it rather than fatal with
+# "undefined config". Exercised by bazel_flags_test.axl.
 build:delivery-query-test --show_result=20

--- a/.bazelrc
+++ b/.bazelrc
@@ -28,9 +28,13 @@ common:pure_go --@rules_go//go/config:pure
 
 common --test_output=errors
 
-# A build-only option that `bazel query` rejects: regression coverage for the
-# delivery resolve query, which must expand the rc for `query` (dropping this)
-# rather than forward the build expansion. See lib/bazel_flags.axl
-# `resolve_query_flags`. Mirrors the AssemblyAI DeepLearning repo's
-# convenience.bazelrc that surfaced the bug.
-build --show_result=20
+# Regression coverage for the delivery resolve query, which expands the rc for
+# the `query` command rather than forwarding the build expansion. See
+# lib/bazel_flags.axl `resolve_query_flags`. A config defined only under
+# `build:` (no `common:`/`query:` section) is invisible to `query`, which has
+# no `build` ancestor — `resolve_query_flags` must drop it rather than let the
+# query fatal with "undefined config". (`bazel/defaults.bazelrc` already
+# carries a `common --show_result=20`, which exercises the build-only-flag side
+# of the fix: it reaches the query wrapped as `--default_override`, which Bazel
+# silently ignores.)
+build:delivery-query-test --show_result=20

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -127,7 +127,7 @@ User-facing migration guide: https://docs.aspect.build/cli/migration/delivery
 
 load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@aspect//lib/artifacts.axl", "artifacts")
-load("@aspect//lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
+load("@aspect//lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce", "resolve_query_flags")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("@aspect//lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@aspect//lib/ci.axl", "resolve_build_url")
@@ -1093,15 +1093,14 @@ def _delivery_impl(ctx):
         info(ctx.std, "Running bazel query: {}".format(query_expr))
 
         # The query carries `--ignore_all_rc_files` (see lib/bazel_flags.axl),
-        # so it reads none of the workspace `.bazelrc`. Forward the same
-        # rc-expanded `expanded_flags` the build phases use, so the query
-        # resolves external repositories the way the build does — otherwise an
-        # rc-set `--noenable_bzlmod` / `--enable_workspace` is dropped and the
-        # query fails on repos the build can see. `.eval()` filters any
-        # version-gated flags against the running Bazel version exactly as
-        # `ctx.bazel.build` does.
+        # so it reads none of the workspace `.bazelrc`. Replay the rc flags
+        # expanded for `query` — not the build's `expanded_flags`, which carry
+        # build-only options (e.g. `--show_result`) the query rejects — so the
+        # query resolves external repositories the way the build does (an
+        # rc-set `--noenable_bzlmod` / `--enable_workspace` would otherwise be
+        # dropped). See `resolve_query_flags`.
         targets = [t.name for t in ctx.bazel.query().raw(query_expr).eval(
-            flags = expanded_flags,
+            flags = resolve_query_flags(ctx, bazel_trait),
             announce_version = announce_version,
             announce_command = announce_command,
         )]

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
@@ -35,6 +35,8 @@ also checked at runtime by `assert_ctx_bazel_ready_for_health_check` (see
     the `query` command, for a task that also runs a sidecar `bazel query`
     under `--ignore_all_rc_files`. Returns the flag list without mutating
     `ctx.bazel.startup_flags` or emitting a disclosure.
+    `requested_config_names` extracts the `--config=` names it tolerates as
+    build-only.
 
   - `resolve_startup_flags` — combine `ctx.args.bazel_startup_flags`
     with `BazelTrait.extra_startup_flags` + transform. Returns the list
@@ -217,6 +219,20 @@ def setup_bazel_command(ctx, command, bazel_trait, base_flags = []):
 
     return expanded_flags
 
+_CONFIG_PREFIX = "--config="
+
+def requested_config_names(flags: list) -> list:
+    """The `--config=NAME` names requested in `flags`.
+
+    Each item is a plain `str` or a `(value, version-constraint)` tuple.
+    Exported for unit testing; used by `resolve_query_flags`."""
+    names = []
+    for flag in flags:
+        value = flag[0] if type(flag) == "tuple" else flag
+        if value.startswith(_CONFIG_PREFIX):
+            names.append(value[len(_CONFIG_PREFIX):])
+    return names
+
 def resolve_query_flags(ctx, bazel_trait):
     """Resolve the `.bazelrc` command flags for a `bazel query` spawn, expanded
     for the `query` command.
@@ -225,13 +241,29 @@ def resolve_query_flags(ctx, bazel_trait):
     `--ignore_all_rc_files` (see `setup_bazel_command`), so a sidecar
     `bazel query` it runs reads none of the workspace `.bazelrc` either. To
     keep the query's external-repository resolution consistent with the build
-    it must replay the rc flags — but expanded for `query`, not `build`:
+    it must replay the rc flags — but expanded for `query`, not `build`.
+
+    This is a separate helper rather than another `setup_bazel_command` call
+    because the query is a *secondary* command: the build already owns
+    `ctx.bazel.startup_flags` and the rc disclosure, which this must not
+    re-do. (`build`/`test` need no such helper — each expands for its own
+    command via `setup_bazel_command`, and `test` inherits `build:*` through
+    Bazel's command graph; only `query`, which has no ancestor, is special.)
+    Expanding for `query`:
 
       - a `build`-section option (e.g. `--show_result`) is simply absent from
         the `query` expansion, so it never reaches — and breaks — the query;
       - a `common`-section option arrives as `--default_override=0:common=…`,
         which `query` silently ignores when it doesn't recognize the wrapped
         option (the same option passed bare would hard-error).
+
+    `query` has no `build` ancestor, so a requested `--config=NAME` that is
+    defined only as a `build:NAME` section (the common case) has no section
+    visible to `query` and would raise `undefined config`. Such configs are
+    passed in `skip_config_if_missing` so they're dropped rather than fatal —
+    they carry build configuration, not the repo-resolution flags the query
+    needs. A config that *does* have a `common:`/`query:` section still
+    expands.
 
     Returns the command flag list (same `str | (str, version-constraint)`
     shape as `setup_bazel_command`) to pass as `ctx.bazel.query().…eval(flags
@@ -240,6 +272,10 @@ def resolve_query_flags(ctx, bazel_trait):
     """
     startup_flags = resolve_startup_flags(ctx, bazel_trait)
     flags = resolve_flags(ctx, bazel_trait)
-    rc = ctx.bazel.parse_rc(startup_flags = startup_flags, flags = flags)
+    rc = ctx.bazel.parse_rc(
+        startup_flags = startup_flags,
+        flags = flags,
+        skip_config_if_missing = requested_config_names(flags),
+    )
     _, expanded_flags = rc.expand_all(command = "query")
     return expanded_flags

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
@@ -260,13 +260,16 @@ def resolve_query_flags(ctx, bazel_trait):
         which `query` silently ignores when it doesn't recognize the wrapped
         option (the same option passed bare would hard-error).
 
-    `query` has no `build` ancestor, so a requested `--config=NAME` that is
-    defined only as a `build:NAME` section (the common case) has no section
-    visible to `query` and would raise `undefined config`. Such configs are
-    passed in `skip_config_if_missing` so they're dropped rather than fatal —
-    they carry build configuration, not the repo-resolution flags the query
-    needs. A config that *does* have a `common:`/`query:` section still
-    expands.
+    `query` has no `build` ancestor, so a requested `--config=NAME` defined
+    only as `build:NAME` (the common case) has no section visible to `query`
+    and would raise `undefined config`. The requested config names are passed
+    in `skip_config_if_missing` so such configs are dropped rather than fatal;
+    they carry build/test configuration, not the repo-resolution flags the
+    query needs, and the build phase (which does error on an undefined config)
+    already validates them. A config that *does* have a `common:`/`query:`
+    section still expands. (A `--config` written into a `common`/`query` rc
+    section that resolves only via `build:` is out of scope — such an rc
+    already breaks a plain `bazel query` in the repo.)
 
     Returns the command flag list (same `str | (str, version-constraint)`
     shape as `setup_bazel_command`) to pass as `ctx.bazel.query().…eval(flags

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
@@ -243,12 +243,15 @@ def resolve_query_flags(ctx, bazel_trait):
     keep the query's external-repository resolution consistent with the build
     it must replay the rc flags — but expanded for `query`, not `build`.
 
-    This is a separate helper rather than another `setup_bazel_command` call
-    because the query is a *secondary* command: the build already owns
-    `ctx.bazel.startup_flags` and the rc disclosure, which this must not
-    re-do. (`build`/`test` need no such helper — each expands for its own
-    command via `setup_bazel_command`, and `test` inherits `build:*` through
-    Bazel's command graph; only `query`, which has no ancestor, is special.)
+    The query shares the build's startup flags — they're command-independent
+    (`--output_base`, `--ignore_all_rc_files`, the literal rc `startup`
+    section) — and inherits them from `ctx.bazel.startup_flags`. This is a
+    separate helper, rather than a second `setup_bazel_command` call, only
+    because that call *appends* to `ctx.bazel.startup_flags` and prints the rc
+    disclosure: calling it again would duplicate both. So this resolves just
+    the per-command flags and touches neither. (`build`/`test` need no such
+    helper — each expands for its own command, and `test` inherits `build:*`
+    through Bazel's command graph; only `query`, with no ancestor, is special.)
     Expanding for `query`:
 
       - a `build`-section option (e.g. `--show_result`) is simply absent from
@@ -268,7 +271,7 @@ def resolve_query_flags(ctx, bazel_trait):
     Returns the command flag list (same `str | (str, version-constraint)`
     shape as `setup_bazel_command`) to pass as `ctx.bazel.query().…eval(flags
     = …)`. Does not mutate `ctx.bazel.startup_flags` and emits no disclosure —
-    the build's `setup_bazel_command` already owns both for the task.
+    the build's `setup_bazel_command` already did both for the task.
     """
     startup_flags = resolve_startup_flags(ctx, bazel_trait)
     flags = resolve_flags(ctx, bazel_trait)

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
@@ -31,6 +31,11 @@ also checked at runtime by `assert_ctx_bazel_ready_for_health_check` (see
     `lib/lifecycle.axl::setup_phase`; call it directly only for unusual
     layering. The smaller building blocks below exist mostly for testing.
 
+  - `resolve_query_flags` — re-resolve the rc command flags expanded for
+    the `query` command, for a task that also runs a sidecar `bazel query`
+    under `--ignore_all_rc_files`. Returns the flag list without mutating
+    `ctx.bazel.startup_flags` or emitting a disclosure.
+
   - `resolve_startup_flags` — combine `ctx.args.bazel_startup_flags`
     with `BazelTrait.extra_startup_flags` + transform. Returns the list
     without mutating `ctx.bazel.startup_flags`.
@@ -210,4 +215,31 @@ def setup_bazel_command(ctx, command, bazel_trait, base_flags = []):
         print(rc.announce(command = command, ansi = color_enabled(ctx.std)))
     trace.log(rc.announce(command = command, ansi = False))
 
+    return expanded_flags
+
+def resolve_query_flags(ctx, bazel_trait):
+    """Resolve the `.bazelrc` command flags for a `bazel query` spawn, expanded
+    for the `query` command.
+
+    A task that spawns `bazel build`/`test` reaches Bazel under
+    `--ignore_all_rc_files` (see `setup_bazel_command`), so a sidecar
+    `bazel query` it runs reads none of the workspace `.bazelrc` either. To
+    keep the query's external-repository resolution consistent with the build
+    it must replay the rc flags — but expanded for `query`, not `build`:
+
+      - a `build`-section option (e.g. `--show_result`) is simply absent from
+        the `query` expansion, so it never reaches — and breaks — the query;
+      - a `common`-section option arrives as `--default_override=0:common=…`,
+        which `query` silently ignores when it doesn't recognize the wrapped
+        option (the same option passed bare would hard-error).
+
+    Returns the command flag list (same `str | (str, version-constraint)`
+    shape as `setup_bazel_command`) to pass as `ctx.bazel.query().…eval(flags
+    = …)`. Does not mutate `ctx.bazel.startup_flags` and emits no disclosure —
+    the build's `setup_bazel_command` already owns both for the task.
+    """
+    startup_flags = resolve_startup_flags(ctx, bazel_trait)
+    flags = resolve_flags(ctx, bazel_trait)
+    rc = ctx.bazel.parse_rc(startup_flags = startup_flags, flags = flags)
+    _, expanded_flags = rc.expand_all(command = "query")
     return expanded_flags

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
@@ -4,7 +4,7 @@ Run with:
   aspect dev test-bazel-flags
 """
 
-load("./bazel_flags.axl", "announce_bazel_args", "requested_config_names", "resolve_announce", "resolve_bazel_announce", "resolve_flags", "resolve_query_flags", "resolve_startup_flags", "setup_bazel_command")
+load("./bazel_flags.axl", "announce_bazel_args", "requested_config_names", "resolve_announce", "resolve_bazel_announce", "resolve_flags", "resolve_startup_flags", "setup_bazel_command")
 
 def _eq(label, got, want):
     if got != want:
@@ -182,22 +182,6 @@ def _test_requested_config_names(ctx):
         ["a", "b", "c"],
     )
 
-# ── resolve_query_flags (integration) ────────────────────────────────────
-
-def _test_resolve_query_flags_drops_build_only_config(ctx):
-    """End-to-end on a real `ctx` against the workspace `.bazelrc`, which has a
-    `build:delivery-query-test` section with no `common:`/`query:` counterpart.
-
-    `query` has no `build` ancestor, so that config is invisible to it.
-    `resolve_query_flags` must pass the requested config name in
-    `skip_config_if_missing` so the expansion drops it — without that this call
-    raises `undefined config 'delivery-query-test' for command 'query'`."""
-    bazel_trait = _fake_trait(extra = ["--config=delivery-query-test"])
-
-    # The assertion is that this does not raise; a build-only `--config` would
-    # otherwise be a fatal `undefined config` for the query.
-    resolve_query_flags(ctx, bazel_trait)
-
 # ── contract enforcement ─────────────────────────────────────────────────
 #
 # The helpers fail with a clear message when a calling task omits the
@@ -220,12 +204,10 @@ def _test_impl(ctx):
     _test_announce_bazel_args_shape(ctx)
     _test_requested_config_names(ctx)
 
-    # The integration subtests touch the real `ctx.bazel` / workspace `.bazelrc`;
-    # run them last. `setup_bazel_command` also mutates `ctx.bazel.startup_flags`,
+    # Run last: `setup_bazel_command` mutates the real `ctx.bazel.startup_flags`,
     # so keeping it after the pure subtests prevents bleed-through.
-    _test_resolve_query_flags_drops_build_only_config(ctx)
     _test_setup_bazel_command_applies_to_ctx_bazel(ctx)
-    print("bazel_flags_test.axl: OK (14 sections)")
+    print("bazel_flags_test.axl: OK (13 sections)")
     return 0
 
 bazel_flags_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
@@ -4,7 +4,7 @@ Run with:
   aspect dev test-bazel-flags
 """
 
-load("./bazel_flags.axl", "announce_bazel_args", "resolve_announce", "resolve_bazel_announce", "resolve_flags", "resolve_startup_flags", "setup_bazel_command")
+load("./bazel_flags.axl", "announce_bazel_args", "requested_config_names", "resolve_announce", "resolve_bazel_announce", "resolve_flags", "resolve_query_flags", "resolve_startup_flags", "setup_bazel_command")
 
 def _eq(label, got, want):
     if got != want:
@@ -168,6 +168,36 @@ def _test_setup_bazel_command_applies_to_ctx_bazel(ctx):
     if "--ignore_all_rc_files" not in startup:
         fail("setup_bazel_command — --ignore_all_rc_files not appended: %r" % startup)
 
+# ── requested_config_names (pure) ────────────────────────────────────────
+
+def _test_requested_config_names(ctx):
+    """Extracts `--config=NAME` names from plain and version-gated flags,
+    ignoring everything else."""
+    _eq("no configs", requested_config_names(["--keep_going", "--show_result=20"]), [])
+    _eq("plain config", requested_config_names(["--config=release", "--keep_going"]), ["release"])
+    _eq("tuple config", requested_config_names([("--config=ci", ">=8.0.0")]), ["ci"])
+    _eq(
+        "mixed",
+        requested_config_names(["--config=a", "--foo", ("--config=b", "<7"), "--config=c"]),
+        ["a", "b", "c"],
+    )
+
+# ── resolve_query_flags (integration) ────────────────────────────────────
+
+def _test_resolve_query_flags_drops_build_only_config(ctx):
+    """End-to-end on a real `ctx` against the workspace `.bazelrc`, which has a
+    `build:delivery-query-test` section with no `common:`/`query:` counterpart.
+
+    `query` has no `build` ancestor, so that config is invisible to it.
+    `resolve_query_flags` must pass the requested config name in
+    `skip_config_if_missing` so the expansion drops it — without that this call
+    raises `undefined config 'delivery-query-test' for command 'query'`."""
+    bazel_trait = _fake_trait(extra = ["--config=delivery-query-test"])
+
+    # The assertion is that this does not raise; a build-only `--config` would
+    # otherwise be a fatal `undefined config` for the query.
+    resolve_query_flags(ctx, bazel_trait)
+
 # ── contract enforcement ─────────────────────────────────────────────────
 #
 # The helpers fail with a clear message when a calling task omits the
@@ -188,11 +218,14 @@ def _test_impl(ctx):
     _test_resolve_announce_explicit_overrides_ci(ctx)
     _test_resolve_bazel_announce_maps_args_to_tuple(ctx)
     _test_announce_bazel_args_shape(ctx)
+    _test_requested_config_names(ctx)
 
-    # setup_bazel_command mutates the real `ctx.bazel.startup_flags`;
-    # run last so the mutation can't bleed into earlier pure subtests.
+    # The integration subtests touch the real `ctx.bazel` / workspace `.bazelrc`;
+    # run them last. `setup_bazel_command` also mutates `ctx.bazel.startup_flags`,
+    # so keeping it after the pure subtests prevents bleed-through.
+    _test_resolve_query_flags_drops_build_only_config(ctx)
     _test_setup_bazel_command_applies_to_ctx_bazel(ctx)
-    print("bazel_flags_test.axl: OK (12 sections)")
+    print("bazel_flags_test.axl: OK (14 sections)")
     return 0
 
 bazel_flags_tests = task(

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -339,7 +339,12 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     ///   query diverge from the build and fail on repos the build can see.
     ///   Accepts the same `str | (str, version-constraint)` shape as
     ///   `ctx.bazel.build` / `.test`; version-gated flags are filtered
-    ///   against the running Bazel version identically.
+    ///   against the running Bazel version identically. Flags MUST be
+    ///   expanded for the `query` command (e.g. via `resolve_query_flags`):
+    ///   a build-only option expanded for `build` (such as `--show_result`)
+    ///   would reach the query as a bare flag and hard-error, whereas a
+    ///   `common`-section option arrives as `--default_override=0:common=…`,
+    ///   which `query` silently ignores.
     /// * `announce_version` - Print an `INFO: Bazel <version>` line before
     ///   spawning. Resolved from the `--announce-bazel-version` task flag.
     /// * `announce_command` - Print an `INFO: Spawning: <command>` line

--- a/crates/bazelrc/src/lib.rs
+++ b/crates/bazelrc/src/lib.rs
@@ -852,6 +852,46 @@ build:b --config=a
         assert!(matches!(err, BazelRcError::UndefinedConfig { .. }));
     }
 
+    #[test]
+    fn build_only_config_is_undefined_for_query() {
+        // `query` has no `build` ancestor, so a config defined only as
+        // `build:<name>` is invisible to it and errors — even though the same
+        // config resolves fine for `build`. (Regression context: the delivery
+        // resolve query.)
+        let dir = make_workspace();
+        let root = dir.path();
+        fs::write(root.join(".bazelrc"), "build:rel --copt=-O2\n").unwrap();
+
+        let rc = BazelRC::new(root, ISOLATE, &flags(&["--config=rel"])).unwrap();
+        assert!(
+            rc.expand_configs("build", &[]).is_ok(),
+            "build sees build:rel"
+        );
+        let err = rc.expand_configs("query", &[]).unwrap_err();
+        assert!(
+            matches!(err, BazelRcError::UndefinedConfig { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn skip_config_if_missing_drops_undefined_config() {
+        // Naming the config in `skip_config_if_missing` turns the otherwise
+        // fatal undefined-config into a silent no-op — how the delivery query
+        // tolerates a build-only `--config` it can't resolve.
+        let dir = make_workspace();
+        let root = dir.path();
+        fs::write(root.join(".bazelrc"), "build:rel --copt=-O2\n").unwrap();
+
+        let rc = BazelRC::new(root, ISOLATE, &flags(&["--config=rel"])).unwrap();
+        let expanded = rc.expand_configs("query", &["rel"]).unwrap();
+        let values: Vec<&str> = expanded.iter().map(|o| o.value.as_str()).collect();
+        assert!(
+            !values.contains(&"--copt=-O2"),
+            "build:rel must not leak to query: {values:?}"
+        );
+    }
+
     // ── File discovery order and deduplication ───────────────────────────────
 
     #[test]


### PR DESCRIPTION
`aspect delivery --query=…` replays the workspace `.bazelrc` on its resolve query so the query resolves external repositories the way the build does. The query runs under `--ignore_all_rc_files`, so those flags reach Bazel on the command line, where `bazel query` rejects anything it doesn't recognize:

- a build-only **option** (e.g. an rc `--show_result`) arrives bare → `Unrecognized option: --show_result=20`;
- a `--config=NAME` defined only as a `build:NAME` section has no section visible to `query` (which, unlike `test`, has no `build` ancestor) → `undefined config 'NAME' for command 'query'`.

`resolve_query_flags` (in `lib/bazel_flags.axl`) re-expands the `.bazelrc` for the **`query`** command:

- a `build`-section option is absent from the `query` expansion, so it never reaches the query;
- a `common`-section option arrives wrapped as `--default_override=0:common=…`, which `query` silently ignores when it doesn't recognize the wrapped option;
- requested `--config` names are passed in `skip_config_if_missing`, so a config with no query-visible section is dropped rather than fatal (it carries build/test configuration, which the build phase already validates); a config with a `common:`/`query:` section still expands.

The query shares the build's command-independent startup flags by inheriting `ctx.bazel.startup_flags`; `resolve_query_flags` resolves only the per-command flags so it doesn't re-append startup flags or re-print the rc disclosure that the build's `setup_bazel_command` already emitted. `build`/`test` need no equivalent — each expands for its own command, and `test` inherits `build:*` via Bazel's command graph. The only Rust change to `query.rs` is a doc note on `eval`'s `flags` param.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Fixed `aspect delivery --query=…` failing with `Unrecognized option` or `undefined config` when the workspace `.bazelrc` sets a build-only flag (e.g. `build --show_result=20`) or a build-only `--config`. The resolve query now expands the `.bazelrc` for the `query` command rather than reusing the build flags.

### Test plan

- Live CI: the repo `.bazelrc` carries `build --show_result=20` (a build-only option `query` rejects), and the `aspect delivery --query` CI task runs its resolve query against this repo — exercising `resolve_query_flags` dropping build-only options end to end.
- `bazelrc` crate: unit tests that a `build:<name>` config is undefined for `query`, and that `skip_config_if_missing` drops it.
- `bazel_flags_test.axl`: unit coverage for `requested_config_names`.
- `test_query_flags` (`.aspect/axl.axl`): a `common`-section override reaches `bazel query` as `--default_override=…` and is silently ignored.
