### PR TITLE
feat(rbe): add RBE advisor task group (rbe check / rbe analyze)

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -24,6 +24,7 @@ load(
 )
 load("@aspect//lib/github.axl", "detect_commit_sha", "github")
 load("@aspect//lib/path_glob.axl", "match_any", "match_path")
+load("@aspect//lib/rbe_advisor.axl", "SpawnFact", "TargetInfo", "aggregate_test_wall", "assign_class", "attach_costs", "check_dynamic", "check_static", "cpu_demand", "mem_demand_gb", "readiness_score", "render_check_report", "size_pool", "sort_violations")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "dedup_and_attribute", "patch_download_cmd", "task_cli_path")
 load("@aspect//lib/result_text.axl", "severity_for_status")
 load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
@@ -3196,9 +3197,157 @@ def impl(ctx: TaskContext) -> int:
     tc = test_build_metadata_lib(tc)
     tc = test_severity_for_status(tc)
     tc = test_gazelle_dir_helpers(tc)
+    tc = test_rbe_advisor(tc)
 
     print(tc, "tests passed")
     return 0
+
+def test_rbe_advisor(tc: int) -> int:
+    # --- demand helpers
+    t_plain = TargetInfo(label = "//a:t1")
+    t_big = TargetInfo(label = "//a:t2", size = "large", tags = ["cpu:4"])
+    tc = test_case(tc, cpu_demand(t_plain) == 1, "rbe: default cpu demand is 1")
+    tc = test_case(tc, cpu_demand(t_big) == 4, "rbe: cpu:N tag drives cpu demand")
+    tc = test_case(tc, mem_demand_gb(t_plain) > 0.2 and mem_demand_gb(t_plain) < 0.4, "rbe: medium mem heuristic ~0.3G")
+    tc = test_case(tc, assign_class(1, 0.3).name == "standard", "rbe: small demand -> standard class")
+    tc = test_case(tc, assign_class(4, 10.0).name == "large", "rbe: 4c/10G -> large class")
+    tc = test_case(tc, assign_class(64, 512.0).name == "xlarge", "rbe: oversized demand clamps to xlarge")
+
+    # --- static checks
+    tagged = TargetInfo(label = "//a:net", tags = ["requires-network", "no-remote-cache"], location = "a/BUILD:12:1")
+    rc = [(".bazelrc", 1, "build --action_env=PATH"), (".bazelrc", 2, "build --action_env=FOO=pinned")]
+    vs = check_static([tagged, t_plain], rc)
+    blockers = [v for v in vs if v.severity.value == "blocker"]
+    tc = test_case(tc, len(blockers) == 1 and blockers[0].check == "tag:requires-network", "rbe: requires-network is a blocker")
+    tc = test_case(tc, blockers[0].location == "a/BUILD:12:1", "rbe: violation carries BUILD location")
+    tc = test_case(tc, "hermetize" in blockers[0].fix, "rbe: violation carries a fix suggestion")
+    rc_violations = [v for v in vs if v.check == "bazelrc"]
+    tc = test_case(tc, len(rc_violations) == 1 and "PATH" in rc_violations[0].detail, "rbe: by-name action_env flagged, pinned value not")
+    opted_out = TargetInfo(label = "//a:optout", tags = ["no-remote-exec"])
+    avs = check_static([opted_out], [])
+    tc = test_case(tc, len(avs) == 1 and avs[0].severity.value == "advisory", "rbe: no-remote-exec is advisory, not blocker")
+
+    # --- dynamic checks
+    spawns = [
+        SpawnFact(label = "//a:t1", mnemonic = "TestRunner", runner = "local", wall_s = 30.0),
+        SpawnFact(label = "//a:local", mnemonic = "TestRunner", runner = "local", wall_s = 5.0),
+        SpawnFact(label = "//a:t2", mnemonic = "TestRunner", runner = "linux-sandbox", wall_s = 60.0, remote_cacheable = False),
+    ]
+    by_label = {
+        "//a:t1": t_plain,
+        "//a:local": TargetInfo(label = "//a:local", tags = ["local"]),
+        "//a:t2": t_big,
+    }
+    dvs = check_dynamic(spawns, by_label)
+    fallbacks = [v for v in dvs if v.check == "runner:local-fallback"]
+    tc = test_case(tc, len(fallbacks) == 1 and fallbacks[0].subject == "//a:t1", "rbe: untagged local runner flagged, tagged one not")
+    tc = test_case(tc, len([v for v in dvs if v.check == "spawn:not-remote-cacheable"]) == 1, "rbe: not-remote-cacheable flagged")
+
+    # assumed-system-dep checks: fire on actual command/env, not tags
+    sysdep_spawns = [
+        SpawnFact(label = "//a:t1", mnemonic = "TestRunner", runner = "darwin-sandbox", wall_s = 5.0, args = ["/usr/local/bin/mytool", "run"]),
+        SpawnFact(label = "//a:t1", mnemonic = "TestRunner", runner = "darwin-sandbox", wall_s = 5.0, args = ["/usr/local/bin/mytool", "again"]),
+        SpawnFact(label = "//a:t2", mnemonic = "Javac", runner = "darwin-sandbox", wall_s = 9.0, args = ["/usr/bin/javac", "A.java"]),
+        SpawnFact(label = "//a:t2", mnemonic = "Javac", runner = "darwin-sandbox", wall_s = 9.0, env = {"JAVA_HOME": "/Users/dev/jdk"}),
+        SpawnFact(label = "//a:ok", mnemonic = "TestRunner", runner = "darwin-sandbox", wall_s = 1.0, args = ["/bin/bash", "-c", "true"]),
+    ]
+    svs = check_dynamic(sysdep_spawns, by_label)
+    tc = test_case(tc, len([v for v in svs if v.check == "spawn:host-path-arg"]) == 1, "rbe: host-only arg path is a blocker, deduped per target")
+    tc = test_case(tc, [v for v in svs if v.check == "spawn:host-path-arg"][0].severity.value == "blocker", "rbe: host-path-arg severity is blocker")
+    tc = test_case(tc, len([v for v in svs if v.check == "spawn:system-tool"]) == 1, "rbe: un-pinned system tool flagged once")
+    tc = test_case(tc, len([v for v in svs if v.check == "spawn:host-path-env"]) == 1, "rbe: host path in env flagged as non_hermetic")
+    tc = test_case(tc, len([v for v in svs if v.subject == "//a:ok"]) == 0, "rbe: allowlisted /bin/bash not flagged")
+    fixed_path = check_dynamic([SpawnFact(label = "//a:t1", mnemonic = "TestRunner", runner = "darwin-sandbox", env = {"PATH": "/bin:/usr/bin:/usr/local/bin"})], by_label)
+    tc = test_case(tc, len(fixed_path) == 0, "rbe: bazel-standardized PATH not flagged as host leak")
+
+    # strict_action_env absence check
+    no_strict = check_static([], [(".bazelrc", 1, "build --jobs=8")])
+    tc = test_case(tc, len([v for v in no_strict if v.check == "bazelrc:missing-strict-action-env"]) == 1, "rbe: missing strict_action_env flagged")
+    with_strict = check_static([], [(".bazelrc", 1, "common --incompatible_strict_action_env")])
+    tc = test_case(tc, len([v for v in with_strict if v.check == "bazelrc:missing-strict-action-env"]) == 0, "rbe: strict_action_env present, no absence violation")
+
+    # declared opt-out spawn: not-remotable downgraded to advisory
+    optout_spawn = SpawnFact(label = "//a:optout", mnemonic = "TestRunner", runner = "linux-sandbox", wall_s = 10.0, remotable = False)
+    ovs = check_dynamic([optout_spawn], {"//a:optout": opted_out})
+    tc = test_case(tc, len(ovs) == 1 and ovs[0].severity.value == "advisory", "rbe: declared not-remotable spawn is advisory")
+    undeclared_spawn = SpawnFact(label = "//a:t1", mnemonic = "TestRunner", runner = "linux-sandbox", wall_s = 10.0, remotable = False)
+    uvs = check_dynamic([undeclared_spawn], by_label)
+    tc = test_case(tc, len(uvs) == 1 and uvs[0].severity.value == "blocker", "rbe: undeclared not-remotable spawn stays a blocker")
+
+    # --- wall-time aggregation: shards/attempts sum; BES is fallback only
+    shard_spawns = [
+        SpawnFact(label = "//a:sharded", mnemonic = "TestRunner", wall_s = 30.0),
+        SpawnFact(label = "//a:sharded", mnemonic = "TestRunner", wall_s = 25.0),
+        SpawnFact(label = "//a:sharded", mnemonic = "Javac", wall_s = 99.0),
+    ]
+    agg = aggregate_test_wall(shard_spawns, {"//a:sharded": {"duration_ms": 30000}, "//a:bes_only": {"duration_ms": 7000}})
+    tc = test_case(tc, agg["//a:sharded"] == 55.0, "rbe: shard/attempt spawn times sum; BES does not override")
+    tc = test_case(tc, agg["//a:bes_only"] == 7.0, "rbe: BES duration fills labels with no spawn metrics")
+    tc = test_case(tc, len(agg) == 2, "rbe: non-TestRunner spawns excluded from test wall")
+
+    # --- scoring
+    tc = test_case(tc, readiness_score([], 100.0) == 100, "rbe: clean run scores 100")
+    tc = test_case(tc, readiness_score(attach_costs(avs + ovs, {"//a:optout": 500.0}), 1000.0) == 100, "rbe: advisory-only violations leave score at 100")
+    one_blocker = [v for v in dvs if v.severity.value == "blocker"]
+    score = readiness_score(attach_costs(one_blocker, {"//a:t1": 30.0}), 1000.0)
+    tc = test_case(tc, score <= 92, "rbe: any blocker caps the score at 92")
+    tc = test_case(tc, score > 0, "rbe: small blocker does not zero the score")
+
+    # --- sizing: 100 medium tests x 60s, cp 120s, target 600s, util 80%
+    targets = {}
+    walls = {}
+    for i in range(100):
+        label = "//pkg:t{}".format(i)
+        targets[label] = TargetInfo(label = label)
+        walls[label] = 60.0
+    plan = size_pool(
+        targets_by_label = targets,
+        wall_by_label = walls,
+        spawns = spawns,
+        critical_path_s = 120.0,
+        target_wall_s = 600.0,
+        utilization = 0.8,
+        headroom = 0.2,
+        builds_per_hour = 1.0,
+        clouds = ["aws"],
+    )
+
+    # total = 100 * 60 * 1.15 = 6900 cpu-s; 6900 / (600 * 0.8) = 14.375 -> 15
+    tc = test_case(tc, plan.target_achievable, "rbe: 600s target above 138s floor is achievable")
+    std = plan.classes["standard"]
+    tc = test_case(tc, std.tests == 100, "rbe: all tests binned standard")
+    tc = test_case(tc, std.executors_steady == 15, "rbe: steady executors = ceil(6900/480) = 15")
+    tc = test_case(tc, std.executors_peak == 18, "rbe: peak executors = ceil(15 * 1.2) = 18")
+    aws = std.instances["aws"]
+    tc = test_case(tc, aws.instance_type == "m7a.4xlarge" and aws.count_max == 2 and aws.count_min == 1, "rbe: aws packing picks m7a.4xlarge 1-2x")
+    tc = test_case(tc, sort_violations(dvs)[0].severity.value == "blocker", "rbe: blockers sort first")
+
+    # --- rendering (grouped layout)
+    plain = render_check_report(vs, 90)
+    tc = test_case(tc, "(a/BUILD:12:1)" in plain, "rbe: report shows BUILD location next to subject")
+    tc = test_case(tc, "  fix: " in plain, "rbe: report renders fix line per group")
+    rc_only = render_check_report([v for v in vs if v.check == "bazelrc"], 90)
+    tc = test_case(tc, "(.bazelrc:1)" not in rc_only, "rbe: bazelrc location == subject, not repeated")
+
+    # two targets, same tag -> one group header, one fix line, two subjects
+    twin = check_static([tagged, TargetInfo(label = "//b:net2", tags = ["requires-network"], location = "b/BUILD:5:1")], [])
+    twin_report = render_check_report([v for v in twin if v.check == "tag:requires-network"], 90)
+    tc = test_case(tc, twin_report.count("tag:requires-network — ") == 1, "rbe: same check+fix groups under one header")
+    tc = test_case(tc, twin_report.count("fix: ") == 1, "rbe: grouped fix printed once")
+    tc = test_case(tc, "(2 findings" in twin_report, "rbe: group header counts findings")
+    tc = test_case(tc, "//a:net" in twin_report and "//b:net2" in twin_report, "rbe: both subjects listed in group")
+
+    # workspace_root strips the location prefix
+    abs_v = check_static([TargetInfo(label = "//c:t", tags = ["requires-network"], location = "/repo/c/BUILD:1:1")], [])
+    tc = test_case(tc, "(c/BUILD:1:1)" in render_check_report(abs_v, 90, workspace_root = "/repo"), "rbe: workspace_root relativizes locations")
+
+    plain = render_check_report(dvs, 90)
+    tc = test_case(tc, "\x1b[" not in plain, "rbe: ansi off emits no escape codes")
+    colored = render_check_report(dvs, 90, ansi = True)
+    tc = test_case(tc, "\x1b[31m[blocker]\x1b[0m" in colored, "rbe: ansi on colors severity tags")
+    tc = test_case(tc, "\x1b[1;32m90/100\x1b[0m" in colored, "rbe: score >=90 renders bold green")
+    tc = test_case(tc, "\x1b[1;31m40/100\x1b[0m" in render_check_report(dvs, 40, ansi = True), "rbe: score <70 renders bold red")
+    return tc
 
 axl = task(
     group = ["tests"],

--- a/crates/aspect-cli/src/builtins/aspect/MODULE.aspect
+++ b/crates/aspect-cli/src/builtins/aspect/MODULE.aspect
@@ -8,6 +8,8 @@ use_task("test.axl", "test")
 use_task("axl_add.axl", "add")
 use_task("delivery.axl", "delivery")
 use_task("lint.axl", "lint")
+use_task("rbe.axl", "check")
+use_task("rbe.axl", "analyze")
 use_task("format.axl", "format")
 use_task("gazelle.axl", "gazelle")
 

--- a/crates/aspect-cli/src/builtins/aspect/README.md
+++ b/crates/aspect-cli/src/builtins/aspect/README.md
@@ -14,6 +14,7 @@ Aspect-CLI ships with six built-in tasks that drive Bazel for the most common CI
 | [format](#format) | `bazel run` of a `format_multirun` | `aspect format [--scope=changed\|all]`                       | `format_results`     |
 | [gazelle](#gazelle) | `bazel run` of a `gazelle()` / `aspect_gazelle()` target | `aspect gazelle [--check]`                                   | `gazelle_results`    |
 | [delivery](#delivery) | Multi-phase delivery flow | `aspect delivery //pkg/foo:release //pkg/bar:release`        | `delivery_results`   |
+| rbe check / rbe analyze | `bazel query` (+ instrumented `bazel test` for `analyze`) | `aspect rbe analyze [--workspace=/path/to/repo] [--report-out=rbe.txt] [--target-wall-time=600] [-- //...]` | *(stdout only; no status surfaces yet)* |
 
 Every task:
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/rbe_advisor.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rbe_advisor.axl
@@ -1,0 +1,826 @@
+"""
+RBE readiness analysis: hermeticity checks + worker-pool capacity sizing.
+
+Pure logic for the `aspect rbe` task group (see ../rbe.axl). Nothing here
+touches Bazel or the filesystem — inputs are typed records built by the
+task layer, outputs are typed records the task layer renders. This keeps
+every check and the sizing math unit-testable from `tests axl`.
+
+Methodology (see docs/rbe-advisor-design.md for the full rationale):
+
+- Hermeticity: static checks over target tags/attrs and .bazelrc lines,
+  plus dynamic checks over execution-log spawn facts from an instrumented
+  local run. Violations are weighted by the CPU-seconds they affect, and
+  any blocker caps the overall score.
+- Sizing: wall time on a pool of W executor slots is approximately
+  T(W) = max(T_critical_path, total_cpu_seconds / (W * utilization)).
+  Tests are binned into worker classes by (cpu, mem) demand; per-class
+  executor counts are packed onto EC2/GCE instance shapes.
+"""
+
+# ---------------------------------------------------------------- types
+
+# `advisory` = surfaced for visibility but not scored: deliberate opt-outs
+# from remote execution (no-remote / no-remote-exec) are a declared choice,
+# not a hermeticity defect — they simply keep running locally under RBE.
+Severity = enum("blocker", "non_hermetic", "efficiency", "advisory")
+
+CloudProvider = enum("aws", "gcp", "both")
+
+TargetInfo = record(
+    label = field(str),
+    rule_class = field(str, default = ""),
+    size = field(str, default = "medium"),
+    tags = field(list, default = []),
+    local_attr = field(bool, default = False),
+    flaky = field(bool, default = False),
+    # BUILD-file position from `bazel query` ("path/BUILD:line:col");
+    # empty when the query backend didn't report one.
+    location = field(str, default = ""),
+)
+
+SpawnFact = record(
+    label = field(str),
+    mnemonic = field(str, default = ""),
+    runner = field(str, default = ""),
+    cacheable = field(bool, default = True),
+    remote_cacheable = field(bool, default = True),
+    remotable = field(bool, default = True),
+    cache_hit = field(bool, default = False),
+    wall_s = field(float, default = 0.0),
+    # Command line and environment from the exec log; drive the
+    # assumed-system-dependency checks (host-only paths, system tools).
+    args = field(list, default = []),
+    env = field(dict, default = {}),
+)
+
+Violation = record(
+    severity = field(Severity),
+    subject = field(str),
+    check = field(str),
+    detail = field(str),
+    cpu_seconds = field(float, default = 0.0),
+    # Where the violation originates: BUILD-file position for target
+    # checks, "file:line" for bazelrc checks. Empty when unknown
+    # (e.g. a dynamic spawn fact whose target wasn't in the query).
+    location = field(str, default = ""),
+    # Concrete remediation suggestion; empty when there's no
+    # one-size-fits-all fix.
+    fix = field(str, default = ""),
+)
+
+WorkerClass = record(
+    name = field(str),
+    cpu = field(int),
+    mem_gb = field(int),
+)
+
+InstancePlan = record(
+    instance_type = field(str),
+    count_min = field(int),
+    count_max = field(int),
+    executors_per_instance = field(int),
+)
+
+ClassPlan = record(
+    worker_class = field(WorkerClass),
+    tests = field(int),
+    cpu_seconds = field(float),
+    executors_steady = field(int),
+    executors_peak = field(int),
+    # cloud name -> InstancePlan; dict because keys are caller-selected clouds.
+    instances = field(dict, default = {}),
+)
+
+SizingPlan = record(
+    total_cpu_seconds = field(float),
+    critical_path_s = field(float),
+    min_achievable_wall_s = field(float),
+    target_wall_s = field(float),
+    target_achievable = field(bool),
+    concurrent_builds = field(float),
+    pct_compute_remotable = field(float),
+    pct_compute_cacheable = field(float),
+    # class name -> ClassPlan
+    classes = field(dict, default = {}),
+)
+
+# ---------------------------------------------------------------- constants
+
+# Bazel test-size heuristic peak RAM (MB), per the test encyclopedia.
+_SIZE_MEM_MB = {"small": 20, "medium": 100, "large": 300, "enormous": 800}
+
+# Heuristic mem -> provisioned mem safety factor. Exec logs don't carry
+# peak RSS, so we provision conservatively. Calibrate against real RBE
+# telemetry before trusting for production pools.
+_MEM_INFLATION = 3.0
+
+# Local wall -> remote wall factor (input fetch, scheduling). Calibrate.
+REMOTE_OVERHEAD = 1.15
+
+# Tag -> (severity, explanation, suggested fix) for tags that degrade
+# or break RBE.
+_BAD_TAGS = {
+    "local": (
+        Severity("blocker"),
+        "runs outside the sandbox and cannot execute remotely",
+        "remove the `local` tag and fix whatever forced it (host paths, daemons, devices); if the target is genuinely machine-bound, switch to `no-remote-exec` to make the opt-out explicit",
+    ),
+    "no-sandbox": (
+        Severity("blocker"),
+        "depends on unsandboxed local state",
+        "make the action sandbox-clean (declare all inputs, drop absolute paths) and remove the `no-sandbox` tag",
+    ),
+    "no-remote": (
+        Severity("advisory"),
+        "declared opt-out from remote execution and cache; will keep running locally",
+        "intentional opt-out — no action needed; revisit if this target dominates wall time",
+    ),
+    "no-remote-exec": (
+        Severity("advisory"),
+        "declared opt-out from remote execution; will keep running locally",
+        "intentional opt-out — no action needed; revisit if this target dominates wall time",
+    ),
+    "requires-network": (
+        Severity("blocker"),
+        "needs network access during the action",
+        "hermetize the dependency (vendor it, fetch in a repository rule, or fake the endpoint); if the network use is essential, keep the tag so RBE schedulers route it to a network-enabled pool",
+    ),
+    "exclusive": (
+        Severity("efficiency"),
+        "serializes the test run; defeats RBE parallelism",
+        "remove `exclusive` if the test no longer needs sole ownership of the machine; otherwise expect it to gate total wall time",
+    ),
+    "no-cache": (
+        Severity("efficiency"),
+        "never cached; re-executes every build",
+        "remove `no-cache` once outputs are deterministic; check for timestamps or randomness in outputs. For large non-deterministic blobs (archives, container images), prefer `no-remote-cache` instead — local caching keeps working, and rebuilding remotely is often cheaper than pushing/pulling the blob",
+    ),
+    "no-remote-cache": (
+        Severity("efficiency"),
+        "excluded from the remote cache",
+        "remove `no-remote-cache` unless outputs contain secrets or machine-specific data — or keep it deliberately for large non-deterministic outputs, where rebuilding every run beats the I/O and network cost of cache round-trips",
+    ),
+}
+
+# .bazelrc red flags: (substring-or-prefix, severity, message, fix).
+# Substring match keeps this dependency-free; false positives in
+# comments are filtered by the caller stripping `#` comments first.
+_RC_CHECKS = [
+    (
+        "--spawn_strategy=local",
+        Severity("blocker"),
+        "forces local spawn strategy; remote execution disabled",
+        "delete the flag (Bazel picks sandboxed/remote automatically) or scope it to a config like `--config=local_dev`",
+    ),
+    (
+        "--spawn_strategy=standalone",
+        Severity("blocker"),
+        "forces standalone spawn strategy; remote execution disabled",
+        "delete the flag (Bazel picks sandboxed/remote automatically) or scope it to a config like `--config=local_dev`",
+    ),
+    (
+        "--workspace_status_command",
+        Severity("non_hermetic"),
+        "volatile workspace status consumed by non-stamp actions breaks caching",
+        "keep volatile keys (timestamps, commit) in the volatile-status file and ensure only `stamp = True` targets consume them; or scope the flag to a release config",
+    ),
+    (
+        "--noincompatible_strict_action_env",
+        Severity("non_hermetic"),
+        "full client env leaks into action cache keys",
+        "remove the flag and allowlist needed vars with pinned values: `--action_env=VAR=value`",
+    ),
+]
+
+# Path prefixes that exist only on a developer machine (or differ per
+# machine). A spawn referencing one passes locally — the sandbox can
+# read the host filesystem — but breaks or poisons the cache on a remote
+# worker. This is the "assumed system dependency" detector: it fires on
+# the actual command line / env, so removing a `local` tag without
+# fixing the root cause does not silence it.
+_HOST_ONLY_MARKERS = ["/home/", "/Users/", "/usr/local/", "/opt/homebrew/", "/opt/local/"]
+
+# System-tool prefixes worth flagging when used as the spawn's
+# executable: an un-pinned host compiler/interpreter means whatever
+# version the machine has — classic autodetected-toolchain leak.
+_SYSTEM_TOOL_PREFIXES = ["/usr/bin/", "/bin/", "/usr/sbin/"]
+
+# Shell plumbing that every executor image ships; invoking these is not
+# a toolchain-hermeticity signal.
+_SYSTEM_TOOL_ALLOWLIST = ["/bin/sh", "/bin/bash", "/usr/bin/env", "/bin/true", "/bin/false"]
+
+# Env values Bazel itself standardizes — identical on every machine, so
+# they trip the host-path markers without being machine-specific.
+_BAZEL_FIXED_ENV_VALUES = [
+    # PATH under --incompatible_strict_action_env
+    "/bin:/usr/bin:/usr/local/bin",
+    # PATH fallback when the client env has none
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+]
+
+WORKER_CLASSES = [
+    WorkerClass(name = "standard", cpu = 1, mem_gb = 4),
+    WorkerClass(name = "medium", cpu = 2, mem_gb = 8),
+    WorkerClass(name = "large", cpu = 4, mem_gb = 16),
+    WorkerClass(name = "xlarge", cpu = 8, mem_gb = 32),
+]
+
+# Per cloud: (instance type, vCPUs, mem GB). 1 vCPU / 2 GB per instance is
+# reserved for the worker agent + OS when packing executors.
+_INSTANCE_CATALOG = {
+    "aws": [
+        ("c7a.xlarge", 4, 8),
+        ("c7a.2xlarge", 8, 16),
+        ("c7a.4xlarge", 16, 32),
+        ("m7a.xlarge", 4, 16),
+        ("m7a.2xlarge", 8, 32),
+        ("m7a.4xlarge", 16, 64),
+        ("r7a.xlarge", 4, 32),
+    ],
+    "gcp": [
+        ("c2d-standard-4", 4, 16),
+        ("c2d-standard-8", 8, 32),
+        ("c2d-standard-16", 16, 64),
+        ("n2d-standard-4", 4, 16),
+        ("n2d-standard-8", 8, 32),
+        ("n2d-highmem-4", 4, 32),
+    ],
+}
+_AGENT_RESERVE_CPU = 1
+_AGENT_RESERVE_MEM_GB = 2
+
+_SEV_ORDER = {"blocker": 0, "non_hermetic": 1, "efficiency": 2, "advisory": 3}
+
+# Tags that declare an intentional local-only target; their spawns
+# reporting not-remotable is expected, not a hermeticity finding.
+_DECLARED_LOCAL_TAGS = ("local", "no-sandbox", "no-remote", "no-remote-exec")
+
+# ---------------------------------------------------------------- helpers
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+def _ceil(x: float) -> int:
+    i = int(x)
+    return i + 1 if x > float(i) else i
+
+def cpu_demand(target: TargetInfo) -> int:
+    """CPU cores a test occupies: the `cpu:N` tag, else 1."""
+    for t in target.tags:
+        if t.startswith("cpu:") and t[4:].isdigit():
+            return int(t[4:])
+    return 1
+
+def mem_demand_gb(target: TargetInfo) -> float:
+    """Provisioned memory: `resources:memory:<MB>` tag, else size-class
+    heuristic inflated by the safety factor."""
+    for t in target.tags:
+        if t.startswith("resources:memory:") and t[17:].isdigit():
+            return int(t[17:]) / 1024.0
+    return _SIZE_MEM_MB.get(target.size, 100) * _MEM_INFLATION / 1024.0
+
+def _first_host_path(strings: list) -> str | None:
+    """First string referencing a host-only path, or None."""
+    for s in strings:
+        for marker in _HOST_ONLY_MARKERS:
+            if marker in s:
+                return s
+    return None
+
+def _system_tool(args: list) -> str | None:
+    """The spawn's executable when it is an un-allowlisted system
+    binary, else None."""
+    if not args:
+        return None
+    tool = args[0]
+    if tool in _SYSTEM_TOOL_ALLOWLIST:
+        return None
+    for prefix in _SYSTEM_TOOL_PREFIXES:
+        if tool.startswith(prefix):
+            return tool
+    return None
+
+# ---------------------------------------------------------------- checks
+
+def check_static(targets: list, rc_lines: list) -> list:
+    """Static hermeticity checks over TargetInfo records and .bazelrc lines.
+
+    `rc_lines` is a list of (source_name, line_number, line) tuples with
+    comments already stripped. Returns list[Violation] (cpu_seconds filled
+    in later by `attach_costs` once spawn timing is known).
+    """
+    out = []
+    for t in targets:
+        for tag in t.tags:
+            if tag in _BAD_TAGS:
+                sev, why, fix = _BAD_TAGS[tag]
+                out.append(Violation(
+                    severity = sev,
+                    subject = t.label,
+                    check = "tag:" + tag,
+                    detail = why,
+                    location = t.location,
+                    fix = fix,
+                ))
+        if t.local_attr:
+            out.append(Violation(
+                severity = Severity("blocker"),
+                subject = t.label,
+                check = "attr:local=True",
+                detail = "local = True forces non-remote execution",
+                location = t.location,
+                fix = "remove `local = True` and fix whatever forced it; if genuinely machine-bound, tag with `no-remote-exec` instead to make the opt-out explicit",
+            ))
+        if t.flaky:
+            out.append(Violation(
+                severity = Severity("efficiency"),
+                subject = t.label,
+                check = "attr:flaky=True",
+                detail = "flaky retries multiply remote executor load",
+                location = t.location,
+                fix = "deflake the test and remove `flaky = True`; each retry consumes another executor slot",
+            ))
+    for src, lineno, line in rc_lines:
+        loc = "{}:{}".format(src, lineno)
+        for needle, sev, msg, fix in _RC_CHECKS:
+            if needle in line:
+                out.append(Violation(
+                    severity = sev,
+                    subject = loc,
+                    check = "bazelrc",
+                    detail = "`{}` — {}".format(line.strip(), msg),
+                    location = loc,
+                    fix = fix,
+                ))
+
+        # --action_env=FOO / --test_env=FOO without `=value` passes the
+        # host's value through, which varies per machine.
+        for flag in ("--action_env=", "--test_env="):
+            idx = line.find(flag)
+            if idx >= 0:
+                rest = line[idx + len(flag):].split(" ")[0]
+                if "=" not in rest:
+                    out.append(Violation(
+                        severity = Severity("non_hermetic"),
+                        subject = loc,
+                        check = "bazelrc",
+                        detail = "`{}` — passes through host env var `{}` by name; value varies per machine and poisons cache keys".format(line.strip(), rest),
+                        location = loc,
+                        fix = "pin the value (`{}{}=<value>`) or drop the passthrough".format(flag, rest),
+                    ))
+
+    # Absence check: without strict_action_env Bazel forwards the host
+    # PATH (and more) into action keys — every machine computes
+    # different cache keys even when nothing is declared wrong.
+    strict_env_seen = False
+    for _, _, line in rc_lines:
+        if "--incompatible_strict_action_env" in line and "--noincompatible_strict_action_env" not in line:
+            strict_env_seen = True
+            break
+    if rc_lines and not strict_env_seen:
+        out.append(Violation(
+            severity = Severity("non_hermetic"),
+            subject = ".bazelrc",
+            check = "bazelrc:missing-strict-action-env",
+            detail = "no `--incompatible_strict_action_env` found — the host PATH leaks into action cache keys, so caches diverge across machines",
+            fix = "add `common --incompatible_strict_action_env` to .bazelrc, then pin any vars actions truly need with `--action_env=VAR=value`",
+        ))
+    return out
+
+def check_dynamic(spawns: list, targets_by_label: dict) -> list:
+    """Dynamic hermeticity checks over SpawnFact records from an
+    instrumented run."""
+    out = []
+
+    # The system-dep checks fire per spawn but a target usually has many
+    # spawns with the same root cause; report each (label, check) once.
+    seen = {}
+    for sp in spawns:
+        target = targets_by_label.get(sp.label)
+        tags = target.tags if target else []
+        loc = target.location if target else ""
+
+        # Assumed system dependencies: paths/tools that the local
+        # sandbox tolerates but a remote worker won't have. These fire
+        # regardless of tags — they detect the root cause, not the
+        # declaration.
+        host_arg = _first_host_path(sp.args)
+        if host_arg != None and (sp.label, "spawn:host-path-arg") not in seen:
+            seen[(sp.label, "spawn:host-path-arg")] = True
+            out.append(Violation(
+                severity = Severity("blocker"),
+                subject = sp.label,
+                check = "spawn:host-path-arg",
+                detail = "{} command line references a host-only path: `{}` — the file will not exist on a remote worker".format(sp.mnemonic, host_arg),
+                cpu_seconds = sp.wall_s,
+                location = loc,
+                fix = "declare the file as an action input (srcs/data/tools) so Bazel ships it to the worker, or take the tool from a hermetic toolchain instead of the host",
+            ))
+        host_env = _first_host_path([v for v in sp.env.values() if v not in _BAZEL_FIXED_ENV_VALUES])
+        if host_env != None and (sp.label, "spawn:host-path-env") not in seen:
+            seen[(sp.label, "spawn:host-path-env")] = True
+            out.append(Violation(
+                severity = Severity("non_hermetic"),
+                subject = sp.label,
+                check = "spawn:host-path-env",
+                detail = "{} environment carries a host-only path: `{}` — varies per machine and poisons cache keys".format(sp.mnemonic, host_env),
+                cpu_seconds = sp.wall_s,
+                location = loc,
+                fix = "pin the variable to a stable value (`--action_env=VAR=value`) or stop passing it through; `--incompatible_strict_action_env` prevents the default leak",
+            ))
+        sys_tool = _system_tool(sp.args)
+        if sys_tool != None and (sp.label, "spawn:system-tool") not in seen:
+            seen[(sp.label, "spawn:system-tool")] = True
+            out.append(Violation(
+                severity = Severity("non_hermetic"),
+                subject = sp.label,
+                check = "spawn:system-tool",
+                detail = "{} invokes the system binary `{}` — whatever version the machine has; differs across workers and developer machines".format(sp.mnemonic, sys_tool),
+                cpu_seconds = sp.wall_s,
+                location = loc,
+                fix = "pin a hermetic toolchain for this tool (e.g. toolchains_llvm, rules_java remote JDK, rules_python interpreter) or vendor it into the repo",
+            ))
+        if sp.runner in ("local", "standalone") and "local" not in tags and "no-sandbox" not in tags:
+            out.append(Violation(
+                severity = Severity("blocker"),
+                subject = sp.label,
+                check = "runner:local-fallback",
+                detail = "{} ran with the `{}` runner without a local/no-sandbox tag — a strategy fell back; would fail or silently localize under RBE".format(sp.mnemonic, sp.runner),
+                cpu_seconds = sp.wall_s,
+                location = loc,
+                fix = "re-run with `--execution_log_compact_file` and check why the {} strategy fell back (often a sandbox failure or a strategy regex in .bazelrc); add an explicit tag if local execution is intended".format(sp.mnemonic),
+            ))
+        if sp.cacheable and not sp.remote_cacheable:
+            out.append(Violation(
+                severity = Severity("efficiency"),
+                subject = sp.label,
+                check = "spawn:not-remote-cacheable",
+                detail = "{} is locally cacheable but not remote-cacheable".format(sp.mnemonic),
+                cpu_seconds = sp.wall_s,
+                location = loc,
+                fix = "look for `no-remote-cache` in tags or `--modify_execution_info` rules covering {}; note this can be intentional — for large non-deterministic outputs, rebuilding each run is often cheaper than cache push/pull".format(sp.mnemonic),
+            ))
+        if not sp.remotable:
+            declared = False
+            for t in _DECLARED_LOCAL_TAGS:
+                if t in tags:
+                    declared = True
+                    break
+            out.append(Violation(
+                severity = Severity("advisory") if declared else Severity("blocker"),
+                subject = sp.label,
+                check = "spawn:not-remotable",
+                detail = "{} is marked not remotable{}".format(
+                    sp.mnemonic,
+                    " (declared via tag)" if declared else "",
+                ),
+                cpu_seconds = sp.wall_s,
+                location = loc,
+                fix = "" if declared else "find what marks {} non-remotable: `local`-family tags on the rule, an execution requirement in the rule implementation, or a strategy flag".format(sp.mnemonic),
+            ))
+    return out
+
+def aggregate_test_wall(spawns: list, bes_details: dict) -> dict:
+    """label -> total test wall seconds.
+
+    Exec-log spawn metrics are primary: sharded and retried tests emit
+    one TestRunner spawn per shard/attempt and every one costs executor
+    time, so they are summed per label. BES test_details can't provide
+    that — each test_result event overwrites the label's entry, so it
+    holds a single attempt's duration. It remains the fallback for
+    labels whose spawns carried no metrics.
+    """
+    out = {}
+    for sp in spawns:
+        if sp.mnemonic == "TestRunner" and sp.wall_s > 0.0:
+            out[sp.label] = out.get(sp.label, 0.0) + sp.wall_s
+    for label, detail in bes_details.items():
+        if label not in out:
+            out[label] = float(detail.get("duration_ms", 0)) / 1000.0
+    return out
+
+def attach_costs(violations: list, wall_by_label: dict) -> list:
+    """Return violations with cpu_seconds backfilled from measured wall
+    time, so static violations rank by the compute they affect."""
+    out = []
+    for v in violations:
+        if v.cpu_seconds > 0.0:
+            out.append(v)
+        else:
+            out.append(Violation(
+                severity = v.severity,
+                subject = v.subject,
+                check = v.check,
+                detail = v.detail,
+                cpu_seconds = wall_by_label.get(v.subject, 0.0),
+                location = v.location,
+                fix = v.fix,
+            ))
+    return out
+
+def sort_violations(violations: list) -> list:
+    return sorted(violations, key = lambda v: (_SEV_ORDER[v.severity.value], -v.cpu_seconds))
+
+def readiness_score(violations: list, total_cpu_s: float) -> int:
+    """100 = clean. Compute-weighted penalty, capped by distinct blocker
+    count — any blocker prevents full migration regardless of how little
+    compute it represents. Advisory violations are surfaced but never
+    scored (weight 0): they record deliberate opt-outs, not defects."""
+    blocker_subjects = {}
+    scored = 0
+    for v in violations:
+        if v.severity.value == "blocker":
+            blocker_subjects[v.subject] = True
+        if v.severity.value != "advisory":
+            scored += 1
+    cap = max(20, 100 - 8 * len(blocker_subjects)) if blocker_subjects else 100
+    if total_cpu_s <= 0.0:
+        n = len(blocker_subjects)
+        return min(cap, max(0, 100 - 15 * n - 3 * (scored - n)))
+    weights = {"blocker": 1.0, "non_hermetic": 0.6, "efficiency": 0.25, "advisory": 0.0}
+
+    # Dedup: one (subject, severity) pair counts its compute once.
+    impacted = {}
+    for v in violations:
+        k = (v.subject, v.severity.value)
+        impacted[k] = max(impacted.get(k, 0.0), v.cpu_seconds)
+    penalty = 0.0
+    for (_, sev), cpu in impacted.items():
+        penalty += weights[sev] * cpu
+    frac = min(1.0, penalty / total_cpu_s)
+    return min(cap, max(0, int(100.0 * (1.0 - frac) + 0.5)))
+
+# ---------------------------------------------------------------- sizing
+
+def assign_class(cpu: int, mem_gb: float) -> WorkerClass:
+    """Smallest worker class that fits the (cpu, mem) demand."""
+    for wc in WORKER_CLASSES:
+        if cpu <= wc.cpu and mem_gb <= float(wc.mem_gb):
+            return wc
+    return WORKER_CLASSES[-1]
+
+def _pick_instance(cloud: str, wc: WorkerClass, executors_steady: int, executors_peak: int) -> InstancePlan | None:
+    """Best instance for a worker class: fewest instances at peak, then
+    least wasted vCPU."""
+    best = None
+    for iname, vcpu, mem in _INSTANCE_CATALOG[cloud]:
+        slots = min(
+            (vcpu - _AGENT_RESERVE_CPU) // wc.cpu,
+            (mem - _AGENT_RESERVE_MEM_GB) // wc.mem_gb,
+        )
+        if slots <= 0:
+            continue
+        count = _ceil_div(executors_peak, slots)
+        waste = count * vcpu - executors_peak * wc.cpu
+        if best == None or (count, waste) < (best[1], best[2]):
+            best = (iname, count, waste, slots)
+    if best == None:
+        return None
+    return InstancePlan(
+        instance_type = best[0],
+        count_min = max(1, _ceil_div(executors_steady, best[3])),
+        count_max = best[1],
+        executors_per_instance = best[3],
+    )
+
+def size_pool(
+        targets_by_label: dict,
+        wall_by_label: dict,
+        spawns: list,
+        critical_path_s: float,
+        target_wall_s: float = 0.0,
+        utilization: float = 0.8,
+        headroom: float = 0.2,
+        builds_per_hour: float = 1.0,
+        clouds: list = ["aws", "gcp"]) -> SizingPlan:
+    """Capacity plan from measured per-target wall time + declared demand.
+
+    `target_wall_s = 0` auto-selects 2x the minimum achievable wall time.
+    """
+    class_cpu_s = {}
+    class_tests = {}
+    total_cpu_s = 0.0
+    for label, wall in wall_by_label.items():
+        t = targets_by_label.get(label) or TargetInfo(label = label)
+        wc = assign_class(cpu_demand(t), mem_demand_gb(t))
+        cpu_s = wall * float(cpu_demand(t)) * REMOTE_OVERHEAD
+        class_cpu_s[wc.name] = class_cpu_s.get(wc.name, 0.0) + cpu_s
+        class_tests[wc.name] = class_tests.get(wc.name, 0) + 1
+        total_cpu_s += cpu_s
+
+    min_wall = critical_path_s * REMOTE_OVERHEAD
+    auto_target = target_wall_s <= 0.0
+    if auto_target:
+        target_wall_s = max(2.0 * min_wall, 60.0)
+    achievable = target_wall_s >= min_wall
+    eff_wall = max(target_wall_s, min_wall, 1.0)
+
+    # Builds sharing the pool concurrently (Little's law).
+    concurrent_builds = max(1.0, builds_per_hour * eff_wall / 3600.0)
+
+    classes = {}
+    for wc in WORKER_CLASSES:
+        cpu_s = class_cpu_s.get(wc.name, 0.0)
+        if cpu_s <= 0.0:
+            continue
+        cores_needed = cpu_s / (eff_wall * utilization)
+        executors = max(1, _ceil(cores_needed / float(wc.cpu) * concurrent_builds))
+        executors_peak = _ceil(float(executors) * (1.0 + headroom))
+        instances = {}
+        for cloud in clouds:
+            plan = _pick_instance(cloud, wc, executors, executors_peak)
+            if plan != None:
+                instances[cloud] = plan
+        classes[wc.name] = ClassPlan(
+            worker_class = wc,
+            tests = class_tests.get(wc.name, 0),
+            cpu_seconds = cpu_s,
+            executors_steady = executors,
+            executors_peak = executors_peak,
+            instances = instances,
+        )
+
+    spawn_cpu = 0.0
+    remotable_cpu = 0.0
+    cacheable_cpu = 0.0
+    for sp in spawns:
+        spawn_cpu += sp.wall_s
+        if sp.remotable:
+            remotable_cpu += sp.wall_s
+        if sp.remote_cacheable:
+            cacheable_cpu += sp.wall_s
+    if spawn_cpu <= 0.0:
+        spawn_cpu = 1.0
+
+    return SizingPlan(
+        total_cpu_seconds = total_cpu_s,
+        critical_path_s = critical_path_s,
+        min_achievable_wall_s = min_wall,
+        target_wall_s = target_wall_s,
+        target_achievable = achievable,
+        concurrent_builds = concurrent_builds,
+        pct_compute_remotable = 100.0 * remotable_cpu / spawn_cpu,
+        pct_compute_cacheable = 100.0 * cacheable_cpu / spawn_cpu,
+        classes = classes,
+    )
+
+# ---------------------------------------------------------------- render
+
+def _fmt0(x: float) -> str:
+    """Format a float with no decimals (Starlark format lacks {:.0f})."""
+    return str(int(x + 0.5))
+
+def _fmt2(x: float) -> str:
+    """Format a float with two decimals."""
+    whole = int(x)
+    cents = int((x - float(whole)) * 100.0 + 0.5)
+    if cents >= 100:
+        whole += 1
+        cents -= 100
+    return "{}.{}{}".format(whole, cents // 10, cents % 10)
+
+# SGR code per severity: blocker red, non_hermetic magenta,
+# efficiency yellow, advisory cyan (informational, not a defect).
+_SEV_SGR = {"blocker": "31", "non_hermetic": "35", "efficiency": "33", "advisory": "36"}
+
+def _styled(s: str, sgr: str, ansi: bool) -> str:
+    """Wrap `s` in an SGR escape when ansi is on; identity otherwise."""
+    return "\x1b[{}m{}\x1b[0m".format(sgr, s) if ansi else s
+
+def _score_sgr(score: int) -> str:
+    """Green ≥90, yellow ≥70, red below — all bold."""
+    if score >= 90:
+        return "1;32"
+    if score >= 70:
+        return "1;33"
+    return "1;31"
+
+def render_disclaimer(ansi: bool = False) -> str:
+    """Experimental-status footer for every rbe report. The sizing factors
+    (memory heuristics, remote overhead, utilization) are documented as
+    uncalibrated in docs/rbe-advisor-design.md §8 — say so where users
+    actually read: the report itself."""
+    return _styled(
+        "Note: `aspect rbe` is experimental. Findings and estimates come from\n" +
+        "heuristics and instrumented local runs — useful for scoping an RBE\n" +
+        "migration, not a guarantee. Treat the capacity plan as a starting\n" +
+        "point and validate against real RBE telemetry before provisioning.",
+        "2",
+        ansi,
+    )
+
+# Cap the per-group subject list; one root cause doesn't need 50 rows.
+_GROUP_ITEM_CAP = 15
+
+def _rel_location(loc: str, workspace_root: str) -> str:
+    """Workspace-relative form of a location for compact display."""
+    if workspace_root and loc.startswith(workspace_root + "/"):
+        return loc[len(workspace_root) + 1:]
+    return loc
+
+def render_check_report(violations: list, score: int, ansi: bool = False, workspace_root: str = "") -> str:
+    """Violations grouped by (severity, check, fix): the shared
+    explanation and fix print once per group, subjects as a compact
+    list. Keeps a 16-target tag epidemic to one screenful instead of
+    sixteen near-identical stanzas."""
+    lines = ["{} {}".format(
+        _styled("## Hermeticity readiness:", "1", ansi),
+        _styled("{}/100".format(score), _score_sgr(score), ansi),
+    ), ""]
+    if not violations:
+        lines.append(_styled("No violations found.", "32", ansi))
+        return "\n".join(lines)
+    counts = {}
+    for v in violations:
+        counts[v.severity.value] = counts.get(v.severity.value, 0) + 1
+    summary = []
+    for sev in ("blocker", "non_hermetic", "efficiency", "advisory"):
+        if counts.get(sev, 0) > 0:
+            summary.append(_styled("{}: {}".format(sev, counts[sev]), _SEV_SGR[sev], ansi))
+    lines.append("  ".join(summary))
+
+    # Group while preserving the severity-then-cost sort of the input.
+    groups = {}
+    order = []
+    for v in violations:
+        k = (v.severity.value, v.check, v.fix)
+        if k not in groups:
+            groups[k] = []
+            order.append(k)
+        groups[k].append(v)
+
+    for k in order:
+        sev, check, fix = k
+        vs = groups[k]
+        details = {}
+        cpu = 0.0
+        for v in vs:
+            details[v.detail] = True
+            cpu += v.cpu_seconds
+        uniform = len(details) == 1
+        meta = "{} finding{}".format(len(vs), "" if len(vs) == 1 else "s")
+        if cpu > 0.0:
+            meta += ", {} cpu-s".format(_fmt0(cpu))
+        lines.append("")
+        lines.append("{} {}{}  {}".format(
+            _styled("[{}]".format(sev), _SEV_SGR[sev], ansi),
+            _styled(check, "1", ansi),
+            " — " + vs[0].detail if uniform else "",
+            _styled("({})".format(meta), "2", ansi),
+        ))
+        if fix:
+            lines.append("  {} {}".format(_styled("fix:", "1;32", ansi), fix))
+        for v in vs[:_GROUP_ITEM_CAP]:
+            item = "    " + _styled(v.subject, "1", ansi)
+            if not uniform:
+                item += " — " + v.detail
+            loc = _rel_location(v.location, workspace_root)
+            if loc and loc != v.subject:
+                item += _styled("  ({})".format(loc), "2", ansi)
+            if v.cpu_seconds > 0.0:
+                item += "  [{} cpu-s]".format(_fmt0(v.cpu_seconds))
+            lines.append(item)
+        if len(vs) > _GROUP_ITEM_CAP:
+            lines.append(_styled("    … and {} more".format(len(vs) - _GROUP_ITEM_CAP), "2", ansi))
+    return "\n".join(lines)
+
+def render_sizing_report(plan: SizingPlan, ansi: bool = False) -> str:
+    lines = [
+        _styled("## Capacity plan", "1", ansi),
+        "",
+        "Total test compute: {} cpu-s  ·  critical path: {}s  ·  min achievable wall: {}s".format(
+            _fmt0(plan.total_cpu_seconds),
+            _fmt0(plan.critical_path_s),
+            _fmt0(plan.min_achievable_wall_s),
+        ),
+        "Target wall time: {}s{}".format(
+            _fmt0(plan.target_wall_s),
+            "" if plan.target_achievable else _styled("  (below critical path — raised to the minimum)", "33", ansi),
+        ),
+        "Remotable compute: {}%  ·  remote-cacheable: {}%  ·  modeled concurrent builds: {}".format(
+            _fmt2(plan.pct_compute_remotable),
+            _fmt2(plan.pct_compute_cacheable),
+            _fmt2(plan.concurrent_builds),
+        ),
+        "",
+    ]
+    for name, cp in plan.classes.items():
+        lines.append("{} ({}c/{}G): {} tests, {} cpu-s, executors {}→{}".format(
+            _styled(name, "1;36", ansi),
+            cp.worker_class.cpu,
+            cp.worker_class.mem_gb,
+            cp.tests,
+            _fmt0(cp.cpu_seconds),
+            cp.executors_steady,
+            cp.executors_peak,
+        ))
+        for cloud, ip in cp.instances.items():
+            lines.append("    {}: {}–{}x {} ({} executors/instance)".format(
+                _styled(cloud, "36", ansi),
+                ip.count_min,
+                ip.count_max,
+                _styled(ip.instance_type, "1", ansi),
+                ip.executors_per_instance,
+            ))
+    return "\n".join(lines)

--- a/crates/aspect-cli/src/builtins/aspect/rbe.axl
+++ b/crates/aspect-cli/src/builtins/aspect/rbe.axl
@@ -1,0 +1,341 @@
+"""
+`aspect rbe` task group: analyze a Bazel workspace for RBE readiness.
+
+Two tasks:
+
+- `aspect rbe check [targets...]` — static hermeticity checks only (target
+  tags/attrs from `bazel query`, plus .bazelrc red flags). Fast; no build.
+- `aspect rbe analyze [targets...]` — runs an instrumented local
+  `bazel test` (execution log + BES), then reports dynamic hermeticity
+  violations and a worker-pool capacity plan (cores / memory / EC2-GCE
+  instance counts) for running the tests under RBE.
+
+All analysis logic lives in lib/rbe_advisor.axl; this file is the thin
+task layer: Bazel I/O in, typed records through, rendered report out.
+
+v0 scope notes:
+- Reports print to stdout. Status-surface integration (TaskLifecycleTrait,
+  a `rbe_results` renderer kind) is deliberately deferred — see the
+  "How to add a new task kind" section of DEVELOPMENT.md when promoting.
+- Memory demand is heuristic (Bazel size class x safety factor); the
+  remote-overhead and utilization factors need calibration against real
+  RBE telemetry. Treat the capacity plan as a starting point, not a quote.
+"""
+
+load("./lib/bazel_results.axl", "init_data", "process_event")
+load("./lib/environment.axl", "color_enabled")
+load("./lib/rbe_advisor.axl", "SpawnFact", "TargetInfo", "aggregate_test_wall", "attach_costs", "check_dynamic", "check_static", "readiness_score", "render_check_report", "render_disclaimer", "render_sizing_report", "size_pool", "sort_violations")
+
+_RC_FILES = [".bazelrc", "tools/bazel.rc", "user.bazelrc"]
+
+def _query_expr(patterns: list) -> str:
+    return "tests({})".format(" + ".join(patterns))
+
+def _attr_value(rule, name: str):
+    """Pull a named attribute's value off a blaze_query.Rule, tolerating
+    shape differences across Bazel versions."""
+    if not hasattr(rule, "attribute"):
+        return None
+    for attr in rule.attribute:
+        if attr.name != name:
+            continue
+        if hasattr(attr, "string_list_value") and attr.string_list_value:
+            return list(attr.string_list_value)
+        if hasattr(attr, "string_value") and attr.string_value:
+            return attr.string_value
+        if hasattr(attr, "boolean_value"):
+            return attr.boolean_value
+        return None
+    return None
+
+def _workspace_dir(ctx: TaskContext) -> str | None:
+    """--workspace arg, or None to run Bazel in the current directory."""
+    ws = ctx.args.workspace
+    if not ws:
+        return None
+    if not ctx.std.fs.exists(ws):
+        fail("--workspace {} does not exist".format(ws))
+    return ws
+
+def _collect_targets(ctx: TaskContext, patterns: list, workspace: str | None) -> dict:
+    """label -> TargetInfo for every test target under the patterns."""
+    out = {}
+    for rule in ctx.bazel.query(current_dir = workspace).raw(_query_expr(patterns)).eval():
+        if not hasattr(rule, "rule_class"):
+            continue  # source/generated files in the result set
+        tags = _attr_value(rule, "tags") or []
+        location = rule.location if hasattr(rule, "location") else None
+        out[rule.name] = TargetInfo(
+            label = rule.name,
+            rule_class = rule.rule_class,
+            size = _attr_value(rule, "size") or "medium",
+            tags = tags if type(tags) == "list" else [],
+            local_attr = _attr_value(rule, "local") == True,
+            flaky = _attr_value(rule, "flaky") == True,
+            location = location or "",
+        )
+    return out
+
+def _read_rc_lines(ctx: TaskContext, workspace_root: str) -> list:
+    """(source, lineno, line) for every non-comment .bazelrc line."""
+    out = []
+    for name in _RC_FILES:
+        path = workspace_root + "/" + name if workspace_root else name
+        if not ctx.std.fs.exists(path):
+            continue
+        lineno = 0
+        for line in ctx.std.fs.read_to_string(path).splitlines():
+            lineno += 1
+            stripped = line.split("#")[0]
+            if stripped.strip():
+                out.append((name, lineno, stripped))
+    return out
+
+def _duration_s(d) -> float:
+    """google.protobuf.Duration -> seconds; 0.0 when absent."""
+    if d == None:
+        return 0.0
+    secs = float(d.seconds) if hasattr(d, "seconds") else 0.0
+    nanos = float(d.nanos) if hasattr(d, "nanos") else 0.0
+    return secs + nanos / 1000000000.0
+
+def _spawn_fact(spawn) -> SpawnFact:
+    """Map a compact execution-log Spawn entry to a SpawnFact, tolerating
+    fields that are absent on older Bazel versions."""
+    wall = 0.0
+    if hasattr(spawn, "metrics") and spawn.metrics != None:
+        m = spawn.metrics
+        wall = _duration_s(m.total_time if hasattr(m, "total_time") else None)
+    env = {}
+    if hasattr(spawn, "env_vars"):
+        for ev in spawn.env_vars:
+            env[ev.name] = ev.value
+    return SpawnFact(
+        args = list(spawn.args) if hasattr(spawn, "args") else [],
+        env = env,
+        label = spawn.target_label,
+        mnemonic = spawn.mnemonic,
+        runner = spawn.runner if hasattr(spawn, "runner") else "",
+        cacheable = spawn.cacheable if hasattr(spawn, "cacheable") else True,
+        remote_cacheable = spawn.remote_cacheable if hasattr(spawn, "remote_cacheable") else True,
+        remotable = spawn.remotable if hasattr(spawn, "remotable") else True,
+        cache_hit = spawn.cache_hit if hasattr(spawn, "cache_hit") else False,
+        wall_s = wall,
+    )
+
+# ---------------------------------------------------------------- check
+
+def _write_report(ctx: TaskContext, path: str, text: str):
+    """Write the ANSI-free report to `path` and announce it."""
+    ctx.std.fs.write(path, text + "\n")
+    print("")
+    print("Report written to " + path)
+
+def _check_impl(ctx: TaskContext) -> int:
+    workspace = _workspace_dir(ctx)
+    ws_root = ctx.bazel.info(current_dir = workspace).get("workspace", "")
+    targets = _collect_targets(ctx, ctx.args.targets, workspace)
+    violations = sort_violations(check_static(targets.values(), _read_rc_lines(ctx, ws_root)))
+    score = readiness_score(violations, 0.0)
+    ansi = color_enabled(ctx.std)
+    note = "(static checks only — run `aspect rbe analyze` for dynamic checks and capacity sizing)"
+    print(render_check_report(violations, score, ansi = ansi, workspace_root = ws_root))
+    print("")
+    print(note)
+    print("")
+    print(render_disclaimer(ansi))
+    if ctx.args.report_out:
+        _write_report(ctx, ctx.args.report_out, "\n".join([
+            render_check_report(violations, score, workspace_root = ws_root),
+            "",
+            note,
+            "",
+            render_disclaimer(),
+        ]))
+    if ctx.args.fail_on_blocker:
+        for v in violations:
+            if v.severity.value == "blocker":
+                return 1
+    return 0
+
+check = task(
+    group = ["rbe"],
+    implementation = _check_impl,
+    args = {
+        "targets": args.positional(
+            minimum = 0,
+            maximum = 512,
+            default = ["//..."],
+            description = "Bazel target patterns whose tests are analyzed. Defaults to //...",
+        ),
+        "fail_on_blocker": args.boolean(
+            default = False,
+            description = "Exit non-zero when any blocker-severity violation is found (for CI gating).",
+        ),
+        "workspace": args.string(
+            default = "",
+            description = "Path to the Bazel workspace to analyze. Defaults to the current directory.",
+        ),
+        "report_out": args.string(
+            default = "",
+            description = "Also write the report (plain text, no color) to this file.",
+        ),
+    },
+)
+
+# ---------------------------------------------------------------- analyze
+
+def _analyze_impl(ctx: TaskContext) -> int:
+    patterns = ctx.args.targets
+    workspace = _workspace_dir(ctx)
+    ws_root = ctx.bazel.info(current_dir = workspace).get("workspace", "")
+    targets = _collect_targets(ctx, patterns, workspace)
+    rc_lines = _read_rc_lines(ctx, ws_root)
+
+    flags = ["--nocache_test_results", "--keep_going"]
+    for f in ctx.args.bazel_flags:
+        flags.append(f)
+
+    # BES iterator handle must exist before the spawn so the early event
+    # burst is buffered (see DEVELOPMENT.md "BES streaming").
+    events = bazel.build_events.iterator()
+    build = ctx.bazel.test(
+        flags = flags,
+        build_events = [events],
+        execution_log = True,
+        current_dir = workspace,
+        *patterns
+    )
+
+    # Drain the execution log BEFORE wait() — the stream is consumed as
+    # part of wait() (see build_methods docs).
+    spawns = []
+    for entry in build.execution_logs():
+        sp = entry.type  # oneof payload: invocation | file | spawn | ...
+        if type(sp) != "spawn" or not sp.target_label:
+            continue
+        spawns.append(_spawn_fact(sp))
+
+    data = init_data()
+    for event in events:
+        process_event(data, event)
+    status = build.wait()
+    if not status.success:
+        print("warning: bazel test exited with code {} — analysis covers the targets that ran".format(status.code))
+
+    # Per-test wall time: summed exec-log spawn metrics (covers every
+    # shard/attempt), BES durations as fallback — see aggregate_test_wall.
+    wall_by_label = aggregate_test_wall(spawns, data["bazel"]["test_details"])
+
+    violations = check_static(targets.values(), rc_lines) + check_dynamic(spawns, targets)
+    violations = sort_violations(attach_costs(violations, wall_by_label))
+
+    total_cpu_s = 0.0
+    for wall in wall_by_label.values():
+        total_cpu_s += wall
+    score = readiness_score(violations, total_cpu_s)
+
+    plan = size_pool(
+        targets_by_label = targets,
+        wall_by_label = wall_by_label,
+        spawns = spawns,
+        critical_path_s = float(data["bazel"]["critical_path_ms"]) / 1000.0,
+        target_wall_s = float(ctx.args.target_wall_time),
+        utilization = float(ctx.args.utilization_pct) / 100.0,
+        headroom = float(ctx.args.headroom_pct) / 100.0,
+        builds_per_hour = float(ctx.args.builds_per_hour),
+        clouds = ["aws", "gcp"] if ctx.args.cloud == "both" else [ctx.args.cloud],
+    )
+
+    ansi = color_enabled(ctx.std)
+    title = "# RBE readiness report"
+    experimental = "(experimental)"
+    if ansi:
+        title = "\x1b[1m{}\x1b[0m \x1b[2m{}\x1b[0m".format(title, experimental)
+    else:
+        title = "{} {}".format(title, experimental)
+    print(title)
+    print("")
+    print(render_check_report(violations, score, ansi = ansi, workspace_root = ws_root))
+    print("")
+    print(render_sizing_report(plan, ansi = ansi))
+    print("")
+    print(render_disclaimer(ansi))
+    if ctx.args.report_out:
+        _write_report(ctx, ctx.args.report_out, "\n".join([
+            "# RBE readiness report (experimental)",
+            "",
+            render_check_report(violations, score, workspace_root = ws_root),
+            "",
+            render_sizing_report(plan),
+            "",
+            render_disclaimer(),
+        ]))
+    if ctx.args.json_out:
+        report = {
+            "experimental": True,
+            "score": score,
+            "violations": [{
+                "severity": v.severity.value,
+                "subject": v.subject,
+                "check": v.check,
+                "detail": v.detail,
+                "cpu_seconds": v.cpu_seconds,
+                "location": v.location,
+                "fix": v.fix,
+            } for v in violations],
+            "sizing": json.decode(json.encode(plan)),
+        }
+        ctx.std.fs.write(ctx.args.json_out, json.encode(report))
+        print("")
+        print("JSON report written to " + ctx.args.json_out)
+    return 0
+
+analyze = task(
+    group = ["rbe"],
+    implementation = _analyze_impl,
+    args = {
+        "targets": args.positional(
+            minimum = 0,
+            maximum = 512,
+            default = ["//..."],
+            description = "Bazel target patterns whose tests are analyzed. Defaults to //...",
+        ),
+        "target_wall_time": args.int(
+            default = 0,
+            description = "Desired test wall-time under RBE, in seconds. 0 (default) auto-selects 2x the critical-path floor.",
+        ),
+        "builds_per_hour": args.int(
+            default = 1,
+            description = "Expected CI build arrival rate sharing the worker pool; scales executor counts for shared pools.",
+        ),
+        "utilization_pct": args.int(
+            default = 80,
+            description = "Assumed executor utilization efficiency (scheduling gaps, I/O stalls), as a percentage.",
+        ),
+        "headroom_pct": args.int(
+            default = 20,
+            description = "Peak headroom added on top of steady-state executor counts, as a percentage.",
+        ),
+        "cloud": args.string(
+            default = "both",
+            description = "Instance catalog to map worker classes onto: aws, gcp, or both.",
+        ),
+        "bazel_flags": args.string_list(
+            long = "bazel-flag",
+            description = "Additional Bazel flags forwarded to the instrumented test run. Repeat to pass multiple.",
+        ),
+        "json_out": args.string(
+            default = "",
+            description = "Also write the full report as JSON to this path.",
+        ),
+        "workspace": args.string(
+            default = "",
+            description = "Path to the Bazel workspace to analyze. Defaults to the current directory.",
+        ),
+        "report_out": args.string(
+            default = "",
+            description = "Also write the report (plain text, no color) to this file.",
+        ),
+    },
+)

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -759,7 +759,7 @@ impl Build {
         announce: AnnounceSpawn,
         rt: AsyncRuntime,
     ) -> Result<Build, std::io::Error> {
-        let (pid, version) = super::info::server_info()?;
+        let (pid, version) = super::info::server_info(current_dir.as_deref())?;
 
         let span = tracing::info_span!(
             "ctx.bazel.build",

--- a/crates/axl-runtime/src/engine/bazel/info.rs
+++ b/crates/axl-runtime/src/engine/bazel/info.rs
@@ -21,16 +21,21 @@ fn parse_release(value: &str) -> Option<semver::Version> {
 /// Query bazel server info (server_pid, release version).
 ///
 /// The version is `None` when Bazel reports a non-release build (see
-/// [`parse_release`]); the pid is always required.
-pub fn server_info() -> io::Result<(u32, Option<semver::Version>)> {
-    server_info_with_startup_flags(&[])
+/// [`parse_release`]); the pid is always required. `workdir` is the
+/// workspace to run `bazel info` in (default: process working directory).
+pub fn server_info(workdir: Option<&str>) -> io::Result<(u32, Option<semver::Version>)> {
+    server_info_with_startup_flags(&[], workdir)
 }
 
 /// Query bazel server info with startup flags prepended before the subcommand.
 pub fn server_info_with_startup_flags(
     startup_flags: &[String],
+    workdir: Option<&str>,
 ) -> io::Result<(u32, Option<semver::Version>)> {
     let mut cmd = super::bazel_command();
+    if let Some(dir) = workdir {
+        cmd.current_dir(dir);
+    }
     cmd.args(startup_flags);
     cmd.arg("info");
     cmd.arg("server_pid");

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -153,9 +153,10 @@ fn resolve_flags<'v>(
 /// (`build` / `test` / `query`) so they filter conditional flags identically.
 fn resolve_flags_for_running_bazel<'v>(
     items: &[Either<values::StringValue<'v>, (values::StringValue<'v>, values::StringValue<'v>)>],
+    workdir: Option<&str>,
 ) -> anyhow::Result<Vec<String>> {
     let version = if items.iter().any(|f| f.is_right()) {
-        info::server_info()
+        info::server_info(workdir)
             .map_err(|e| anyhow::anyhow!("failed to get Bazel server info: {}", e))?
             .1
     } else {
@@ -350,7 +351,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             Either::Left(b) => (b, vec![]),
             Either::Right(sinks) => (true, sinks.items),
         };
-        let resolved_flags = resolve_flags_for_running_bazel(&flags.items)?;
+        let current_dir = current_dir.into_option();
+        let resolved_flags = resolve_flags_for_running_bazel(&flags.items, current_dir.as_deref())?;
         let resolved_startup_flags = read_startup_flags(this)?;
         let env = Env::from_eval(eval)?;
         let (stdout, stderr) = resolve_stdio(stdio, stdout, stderr)?;
@@ -364,7 +366,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             resolved_startup_flags,
             stdout,
             stderr,
-            current_dir.into_option(),
+            current_dir,
             build::AnnounceSpawn {
                 version: announce_version,
                 command: announce_command,
@@ -461,7 +463,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             Either::Left(b) => (b, vec![]),
             Either::Right(sinks) => (true, sinks.items),
         };
-        let resolved_flags = resolve_flags_for_running_bazel(&flags.items)?;
+        let current_dir = current_dir.into_option();
+        let resolved_flags = resolve_flags_for_running_bazel(&flags.items, current_dir.as_deref())?;
         let resolved_startup_flags = read_startup_flags(this)?;
         let env = Env::from_eval(eval)?;
         let (stdout, stderr) = resolve_stdio(stdio, stdout, stderr)?;
@@ -475,7 +478,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             resolved_startup_flags,
             stdout,
             stderr,
-            current_dir.into_option(),
+            current_dir,
             build::AnnounceSpawn {
                 version: announce_version,
                 command: announce_command,
@@ -506,9 +509,12 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///     .kind("source file")
     ///     .eval()
     /// ```
-    fn query<'v>(this: values::Value<'v>) -> anyhow::Result<query::Query> {
+    fn query<'v>(
+        this: values::Value<'v>,
+        #[starlark(require = named, default = NoneOr::None)] current_dir: NoneOr<String>,
+    ) -> anyhow::Result<query::Query> {
         let startup_flags = read_startup_flags(this)?;
-        Ok(query::Query::new(startup_flags))
+        Ok(query::Query::new(startup_flags, current_dir.into_option()))
     }
 
     /// Run `bazel info` and return all key/value pairs as a dict.
@@ -517,7 +523,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     /// with a non-zero code.
     ///
     /// # Arguments
-    /// * `workdir`: workspace root to run `bazel info` in (default: inferred from ctx)
+    /// * `current_dir`: workspace root to run `bazel info` in (default: process working directory)
     ///
     /// **Examples**
     ///
@@ -527,10 +533,16 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///     print(info["output_base"])
     ///     print(info["execution_root"])
     /// ```
-    fn info<'v>(this: values::Value<'v>) -> anyhow::Result<SmallMap<String, String>> {
+    fn info<'v>(
+        this: values::Value<'v>,
+        #[starlark(require = named, default = NoneOr::None)] current_dir: NoneOr<String>,
+    ) -> anyhow::Result<SmallMap<String, String>> {
         let startup_flags = read_startup_flags(this)?;
 
         let mut cmd = bazel_command();
+        if let Some(dir) = current_dir.into_option() {
+            cmd.current_dir(dir);
+        }
         cmd.args(&startup_flags);
         cmd.arg("info");
         cmd.stdout(Stdio::piped());

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -168,13 +168,16 @@ pub struct Query {
     expr: RefCell<String>,
     #[allocative(skip)]
     startup_flags: Vec<String>,
+    #[allocative(skip)]
+    workdir: Option<String>,
 }
 
 impl Query {
-    pub fn new(startup_flags: Vec<String>) -> Self {
+    pub fn new(startup_flags: Vec<String>, workdir: Option<String>) -> Self {
         Self {
             expr: RefCell::new(String::new()),
             startup_flags,
+            workdir,
         }
     }
 
@@ -183,8 +186,12 @@ impl Query {
         startup_flags: &[String],
         flags: &[String],
         announce: super::build::AnnounceSpawn,
+        workdir: Option<&str>,
     ) -> anyhow::Result<TargetSet> {
         let mut cmd = super::bazel_command();
+        if let Some(dir) = workdir {
+            cmd.current_dir(dir);
+        }
         cmd.args(startup_flags);
         cmd.arg("query");
         cmd.arg(expr);
@@ -209,7 +216,7 @@ impl Query {
         // extra `bazel info`, so only pay for it when actually announcing.
         if announce.version || announce.command {
             let version = if announce.version {
-                super::info::server_info_with_startup_flags(startup_flags)
+                super::info::server_info_with_startup_flags(startup_flags, workdir)
                     .ok()
                     .and_then(|(_pid, version)| version)
             } else {
@@ -299,6 +306,7 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
         Ok(Query {
             expr: RefCell::new(expr.as_str().to_string()),
             startup_flags: query.startup_flags.clone(),
+            workdir: query.workdir.clone(),
         })
     }
 
@@ -360,12 +368,18 @@ pub(crate) fn query_methods(registry: &mut MethodsBuilder) {
     ) -> anyhow::Result<TargetSet> {
         let this = this.downcast_ref_err::<Query>().into_anyhow_result()?;
         let expr = this.expr.borrow();
-        let flags = super::resolve_flags_for_running_bazel(&flags.items)?;
+        let flags = super::resolve_flags_for_running_bazel(&flags.items, this.workdir.as_deref())?;
         let announce = super::build::AnnounceSpawn {
             version: announce_version,
             command: announce_command,
         };
-        Query::query(&expr, &this.startup_flags, &flags, announce)
+        Query::query(
+            &expr,
+            &this.startup_flags,
+            &flags,
+            announce,
+            this.workdir.as_deref(),
+        )
     }
 }
 

--- a/docs/rbe-advisor-design.md
+++ b/docs/rbe-advisor-design.md
@@ -1,0 +1,85 @@
+# RBE Advisor — Design Doc
+
+**Status:** Draft for team discussion
+**Author:** Jeff Pignataro (drafted with Claude)
+**Date:** 2026-06-12
+
+## 1. Problem
+
+Teams evaluating remote build execution (RBE) for a Bazel repository face two questions that today require expensive manual discovery: *will my build actually work remotely* (hermeticity), and *what infrastructure do I need to run it well* (capacity). We want a tool an engineer can run against a local checkout that produces a hermeticity readiness report and a capacity plan — estimated cores, memory, and instance counts (EC2/GCE) to run the repo's tests on RBE efficiently and reliably.
+
+## 2. Goals and non-goals
+
+The tool must run with no RBE backend present: everything is derived from static analysis of the workspace plus instrumented local builds. It must be backend-agnostic — output is a generic REAPI worker-pool spec (worker classes × counts) mapped to concrete AWS and GCP instance types. It should be cheap to run (one full local test run, or zero builds in static-only mode) and produce both a human report and machine-readable JSON.
+
+Non-goals for v1: scoring build *correctness* beyond hermeticity (e.g., flakiness root-causing), cost optimization across spot/reserved pricing, and live integration with a running RBE cluster. CI-telemetry ingestion (BEP/exec logs from Buildkite artifacts) is a v2 extension, not v1.
+
+## 3. Data sources
+
+| Source | How obtained | What it gives us |
+|---|---|---|
+| `bazel query --output=xml` | static | Test targets, `size`, `timeout`, `tags`, `flaky`, rule classes, `local=True` attrs |
+| `bazel cquery`/`aquery` | static (analysis phase) | Action mnemonics, input/output counts → cache traffic estimate |
+| `.bazelrc` chain + `MODULE.bazel`/`WORKSPACE` | static | Strategy flags, env leakage, unpinned repos, toolchain hermeticity |
+| Execution log (`--execution_log_json_file` or compact) | one instrumented run | Per-spawn: runner, cacheability, remote-cacheable bit, wall time, input/output digests and sizes, env |
+| JSON profile (`--profile`) | same run | Action timeline → total CPU-seconds, concurrency curve, critical path |
+| `test.xml` / BEP | same run | Per-test (and per-shard) durations |
+| Second instrumented run (optional) | determinism check | Output digest diffs → non-determinism detection |
+
+The collector writes all of this into a **bundle**: a directory with the raw artifacts plus a normalized SQLite database (`bundle.db`). All analysis runs offline against the bundle, so an engineer can collect on their machine and share the bundle for analysis, and we can build future analyzers without re-running builds.
+
+## 4. Hermeticity analysis
+
+Two layers: static checks that run in seconds without building, and dynamic checks derived from the instrumented run(s).
+
+**Static checks.** Tag-based: `local`, `no-sandbox`, `no-cache`, `no-remote`, `no-remote-exec`, `requires-network`, `exclusive` — each marks a target that will degrade or break under RBE. Attribute-based: `local = True` on genrules/tests. Configuration: `--spawn_strategy=local|standalone`, broad `--action_env`/`--test_env` passthrough, absence of `--incompatible_strict_action_env`, sandboxing disabled, `--workspace_status_command` producing volatile keys consumed by non-stamp actions. Dependency hygiene: `http_archive`/`git_repository` without integrity pins, repository rules invoking system binaries, autodetected (non-hermetic) C++/JVM toolchains.
+
+**Dynamic checks.** From the exec log: spawns that actually ran with the `local` runner despite no tag (strategy fallbacks), spawns marked not-remote-cacheable, absolute paths appearing in command lines or env vars, env vars referencing `$HOME`/user paths, and input files outside the workspace/external roots. With a second clean run: actions whose output digests differ between runs → non-deterministic (timestamps, archive ordering, embedded paths) — these poison the remote cache and must be fixed or tagged.
+
+**Output.** A readiness score (weighted by how many CPU-seconds of the build the violating targets represent, not just target count — one `local` test that's 40% of test wall time matters more than fifty trivial ones), and a severity-ranked violation table: *blocker* (will fail or must run locally), *non-hermetic* (machine-varying inputs leak into actions or caches), *efficiency* (uncacheable/unshardable), *advisory* (deliberate opt-outs like `no-remote`/`no-remote-exec` — surfaced for visibility but excluded from the score, since a declared local-only target is a choice, not a hermeticity defect), each with the concrete remediation (tag to remove, flag to set, toolchain to pin). Remediations acknowledge legitimate trade-offs: for a large non-deterministic output (archive, container image), `no-remote-cache` can be the *right* configuration — rebuilding each run is often faster and cheaper than the I/O and network cost of pushing/pulling the blob through the cache.
+
+## 5. Sizing model
+
+**Per-test resource demand.** CPU: 1 core unless a `cpu:N` tag or `resources:` tag overrides. Memory: measured where available, else Bazel size-class heuristics (small 20 MB, medium 100 MB, large 300 MB, enormous 800 MB) inflated by a safety factor, with measured wall time from the exec log / test.xml replacing the timeout class. Sharded tests are modeled per-shard.
+
+**Throughput model.** From the profile we get total compute `C` (CPU-seconds across all test/action spawns) and the critical path `T_cp`. Wall time on a pool of `W` executor slots is approximately `T(W) = max(T_cp, C / (W × u))` where `u` is utilization efficiency (default 0.8, accounting for scheduling gaps and I/O stalls). Given a target wall time `T*` (user flag, default: 2× critical path), required slots are `W = ⌈C / (T* × u)⌉`. The tool also reports the concurrency curve from the profile so users see the marginal value of more slots, and warns when `T*` < `T_cp` (unachievable without breaking the critical path — usually one long `enormous` test, which we name).
+
+**Worker classes and packing.** Tests are binned into worker classes by their (cpu, mem) demand — default classes: standard (1 cpu / 4 GB), medium (2 cpu / 8 GB), large (4 cpu / 16 GB), with class boundaries derived from the actual demand distribution rather than fixed. Per class we compute peak concurrent demand (p95 of the class's concurrency timeline, plus configurable headroom, default 20%). Executors pack onto instances as `min(⌊vCPU/class_cpu⌋, ⌊RAM/class_mem⌋)` per instance, leaving 1 vCPU / 2 GB for the worker agent and OS. Instance counts come from `⌈slots_needed / slots_per_instance⌉`.
+
+**Cloud mapping.** A static table of sensible defaults — AWS: c7a/m7a families (compute- vs memory-leaning classes); GCP: c2d/n2d equivalents — chosen per class by best slots-per-dollar fit at on-demand pricing ratios (cpu:mem ratio matching, not live pricing in v1). Output includes a min (steady-state) and max (peak, for autoscaling) instance count per class, scaled by a `--builds-per-hour` concurrency multiplier for shared CI pools.
+
+**Efficacy estimate.** From cacheability bits and action input volatility we report: % of compute that is remotely executable, % cacheable, and a projected wall-time range for a warm-cache incremental run vs. cold full run — this is the "is RBE worth it here" number.
+
+## 6. CLI
+
+```
+rbe-advisor collect [--targets //...] [--runs 2] [-o bundle/]   # instrumented local run(s) → bundle
+rbe-advisor check   [--bundle bundle/ | --workspace .]          # hermeticity report (static-only without bundle)
+rbe-advisor size    --bundle bundle/ [--target-wall-time 10m]
+                    [--cloud aws|gcp|both] [--headroom 0.2]
+                    [--builds-per-hour N] [--utilization 0.8]
+rbe-advisor report  --bundle bundle/ [--format md|json]          # full combined report
+```
+
+`collect` is the only command that touches Bazel; everything else is offline on the bundle, which keeps the analysis testable and lets us ingest CI-produced logs later by writing an alternate collector.
+
+## 7. Architecture
+
+```
+collectors/            analyzers/              renderers/
+  bazel_local.py  ─┐     hermeticity.py  ─┐      markdown.py
+  (v2: ci_bep.py) ─┤──►  sizing.py       ─┤──►   json.py
+                   │     efficacy.py     ─┘
+                   ▼
+              bundle/ (raw artifacts + SQLite)
+```
+
+The normalized SQLite schema (tables: `targets`, `spawns`, `profile_spans`, `violations`) is the contract between collection and analysis. New checks are rows-in/rows-out queries, which keeps them independently testable.
+
+## 8. Risks and open questions
+
+Memory measurement is the weakest input: Bazel doesn't report per-spawn peak RSS in the exec log on all platforms, so v1 leans on size-class heuristics with a safety factor; we should validate against real RBE telemetry from a few known deployments and tune the inflation factor. Local timing ≠ remote timing: remote executors differ in single-core perf and add I/O for input fetching; we apply a configurable remote-overhead factor (default 1.15) and should calibrate it the same way. Finally, the concurrency multiplier for shared pools assumes Poisson-ish CI arrivals; bursty merge-train traffic may need a peak-window model in v2.
+
+## 9. Phasing
+
+v0 (prototype, this session): static hermeticity checks, exec-log/profile ingestion, sizing math, EC2/GCE mapping, markdown+JSON report. v1: SQLite bundle, dynamic determinism check (two-run digest diff), per-shard modeling, validated heuristic factors. v2: CI telemetry collectors (Buildkite artifacts/BEP), historical trending, live pricing.


### PR DESCRIPTION
New built-in `aspect rbe` task group ([ENG-1693](https://linear.app/aspect-build/issue/ENG-1693)) that evaluates a Bazel workspace for remote-execution readiness with no RBE backend required. Design rationale in `docs/rbe-advisor-design.md`.

- **`aspect rbe check`** — static hermeticity checks over target tags/attrs (from `bazel query`) and `.bazelrc` red flags. Fast, no build. `--fail-on-blocker` for CI gating.
- **`aspect rbe analyze`** — runs an instrumented local `bazel test` (compact execution log + BES), then reports dynamic hermeticity violations plus a worker-pool capacity plan: executor counts from the measured compute/critical-path, packed onto EC2/GCE instance shapes.

Notable behaviors:

- Checks detect **root causes, not just declarations**: host-only paths in spawn args/env (`/Users/…`, `/usr/local/…`), un-pinned system tools as the spawn executable (autodetected-toolchain leak), and missing `--incompatible_strict_action_env` all fire from the exec log regardless of tags — removing a `local` tag without fixing the cause does not silence them. Bazel's standardized action `PATH` is allowlisted to avoid a false positive.
- Severity model `blocker` / `non_hermetic` / `efficiency` / `advisory`: declared opt-outs (`no-remote`, `no-remote-exec`, and their expected not-remotable spawns) are surfaced as advisory but never scored — a declared local-only target is a choice, not a hermeticity defect.
- Every violation carries its BUILD-file location (`bazel query` rule location) and a concrete fix suggestion; the report groups by (severity, check, fix) so a 16-target tag epidemic renders as one stanza, not sixteen.
- `--workspace` runs the analysis against any repo from anywhere; `--report-out` writes a plain-text copy and `--json-out` (analyze) a machine-readable one. ANSI color on TTY/recognized CI, gated by `color_enabled`.
- The report header and footer mark the tool **experimental**: the sizing factors (memory heuristics, remote overhead, utilization) are documented as uncalibrated.

Runtime changes (`axl-runtime`): `current_dir` support on `ctx.bazel.query()` and `ctx.bazel.info()`, and a `workdir` parameter threaded through `server_info` / `resolve_flags_for_running_bazel`, so every Bazel invocation a task makes can target another workspace.

All analysis logic is pure AXL in `lib/rbe_advisor.axl` (no Bazel/filesystem access), unit-tested from `.aspect/axl.axl`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (builtins `README.md`; full design doc added at `docs/rbe-advisor-design.md`)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Added experimental `aspect rbe check` and `aspect rbe analyze` tasks that score a workspace's remote-build-execution readiness (hermeticity violations with locations and suggested fixes) and estimate the worker-pool capacity (executors, EC2/GCE instances) needed to run its tests under RBE.
- `ctx.bazel.query()` and `ctx.bazel.info()` now accept a `current_dir` argument to run against a workspace other than the current directory.

### Test plan

- `aspect tests axl` → 816 tests pass, including 45 new `rbe:` cases covering demand heuristics, static/dynamic checks, advisory scoring, sizing math (executor/instance packing), and the grouped/colored renderer.
- `cargo test -p axl-runtime` passes (covers the `current_dir` plumbing).
- Manual end-to-end, run from outside the repo:
  - `aspect-cli rbe check --workspace <repo> --report-out rbe.txt -- //examples/test_states/...` — grouped report with locations/fixes; file output has zero ANSI codes.
  - `aspect-cli rbe analyze --workspace <repo> -- //examples/test_states/...` — instrumented test run, readiness report + capacity plan.
  - Verified BUILD-file locations and the system-dep checks against a synthetic workspace with `requires-network` / `no-sandbox` / `no-remote-exec` targets and an unpinned `--action_env=PATH`.
