### PR TITLE
Don't spin forever waiting for warming when the marker path is unset

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
@@ -449,6 +449,13 @@ def is_warming_complete(std) -> bool:
     path = std.env.var("ASPECT_WORKFLOWS_RUNNER_WARMING_COMPLETE_MARKER_FILE")
     return bool(path) and std.fs.exists(path)
 
+def is_warming_observable(std) -> bool:
+    """True when the runner agent published the warming completion marker
+    path, i.e. `is_warming_complete` can ever return True. Guards waits on
+    warming completion against spinning forever on a runner that enables
+    warming without publishing the marker path."""
+    return bool(std.env.var("ASPECT_WORKFLOWS_RUNNER_WARMING_COMPLETE_MARKER_FILE"))
+
 def parse_git_url_name(url: str) -> str:
     """Extract the repo name from a git URL; "" on empty input."""
     if not url:

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check.axl
@@ -19,7 +19,7 @@ canonical helpers that satisfy it.
 """
 
 load("@std//time.axl", "time")
-load("./environment.axl", "AWS_LOG_GROUP", "get_workflows_environment", "is_warming_complete")
+load("./environment.axl", "AWS_LOG_GROUP", "get_workflows_environment", "is_warming_complete", "is_warming_observable", "warn")
 
 def _url_encode(s):
     """Percent-encode a string for use in URLs."""
@@ -90,6 +90,10 @@ def _wait_for_warming(std, environment):
     configured / already done). Side-effect only: re-reads the environment
     so the caller sees `warming_complete` / `warming_current_cache` set.
 
+    If the runner enables warming without publishing the completion marker
+    path, completion can never be observed — warn and skip the wait rather
+    than spin forever.
+
     Display is intentionally separate (`_display_warming`): the saved
     Runner Health output from the previous job should render *first*, then
     per-section sub-blocks (Warming, Bazel Health) underneath.
@@ -101,6 +105,11 @@ def _wait_for_warming(std, environment):
     # The bootstrap process runs concurrently. If it hits a critical error,
     # it terminates the runner — so this loop will not hang indefinitely.
     if not environment.runner.warming_complete:
+        if not is_warming_observable(std):
+            warn(std, "Warming is enabled on this runner but " +
+                      "ASPECT_WORKFLOWS_RUNNER_WARMING_COMPLETE_MARKER_FILE is " +
+                      "not set; unable to wait for warming to complete.")
+            return environment
         print("Waiting for warming to complete...")
         for _ in time.sleep_iter(1000):
             if is_warming_complete(std):

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
@@ -7,11 +7,16 @@
   - `render_local_job_history` / `rewrite_runner_health_output` — the
     Vigor-output rewrite that swaps Vigor's buggy first-10 Job History
     section for a locally-rendered last-10 section.
+  - `is_warming_observable` (from `environment.axl`) — the predicate
+    `_wait_for_warming` bails on so the warming wait can't spin forever
+    on a runner that enables warming without publishing the completion
+    marker path.
 
 Run with:
   aspect dev test-health-check-ready
 """
 
+load("./environment.axl", "is_warming_observable")
 load(
     "./health_check.axl",
     "ctx_bazel_ready_for_health_check",
@@ -218,6 +223,19 @@ def _test_rewrite_no_section_is_identity(ctx):
     _eq("no-section — identity", got, output)
     _assert("no-section — did not synthesize Job History", "Job History" not in got)
 
+def _test_warming_observable_tracks_marker_env(ctx):
+    """`is_warming_observable` follows the marker-path env var. When the
+    runner enables warming without publishing the path, `_wait_for_warming`
+    must bail (previously: an unbreakable wait loop) — so the predicate has
+    to be False on an unset/empty var and True once a path is published."""
+    env = ctx.std.env
+    prior = env.var("ASPECT_WORKFLOWS_RUNNER_WARMING_COMPLETE_MARKER_FILE") or ""
+    env.set_var("ASPECT_WORKFLOWS_RUNNER_WARMING_COMPLETE_MARKER_FILE", "")
+    _eq("marker path unset — not observable", is_warming_observable(ctx.std), False)
+    env.set_var("ASPECT_WORKFLOWS_RUNNER_WARMING_COMPLETE_MARKER_FILE", "/tmp/warming_complete")
+    _eq("marker path set — observable", is_warming_observable(ctx.std), True)
+    env.set_var("ASPECT_WORKFLOWS_RUNNER_WARMING_COMPLETE_MARKER_FILE", prior)
+
 def _test_rewrite_only_replaces_first_match(ctx):
     """A second Job History section (shouldn't happen, but the format
     doesn't forbid it) is left alone — the rewrite is deterministic and
@@ -256,7 +274,8 @@ def _test_impl(ctx):
     _test_rewrite_replaces_job_history_when_last_section(ctx)
     _test_rewrite_no_section_is_identity(ctx)
     _test_rewrite_only_replaces_first_match(ctx)
-    print("health_check_ready_test.axl: OK (14 sections)")
+    _test_warming_observable_tracks_marker_env(ctx)
+    print("health_check_ready_test.axl: OK (15 sections)")
     return 0
 
 health_check_ready_tests = task(


### PR DESCRIPTION
`_wait_for_warming` in `lib/health_check.axl` polls `is_warming_complete()`, which can never return True when `ASPECT_WORKFLOWS_RUNNER_WARMING_ENABLED` is set but `ASPECT_WORKFLOWS_RUNNER_WARMING_COMPLETE_MARKER_FILE` is not — on such a misconfigured runner the setup-phase health check spins forever. (Found while re-implementing the warming wait in aspect-build/setup-aspect#4, which guards against this case; this brings the CLI in line.)

The fix adds `is_warming_observable(std)` to `environment.axl` (true when the runner agent published the marker path) and has `_wait_for_warming` emit a `WARNING:` and skip the wait when completion can never be observed, instead of entering the poll loop.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- The setup-phase warming wait on Aspect Workflows runners now warns and continues, rather than hanging indefinitely, when the runner enables warming without publishing the completion marker file path.

### Test plan

- New test cases added: `is_warming_observable` (the predicate the wait loop bails on) is covered in `health_check_ready_test.axl`; all 15 sections pass via `aspect dev test-health-check-ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
