### PR TITLE
fix(circleci): pin x-amz-content-sha256 and suppress Expect on the S3 PUT

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -239,6 +239,19 @@ def s3_sigv4_put_args(region, aws_creds, path, headers = None):
     optional `{k: v}` of extra request headers folded into the signed set
     (artifact tags, the test-result `Content-Type`). Public so
     `circleci_test.axl` can load it.
+
+    Two headers are pinned rather than left to curl:
+
+      - `x-amz-content-sha256: UNSIGNED-PAYLOAD` — curl's `--aws-sigv4` adds
+        this itself for small bodies, but on some versions (e.g. 7.88) drops
+        it once the body is large enough to trigger `Expect: 100-continue`,
+        so S3 rejects the larger uploads with `400 InvalidRequest: Missing
+        required header ... x-amz-content-sha256`. We always send it; the
+        value matches what `--aws-sigv4` signs, so it's a no-op where curl
+        would have added it.
+      - `Expect:` (empty) — drops curl's automatic `Expect: 100-continue` on
+        larger bodies, which is both the trigger for the bug above and a
+        wasted round-trip.
     """
     args = _CURL_S3_BASE_ARGS + [
         "--aws-sigv4",
@@ -247,6 +260,10 @@ def s3_sigv4_put_args(region, aws_creds, path, headers = None):
         aws_creds["AccessKeyID"] + ":" + aws_creds["SecretAccessKey"],
         "-H",
         "x-amz-security-token: " + aws_creds["SessionToken"],
+        "-H",
+        "x-amz-content-sha256: UNSIGNED-PAYLOAD",
+        "-H",
+        "Expect:",
         "-T",
         path,
         "-X",

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci.axl
@@ -231,6 +231,10 @@ def _header_args(headers):
         args = args + ["-H", k + ": " + v]
     return args
 
+def _s3_object_url(bucket, region, key):
+    """Virtual-hosted S3 URL for `key` in `bucket`/`region`."""
+    return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key
+
 def s3_sigv4_put_args(region, aws_creds, path, headers = None):
     """curl args for a sigv4-signed PUT using the job-scoped STS credentials.
 
@@ -344,7 +348,7 @@ def _s3_put(ctx, session, path, name):
     prefix = artifact_resp["prefix"]
     tags = artifact_resp.get("key", {}).get("tags", {})
 
-    s3_url = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + prefix + "/" + name
+    s3_url = _s3_object_url(bucket, region, prefix + "/" + name)
 
     extra_headers = {}
     if tags:
@@ -450,7 +454,7 @@ def test_results_object_url(bucket: str, region: str, location: str) -> str:
     """
     if location.startswith("http://") or location.startswith("https://"):
         return location
-    return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + location
+    return _s3_object_url(bucket, region, location)
 
 def _post_test_result(ctx, session, step_id):
     """Register an upload for `step_id`; the Key dict, or None if rejected."""

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
@@ -160,6 +160,13 @@ def _header_value(args, name):
             return args[i + 1][len(prefix):]
     return None
 
+def _has_header_arg(args, header):
+    """True if `-H <header>` appears verbatim (for value-less headers like `Expect:`)."""
+    for i in range(len(args) - 1):
+        if args[i] == "-H" and args[i + 1] == header:
+            return True
+    return False
+
 _FAKE_CREDS = {"AccessKeyID": "AKIA", "SecretAccessKey": "secret", "SessionToken": "tok"}
 
 def _test_sigv4_args_self_sign(_ctx):
@@ -183,6 +190,19 @@ def _test_sigv4_args_test_result_content_type(_ctx):
     """The test-result path folds the runner's Content-Type into the signed set."""
     args = s3_sigv4_put_args("r", _FAKE_CREDS, "/tmp/tr.tar.gz", {"Content-Type": "application/gzip"})
     _eq("content-type signed", _header_value(args, "Content-Type"), "application/gzip")
+
+def _test_sigv4_args_pins_content_sha256(_ctx):
+    """`x-amz-content-sha256` is always sent — curl 7.88 drops it on large
+    (Expect: 100-continue) bodies, which S3 rejects as a missing header."""
+    args = s3_sigv4_put_args("r", _FAKE_CREDS, "/tmp/big.tar.gz")
+    _eq("content-sha256 pinned", _header_value(args, "x-amz-content-sha256"), "UNSIGNED-PAYLOAD")
+
+def _test_sigv4_args_suppresses_expect(_ctx):
+    """`-H Expect:` (empty, no value) drops curl's automatic
+    `Expect: 100-continue` on larger bodies (the trigger for the bug)."""
+    args = s3_sigv4_put_args("r", _FAKE_CREDS, "/tmp/big.tar.gz")
+    if not _has_header_arg(args, "Expect:"):
+        fail("expected `-H Expect:` to suppress 100-continue: %r" % args)
 
 # ---------------------------------------------------------------------------
 # redact_curl_trace — strip SigV4 secrets from curl -v output (logged and,
@@ -271,6 +291,8 @@ _UNIT_TESTS = [
     _test_sigv4_args_self_sign,
     _test_sigv4_args_artifact_tags,
     _test_sigv4_args_test_result_content_type,
+    _test_sigv4_args_pins_content_sha256,
+    _test_sigv4_args_suppresses_expect,
     _test_redact_curl_trace_elides_secrets,
     _test_redact_curl_trace_transport_error_no_leak,
     _test_skip_self_closing,

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
@@ -252,6 +252,12 @@ def _test_redact_curl_trace_transport_error_no_leak(_ctx):
     if "Connection reset by peer" not in detail:
         fail("transport-error detail dropped the actual error: %r" % detail)
 
+def _test_redact_curl_trace_plain_error_unchanged(_ctx):
+    """A plain curl error (no `-v`, so no `> ` request lines) passes through
+    untouched — redaction runs on every curl_err, not just verbose ones."""
+    msg = "curl: (6) Could not resolve host: bucket.s3.amazonaws.com"
+    _eq("plain error unchanged", redact_curl_trace(msg), msg)
+
 # ---------------------------------------------------------------------------
 # mark_testcases_skipped — move cached tests into the "skipped" bucket
 # ---------------------------------------------------------------------------
@@ -295,6 +301,7 @@ _UNIT_TESTS = [
     _test_sigv4_args_suppresses_expect,
     _test_redact_curl_trace_elides_secrets,
     _test_redact_curl_trace_transport_error_no_leak,
+    _test_redact_curl_trace_plain_error_unchanged,
     _test_skip_self_closing,
     _test_skip_with_body,
     _test_skip_multiple,


### PR DESCRIPTION
## Problem

Large CircleCI test-results uploads failed with:

```
WARNING: CircleCI test results upload failed: S3 upload HTTP 400 (InvalidRequest): Missing required header for this request: x-amz-content-sha256
```

Small archives uploaded fine; real test suites (a 1.4 MB archive in the field) failed.

## Root cause

curl's `--aws-sigv4` adds `x-amz-content-sha256` itself — but on some curl versions (confirmed on a runner's **curl 7.88.1**) it drops the header once the body is large enough to trigger `Expect: 100-continue` (~1KB+). The signature still lists the header in `SignedHeaders`, but it isn't sent, so S3 rejects the request. That's why the size split: small archives stayed under the `Expect` threshold and worked; larger ones did not.

A runner trace confirmed the failing request carried `Expect: 100-continue` and no `x-amz-content-sha256`.

## Fix

`s3_sigv4_put_args` now pins two headers on the signed PUT:

- `x-amz-content-sha256: UNSIGNED-PAYLOAD` — sent explicitly so it's always present regardless of curl's behavior. The value matches what `--aws-sigv4` signs, so it's a no-op where curl would have added it.
- `-H Expect:` — drops curl's automatic `Expect: 100-continue` on larger bodies, removing the trigger (and a wasted round-trip).

Both upload flows (artifacts and test results) share this builder, so both are covered, and the fix is independent of the runner's curl version.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Fixed large CircleCI test-results (and artifact) uploads failing with `400 InvalidRequest: Missing required header ... x-amz-content-sha256` on runners whose curl drops the header for `Expect: 100-continue` bodies.

### Test plan

- `aspect dev test-circleci` → `circleci.axl: OK (35 tests)`, including coverage that the PUT args pin `x-amz-content-sha256: UNSIGNED-PAYLOAD` and send `-H Expect:`.
- Reproduced the curl behavior locally (large body → `Expect: 100-continue`) and verified the pinned headers produce a well-formed signed request.
- Needs a live CircleCI run with a >~1KB test archive to confirm end-to-end.

