### PR TITLE
feat(auth): add credential-helper subcommand for Bazel

### DIFF
--- a/crates/aspect-cli/BUILD.bazel
+++ b/crates/aspect-cli/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//bazel/release:release.bzl", "release")
-load("//bazel/rust:defs.bzl", "rust_binary")
+load("//bazel/rust:defs.bzl", "rust_binary", "rust_test")
 load("//bazel/rust:multi_platform_rust_binaries.bzl", "multi_platform_rust_binaries")
 
 rust_binary(
@@ -44,6 +44,18 @@ rust_binary(
         "@crates//:tracing-opentelemetry",
         "@crates//:tracing-subscriber",
         "@crates//:uuid",
+    ],
+)
+
+rust_test(
+    name = "test",
+    compile_data = glob([
+        "src/builtins/**/*.axl",
+        "src/builtins/**/*.aspect",
+    ]),
+    crate = ":aspect-cli",
+    deps = [
+        "@crates//:tempfile",
     ],
 )
 

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -37,9 +37,17 @@ login = task(
     group = ["auth"],
     implementation = _login_impl,
     args = {
-        "with_token": args.boolean(default = False),
-        "with_api_token": args.boolean(default = False),
-        "profile": args.string(),
+        "with_token": args.boolean(
+            default = False,
+            description = "Log in with a JWT read from stdin instead of the browser flow.",
+        ),
+        "with_api_token": args.boolean(
+            default = False,
+            description = "Log in with an 'id:secret' API token read from stdin instead of the browser flow.",
+        ),
+        "profile": args.string(
+            description = "Credentials profile name. Defaults to $ASPECT_AUTH_PROFILE, then \"default\".",
+        ),
     },
 )
 
@@ -52,7 +60,9 @@ logout = task(
     group = ["auth"],
     implementation = _logout_impl,
     args = {
-        "profile": args.string(),
+        "profile": args.string(
+            description = "Credentials profile name. Defaults to $ASPECT_AUTH_PROFILE, then \"default\".",
+        ),
     },
 )
 
@@ -72,6 +82,8 @@ whoami = task(
     group = ["auth"],
     implementation = _whoami_impl,
     args = {
-        "profile": args.string(),
+        "profile": args.string(
+            description = "Credentials profile name. Defaults to $ASPECT_AUTH_PROFILE, then \"default\".",
+        ),
     },
 )

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -41,6 +41,11 @@ pub enum CmdError {
     TooManyGroups(String, String, usize),
     #[error("task {0:?} in group {1:?} (defined in {2:?}) conflicts with another task or group")]
     NameConflict(String, Vec<String>, String),
+    #[error(
+        "task {0:?} (defined in {1:?}) uses the reserved command name {2:?}; \
+         rename it or nest it under a group"
+    )]
+    ReservedName(String, String, String),
     #[error("no task selected")]
     NoTaskSelected,
 }
@@ -748,6 +753,16 @@ impl Tree {
                 MAX_TASK_GROUPS,
             ));
         }
+        // A top-level `get` task is unreachable: `main` routes `aspect get` to
+        // the credential helper before task parsing. Reject it rather than let
+        // it silently never run. Nested under a group it is reachable and fine.
+        if group.is_empty() && task.name() == crate::credential_helper::GET_COMMAND {
+            return Err(CmdError::ReservedName(
+                task.name(),
+                label.to_owned(),
+                crate::credential_helper::GET_COMMAND.to_owned(),
+            ));
+        }
         self.insert_at(&task.name(), &group[..], &group[..], label, cmd)
     }
 
@@ -1075,6 +1090,45 @@ mod tests {
             Err(CmdError::NameConflict(name, ..)) => assert_eq!(name, "dup"),
             other => panic!("expected NameConflict, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn build_rejects_top_level_task_named_get() {
+        let t = stub_task(crate::credential_helper::GET_COMMAND, &[], SmallMap::new());
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        match cmd.build("0.0.0") {
+            Err(CmdError::ReservedName(name, ..)) => {
+                assert_eq!(name, crate::credential_helper::GET_COMMAND);
+            }
+            other => panic!("expected ReservedName, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn build_allows_get_task_nested_in_group() {
+        // Bazel only invokes the bare `aspect get`, so `aspect dev get` is fine.
+        let t = stub_task(
+            crate::credential_helper::GET_COMMAND,
+            &["dev"],
+            SmallMap::new(),
+        );
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let root = cmd.build("0.0.0").expect("build ok");
+        let dev = root.find_subcommand("dev").expect("dev group present");
+        assert!(
+            dev.find_subcommand(crate::credential_helper::GET_COMMAND)
+                .is_some()
+        );
     }
 
     // ── Dispatch ───────────────────────────────────────────────────────────

--- a/crates/aspect-cli/src/credential_helper.rs
+++ b/crates/aspect-cli/src/credential_helper.rs
@@ -1,0 +1,63 @@
+//! Bazel `--credential_helper` implementation.
+//!
+//! Bazel invokes the helper configured by `--credential_helper`
+//! (<https://bazel.build/reference/command-line-reference#flag--credential_helper>)
+//! as a short-lived subprocess with the command as its first argument, a request
+//! JSON on stdin, and a response JSON on stdout. Bazel calls it as `<helper> get`,
+//! so the command is `argv[1]`. The protocol's one command is `get`: read
+//! `{"uri": "..."}` and return `{"headers": {"Authorization": ["Bearer <jwt>"]}}`.
+//!
+//! This helper emits the Aspect login JWT so Bazel attaches it to BES and
+//! remote-cache gRPC requests. It deliberately bypasses workspace discovery and
+//! the rest of the CLI: a tool may invoke it from anywhere and expects it to be
+//! fast, so `main` intercepts it before the async runtime. `aspect` thus
+//! reserves `get` as a top-level command name; a user task cannot shadow it.
+
+use anyhow::Context;
+use axl_runtime::engine::{resolve_access_token, resolve_profile};
+
+/// The credential-helper command, as the spec passes it (`argv[1]`). Also the
+/// reserved top-level command name the CLI guards in `cmd`.
+pub const GET_COMMAND: &str = "get";
+
+/// Whether argv designates the credential helper (`aspect get`).
+pub fn is_invocation() -> bool {
+    std::env::args().nth(1).as_deref() == Some(GET_COMMAND)
+}
+
+/// Run the `get` command, writing the response JSON to stdout: resolve the
+/// Aspect login JWT and return it as a bearer `Authorization` header. An
+/// unresolved token is an error (non-zero exit) so a tool never attaches a
+/// credential a server will reject.
+///
+/// Runs before the CLI enters its main async runtime. `resolve_access_token` is
+/// synchronous but its token-exchange and refresh paths internally call
+/// `Handle::current().block_on(..)`, which needs a runtime registered on this
+/// thread. We `enter()` a runtime to register the handle rather than driving an
+/// outer future with `block_on`, since a nested `block_on` would panic.
+pub fn run() -> anyhow::Result<()> {
+    // The request `uri` is not needed (the same token is attached to every
+    // Aspect endpoint), but stdin must be drained so the tool's write side does
+    // not block.
+    std::io::copy(&mut std::io::stdin(), &mut std::io::sink())
+        .context("draining credential-helper request from stdin")?;
+
+    // No flag is available on the helper path, so the profile comes from the
+    // shared ASPECT_AUTH_PROFILE env var (or the default).
+    let profile = resolve_profile(None);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building the credential-helper runtime")?;
+    let _guard = runtime.enter();
+    let token = resolve_access_token(&profile)
+        .context("resolving the Aspect access token")?
+        .context("no Aspect credentials found; run `aspect auth login`")?;
+
+    let response = serde_json::json!({
+        "headers": { "Authorization": [format!("Bearer {token}")] }
+    });
+    println!("{response}");
+    Ok(())
+}

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod builtins;
 mod cmd;
+mod credential_helper;
 mod helpers;
 mod trace;
 mod trace_buffer;
@@ -207,6 +208,18 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
 }
 
 fn main() -> ExitCode {
+    // Intercept the Bazel credential helper (`aspect get`) before the async
+    // runtime and workspace discovery so it stays fast (see `credential_helper`).
+    if credential_helper::is_invocation() {
+        return match credential_helper::run() {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(err) => {
+                eprintln!("error: {err:?}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
     match run() {
         Ok(code) => code,
         Err(err) => {

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -586,6 +586,82 @@ async fn refresh_access_token(entry: &CredentialsEntry) -> anyhow::Result<Creden
     })
 }
 
+/// Shown when a stored session is expired and cannot be silently refreshed.
+const SESSION_EXPIRED_MESSAGE: &str =
+    "session expired\n\nRun `aspect auth login` to re-authenticate.";
+
+/// What to do with a stored credentials entry, decided purely from the entry
+/// (no IO). Lets the expiry policy be unit-tested without disk or network.
+enum TokenAction {
+    /// The token is current; use it as-is.
+    Use,
+    /// The token is expired but refreshable; mint a new one.
+    Refresh,
+    /// The token is expired and cannot be refreshed; the caller must error.
+    Expired,
+}
+
+fn classify_token(entry: &CredentialsEntry) -> TokenAction {
+    if !is_expired_jwt(entry) {
+        TokenAction::Use
+    } else if can_refresh(entry) {
+        TokenAction::Refresh
+    } else {
+        TokenAction::Expired
+    }
+}
+
+/// Environment variable naming the credentials profile to use when no explicit
+/// profile is given. The single selector shared by the `auth` tasks and the
+/// Bazel credential helper (which has no way to pass a flag), so one
+/// `export ASPECT_AUTH_PROFILE=...` drives both.
+pub const PROFILE_ENV: &str = "ASPECT_AUTH_PROFILE";
+
+/// The credentials profile when none is configured.
+const DEFAULT_PROFILE: &str = "default";
+
+/// Resolve the effective profile name: an explicit (non-empty) value wins, then
+/// [`PROFILE_ENV`] (non-empty), then [`DEFAULT_PROFILE`]. An empty `explicit` is
+/// treated as absent (the `auth` tasks pass `""` when `--profile` is omitted),
+/// so it still falls through to the env var.
+pub fn resolve_profile(explicit: Option<&str>) -> String {
+    let non_empty = |s: String| (!s.is_empty()).then_some(s);
+    explicit
+        .map(str::to_owned)
+        .and_then(non_empty)
+        .or_else(|| std::env::var(PROFILE_ENV).ok().and_then(non_empty))
+        .unwrap_or_else(|| DEFAULT_PROFILE.to_owned())
+}
+
+/// Resolve the current access token (JWT) for `profile` (already resolved, e.g.
+/// via [`resolve_profile`]), preferring an explicit `ASPECT_API_TOKEN` over
+/// stored login credentials, and auto-refreshing an expired-but-refreshable
+/// token (persisting the refresh). Returns `None` when no credential exists for
+/// the profile, and errors when the stored token is expired and cannot be
+/// refreshed: it never returns a known-expired token, so a consumer (e.g. the
+/// credential helper) does not emit one a server will 401. Requires a Tokio
+/// runtime (the refresh path blocks on async HTTP).
+pub fn resolve_access_token(profile: &str) -> anyhow::Result<Option<String>> {
+    if let Some(entry) = credentials_from_api_token_env()? {
+        return Ok(Some(entry.access_token));
+    }
+    let mut map = load_all_credentials()?;
+    let Some(entry) = map.get(profile).cloned() else {
+        return Ok(None);
+    };
+    match classify_token(&entry) {
+        TokenAction::Use => Ok(Some(entry.access_token)),
+        TokenAction::Expired => Err(anyhow::anyhow!(SESSION_EXPIRED_MESSAGE)),
+        TokenAction::Refresh => {
+            let refreshed = block_on(refresh_access_token(&entry))
+                .map_err(|_| anyhow::anyhow!(SESSION_EXPIRED_MESSAGE))?;
+            map.insert(profile.to_string(), refreshed.clone());
+            save_all_credentials(&map)?;
+            Ok(Some(refreshed.access_token))
+        }
+    }
+}
+
 #[derive(Debug, Display, ProvidesStaticType, NoSerialize, Allocative, Clone)]
 #[display("<AuthCredentials>")]
 pub struct AuthCredentials {
@@ -854,13 +930,9 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         let creds = creds
             .downcast_ref_err::<AuthCredentials>()
             .into_anyhow_result()?;
-        let profile_opt = profile.into_option();
-        let profile = profile_opt
-            .as_deref()
-            .filter(|p| !p.is_empty())
-            .unwrap_or("default");
+        let profile = resolve_profile(profile.into_option().as_deref());
         let mut map = load_all_credentials()?;
-        map.insert(profile.to_string(), creds.to_entry());
+        map.insert(profile, creds.to_entry());
         save_all_credentials(&map)?;
         Ok(values::Value::new_none())
     }
@@ -869,13 +941,9 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         #[allow(unused)] this: values::Value<'v>,
         #[starlark(require = named, default = NoneOr::None)] profile: NoneOr<String>,
     ) -> anyhow::Result<values::Value<'v>> {
-        let profile_opt = profile.into_option();
-        let profile = profile_opt
-            .as_deref()
-            .filter(|p| !p.is_empty())
-            .unwrap_or("default");
+        let profile = resolve_profile(profile.into_option().as_deref());
         let mut map = load_all_credentials()?;
-        map.remove(profile);
+        map.remove(&profile);
         save_all_credentials(&map)?;
         Ok(values::Value::new_none())
     }
@@ -885,25 +953,20 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named, default = NoneOr::None)] profile: NoneOr<String>,
         heap: values::Heap<'v>,
     ) -> anyhow::Result<values::Value<'v>> {
-        let profile_opt = profile.into_option();
-        let profile = profile_opt
-            .as_deref()
-            .filter(|p| !p.is_empty())
-            .unwrap_or("default");
+        let profile = resolve_profile(profile.into_option().as_deref());
         // Prefer an explicit ASPECT_API_TOKEN source over cache login credentials.
         if let Some(entry) = credentials_from_api_token_env()? {
             return Ok(heap.alloc(AuthCredentials::from_entry(&entry)));
         }
-        let map = load_all_credentials()?;
-        let Some(entry) = map.get(profile).cloned() else {
+        let mut map = load_all_credentials()?;
+        let Some(entry) = map.get(&profile).cloned() else {
             return Ok(values::Value::new_none());
         };
         // Auto-refresh if expired and refreshable
         let entry = if is_expired_jwt(&entry) && can_refresh(&entry) {
             match block_on(refresh_access_token(&entry)) {
                 Ok(refreshed) => {
-                    let mut map = map;
-                    map.insert(profile.to_string(), refreshed.clone());
+                    map.insert(profile.clone(), refreshed.clone());
                     save_all_credentials(&map)?;
                     refreshed
                 }
@@ -929,4 +992,120 @@ fn register_auth_types(globals: &mut GlobalsBuilder) {
 
 pub fn register_globals(globals: &mut GlobalsBuilder) {
     globals.namespace("auth", register_auth_types);
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    use super::*;
+
+    /// A JWT whose payload is `{"exp": <exp>}` (header and signature are
+    /// placeholders; only the payload is decoded). `exp` of `None` omits the
+    /// claim entirely.
+    fn jwt_with_exp(exp: Option<u64>) -> String {
+        let payload = match exp {
+            Some(exp) => format!("{{\"exp\":{exp}}}"),
+            None => "{}".to_string(),
+        };
+        format!("header.{}.sig", URL_SAFE_NO_PAD.encode(payload))
+    }
+
+    fn entry(access_token: String) -> CredentialsEntry {
+        CredentialsEntry {
+            access_token,
+            refresh_token: String::new(),
+            email: "user@example.com".to_string(),
+            name: "User".to_string(),
+            tenant_id: "tenant".to_string(),
+            auth_domain: None,
+            auth_client_id: None,
+        }
+    }
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    #[test]
+    fn is_expired_jwt_classifies_by_exp() {
+        // A token well in the future is current.
+        assert!(!is_expired_jwt(&entry(jwt_with_exp(Some(now() + 3600)))));
+        // One in the past is expired, as is one inside the 60s pre-expiry buffer.
+        assert!(is_expired_jwt(&entry(jwt_with_exp(Some(now() - 1)))));
+        assert!(is_expired_jwt(&entry(jwt_with_exp(Some(now() + 30)))));
+        // No `exp` claim means non-expiring.
+        assert!(!is_expired_jwt(&entry(jwt_with_exp(None))));
+    }
+
+    #[test]
+    fn is_expired_jwt_treats_malformed_tokens_as_expired() {
+        assert!(is_expired_jwt(&entry("not-a-jwt".to_string())));
+        assert!(is_expired_jwt(&entry("only.two".to_string())));
+        assert!(is_expired_jwt(&entry("a.!!!.c".to_string())));
+    }
+
+    #[test]
+    fn can_refresh_requires_token_domain_and_client_id() {
+        let mut e = entry(jwt_with_exp(Some(now() - 1)));
+        assert!(!can_refresh(&e));
+        e.refresh_token = "refresh".to_string();
+        assert!(!can_refresh(&e));
+        e.auth_domain = Some("https://auth.example".to_string());
+        assert!(!can_refresh(&e));
+        e.auth_client_id = Some("client".to_string());
+        assert!(can_refresh(&e));
+    }
+
+    #[test]
+    fn resolve_profile_prefers_explicit_then_env_then_default() {
+        // An explicit, non-empty profile always wins, regardless of the env.
+        assert_eq!(resolve_profile(Some("ci")), "ci");
+
+        // This test mutates the process env, so it must run serially with any
+        // other PROFILE_ENV reader; it is currently the only one.
+        let saved = std::env::var(PROFILE_ENV).ok();
+
+        // SAFETY: single-threaded test body; restored before returning.
+        unsafe { std::env::set_var(PROFILE_ENV, "from-env") };
+        // An absent or empty explicit profile falls through to the env var.
+        assert_eq!(resolve_profile(None), "from-env");
+        assert_eq!(resolve_profile(Some("")), "from-env");
+        // An explicit profile still overrides the env.
+        assert_eq!(resolve_profile(Some("explicit")), "explicit");
+
+        // With the env unset, everything falls through to the default.
+        unsafe { std::env::remove_var(PROFILE_ENV) };
+        assert_eq!(resolve_profile(None), DEFAULT_PROFILE);
+        assert_eq!(resolve_profile(Some("")), DEFAULT_PROFILE);
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var(PROFILE_ENV, v) },
+            None => unsafe { std::env::remove_var(PROFILE_ENV) },
+        }
+    }
+
+    #[test]
+    fn classify_token_covers_each_branch() {
+        // Current token: use as-is.
+        assert!(matches!(
+            classify_token(&entry(jwt_with_exp(Some(now() + 3600)))),
+            TokenAction::Use
+        ));
+        // Expired and not refreshable: error (never returned as-is).
+        assert!(matches!(
+            classify_token(&entry(jwt_with_exp(Some(now() - 1)))),
+            TokenAction::Expired
+        ));
+        // Expired but refreshable: refresh.
+        let mut refreshable = entry(jwt_with_exp(Some(now() - 1)));
+        refreshable.refresh_token = "refresh".to_string();
+        refreshable.auth_domain = Some("https://auth.example".to_string());
+        refreshable.auth_client_id = Some("client".to_string());
+        assert!(matches!(classify_token(&refreshable), TokenAction::Refresh));
+    }
 }

--- a/crates/axl-runtime/src/engine/mod.rs
+++ b/crates/axl-runtime/src/engine/mod.rs
@@ -12,6 +12,11 @@ mod std;
 mod template;
 mod wasm;
 
+/// Re-exported for the credential helper: resolve the effective credentials
+/// profile, and resolve the current Aspect access token (JWT) for a profile,
+/// auto-refreshing if needed.
+pub use aspect::auth::{resolve_access_token, resolve_profile};
+
 pub mod feature;
 pub mod names;
 pub mod r#trait;


### PR DESCRIPTION
## Summary

Implements Bazel's [`--credential_helper` protocol](https://bazel.build/reference/command-line-reference#flag--credential_helper) so Bazel attaches the Aspect login JWT to BES and remote-cache gRPC requests. Bazel invokes the binary as `aspect get`: the helper reads the request from stdin and writes `{"headers": {"Authorization": ["Bearer <jwt>"]}}` to stdout. A user runs `aspect auth login` once; the helper then surfaces that token (auto-refreshing when expired) on every Bazel invocation.

## What changed

- **`crates/aspect-cli/src/credential_helper.rs`** (new) — the helper. `is_invocation()` detects the `aspect get` invocation; `run()` drains stdin, resolves the token, and writes the response. It is intercepted at the top of `main()` before the async runtime and workspace discovery, so it stays fast and works outside an Aspect workspace, and owns a small current-thread runtime (`enter`ed, since `resolve_access_token`'s token-exchange/refresh paths block on async internally).
- **`crates/aspect-cli/src/cmd.rs`** — reserves `get` as a top-level command name: a top-level task named `get` is rejected with a clear `ReservedName` error (nesting under a group is allowed, since Bazel only invokes the bare `aspect get`).
- **`crates/axl-runtime/src/engine/aspect/auth.rs`** — `resolve_access_token(profile)`: prefers `ASPECT_API_TOKEN`, returns a current token as-is, auto-refreshes an expired-but-refreshable token (persisting it), and errors when an expired token cannot be refreshed (never returns a known-expired token a server would 401). The expiry policy is factored into a pure `classify_token` for unit testing. A shared `resolve_profile` now selects the credentials profile for the `auth` tasks and the helper alike.
- **`crates/aspect-cli/src/builtins/aspect/auth.axl`** — documents the `--profile` flag's `ASPECT_AUTH_PROFILE` / `default` fallback.

### Profile selection

One resolver picks the credentials profile everywhere: an explicit `--profile` wins, then `ASPECT_AUTH_PROFILE`, then `"default"`. The credential helper has no flag (Bazel passes only `get`), so the env var is its selector — a single `export ASPECT_AUTH_PROFILE=dev` drives both `aspect auth login` and the Bazel-invoked `aspect get`.

The protocol's only command is `get`; there are no other actions or response fields to handle.

## Are these changes visible to end-users?

Yes — `aspect` gains the Bazel credential-helper behavior, wired via `--credential_helper=%workspace%/path/to/aspect`.

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

## Suggested release notes

- `aspect` now implements Bazel's credential-helper protocol (`--credential_helper`), attaching the Aspect login JWT to BES and remote-cache requests. Expired tokens auto-refresh; run `aspect auth login` once. Select a non-default profile with `--profile` or `ASPECT_AUTH_PROFILE`.

## Test plan

- New unit tests for the token expiry policy (`is_expired_jwt`, `can_refresh`, `classify_token`) and profile resolution (`resolve_profile`).
- New unit tests for the `get` reservation: a top-level `get` task is rejected; a `get` task nested in a group is allowed.
- Manual: after `aspect auth login`, `echo '{"uri":"https://bes.example"}' | aspect get` prints a `{"headers":{"Authorization":["Bearer ..."]}}` response; `ASPECT_AUTH_PROFILE=<name>` selects that profile; with no credentials it exits non-zero with `no Aspect credentials found; run aspect auth login`.
- Wired as Bazel's `--credential_helper`, an authenticated build streams BES events through the JWT-validating ALB.
