### PR TITLE
fix(runnable): replay the target's env attribute when spawning built binaries

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -144,7 +144,7 @@ load("@aspect//lib/github.axl", "detect_commit_sha")
 load("@aspect//lib/health_check.axl", "HealthCheckTrait")
 load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "apparent_label", "runnable")
+load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "apparent_label", "runenv_aspect_flags", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
 load("@aspect//lib/tips.axl", "tips")
 load("@std//time.axl", "sleep_iter", "time")
@@ -1261,9 +1261,12 @@ def _delivery_impl(ctx):
         #   release_bazel_flags     — release-only flags via `--release-bazel-flag`
         #                             (e.g. `--stamp`).
         #   LOCAL_SPAWN_FLAGS       — mandatory; last so nothing can flip them.
+        #   runenv_aspect_flags     — inject the run-environment aspect so the
+        #                             deliverable's `env` attribute is replayed
+        #                             on spawn (e.g. JQ_BIN for a `set -u` script).
         #   --noremote_upload_local_results — release artifacts shouldn't pollute
         #                             the shared remote cache (delivery-specific).
-        phase3_flags = LOCAL_SPAWN_BASE_FLAGS + list(expanded_flags) + list(ctx.args.release_bazel_flags) + LOCAL_SPAWN_FLAGS + [
+        phase3_flags = LOCAL_SPAWN_BASE_FLAGS + list(expanded_flags) + list(ctx.args.release_bazel_flags) + LOCAL_SPAWN_FLAGS + runenv_aspect_flags(ctx) + [
             "--noremote_upload_local_results",
         ]
         _t_download = time.monotonic()

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -31,7 +31,7 @@ load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskL
 load("./lib/path_glob.axl", "match_any")
 load("./lib/path_normalize.axl", "normalize_files_for_cwd")
 load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runenv_aspect_flags", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
 
@@ -370,6 +370,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
     flags.extend(LOCAL_SPAWN_FLAGS)
+
+    # Replay the formatter target's `env` attribute on spawn (matching `bazel run`).
+    flags.extend(runenv_aspect_flags(ctx))
 
     r = runnable(ctx, [ctx.args.formatter_target])
 

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -198,7 +198,7 @@ load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
 load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "runenv_aspect_flags", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
 
@@ -600,6 +600,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         return _emit_final(ctx, lifecycle, data, 0)
 
     flags.extend(LOCAL_SPAWN_FLAGS)
+
+    # Replay the gazelle target's `env` attribute on spawn (matching `bazel run`).
+    flags.extend(runenv_aspect_flags(ctx))
 
     r = runnable(ctx, [ctx.args.gazelle_target])
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -2,6 +2,14 @@ load("./bazel_results.axl", "bes_get")
 
 _DEFAULT_WORKSPACE_NAME = "_main"
 
+# Output group + JSON-file suffix the `runenv` aspect uses. These mirror the
+# literals baked into `_RUNENV_ASPECT_BZL` below — the aspect runs as a
+# separate Starlark file and can't reference these constants, so keep the two
+# in sync. `_process_bes` reads the group from BES alongside `default`;
+# `_collect_runenv` matches the suffix to find the file.
+_RUNENV_OUTPUT_GROUP = "aspect_runenv"
+_RUNENV_FILE_SUFFIX = ".aspect_runenv.json"
+
 # Mandatory Bazel flags for a task that immediately spawns the built binary
 # (format, gazelle, run, delivery phase 3). Append these LAST so they win
 # over any user rc / `--bazel-flag` value that would flip them: the spawn
@@ -47,6 +55,56 @@ RUN_IN_DESCRIPTION = (
     "`/` are taken as absolute; paths starting with `./` or `../` " +
     "resolve against the user's cwd."
 )
+
+# Bazel rule source for the `runenv` aspect. Reads each target's
+# `RunEnvironmentInfo` — the provider that carries the resolved `env`
+# attribute `bazel run` injects into the spawned process — and writes it as
+# JSON to a declared output in the `aspect_runenv` output group. `_spawn`
+# reads this file and replays the env so direct spawns match `bazel run`.
+#
+# Not every binary rule populates `RunEnvironmentInfo`: legacy native
+# `sh_binary` historically does not (https://github.com/bazelbuild/bazel/issues/23658),
+# while rules_shell's Starlark `sh_binary` and most language rulesets do.
+# The `RunEnvironmentInfo in target` guard makes the aspect a no-op for the
+# former, so its spawn sees no target env.
+#
+# Values are already location/rootpath-expanded at analysis time and are
+# stored relative to the runfiles workspace dir (rootpath semantics), which
+# is exactly the cwd `_spawn` uses — so they are replayed verbatim, never
+# rewritten to absolute paths.
+_RUNENV_ASPECT_BZL = """def _runenv_impl(target, ctx):
+    if RunEnvironmentInfo not in target:
+        return []
+    run_env = target[RunEnvironmentInfo]
+    out = ctx.actions.declare_file(target.label.name + ".aspect_runenv.json")
+    ctx.actions.write(out, json.encode(struct(
+        environment = run_env.environment,
+        inherited_environment = run_env.inherited_environment,
+    )))
+    return [OutputGroupInfo(aspect_runenv = depset([out]))]
+
+runenv = aspect(implementation = _runenv_impl)
+"""
+
+def runenv_aspect_flags(ctx) -> list[str]:
+    """Materialize the `runenv` aspect repo and return the flags that inject it.
+
+    Append the result to a build whose BES is streamed into a `runnable()`
+    tracker; the tracker then collects each target's resolved run environment
+    and `spawn` replays it. Writes a throwaway repo (empty `REPO.bazel` /
+    `BUILD.bazel` plus the aspect `.bzl`) under a task-scoped `/tmp` dir, the
+    same injectable-repo pattern delivery's hashsum aspect uses.
+    """
+    repo_dir = "/tmp/aspect_runenv_" + ctx.task.key
+    ctx.std.fs.create_dir_all(repo_dir)
+    ctx.std.fs.write(repo_dir + "/REPO.bazel", "")
+    ctx.std.fs.write(repo_dir + "/BUILD.bazel", "")
+    ctx.std.fs.write(repo_dir + "/runenv.bzl", _RUNENV_ASPECT_BZL)
+    return [
+        "--aspects=@aspect_runenv//:runenv.bzl%runenv",
+        "--output_groups=+" + _RUNENV_OUTPUT_GROUP,
+        "--inject_repository=aspect_runenv=" + repo_dir,
+    ]
 
 def resolve_run_in(ctx, choice: str) -> str | None:
     """Resolve `--run-in=<choice>` to an absolute cwd for the spawn.
@@ -182,6 +240,8 @@ def _process_bes(state: struct, event):
             for og in (bes_get(event.payload, "output_group", None) or []):
                 if og.name == "default":
                     state.target_fileset[label_key] = og.file_sets
+                elif og.name == _RUNENV_OUTPUT_GROUP:
+                    state.runenv_fileset[label_key] = og.file_sets
     elif event.kind == "workspace_config":
         # WorkspaceConfig.local_exec_root is "<output_base>/execroot/<workspace_name>".
         # Its basename is the canonical repo name Bazel uses inside runfiles trees.
@@ -233,12 +293,46 @@ def _get_default_outputs(state: struct, target: str) -> list[str]:
         return []
     return _collect_fileset_paths(state, state.target_fileset[target])
 
+def _collect_runenv(state: struct, target: str) -> struct | None:
+    """Read the `runenv` aspect's JSON for `target`, or None if absent.
+
+    Returns `struct(environment: dict, inherited_environment: list[str])` when
+    the aspect ran for the target AND its declared file is on disk; None when
+    no `aspect_runenv` output group was reported (aspect not injected, or the
+    rule has no `RunEnvironmentInfo`), the file isn't materialized, or it can't
+    be parsed. On None, the caller leaves the entrypoint's env fields empty and
+    `_spawn` injects no target env.
+
+    Reading requires `state.ctx` (filesystem access) and the JSON on disk —
+    callers run this only after the build that requested the `aspect_runenv`
+    output group has completed (the file is a requested top-level output, so
+    `--remote_download_outputs=toplevel` materializes it).
+    """
+    if state.ctx == None:
+        return None
+    target = apparent_label(target, state.current_package)
+    if target not in state.runenv_fileset:
+        return None
+    for path in _collect_fileset_paths(state, state.runenv_fileset[target]):
+        if not path.endswith(_RUNENV_FILE_SUFFIX):
+            continue
+        if not state.ctx.std.fs.exists(path):
+            return None
+        decoded = json.decode(state.ctx.std.fs.read_to_string(path))
+        return struct(
+            environment = decoded.get("environment", {}) or {},
+            inherited_environment = decoded.get("inherited_environment", []) or [],
+        )
+    return None
+
 def _determine_entrypoint(state: struct, target: str) -> struct | None:
     """Resolve `target` to an executable path and runfiles directory.
 
-    Returns `struct(path, runfiles_dir, runfiles_workspace_dir)` or
-    `None` when the target produced no BES `target_completed` event or
-    its default output group has no selectable executable.
+    Returns `struct(path, runfiles_dir, runfiles_workspace_dir, environment,
+    inherited_environment)` or `None` when the target produced no BES
+    `target_completed` event or its default output group has no selectable
+    executable. The two env fields carry the target's resolved `env` attribute
+    when the `runenv` aspect was injected (empty otherwise); `_spawn` replays them.
 
     `runfiles_dir` is the resolved runfiles directory path (e.g.
     `…/format.runfiles`), or `None` when no `<entrypoint>.runfiles`
@@ -305,10 +399,17 @@ def _determine_entrypoint(state: struct, target: str) -> struct | None:
             runfiles_dir = entrypoint + ".runfiles"
             runfiles_workspace_dir = runfiles_dir + "/" + (state.workspace_name[0] or _DEFAULT_WORKSPACE_NAME)
 
+    # Resolved run environment from the `runenv` aspect, when injected; None
+    # otherwise (`_spawn` then sets no target env). Read here, at entrypoint
+    # resolution, so `_spawn` stays a pure function of `ep`.
+    runenv = _collect_runenv(state, target)
+
     return struct(
         path = entrypoint,
         runfiles_dir = runfiles_dir,
         runfiles_workspace_dir = runfiles_workspace_dir,
+        environment = runenv.environment if runenv else {},
+        inherited_environment = runenv.inherited_environment if runenv else [],
     )
 
 def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture: bool = False, cwd: str | None = None) -> std.process.Child:
@@ -325,17 +426,40 @@ def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture
     for tools that want the canonical workspace root inside runfiles without
     re-deriving it from RUNFILES_DIR.
 
+    Replays the target's resolved `env` attribute (`ep.environment` /
+    `ep.inherited_environment`, populated by the `runenv` aspect) so direct
+    spawns match `bazel run` — e.g. a `set -u` script reading `${JQ_BIN}` from
+    `env` finds it set. These are applied FIRST so the runfiles / BUILD_* /
+    ASPECT_* vars below win on any key collision — the target env must not
+    clobber the runfiles plumbing the spawn depends on. `environment` values
+    are set verbatim (already rootpath-expanded relative to the runfiles
+    workspace dir, the cwd used below); `inherited_environment` names are
+    copied from the aspect process's own environment when present.
+
     Working directory defaults to `runfiles_dir/<workspace>` (matching `bazel run`)
     when a runfiles tree is present, falling back to the aspect invocation directory
     when the target has no runfiles tree. Pass `cwd` explicitly to override — both
     `run.axl` and `format.axl` resolve `--run-in=<choice>` via `resolve_run_in()` and
     forward the result here so targets that don't switch to `$BUILD_WORKSPACE_DIRECTORY`
     on their own (such as `@buildifier_prebuilt//buildifier`) resolve workspace-relative
-    arguments against the user's cwd.
+    arguments against the user's cwd. Note: a `--run-in` override moves the cwd
+    away from the runfiles workspace dir, so verbatim rootpath-form `env` values
+    won't resolve — the same limitation `bazel run` has, which always uses the
+    runfiles workspace cwd.
     """
     effective_cwd = cwd or ep.runfiles_workspace_dir or ctx.std.env.current_dir()
-    cmd = ctx.std.process.command(ep.path) \
-        .current_dir(effective_cwd) \
+    cmd = ctx.std.process.command(ep.path).current_dir(effective_cwd)
+
+    # Target `env` first, so the runfiles / BUILD_* / ASPECT_* vars set below
+    # take precedence on any collision.
+    for key, value in ep.environment.items():
+        cmd = cmd.env(key, value)
+    for key in ep.inherited_environment:
+        inherited = ctx.std.env.var(key)
+        if inherited != None:
+            cmd = cmd.env(key, inherited)
+
+    cmd = cmd \
         .env("BUILD_WORKSPACE_DIRECTORY", ctx.std.env.bazel_root_dir()) \
         .env("BUILD_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
         .env("ASPECT_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
@@ -359,14 +483,17 @@ def runnable(ctx, targets: list[str]) -> struct:
     Feed BES events via `.event(event)` as they arrive from the build. Once the
     build completes, query results per target through the returned struct:
 
-      determine_entrypoint(target) → struct(path, runfiles_dir, runfiles_workspace_dir) | None
+      determine_entrypoint(target) → struct(path, runfiles_dir, runfiles_workspace_dir, environment, inherited_environment) | None
           Best executable output for `target` from its BES default output group,
           or None if no BES data was received for it. `runfiles_dir` is the
           resolved runfiles directory (e.g. `…/format.runfiles`), or `None`
           when no `<entrypoint>.runfiles` directory exists on disk.
           `runfiles_workspace_dir` is `runfiles_dir + "/" + <workspace>` (the
           cwd `bazel run` uses; usually `…/format.runfiles/_main`), or `None`
-          when `runfiles_dir` is `None`.
+          when `runfiles_dir` is `None`. `environment` (dict) and
+          `inherited_environment` (list[str]) carry the target's resolved `env`
+          attribute when the caller injected the `runenv` aspect (see
+          `runenv_aspect_flags`); both are empty otherwise. `spawn` replays them.
 
       get_default_outputs(target) → list[str]
           Absolute paths of every file in `target`'s default output group,
@@ -377,11 +504,14 @@ def runnable(ctx, targets: list[str]) -> struct:
           responsible for materializing what it intends to read.
 
       spawn(ep, args, capture=False, cwd=None) → Child
-          Spawn `ep.path` with Bazel runfiles environment variables set.
-          `cwd` defaults to `ep.runfiles_dir/<workspace>` when a runfiles tree
-          is present (matching `bazel run`), falling back to the aspect
-          invocation directory when there is no runfiles tree. Pass an
-          explicit `cwd` to override — e.g. the resolved value from `--run-in=<choice>`.
+          Spawn `ep.path` with Bazel runfiles environment variables set, plus
+          the target's `env` attribute replayed from `ep.environment` /
+          `ep.inherited_environment` (matching `bazel run`; empty unless the
+          `runenv` aspect was injected). `cwd` defaults to
+          `ep.runfiles_dir/<workspace>` when a runfiles tree is present
+          (matching `bazel run`), falling back to the aspect invocation
+          directory when there is no runfiles tree. Pass an explicit `cwd` to
+          override — e.g. the resolved value from `--run-in=<choice>`.
     """
     current_package = _current_package(ctx) if ctx else ""
     state = struct(
@@ -390,6 +520,10 @@ def runnable(ctx, targets: list[str]) -> struct:
         targets = {apparent_label(t, current_package): t for t in targets},
         filesets = {},
         target_fileset = {},
+        # Filesets of the `aspect_runenv` output group, populated only when a
+        # caller injects the `runenv` aspect (via `runenv_aspect_flags`). Empty
+        # otherwise, so `determine_entrypoint` reports no target env.
+        runenv_fileset = {},
         # Single-element list so `_process_bes` can mutate it (struct fields are
         # otherwise read-only after construction).
         workspace_name = [""],

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,7 +1,8 @@
 """Unit tests for lib/runnable.axl: apparent_label normalization, BES matching,
-entrypoint selection (passes 1–3), and runfiles directory detection."""
+entrypoint selection (passes 1–3), runfiles directory detection, and the
+`runenv` aspect's resolved-`env` collection."""
 
-load("./runnable.axl", "apparent_label", "resolve_run_in", "runnable")
+load("./runnable.axl", "apparent_label", "resolve_run_in", "runenv_aspect_flags", "runnable")
 
 def _eq(label, got, want):
     if got != want:
@@ -350,15 +351,18 @@ def _test_pass3_skips_non_executable(ctx):
 # disk with a minimal mock ctx.
 # ---------------------------------------------------------------------------
 
-def _make_mock_ctx(existing_paths, executable_paths = None):
+def _make_mock_ctx(existing_paths, executable_paths = None, file_contents = None):
     """Minimal TaskContext mock for filesystem detection tests.
 
     existing_paths: absolute paths that `std.fs.exists()` returns True for.
     executable_paths: absolute paths that `std.fs.metadata().executable` is True
         for. None means "every path is executable" — the right default for tests
         that don't exercise pass-3's executable-bit check.
+    file_contents: optional {path: str} for `std.fs.read_to_string`, used by the
+        runenv tests; paths here are also treated as existing.
     """
     is_executable = (lambda path: True) if executable_paths == None else (lambda path: path in executable_paths)
+    contents = file_contents or {}
     return struct(
         std = struct(
             env = struct(
@@ -366,9 +370,24 @@ def _make_mock_ctx(existing_paths, executable_paths = None):
                 current_dir = lambda: "/workspace",
             ),
             fs = struct(
-                exists = lambda path: path in existing_paths,
+                exists = lambda path: path in existing_paths or path in contents,
                 metadata = lambda path: struct(executable = is_executable(path)),
+                read_to_string = lambda path: contents[path],
             ),
+        ),
+    )
+
+def _make_runenv_target_event(bes_label, default_set_id, runenv_set_id):
+    """target_completed event carrying both the `default` and the
+    `aspect_runenv` output groups (the latter from the injected runenv aspect)."""
+    return struct(
+        kind = "target_completed",
+        id = struct(label = bes_label),
+        payload = struct(
+            output_group = [
+                struct(name = "default", file_sets = [struct(id = default_set_id)]),
+                struct(name = "aspect_runenv", file_sets = [struct(id = runenv_set_id)]),
+            ],
         ),
     )
 
@@ -409,6 +428,101 @@ def _test_filesystem_no_runfiles(ctx):
         fail("fs/no-runfiles: expected runfiles_dir=None (no .runfiles on disk), got %r" % ep.runfiles_dir)
     if ep.runfiles_workspace_dir != None:
         fail("fs/no-runfiles: expected runfiles_workspace_dir=None (no runfiles_dir), got %r" % ep.runfiles_workspace_dir)
+
+# ---------------------------------------------------------------------------
+# runenv tests — the `runenv` aspect's resolved `env` attribute, collected
+# from the `aspect_runenv` output group and surfaced on the entrypoint struct
+# so `_spawn` can replay it (matching `bazel run`).
+# ---------------------------------------------------------------------------
+
+def _test_runenv_collected_from_aspect_output_group(ctx):
+    """When the aspect's JSON is present, environment + inherited_environment
+    surface on the entrypoint struct."""
+    runenv_path = "/out/bin/cloud/anyscale/monitor/service.release.aspect_runenv.json"
+    mock = _make_mock_ctx(
+        existing_paths = ["/out/bin/cloud/anyscale/monitor/service.release.runfiles"],
+        file_contents = {runenv_path: json.encode({
+            "environment": {"JQ_BIN": "../jq_toolchains+/jq", "REPOSITORY": "anyscale"},
+            "inherited_environment": ["HOME"],
+        })},
+    )
+    r = runnable(mock, ["//cloud/anyscale/monitor:service.release"])
+    r.event(_make_fileset_event("default", ["/out/bin/cloud/anyscale/monitor/service.release"]))
+    r.event(_make_fileset_event("runenv", [runenv_path]))
+    r.event(_make_runenv_target_event("//cloud/anyscale/monitor:service.release", "default", "runenv"))
+    ep = r.determine_entrypoint("//cloud/anyscale/monitor:service.release")
+    if ep == None:
+        fail("runenv: expected entrypoint, got None")
+    _eq("runenv: JQ_BIN verbatim", ep.environment.get("JQ_BIN"), "../jq_toolchains+/jq")
+    _eq("runenv: REPOSITORY", ep.environment.get("REPOSITORY"), "anyscale")
+    _eq("runenv: inherited", ep.inherited_environment, ["HOME"])
+
+def _test_runenv_absent_yields_empty_env(ctx):
+    """No aspect_runenv output group (aspect not injected / no
+    RunEnvironmentInfo) → empty environment + inherited_environment."""
+    mock = _make_mock_ctx(["/out/bin/tools/format/runner.runfiles"])
+    r = runnable(mock, ["//tools/format:runner"])
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/format/runner"]))
+    r.event(_make_target_event("//tools/format:runner", "s1"))
+    ep = r.determine_entrypoint("//tools/format:runner")
+    if ep == None:
+        fail("runenv-absent: expected entrypoint, got None")
+    _eq("runenv-absent: empty environment", ep.environment, {})
+    _eq("runenv-absent: empty inherited", ep.inherited_environment, [])
+
+def _test_runenv_empty_when_ctx_none(ctx):
+    """Without a ctx (no filesystem), the JSON can't be read → empty env even
+    when the output group was reported."""
+    r = runnable(None, ["//tools/format:runner"])
+    r.event(_make_fileset_event("default", ["/out/bin/tools/format/runner"]))
+    r.event(_make_fileset_event("runenv", ["/out/bin/tools/format/runner.aspect_runenv.json"]))
+    r.event(_make_runenv_target_event("//tools/format:runner", "default", "runenv"))
+    ep = r.determine_entrypoint("//tools/format:runner")
+    if ep == None:
+        fail("runenv-ctx-none: expected entrypoint, got None")
+    _eq("runenv-ctx-none: empty environment", ep.environment, {})
+
+def _test_runenv_partial_json_defaults_missing_keys(ctx):
+    """A JSON missing `inherited_environment` (e.g. a rule that set only
+    `environment`) decodes to an empty list, not a failure."""
+    runenv_path = "/out/bin/tools/format/runner.aspect_runenv.json"
+    mock = _make_mock_ctx(
+        existing_paths = ["/out/bin/tools/format/runner.runfiles"],
+        file_contents = {runenv_path: json.encode({"environment": {"FOO": "bar"}})},
+    )
+    r = runnable(mock, ["//tools/format:runner"])
+    r.event(_make_fileset_event("default", ["/out/bin/tools/format/runner"]))
+    r.event(_make_fileset_event("runenv", [runenv_path]))
+    r.event(_make_runenv_target_event("//tools/format:runner", "default", "runenv"))
+    ep = r.determine_entrypoint("//tools/format:runner")
+    if ep == None:
+        fail("runenv-partial: expected entrypoint, got None")
+    _eq("runenv-partial: environment", ep.environment, {"FOO": "bar"})
+    _eq("runenv-partial: inherited defaults empty", ep.inherited_environment, [])
+
+def _test_runenv_aspect_flags_writes_repo_and_returns_flags(ctx):
+    """`runenv_aspect_flags` materializes a task-scoped injectable repo and
+    returns the aspect / output-group / inject-repository flags pointing at it."""
+    writes = {}
+    mock = struct(
+        task = struct(key = "fmt-123"),
+        std = struct(fs = struct(
+            create_dir_all = lambda path: writes.setdefault("__dir__", path),
+            write = lambda path, content: writes.setdefault(path, content),
+        )),
+    )
+    flags = runenv_aspect_flags(mock)
+    repo = "/tmp/aspect_runenv_fmt-123"
+    _eq("flags/dir", writes["__dir__"], repo)
+    if repo + "/REPO.bazel" not in writes or repo + "/BUILD.bazel" not in writes:
+        fail("flags: expected empty REPO.bazel + BUILD.bazel, wrote %r" % writes.keys())
+    if "RunEnvironmentInfo" not in writes[repo + "/runenv.bzl"]:
+        fail("flags: runenv.bzl missing aspect source")
+    _eq("flags/list", flags, [
+        "--aspects=@aspect_runenv//:runenv.bzl%runenv",
+        "--output_groups=+aspect_runenv",
+        "--inject_repository=aspect_runenv=" + repo,
+    ])
 
 # ---------------------------------------------------------------------------
 # runfiles_workspace_dir tests — `<runfiles_dir>/<workspace>`, the cwd
@@ -631,6 +745,11 @@ _UNIT_TESTS = [
     _test_filesystem_sh_extension,
     _test_filesystem_bash_extension,
     _test_filesystem_no_runfiles,
+    _test_runenv_collected_from_aspect_output_group,
+    _test_runenv_absent_yields_empty_env,
+    _test_runenv_empty_when_ctx_none,
+    _test_runenv_partial_json_defaults_missing_keys,
+    _test_runenv_aspect_flags_writes_repo_and_returns_flags,
     _test_run_in_empty_is_none,
     _test_run_in_runfiles_is_none,
     _test_run_in_cwd,

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -9,7 +9,7 @@ load("./lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_bui
 load("./lib/environment.axl", "error")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
-load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
+load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runenv_aspect_flags", "runnable")
 load("./lib/tips.axl", "tips")
 
 def _terminal_status(data, exit_code):
@@ -83,6 +83,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
     flags.extend(LOCAL_SPAWN_FLAGS)
+
+    # Replay the target's `env` attribute on spawn (matching `bazel run`).
+    flags.extend(runenv_aspect_flags(ctx))
 
     r = runnable(ctx, [target])
     events = bazel.build_events.iterator()


### PR DESCRIPTION
`aspect run` / `format` / `gazelle` / `delivery` spawn the built binary directly from its runfiles tree rather than shelling out to `bazel run`. That path never applied the target's `env = {...}` attribute — which `bazel run` injects at run time from the `RunEnvironmentInfo` provider — so any var declared in `env` was simply absent. A `set -u` script that reads one (e.g. `JQ_BIN`) failed with `JQ_BIN: unbound variable`.

The resolved `env` lives in neither the on-disk wrapper nor BES, so it can only be recovered via the provider. A small `runenv` aspect reads `RunEnvironmentInfo.environment` / `.inherited_environment` and writes them to JSON in an `aspect_runenv` output group. The runnable tracker collects that file from BES and `spawn` replays the env — `environment` values verbatim (already rootpath-expanded relative to the runfiles workspace dir, which is the spawn cwd), `inherited_environment` names copied from the process env. Target env is applied before the runfiles/`BUILD_*`/`ASPECT_*` vars so the runfiles plumbing wins on any collision.

The aspect is a no-op for rules that don't populate `RunEnvironmentInfo` (e.g. legacy native `sh_binary`, [bazelbuild/bazel#23658](https://github.com/bazelbuild/bazel/issues/23658)), in which case the spawn behaves as before.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`aspect run`, `format`, `gazelle`, and `delivery` now apply a target's `env` attribute when running the built binary, matching `bazel run`. Fixes `unbound variable` errors for scripts that read env-injected vars under `set -u`.

### Test plan

- New test cases added (`lib/runnable_test.axl`: env collection, partial JSON, absent provider, ctx-less, and the aspect-flags helper)
- Covered by existing test cases (`aspect dev test-runnable`, `aspect tests axl`)
