### PR TITLE
feat(gitlab): support self-hosted GitLab via configurable API base

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -172,6 +172,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
     project_path = mr["project_path"]
     sha = mr["sha"]
     mr_iid = mr["mr_iid"]
+    api_base = gitlab.resolve_api_base(ctx.std.env)
 
     _ci_links_base = _collect_ci_links(ctx, workflows_results_url(ctx.std))
 
@@ -233,6 +234,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             name = _state["_status_name"],
             target_url = target_url or None,
             description = description or None,
+            api_base = api_base,
             auth_kind = "bearer",
         )
         if not result["success"]:

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
@@ -238,6 +238,7 @@ def _post_comments(ctx, gl, comments, existing_markers, task_key):
             mr_iid = gl["mr_iid"],
             body = c["body"],
             position = position,
+            api_base = gl["api_base"],
             auth_kind = "bearer",
         )
         if res["success"]:
@@ -250,7 +251,7 @@ def _post_comments(ctx, gl, comments, existing_markers, task_key):
 def _get_existing_markers(ctx, gl, task_key):
     """Return `{marker: discussion_id}` for THIS task's existing lint
     discussions on the MR (dedup against prior runs)."""
-    listed = gitlab.discussions.list(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], auth_kind = "bearer")
+    listed = gitlab.discussions.list(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], api_base = gl["api_base"], auth_kind = "bearer")
     if not listed["success"]:
         return {}
     markers = {}
@@ -459,7 +460,7 @@ def _cleanup_and_resolve(ctx, gl, relevant_diagnostics, run_id, task_key, sugges
     for m in suggestion_markers:
         desired[m] = True
 
-    listed = gitlab.discussions.list(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], auth_kind = "bearer")
+    listed = gitlab.discussions.list(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], api_base = gl["api_base"], auth_kind = "bearer")
     if not listed["success"]:
         return
 
@@ -473,9 +474,9 @@ def _cleanup_and_resolve(ctx, gl, relevant_diagnostics, run_id, task_key, sugges
     genuinely_clean = not relevant_diagnostics and not suggestion_markers
     plan = compute_cleanup(listed["discussions"], desired, run_id, task_key, genuinely_clean = genuinely_clean)
     for e in plan["delete"]:
-        gitlab.discussions.delete(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], discussion_id = e["discussion_id"], note_id = e["note_id"], auth_kind = "bearer")
+        gitlab.discussions.delete(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], discussion_id = e["discussion_id"], note_id = e["note_id"], api_base = gl["api_base"], auth_kind = "bearer")
     for did in plan["resolve"]:
-        gitlab.discussions.resolve(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], discussion_id = did, resolved = True, auth_kind = "bearer")
+        gitlab.discussions.resolve(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], discussion_id = did, resolved = True, api_base = gl["api_base"], auth_kind = "bearer")
 
 def _gitlab_lint_impl(ctx: FeatureContext):
     lint_trait = ctx.traits[LintTrait]
@@ -503,9 +504,11 @@ def _gitlab_lint_impl(ctx: FeatureContext):
         _LOG.warn(ctx.std, "Authentication failed for %s — %s" % (mr["project_path"], auth_reason.get("reason", "unknown")))
         return
 
+    api_base = gitlab.resolve_api_base(ctx.std.env)
+
     # One call gets both the `diff_refs` SHA triple (for positions) and the
     # per-file diffs (for the new_line→old_line classification below).
-    mr_res = gitlab.merge_requests.list_changes(ctx, token = token, project = mr["project_path"], mr_iid = mr["mr_iid"], auth_kind = "bearer")
+    mr_res = gitlab.merge_requests.list_changes(ctx, token = token, project = mr["project_path"], mr_iid = mr["mr_iid"], api_base = api_base, auth_kind = "bearer")
     if not mr_res["success"]:
         _LOG.warn(ctx.std, "Could not fetch MR %d changes: %s" % (mr["mr_iid"], mr_res.get("error", "unknown")))
         return
@@ -530,6 +533,7 @@ def _gitlab_lint_impl(ctx: FeatureContext):
         "token": token,
         "project_path": mr["project_path"],
         "mr_iid": mr["mr_iid"],
+        "api_base": api_base,
         "diff_refs": diff_refs,
         "changed_lines": {},
         "prefix": "",

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -125,6 +125,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
     project_id = mr.get("project_id")
     mr_iid = mr["mr_iid"]
     head_sha = mr["sha"]
+    api_base = gitlab.resolve_api_base(ctx.std.env)
     marker = _MARKER_FMT % mr_iid
 
     # GitLab CI pipeline + job identity. CI_PIPELINE_ID is the unique
@@ -200,7 +201,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
             # The notes API doesn't expose a single-note GET that filters by id
             # uniquely without `list`; we approximate by listing and matching id.
             # Cheap on a small page; expensive only when the MR has many notes.
-            listed = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, auth_kind = "bearer")
+            listed = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base, auth_kind = "bearer")
             if not listed["success"]:
                 _LOG.warn(ctx.std, "List notes failed: %s" % listed.get("error", "unknown"))
                 return None
@@ -211,7 +212,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
             # Note vanished — fall through to re-discovery.
             _state.pop("_note_id", None)
 
-        listed = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, auth_kind = "bearer")
+        listed = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base, auth_kind = "bearer")
         if not listed["success"]:
             _LOG.warn(ctx.std, "List notes failed: %s" % listed.get("error", "unknown"))
             return None
@@ -234,6 +235,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
                 mr_iid = mr_iid,
                 note_id = _state["_note_id"],
                 body = body,
+                api_base = api_base,
                 auth_kind = "bearer",
             )
             if not res["success"]:
@@ -247,6 +249,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
             project = project_path,
             mr_iid = mr_iid,
             body = body,
+            api_base = api_base,
             auth_kind = "bearer",
         )
         if not res["success"]:
@@ -257,7 +260,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
         # Race mitigation: if two tasks both POSTed within the same
         # window, keep the lowest note id and delete the rest. Stable
         # choice across writers so they converge on the same survivor.
-        listed2 = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, auth_kind = "bearer")
+        listed2 = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base, auth_kind = "bearer")
         if not listed2["success"]:
             return True
         dupes = [n for n in listed2["notes"] if marker in (n.get("body") or "")]
@@ -273,6 +276,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
                 project = project_path,
                 mr_iid = mr_iid,
                 note_id = d["id"],
+                api_base = api_base,
                 auth_kind = "bearer",
             )
             if not del_res["success"]:

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab.axl
@@ -386,6 +386,45 @@ def _extract_project_path_from_url(url):
         tail = tail[:-len(".git")]
     return tail
 
+# API base resolution
+#
+# Self-hosted GitLab instances live on their own host (e.g.
+# `https://gitlab.example.com/api/v4`), so the API base can't stay a
+# hard-coded constant. Resolution precedence:
+#
+#   1. ASPECT_GITLAB_API_URL — explicit override. Matches the
+#      `ASPECT_GITLAB_*` escape-hatch family in `gitlab_detect.axl` (for
+#      Aspect-Workflows runners on a non-GitLab CI host posting back to
+#      a self-hosted GitLab MR). Accepts either a full API base
+#      (`https://host/api/v4`) or a bare instance root (`https://host`),
+#      to which `/api/v4` is appended.
+#   2. CI_API_V4_URL — set natively by GitLab CI on every job; already
+#      points at the running instance's API. Zero config on self-hosted
+#      GitLab CI.
+#   3. DEFAULT_GITLAB_API — public gitlab.com.
+
+def _normalize_api_base(url) -> str:
+    """Trim a trailing slash and append `/api/v4` when the URL looks
+    like a bare instance root (no `/api/v` segment present)."""
+    url = url.rstrip("/")
+    if url.find("/api/v") < 0:
+        url = url + "/api/v4"
+    return url
+
+def _resolve_api_base(env) -> str:
+    """Resolve the GitLab REST v4 API base from the environment.
+
+    See the section comment above for precedence. Always returns a
+    usable base — falls back to `DEFAULT_GITLAB_API` (gitlab.com) when
+    neither env var is set."""
+    explicit = env.var("ASPECT_GITLAB_API_URL") or ""
+    if explicit:
+        return _normalize_api_base(explicit)
+    ci = env.var("CI_API_V4_URL") or ""
+    if ci:
+        return _normalize_api_base(ci)
+    return DEFAULT_GITLAB_API
+
 # Authentication
 #
 # Mirrors the shape of `lib/github.axl::_authenticate`. Exchanges the
@@ -566,6 +605,7 @@ gitlab = struct(
     encode_project_path = encode_project_path,
     extract_host = _extract_host,
     extract_project_path = _extract_project_path_from_url,
+    resolve_api_base = _resolve_api_base,
     authenticate = _authenticate,
     validate_role = validate_role,
     VALID_ROLES = VALID_ROLES,

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_test.axl
@@ -119,6 +119,40 @@ def _test_impl(ctx):
         "",
     )
 
+    # resolve_api_base — precedence + normalization. `env` is faked as a
+    # struct with a `.var(name)` lookup, matching the std env shape.
+    def _env(vars):
+        return struct(var = lambda name: vars.get(name, ""))
+
+    _eq(
+        "resolve_api_base / default when nothing set",
+        gitlab.resolve_api_base(_env({})),
+        "https://gitlab.com/api/v4",
+    )
+    _eq(
+        "resolve_api_base / CI_API_V4_URL (native GitLab CI)",
+        gitlab.resolve_api_base(_env({"CI_API_V4_URL": "https://self-hosted.gitlab.com/api/v4"})),
+        "https://self-hosted.gitlab.com/api/v4",
+    )
+    _eq(
+        "resolve_api_base / explicit override wins over CI_API_V4_URL",
+        gitlab.resolve_api_base(_env({
+            "ASPECT_GITLAB_API_URL": "https://override.gitlab.com/api/v4",
+            "CI_API_V4_URL": "https://self-hosted.gitlab.com/api/v4",
+        })),
+        "https://override.gitlab.com/api/v4",
+    )
+    _eq(
+        "resolve_api_base / bare instance root gets /api/v4 appended",
+        gitlab.resolve_api_base(_env({"ASPECT_GITLAB_API_URL": "https://self-hosted.gitlab.com"})),
+        "https://self-hosted.gitlab.com/api/v4",
+    )
+    _eq(
+        "resolve_api_base / trailing slash trimmed",
+        gitlab.resolve_api_base(_env({"ASPECT_GITLAB_API_URL": "https://self-hosted.gitlab.com/api/v4/"})),
+        "https://self-hosted.gitlab.com/api/v4",
+    )
+
     # commit_status.STATES exposed
     if "success" not in gitlab.commit_status.STATES:
         fail("commit_status.STATES missing 'success'")
@@ -240,6 +274,7 @@ def _test_impl(ctx):
         "encode_project_path",
         "extract_host",
         "extract_project_path",
+        "resolve_api_base",
         "authenticate",
         "validate_role",
         "VALID_ROLES",


### PR DESCRIPTION
## Problem

The GitLab features hard-coded `https://gitlab.com/api/v4` as the API base (`DEFAULT_GITLAB_API` in `lib/gitlab.axl`). Every `gitlab.*` helper already accepted an `api_base` parameter, but no caller ever passed one — so commit statuses, the rolling MR status comment, and inline lint discussions could only ever target `gitlab.com`. Self-hosted GitLab instances had no way in.

## Change

Add `gitlab.resolve_api_base(env)` and thread the resolved base through every `gitlab.*` call in the three GitLab features.

Resolution precedence:

1. **`ASPECT_GITLAB_API_URL`** — explicit override, matching the existing `ASPECT_GITLAB_*` escape-hatch family in `gitlab_detect.axl` (for Aspect-Workflows runners on a non-GitLab CI host posting back to a self-hosted GitLab MR). Accepts either a full API base (`https://self-hosted.gitlab.com/api/v4`) or a bare instance root (`https://self-hosted.gitlab.com`), to which `/api/v4` is appended. A trailing slash is trimmed.
2. **`CI_API_V4_URL`** — set natively by GitLab CI on every job and already points at the running instance's API, so **self-hosted GitLab CI needs zero extra config**.
3. **`https://gitlab.com/api/v4`** — unchanged default when neither is set.

Threaded through all three features:
- `feature/gitlab_commit_statuses.axl` — the commit-status POST
- `feature/gitlab_status_comments.axl` — all six notes list/create/update/delete calls
- `feature/gitlab_lint_comments.axl` — `merge_requests.list_changes` + all five discussions calls (carried on the `gl` context dict)

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no — flagged for a follow-up docsite update
- Breaking change (forces users to change their own code or config): no — default behavior on `gitlab.com` is unchanged
- Suggested release notes appear below: yes

- GitLab integrations (commit statuses, MR status comments, inline lint discussions) now work against self-hosted GitLab. Under GitLab CI this is automatic via `CI_API_V4_URL`; elsewhere set `ASPECT_GITLAB_API_URL` to your instance's API base.

### Test plan

- Added five `resolve_api_base` unit cases to `lib/gitlab_test.axl` (default, `CI_API_V4_URL`, override precedence, bare-root `/api/v4` append, trailing-slash trim) plus the facade shape check.
- `aspect dev test-gitlab-client` → `gitlab.axl smoke: OK`
- `aspect tests axl` → `790 tests passed` (confirms all three edited feature files still load)