### PR TITLE
fix(delivery): expand --config in release_bazel_flags against the rc

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -187,6 +187,7 @@ def config(ctx: ConfigContext):
     ctx.tasks["lint"].args.targets = ["//examples/lint/..."]
 
     ctx.tasks["delivery"].args.query = "attr(tags, deliverable, //...)"
+    ctx.tasks["delivery"].args.release_bazel_flags = ["--config=release"]
     ctx.tasks["delivery"].args.warn_not_runnable = True
 
     ctx.tasks["build"].args.targets = ["//...", "-//exclude/..."]

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -121,7 +121,7 @@ User-facing migration guide: https://docs.aspect.build/cli/migration/delivery
 
 load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@aspect//lib/artifacts.axl", "artifacts")
-load("@aspect//lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce", "resolve_query_flags")
+load("@aspect//lib/bazel_flags.axl", "announce_bazel_args", "expand_config_flags", "resolve_bazel_announce", "resolve_query_flags")
 load("@aspect//lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("@aspect//lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@aspect//lib/ci.axl", "resolve_build_url")
@@ -1201,14 +1201,21 @@ def _delivery_impl(ctx):
             phase = Phase(name = "download", description = "Download runfiles", emoji = "📥"),
         )
 
+        # Expand any `--config=NAME` in release_bazel_flags against the rc — the
+        # release build reaches Bazel under --ignore_all_rc_files, so an
+        # unexpanded `--config=release` would fail with "Config value not
+        # defined" (the task's own expanded_flags already went through this).
+        release_flags = expand_config_flags(ctx, bazel_trait, ctx.args.release_bazel_flags)
+
         # Phase 3 flag order (last-wins):
         #   LOCAL_SPAWN_BASE_FLAGS  — defaults first so user/rc overrides win.
         #   expanded_flags          — user `--bazel-flag` / rc settings.
-        #   release_bazel_flags     — `--release-bazel-flag` (e.g. `--stamp`).
+        #   release_flags           — `--release-bazel-flag` (e.g. `--stamp`,
+        #                             `--config=release`), rc-config-expanded.
         #   LOCAL_SPAWN_FLAGS       — mandatory; last so nothing flips them.
         #   --noremote_upload_local_results — keep release artifacts out of the
         #                             shared remote cache (delivery-specific).
-        phase3_flags = LOCAL_SPAWN_BASE_FLAGS + list(expanded_flags) + list(ctx.args.release_bazel_flags) + LOCAL_SPAWN_FLAGS + [
+        phase3_flags = LOCAL_SPAWN_BASE_FLAGS + list(expanded_flags) + list(release_flags) + LOCAL_SPAWN_FLAGS + [
             "--noremote_upload_local_results",
         ]
         _t_download = time.monotonic()

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
@@ -285,3 +285,23 @@ def resolve_query_flags(ctx, bazel_trait):
     )
     _, expanded_flags = rc.expand_all(command = "query")
     return expanded_flags
+
+def expand_config_flags(ctx, bazel_trait, extra_flags, command = "build"):
+    """Expand the `--config=NAME` references in `extra_flags` against the rc.
+
+    Tasks reach Bazel under `--ignore_all_rc_files`, so any `--config=NAME` in a
+    flag list that bypasses `setup_bazel_command`'s expansion (e.g. delivery's
+    `release_bazel_flags`, appended after `expanded_flags`) would otherwise hit
+    Bazel un-expanded and fail with "Config value 'NAME' is not defined". Parse
+    the workspace rc with `extra_flags` and expand for `command` so a
+    `--config=release` resolves to its `common:release`/`build:release` options,
+    exactly as the task's own flags do.
+
+    Returns the expanded flag list (same shape as `setup_bazel_command`).
+    Non-`--config` flags pass through unchanged. Mutates nothing on `ctx.bazel`
+    (no startup flags added, no disclosure) — the task's setup already did that.
+    """
+    startup_flags = resolve_startup_flags(ctx, bazel_trait)
+    rc = ctx.bazel.parse_rc(startup_flags = startup_flags, flags = list(extra_flags))
+    _, expanded_flags = rc.expand_all(command = command)
+    return expanded_flags

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags.axl
@@ -292,16 +292,36 @@ def expand_config_flags(ctx, bazel_trait, extra_flags, command = "build"):
     Tasks reach Bazel under `--ignore_all_rc_files`, so any `--config=NAME` in a
     flag list that bypasses `setup_bazel_command`'s expansion (e.g. delivery's
     `release_bazel_flags`, appended after `expanded_flags`) would otherwise hit
-    Bazel un-expanded and fail with "Config value 'NAME' is not defined". Parse
-    the workspace rc with `extra_flags` and expand for `command` so a
+    Bazel un-expanded and fail with "Config value 'NAME' is not defined". So a
     `--config=release` resolves to its `common:release`/`build:release` options,
     exactly as the task's own flags do.
 
-    Returns the expanded flag list (same shape as `setup_bazel_command`).
-    Non-`--config` flags pass through unchanged. Mutates nothing on `ctx.bazel`
-    (no startup flags added, no disclosure) — the task's setup already did that.
+    Returns ONLY the options `extra_flags` contributes — the delta between
+    expanding the rc with `extra_flags` and without them. This is deliberate:
+    `rc.expand_all` always prepends the full `command` rc base (so its result is
+    not just the passed flags), and the caller appends this AFTER the task's own
+    `expanded_flags`. Returning the whole base again would re-apply rc defaults
+    last and clobber the user's `--bazel-flag` overrides (last-wins). The delta
+    is `extra_flags` with each `--config=NAME` replaced by its section options,
+    and nothing the base already provided. Order within the delta is preserved.
+
+    Mutates nothing on `ctx.bazel` (no startup flags added, no disclosure) — the
+    task's setup already did that.
     """
     startup_flags = resolve_startup_flags(ctx, bazel_trait)
-    rc = ctx.bazel.parse_rc(startup_flags = startup_flags, flags = list(extra_flags))
-    _, expanded_flags = rc.expand_all(command = command)
-    return expanded_flags
+
+    # Base expansion (no extra flags) vs. with extra flags; the suffix the latter
+    # adds is exactly what extra_flags + their config expansions contribute.
+    base_rc = ctx.bazel.parse_rc(startup_flags = startup_flags, flags = [])
+    _, base_flags = base_rc.expand_all(command = command)
+
+    full_rc = ctx.bazel.parse_rc(
+        startup_flags = startup_flags,
+        flags = list(extra_flags),
+        skip_config_if_missing = requested_config_names(list(extra_flags)),
+    )
+    _, full_flags = full_rc.expand_all(command = command)
+
+    # expand_all lists base options first, then the passed flags' expansion; the
+    # tail beyond the base length is the extra_flags' contribution.
+    return full_flags[len(base_flags):]


### PR DESCRIPTION
## Summary

`aspect delivery`'s release build reaches Bazel under `--ignore_all_rc_files` — the CLI parses the workspace `.bazelrc` itself and replays it as expanded flags. The task's own flags go through that `--config=` expansion, but **`release_bazel_flags` were appended raw** to the phase-3 command, so a `--config=NAME` in them hit Bazel unexpanded and failed:

```
ERROR: Config value 'release' is not defined in any .rc file
```

This regressed when `release_bazel_flags` was introduced. A project that sets `ctx.tasks["delivery"].args.release_bazel_flags = ["--config=release"]` (the natural way to reuse a `common:release` rc config for stamped release builds) can't deliver.

## Fix

- Add `expand_config_flags(ctx, bazel_trait, flags, command="build")` to `lib/bazel_flags.axl` — parses the rc with the given flags and `expand_all`s for the command, mirroring `resolve_query_flags`. Resolves any `--config=NAME` to its underlying options; non-config flags pass through.
- In `delivery.axl` phase 3, run `release_bazel_flags` through `expand_config_flags` before assembling `phase3_flags`.

## Test plan

- Rendered a project with `release_bazel_flags = ["--config=release"]` and a `common:release --stamp --workspace_status_command=...` rc line. With the fix, the phase-3 command contains the expanded `--stamp --workspace_status_command=...` (verified via `ASPECT_DEBUG=1`) and no longer errors with "Config value 'release' is not defined". `--config=release` no longer appears raw.
- `aspect buildifier` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
