### PR TITLE
fix(lint): name the failing linter when fail_on_linter_error trips

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -29,7 +29,7 @@ load("@aspect//lib/result_text.axl", "severity_for_status")
 load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
 load("@aspect//lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics", "sarif_to_review_comments")
 load("@aspect//lib/tips.axl", "tips")
-load("@aspect//lint.axl", "file_uri_to_path", "filter_all", "filter_changeset")
+load("@aspect//lint.axl", "file_uri_to_path", "filter_all", "filter_changeset", "linter_error_message")
 load("@demo//answer.axl", "ANSWER")
 load("./lambda.axl", "lambda_with_global_bind")
 
@@ -2435,6 +2435,24 @@ def test_lint_filters(tc: int) -> int:
 
     return tc
 
+def test_linter_error_message(tc: int) -> int:
+    """Coverage for lint.linter_error_message — the fail_on_linter_error text."""
+    single = linter_error_message({"PMD": True}, "hard")
+    tc = test_case(tc, "exited non-zero: PMD." in single, "linter_error_message: names the single tool")
+    tc = test_case(tc, "strategy=hard" in single, "linter_error_message: includes strategy")
+    tc = test_case(tc, "🔬 Lint phase" in single, "linter_error_message: points at the raw output")
+
+    # Multiple tools are sorted for a stable message.
+    multi = linter_error_message({"Ruff": True, "PMD": True}, "hard")
+    tc = test_case(tc, "exited non-zero: PMD, Ruff." in multi, "linter_error_message: sorts multiple tools")
+
+    # Empty set (unparsable BES name) → unnamed fallback, still actionable.
+    none = linter_error_message({}, "hard")
+    tc = test_case(tc, none.startswith("A linter process exited non-zero."), "linter_error_message: unnamed fallback")
+    tc = test_case(tc, "strategy=hard" in none, "linter_error_message: fallback keeps strategy")
+
+    return tc
+
 def test_fmt_elapsed(tc: int) -> int:
     """Coverage for delivery.fmt_elapsed — duration formatting."""
     cases = [
@@ -3178,6 +3196,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_process_bes_target_completed(ctx, tc)
     tc = test_validate_role(tc)
     tc = test_lint_filters(tc)
+    tc = test_linter_error_message(tc)
     tc = test_fmt_elapsed(tc)
     tc = test_summary_title(tc)
     tc = test_resolve_aspect_url(tc)

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -529,9 +529,11 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
     """Read and process one BES lint output file.
 
     Returns None when the file isn't on disk yet (remote download in flight),
-    else {"interesting": bool, "linter_exit_code": int}. Bazel moves outputs to
-    their final path atomically (moveOutputsToFinalLocation), so fs.exists()==True
-    means fully written:
+    else {"interesting": bool, "linter_exit_code": int, "failed_tool": str}.
+    `failed_tool` names the linter when its `.exit_code` was non-zero (else ""),
+    so the fail_on_linter_error path can report which tool failed. Bazel moves
+    outputs to their final path atomically (moveOutputsToFinalLocation), so
+    fs.exists()==True means fully written:
     https://github.com/bazelbuild/bazel/blob/d3c9a2080e30cecd661c02a8f0cce84caa696aed/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java#L930
     SARIF is filtered per-batch against the (pure) strategy scope, so per-batch
     results equal a terminal pass and findings don't flicker as batches arrive.
@@ -540,7 +542,7 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
         if not ctx.std.fs.exists(filepath):
             return None
         ctx.std.io.stderr.write(ctx.std.fs.read_to_string(filepath))
-        return {"interesting": False, "linter_exit_code": 0}
+        return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
     if file.name.endswith(".report"):
         if not ctx.std.fs.exists(filepath):
@@ -550,11 +552,11 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
             lint_accumulate(data, strategy.filter(parse_sarif_diagnostics(report), changed_files))
             for hook in lint_trait.lint_report:
                 hook(ctx, filepath)
-            return {"interesting": True, "linter_exit_code": 0}
+            return {"interesting": True, "linter_exit_code": 0, "failed_tool": ""}
         ctx.std.io.stdout.write(report)
         if github_output:
             ctx.std.fs.write(github_output, "lint-report=" + filepath)
-        return {"interesting": False, "linter_exit_code": 0}
+        return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
     if file.name.endswith(".patch"):
         if not ctx.std.fs.exists(filepath):
@@ -562,18 +564,22 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
         patches.append(filepath)
         for hook in lint_trait.lint_patch:
             hook(ctx, filepath, file.name)
-        return {"interesting": False, "linter_exit_code": 0}
+        return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
     if file.name.endswith(".exit_code"):
         if not ctx.std.fs.exists(filepath):
             return None
-        return {"interesting": False, "linter_exit_code": int(ctx.std.fs.read_to_string(filepath).rstrip())}
+        exit_code = int(ctx.std.fs.read_to_string(filepath).rstrip())
+        failed_tool = detect_lint_tool(file.name) if exit_code != 0 else ""
+        return {"interesting": False, "linter_exit_code": exit_code, "failed_tool": failed_tool}
 
-    return {"interesting": False, "linter_exit_code": 0}
+    return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
-def _drain_pending_files(ctx, pending, data, strategy, changed_files, lint_trait, github_output, patches):
+def _drain_pending_files(ctx, pending, data, strategy, changed_files, lint_trait, github_output, patches, failed_linters):
     """One pass over pending files → (still_pending, was_interesting, linter_exit_code).
     still_pending holds files whose remote download hasn't landed yet.
+    `failed_linters` is a set-like dict accumulating tool names whose `.exit_code`
+    was non-zero, so the caller can report which linters failed.
     """
     still_pending = []
     interesting = False
@@ -588,6 +594,8 @@ def _drain_pending_files(ctx, pending, data, strategy, changed_files, lint_trait
                 interesting = True
             if result["linter_exit_code"] != 0:
                 linter_exit_code = 1
+                if result["failed_tool"]:
+                    failed_linters[result["failed_tool"]] = True
     return (still_pending, interesting, linter_exit_code)
 
 # buildifier: disable=function-docstring
@@ -725,6 +733,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     )
 
     linter_exit_code = 0
+
+    # Tool names whose `.exit_code` was non-zero; reported in the
+    # fail_on_linter_error path so the failure names the offending linter.
+    failed_linters = {}
     patches = []
     github_output = ctx.std.env.var("GITHUB_OUTPUT")
 
@@ -750,6 +762,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             lint_trait,
             github_output,
             patches,
+            failed_linters,
         )
         if pending_interesting:
             interesting = True
@@ -779,6 +792,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                                 interesting = True
                             if result["linter_exit_code"] != 0:
                                 linter_exit_code = 1
+                                if result["failed_tool"]:
+                                    failed_linters[result["failed_tool"]] = True
         if interesting or now_ms(ctx) - last_emit_ms >= MIN_HEARTBEAT_INTERVAL_MS:
             # Flip to "failing" on mid-build action failure so the breakdown tags Lint.
             had_action_failure = data["bazel"].get("failed_actions_total", 0) > 0
@@ -817,6 +832,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 lint_trait,
                 github_output,
                 patches,
+                failed_linters,
             )
             if pending_exit_code != 0:
                 linter_exit_code = 1
@@ -944,6 +960,22 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     elif strategy.fail_on_severity and any([d["severity"] == strategy.fail_on_severity for d in relevant]):
         exit_code = 1
     elif strategy.fail_on_linter_error and linter_exit_code != 0:
+        # A linter process exited non-zero without producing findings — otherwise
+        # this path surfaces nothing, leaving an unexplained exit 1. Name the
+        # offending tool(s) and point at the raw `🔬 Lint` output above.
+        if failed_linters:
+            tools = ", ".join(sorted(failed_linters.keys()))
+            error(ctx.std, (
+                "Linter process(es) exited non-zero: %s. " % tools +
+                "See the linter output under the 🔬 Lint phase above for details. " +
+                "(strategy=%s fails on any linter error.)" % _strategy_name(strategy)
+            ))
+        else:
+            error(ctx.std, (
+                "A linter process exited non-zero. " +
+                "See the linter output under the 🔬 Lint phase above for details. " +
+                "(strategy=%s fails on any linter error.)" % _strategy_name(strategy)
+            ))
         exit_code = 1
     else:
         exit_code = 0

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -336,6 +336,22 @@ def _strategy_name(strategy):
         return "soft"
     return "custom"
 
+def linter_error_message(failed_linters, strategy_name):
+    """Message for the fail_on_linter_error path, naming the offending tool(s)
+    when known. A non-zero `.exit_code` whose BES name didn't parse leaves
+    `failed_linters` empty, so fall back to an unnamed message.
+
+    `failed_linters` is a set-like dict of tool names.
+    """
+    if failed_linters:
+        head = "Linter process(es) exited non-zero: %s." % ", ".join(sorted(failed_linters.keys()))
+    else:
+        head = "A linter process exited non-zero."
+    return (
+        "%s See the linter output under the 🔬 Lint phase above for details. " % head +
+        "(strategy=%s fails on any linter error.)" % strategy_name
+    )
+
 _SEV_CLI_ICON = {
     "error": "🚨",
     "warning": "⚠️",
@@ -575,28 +591,34 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
 
     return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
+def _record_lint_result(result, failed_linters):
+    """Fold one non-None `_try_process_lint_file` result into `failed_linters`
+    (a set-like dict of tool names that exited non-zero) and return
+    `(interesting, exit_nonzero)`. Shared by the live BES loop and the
+    post-build drain so both treat a result identically.
+    """
+    if result["linter_exit_code"] != 0 and result["failed_tool"]:
+        failed_linters[result["failed_tool"]] = True
+    return (result["interesting"], result["linter_exit_code"] != 0)
+
 def _drain_pending_files(ctx, pending, data, strategy, changed_files, lint_trait, github_output, patches, failed_linters):
-    """One pass over pending files → (still_pending, was_interesting, linter_exit_code).
+    """One pass over pending files → (still_pending, was_interesting, exit_nonzero).
     still_pending holds files whose remote download hasn't landed yet.
-    `failed_linters` is a set-like dict accumulating tool names whose `.exit_code`
-    was non-zero, so the caller can report which linters failed.
+    `failed_linters` accumulates tool names whose `.exit_code` was non-zero.
     """
     still_pending = []
     interesting = False
-    linter_exit_code = 0
+    exit_nonzero = False
     for pfile in pending:
         pfilepath = file_uri_to_path(pfile.file)
         result = _try_process_lint_file(ctx, pfile, pfilepath, data, strategy, changed_files, lint_trait, github_output, patches)
         if result == None:
             still_pending.append(pfile)
         else:
-            if result["interesting"]:
-                interesting = True
-            if result["linter_exit_code"] != 0:
-                linter_exit_code = 1
-                if result["failed_tool"]:
-                    failed_linters[result["failed_tool"]] = True
-    return (still_pending, interesting, linter_exit_code)
+            file_interesting, file_exit_nonzero = _record_lint_result(result, failed_linters)
+            interesting = interesting or file_interesting
+            exit_nonzero = exit_nonzero or file_exit_nonzero
+    return (still_pending, interesting, exit_nonzero)
 
 # buildifier: disable=function-docstring
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
@@ -753,7 +775,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for _tick in sleep_iter(BES_DRAIN_TICK_MS):
         interesting = False
 
-        pending_files, pending_interesting, pending_exit_code = _drain_pending_files(
+        pending_files, pending_interesting, pending_exit_nonzero = _drain_pending_files(
             ctx,
             pending_files,
             data,
@@ -766,7 +788,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         )
         if pending_interesting:
             interesting = True
-        if pending_exit_code != 0:
+        if pending_exit_nonzero:
             linter_exit_code = 1
 
         for _ in range(10000):
@@ -788,12 +810,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                         if result == None:
                             pending_files.append(file)
                         else:
-                            if result["interesting"]:
-                                interesting = True
-                            if result["linter_exit_code"] != 0:
+                            file_interesting, file_exit_nonzero = _record_lint_result(result, failed_linters)
+                            interesting = interesting or file_interesting
+                            if file_exit_nonzero:
                                 linter_exit_code = 1
-                                if result["failed_tool"]:
-                                    failed_linters[result["failed_tool"]] = True
         if interesting or now_ms(ctx) - last_emit_ms >= MIN_HEARTBEAT_INTERVAL_MS:
             # Flip to "failing" on mid-build action failure so the breakdown tags Lint.
             had_action_failure = data["bazel"].get("failed_actions_total", 0) > 0
@@ -823,7 +843,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         post_build_deadline_ms = post_build_start_ms + _POST_BUILD_DOWNLOAD_TIMEOUT_MS
         slow_warned = False
         for _i in range(_POST_BUILD_DOWNLOAD_TIMEOUT_MS // BES_DRAIN_TICK_MS + 1):
-            pending_files, _, pending_exit_code = _drain_pending_files(
+            pending_files, _, pending_exit_nonzero = _drain_pending_files(
                 ctx,
                 pending_files,
                 data,
@@ -834,7 +854,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 patches,
                 failed_linters,
             )
-            if pending_exit_code != 0:
+            if pending_exit_nonzero:
                 linter_exit_code = 1
             if not pending_files:
                 break
@@ -960,22 +980,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     elif strategy.fail_on_severity and any([d["severity"] == strategy.fail_on_severity for d in relevant]):
         exit_code = 1
     elif strategy.fail_on_linter_error and linter_exit_code != 0:
-        # A linter process exited non-zero without producing findings — otherwise
-        # this path surfaces nothing, leaving an unexplained exit 1. Name the
-        # offending tool(s) and point at the raw `🔬 Lint` output above.
-        if failed_linters:
-            tools = ", ".join(sorted(failed_linters.keys()))
-            error(ctx.std, (
-                "Linter process(es) exited non-zero: %s. " % tools +
-                "See the linter output under the 🔬 Lint phase above for details. " +
-                "(strategy=%s fails on any linter error.)" % _strategy_name(strategy)
-            ))
-        else:
-            error(ctx.std, (
-                "A linter process exited non-zero. " +
-                "See the linter output under the 🔬 Lint phase above for details. " +
-                "(strategy=%s fails on any linter error.)" % _strategy_name(strategy)
-            ))
+        # Without this the path surfaces nothing: a linter that crashed without
+        # emitting findings would fail with an unexplained exit 1.
+        error(ctx.std, linter_error_message(failed_linters, _strategy_name(strategy)))
         exit_code = 1
     else:
         exit_code = 0


### PR DESCRIPTION
The `lint` task's `hard` strategy fails whenever a linter **process** exits non-zero (`fail_on_linter_error`), independent of whether it produced findings. That branch in the exit-code logic printed nothing, so a linter that crashed or errored without emitting SARIF produced an unexplained `exit code 1` — surfaced only as a `🔎 Filter (failed)` tag in the breakdown, with no indication of which linter or why.

This recovers the failing tool name from the `.exit_code` BES marker (via the existing `detect_lint_tool`), accumulates the offending tools, and emits an error at the failure point naming them and pointing at the raw `🔬 Lint` output:

> `Linter process(es) exited non-zero: PMD, Ruff. See the linter output under the 🔬 Lint phase above for details. (strategy=hard fails on any linter error.)`

When a marker's name can't be parsed, it falls back to an unnamed-but-actionable message.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

**Suggested release notes:**

- `aspect lint` now names the offending linter when a linter process exits non-zero under the `hard` strategy, instead of failing with an unexplained `exit code 1`.

### Test plan

- New test cases added: `test_linter_error_message` in `.aspect/axl.axl` covers the message helper (single/multiple/unnamed tools).
- `aspect-cli tests axl` — 796 tests pass
- `aspect-cli dev test-lint-template-snapshots` — all 8 scenarios render without error
- `cargo build -p aspect-cli` — passes
