### PR TITLE
refactor(gitlab): default auth_kind to "bearer" in lib/gitlab.axl

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -235,7 +235,6 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             target_url = target_url or None,
             description = description or None,
             api_base = api_base,
-            auth_kind = "bearer",
         )
         if not result["success"]:
             _LOG.warn(ctx.std, "commit_status POST failed (state=%s): %s" % (

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
@@ -239,7 +239,6 @@ def _post_comments(ctx, gl, comments, existing_markers, task_key):
             body = c["body"],
             position = position,
             api_base = gl["api_base"],
-            auth_kind = "bearer",
         )
         if res["success"]:
             if marker:
@@ -251,7 +250,7 @@ def _post_comments(ctx, gl, comments, existing_markers, task_key):
 def _get_existing_markers(ctx, gl, task_key):
     """Return `{marker: discussion_id}` for THIS task's existing lint
     discussions on the MR (dedup against prior runs)."""
-    listed = gitlab.discussions.list(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], api_base = gl["api_base"], auth_kind = "bearer")
+    listed = gitlab.discussions.list(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], api_base = gl["api_base"])
     if not listed["success"]:
         return {}
     markers = {}
@@ -460,7 +459,7 @@ def _cleanup_and_resolve(ctx, gl, relevant_diagnostics, run_id, task_key, sugges
     for m in suggestion_markers:
         desired[m] = True
 
-    listed = gitlab.discussions.list(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], api_base = gl["api_base"], auth_kind = "bearer")
+    listed = gitlab.discussions.list(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], api_base = gl["api_base"])
     if not listed["success"]:
         return
 
@@ -474,9 +473,9 @@ def _cleanup_and_resolve(ctx, gl, relevant_diagnostics, run_id, task_key, sugges
     genuinely_clean = not relevant_diagnostics and not suggestion_markers
     plan = compute_cleanup(listed["discussions"], desired, run_id, task_key, genuinely_clean = genuinely_clean)
     for e in plan["delete"]:
-        gitlab.discussions.delete(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], discussion_id = e["discussion_id"], note_id = e["note_id"], api_base = gl["api_base"], auth_kind = "bearer")
+        gitlab.discussions.delete(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], discussion_id = e["discussion_id"], note_id = e["note_id"], api_base = gl["api_base"])
     for did in plan["resolve"]:
-        gitlab.discussions.resolve(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], discussion_id = did, resolved = True, api_base = gl["api_base"], auth_kind = "bearer")
+        gitlab.discussions.resolve(ctx, token = gl["token"], project = gl["project_path"], mr_iid = gl["mr_iid"], discussion_id = did, resolved = True, api_base = gl["api_base"])
 
 def _gitlab_lint_impl(ctx: FeatureContext):
     lint_trait = ctx.traits[LintTrait]
@@ -508,7 +507,7 @@ def _gitlab_lint_impl(ctx: FeatureContext):
 
     # One call gets both the `diff_refs` SHA triple (for positions) and the
     # per-file diffs (for the new_line→old_line classification below).
-    mr_res = gitlab.merge_requests.list_changes(ctx, token = token, project = mr["project_path"], mr_iid = mr["mr_iid"], api_base = api_base, auth_kind = "bearer")
+    mr_res = gitlab.merge_requests.list_changes(ctx, token = token, project = mr["project_path"], mr_iid = mr["mr_iid"], api_base = api_base)
     if not mr_res["success"]:
         _LOG.warn(ctx.std, "Could not fetch MR %d changes: %s" % (mr["mr_iid"], mr_res.get("error", "unknown")))
         return

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -201,7 +201,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
             # The notes API doesn't expose a single-note GET that filters by id
             # uniquely without `list`; we approximate by listing and matching id.
             # Cheap on a small page; expensive only when the MR has many notes.
-            listed = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base, auth_kind = "bearer")
+            listed = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base)
             if not listed["success"]:
                 _LOG.warn(ctx.std, "List notes failed: %s" % listed.get("error", "unknown"))
                 return None
@@ -212,7 +212,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
             # Note vanished — fall through to re-discovery.
             _state.pop("_note_id", None)
 
-        listed = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base, auth_kind = "bearer")
+        listed = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base)
         if not listed["success"]:
             _LOG.warn(ctx.std, "List notes failed: %s" % listed.get("error", "unknown"))
             return None
@@ -236,7 +236,6 @@ def _gitlab_status_comments(ctx: FeatureContext):
                 note_id = _state["_note_id"],
                 body = body,
                 api_base = api_base,
-                auth_kind = "bearer",
             )
             if not res["success"]:
                 _LOG.warn(ctx.std, "Update note failed: %s" % res.get("error", "unknown"))
@@ -250,7 +249,6 @@ def _gitlab_status_comments(ctx: FeatureContext):
             mr_iid = mr_iid,
             body = body,
             api_base = api_base,
-            auth_kind = "bearer",
         )
         if not res["success"]:
             _LOG.warn(ctx.std, "Create note failed: %s" % res.get("error", "unknown"))
@@ -260,7 +258,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
         # Race mitigation: if two tasks both POSTed within the same
         # window, keep the lowest note id and delete the rest. Stable
         # choice across writers so they converge on the same survivor.
-        listed2 = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base, auth_kind = "bearer")
+        listed2 = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base)
         if not listed2["success"]:
             return True
         dupes = [n for n in listed2["notes"] if marker in (n.get("body") or "")]
@@ -277,7 +275,6 @@ def _gitlab_status_comments(ctx: FeatureContext):
                 mr_iid = mr_iid,
                 note_id = d["id"],
                 api_base = api_base,
-                auth_kind = "bearer",
             )
             if not del_res["success"]:
                 _LOG.trace("Cleanup of duplicate note %s failed; will retry next cycle" % d["id"])

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab.axl
@@ -4,10 +4,11 @@ Mirrors `lib/github.axl` so per-VCS feature modules share call-site
 ergonomics. Callers pass a `token` (PAT, group/project access token, or
 OAuth bearer); `auth_kind` picks the header convention:
 
-  * `"private_token"` (default) → `PRIVATE-TOKEN: <token>` (PATs, group/
-    project access tokens).
-  * `"bearer"`                  → `Authorization: Bearer <token>` (OAuth/
-    Application tokens, e.g. the Aspect GitLab App once ENG-1650 lands).
+  * `"bearer"` (default)        → `Authorization: Bearer <token>` (OAuth/
+    Application tokens, e.g. the Aspect GitLab App — the canonical
+    Marvin-minted token).
+  * `"private_token"`           → `PRIVATE-TOKEN: <token>` (PATs, group/
+    project access tokens; opt-in).
 """
 
 DEFAULT_GITLAB_API = "https://gitlab.com/api/v4"
@@ -19,7 +20,7 @@ def _auth_headers(token, auth_kind):
         return {"Authorization": "Bearer " + token}
     return {"PRIVATE-TOKEN": token}
 
-def _do_request(ctx, method, url, token, auth_kind = "private_token", payload = None):
+def _do_request(ctx, method, url, token, auth_kind = "bearer", payload = None):
     headers = {
         "Accept": "application/json",
         "Content-Type": "application/json",
@@ -103,7 +104,7 @@ def _project_url(api_base, project, suffix):
 
 _COMMIT_STATUS_STATES = ["pending", "running", "success", "failed", "canceled", "skipped"]
 
-def _commit_status_post(ctx, token, project, sha, state, name, target_url = None, description = None, coverage = None, pipeline_id = None, ref = None, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _commit_status_post(ctx, token, project, sha, state, name, target_url = None, description = None, coverage = None, pipeline_id = None, ref = None, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     """Post a commit status to a SHA. GitLab does not have a distinct
     create/update split — POSTing the same `(name, sha, ref)` triple
     transitions the existing entry."""
@@ -154,7 +155,7 @@ def _commit_status_skipped(ctx, token, project, sha, name, **kwargs):
 # Admin registers the check on the project (one-time, not managed here);
 # pipelines respond against `(mr_iid, sha, external_status_check_id)`.
 
-def _external_status_check_respond(ctx, token, project, mr_iid, sha, external_status_check_id, status, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _external_status_check_respond(ctx, token, project, mr_iid, sha, external_status_check_id, status, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     """Set the response for a registered External Status Check.
 
     `status` is one of `passed`, `failed`, or `pending`.
@@ -172,7 +173,7 @@ def _external_status_check_respond(ctx, token, project, mr_iid, sha, external_st
         return {"success": True, "response": body if type(body) == "dict" else None}
     return {"success": False, "error": "request failed: %d" % status_code, "status": status_code, "body": body}
 
-def _external_status_check_list(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _external_status_check_list(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     """List registered External Status Checks visible on an MR.
 
     Useful for discovering the `external_status_check_id` to respond
@@ -186,7 +187,7 @@ def _external_status_check_list(ctx, token, project, mr_iid, api_base = DEFAULT_
 
 # Merge Request Notes (the GitLab equivalent of a GitHub issue/PR comment)
 
-def _notes_list(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _notes_list(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     """List notes on an MR, paginated (100/page, walk to short page or cap)."""
     base = _project_url(api_base, project, "/merge_requests/" + str(mr_iid) + "/notes")
     per_page = 100
@@ -204,35 +205,35 @@ def _notes_list(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth
             break
     return {"success": True, "notes": all_notes}
 
-def _notes_create(ctx, token, project, mr_iid, body, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _notes_create(ctx, token, project, mr_iid, body, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     url = _project_url(api_base, project, "/merge_requests/" + str(mr_iid) + "/notes")
     success, status_code, resp = _do_request(ctx, "POST", url, token, auth_kind = auth_kind, payload = {"body": body})
     if success:
         return {"success": True, "note_id": resp.get("id") if type(resp) == "dict" else None, "note": resp}
     return {"success": False, "error": "request failed: %d" % status_code, "status": status_code, "body": resp}
 
-def _notes_update(ctx, token, project, mr_iid, note_id, body, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _notes_update(ctx, token, project, mr_iid, note_id, body, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     url = _project_url(api_base, project, "/merge_requests/" + str(mr_iid) + "/notes/" + str(note_id))
     success, status_code, resp = _do_request(ctx, "PUT", url, token, auth_kind = auth_kind, payload = {"body": body})
     if success:
         return {"success": True, "note_id": resp.get("id") if type(resp) == "dict" else note_id, "note": resp}
     return {"success": False, "error": "request failed: %d" % status_code, "status": status_code, "body": resp}
 
-def _notes_delete(ctx, token, project, mr_iid, note_id, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _notes_delete(ctx, token, project, mr_iid, note_id, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     url = _project_url(api_base, project, "/merge_requests/" + str(mr_iid) + "/notes/" + str(note_id))
     success, status_code, _ = _do_request(ctx, "DELETE", url, token, auth_kind = auth_kind)
     return {"success": success, "status": status_code}
 
 # Merge Request fetch
 
-def _mr_get(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _mr_get(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     url = _project_url(api_base, project, "/merge_requests/" + str(mr_iid))
     success, status_code, body = _do_request(ctx, "GET", url, token, auth_kind = auth_kind)
     if success:
         return {"success": True, "merge_request": body}
     return {"success": False, "error": "request failed: %d" % status_code, "status": status_code, "body": body}
 
-def _mr_list_changes(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _mr_list_changes(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     """List file changes for an MR. Returns GitLab's raw `changes` array
     (each entry: `old_path`, `new_path`, `diff`, …).
 
@@ -252,7 +253,7 @@ def _mr_list_changes(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API,
 # GitHub-PR-review-comment equivalent; used by GitlabLintComments).
 # https://docs.gitlab.com/ee/api/discussions.html#merge-requests
 
-def _discussions_list(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _discussions_list(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     """List discussions on an MR, paginated. Mirrors `_notes_list`.
 
     Each discussion: `id` (string hash) + `notes` list; each note has
@@ -274,7 +275,7 @@ def _discussions_list(ctx, token, project, mr_iid, api_base = DEFAULT_GITLAB_API
             break
     return {"success": True, "discussions": all_discussions}
 
-def _discussions_create(ctx, token, project, mr_iid, body, position, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _discussions_create(ctx, token, project, mr_iid, body, position, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     """Create a position-bound discussion on an MR diff line.
 
     `position` must be a dict shaped:
@@ -290,7 +291,7 @@ def _discussions_create(ctx, token, project, mr_iid, body, position, api_base = 
         return {"success": True, "discussion_id": resp.get("id") if type(resp) == "dict" else None, "discussion": resp}
     return {"success": False, "error": "request failed: %d" % status_code, "status": status_code, "body": resp}
 
-def _discussions_delete(ctx, token, project, mr_iid, discussion_id, note_id, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _discussions_delete(ctx, token, project, mr_iid, discussion_id, note_id, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     """Delete a single note from a discussion (removes stale annotations).
 
     GitLab has no delete-whole-discussion endpoint, but a position-bound
@@ -300,7 +301,7 @@ def _discussions_delete(ctx, token, project, mr_iid, discussion_id, note_id, api
     success, status_code, _ = _do_request(ctx, "DELETE", url, token, auth_kind = auth_kind)
     return {"success": success, "status": status_code}
 
-def _discussions_resolve(ctx, token, project, mr_iid, discussion_id, resolved = True, api_base = DEFAULT_GITLAB_API, auth_kind = "private_token"):
+def _discussions_resolve(ctx, token, project, mr_iid, discussion_id, resolved = True, api_base = DEFAULT_GITLAB_API, auth_kind = "bearer"):
     """Resolve (or unresolve) a discussion thread. GitLab takes `resolved`
     as a query parameter, not a body field."""
     resolved_str = "true" if resolved else "false"


### PR DESCRIPTION
`lib/gitlab.axl` defaulted `auth_kind = "private_token"` on `_do_request` and every public helper, but Marvin-minted tokens are always OAuth bearer tokens — so every real callsite (`GitlabCommitStatuses`, `GitlabStatusComments`, `GitlabLintComments`) passed `auth_kind="bearer"` explicitly. The default was inverted for the canonical use case ([ENG-1689](https://linear.app/aspect-build/issue/ENG-1689), deferred follow-up from ENG-1651).

This flips the default to `"bearer"` across `_do_request` and all 14 public helpers, drops the 13 now-redundant explicit `auth_kind="bearer"` args at the callsites, and keeps `"private_token"` available as an opt-in for PAT / group-access-token callers. Runtime behavior is unchanged — the callsites resolved to bearer before and resolve to bearer now.

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- `aspect-cli dev test-gitlab-client` — `gitlab.axl smoke: OK`
- `aspect-cli dev test-gitlab-features` — OK
- `aspect-cli dev test-gitlab-lint-comments` — OK
- `aspect-cli tests axl` — 796 tests pass
