### PR TITLE
feat(status): inline failure snippets on CI status surfaces

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3238,6 +3238,7 @@ def test_log_snippet(ctx: TaskContext, tc: int, temp_dir: str) -> int:
                             "<system-out>real pytest output here</system-out></testcase></testsuite></testsuites>")
     r9 = extract_junit_failure(ctx.std, synth)
     tc = test_case(tc, r9.source.value == "none", "extract_junit_failure: synthesized 'exited with error code' → none (fall back to log)")
+
     # A real <failure> whose message happens to start similarly but HAS a body is
     # kept (only empty low-signal elements are rejected).
     real = d + "/real.xml"
@@ -3292,14 +3293,20 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     r["bazel"]["failed_actions"] = [{"label": "//pkg:broken", "mnemonics": ["CppCompile"], "stderr_path": stderr1}]
     r["bazel"]["failed_action_labels"] = ["//pkg:broken"]
     r["bazel"]["failed_targets"] = [{"label": "//pkg:broken"}]
+    r["bazel"]["target_kinds"] = {"//pkg:fail_test": "py_test", "//pkg:broken": "cc_library"}
     r["bazel"]["targets_total"] = 2
 
     out = render_check_output(ctx, r, "failed", render_ctx, links, snippet_options = opts, max_snippets = max_snips)
     tc = test_case(tc, "FAILED: expected 1 got 2" in out["text"], "render: inlines failed-test log snippet")
     tc = test_case(tc, "no member named 'foo'" in out["text"], "render: inlines failed-action stderr snippet")
-    # Inline under the bucket's <details> (no nested per-row <details>), labeled
-    # by `code` span, in a fenced block.
-    tc = test_case(tc, "`//pkg:fail_test`:" in out["text"], "render: snippet labeled by code span")
+
+    # Inline under the bucket's <details> (no nested per-row <details>), with the
+    # PR-comment-style header: "❌ <kind> `<label>` <verb>:" (duration folded in
+    # for tests, "failed to build" for actions).
+    tc = test_case(tc, "❌ py_test `//pkg:fail_test` failed in 3s:" in out["text"], "render: test snippet header (kind + label + duration)")
+    tc = test_case(tc, "❌ cc_library `//pkg:broken` failed to build:" in out["text"], "render: build snippet header (kind + label)")
+
+    # The snippet-shown labels are NOT also listed in the <pre> table (no dup).
     tc = test_case(tc, "<summary><code>//pkg:fail_test</code> output</summary>" not in out["text"], "render: no nested per-row <details>")
 
     # max_snippets = 0 (or no options) disables snippets entirely.

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -13,6 +13,7 @@ load(
     "version_gte",
     "version_tuple",
 )
+load("@aspect//lib/check_dispatch.axl", "SURFACE_PR_COMMENT", "SURFACE_STATUS_CHECK", "snippet_budget_for")
 load("@aspect//lib/ci.axl", "detect_build_url")
 load("@aspect//lib/deliveryd.axl", deliveryd_parse_endpoint = "parse_endpoint")
 load("@aspect//lib/environment.axl", "color_enabled", "detect_ci", "parse_git_url_name", "sanitize_filename")
@@ -23,6 +24,7 @@ load(
     "extract_changed_dirs",
 )
 load("@aspect//lib/github.axl", "detect_commit_sha", "github")
+load("@aspect//lib/log_snippet.axl", "SnippetOptions", "code_fence_for", "extract_junit_failure", "extract_snippet")
 load("@aspect//lib/path_glob.axl", "match_any", "match_path")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "dedup_and_attribute", "patch_download_cmd", "task_cli_path")
 load("@aspect//lib/result_text.axl", "severity_for_status")
@@ -3130,6 +3132,182 @@ def test_sarif_lib(tc: int) -> int:
 
     return tc
 
+def test_log_snippet(ctx: TaskContext, tc: int, temp_dir: str) -> int:
+    """lib/log_snippet.axl extraction, windowing, ANSI strip, JUnit-first, caps."""
+    d = temp_dir + "/axl_log_snippet_test"
+    if ctx.std.fs.exists(d):
+        ctx.std.fs.remove_dir_all(d)
+    ctx.std.fs.create_dir_all(d)
+
+    # Small log, marker near the end → window anchored on the marker.
+    small = d + "/small.log"
+    ctx.std.fs.write(small, "setup ok\nrunning case_1\nrunning case_2\nFAILED: assertion x == y\n  at foo.py:42\n")
+    r = extract_snippet(ctx.std, small)
+    tc = test_case(tc, r.source.value == "log", "extract_snippet: small log → source=log")
+    tc = test_case(tc, "FAILED: assertion x == y" in r.text, "extract_snippet: keeps the failure marker line")
+    tc = test_case(tc, "at foo.py:42" in r.text, "extract_snippet: keeps post-marker context")
+    tc = test_case(tc, not r.truncated, "extract_snippet: small log not flagged truncated")
+
+    # No marker → tail fallback caps to max_lines and flags truncated.
+    nomark_lines = []
+    for i in range(40):
+        nomark_lines.append("line %d ordinary output" % i)
+    nomark = d + "/nomark.log"
+    ctx.std.fs.write(nomark, "\n".join(nomark_lines) + "\n")
+    r2 = extract_snippet(ctx.std, nomark, SnippetOptions(max_lines = 10))
+    tc = test_case(tc, r2.source.value == "log", "extract_snippet: no-marker log → source=log")
+    tc = test_case(tc, len(r2.text.split("\n")) <= 10, "extract_snippet: no-marker tail capped to max_lines")
+    tc = test_case(tc, "line 39 ordinary output" in r2.text, "extract_snippet: tail keeps the last line")
+    tc = test_case(tc, "line 0 ordinary output" not in r2.text, "extract_snippet: tail drops the head")
+    tc = test_case(tc, r2.truncated, "extract_snippet: windowed log flagged truncated")
+
+    # ANSI escapes and \r progress spam are stripped before line counting.
+    ansi = d + "/ansi.log"
+    ctx.std.fs.write(ansi, "\033[32mok\033[0m\nprogress 10%\rprogress 99%\rprogress 100%\n\033[31mError: boom\033[0m\n")
+    r3 = extract_snippet(ctx.std, ansi)
+    tc = test_case(tc, "\033" not in r3.text, "extract_snippet: ANSI escapes stripped")
+    tc = test_case(tc, "Error: boom" in r3.text, "extract_snippet: text after ANSI strip preserved")
+    tc = test_case(tc, "progress 100%" in r3.text and "progress 10%" not in r3.text, "extract_snippet: \\r progress collapsed to last segment")
+
+    # Byte cap: a log larger than max_read_bytes is sliced and flagged truncated.
+    big = d + "/big.log"
+    ctx.std.fs.write(big, "x" * 5000 + "\nError: tail marker\n")
+    r4 = extract_snippet(ctx.std, big, SnippetOptions(max_read_bytes = 1000))
+    tc = test_case(tc, r4.truncated, "extract_snippet: over-cap read flagged truncated")
+
+    # Heap safety: only the capped prefix is read, never the whole file — the
+    # marker past byte 1000 must NOT appear (would mean we read it all).
+    tc = test_case(tc, "tail marker" not in r4.text, "extract_snippet: capped read stops before the tail (no full-file read)")
+
+    # The capped fs primitive returns at most max_bytes chars.
+    capped = ctx.std.fs.try_read_to_string_capped(big, 100)
+    tc = test_case(tc, len(capped) == 100, "try_read_to_string_capped: reads exactly the cap on a larger file")
+    tc = test_case(tc, ctx.std.fs.try_read_to_string_capped(d + "/missing.log", 100) == "", "try_read_to_string_capped: missing path → empty")
+
+    # Multi-byte char split at the cap: the partial trailing char is dropped, not
+    # emitted as a replacement char, and the valid prefix is intact.
+    mb = d + "/mb.log"
+    ctx.std.fs.write(mb, "ab" + "€" + "cd")  # '€' is 3 bytes (e2 82 ac)
+    mb_capped = ctx.std.fs.try_read_to_string_capped(mb, 3)  # "ab" + first byte of €
+    tc = test_case(tc, mb_capped == "ab", "try_read_to_string_capped: drops a cap-split multi-byte char")
+    tc = test_case(tc, "�" not in mb_capped, "try_read_to_string_capped: no replacement char on split")
+
+    # code_fence_for: widens past the longest backtick run so log content can't
+    # close the fence early.
+    tc = test_case(tc, code_fence_for("plain text") == "```", "code_fence_for: default 3 backticks")
+    tc = test_case(tc, code_fence_for("a ``` b") == "````", "code_fence_for: widens past a 3-backtick run")
+    tc = test_case(tc, code_fence_for("`````` huge") == "```````", "code_fence_for: widens past a 6-backtick run")
+
+    # Missing path → source=none (graceful degrade, no fail).
+    r5 = extract_snippet(ctx.std, d + "/does_not_exist.log")
+    tc = test_case(tc, r5.source.value == "none", "extract_snippet: missing path → source=none")
+    tc = test_case(tc, r5.text == "", "extract_snippet: missing path → empty text")
+    r5b = extract_snippet(ctx.std, "")
+    tc = test_case(tc, r5b.source.value == "none", "extract_snippet: empty path → source=none")
+
+    # JUnit XML preferred: <failure> message + body extracted, entities unescaped.
+    xml = d + "/test.xml"
+    ctx.std.fs.write(xml, "<testsuites><testsuite><testcase name=\"t1\">" +
+                          "<failure message=\"x &lt; y was false\" type=\"AssertionError\">" +
+                          "Traceback:\n  assert x &lt; y\n</failure></testcase></testsuite></testsuites>")
+    r6 = extract_junit_failure(ctx.std, xml)
+    tc = test_case(tc, r6.source.value == "xml", "extract_junit_failure: <failure> → source=xml")
+    tc = test_case(tc, "AssertionError: x < y was false" in r6.text, "extract_junit_failure: type+message header, unescaped")
+    tc = test_case(tc, "assert x < y" in r6.text, "extract_junit_failure: body text included + unescaped")
+
+    # Self-closing <error/> with only a message attr.
+    xml2 = d + "/err.xml"
+    ctx.std.fs.write(xml2, "<testsuite><testcase><error message=\"segfault\" type=\"Crash\"/></testcase></testsuite>")
+    r7 = extract_junit_failure(ctx.std, xml2)
+    tc = test_case(tc, r7.source.value == "xml", "extract_junit_failure: self-closing <error/> → source=xml")
+    tc = test_case(tc, "Crash: segfault" in r7.text, "extract_junit_failure: self-closing error header")
+
+    # No <failure>/<error> in the XML → none (caller falls back to the log).
+    xml3 = d + "/pass.xml"
+    ctx.std.fs.write(xml3, "<testsuite><testcase name=\"ok\"/></testsuite>")
+    r8 = extract_junit_failure(ctx.std, xml3)
+    tc = test_case(tc, r8.source.value == "none", "extract_junit_failure: no failure element → source=none")
+
+    ctx.std.fs.remove_dir_all(d)
+    return tc
+
+def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
+    """End-to-end: render_check_output inlines test/action snippets, budgets,
+    overflow note, and snippet-first trimming under the size cap."""
+    d = temp_dir + "/axl_render_snippet_test"
+    if ctx.std.fs.exists(d):
+        ctx.std.fs.remove_dir_all(d)
+    ctx.std.fs.create_dir_all(d)
+
+    links = {
+        "ci_label": "GitHub Actions",
+        "ci_url": "https://github.com/example/repo/actions/runs/123",
+        "aspect_url": "",
+        "results_base_url": "",
+        "artifacts_browse_url": "",
+        "artifact_urls": {},
+        "testlogs_label_urls": {},
+    }
+    render_ctx = {
+        "triggered_by": "tester",
+        "subject": "//...",
+        "started_ms": 1744630000000,
+        "ended_ms": 1744630002000,
+        "progress": "",
+    }
+
+    log1 = d + "/fail1.log"
+    ctx.std.fs.write(log1, "running case\nFAILED: expected 1 got 2\n  at t.py:7\n")
+    stderr1 = d + "/stderr1.txt"
+    ctx.std.fs.write(stderr1, "t.cc:9:3: error: no member named 'foo'\n")
+
+    opts, max_snips = snippet_budget_for(SURFACE_PR_COMMENT)
+
+    # A failed test with a resolved log_path + a failed action with stderr_path.
+    r = init_data()
+    r["bazel"]["build_command"] = "test"
+    r["bazel"]["failed_test_total"] = 1
+    r["bazel"]["failed_tests"] = [{"label": "//pkg:fail_test", "cached": False, "duration_ms": 3000, "status": "failed"}]
+    r["bazel"]["test_details"] = {"//pkg:fail_test": {"log_path": log1, "xml_path": "", "duration_ms": 3000}}
+    r["bazel"]["failed_actions_total"] = 1
+    r["bazel"]["failed_actions"] = [{"label": "//pkg:broken", "mnemonics": ["CppCompile"], "stderr_path": stderr1}]
+    r["bazel"]["failed_action_labels"] = ["//pkg:broken"]
+    r["bazel"]["failed_targets"] = [{"label": "//pkg:broken"}]
+    r["bazel"]["targets_total"] = 2
+
+    out = render_check_output(ctx, r, "failed", render_ctx, links, snippet_options = opts, max_snippets = max_snips)
+    tc = test_case(tc, "FAILED: expected 1 got 2" in out["text"], "render: inlines failed-test log snippet")
+    tc = test_case(tc, "no member named 'foo'" in out["text"], "render: inlines failed-action stderr snippet")
+    tc = test_case(tc, "<summary><code>//pkg:fail_test</code> output</summary>" in out["text"], "render: snippet wrapped in labeled <details>")
+
+    # max_snippets = 0 (or no options) disables snippets entirely.
+    out_off = render_check_output(ctx, r, "failed", render_ctx, links)
+    tc = test_case(tc, "FAILED: expected 1 got 2" not in out_off["text"], "render: snippets off by default (max_snippets=0)")
+    tc = test_case(tc, "//pkg:fail_test" in out_off["text"], "render: failure label still shown with snippets off")
+
+    # Budget overflow: 3 failed tests, budget of 1 → 1 snippet + "more not shown".
+    log_a = d + "/a.log"
+    ctx.std.fs.write(log_a, "Error: alpha failed\n")
+    r2 = init_data()
+    r2["bazel"]["build_command"] = "test"
+    r2["bazel"]["failed_test_total"] = 3
+    r2["bazel"]["failed_tests"] = [
+        {"label": "//pkg:a_test", "cached": False, "duration_ms": 10, "status": "failed"},
+        {"label": "//pkg:b_test", "cached": False, "duration_ms": 10, "status": "failed"},
+        {"label": "//pkg:c_test", "cached": False, "duration_ms": 10, "status": "failed"},
+    ]
+    r2["bazel"]["test_details"] = {
+        "//pkg:a_test": {"log_path": log_a, "xml_path": "", "duration_ms": 10},
+        "//pkg:b_test": {"log_path": log_a, "xml_path": "", "duration_ms": 10},
+        "//pkg:c_test": {"log_path": log_a, "xml_path": "", "duration_ms": 10},
+    }
+    r2["bazel"]["targets_total"] = 3
+    out2 = render_check_output(ctx, r2, "failed", render_ctx, links, snippet_options = SnippetOptions(max_lines = 15), max_snippets = 1)
+    tc = test_case(tc, "more failure" in out2["text"] and "output not shown" in out2["text"], "render: budget overflow note shown")
+
+    ctx.std.fs.remove_dir_all(d)
+    return tc
+
 def impl(ctx: TaskContext) -> int:
     tc = 0
 
@@ -3211,6 +3389,8 @@ def impl(ctx: TaskContext) -> int:
     tc = test_build_metadata_lib(tc)
     tc = test_severity_for_status(tc)
     tc = test_gazelle_dir_helpers(tc)
+    tc = test_log_snippet(ctx, tc, temp_dir)
+    tc = test_bazel_render_snippets(ctx, tc, temp_dir)
 
     print(tc, "tests passed")
     return 0

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3297,7 +3297,10 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     out = render_check_output(ctx, r, "failed", render_ctx, links, snippet_options = opts, max_snippets = max_snips)
     tc = test_case(tc, "FAILED: expected 1 got 2" in out["text"], "render: inlines failed-test log snippet")
     tc = test_case(tc, "no member named 'foo'" in out["text"], "render: inlines failed-action stderr snippet")
-    tc = test_case(tc, "<summary><code>//pkg:fail_test</code> output</summary>" in out["text"], "render: snippet wrapped in labeled <details>")
+    # Inline under the bucket's <details> (no nested per-row <details>), labeled
+    # by `code` span, in a fenced block.
+    tc = test_case(tc, "`//pkg:fail_test`:" in out["text"], "render: snippet labeled by code span")
+    tc = test_case(tc, "<summary><code>//pkg:fail_test</code> output</summary>" not in out["text"], "render: no nested per-row <details>")
 
     # max_snippets = 0 (or no options) disables snippets entirely.
     out_off = render_check_output(ctx, r, "failed", render_ctx, links)
@@ -3323,6 +3326,20 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     r2["bazel"]["targets_total"] = 3
     out2 = render_check_output(ctx, r2, "failed", render_ctx, links, snippet_options = SnippetOptions(max_lines = 15), max_snippets = 1)
     tc = test_case(tc, "more failure" in out2["text"] and "output not shown" in out2["text"], "render: budget overflow note shown")
+
+    # Truncation markers: a long no-marker log keeps the tail and shows a leading
+    # `…` for the dropped head (max_lines small forces windowing).
+    big = d + "/big.log"
+    ctx.std.fs.write(big, "\n".join(["line %d" % i for i in range(50)]) + "\n")
+    r3 = init_data()
+    r3["bazel"]["build_command"] = "test"
+    r3["bazel"]["failed_test_total"] = 1
+    r3["bazel"]["failed_tests"] = [{"label": "//pkg:big_test", "cached": False, "duration_ms": 10, "status": "failed"}]
+    r3["bazel"]["test_details"] = {"//pkg:big_test": {"log_path": big, "xml_path": "", "duration_ms": 10}}
+    r3["bazel"]["targets_total"] = 1
+    out3 = render_check_output(ctx, r3, "failed", render_ctx, links, snippet_options = SnippetOptions(max_lines = 5), max_snippets = 1)
+    tc = test_case(tc, "…\nline 45" in out3["text"], "render: dropped-head truncation marker (leading …)")
+    tc = test_case(tc, "line 49" in out3["text"], "render: windowed snippet keeps the tail")
 
     ctx.std.fs.remove_dir_all(d)
     return tc

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3228,6 +3228,25 @@ def test_log_snippet(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     r8 = extract_junit_failure(ctx.std, xml3)
     tc = test_case(tc, r8.source.value == "none", "extract_junit_failure: no failure element → source=none")
 
+    # Bazel-SYNTHESIZED XML (sh_test/cc_test without native JUnit): a generic
+    # empty <error message="exited with error code 1"> with the real output in
+    # <system-out>. The JUnit path must MISS so the caller falls back to test.log
+    # — else the snippet reads the useless "exited with error code 1".
+    synth = d + "/synth.xml"
+    ctx.std.fs.write(synth, "<testsuites><testsuite><testcase name=\"t\">" +
+                            "<error message=\"exited with error code 1\"></error>" +
+                            "<system-out>real pytest output here</system-out></testcase></testsuite></testsuites>")
+    r9 = extract_junit_failure(ctx.std, synth)
+    tc = test_case(tc, r9.source.value == "none", "extract_junit_failure: synthesized 'exited with error code' → none (fall back to log)")
+    # A real <failure> whose message happens to start similarly but HAS a body is
+    # kept (only empty low-signal elements are rejected).
+    real = d + "/real.xml"
+    ctx.std.fs.write(real, "<testsuite><testcase><failure message=\"exited with error code 1\">" +
+                           "assert 5 == 6\n</failure></testcase></testsuite>")
+    r10 = extract_junit_failure(ctx.std, real)
+    tc = test_case(tc, r10.source.value == "xml", "extract_junit_failure: low-signal message WITH body kept")
+    tc = test_case(tc, "assert 5 == 6" in r10.text, "extract_junit_failure: body retained when present")
+
     ctx.std.fs.remove_dir_all(d)
     return tc
 

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -405,6 +405,14 @@ def config(ctx: ConfigContext):
         "--build_metadata=ASPECT_WORKFLOWS_LINKS=[Docs](https://aspect.build/docs),[Website](https://aspect.build/)",
     ])
 
+    # On CI, run with `--config=ci` (see .bazelrc) — notably `--keep_going`, so a
+    # failed build action surfaces every failing target/test in one run instead
+    # of aborting the test phase before any test executes.
+    if bool(ctx.std.env.var("CI")):
+        ctx.traits[BazelTrait].extra_flags.extend([
+            "--config=ci",
+        ])
+
     # Configure user_task's attrs by path (group/name).
     t = ctx.tasks["user/nested/user-task"]
     t.args.message = "hello axl"

--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,12 @@ common:release --workspace_status_command "${PWD}/bazel/workspace_status.sh"
 common:release --compilation_mode=opt
 common:release --@rules_rust//rust/settings:lto=fat
 
+# Don't stop at the first failure on CI — surface every failing target/test in
+# one run (a failed build action otherwise aborts the test phase before any
+# test executes). Applied via `--config=ci`, injected by .aspect/config.axl when
+# CI is set.
+common:ci --keep_going
+
 # Use Go's internal linker rather than the cc_toolchain — required when
 # building gazelle from source on Linux because toolchains_llvm_bootstrapped's
 # lld can't accept Go's non-PIC relocations (relocation R_X86_64_64 ...

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -288,6 +288,56 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test Task (ASPECT_DEBUG=1)
         run: ASPECT_DEBUG=1 aspect test --task-key test-gha-debug
+  # Build/test on an EPHEMERAL GitHub-hosted runner (no Aspect Workflows
+  # bb_clientd FUSE mount). Scoped to //examples/... so it's fast. The remote
+  # cache is disabled (--remote_cache=) so Bazel keeps outputs local and BES
+  # reports `file://` URIs for test.log / action stderr — the path the inline
+  # failure snippets resolve without the FUSE mount. A --disk_cache keeps it
+  # quick across runs. This is the surface that exercises the non-FUSE snippet
+  # path end-to-end; once our multi-tenant remote cache is available on
+  # ephemeral runners we can add a bytestream:// variant too.
+  #
+  # NOTE: while the DO-NOT-LAND commit drops the `manual` tag from
+  # //examples/test_states:demo_{test,build}_fail, these jobs go red on purpose
+  # and render the inline snippets on this PR's surfaces.
+  build-task-ephemeral:
+    runs-on: ubuntu-latest
+    needs: [pre-build]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          launcher-install: false
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+      - name: Build Task (ephemeral)
+        run: |
+          aspect build --task-key build-gha-ephemeral \
+            --bazel-flag=--remote_cache= \
+            --bazel-flag=--disk_cache="$RUNNER_TEMP/aspect-disk-cache" \
+            -- //examples/...
+  test-task-ephemeral:
+    runs-on: ubuntu-latest
+    needs: [pre-build]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          launcher-install: false
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+      - name: Test Task (ephemeral)
+        # --keep_going so a build-action failure (demo_build_fail genrule)
+        # doesn't abort the test phase — both the failed test (test.log snippet)
+        # and the failed action (stderr snippet) then surface together.
+        run: |
+          aspect test --task-key test-gha-ephemeral \
+            --bazel-flag=--remote_cache= \
+            --bazel-flag=--keep_going \
+            --bazel-flag=--disk_cache="$RUNNER_TEMP/aspect-disk-cache" \
+            -- //examples/...
   # Render each template preset with the freshly-built `aspect init` and build
   # the generated workspace. Catches CLI-side breakage of the init renderer
   # against the live template. `--template-ref=main` tests the current template

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -329,13 +329,13 @@ jobs:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test Task (ephemeral)
-        # --keep_going so a build-action failure (demo_build_fail genrule)
-        # doesn't abort the test phase — both the failed test (test.log snippet)
-        # and the failed action (stderr snippet) then surface together.
+        # --keep_going comes from `--config=ci` (injected by .aspect/config.axl on
+        # CI), so a build-action failure (demo_build_fail genrule) doesn't abort
+        # the test phase — both the failed test (test.log snippet) and the failed
+        # action (stderr snippet) surface together.
         run: |
           aspect test --task-key test-gha-ephemeral \
             --bazel-flag=--remote_cache= \
-            --bazel-flag=--keep_going \
             --bazel-flag=--disk_cache="$RUNNER_TEMP/aspect-disk-cache" \
             -- //examples/...
   # Render each template preset with the freshly-built `aspect init` and build

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -22,10 +22,12 @@ Usage in `.aspect/config.axl`:
 load("../lib/bazel_results.axl", "format_run_date", "html_escape", "now_ms", "render_bes_url", "resolve_aspect_url")
 load(
     "../lib/check_dispatch.axl",
+    "SURFACE_BUILDKITE",
     "apply_artifact_links",
     "make_render_ctx",
     "renderer_for_kind",
     "should_emit_update",
+    "snippet_budget_for",
 )
 load("../lib/ci.axl", "resolve_build_url")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
@@ -313,6 +315,7 @@ def _buildkite_annotations(ctx: FeatureContext):
         elif not should_emit_update(_state, now_ms(ctx), min_update_interval_ms, final):
             return
 
+        _snippet_opts, _max_snippets = snippet_budget_for(SURFACE_BUILDKITE)
         out = renderer.render(
             ctx,
             data,
@@ -321,6 +324,8 @@ def _buildkite_annotations(ctx: FeatureContext):
             _make_links(data),
             None,
             None,
+            snippet_options = _snippet_opts,
+            max_snippets = _max_snippets,
         )
         body = _format_body(out, update.kind, status, task_label = _state.get("_task_label", ""), final = final)
         style = severity_for_status(status)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -27,11 +27,13 @@ load(
 )
 load(
     "../lib/check_dispatch.axl",
+    "SURFACE_STATUS_CHECK",
     "apply_artifact_links",
     "kind_for_task",
     "make_render_ctx",
     "renderer_for_kind",
     "should_emit_update",
+    "snippet_budget_for",
 )
 load("../lib/checkrun.axl", "checkrun")
 load("../lib/ci.axl", "detect_ci_host", "resolve_build_url")
@@ -410,6 +412,7 @@ def _github_status_checks(ctx: FeatureContext):
         elif final:
             _state["_ended_ms"] = now_ms(ctx)  # terminal render needs it for duration
 
+        _snippet_opts, _max_snippets = snippet_budget_for(SURFACE_STATUS_CHECK)
         output = renderer.render(
             ctx,
             data,
@@ -418,6 +421,8 @@ def _github_status_checks(ctx: FeatureContext):
             _make_links(data),
             templates,
             metadata_keys,
+            snippet_options = _snippet_opts,
+            max_snippets = _max_snippets,
         )
 
         # Annotations only on the terminal update — GitHub appends across

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -165,12 +165,14 @@ _No tasks have reported yet._
 {{ section("flagged",     "⚠️", sections.flagged) -}}
 {{ section("successful",  "✅", sections.successful) -}}
 {% macro snippet_block(s) %}
-❌ {{ s.kind or (s.bucket if s.bucket != "timeout" else "test") }}{% if s.task_label %} ({{ s.task_label }}){% endif %} · `{{ s.label }}` {{ s.verb }}:
+❌ {{ s.kind or (s.bucket if s.bucket != "timeout" else "test") }} `{{ s.label }}` {{ s.verb }}:
 {{ s.fence }}text
 {% if s.trunc_head %}…
 {% endif %}{{ s.snippet }}
 {% if s.trunc_tail %}…
 {% endif %}{{ s.fence }}
+{% if s.task_label %}<sub>{{ s.task_label }}</sub>
+{% endif %}
 {% endmacro -%}
 {% if build_snippets %}
 ## 💥 Build Failures
@@ -704,6 +706,7 @@ def _select_snippets(entries, shown_keys):
                     "label": label,
                     "kind": s.get("kind", ""),
                     "bucket": s.get("bucket", "test"),
+                    "duration_ms": s.get("duration_ms", 0) or 0,
                     "snippet": snippet_text,
                     "truncated": bool(s.get("truncated", False)),
                     "trunc_head": bool(s.get("trunc_head", False)),
@@ -753,21 +756,30 @@ def _split_snippet_rows(rows):
     """Partition selected snippet rows into (build, test) groups, decorating each
     with the render fields the template needs:
 
-      `task_label` — `task_keys` joined for the header (matches Repro/Fix).
-      `verb`       — "failed to build" (build bucket) / "failed" (test/timeout).
+      `task_label` — `task_keys` joined; rendered small below the snippet.
+      `verb`       — the header tail: "failed to build" (build), "failed" /
+                     "failed in <dur>" (test), "timed out" / "timed out after
+                     <dur>" (timeout). Duration is omitted when 0 (build actions
+                     have no reliable duration).
 
     The "build" bucket is action-stderr failures; "test"/"timeout" are test
-    failures (timeout adds a "(timed out)" rider, kept on the row's `bucket`)."""
+    failures."""
     build_rows = []
     test_rows = []
     for r in rows:
         row = dict(r)
         row["task_label"] = ", ".join(r.get("task_keys", []) or [])
-        if r.get("bucket") == "build":
+        dur = r.get("duration_ms", 0) or 0
+        dur_str = (" in " + format_duration_ms(dur)) if dur > 0 else ""
+        bucket = r.get("bucket")
+        if bucket == "build":
             row["verb"] = "failed to build"
             build_rows.append(row)
+        elif bucket == "timeout":
+            row["verb"] = "timed out" + ((" after " + format_duration_ms(dur)) if dur > 0 else "")
+            test_rows.append(row)
         else:
-            row["verb"] = "timed out" if r.get("bucket") == "timeout" else "failed"
+            row["verb"] = "failed" + dur_str
             test_rows.append(row)
     return (build_rows, test_rows)
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -737,20 +737,21 @@ def _select_snippets(entries, shown_keys):
     return (rows, new_shown, overflow)
 
 def _by_task_overflow(dropped):
-    """Build `{total, by_task}` for dropped rows that each carry `task_keys`.
-    `total` = number of dropped rows; `by_task` attributes each to every task in
-    its `task_keys`, sorted by count desc then name."""
-    by_task = {}
+    """Build `{total, tasks}` for dropped rows that each carry `task_keys`.
+    `total` = number of distinct dropped (deduped) items; `tasks` = the set of
+    tasks that hold at least one hidden item, sorted. Per-task COUNTS would
+    double-count a deduped item shared by N tasks (sum > total), so we list the
+    tasks ("across a, b, …") without counts — see `_format_overflow_note`."""
+    seen = {}
+    tasks = []
     total = 0
     for r in dropped:
         total += 1
         for tk in r.get("task_keys", []) or []:
-            by_task[tk] = by_task.get(tk, 0) + 1
-    rows = sorted(
-        [{"task_key": tk, "count": n} for tk, n in by_task.items()],
-        key = lambda x: (-x["count"], x["task_key"]),
-    )
-    return {"total": total, "by_task": rows}
+            if tk and tk not in seen:
+                seen[tk] = True
+                tasks.append(tk)
+    return {"total": total, "tasks": sorted(tasks)}
 
 def _split_snippet_rows(rows):
     """Partition selected snippet rows into (build, test) groups, decorating each
@@ -964,18 +965,18 @@ def _collect_tip_rows(ctx, entries):
     return out
 
 def _format_overflow_note(overflow, noun_singular, noun_plural):
-    """Human-readable "N more <noun> — not shown (M in `task-a`, …)" line, or ""
-    when nothing overflowed. `overflow` is `{total, by_task}` from a selector.
-    Per-task attribution lets a reviewer see which jobs hold the hidden items."""
+    """Human-readable "N more <noun> — not shown (across `task-a`, …)" line, or
+    "" when nothing overflowed. `overflow` is `{total, tasks}` from a selector.
+    Lists the tasks holding hidden items WITHOUT per-task counts — a deduped
+    item shared by N tasks would make per-task counts sum past the total."""
     if not overflow:
         return ""
     total = overflow.get("total", 0)
     if total <= 0:
         return ""
-    by_task = overflow.get("by_task", []) or []
     noun = noun_singular if total == 1 else noun_plural
-    parts = ["%d in `%s`" % (e["count"], e["task_key"]) for e in by_task if e.get("task_key")]
-    suffix = " (%s)" % ", ".join(parts) if parts else ""
+    tasks = [tk for tk in (overflow.get("tasks", []) or []) if tk]
+    suffix = " (across %s)" % ", ".join(["`%s`" % tk for tk in tasks]) if tasks else ""
     return "_+ %d more %s — not shown%s._" % (total, noun, suffix)
 
 def _render_body(ctx, marker, entries, started_at, body_template, status_badges, sections, last_updated_at = "", api_usage = "", state = None, snippet_rows = None, snippet_overflow = None, repro_rows = None, fix_rows = None, repro_overflow = None, fix_overflow = None):

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -26,8 +26,11 @@ collapses to one snippet attributed to all of them (`task_keys`) rather than
 rendering N identical copies — then sticky-selects (an already-shown snippet is
 never evicted by a later-arriving one), deterministic fill, hard-capped at
 `_MAX_COMMENT_SNIPPETS`. The chosen keys persist in the state block so selection
-can't flip-flop as sibling jobs report in. Snippet blocks render expanded
-(`<details open>`); the reader collapses what they're done with.
+can't flip-flop as sibling jobs report in. Rows render grouped under "💥 Build
+Failures" / "❌ Test Failures" (by bucket), each with a Repro/Fix-style header
+(`❌ <kind> (<tasks>) · \`<label>\` <verb>:`) and a fenced block; a `…` line
+marks a head/tail-truncated log. `_split_snippet_rows` does the grouping +
+decoration.
 
 The repro / fix command sections use the same selection (`_select_sticky` over
 deduped, deterministically-sorted rows, capped at `_MAX_COMMENT_REPROS` /
@@ -41,7 +44,7 @@ Body-template variables:
     status_badges  — {badge_key -> label}.
     rollup         — {error, warning, running, passed, aborted} counts.
     entries        — per-task entry dicts, alphabetical by (job, name, key).
-    snippet_rows / repro_rows / fix_rows — globally-selected items per section.
+    build_snippets / test_snippets / repro_rows / fix_rows — selected items per section.
     *_overflow_note — "N more not shown" line for each capped section.
 """
 
@@ -161,21 +164,25 @@ _No tasks have reported yet._
 {{ section("failing",     "❌", sections.failing) -}}
 {{ section("flagged",     "⚠️", sections.flagged) -}}
 {{ section("successful",  "✅", sections.successful) -}}
-{% if snippet_rows %}
-## 🔎 Failure output
-{% for s in snippet_rows %}
-<details open><summary><code>{{ s.label }}</code>{% if s.bucket == "timeout" %} (timed out){% endif %} output{% if s.task_keys %} · {{ s.task_keys|join(", ") }}{% endif %}</summary>
-
+{% macro snippet_block(s) %}
+❌ {{ s.kind or (s.bucket if s.bucket != "timeout" else "test") }}{% if s.task_label %} ({{ s.task_label }}){% endif %} · `{{ s.label }}` {{ s.verb }}:
 {{ s.fence }}text
-{{ s.snippet }}
-{{ s.fence }}
-{% if s.truncated %}_…output truncated_{% endif %}
-</details>
-{% endfor %}
+{% if s.trunc_head %}…
+{% endif %}{{ s.snippet }}
+{% if s.trunc_tail %}…
+{% endif %}{{ s.fence }}
+{% endmacro -%}
+{% if build_snippets %}
+## 💥 Build Failures
+{% for s in build_snippets %}{{ snippet_block(s) }}{% endfor %}
+{% endif -%}
+{% if test_snippets %}
+## ❌ Test Failures
+{% for s in test_snippets %}{{ snippet_block(s) }}{% endfor %}
+{% endif -%}
 {% if snippet_overflow_note %}
 {{ snippet_overflow_note }}
 {% endif %}
-{% endif -%}
 {% if tip_rows %}
 ## 💡 Tips
 {% for tip in tip_rows %}
@@ -699,6 +706,8 @@ def _select_snippets(entries, shown_keys):
                     "bucket": s.get("bucket", "test"),
                     "snippet": snippet_text,
                     "truncated": bool(s.get("truncated", False)),
+                    "trunc_head": bool(s.get("trunc_head", False)),
+                    "trunc_tail": bool(s.get("trunc_tail", False)),
                     # Fence sized past any backtick run so log content can't close
                     # the code block early (CommonMark fence-injection guard).
                     "fence": code_fence_for(snippet_text),
@@ -739,6 +748,28 @@ def _by_task_overflow(dropped):
         key = lambda x: (-x["count"], x["task_key"]),
     )
     return {"total": total, "by_task": rows}
+
+def _split_snippet_rows(rows):
+    """Partition selected snippet rows into (build, test) groups, decorating each
+    with the render fields the template needs:
+
+      `task_label` — `task_keys` joined for the header (matches Repro/Fix).
+      `verb`       — "failed to build" (build bucket) / "failed" (test/timeout).
+
+    The "build" bucket is action-stderr failures; "test"/"timeout" are test
+    failures (timeout adds a "(timed out)" rider, kept on the row's `bucket`)."""
+    build_rows = []
+    test_rows = []
+    for r in rows:
+        row = dict(r)
+        row["task_label"] = ", ".join(r.get("task_keys", []) or [])
+        if r.get("bucket") == "build":
+            row["verb"] = "failed to build"
+            build_rows.append(row)
+        else:
+            row["verb"] = "timed out" if r.get("bucket") == "timeout" else "failed"
+            test_rows.append(row)
+    return (build_rows, test_rows)
 
 # Per-bucket severity rank (highest first). Drives the per-row emoji and
 # in-section ordering.
@@ -960,6 +991,7 @@ def _render_body(ctx, marker, entries, started_at, body_template, status_badges,
         _finalize_command_rows(repro_rows)
         _finalize_command_rows(fix_rows)
     tip_rows = _collect_tip_rows(ctx, entries)
+    build_snippets, test_snippets = _split_snippet_rows(snippet_rows or [])
     body = ctx.template.jinja2(body_template, data = {
         "marker": marker,
         "entries": entries,
@@ -971,7 +1003,10 @@ def _render_body(ctx, marker, entries, started_at, body_template, status_badges,
         "repro_overflow_note": _format_overflow_note(repro_overflow, "reproduce command", "reproduce commands"),
         "fix_overflow_note": _format_overflow_note(fix_overflow, "fix command", "fix commands"),
         "tip_rows": tip_rows,
-        "snippet_rows": snippet_rows or [],
+        # Snippets grouped by bucket so the template renders a "Build Failures" /
+        # "Test Failures" section; each row decorated with `task_label` + `verb`.
+        "build_snippets": build_snippets,
+        "test_snippets": test_snippets,
         "snippet_overflow_note": _format_overflow_note(snippet_overflow, "failure", "failures"),
         "api_usage": api_usage,
         "last_updated_at": last_updated_at,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1,4 +1,4 @@
-"""GitHub Status Comments feature — aggregates per-task status from sibling CI jobs into one PR comment.
+"""GitHub Status Comments feature \342\200\224 aggregates per-task status from sibling CI jobs into one PR comment.
 
 Every job is both a producer (uploads its task identity + data subset as an
 artifact) and a writer (polls own-run + sibling-workflow artifacts and
@@ -11,8 +11,8 @@ across any workflow on the same PR).
 
 Comment shape is precomputed in AXL; the Jinja2 template is a pure
 renderer. `_prepare_for_render` decorates each entry with:
-  - `_severity`     "error"|"warning"|"info"|"success" — badge + row sort.
-  - `_badge_key`    "failed"|"warning"|"running"|"passed"|"aborted" — keys
+  - `_severity`     "error"|"warning"|"info"|"success" \342\200\224 badge + row sort.
+  - `_badge_key`    "failed"|"warning"|"running"|"passed"|"aborted" \342\200\224 keys
                     into `status_badges[...]`.
   - `_links_text`   Multi-link Markdown for the Links cell (omits unset URLs).
   - `_result_text`  Kind-specific Result cell text + elapsed.
@@ -21,31 +21,31 @@ Inline failure snippets: each job extracts its own (it owns the local
 test.log / action-stderr paths; sibling writers can't read them) on its
 terminal update and ships them in its status artifact under `failure_snippets`.
 The writer picks which to show across all tasks via `_select_snippets`, which
-first DEDUPES by `(label, snippet)` — the same target failing in several jobs
+first DEDUPES by `(label, snippet)` \342\200\224 the same target failing in several jobs
 collapses to one snippet attributed to all of them (`task_keys`) rather than
-rendering N identical copies — then sticky-selects (an already-shown snippet is
+rendering N identical copies \342\200\224 then sticky-selects (an already-shown snippet is
 never evicted by a later-arriving one), deterministic fill, hard-capped at
 `_MAX_COMMENT_SNIPPETS`. The chosen keys persist in the state block so selection
-can't flip-flop as sibling jobs report in. Rows render grouped under "💥 Build
-Failures" / "❌ Test Failures" (by bucket), each with a Repro/Fix-style header
-(`❌ <kind> (<tasks>) · \`<label>\` <verb>:`) and a fenced block; a `…` line
+can't flip-flop as sibling jobs report in. Rows render grouped under "\360\237\222\245 Build
+Failures" / "\342\235\214 Test Failures" (by bucket), each with a Repro/Fix-style header
+(`\342\235\214 <kind> (<tasks>) \302\267 \\`<label>\\` <verb>:`) and a fenced block; a `\342\200\246` line
 marks a head/tail-truncated log. `_split_snippet_rows` does the grouping +
 decoration.
 
 The repro / fix command sections use the same selection (`_select_sticky` over
 deduped, deterministically-sorted rows, capped at `_MAX_COMMENT_REPROS` /
 `_MAX_COMMENT_FIXES`, persisted as `shown_repros` / `shown_fixes`). Each capped
-section ends in an "N more — not shown (M in `task`, …)" note that attributes
+section ends in an "N more \342\200\224 not shown (M in `task`, \342\200\246)" note that attributes
 the hidden items per contributing task.
 
 Body-template variables:
-    marker         — HTML comment identifying this comment across PATCHes.
-    started_at     — Earliest sibling-task start time, UTC.
-    status_badges  — {badge_key -> label}.
-    rollup         — {error, warning, running, passed, aborted} counts.
-    entries        — per-task entry dicts, alphabetical by (job, name, key).
-    build_snippets / test_snippets / repro_rows / fix_rows — selected items per section.
-    *_overflow_note — "N more not shown" line for each capped section.
+    marker         \342\200\224 HTML comment identifying this comment across PATCHes.
+    started_at     \342\200\224 Earliest sibling-task start time, UTC.
+    status_badges  \342\200\224 {badge_key -> label}.
+    rollup         \342\200\224 {error, warning, running, passed, aborted} counts.
+    entries        \342\200\224 per-task entry dicts, alphabetical by (job, name, key).
+    build_snippets / test_snippets / repro_rows / fix_rows \342\200\224 selected items per section.
+    *_overflow_note \342\200\224 "N more not shown" line for each capped section.
 """
 
 load("@std//base64.axl", "base64")
@@ -171,7 +171,7 @@ _No tasks have reported yet._
 {% endif %}{{ s.snippet }}
 {% if s.trunc_tail %}…
 {% endif %}{{ s.fence }}
-{% if s.task_label %}<sub>{{ s.task_label }}</sub>
+{% if s.task_label %}<sub>in {{ s.task_noun }} {{ s.task_label }}</sub>
 {% endif %}
 {% endmacro -%}
 {% if build_snippets %}
@@ -728,7 +728,10 @@ def _select_snippets(entries, shown_keys):
         key = lambda v: (_SNIPPET_BUCKET_RANK.get(v["bucket"], 9), v["label"]),
     )
     rows, new_shown, dropped = _select_sticky(
-        candidates, shown_keys, _MAX_COMMENT_SNIPPETS, lambda v: v["_key"],
+        candidates,
+        shown_keys,
+        _MAX_COMMENT_SNIPPETS,
+        lambda v: v["_key"],
     )
 
     # Overflow over DISTINCT failures not shown, attributed to the tasks holding
@@ -757,7 +760,9 @@ def _split_snippet_rows(rows):
     """Partition selected snippet rows into (build, test) groups, decorating each
     with the render fields the template needs:
 
-      `task_label` — `task_keys` joined; rendered small below the snippet.
+      `task_label` — `task_keys` joined; rendered "in <task_noun> <task_label>"
+                     small below the snippet.
+      `task_noun`  — "task" / "tasks" for the small-text line.
       `verb`       — the header tail: "failed to build" (build), "failed" /
                      "failed in <dur>" (test), "timed out" / "timed out after
                      <dur>" (timeout). Duration is omitted when 0 (build actions
@@ -769,7 +774,9 @@ def _split_snippet_rows(rows):
     test_rows = []
     for r in rows:
         row = dict(r)
-        row["task_label"] = ", ".join(r.get("task_keys", []) or [])
+        tks = r.get("task_keys", []) or []
+        row["task_label"] = ", ".join(tks)
+        row["task_noun"] = "task" if len(tks) == 1 else "tasks"
         dur = r.get("duration_ms", 0) or 0
         dur_str = (" in " + format_duration_ms(dur)) if dur > 0 else ""
         bucket = r.get("bucket")
@@ -834,6 +841,7 @@ def _collect_repro_fix_rows(sections):
             ranks = [task_rank.get(tk, 0) for tk in r["task_keys"]] or [0]
             r["_rank"] = max(ranks)
             r["severity_emoji"] = _RANK_EMOJI.get(r["_rank"], "")
+
             # Stable identity for sticky selection — the dedup triple, persisted
             # in the state block (independent of which tasks contributed).
             r["_key"] = _command_key(r["kind"], r["command"], r["description"])
@@ -1615,9 +1623,17 @@ def _github_status_comments(ctx: FeatureContext):
         # against the global cap; the rest collapse into an "N more" note.
         all_repro_rows, all_fix_rows = _collect_repro_fix_rows(sections)
         repro_rows, repro_shown, repro_dropped = _select_sticky(
-            all_repro_rows, _prior("shown_repros"), _MAX_COMMENT_REPROS, lambda r: r["_key"])
+            all_repro_rows,
+            _prior("shown_repros"),
+            _MAX_COMMENT_REPROS,
+            lambda r: r["_key"],
+        )
         fix_rows, fix_shown, fix_dropped = _select_sticky(
-            all_fix_rows, _prior("shown_fixes"), _MAX_COMMENT_FIXES, lambda r: r["_key"])
+            all_fix_rows,
+            _prior("shown_fixes"),
+            _MAX_COMMENT_FIXES,
+            lambda r: r["_key"],
+        )
         _finalize_command_rows(repro_rows)
         _finalize_command_rows(fix_rows)
         repro_overflow = _by_task_overflow(repro_dropped)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -17,18 +17,39 @@ renderer. `_prepare_for_render` decorates each entry with:
   - `_links_text`   Multi-link Markdown for the Links cell (omits unset URLs).
   - `_result_text`  Kind-specific Result cell text + elapsed.
 
+Inline failure snippets: each job extracts its own (it owns the local
+test.log / action-stderr paths; sibling writers can't read them) on its
+terminal update and ships them in its status artifact under `failure_snippets`.
+The writer picks which to show across all tasks via `_select_snippets`, which
+first DEDUPES by `(label, snippet)` — the same target failing in several jobs
+collapses to one snippet attributed to all of them (`task_keys`) rather than
+rendering N identical copies — then sticky-selects (an already-shown snippet is
+never evicted by a later-arriving one), deterministic fill, hard-capped at
+`_MAX_COMMENT_SNIPPETS`. The chosen keys persist in the state block so selection
+can't flip-flop as sibling jobs report in. Snippet blocks render expanded
+(`<details open>`); the reader collapses what they're done with.
+
+The repro / fix command sections use the same selection (`_select_sticky` over
+deduped, deterministically-sorted rows, capped at `_MAX_COMMENT_REPROS` /
+`_MAX_COMMENT_FIXES`, persisted as `shown_repros` / `shown_fixes`). Each capped
+section ends in an "N more — not shown (M in `task`, …)" note that attributes
+the hidden items per contributing task.
+
 Body-template variables:
     marker         — HTML comment identifying this comment across PATCHes.
     started_at     — Earliest sibling-task start time, UTC.
     status_badges  — {badge_key -> label}.
     rollup         — {error, warning, running, passed, aborted} counts.
     entries        — per-task entry dicts, alphabetical by (job, name, key).
+    snippet_rows / repro_rows / fix_rows — globally-selected items per section.
+    *_overflow_note — "N more not shown" line for each capped section.
 """
 
 load("@std//base64.axl", "base64")
 load("@std//time.axl", "monotonic", "time")
 load(
     "../lib/bazel_results.axl",
+    "extract_failure_snippets",
     "format_duration_ms",
     "format_run_date",
     "init_data",
@@ -36,11 +57,13 @@ load(
     "render_bes_url",
     "resolve_aspect_url",
 )
+load("../lib/check_dispatch.axl", "SURFACE_PR_COMMENT", "snippet_budget_for")
 load("../lib/checkrun.axl", "checkrun")
 load("../lib/ci.axl", "resolve_build_url")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/github.axl", "github")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait")
+load("../lib/log_snippet.axl", "code_fence_for")
 load(
     "../lib/rate_limit.axl",
     "BUCKET_APP",
@@ -77,8 +100,9 @@ _MARKER_FMT = "<!-- aspect-ci-status:pr-%d -->"
 # The PR comment is the canonical cross-workflow source of truth — each
 # workflow's artifact swarm sees only its own run_id's artifacts, so the
 # comment carries `workflow_runs` slots, per-task `entries` snapshot,
-# `head_sha`, and `last_upsert_epoch_s` as base64 JSON in an HTML comment.
-# base64 keeps the literal `-->` terminator out of the payload.
+# `head_sha`, `last_upsert_epoch_s`, and the sticky selection sets
+# `shown_snippets` / `shown_repros` / `shown_fixes` as base64 JSON in an HTML
+# comment. base64 keeps the literal `-->` terminator out of the payload.
 _STATE_BLOCK_OPEN = "<!-- aspect-ci-status-state-v1:"
 _STATE_BLOCK_CLOSE = " -->"
 
@@ -137,6 +161,21 @@ _No tasks have reported yet._
 {{ section("failing",     "❌", sections.failing) -}}
 {{ section("flagged",     "⚠️", sections.flagged) -}}
 {{ section("successful",  "✅", sections.successful) -}}
+{% if snippet_rows %}
+## 🔎 Failure output
+{% for s in snippet_rows %}
+<details open><summary><code>{{ s.label }}</code>{% if s.bucket == "timeout" %} (timed out){% endif %} output{% if s.task_keys %} · {{ s.task_keys|join(", ") }}{% endif %}</summary>
+
+{{ s.fence }}text
+{{ s.snippet }}
+{{ s.fence }}
+{% if s.truncated %}_…output truncated_{% endif %}
+</details>
+{% endfor %}
+{% if snippet_overflow_note %}
+{{ snippet_overflow_note }}
+{% endif %}
+{% endif -%}
 {% if tip_rows %}
 ## 💡 Tips
 {% for tip in tip_rows %}
@@ -158,6 +197,9 @@ _No tasks have reported yet._
 {% endif %}{{ r.command }}
 ```
 {% endfor %}
+{% if fix_overflow_note %}
+{{ fix_overflow_note }}
+{% endif %}
 """ + ASPECT_CLI_INSTALL_HINT_MARKDOWN + """
 {% endif -%}
 {% if repro_rows %}
@@ -169,6 +211,9 @@ _No tasks have reported yet._
 {% endif %}{{ r.command }}
 ```
 {% endfor %}
+{% if repro_overflow_note %}
+{{ repro_overflow_note }}
+{% endif %}
 """ + ASPECT_CLI_INSTALL_HINT_MARKDOWN + """
 {% endif -%}
 {% endif %}
@@ -506,11 +551,18 @@ def _results_subset(
         current_phase_elapsed_ms,
         progress_styles,
         failed_in_phase,
-        start_time_ms = 0):
+        start_time_ms = 0,
+        failure_snippets = None):
     """Slice `init_data()` + live state to the fields the renderer needs.
     Kind-agnostic (counts ship via `progress.body`; repro/fix pass through,
     deduped at render). `data` is frozen on the final update so fields are
-    copied out; live-state fields come from `_state`."""
+    copied out; live-state fields come from `_state`.
+
+    `failure_snippets` is the producer's own inline failure snippets (plain
+    dicts; only this job can read its log/stderr paths) — extracted on the
+    terminal update by the caller and shipped in the artifact, since sibling
+    writers can't re-derive them. The writer dedupes them across tasks and
+    sticky-selects against the global budget at render."""
     bz = data.get("bazel", {})
     return {
         "elapsed_ms": elapsed_ms,
@@ -526,9 +578,167 @@ def _results_subset(
         # Producer-authored; deduped across siblings by `_collect_repro_fix_rows`.
         "repro_commands": list(data.get("repro_commands", []) or []),
         "fix_commands": list(data.get("fix_commands", []) or []),
+        # Producer-authored inline failure snippets [{label,kind,bucket,snippet,
+        # truncated}]; deduped + sticky-selected against the global budget at render.
+        "failure_snippets": list(failure_snippets or []),
         # abort_reason: human-readable rider (timeout, OOM, ctrl-c, …).
         "abort_reason": bz.get("abort_reason", ""),
     }
+
+# Global cap on inline failure snippets shown in the whole PR comment, across
+# all tasks. The per-task producer cap (SURFACE_PR_COMMENT) bounds what each job
+# ships; this bounds what the aggregate renders. 5 lets one all-failing task
+# fill the comment while still leaving room when failures spread across tasks.
+_MAX_COMMENT_SNIPPETS = 5
+
+# Global caps on the repro / fix command sections (post-dedup, across all
+# tasks). Like snippets, these are sticky-selected so the shown set doesn't
+# flip-flop as sibling jobs report; the rest collapse into an "N more" note.
+_MAX_COMMENT_REPROS = 5
+_MAX_COMMENT_FIXES = 5
+
+# Snippet buckets that may carry an inline snippet, highest precedence first.
+_SNIPPET_BUCKET_RANK = {"build": 0, "test": 1, "timeout": 2}
+
+def _snippet_key(label, snippet):
+    """Stable dedup identity for a failure snippet across tasks + PATCHes: same
+    target AND same output collapse to one row (see `_select_snippets`)."""
+    return label + "\x00" + snippet
+
+def _select_sticky(candidates, shown_keys, max_items, key_of):
+    """Generic sticky + deterministic + hard-capped selection over a presorted
+    `candidates` list. Shared by snippets and repro/fix commands.
+
+    `candidates` must already be in the deterministic fill order the caller
+    wants. `key_of(item)` returns an item's stable identity string (persisted in
+    the state block). `shown_keys` is the prior persisted order.
+
+      1. Re-show every still-present prior key, in persisted order (append-only —
+         never evicted by a newcomer that sorts earlier).
+      2. Fill remaining budget from candidates not yet shown, in their order.
+      3. Hard-cap at `max_items`.
+
+    Returns `(selected, new_shown_keys, dropped)` — `dropped` is the candidates
+    that didn't make the cut (in candidate order), for caller-specific overflow."""
+    by_key = {}
+    for c in candidates:
+        k = key_of(c)
+        if k not in by_key:
+            by_key[k] = c
+
+    selected = []
+    new_shown = []
+    taken = {}
+
+    for k in shown_keys:
+        if len(selected) >= max_items:
+            break
+        if k in by_key and k not in taken:
+            selected.append(by_key[k])
+            new_shown.append(k)
+            taken[k] = True
+
+    for c in candidates:
+        if len(selected) >= max_items:
+            break
+        k = key_of(c)
+        if k not in taken:
+            selected.append(c)
+            new_shown.append(k)
+            taken[k] = True
+
+    dropped = [c for c in candidates if key_of(c) not in taken]
+    return (selected, new_shown, dropped)
+
+def _select_snippets(entries, shown_keys):
+    """Pick which inline failure snippets the comment shows, stably.
+
+    Identical failures are DEDUPED across tasks first: the same target failing
+    in several jobs (e.g. a build target built by build-gha, build-gha-debug and
+    the test task) collapses to ONE snippet attributed to all of them
+    (`task_keys`), rather than rendering the same output N times and crowding out
+    distinct failures. The dedup identity is `(label, snippet)` — same target AND
+    same output.
+
+    Anti-flip-flop contract (see PR-comment design): selection is append-only
+    within a run and hard-capped at `_MAX_COMMENT_SNIPPETS`.
+
+      1. Re-show every already-shown snippet still present, in persisted order. A
+         snippet, once shown, is NEVER evicted by a later-arriving one.
+      2. Fill remaining budget from not-yet-shown candidates in a DETERMINISTIC
+         order — (bucket_rank, label) — so the same inputs pick the same rows.
+      3. Never exceed the budget.
+
+    `entries` are merged per-task dicts (each may carry `failure_snippets`).
+    `shown_keys` is the persisted list of dedup keys shown so
+    far. Returns `(snippet_rows, new_shown_keys, overflow)` where snippet_rows are
+    render dicts `{label, kind, bucket, snippet, truncated, fence, task_keys}` and
+    `overflow` is `{total, by_task}` over DISTINCT (deduped) failures not shown —
+    `total` is the global count, `by_task` attributes the not-shown to the tasks
+    that hold them (a hidden failure shared by N tasks counts once per task)."""
+
+    # Dedup available snippets by (label, snippet) across tasks, unioning the
+    # contributing task_keys (first-seen order).
+    available = {}
+    order = []
+    for e in entries:
+        task_key = e.get("key", "") or e.get("name", "")
+        for s in e.get("failure_snippets", []) or []:
+            if type(s) != "dict":
+                continue
+            label = s.get("label", "")
+            snippet_text = s.get("snippet", "")
+            if not label or not snippet_text:
+                continue
+            key = _snippet_key(label, snippet_text)
+            slot = available.get(key)
+            if slot == None:
+                available[key] = {
+                    "label": label,
+                    "kind": s.get("kind", ""),
+                    "bucket": s.get("bucket", "test"),
+                    "snippet": snippet_text,
+                    "truncated": bool(s.get("truncated", False)),
+                    # Fence sized past any backtick run so log content can't close
+                    # the code block early (CommonMark fence-injection guard).
+                    "fence": code_fence_for(snippet_text),
+                    "task_keys": [task_key] if task_key else [],
+                    "_key": key,
+                }
+                order.append(key)
+            elif task_key and task_key not in slot["task_keys"]:
+                slot["task_keys"].append(task_key)
+
+    # Deterministic candidate order — (bucket_rank, label) — fed to the shared
+    # sticky+capped core. Dedup key (label+content) is the sticky identity.
+    candidates = sorted(
+        [available[k] for k in order],
+        key = lambda v: (_SNIPPET_BUCKET_RANK.get(v["bucket"], 9), v["label"]),
+    )
+    rows, new_shown, dropped = _select_sticky(
+        candidates, shown_keys, _MAX_COMMENT_SNIPPETS, lambda v: v["_key"],
+    )
+
+    # Overflow over DISTINCT failures not shown, attributed to the tasks holding
+    # them (a dropped failure shared by N tasks counts once per task).
+    overflow = _by_task_overflow(dropped)
+    return (rows, new_shown, overflow)
+
+def _by_task_overflow(dropped):
+    """Build `{total, by_task}` for dropped rows that each carry `task_keys`.
+    `total` = number of dropped rows; `by_task` attributes each to every task in
+    its `task_keys`, sorted by count desc then name."""
+    by_task = {}
+    total = 0
+    for r in dropped:
+        total += 1
+        for tk in r.get("task_keys", []) or []:
+            by_task[tk] = by_task.get(tk, 0) + 1
+    rows = sorted(
+        [{"task_key": tk, "count": n} for tk, n in by_task.items()],
+        key = lambda x: (-x["count"], x["task_key"]),
+    )
+    return {"total": total, "by_task": rows}
 
 # Per-bucket severity rank (highest first). Drives the per-row emoji and
 # in-section ordering.
@@ -580,21 +790,34 @@ def _collect_repro_fix_rows(sections):
             ranks = [task_rank.get(tk, 0) for tk in r["task_keys"]] or [0]
             r["_rank"] = max(ranks)
             r["severity_emoji"] = _RANK_EMOJI.get(r["_rank"], "")
+            # Stable identity for sticky selection — the dedup triple, persisted
+            # in the state block (independent of which tasks contributed).
+            r["_key"] = _command_key(r["kind"], r["command"], r["description"])
 
-        sorted_rows = sorted(rows, key = lambda r: -r["_rank"])
-
-        # Collapse consecutive repeated (kind, task_keys) headings — a task
-        # may contribute multiple commands (e.g. `aspect …` + `bazel …`).
-        prev_heading_key = None
-        for r in sorted_rows:
-            heading_key = (r["kind"], tuple(r["task_keys"]))
-            r["show_heading"] = heading_key != prev_heading_key
-            prev_heading_key = heading_key
+        # Deterministic order: severity desc, then kind/command/description, so
+        # the same inputs always pick the same rows regardless of arrival order
+        # (the old `-_rank`-only sort left ties to churn across PATCHes).
+        sorted_rows = sorted(rows, key = lambda r: (-r["_rank"], r["kind"], r["command"], r["description"]))
         return sorted_rows
 
     repro_rows = _gather(("failed", "failing", "flagged"), "repro_commands")
     fix_rows = _gather(("running", "failed", "failing", "flagged", "successful"), "fix_commands")
     return (repro_rows, fix_rows)
+
+def _command_key(kind, command, description):
+    """Stable identity for a deduped repro/fix command across PATCHes."""
+    return (kind or "") + "\x00" + (command or "") + "\x00" + (description or "")
+
+def _finalize_command_rows(rows):
+    """Set `show_heading` on the FINAL (post-selection) row order: collapse
+    consecutive repeated `(kind, task_keys)` headings — a task may contribute
+    multiple commands (e.g. `aspect …` + `bazel …`)."""
+    prev_heading_key = None
+    for r in rows:
+        heading_key = (r["kind"], tuple(r["task_keys"]))
+        r["show_heading"] = heading_key != prev_heading_key
+        prev_heading_key = heading_key
+    return rows
 
 # Cap on suggestion+info tips combined (important/warning always render
 # in full). See `_collect_tip_rows`.
@@ -697,7 +920,22 @@ def _collect_tip_rows(ctx, entries):
         out.append(decorated)
     return out
 
-def _render_body(ctx, marker, entries, started_at, body_template, status_badges, sections, last_updated_at = "", api_usage = "", state = None):
+def _format_overflow_note(overflow, noun_singular, noun_plural):
+    """Human-readable "N more <noun> — not shown (M in `task-a`, …)" line, or ""
+    when nothing overflowed. `overflow` is `{total, by_task}` from a selector.
+    Per-task attribution lets a reviewer see which jobs hold the hidden items."""
+    if not overflow:
+        return ""
+    total = overflow.get("total", 0)
+    if total <= 0:
+        return ""
+    by_task = overflow.get("by_task", []) or []
+    noun = noun_singular if total == 1 else noun_plural
+    parts = ["%d in `%s`" % (e["count"], e["task_key"]) for e in by_task if e.get("task_key")]
+    suffix = " (%s)" % ", ".join(parts) if parts else ""
+    return "_+ %d more %s — not shown%s._" % (total, noun, suffix)
+
+def _render_body(ctx, marker, entries, started_at, body_template, status_badges, sections, last_updated_at = "", api_usage = "", state = None, snippet_rows = None, snippet_overflow = None, repro_rows = None, fix_rows = None, repro_overflow = None, fix_overflow = None):
     """Render the comment body via the (possibly overridden) Jinja2 template.
 
     `entries` must be `_prepare_for_render`-d so the template is a pure
@@ -709,13 +947,18 @@ def _render_body(ctx, marker, entries, started_at, body_template, status_badges,
     renders twice — once with both `""` (deterministic diff baseline for
     the PATCH short-circuit) and once live for the upsert.
 
-    `repro_rows` / `fix_rows` / `tip_rows` are the deduped + attributed
-    outputs of `_collect_repro_fix_rows` / `_collect_tip_rows`.
+    `repro_rows` / `fix_rows` are the sticky-selected + finalized command rows
+    (with `*_overflow` notes); when `None` they're computed unselected from
+    `sections` (snapshot tests / non-merge callers that don't carry state).
+    `tip_rows` is `_collect_tip_rows`'s output.
 
     `state` — when set, appends the cross-workflow state block (the
     canonical source of truth across PR workflows). `None` omits it
     (snapshot tests / non-merge callers)."""
-    repro_rows, fix_rows = _collect_repro_fix_rows(sections)
+    if repro_rows == None and fix_rows == None:
+        repro_rows, fix_rows = _collect_repro_fix_rows(sections)
+        _finalize_command_rows(repro_rows)
+        _finalize_command_rows(fix_rows)
     tip_rows = _collect_tip_rows(ctx, entries)
     body = ctx.template.jinja2(body_template, data = {
         "marker": marker,
@@ -725,7 +968,11 @@ def _render_body(ctx, marker, entries, started_at, body_template, status_badges,
         "sections": sections,
         "repro_rows": repro_rows,
         "fix_rows": fix_rows,
+        "repro_overflow_note": _format_overflow_note(repro_overflow, "reproduce command", "reproduce commands"),
+        "fix_overflow_note": _format_overflow_note(fix_overflow, "fix command", "fix commands"),
         "tip_rows": tip_rows,
+        "snippet_rows": snippet_rows or [],
+        "snippet_overflow_note": _format_overflow_note(snippet_overflow, "failure", "failures"),
         "api_usage": api_usage,
         "last_updated_at": last_updated_at,
         "cli_version": ctx.std.env.aspect_cli_version(),
@@ -741,7 +988,8 @@ def _serialize_state(state):
     base64-wraps the JSON so the literal `-->` terminator can't appear
     inside. Round-tripped via `_parse_state`. `state`: `head_sha`,
     `last_upsert_epoch_s`, `workflow_runs` (`[{run_id, workflow_name}]`),
-    `entries` (snapshots; TTL/race fallback)."""
+    `entries` (snapshots; TTL/race fallback), and the sticky selection sets
+    `shown_snippets` / `shown_repros` / `shown_fixes`."""
     encoded = base64.encode(json.encode(state))
     return _STATE_BLOCK_OPEN + encoded + _STATE_BLOCK_CLOSE
 
@@ -760,11 +1008,11 @@ def _is_standard_base64(s):
 def _parse_state(body):
     """Extract the cross-workflow state block from a comment body.
 
-    Returns `{head_sha, last_upsert_epoch_s, workflow_runs, entries}`, or
-    `None` when absent/malformed (caller falls back to current-workflow-
-    only). Wrong-typed fields (e.g. after a manual edit) normalize to
-    defaults; list fields drop non-dict elements so downstream can assume
-    dict rows."""
+    Returns `{head_sha, last_upsert_epoch_s, workflow_runs, entries,
+    shown_snippets, shown_repros, shown_fixes}`, or `None` when absent/malformed
+    (caller falls back to current-workflow-only). Wrong-typed fields (e.g. after
+    a manual edit) normalize to defaults; list fields drop non-dict / non-string
+    elements so downstream can assume well-typed rows."""
     if not body:
         return None
     start = body.find(_STATE_BLOCK_OPEN)
@@ -786,6 +1034,9 @@ def _parse_state(body):
     entries = decoded.get("entries")
     parsed_entries = [e for e in entries if type(e) == "dict"] if type(entries) == "list" else []
 
+    def _string_list(v):
+        return [k for k in v if type(k) == "string"] if type(v) == "list" else []
+
     # JSON round-trip flattens ReproFixCommand records to dicts; rehydrate
     # so `_collect_repro_fix_rows` can do `c.command`/`c.description`.
     # Only touch present keys so older-release entries round-trip unchanged.
@@ -799,6 +1050,10 @@ def _parse_state(body):
         "last_upsert_epoch_s": epoch if type(epoch) == "int" else 0,
         "workflow_runs": [r for r in workflow_runs if type(r) == "dict"] if type(workflow_runs) == "list" else [],
         "entries": parsed_entries,
+        # Sticky selection state (lists of opaque keys); drop non-strings.
+        "shown_snippets": _string_list(decoded.get("shown_snippets")),
+        "shown_repros": _string_list(decoded.get("shown_repros")),
+        "shown_fixes": _string_list(decoded.get("shown_fixes")),
     }
 
 def _live_runs(workflow_runs, my_run_id, my_workflow_name):
@@ -1292,6 +1547,36 @@ def _github_status_comments(ctx: FeatureContext):
         prepared = _prepare_for_render(_dedup_for_display(new_state["entries"]))
         sections = _bucket_entries(prepared)
 
+        # Sticky + deterministic selection for snippets and repro/fix commands,
+        # across siblings. Computed once so both renders agree; the chosen keys
+        # persist in the state block so a later sibling can't evict an
+        # already-shown item. Only reuse a prior sticky set on the SAME head_sha
+        # — a new commit starts fresh (matching the entry-refresh guard above),
+        # so a stale key from the previous commit can't consume a slot.
+        same_head = parsed and parsed.get("head_sha") == head_sha
+
+        def _prior(key):
+            if not same_head:
+                return []
+            return [k for k in (parsed.get(key) or []) if type(k) == "string"]
+
+        snippet_rows, shown_keys, snippet_overflow = _select_snippets(prepared, _prior("shown_snippets"))
+        new_state["shown_snippets"] = shown_keys
+
+        # Repro / fix commands: dedup + deterministic-sort, then sticky-select
+        # against the global cap; the rest collapse into an "N more" note.
+        all_repro_rows, all_fix_rows = _collect_repro_fix_rows(sections)
+        repro_rows, repro_shown, repro_dropped = _select_sticky(
+            all_repro_rows, _prior("shown_repros"), _MAX_COMMENT_REPROS, lambda r: r["_key"])
+        fix_rows, fix_shown, fix_dropped = _select_sticky(
+            all_fix_rows, _prior("shown_fixes"), _MAX_COMMENT_FIXES, lambda r: r["_key"])
+        _finalize_command_rows(repro_rows)
+        _finalize_command_rows(fix_rows)
+        repro_overflow = _by_task_overflow(repro_dropped)
+        fix_overflow = _by_task_overflow(fix_dropped)
+        new_state["shown_repros"] = repro_shown
+        new_state["shown_fixes"] = fix_shown
+
         # Earliest start across all siblings, pinned so it doesn't wobble.
         earliest_ms = _earliest_start_ms(prepared)
         started_at = format_run_date(ctx, earliest_ms)
@@ -1311,6 +1596,12 @@ def _github_status_comments(ctx: FeatureContext):
             status_badges,
             sections,
             state = stable_state,
+            snippet_rows = snippet_rows,
+            snippet_overflow = snippet_overflow,
+            repro_rows = repro_rows,
+            fix_rows = fix_rows,
+            repro_overflow = repro_overflow,
+            fix_overflow = fix_overflow,
         )
         if _state.get("_last_stable_body") == stable_body:
             return
@@ -1327,6 +1618,12 @@ def _github_status_comments(ctx: FeatureContext):
             last_updated_at = format_run_date(ctx, now_ms(ctx)),
             api_usage = usage_footer(ctx),
             state = final_state,
+            snippet_rows = snippet_rows,
+            snippet_overflow = snippet_overflow,
+            repro_rows = repro_rows,
+            fix_rows = fix_rows,
+            repro_overflow = repro_overflow,
+            fix_overflow = fix_overflow,
         )
         if not _upsert_comment(ctx, token, final_body):
             # Skip stamping — the swarm should retry, not honor a stale
@@ -1409,6 +1706,14 @@ def _github_status_comments(ctx: FeatureContext):
             # Generic BES link from `--bes_results_url` + invocation_id.
             bes_url = render_bes_url(data)
 
+            # Inline failure snippets: bazel_results only, and only on the
+            # terminal update (data frozen, log/stderr paths materialized).
+            # Each job ships its own; sibling writers can't read its files.
+            failure_snippets = None
+            if update.final and update.kind == "bazel_results":
+                _snip_opts, _max_per_task = snippet_budget_for(SURFACE_PR_COMMENT)
+                failure_snippets = extract_failure_snippets(ctx.std, data, _snip_opts, _max_per_task)
+
             cur = ctx.task.current_phase()
             _state["_results_subset"] = _results_subset(
                 data,
@@ -1421,6 +1726,7 @@ def _github_status_comments(ctx: FeatureContext):
                 _state.get("_progress_styles"),
                 _state.get("_failed_in_phase", ""),
                 start_time_ms = data.get("start_time_ms", 0) or 0,
+                failure_snippets = failure_snippets,
             )
 
         # Bypass throttle on `update.final` (all terminal verdicts) and the
@@ -1473,6 +1779,30 @@ def bucket_entries(entries):
     """Public test hook; see `_bucket_entries`."""
     return _bucket_entries(entries)
 
+def select_snippets(entries, shown_keys):
+    """Public test hook; see `_select_snippets`."""
+    return _select_snippets(entries, shown_keys)
+
+def snippet_key(label, snippet):
+    """Public test hook; see `_snippet_key`."""
+    return _snippet_key(label, snippet)
+
+def select_sticky(candidates, shown_keys, max_items, key_of):
+    """Public test hook; see `_select_sticky`."""
+    return _select_sticky(candidates, shown_keys, max_items, key_of)
+
+def collect_repro_fix_rows(sections):
+    """Public test hook; see `_collect_repro_fix_rows`."""
+    return _collect_repro_fix_rows(sections)
+
+def by_task_overflow(dropped):
+    """Public test hook; see `_by_task_overflow`."""
+    return _by_task_overflow(dropped)
+
+def format_overflow_note(overflow, noun_singular, noun_plural):
+    """Public test hook; see `_format_overflow_note`."""
+    return _format_overflow_note(overflow, noun_singular, noun_plural)
+
 def dedup_by_run_attempt(entries):
     """Public test hook; see `_dedup_by_run_attempt`."""
     return _dedup_by_run_attempt(entries)
@@ -1485,7 +1815,7 @@ def should_quiet_delete_log(last_upload_at, now):
     """Public test hook; see `_should_quiet_delete_log`."""
     return _should_quiet_delete_log(last_upload_at, now)
 
-def render_body(ctx, marker, entries, started_at, body_template, status_badges, sections, state = None):
+def render_body(ctx, marker, entries, started_at, body_template, status_badges, sections, state = None, snippet_rows = None, snippet_overflow = None):
     """Public test hook; see `_render_body`."""
     return _render_body(
         ctx,
@@ -1496,6 +1826,8 @@ def render_body(ctx, marker, entries, started_at, body_template, status_badges, 
         status_badges,
         sections,
         state = state,
+        snippet_rows = snippet_rows,
+        snippet_overflow = snippet_overflow,
     )
 
 def serialize_state(state):

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -735,7 +735,7 @@ def _check_state_serialize_round_trip():
     _eq("round-trip shown_repros", parsed["shown_repros"], state["shown_repros"])
     _eq("round-trip shown_fixes", parsed["shown_fixes"], state["shown_fixes"])
 
-def _snip(label, bucket = "test", text = "boom", truncated = False, kind = "", trunc_head = False, trunc_tail = False):
+def _snip(label, bucket = "test", text = "boom", truncated = False, kind = "", trunc_head = False, trunc_tail = False, duration_ms = 0):
     # kind defaults to the bucket word ("build"/"test") used in the header line.
     return {
         "label": label,
@@ -745,6 +745,7 @@ def _snip(label, bucket = "test", text = "boom", truncated = False, kind = "", t
         "trunc_head": trunc_head,
         "trunc_tail": trunc_tail,
         "kind": kind or ("build" if bucket == "build" else "test"),
+        "duration_ms": duration_ms,
     }
 
 def _entry_with_snippets(key, snippets):
@@ -824,14 +825,15 @@ def _check_select_snippets(ctx):
     _eq("select: malformed/empty snippets skipped", len(rows5), 0)
 
     # End-to-end: rows render grouped under "Build Failures" / "Test Failures",
-    # no per-row <details>, header matching the Repro/Fix treatment, with the
-    # contributing task(s) and a fenced block.
+    # no per-row <details>; header reads "❌ <kind> `<label>` <verb>:" (rule kind,
+    # no inline tasks), with the contributing task(s) in a <sub> line BELOW the
+    # snippet and the test duration folded into the verb.
     failed_entry = _entry("test", "test-task", "test-gha", "bazel_results", "failed", make_test_failed(), 90000)
     prepared = prepare_for_render([failed_entry])
     snip_entry = _entry_with_snippets("test-task", [
-        _snip("//pkg:broken", "build", "no member named 'foo'"),
-        _snip("//pkg:fail_test", "test", "FAILED: expected 1 got 2"),
-        _snip("//pkg:slow_test", "timeout", "timed out after 60s"),
+        _snip("//pkg:broken", "build", "no member named 'foo'", kind = "genrule"),
+        _snip("//pkg:fail_test", "test", "FAILED: expected 1 got 2", kind = "sh_test", duration_ms = 149),
+        _snip("//pkg:slow_test", "timeout", "timed out after 60s", kind = "sh_test", duration_ms = 60000),
     ])
     sel_rows, _, _ = select_snippets([snip_entry], [])
     body = render_body(
@@ -840,12 +842,14 @@ def _check_select_snippets(ctx):
     )
     _eq("select: render emits Build Failures group", "## 💥 Build Failures" in body, True)
     _eq("select: render emits Test Failures group", "## ❌ Test Failures" in body, True)
-    _eq("select: build header matches repro/fix treatment",
-        "❌ build (test-task) · `//pkg:broken` failed to build:" in body, True)
-    _eq("select: test header matches repro/fix treatment",
-        "❌ test (test-task) · `//pkg:fail_test` failed:" in body, True)
-    _eq("select: timeout header uses 'timed out' verb",
-        "❌ test (test-task) · `//pkg:slow_test` timed out:" in body, True)
+    _eq("select: build header is kind + label (no inline tasks)",
+        "❌ genrule `//pkg:broken` failed to build:" in body, True)
+    _eq("select: test header folds in duration",
+        "❌ sh_test `//pkg:fail_test` failed in 149ms:" in body, True)
+    _eq("select: timeout header uses 'timed out after <dur>'",
+        "❌ sh_test `//pkg:slow_test` timed out after 1m:" in body, True)
+    _eq("select: contributing tasks render in a <sub> line below the snippet",
+        "<sub>test-task</sub>" in body, True)
     _eq("select: render includes snippet text", "FAILED: expected 1 got 2" in body, True)
     _eq("select: no per-row <details>", "<details open><summary>" not in body, True)
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -791,7 +791,7 @@ def _check_select_snippets(ctx):
     _eq("select: hard cap at global budget (5)", len(rows3), 5)
     _eq("select: shown set also capped at 5", len(shown3), 5)
     _eq("select: 6 distinct, 5 shown → 1 overflow", overflow3["total"], 1)
-    _eq("select: overflow attributed to the holding task", overflow3["by_task"], [{"task_key": "z-task", "count": 1}])
+    _eq("select: overflow lists the holding task", overflow3["tasks"], ["z-task"])
 
     # Stickiness under contention: the already-shown snippet sorts LAST, so
     # without stickiness it would be evicted when 6 compete for 5 slots. It must
@@ -806,14 +806,13 @@ def _check_select_snippets(ctx):
     _eq("select: earlier-sorting unshown evicted, not the sticky", "//z:t4" in labels_sticky, False)
 
     # Multi-task overflow attribution: two distinct dropped failures, each held by
-    # a different task, sorted by count desc.
+    # a different task; `tasks` lists both (sorted), `total` counts distinct items.
     crowd = [_snip("//c:t%d" % i, "test", "boom %d" % i) for i in range(5)]
     t1 = _entry_with_snippets("task-x", crowd + [_snip("//x:extra", "test", "x boom")])
     t2 = _entry_with_snippets("task-y", crowd + [_snip("//y:extra", "test", "y boom")])
     _, _, overflow_multi = select_snippets([t1, t2], [])
     _eq("select: multi-task overflow total (2 distinct dropped)", overflow_multi["total"], 2)
-    _eq("select: multi-task overflow attributes each holder",
-        overflow_multi["by_task"], [{"task_key": "task-x", "count": 1}, {"task_key": "task-y", "count": 1}])
+    _eq("select: multi-task overflow lists holding tasks", overflow_multi["tasks"], ["task-x", "task-y"])
 
     # Sticky entries gone (failure no longer present) drop out cleanly.
     _, shown4, _ = select_snippets([e_a], [snippet_key("//gone:t", "x")])
@@ -853,7 +852,7 @@ def _check_select_snippets(ctx):
     _eq("select: render includes snippet text", "FAILED: expected 1 got 2" in body, True)
     _eq("select: no per-row <details>", "<details open><summary>" not in body, True)
 
-    # Overflow note renders with per-task attribution (1 distinct dropped failure).
+    # Overflow note lists the task holding the hidden failure (1 distinct dropped).
     over_snips = [_snip("//pkg:t%d" % i, "test", "boom %d" % i) for i in range(6)]
     over_entry = _entry_with_snippets("test-task", over_snips)
     over_rows, _, over_of = select_snippets([over_entry], [])
@@ -861,8 +860,8 @@ def _check_select_snippets(ctx):
         ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
         bucket_entries(prepared), snippet_rows = over_rows, snippet_overflow = over_of,
     )
-    _eq("select: overflow note rendered with per-task attribution",
-        "_+ 1 more failure — not shown (1 in `test-task`)._" in over_body, True)
+    _eq("select: overflow note lists holding task with 'across'",
+        "_+ 1 more failure — not shown (across `test-task`)._" in over_body, True)
 
     # Fence injection: a snippet containing a ``` run must not break out of the
     # code block — the fence widens past the longest run so it stays enclosed.
@@ -916,29 +915,29 @@ def _check_select_sticky():
     _eq("sticky: stale prior key skipped", [r["k"] for r in sel3], ["b", "a"])
 
 def _check_by_task_overflow():
-    """_by_task_overflow: dropped rows attribute per contributing task (shared by
-    snippets and repro/fix commands)."""
+    """_by_task_overflow: total counts DISTINCT dropped items; `tasks` is the set
+    of tasks holding hidden items (no per-task counts — they'd double-count a
+    deduped item shared by N tasks). Shared by snippets and repro/fix commands."""
     dropped = [
         {"command": "x", "task_keys": ["task-a", "task-b"]},
         {"command": "y", "task_keys": ["task-b"]},
     ]
     of = by_task_overflow(dropped)
-    _eq("by_task_overflow: total counts rows", of["total"], 2)
-    # task-b in both dropped rows (2), task-a in one (1) → sorted desc.
-    _eq("by_task_overflow: per-task attribution sorted desc",
-        of["by_task"], [{"task_key": "task-b", "count": 2}, {"task_key": "task-a", "count": 1}])
-    _eq("by_task_overflow: empty → zero", by_task_overflow([]), {"total": 0, "by_task": []})
+    _eq("by_task_overflow: total counts distinct dropped items", of["total"], 2)
+    # task-a + task-b hold hidden items; listed once each, sorted.
+    _eq("by_task_overflow: tasks deduped + sorted", of["tasks"], ["task-a", "task-b"])
+    _eq("by_task_overflow: empty → zero", by_task_overflow([]), {"total": 0, "tasks": []})
 
 def _check_format_overflow_note():
-    """_format_overflow_note: singular/plural + per-task suffix, "" when empty."""
-    _eq("overflow note: empty → ''", format_overflow_note({"total": 0, "by_task": []}, "x", "xs"), "")
+    """_format_overflow_note: singular/plural + 'across' task list, "" when empty."""
+    _eq("overflow note: empty → ''", format_overflow_note({"total": 0, "tasks": []}, "x", "xs"), "")
     _eq("overflow note: None → ''", format_overflow_note(None, "x", "xs"), "")
     _eq("overflow note: singular noun",
-        format_overflow_note({"total": 1, "by_task": [{"task_key": "t", "count": 1}]}, "failure", "failures"),
-        "_+ 1 more failure — not shown (1 in `t`)._")
-    _eq("overflow note: plural + multi-task",
-        format_overflow_note({"total": 5, "by_task": [{"task_key": "a", "count": 3}, {"task_key": "b", "count": 2}]}, "failure", "failures"),
-        "_+ 5 more failures — not shown (3 in `a`, 2 in `b`)._")
+        format_overflow_note({"total": 1, "tasks": ["t"]}, "failure", "failures"),
+        "_+ 1 more failure — not shown (across `t`)._")
+    _eq("overflow note: plural + multi-task 'across'",
+        format_overflow_note({"total": 5, "tasks": ["a", "b"]}, "failure", "failures"),
+        "_+ 5 more failures — not shown (across `a`, `b`)._")
 
 def _check_parse_state_absent():
     """parse_state returns None when the body has no state block —

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -29,17 +29,17 @@ load(
     "DEFAULT_STATUS_BADGES",
     "MARKER_FMT",
     "bucket_entries",
+    "by_task_overflow",
+    "collect_repro_fix_rows",
     "collect_tip_rows",
     "dedup_by_run_attempt",
     "dedup_for_display",
+    "format_overflow_note",
     "lease_held",
     "max_recent_upsert_epoch",
     "merge_state",
     "parse_state",
     "prepare_for_render",
-    "collect_repro_fix_rows",
-    "by_task_overflow",
-    "format_overflow_note",
     "render_body",
     "results_subset",
     "select_snippets",
@@ -773,8 +773,11 @@ def _check_select_snippets(ctx):
     ]
     rows_dup, _, overflow_dup = select_snippets(dup, [])
     _eq("select: identical failure deduped to one row", len(rows_dup), 1)
-    _eq("select: deduped row attributes all contributing tasks",
-        rows_dup[0]["task_keys"], ["build-gha", "build-gha-debug", "test-gha"])
+    _eq(
+        "select: deduped row attributes all contributing tasks",
+        rows_dup[0]["task_keys"],
+        ["build-gha", "build-gha-debug", "test-gha"],
+    )
     _eq("select: deduped → no overflow", overflow_dup["total"], 0)
 
     # Different content for the same label is NOT deduped (distinct failures).
@@ -836,19 +839,37 @@ def _check_select_snippets(ctx):
     ])
     sel_rows, _, _ = select_snippets([snip_entry], [])
     body = render_body(
-        ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
-        bucket_entries(prepared), snippet_rows = sel_rows,
+        ctx,
+        MARKER_FMT % 1,
+        prepared,
+        "",
+        DEFAULT_BODY_TEMPLATE,
+        DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared),
+        snippet_rows = sel_rows,
     )
     _eq("select: render emits Build Failures group", "## 💥 Build Failures" in body, True)
     _eq("select: render emits Test Failures group", "## ❌ Test Failures" in body, True)
-    _eq("select: build header is kind + label (no inline tasks)",
-        "❌ genrule `//pkg:broken` failed to build:" in body, True)
-    _eq("select: test header folds in duration",
-        "❌ sh_test `//pkg:fail_test` failed in 149ms:" in body, True)
-    _eq("select: timeout header uses 'timed out after <dur>'",
-        "❌ sh_test `//pkg:slow_test` timed out after 1m:" in body, True)
-    _eq("select: contributing tasks render in a <sub> line below the snippet",
-        "<sub>test-task</sub>" in body, True)
+    _eq(
+        "select: build header is kind + label (no inline tasks)",
+        "❌ genrule `//pkg:broken` failed to build:" in body,
+        True,
+    )
+    _eq(
+        "select: test header folds in duration",
+        "❌ sh_test `//pkg:fail_test` failed in 149ms:" in body,
+        True,
+    )
+    _eq(
+        "select: timeout header uses 'timed out after <dur>'",
+        "❌ sh_test `//pkg:slow_test` timed out after 1m:" in body,
+        True,
+    )
+    _eq(
+        "select: contributing task renders 'in task' below the snippet",
+        "<sub>in task test-task</sub>" in body,
+        True,
+    )
     _eq("select: render includes snippet text", "FAILED: expected 1 got 2" in body, True)
     _eq("select: no per-row <details>", "<details open><summary>" not in body, True)
 
@@ -857,11 +878,21 @@ def _check_select_snippets(ctx):
     over_entry = _entry_with_snippets("test-task", over_snips)
     over_rows, _, over_of = select_snippets([over_entry], [])
     over_body = render_body(
-        ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
-        bucket_entries(prepared), snippet_rows = over_rows, snippet_overflow = over_of,
+        ctx,
+        MARKER_FMT % 1,
+        prepared,
+        "",
+        DEFAULT_BODY_TEMPLATE,
+        DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared),
+        snippet_rows = over_rows,
+        snippet_overflow = over_of,
     )
-    _eq("select: overflow note lists holding task with 'across'",
-        "_+ 1 more failure — not shown (across `test-task`)._" in over_body, True)
+    _eq(
+        "select: overflow note lists holding task with 'across'",
+        "_+ 1 more failure — not shown (across `test-task`)._" in over_body,
+        True,
+    )
 
     # Fence injection: a snippet containing a ``` run must not break out of the
     # code block — the fence widens past the longest run so it stays enclosed.
@@ -871,8 +902,14 @@ def _check_select_snippets(ctx):
     evil_rows, _, _ = select_snippets([evil], [])
     _eq("select: fence widened past inner backticks", evil_rows[0]["fence"], "````")
     evil_body = render_body(
-        ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
-        bucket_entries(prepared), snippet_rows = evil_rows,
+        ctx,
+        MARKER_FMT % 1,
+        prepared,
+        "",
+        DEFAULT_BODY_TEMPLATE,
+        DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared),
+        snippet_rows = evil_rows,
     )
     _eq(
         "select: injected fence does not escape (heading stays literal)",
@@ -887,11 +924,20 @@ def _check_select_snippets(ctx):
     ])
     trunc_rows, _, _ = select_snippets([trunc], [])
     trunc_body = render_body(
-        ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
-        bucket_entries(prepared), snippet_rows = trunc_rows,
+        ctx,
+        MARKER_FMT % 1,
+        prepared,
+        "",
+        DEFAULT_BODY_TEMPLATE,
+        DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared),
+        snippet_rows = trunc_rows,
     )
-    _eq("select: head+tail truncation renders … above and below",
-        "```text\n…\nmiddle output\n…\n```" in trunc_body, True)
+    _eq(
+        "select: head+tail truncation renders … above and below",
+        "```text\n…\nmiddle output\n…\n```" in trunc_body,
+        True,
+    )
 
 def _check_select_sticky():
     """_select_sticky: the generic sticky + deterministic + capped core shared
@@ -924,6 +970,7 @@ def _check_by_task_overflow():
     ]
     of = by_task_overflow(dropped)
     _eq("by_task_overflow: total counts distinct dropped items", of["total"], 2)
+
     # task-a + task-b hold hidden items; listed once each, sorted.
     _eq("by_task_overflow: tasks deduped + sorted", of["tasks"], ["task-a", "task-b"])
     _eq("by_task_overflow: empty → zero", by_task_overflow([]), {"total": 0, "tasks": []})
@@ -932,12 +979,16 @@ def _check_format_overflow_note():
     """_format_overflow_note: singular/plural + 'across' task list, "" when empty."""
     _eq("overflow note: empty → ''", format_overflow_note({"total": 0, "tasks": []}, "x", "xs"), "")
     _eq("overflow note: None → ''", format_overflow_note(None, "x", "xs"), "")
-    _eq("overflow note: singular noun",
+    _eq(
+        "overflow note: singular noun",
         format_overflow_note({"total": 1, "tasks": ["t"]}, "failure", "failures"),
-        "_+ 1 more failure — not shown (across `t`)._")
-    _eq("overflow note: plural + multi-task 'across'",
+        "_+ 1 more failure — not shown (across `t`)._",
+    )
+    _eq(
+        "overflow note: plural + multi-task 'across'",
         format_overflow_note({"total": 5, "tasks": ["a", "b"]}, "failure", "failures"),
-        "_+ 5 more failures — not shown (across `a`, `b`)._")
+        "_+ 5 more failures — not shown (across `a`, `b`)._",
+    )
 
 def _check_parse_state_absent():
     """parse_state returns None when the body has no state block —

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -37,10 +37,16 @@ load(
     "merge_state",
     "parse_state",
     "prepare_for_render",
+    "collect_repro_fix_rows",
+    "by_task_overflow",
+    "format_overflow_note",
     "render_body",
     "results_subset",
+    "select_snippets",
+    "select_sticky",
     "serialize_state",
     "should_quiet_delete_log",
+    "snippet_key",
 )
 load(
     "./test_fixtures.axl",
@@ -699,7 +705,7 @@ def _check_max_recent_upsert_epoch():
 
 def _check_state_serialize_round_trip():
     """serialize_state → parse_state round-trips head_sha, lease epoch,
-    workflow_runs, and entries."""
+    workflow_runs, entries, and the sticky shown_snippets selection."""
     state = {
         "head_sha": "abc",
         "last_upsert_epoch_s": 1700000000,
@@ -711,6 +717,9 @@ def _check_state_serialize_round_trip():
             {"name": "build", "key": "build", "workflow_run_id": "100"},
             {"name": "lint", "key": "lint", "workflow_run_id": "200"},
         ],
+        "shown_snippets": [snippet_key("//pkg:a", "boom a"), snippet_key("//pkg:b", "boom b")],
+        "shown_repros": ["test\x00aspect test //pkg:a\x00"],
+        "shown_fixes": ["format\x00aspect format\x00"],
     }
     block = serialize_state(state)
     parsed = parse_state("some body content\n\n" + block + "\n")
@@ -720,6 +729,184 @@ def _check_state_serialize_round_trip():
     _eq("round-trip last_upsert_epoch_s", parsed["last_upsert_epoch_s"], 1700000000)
     _eq("round-trip workflow_runs", parsed["workflow_runs"], state["workflow_runs"])
     _eq("round-trip entries", parsed["entries"], state["entries"])
+
+    # Regression: sticky selection sets must survive so stickiness works across PATCHes.
+    _eq("round-trip shown_snippets", parsed["shown_snippets"], state["shown_snippets"])
+    _eq("round-trip shown_repros", parsed["shown_repros"], state["shown_repros"])
+    _eq("round-trip shown_fixes", parsed["shown_fixes"], state["shown_fixes"])
+
+def _snip(label, bucket = "test", text = "boom", truncated = False, kind = ""):
+    return {"label": label, "bucket": bucket, "snippet": text, "truncated": truncated, "kind": kind}
+
+def _entry_with_snippets(key, snippets):
+    return {"name": key, "key": key, "failure_snippets": snippets}
+
+def _check_select_snippets(ctx):
+    """_select_snippets: dedup-by-(label,content) across tasks, sticky,
+    deterministic, hard-capped at the global budget."""
+
+    # Deterministic fill from empty: stable (bucket_rank, label) order. build
+    # bucket (rank 0) sorts ahead of test (rank 1).
+    e_a = _entry_with_snippets("a-task", [_snip("//a:t2", "test"), _snip("//a:t1", "build")])
+    e_b = _entry_with_snippets("b-task", [_snip("//b:t1", "test")])
+    rows, shown, overflow = select_snippets([e_b, e_a], [])
+    _eq("select: deterministic order (bucket,label)", [r["label"] for r in rows], ["//a:t1", "//a:t2", "//b:t1"])
+    _eq("select: shown keys mirror rows", shown, [r["_key"] for r in rows])
+    _eq("select: all shown → no overflow", overflow["total"], 0)
+
+    # Cross-task dedup: the SAME (label, content) failing in three jobs collapses
+    # to ONE row attributed to all three (the core fix — no 3× duplicate output).
+    dup = [
+        _entry_with_snippets("build-gha", [_snip("//x:lib", "build", "compile error")]),
+        _entry_with_snippets("build-gha-debug", [_snip("//x:lib", "build", "compile error")]),
+        _entry_with_snippets("test-gha", [_snip("//x:lib", "build", "compile error")]),
+    ]
+    rows_dup, _, overflow_dup = select_snippets(dup, [])
+    _eq("select: identical failure deduped to one row", len(rows_dup), 1)
+    _eq("select: deduped row attributes all contributing tasks",
+        rows_dup[0]["task_keys"], ["build-gha", "build-gha-debug", "test-gha"])
+    _eq("select: deduped → no overflow", overflow_dup["total"], 0)
+
+    # Different content for the same label is NOT deduped (distinct failures).
+    diff = [
+        _entry_with_snippets("a", [_snip("//x:t", "test", "boom A")]),
+        _entry_with_snippets("b", [_snip("//x:t", "test", "boom B")]),
+    ]
+    rows_diff, _, _ = select_snippets(diff, [])
+    _eq("select: same label different content stays distinct", len(rows_diff), 2)
+
+    # Hard cap: 6 distinct failures, budget 5 → exactly 5 shown, 1 dropped.
+    many = _entry_with_snippets("z-task", [_snip("//z:t%d" % i, "test", "boom %d" % i) for i in range(6)])
+    rows3, shown3, overflow3 = select_snippets([many], [])
+    _eq("select: hard cap at global budget (5)", len(rows3), 5)
+    _eq("select: shown set also capped at 5", len(shown3), 5)
+    _eq("select: 6 distinct, 5 shown → 1 overflow", overflow3["total"], 1)
+    _eq("select: overflow attributed to the holding task", overflow3["by_task"], [{"task_key": "z-task", "count": 1}])
+
+    # Stickiness under contention: the already-shown snippet sorts LAST, so
+    # without stickiness it would be evicted when 6 compete for 5 slots. It must
+    # survive; the earlier-sorting-but-unshown candidate is dropped instead.
+    six = _entry_with_snippets("z-task", [_snip("//z:t%d" % i, "test", "boom %d" % i) for i in range(6)])
+    prior_last = [snippet_key("//z:t5", "boom 5")]  # sorts last by label
+    rows_sticky, _, _ = select_snippets([six], prior_last)
+    labels_sticky = [r["label"] for r in rows_sticky]
+    _eq("select: sticky last-sorting survives contention", "//z:t5" in labels_sticky, True)
+    _eq("select: sticky leads the row order", labels_sticky[0], "//z:t5")
+    _eq("select: an unshown candidate is the one dropped", len(rows_sticky), 5)
+    _eq("select: earlier-sorting unshown evicted, not the sticky", "//z:t4" in labels_sticky, False)
+
+    # Multi-task overflow attribution: two distinct dropped failures, each held by
+    # a different task, sorted by count desc.
+    crowd = [_snip("//c:t%d" % i, "test", "boom %d" % i) for i in range(5)]
+    t1 = _entry_with_snippets("task-x", crowd + [_snip("//x:extra", "test", "x boom")])
+    t2 = _entry_with_snippets("task-y", crowd + [_snip("//y:extra", "test", "y boom")])
+    _, _, overflow_multi = select_snippets([t1, t2], [])
+    _eq("select: multi-task overflow total (2 distinct dropped)", overflow_multi["total"], 2)
+    _eq("select: multi-task overflow attributes each holder",
+        overflow_multi["by_task"], [{"task_key": "task-x", "count": 1}, {"task_key": "task-y", "count": 1}])
+
+    # Sticky entries gone (failure no longer present) drop out cleanly.
+    _, shown4, _ = select_snippets([e_a], [snippet_key("//gone:t", "x")])
+    _eq("select: stale shown key dropped when failure absent", snippet_key("//gone:t", "x") in shown4, False)
+
+    # Malformed / empty snippets are ignored.
+    junk = _entry_with_snippets("j", [{"label": "", "snippet": "x"}, {"label": "//j:t", "snippet": ""}])
+    rows5, _, _ = select_snippets([junk], [])
+    _eq("select: malformed/empty snippets skipped", len(rows5), 0)
+
+    # End-to-end: selected rows render a "Failure output" section with a labeled,
+    # task-attributed, OPEN-by-default collapsible block + the truncated hint.
+    failed_entry = _entry("test", "test-task", "test-gha", "bazel_results", "failed", make_test_failed(), 90000)
+    prepared = prepare_for_render([failed_entry])
+    snip_entry = _entry_with_snippets("test-task", [
+        _snip("//pkg:fail_test", "test", "FAILED: expected 1 got 2", True),
+        _snip("//pkg:slow_test", "timeout", "timed out after 60s", False),
+    ])
+    sel_rows, _, _ = select_snippets([snip_entry], [])
+    body = render_body(
+        ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared), snippet_rows = sel_rows,
+    )
+    _eq("select: render emits Failure output section", "## 🔎 Failure output" in body, True)
+    _eq("select: render details default to open",
+        "<details open><summary><code>//pkg:fail_test</code> output · test-task</summary>" in body, True)
+    _eq("select: render includes snippet text", "FAILED: expected 1 got 2" in body, True)
+    _eq("select: render flags truncation", "_…output truncated_" in body, True)
+    _eq("select: render marks timeout bucket", "(timed out) output · test-task</summary>" in body, True)
+
+    # Overflow note renders with per-task attribution (1 distinct dropped failure).
+    over_snips = [_snip("//pkg:t%d" % i, "test", "boom %d" % i) for i in range(6)]
+    over_entry = _entry_with_snippets("test-task", over_snips)
+    over_rows, _, over_of = select_snippets([over_entry], [])
+    over_body = render_body(
+        ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared), snippet_rows = over_rows, snippet_overflow = over_of,
+    )
+    _eq("select: overflow note rendered with per-task attribution",
+        "_+ 1 more failure — not shown (1 in `test-task`)._" in over_body, True)
+
+    # Fence injection: a snippet containing a ``` run must not break out of the
+    # code block — the fence widens past the longest run so it stays enclosed.
+    evil = _entry_with_snippets("evil-task", [
+        _snip("//evil:t", "test", "before\n```\n# fake heading\n```\nafter", False),
+    ])
+    evil_rows, _, _ = select_snippets([evil], [])
+    _eq("select: fence widened past inner backticks", evil_rows[0]["fence"], "````")
+    evil_body = render_body(
+        ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared), snippet_rows = evil_rows,
+    )
+    _eq(
+        "select: injected fence does not escape (heading stays literal)",
+        "````text\nbefore\n```\n# fake heading\n```\nafter\n````" in evil_body,
+        True,
+    )
+
+def _check_select_sticky():
+    """_select_sticky: the generic sticky + deterministic + capped core shared
+    by snippets and repro/fix commands."""
+    key_of = lambda r: r["k"]
+
+    # Deterministic fill (candidates presorted) up to the cap; rest dropped.
+    cands = [{"k": "a"}, {"k": "b"}, {"k": "c"}, {"k": "d"}]
+    sel, shown, dropped = select_sticky(cands, [], 2, key_of)
+    _eq("sticky: fills to cap in candidate order", [r["k"] for r in sel], ["a", "b"])
+    _eq("sticky: shown keys mirror selection", shown, ["a", "b"])
+    _eq("sticky: rest dropped", [r["k"] for r in dropped], ["c", "d"])
+
+    # Stickiness: a prior key that now sorts LAST still shows and isn't evicted.
+    sel2, shown2, dropped2 = select_sticky(cands, ["d"], 2, key_of)
+    _eq("sticky: prior key shows first", [r["k"] for r in sel2], ["d", "a"])
+    _eq("sticky: non-sticky overflow dropped", [r["k"] for r in dropped2], ["b", "c"])
+
+    # A stale prior key (no longer a candidate) is skipped, not counted.
+    sel3, shown3, _ = select_sticky(cands, ["gone", "b"], 2, key_of)
+    _eq("sticky: stale prior key skipped", [r["k"] for r in sel3], ["b", "a"])
+
+def _check_by_task_overflow():
+    """_by_task_overflow: dropped rows attribute per contributing task (shared by
+    snippets and repro/fix commands)."""
+    dropped = [
+        {"command": "x", "task_keys": ["task-a", "task-b"]},
+        {"command": "y", "task_keys": ["task-b"]},
+    ]
+    of = by_task_overflow(dropped)
+    _eq("by_task_overflow: total counts rows", of["total"], 2)
+    # task-b in both dropped rows (2), task-a in one (1) → sorted desc.
+    _eq("by_task_overflow: per-task attribution sorted desc",
+        of["by_task"], [{"task_key": "task-b", "count": 2}, {"task_key": "task-a", "count": 1}])
+    _eq("by_task_overflow: empty → zero", by_task_overflow([]), {"total": 0, "by_task": []})
+
+def _check_format_overflow_note():
+    """_format_overflow_note: singular/plural + per-task suffix, "" when empty."""
+    _eq("overflow note: empty → ''", format_overflow_note({"total": 0, "by_task": []}, "x", "xs"), "")
+    _eq("overflow note: None → ''", format_overflow_note(None, "x", "xs"), "")
+    _eq("overflow note: singular noun",
+        format_overflow_note({"total": 1, "by_task": [{"task_key": "t", "count": 1}]}, "failure", "failures"),
+        "_+ 1 more failure — not shown (1 in `t`)._")
+    _eq("overflow note: plural + multi-task",
+        format_overflow_note({"total": 5, "by_task": [{"task_key": "a", "count": 3}, {"task_key": "b", "count": 2}]}, "failure", "failures"),
+        "_+ 5 more failures — not shown (3 in `a`, 2 in `b`)._")
 
 def _check_parse_state_absent():
     """parse_state returns None when the body has no state block —
@@ -1312,6 +1499,10 @@ def _test_impl(ctx):
     _check_merge_state_entries_sorted()
     _check_render_body_emits_state_block(ctx)
     _check_render_body_no_state_block_when_state_none(ctx)
+    _check_select_snippets(ctx)
+    _check_select_sticky()
+    _check_by_task_overflow()
+    _check_format_overflow_note()
 
     scenarios = [
         (

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -735,8 +735,17 @@ def _check_state_serialize_round_trip():
     _eq("round-trip shown_repros", parsed["shown_repros"], state["shown_repros"])
     _eq("round-trip shown_fixes", parsed["shown_fixes"], state["shown_fixes"])
 
-def _snip(label, bucket = "test", text = "boom", truncated = False, kind = ""):
-    return {"label": label, "bucket": bucket, "snippet": text, "truncated": truncated, "kind": kind}
+def _snip(label, bucket = "test", text = "boom", truncated = False, kind = "", trunc_head = False, trunc_tail = False):
+    # kind defaults to the bucket word ("build"/"test") used in the header line.
+    return {
+        "label": label,
+        "bucket": bucket,
+        "snippet": text,
+        "truncated": truncated,
+        "trunc_head": trunc_head,
+        "trunc_tail": trunc_tail,
+        "kind": kind or ("build" if bucket == "build" else "test"),
+    }
 
 def _entry_with_snippets(key, snippets):
     return {"name": key, "key": key, "failure_snippets": snippets}
@@ -814,25 +823,31 @@ def _check_select_snippets(ctx):
     rows5, _, _ = select_snippets([junk], [])
     _eq("select: malformed/empty snippets skipped", len(rows5), 0)
 
-    # End-to-end: selected rows render a "Failure output" section with a labeled,
-    # task-attributed, OPEN-by-default collapsible block + the truncated hint.
+    # End-to-end: rows render grouped under "Build Failures" / "Test Failures",
+    # no per-row <details>, header matching the Repro/Fix treatment, with the
+    # contributing task(s) and a fenced block.
     failed_entry = _entry("test", "test-task", "test-gha", "bazel_results", "failed", make_test_failed(), 90000)
     prepared = prepare_for_render([failed_entry])
     snip_entry = _entry_with_snippets("test-task", [
-        _snip("//pkg:fail_test", "test", "FAILED: expected 1 got 2", True),
-        _snip("//pkg:slow_test", "timeout", "timed out after 60s", False),
+        _snip("//pkg:broken", "build", "no member named 'foo'"),
+        _snip("//pkg:fail_test", "test", "FAILED: expected 1 got 2"),
+        _snip("//pkg:slow_test", "timeout", "timed out after 60s"),
     ])
     sel_rows, _, _ = select_snippets([snip_entry], [])
     body = render_body(
         ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
         bucket_entries(prepared), snippet_rows = sel_rows,
     )
-    _eq("select: render emits Failure output section", "## 🔎 Failure output" in body, True)
-    _eq("select: render details default to open",
-        "<details open><summary><code>//pkg:fail_test</code> output · test-task</summary>" in body, True)
+    _eq("select: render emits Build Failures group", "## 💥 Build Failures" in body, True)
+    _eq("select: render emits Test Failures group", "## ❌ Test Failures" in body, True)
+    _eq("select: build header matches repro/fix treatment",
+        "❌ build (test-task) · `//pkg:broken` failed to build:" in body, True)
+    _eq("select: test header matches repro/fix treatment",
+        "❌ test (test-task) · `//pkg:fail_test` failed:" in body, True)
+    _eq("select: timeout header uses 'timed out' verb",
+        "❌ test (test-task) · `//pkg:slow_test` timed out:" in body, True)
     _eq("select: render includes snippet text", "FAILED: expected 1 got 2" in body, True)
-    _eq("select: render flags truncation", "_…output truncated_" in body, True)
-    _eq("select: render marks timeout bucket", "(timed out) output · test-task</summary>" in body, True)
+    _eq("select: no per-row <details>", "<details open><summary>" not in body, True)
 
     # Overflow note renders with per-task attribution (1 distinct dropped failure).
     over_snips = [_snip("//pkg:t%d" % i, "test", "boom %d" % i) for i in range(6)]
@@ -861,6 +876,19 @@ def _check_select_snippets(ctx):
         "````text\nbefore\n```\n# fake heading\n```\nafter\n````" in evil_body,
         True,
     )
+
+    # Truncation markers: a head-and-tail-cut snippet renders a `…` line above
+    # and below the body.
+    trunc = _entry_with_snippets("t-task", [
+        _snip("//pkg:t", "test", "middle output", trunc_head = True, trunc_tail = True),
+    ])
+    trunc_rows, _, _ = select_snippets([trunc], [])
+    trunc_body = render_body(
+        ctx, MARKER_FMT % 1, prepared, "", DEFAULT_BODY_TEMPLATE, DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared), snippet_rows = trunc_rows,
+    )
+    _eq("select: head+tail truncation renders … above and below",
+        "```text\n…\nmiddle output\n…\n```" in trunc_body, True)
 
 def _check_select_sticky():
     """_select_sticky: the generic sticky + deterministic + capped core shared

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -2679,13 +2679,13 @@ FIX_COMMANDS_BLOCK = """{%- if fix_commands %}
 # Rendered as a Jinja2 macro so each bucket reuses the same markup.
 SNIPPET_MACRO = """{% macro failure_snippets(rows) %}
 {%- for t in rows %}{% if t.snippet %}
-<details open><summary><code>{{ t.label }}</code> output</summary>
 
+`{{ t.label }}`:
 {{ t.snippet_fence }}text
-{{ t.snippet }}
-{{ t.snippet_fence }}
-{% if t.snippet_truncated %}_…output truncated_{% endif %}
-</details>
+{% if t.snippet_trunc_head %}…
+{% endif %}{{ t.snippet }}
+{% if t.snippet_trunc_tail %}…
+{% endif %}{{ t.snippet_fence }}
 {% endif %}{%- endfor %}
 {%- endmacro %}"""
 
@@ -3587,6 +3587,17 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
     _snippets_enabled = std != None and max_snippets > 0 and snippet_options != None
     _snippet_budget = [max_snippets if _snippets_enabled else 0]
 
+    def _apply_snippet(entry, res):
+        """Set the snippet render fields on a table row from a SnippetResult.
+        `snippet_fence` is sized past any backtick run so log content can't close
+        the code block early; `snippet_trunc_head`/`_tail` drive the `…` markers."""
+        entry["snippet"] = res.text
+        entry["snippet_truncated"] = res.truncated
+        entry["snippet_trunc_head"] = res.trunc_head
+        entry["snippet_trunc_tail"] = res.trunc_tail
+        entry["snippet_fence"] = code_fence_for(res.text)
+        _snippet_budget[0] -= 1
+
     def _attach_test_snippet(entry):
         """Read a failed test's snippet, preferring JUnit test.xml over test.log."""
         if _snippet_budget[0] <= 0:
@@ -3597,13 +3608,7 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
             res = extract_snippet(std, detail.get("log_path", ""), snippet_options)
         if not has_snippet(res):
             return
-        entry["snippet"] = res.text
-        entry["snippet_truncated"] = res.truncated
-
-        # Fence sized past any backtick run in the body so log content can't
-        # close the code block early (CommonMark fence-injection guard).
-        entry["snippet_fence"] = code_fence_for(res.text)
-        _snippet_budget[0] -= 1
+        _apply_snippet(entry, res)
 
     def _attach_action_snippet(action, entry):
         """Read a failed action's stderr snippet (by path) onto the table row."""
@@ -3612,10 +3617,7 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         res = extract_snippet(std, action.get("stderr_path", ""), snippet_options)
         if not has_snippet(res):
             return
-        entry["snippet"] = res.text
-        entry["snippet_truncated"] = res.truncated
-        entry["snippet_fence"] = code_fence_for(res.text)
-        _snippet_budget[0] -= 1
+        _apply_snippet(entry, res)
 
     # Failures table: Label | Target Type | Mnemonic (comma-joined when a target
     # failed multiple actions). Build-failure snippets are attached first so they
@@ -3938,6 +3940,8 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
             "bucket": bucket,
             "snippet": res.text,
             "truncated": res.truncated,
+            "trunc_head": res.trunc_head,
+            "trunc_tail": res.trunc_tail,
         })
 
     # Build-action stderr first (precedence), then failed tests, then timeouts.

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -2677,10 +2677,13 @@ FIX_COMMANDS_BLOCK = """{%- if fix_commands %}
 # Per-row inline failure snippets: a collapsed code block under a failure table,
 # one per row carrying a `snippet` (attached in build_details_data, budget-gated).
 # Rendered as a Jinja2 macro so each bucket reuses the same markup.
+# Renders a row's failure header (always) + its code block (when `snippet` is
+# still set). The trim ladder can pop `snippet` under the size cap to shed the
+# heavy log while keeping the one-line header visible.
 SNIPPET_MACRO = """{% macro failure_snippets(rows) %}
-{%- for t in rows %}{% if t.snippet %}
-
-`{{ t.label }}`:
+{%- for t in rows %}
+❌ {{ t.kind }} `{{ t.label }}` {{ t.snippet_verb }}:
+{%- if t.snippet %}
 {{ t.snippet_fence }}text
 {% if t.snippet_trunc_head %}…
 {% endif %}{{ t.snippet }}
@@ -2701,10 +2704,10 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 :hourglass_flowing_sand: **Build in progress** — target data will appear here as Bazel reports them.
 {% endif %}
 {%- else %}
-{%- if build_failures or derived_failures %}
+{%- if build_failures or build_failures_snippets or derived_failures %}
 <details open>
 <summary>{{ build_failures_icon }} {{ build_failures_header }}</summary>
-
+{{ failure_snippets(build_failures_snippets) }}
 {% if build_failures %}<pre>
 {{- build_failures_table_head }}
 {{ build_failures_table_sep }}
@@ -2712,7 +2715,6 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 {{ t.aligned_label }} | {{ t.aligned_kind }} | {{ t.aligned_mnemonic }}
 {%- endfor %}
 {% if build_failures_overflow %}_{{ build_failures_overflow }} more root failure(s) not shown._{% endif %}</pre>
-{{ failure_snippets(build_failures) }}
 {% endif %}
 {% if derived_failures %}
 <details><summary>{{ derived_failures_count }} more target{{ derived_failures_plural }} blocked by a failed dependency</summary>
@@ -2729,31 +2731,31 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 </details>
 
 {% endif %}
-{%- if failed_tests %}
+{%- if failed_tests or failed_tests_snippets %}
 <details open>
 <summary>{{ failed_tests_icon }} {{ failed_tests_header }}</summary>
-
-<pre>
+{{ failure_snippets(failed_tests_snippets) }}
+{% if failed_tests %}<pre>
 {{- failed_tests_table_head }}
 {{ failed_tests_table_sep }}
 {%- for t in failed_tests %}
 {{ t.aligned_label }} | {{ t.aligned_kind }} | {{ t.aligned_duration }}{% if failed_tests_has_artifacts %} | {{ t.aligned_artifacts }}{% endif %}
 {%- endfor %}</pre>
-{{ failure_snippets(failed_tests) }}
+{% endif %}
 </details>
 
 {% endif %}
-{%- if timeout_tests %}
+{%- if timeout_tests or timeout_tests_snippets %}
 <details open>
 <summary>{{ timeout_tests_icon }} {{ timeout_tests_header }}</summary>
-
-<pre>
+{{ failure_snippets(timeout_tests_snippets) }}
+{% if timeout_tests %}<pre>
 {{- timeout_tests_table_head }}
 {{ timeout_tests_table_sep }}
 {%- for t in timeout_tests %}
 {{ t.aligned_label }} | {{ t.aligned_kind }} | {{ t.aligned_duration }}{% if timeout_tests_has_artifacts %} | {{ t.aligned_artifacts }}{% endif %}
 {%- endfor %}</pre>
-{{ failure_snippets(timeout_tests) }}
+{% endif %}
 </details>
 
 {% endif %}
@@ -3619,10 +3621,19 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
             return
         _apply_snippet(entry, res)
 
+    def _without_snippet(rows):
+        """Rows that did NOT get an inline snippet — these go in the <pre> table;
+        the rows that DID are rendered as snippet blocks instead (no duplicate)."""
+        return [r for r in rows if not r.get("snippet")]
+
+    def _with_snippet(rows):
+        """Rows that got an inline snippet (rendered by the snippet macro)."""
+        return [r for r in rows if r.get("snippet")]
+
     # Failures table: Label | Target Type | Mnemonic (comma-joined when a target
     # failed multiple actions). Build-failure snippets are attached first so they
     # win the shared budget over test failures.
-    _build_failures_for_table = []
+    _build_failures_rows = []
     for a in data["bazel"].get("failed_actions", []):
         original_label = a.get("label", "")
         mnemonics = a.get("mnemonics", []) or []
@@ -3633,9 +3644,12 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         }
         if _snippets_enabled:
             _attach_action_snippet(a, row)
-        _build_failures_for_table.append(row)
+        _build_failures_rows.append(row)
+
+    # Snippet rows render as blocks; the table lists only the rest.
+    _build_failures_snippets = _with_snippet(_build_failures_rows)
     _build_failures_table = _align_for_pre(
-        _build_failures_for_table,
+        _without_snippet(_build_failures_rows),
         has_duration = False,
         has_mnemonic = True,
     )
@@ -3655,11 +3669,28 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
     _derived_table = _align_for_pre(derived_failures, has_duration = False)
     _skipped_table = _align_for_pre(skipped_for_table, has_duration = False)
 
-    # Failed/timeout/flaky buckets use the same aligned shape as passed/cached.
-    # Failed + timeout get snippets (flaky is transient noise — labels only).
-    _failed_table = _align_for_pre(_failed_with_snippets(failed_by_status["failed"]), has_duration = True)
-    _timeout_table = _align_for_pre(_failed_with_snippets(failed_by_status["timeout"]), has_duration = True)
+    # Failed/timeout buckets: rows with a snippet render as blocks, the rest fill
+    # the aligned <pre> table (no duplication). Flaky is transient noise — table
+    # only, no snippets.
+    _failed_rows = _failed_with_snippets(failed_by_status["failed"])
+    _timeout_rows = _failed_with_snippets(failed_by_status["timeout"])
+    _failed_snippets = _with_snippet(_failed_rows)
+    _timeout_snippets = _with_snippet(_timeout_rows)
+    _failed_table = _align_for_pre(_without_snippet(_failed_rows), has_duration = True)
+    _timeout_table = _align_for_pre(_without_snippet(_timeout_rows), has_duration = True)
     _flaky_table = _align_for_pre(_with_duration(data["bazel"].get("flaky_tests", [])), has_duration = True)
+
+    # Header verb for inline snippet blocks (consistent with the PR comment):
+    # "failed to build" / "failed [in <dur>]" / "timed out [after <dur>]". `dur`
+    # is the pre-formatted duration string ("" when unknown, e.g. build actions).
+    def _decorate_snippet_verb(rows, base, dur_word):
+        for r in rows:
+            dur = r.get("duration", "")
+            r["snippet_verb"] = (base + " " + dur_word + " " + dur) if (dur_word and dur) else base
+
+    _decorate_snippet_verb(_build_failures_snippets, "failed to build", "")
+    _decorate_snippet_verb(_failed_snippets, "failed", "in")
+    _decorate_snippet_verb(_timeout_snippets, "timed out", "after")
 
     # One global "more output not shown" note across the snippet-eligible buckets.
     # Only meaningful once at least one snippet rendered AND more failures remain.
@@ -3726,6 +3757,8 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         "build_failures": _build_failures_table["rows"],
         "build_failures_table_head": _build_failures_table["header"],
         "build_failures_table_sep": _build_failures_table["separator"],
+        # Rows that got an inline snippet — rendered as blocks, NOT in the table.
+        "build_failures_snippets": _build_failures_snippets,
         "build_failures_count": build_failure_count,
         "build_failures_header": _bucket_header(_BUCKET_FAILED_TO_BUILD, build_failure_count),
         "build_failures_overflow": str(failed_actions_overflow) if failed_actions_overflow > 0 else "",
@@ -3750,12 +3783,14 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         "failed_tests_table_head": _failed_table["header"],
         "failed_tests_table_sep": _failed_table["separator"],
         "failed_tests_has_artifacts": _failed_table.get("has_artifacts", False),
+        "failed_tests_snippets": _failed_snippets,
         "failed_tests_header": _bucket_header(_BUCKET_TEST_FAILED, failed_test_count),
         "failed_tests_icon": _BUCKET_ICONS[_BUCKET_TEST_FAILED],
         "timeout_tests": _timeout_table["rows"],
         "timeout_tests_table_head": _timeout_table["header"],
         "timeout_tests_table_sep": _timeout_table["separator"],
         "timeout_tests_has_artifacts": _timeout_table.get("has_artifacts", False),
+        "timeout_tests_snippets": _timeout_snippets,
         "timeout_tests_header": _bucket_header(_BUCKET_TEST_TIMEOUT, timeout_test_count),
         "timeout_tests_icon": _BUCKET_ICONS[_BUCKET_TEST_TIMEOUT],
         "flaky_tests": _flaky_table["rows"],
@@ -4088,6 +4123,9 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     #   1. Build Metadata  2. Workspace Status  3. Invocation  4. Performance
     #   5. parsed-options lists  6. halve built_targets  7. halve passed_tests
     #   8. drop cached_tests (last resort)
+    # Shed the heavy log body but keep each failure's one-line header (the macro
+    # renders the header whenever the row is present; the code block only when
+    # `snippet` is still set).
     def _drop_snippets(rows):
         for r in rows:
             if "snippet" in r:
@@ -4096,17 +4134,17 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     if len(details_text) > _DETAILS_LIMIT and max_snippets > 0:
         if debug_render:
             trace.log("debug [render_check_output]   OVER LIMIT (" + str(len(details_text)) +
-                      "), dropping inline snippets from secondary failure buckets")
-        _drop_snippets(details_data.get("failed_tests", []))
-        _drop_snippets(details_data.get("timeout_tests", []))
+                      "), dropping inline snippet bodies from secondary failure buckets")
+        _drop_snippets(details_data.get("failed_tests_snippets", []))
+        _drop_snippets(details_data.get("timeout_tests_snippets", []))
         details_data["snippets_overflow"] = ""
         details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
     if len(details_text) > _DETAILS_LIMIT and max_snippets > 0:
         if debug_render:
             trace.log("debug [render_check_output]   still OVER (" + str(len(details_text)) +
-                      "), dropping all inline snippets")
-        _drop_snippets(details_data.get("build_failures", []))
+                      "), dropping all inline snippet bodies")
+        _drop_snippets(details_data.get("build_failures_snippets", []))
         details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
     if len(details_text) > _DETAILS_LIMIT:

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -3918,8 +3918,9 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
     matching the check-surface order.
 
     Returns a list of plain dicts (JSON-round-trippable through the artifact):
-    `[{label, kind, bucket, snippet, truncated}]` (bucket is
-    "build" | "test" | "timeout"), capped at `max_per_task`. Empty when off
+    `[{label, kind, bucket, snippet, truncated, trunc_head, trunc_tail,
+    duration_ms}]` (bucket is "build" | "test" | "timeout"; duration_ms is the
+    test wall time, 0 for build actions), capped at `max_per_task`. Empty when off
     (max_per_task <= 0 / no options). The writer dedupes identical failures
     across tasks and computes overflow from what it drops at render.
     """
@@ -3931,7 +3932,7 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
     test_details = bz.get("test_details", {}) or {}
     out = []
 
-    def _take(label, kind, bucket, res):
+    def _take(label, kind, bucket, res, duration_ms = 0):
         if not has_snippet(res):
             return
         out.append({
@@ -3942,6 +3943,9 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
             "truncated": res.truncated,
             "trunc_head": res.trunc_head,
             "trunc_tail": res.trunc_tail,
+            # Test wall time (ms); 0 for build actions (BES action timing is
+            # unreliable and not captured). Rendered as "failed in <dur>".
+            "duration_ms": duration_ms or 0,
         })
 
     # Build-action stderr first (precedence), then failed tests, then timeouts.
@@ -3966,7 +3970,13 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
         res = extract_junit_failure(std, detail.get("xml_path", ""), snippet_options)
         if not has_snippet(res):
             res = extract_snippet(std, detail.get("log_path", ""), snippet_options)
-        _take(label, t.get("kind", "") or target_kinds.get(label, ""), bucket, res)
+        _take(
+            label,
+            t.get("kind", "") or target_kinds.get(label, ""),
+            bucket,
+            res,
+            duration_ms = t.get("duration_ms", 0) or detail.get("duration_ms", 0),
+        )
 
     return out
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -12,7 +12,7 @@ Event kinds consumed:
   "configuration"            — captures cpu arch and compilation_mode (target config only)
   "action_completed"         — accumulates failed build actions (up to MAX_FAILED_ACTIONS)
   "target_completed"         — accumulates failed build targets
-  "test_result"              — captures per-attempt log URI and duration (keyed by label)
+  "test_result"              — captures per-attempt test.log + test.xml paths and duration (keyed by label)
   "test_summary"             — buckets tests into failed / flaky / passed; tracks duration
   "build_metrics"            — captures action/target/package counts and timing
   "aborted"                  — captures build abort reason and description
@@ -23,7 +23,7 @@ Payload fields used:
   BuildMetadata.metadata             — dict[str,str] of --build_metadata/--bes_metadata pairs
   WorkspaceStatus.item               — repeated list of {key, value} structs (proto field is "item")
   Configuration.cpu, .compilation_mode, .is_tool_configuration
-  ActionExecuted.success, .type, .stderr (File)
+  ActionExecuted.success, .type, .stderr (File — uri only, never .contents)
   TargetComplete.success
   TestResult.test_action_output (File list), .test_attempt_duration_millis
   TestSummary.overall_status, .total_num_cached, .total_run_duration_millis (split by cached/executed)
@@ -35,9 +35,13 @@ Payload fields used:
   Aborted.abort_reason, .description
   event.id.label       — target label for all event types
 
-stderr is deliberately NOT captured: BES can inline action stderr (observed
-40+ MB in the wild), too costly on the Starlark heap. We show the failing
-label + action mnemonics; users follow the CI link for the raw log.
+stderr CONTENTS are deliberately not held on the Starlark heap: BES can inline
+action stderr via the File.contents oneof (observed 40+ MB in the wild). We read
+only the File.uri and resolve it to a local path (failed_actions[].stderr_path),
+exactly as test.log is. The path is materialized on demand by lib/log_snippet
+(bounded read) at render time for the inline failure snippet; the raw bytes are
+never copied into a Starlark value here. When no snippet is rendered, the
+surface still shows the failing label + action mnemonics + the CI link.
 """
 
 load("./ci.axl", "detect_ci_host", "resolve_build_url")
@@ -47,6 +51,7 @@ load(
     "display_cloud_provider",
     "is_aspect_workflows_runner",
 )
+load("./log_snippet.axl", "SnippetOptions", "code_fence_for", "extract_junit_failure", "extract_snippet", "has_snippet")
 load("./path_glob.axl", "match_path")
 load("./repro_commands.axl", "ASPECT_CLI_INSTALL_HINT_MARKDOWN")
 load("./result_text.axl", "emoji_for_status")
@@ -75,9 +80,12 @@ MIN_HEARTBEAT_INTERVAL_MS = 5000
 # don't stall the loop.
 BES_DRAIN_TICK_MS = 250
 
-# bb_clientd FUSE mount root for resolving bytestream:// URIs. Must match the
-# Aspect Workflows runner environment.
-_BB_CLIENTD_ROOT = "/var/cache/bb_clientd"
+# bb_clientd FUSE mount root for resolving bytestream:// URIs on Aspect
+# Workflows runners. MUST match lib/artifacts.axl's `_BB_CLIENTD_ROOT` — they
+# resolve the same CAS blobs (artifacts uploads test.log; we read it for
+# snippets), and a mismatch silently breaks reads (path doesn't exist → empty
+# snippet). Can't share via load(): artifacts.axl already loads bazel_results.
+_BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
 
 # TestSummary overall_status values from BlazeTestStatus proto enum. starbuf_derive
 # lowercases CamelCase to snake_case: Failed → "failed", FailedToBuild → "failed_to_build".
@@ -194,12 +202,16 @@ def bes_get(obj, field, default = None):
 def _file_uri_to_path(uri):
     """Convert a file:// or bytestream:// URI to a local filesystem path.
 
-    bytestream:// URIs are resolved via the bb_clientd FUSE mount:
+    `file://` (disk-cache / local outputs) is returned verbatim; `bytestream://`
+    (remote cache) is resolved via the bb_clientd FUSE mount:
       bytestream://host:port/blobs/<hash>/<size>
       -> {_BB_CLIENTD_ROOT}/cas/{host}/blobs/sha256/file/{hash}-{size}
+
+    Returns "" for a non-string `uri` — the BES `File.file` oneof yields bytes
+    when contents are inlined (not a URI), which we can't turn into a path.
     """
-    if not uri:
-        return uri
+    if type(uri) != "string" or not uri:
+        return ""
     if uri.startswith("file://"):
         return uri[len("file://"):]
     if uri.startswith("bytestream://"):
@@ -269,8 +281,10 @@ def init_data():
             # in skipped_targets_total.
             "skipped_targets": [],
             "skipped_targets_total": 0,
-            # Failed actions grouped by label: [{label, mnemonics}] (deduped).
-            # Capped at MAX_FAILED_ACTIONS labels. stderr deliberately not captured.
+            # Failed actions grouped by label: [{label, mnemonics, stderr_path}]
+            # (deduped). Capped at MAX_FAILED_ACTIONS labels. stderr_path is the
+            # local path resolved from the BES stderr File.uri ("" when absent),
+            # read on demand for the inline snippet — never the raw bytes.
             "failed_actions": [],
             # May exceed len(failed_actions) due to cap.
             "failed_actions_total": 0,
@@ -293,8 +307,9 @@ def init_data():
             # Cached-test wall time (ms) — time saved by the cache.
             "cached_duration_ms": 0,
             # Per-test detail from test_result (keyed by label, last attempt wins):
-            # {label -> {log_path: str, duration_ms: int}}. log_path is local
-            # (resolved from the BES URI), or "" if remote / unavailable.
+            # {label -> {log_path, xml_path, duration_ms}}. log_path/xml_path are
+            # local (resolved from the BES URI), or "" if remote / unavailable.
+            # Read on demand at render time for the inline failure snippet.
             "test_details": {},
 
             # label -> rule kind (e.g. "cc_library", "py_test") from
@@ -503,9 +518,9 @@ def process_event(data, event):
         success = bes_get(payload, "success", None)
         label = bes_get(event.id, "label", "") or ""
 
-        # Mnemonic is small (unlike payload.stderr, never touched). Build-wide
-        # per-mnemonic totals come authoritatively from build_metrics — counting
-        # here would under-report cached actions on incrementals.
+        # Mnemonic is small. Build-wide per-mnemonic totals come authoritatively
+        # from build_metrics — counting here would under-report cached actions on
+        # incrementals.
         mnemonic = bes_get(payload, "type", "") or ""
         if success == None:
             trace.log("warning: BES action_completed event missing expected field 'success' (label=" + label + ")")
@@ -517,8 +532,14 @@ def process_event(data, event):
             if label and label not in data["bazel"]["failed_action_labels"]:
                 data["bazel"]["failed_action_labels"].append(label)
 
+            # Resolve the stderr File.uri to a local path only (never .contents):
+            # read on demand for the inline snippet, kept off the Starlark heap.
+            stderr_uri = bes_get(bes_get(payload, "stderr", None), "file", "") or ""
+            stderr_path = _file_uri_to_path(stderr_uri)
+
             # One entry per label, deduped mnemonics (a target can fail multiple
-            # actions, e.g. CppCompile + CppLink).
+            # actions, e.g. CppCompile + CppLink). First action's stderr_path
+            # wins (typically the primary failure, e.g. CppCompile before Link).
             entry = None
             for a in data["bazel"]["failed_actions"]:
                 if a.get("label", "") == label:
@@ -527,10 +548,13 @@ def process_event(data, event):
             if entry:
                 if mnemonic and mnemonic not in entry["mnemonics"]:
                     entry["mnemonics"].append(mnemonic)
+                if not entry.get("stderr_path") and stderr_path:
+                    entry["stderr_path"] = stderr_path
             elif len(data["bazel"]["failed_actions"]) < MAX_FAILED_ACTIONS:
                 data["bazel"]["failed_actions"].append({
                     "label": label,
                     "mnemonics": [mnemonic] if mnemonic else [],
+                    "stderr_path": stderr_path,
                 })
                 return True
         return False
@@ -590,14 +614,22 @@ def process_event(data, event):
         label = bes_get(event.id, "label", "") or ""
         payload = event.payload
         log_uri = ""
+        xml_uri = ""
         if payload:
             for output in (bes_get(payload, "test_action_output", None) or []):
-                if output and bes_get(output, "name", "") == "test.log":
+                if not output:
+                    continue
+                name = bes_get(output, "name", "")
+                if name == "test.log":
                     log_uri = bes_get(output, "file", "") or ""
-                    break
+                elif name == "test.xml":
+                    xml_uri = bes_get(output, "file", "") or ""
         duration_ms = (bes_get(payload, "test_attempt_duration_millis", 0) or 0) if payload else 0
         data["bazel"]["test_details"][label] = {
             "log_path": _file_uri_to_path(log_uri),
+            # JUnit XML, when present: lets the snippet prefer structured
+            # <failure>/<error> output over scraping the raw test.log.
+            "xml_path": _file_uri_to_path(xml_uri),
             "duration_ms": duration_ms,
         }
 
@@ -2642,6 +2674,21 @@ FIX_COMMANDS_BLOCK = """{%- if fix_commands %}
 
 {% endif %}"""
 
+# Per-row inline failure snippets: a collapsed code block under a failure table,
+# one per row carrying a `snippet` (attached in build_details_data, budget-gated).
+# Rendered as a Jinja2 macro so each bucket reuses the same markup.
+SNIPPET_MACRO = """{% macro failure_snippets(rows) %}
+{%- for t in rows %}{% if t.snippet %}
+<details open><summary><code>{{ t.label }}</code> output</summary>
+
+{{ t.snippet_fence }}text
+{{ t.snippet }}
+{{ t.snippet_fence }}
+{% if t.snippet_truncated %}_…output truncated_{% endif %}
+</details>
+{% endif %}{%- endfor %}
+{%- endmacro %}"""
+
 # Bazel-targets detail block: build failures (root + dep-broken),
 # failed/timeout/flaky tests, optional repro/fix (gated by
 # render_repro_in_targets), built-targets / cached-tests tables. Split out of
@@ -2665,6 +2712,7 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 {{ t.aligned_label }} | {{ t.aligned_kind }} | {{ t.aligned_mnemonic }}
 {%- endfor %}
 {% if build_failures_overflow %}_{{ build_failures_overflow }} more root failure(s) not shown._{% endif %}</pre>
+{{ failure_snippets(build_failures) }}
 {% endif %}
 {% if derived_failures %}
 <details><summary>{{ derived_failures_count }} more target{{ derived_failures_plural }} blocked by a failed dependency</summary>
@@ -2691,6 +2739,7 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 {%- for t in failed_tests %}
 {{ t.aligned_label }} | {{ t.aligned_kind }} | {{ t.aligned_duration }}{% if failed_tests_has_artifacts %} | {{ t.aligned_artifacts }}{% endif %}
 {%- endfor %}</pre>
+{{ failure_snippets(failed_tests) }}
 </details>
 
 {% endif %}
@@ -2704,7 +2753,12 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 {%- for t in timeout_tests %}
 {{ t.aligned_label }} | {{ t.aligned_kind }} | {{ t.aligned_duration }}{% if timeout_tests_has_artifacts %} | {{ t.aligned_artifacts }}{% endif %}
 {%- endfor %}</pre>
+{{ failure_snippets(timeout_tests) }}
 </details>
+
+{% endif %}
+{%- if snippets_overflow %}
+_+ {{ snippets_overflow }} more failure{{ snippets_overflow_plural }} — output not shown._
 
 {% endif %}
 {%- if flaky_tests %}
@@ -3000,7 +3054,10 @@ SHARED_DETAILS_BODY_TEMPLATE = """{% if artifacts_browse_url or artifact_links %
 # Build/test detail template: aborted prelude, hoisted Bazel targets as the
 # primary slot, then SHARED (which skips its own Bazel targets via
 # include_bazel_targets=False).
-DETAILS_TEMPLATE = """{% if aborted %}
+# SNIPPET_MACRO is defined once at the top so `failure_snippets(...)` is in scope
+# for every embedded copy of BAZEL_TARGETS_TEMPLATE (hoisted slot + SHARED slot).
+DETAILS_TEMPLATE = SNIPPET_MACRO + """
+{% if aborted %}
 > :warning: **Build aborted**{% if abort_reason %} (`{{ abort_reason }}`){% endif %}{% if abort_description %}: {{ abort_description }}{% endif %}
 
 {% endif %}
@@ -3332,7 +3389,7 @@ def _build_invocation_stats(data):
         "miss_reasons_table": miss_reasons_pre,
     }
 
-def build_details_data(data, links, render_ctx = None, status = "", start_date = "", finish_date = "", std = None, task_phases = None, task_active = None, task_elapsed_ms = 0, include_bazel_targets = True, render_repro_in_targets = False):
+def build_details_data(data, links, render_ctx = None, status = "", start_date = "", finish_date = "", std = None, task_phases = None, task_active = None, task_elapsed_ms = 0, include_bazel_targets = True, render_repro_in_targets = False, snippet_options = None, max_snippets = 0):
     """Build Jinja2 template data for DETAILS_TEMPLATE.
 
     start_date / finish_date are pre-formatted by the caller (format_run_date
@@ -3348,6 +3405,11 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
       render_repro_in_targets: True for build/test (Reproduce/Fix render atop
                                the primary Bazel targets slot); False otherwise
                                (per-task templates render their own).
+      snippet_options:         `SnippetOptions` (per-surface line/byte budget) for
+                               inline failure snippets, or None to disable.
+      max_snippets:            Max failure rows (shared across build-failure and
+                               test-failure buckets, in render order) that get an
+                               inline snippet. 0 disables. Requires `std`.
     """
 
     # Command-line views from options_parsed (not structured_command_line).
@@ -3517,6 +3579,73 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
     derived_failures_overflow = derived_failures_count - len(derived_failures)
     skipped_overflow = skipped_count - len(skipped_for_table)
 
+    # Inline failure snippets. One shared budget (`_snippet_budget[0]`) across all
+    # failure buckets, consumed in render order (build failures → failed tests →
+    # timeouts) so the most-relevant failures get output first. Each attach
+    # mutates `entry["snippet"]`/`["snippet_truncated"]` in place; rows beyond the
+    # budget render plain (the template emits a "more — output not shown" line).
+    _snippets_enabled = std != None and max_snippets > 0 and snippet_options != None
+    _snippet_budget = [max_snippets if _snippets_enabled else 0]
+
+    def _attach_test_snippet(entry):
+        """Read a failed test's snippet, preferring JUnit test.xml over test.log."""
+        if _snippet_budget[0] <= 0:
+            return
+        detail = data["bazel"].get("test_details", {}).get(entry.get("label", ""), {}) or {}
+        res = extract_junit_failure(std, detail.get("xml_path", ""), snippet_options)
+        if not has_snippet(res):
+            res = extract_snippet(std, detail.get("log_path", ""), snippet_options)
+        if not has_snippet(res):
+            return
+        entry["snippet"] = res.text
+        entry["snippet_truncated"] = res.truncated
+
+        # Fence sized past any backtick run in the body so log content can't
+        # close the code block early (CommonMark fence-injection guard).
+        entry["snippet_fence"] = code_fence_for(res.text)
+        _snippet_budget[0] -= 1
+
+    def _attach_action_snippet(action, entry):
+        """Read a failed action's stderr snippet (by path) onto the table row."""
+        if _snippet_budget[0] <= 0:
+            return
+        res = extract_snippet(std, action.get("stderr_path", ""), snippet_options)
+        if not has_snippet(res):
+            return
+        entry["snippet"] = res.text
+        entry["snippet_truncated"] = res.truncated
+        entry["snippet_fence"] = code_fence_for(res.text)
+        _snippet_budget[0] -= 1
+
+    # Failures table: Label | Target Type | Mnemonic (comma-joined when a target
+    # failed multiple actions). Build-failure snippets are attached first so they
+    # win the shared budget over test failures.
+    _build_failures_for_table = []
+    for a in data["bazel"].get("failed_actions", []):
+        original_label = a.get("label", "")
+        mnemonics = a.get("mnemonics", []) or []
+        row = {
+            "label": _truncate_label(original_label),
+            "kind": target_kinds_map.get(original_label, ""),
+            "mnemonic": ", ".join(mnemonics),
+        }
+        if _snippets_enabled:
+            _attach_action_snippet(a, row)
+        _build_failures_for_table.append(row)
+    _build_failures_table = _align_for_pre(
+        _build_failures_for_table,
+        has_duration = False,
+        has_mnemonic = True,
+    )
+
+    def _failed_with_snippets(tests):
+        """`_with_duration` + a snippet on each row (budget permitting)."""
+        rows = _with_duration(tests)
+        if _snippets_enabled:
+            for row in rows:
+                _attach_test_snippet(row)
+        return rows
+
     # Column-aligned <pre> tables.
     _passed_table = _align_for_pre(_with_duration(passed_executed), has_duration = True)
     _cached_table = _align_for_pre(_with_duration(passed_cached), has_duration = True)
@@ -3525,26 +3654,16 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
     _skipped_table = _align_for_pre(skipped_for_table, has_duration = False)
 
     # Failed/timeout/flaky buckets use the same aligned shape as passed/cached.
-    _failed_table = _align_for_pre(_with_duration(failed_by_status["failed"]), has_duration = True)
-    _timeout_table = _align_for_pre(_with_duration(failed_by_status["timeout"]), has_duration = True)
+    # Failed + timeout get snippets (flaky is transient noise — labels only).
+    _failed_table = _align_for_pre(_failed_with_snippets(failed_by_status["failed"]), has_duration = True)
+    _timeout_table = _align_for_pre(_failed_with_snippets(failed_by_status["timeout"]), has_duration = True)
     _flaky_table = _align_for_pre(_with_duration(data["bazel"].get("flaky_tests", [])), has_duration = True)
 
-    # Failures table: Label | Target Type | Mnemonic (comma-joined when a target
-    # failed multiple actions).
-    _build_failures_for_table = []
-    for a in data["bazel"].get("failed_actions", []):
-        original_label = a.get("label", "")
-        mnemonics = a.get("mnemonics", []) or []
-        _build_failures_for_table.append({
-            "label": _truncate_label(original_label),
-            "kind": target_kinds_map.get(original_label, ""),
-            "mnemonic": ", ".join(mnemonics),
-        })
-    _build_failures_table = _align_for_pre(
-        _build_failures_for_table,
-        has_duration = False,
-        has_mnemonic = True,
-    )
+    # One global "more output not shown" note across the snippet-eligible buckets.
+    # Only meaningful once at least one snippet rendered AND more failures remain.
+    _snippets_shown = (max_snippets - _snippet_budget[0]) if _snippets_enabled else 0
+    _snippet_eligible_total = build_failure_count + failed_test_count + timeout_test_count
+    _snippets_overflow = (_snippet_eligible_total - _snippets_shown) if _snippets_shown > 0 else 0
 
     # Task timing: aligned <pre> (Phase | Description | Duration).
     _task_timing_rows_data = _build_task_timing_rows(task_phases, task_active, status)
@@ -3609,6 +3728,10 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         "build_failures_header": _bucket_header(_BUCKET_FAILED_TO_BUILD, build_failure_count),
         "build_failures_overflow": str(failed_actions_overflow) if failed_actions_overflow > 0 else "",
         "build_failures_icon": _BUCKET_ICONS[_BUCKET_FAILED_TO_BUILD],
+        # Inline-snippet overflow: failures past the shared snippet budget whose
+        # output isn't shown. "" when snippets are off or all fit.
+        "snippets_overflow": str(_snippets_overflow) if _snippets_overflow > 0 else "",
+        "snippets_overflow_plural": "s" if _snippets_overflow != 1 else "",
         # Producer-authored repro/fix lists (lib/repro_commands.axl); template
         # emits the "🔁 Reproduce" / "🛠️ Fix" sections.
         "repro_commands": list(data.get("repro_commands", []) or []),
@@ -3782,20 +3905,85 @@ def _build_task_timing_rows(phases, active, status):
         })
     return rows
 
-def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None):
+def extract_failure_snippets(std, data, snippet_options, max_per_task):
+    """Extract up to `max_per_task` inline failure snippets from a frozen
+    bazel_results `data`, for the PR-summary-comment producer.
+
+    A snippet can only be read by the job that ran the failure (it owns the
+    local test.log / action-stderr paths); sibling jobs can't. So each job
+    extracts its own here on its terminal update and ships the result in its
+    status artifact. Build-action failures take precedence over test failures,
+    matching the check-surface order.
+
+    Returns a list of plain dicts (JSON-round-trippable through the artifact):
+    `[{label, kind, bucket, snippet, truncated}]` (bucket is
+    "build" | "test" | "timeout"), capped at `max_per_task`. Empty when off
+    (max_per_task <= 0 / no options). The writer dedupes identical failures
+    across tasks and computes overflow from what it drops at render.
+    """
+    bz = data.get("bazel", {})
+    if max_per_task <= 0 or snippet_options == None or std == None:
+        return []
+
+    target_kinds = bz.get("target_kinds", {}) or {}
+    test_details = bz.get("test_details", {}) or {}
+    out = []
+
+    def _take(label, kind, bucket, res):
+        if not has_snippet(res):
+            return
+        out.append({
+            "label": label,
+            "kind": kind,
+            "bucket": bucket,
+            "snippet": res.text,
+            "truncated": res.truncated,
+        })
+
+    # Build-action stderr first (precedence), then failed tests, then timeouts.
+    for a in bz.get("failed_actions", []):
+        if len(out) >= max_per_task:
+            break
+        label = a.get("label", "")
+        _take(
+            label,
+            target_kinds.get(label, ""),
+            "build",
+            extract_snippet(std, a.get("stderr_path", ""), snippet_options),
+        )
+
+    for t in bz.get("failed_tests", []):
+        if len(out) >= max_per_task:
+            break
+        s = t.get("status", "failed")
+        bucket = "timeout" if s == "timeout" else "test"
+        label = t.get("label", "")
+        detail = test_details.get(label, {}) or {}
+        res = extract_junit_failure(std, detail.get("xml_path", ""), snippet_options)
+        if not has_snippet(res):
+            res = extract_snippet(std, detail.get("log_path", ""), snippet_options)
+        _take(label, t.get("kind", "") or target_kinds.get(label, ""), bucket, res)
+
+    return out
+
+def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None, snippet_options = None, max_snippets = 0):
     """Render {title, summary, text} for a GitHub check run output field.
 
     Public entry point for the "bazel_results" task_update kind; features call it
     from their task_update handler.
 
     Args:
-        ctx:           TaskContext
-        data:          dict from init_data(), updated by process_event
-        status:        "running" | "failing" | "passed" | "failed"
-        render_ctx:    feature display context — see build_summary_data
-        links:         dict with ci_label, ci_url, aspect_url
-        templates:     optional "summary"/"details" Jinja2 overrides
-        metadata_keys: extra BES metadata keys to surface; ["*"] = all
+        ctx:             TaskContext
+        data:            dict from init_data(), updated by process_event
+        status:          "running" | "failing" | "passed" | "failed"
+        render_ctx:      feature display context — see build_summary_data
+        links:           dict with ci_label, ci_url, aspect_url
+        templates:       optional "summary"/"details" Jinja2 overrides
+        metadata_keys:   extra BES metadata keys to surface; ["*"] = all
+        snippet_options: `SnippetOptions` line/byte budget for inline failure
+                         snippets, or None to disable (per-surface, see callers).
+        max_snippets:    max failure rows (shared across build/test buckets) to
+                         show inline output for; 0 disables.
     """
 
     # Render-debug gated on `_ASPECT_DEBUG_STATUS_RENDER_CHECK` (surfaces
@@ -3854,6 +4042,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         include_bazel_targets = False,
         # Bazel targets is the primary slot, so Reproduce/Fix render at its top.
         render_repro_in_targets = True,
+        snippet_options = snippet_options,
+        max_snippets = max_snippets,
     )
 
     if debug_render:
@@ -3876,11 +4066,35 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
     # Fit details within the GitHub limit; each step re-renders only if still
-    # over. Drop reference sections (redundant with Aspect Web UI) before the
-    # bucket lists users actually came for:
+    # over. Inline snippets are extra (not the data users primarily came for), so
+    # they shed FIRST — secondary buckets, then all of them — before any of the
+    # established trims below. Reference sections (redundant with Aspect Web UI)
+    # go next, before the failure/target lists themselves:
+    #   0a. snippets in secondary buckets  0b. all snippets
     #   1. Build Metadata  2. Workspace Status  3. Invocation  4. Performance
     #   5. parsed-options lists  6. halve built_targets  7. halve passed_tests
     #   8. drop cached_tests (last resort)
+    def _drop_snippets(rows):
+        for r in rows:
+            if "snippet" in r:
+                r.pop("snippet")
+
+    if len(details_text) > _DETAILS_LIMIT and max_snippets > 0:
+        if debug_render:
+            trace.log("debug [render_check_output]   OVER LIMIT (" + str(len(details_text)) +
+                      "), dropping inline snippets from secondary failure buckets")
+        _drop_snippets(details_data.get("failed_tests", []))
+        _drop_snippets(details_data.get("timeout_tests", []))
+        details_data["snippets_overflow"] = ""
+        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+
+    if len(details_text) > _DETAILS_LIMIT and max_snippets > 0:
+        if debug_render:
+            trace.log("debug [render_check_output]   still OVER (" + str(len(details_text)) +
+                      "), dropping all inline snippets")
+        _drop_snippets(details_data.get("build_failures", []))
+        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+
     if len(details_text) > _DETAILS_LIMIT:
         if debug_render:
             trace.log("debug [render_check_output]   OVER LIMIT (" + str(len(details_text)) +

--- a/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
@@ -55,6 +55,7 @@ load(
     lint_init_data = "init_data",
     lint_render_check_output = "render_check_output",
 )
+load("./log_snippet.axl", "SnippetOptions")
 
 # Dispatch table: `task_update.kind` → struct(init, render). Adding a
 # new kind: implement `init_data()` + `render_check_output()` in a
@@ -108,6 +109,26 @@ def kind_for_task(task_name):
     Falls back to "bazel_results" for unknown task names.
     """
     return _TASK_KIND_DEFAULTS.get(task_name, "bazel_results")
+
+# Per-surface inline-snippet budgets (max snippets shown + per-snippet line cap).
+# Status checks / BK annotations are glanceable and bump the surface size caps
+# (GitHub 65 KB, BK 1 MiB), so they stay tight; the PR summary comment is the
+# detailed surface and matches Marvin v1's role with a larger budget. Returned as
+# `(SnippetOptions, max_snippets)`; max_snippets == 0 disables snippets.
+SURFACE_STATUS_CHECK = "status_check"
+SURFACE_BUILDKITE = "buildkite"
+SURFACE_PR_COMMENT = "pr_comment"
+
+_SNIPPET_BUDGETS = {
+    SURFACE_STATUS_CHECK: (SnippetOptions(max_lines = 15), 3),
+    SURFACE_BUILDKITE: (SnippetOptions(max_lines = 15), 3),
+    SURFACE_PR_COMMENT: (SnippetOptions(max_lines = 30), 5),
+}
+
+def snippet_budget_for(surface):
+    """Return `(SnippetOptions, max_snippets)` for a surface; `(None, 0)` (snippets
+    off) for an unknown surface."""
+    return _SNIPPET_BUDGETS.get(surface, (None, 0))
 
 def to_display_name(name):
     """Convert a snake_case task name to a CamelCase display name.

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
@@ -474,11 +474,12 @@ def _config_items(data):
 
 # ─── Entry point ──────────────────────────────────────────────────────────────
 
-def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None):
+def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None, snippet_options = None, max_snippets = 0):
     """Render title, summary, and text for a delivery check run.
 
     Matches the bazel_results / lint_results interface so GithubStatusChecks
-    can dispatch by task_update.kind interchangeably.
+    can dispatch by task_update.kind interchangeably. snippet_options/max_snippets
+    are accepted for parity and ignored (delivery has no log snippets).
     """
     t = templates or {}
     run_date = format_run_date(ctx, data.get("start_time_ms", 0))

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
@@ -320,11 +320,12 @@ def _build_details_data(data, status):
 
 # ─── Entry point ──────────────────────────────────────────────────────────────
 
-def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None):
+def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None, snippet_options = None, max_snippets = 0):
     """Render title, summary, and text for a format check run.
 
     Matches the bazel_results / lint_results interface so GithubStatusChecks
     and BuildkiteAnnotations can dispatch by task_update.kind interchangeably.
+    snippet_options/max_snippets are accepted for parity and ignored.
     """
     t = templates or {}
     run_date = format_run_date(ctx, data.get("start_time_ms", 0))

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
@@ -375,11 +375,12 @@ def _build_details_data(data, status):
 
 # ─── Entry point ──────────────────────────────────────────────────────────────
 
-def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None):
+def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None, snippet_options = None, max_snippets = 0):
     """Render title, summary, and text for a gazelle check run.
 
     Matches the bazel_results / lint_results interface so GithubStatusChecks
     and BuildkiteAnnotations can dispatch by task_update.kind interchangeably.
+    snippet_options/max_snippets are accepted for parity and ignored.
     """
     t = templates or {}
     run_date = format_run_date(ctx, data.get("start_time_ms", 0))

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
@@ -788,9 +788,12 @@ def chunk_annotations(annotations, batch_size = ANNOTATIONS_PER_BATCH):
         i += batch_size
     return out
 
-def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None):
+def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None, snippet_options = None, max_snippets = 0):
     """Render title, summary, and text for a lint check run. Shape matches
     bazel_results.render_check_output so dispatch can call either by kind.
+
+    snippet_options/max_snippets are accepted for signature parity with the
+    bazel_results renderer and ignored here (lint has no log snippets).
     """
     t = templates or {}
     run_date = format_run_date(ctx, data.get("start_time_ms", 0))

--- a/crates/aspect-cli/src/builtins/aspect/lib/log_snippet.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/log_snippet.axl
@@ -1,0 +1,343 @@
+"""Extract a short, high-signal failure snippet from a test/build log.
+
+On a failure, the status surfaces (GitHub/GitLab status checks, Buildkite
+annotations, PR summary comments) want to show the *output* that explains the
+failure inline — not just the failing label. This module turns a log file on
+disk into a compact, cleaned snippet suitable for a fenced code block.
+
+Strategy, in order of preference:
+  1. Structured first — `extract_junit_failure` scans a JUnit `test.xml` for the
+     first `<failure>`/`<error>` element and emits its message + stack trace.
+     Zero heuristics; the framework already isolated the failure.
+  2. Heuristic fallback — `extract_snippet` reads the raw `test.log` / action
+     stderr and applies "tail-with-error-anchor windowing": strip ANSI/CR noise,
+     locate the last failure-marker line, and emit a window around it (plus a
+     little head context for compile errors), falling back to the tail of the
+     buffer when no marker is found.
+
+Reads are bounded at the byte level. The historical "BES can inline 40+ MB of
+action stderr onto the Starlark heap" concern (see lib/bazel_results.axl) is
+about reading a BES `File.contents` oneof — NOT about reading a file by path.
+Here we read the on-disk file via `try_read_to_string_capped`, which pulls only
+the first `max_read_bytes` (+1, to detect truncation) into memory — never the
+whole file — so even a multi-MB log degrades to a truncated prefix without
+spiking the heap.
+
+The runtime has no regex module (see lib/lifecycle.axl), so cleaning and marker
+detection are plain character/substring walks.
+
+Pure logic (`*_from_text`) is split from the I/O wrappers so it is unit-testable
+without a filesystem; the wrappers take `std` (= `ctx.std`) and degrade to
+`source = "none"` on any missing/unreadable path.
+"""
+
+SnippetOptions = record(
+    # Max lines kept in the emitted snippet body.
+    max_lines = field(int, default = 20),
+    # Hard cap on bytes/chars read from disk; a larger file is sliced to this
+    # prefix and flagged truncated.
+    max_read_bytes = field(int, default = 262144),
+    # Lines of context kept before / after the anchor marker line.
+    context_before = field(int, default = 8),
+    context_after = field(int, default = 6),
+)
+
+# Snippet provenance. "none" means nothing usable was found (missing path,
+# empty/unreadable file, or a JUnit parse miss) — the caller renders no snippet.
+SnippetSource = enum("xml", "log", "none")
+
+SnippetResult = record(
+    # Cleaned snippet body, newline-joined, no code fence. "" when source=none.
+    text = field(str, default = ""),
+    # True when lines were elided (windowed/over max_lines) or the read hit the
+    # byte cap — surfaces a "…truncated" hint on the surface.
+    truncated = field(bool, default = False),
+    source = field(SnippetSource, default = SnippetSource("none")),
+)
+
+_EMPTY = SnippetResult(text = "", truncated = False, source = SnippetSource("none"))
+
+def has_snippet(res):
+    """True when `res` carries usable snippet text (source != none, text != "")."""
+    return res.source.value != "none" and res.text != ""
+
+# Smallest fence we ever emit (a plain ```), widened past any backtick run in
+# the body so log content can't close the fence early and break out into
+# Markdown/HTML (CommonMark closes a fence only with >= the opening run length).
+_MIN_FENCE_LEN = 3
+
+def code_fence_for(text):
+    """Return a backtick fence (>= ```) guaranteed not to be closed by any
+    backtick run inside `text`. The longest run of consecutive backticks in the
+    body + 1, floored at 3. Callers wrap the snippet as `<fence>text\\n<fence>`."""
+    longest = 0
+    run = 0
+    for c in text.elems():
+        if c == "`":
+            run += 1
+            if run > longest:
+                longest = run
+        else:
+            run = 0
+    n = longest + 1
+    if n < _MIN_FENCE_LEN:
+        n = _MIN_FENCE_LEN
+    return "`" * n
+
+# Case-insensitive substrings that anchor the failure region. Converges on the
+# union used by GitHub problem matchers / Jenkins log-parser rule sets across
+# pytest / go test / cargo test / JUnit / compilers. Matched as lowercased
+# substrings (no regex), so they catch "ERROR:", "FAILED", "Traceback", etc.
+_FAILURE_MARKERS = [
+    "error",
+    "fail",
+    "fatal",
+    "panic",
+    "traceback",
+    "exception",
+    "assert",
+    "expected",
+    "segfault",
+    "sigsegv",
+    "core dumped",
+    "undefined reference",
+    "timed out",
+    "timeout",
+]
+
+def _strip_ansi(text):
+    """Remove ANSI CSI/SGR escapes (`\\033[`…final-byte) and OSC sequences
+    (`\\033]`…BEL). Character walk — the runtime has no regex module."""
+    if not text or "\033" not in text:
+        return text
+    out = []
+    i = 0
+    n = len(text)
+    for _ in range(n):
+        if i >= n:
+            break
+        c = text[i]
+        if c == "\033" and i + 1 < n and text[i + 1] == "[":
+            # CSI: parameter/intermediate bytes (digits, ;, :, space-/ ) then a
+            # single final byte terminates. Treat any non-parameter byte as final.
+            j = i + 2
+            for _ in range(n - j):
+                if j >= n:
+                    break
+                cj = text[j]
+                j += 1
+                if cj not in "0123456789;:":
+                    break
+            i = j
+        elif c == "\033" and i + 1 < n and text[i + 1] == "]":
+            # OSC: skip to BEL (0x07) or string terminator ESC\\.
+            j = i + 2
+            for _ in range(n - j):
+                if j >= n:
+                    break
+                if text[j] == "\007":
+                    j += 1
+                    break
+                j += 1
+            i = j
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+def _clean_lines(text):
+    """Split into display lines after ANSI stripping, progress-bar collapse, and
+    de-duplication of consecutive identical lines.
+
+    Carriage returns redraw a terminal line in place, so only the segment after
+    the last `\\r` on a physical line survives (drops progress-bar spam). Runs of
+    identical lines collapse to one. Returns a list of lines (no trailing \\n).
+    """
+    cleaned = _strip_ansi(text)
+    lines = []
+    prev = None
+    for raw in cleaned.split("\n"):
+        line = raw.rstrip("\r")
+        if "\r" in line:
+            line = line.split("\r")[-1]
+        if line == prev:
+            continue
+        prev = line
+        lines.append(line)
+
+    # Drop a trailing empty line from the final newline.
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+def _last_marker_index(lines):
+    """Index of the last line containing a failure marker, or -1 if none."""
+    idx = -1
+    for i in range(len(lines)):
+        low = lines[i].lower()
+        for m in _FAILURE_MARKERS:
+            if m in low:
+                idx = i
+                break
+    return idx
+
+def _window(lines, options):
+    """Pick the most relevant <= max_lines window from cleaned `lines`.
+
+    Anchors on the last failure marker (failures usually report near the end);
+    emits `[anchor - context_before, anchor + context_after]`, then caps to
+    max_lines keeping the marker. With no marker, returns the tail. Returns
+    (window_lines, elided) where `elided` is True if any line was dropped.
+    """
+    total = len(lines)
+    if total <= options.max_lines:
+        return (lines, False)
+
+    anchor = _last_marker_index(lines)
+    if anchor < 0:
+        # No marker — trust the tail.
+        return (lines[total - options.max_lines:], True)
+
+    start = anchor - options.context_before
+    if start < 0:
+        start = 0
+    end = anchor + options.context_after + 1
+    if end > total:
+        end = total
+    window = lines[start:end]
+
+    # Enforce max_lines, biasing toward keeping the marker (drop from the front).
+    if len(window) > options.max_lines:
+        window = window[len(window) - options.max_lines:]
+    return (window, True)
+
+def extract_snippet_from_text(text, hit_cap, options):
+    """Pure: turn raw log `text` into a SnippetResult via tail-with-error-anchor
+    windowing. `hit_cap` is True when `text` was already byte-capped upstream."""
+    if not text:
+        return _EMPTY
+    lines = _clean_lines(text)
+    if not lines:
+        return _EMPTY
+    window, elided = _window(lines, options)
+    if not window:
+        return _EMPTY
+    return SnippetResult(
+        text = "\n".join(window),
+        truncated = elided or hit_cap,
+        source = SnippetSource("log"),
+    )
+
+def _attr_value(tag, name):
+    """Value of `name="..."` within an XML start-tag string, or "". Handles only
+    double-quoted values (the JUnit writers we target always double-quote)."""
+    key = name + "=\""
+    at = tag.find(key)
+    if at < 0:
+        return ""
+    start = at + len(key)
+    end = tag.find("\"", start)
+    if end < 0:
+        return ""
+    return tag[start:end]
+
+def _xml_unescape(s):
+    """Reverse the five predefined XML entities. Sufficient for JUnit text/attrs."""
+    if "&" not in s:
+        return s
+    return (s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&"))
+
+def extract_junit_failure_from_text(xml, options):
+    """Pure: emit the first JUnit `<failure>`/`<error>` message + body as a
+    SnippetResult, or `none` on any parse miss (caller falls back to the log).
+
+    Lightweight scan, not a real parser: find the first `<failure`/`<error`
+    start-tag, read its `message`/`type` attrs, then capture body text up to the
+    matching close tag (or self-closing `/>`). Windowed/capped like a log snippet.
+    """
+    if not xml:
+        return _EMPTY
+
+    best = -1
+    kind = ""
+    for tagname in ["<failure", "<error"]:
+        at = xml.find(tagname)
+        if at >= 0 and (best < 0 or at < best):
+            best = at
+            kind = tagname
+    if best < 0:
+        return _EMPTY
+
+    tag_end = xml.find(">", best)
+    if tag_end < 0:
+        return _EMPTY
+    start_tag = xml[best:tag_end + 1]
+
+    message = _attr_value(start_tag, "message")
+    typ = _attr_value(start_tag, "type")
+
+    body = ""
+    if not start_tag.rstrip().endswith("/>"):
+        close = xml.find("</", tag_end + 1)
+        if close > tag_end:
+            body = xml[tag_end + 1:close]
+
+    header = ""
+    if typ and message:
+        header = typ + ": " + message
+    else:
+        header = message or typ
+
+    parts = []
+    if header:
+        parts.append(_xml_unescape(header.strip()))
+    body = _xml_unescape(body).strip()
+    if body:
+        parts.append(body)
+    if not parts:
+        return _EMPTY
+
+    lines = _clean_lines("\n".join(parts))
+    if not lines:
+        return _EMPTY
+    window, elided = _window(lines, options)
+    return SnippetResult(
+        text = "\n".join(window),
+        truncated = elided,
+        source = SnippetSource("xml"),
+    )
+
+def _read_bounded(std, path, max_read_bytes):
+    """Read up to `max_read_bytes` bytes from `path`. Returns (text, hit_cap).
+
+    Reads only the capped prefix into memory via `try_read_to_string_capped`
+    (never the whole file), so a multi-MB log can't spike the heap — the very
+    case this feature targets. Reads one extra byte to detect truncation: when
+    the result exceeds the cap, it's sliced and `hit_cap` is True. Missing /
+    unreadable paths degrade to `("", False)` rather than failing the task.
+    """
+    if not path:
+        return ("", False)
+    text = std.fs.try_read_to_string_capped(path, max_read_bytes + 1)
+    if not text:
+        return ("", False)
+    if len(text) > max_read_bytes:
+        return (text[:max_read_bytes], True)
+    return (text, False)
+
+def extract_snippet(std, path, options = None):
+    """I/O wrapper: read `path` (bounded) and window it. `none` if unreadable."""
+    opts = options or SnippetOptions()
+    text, hit_cap = _read_bounded(std, path, opts.max_read_bytes)
+    return extract_snippet_from_text(text, hit_cap, opts)
+
+def extract_junit_failure(std, xml_path, options = None):
+    """I/O wrapper: read a JUnit `test.xml` (bounded) and emit its first failure.
+    `none` on missing path or parse miss — caller should then try the raw log."""
+    opts = options or SnippetOptions()
+    text, _hit_cap = _read_bounded(std, xml_path, opts.max_read_bytes)
+    return extract_junit_failure_from_text(text, opts)

--- a/crates/aspect-cli/src/builtins/aspect/lib/log_snippet.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/log_snippet.axl
@@ -50,8 +50,12 @@ SnippetResult = record(
     # Cleaned snippet body, newline-joined, no code fence. "" when source=none.
     text = field(str, default = ""),
     # True when lines were elided (windowed/over max_lines) or the read hit the
-    # byte cap — surfaces a "…truncated" hint on the surface.
+    # byte cap. `truncated` is the OR of the two below (back-compat); `trunc_head`
+    # / `trunc_tail` say which end was cut, so the renderer places a `…` marker
+    # only on the side that lost content.
     truncated = field(bool, default = False),
+    trunc_head = field(bool, default = False),
+    trunc_tail = field(bool, default = False),
     source = field(SnippetSource, default = SnippetSource("none")),
 )
 
@@ -187,16 +191,17 @@ def _window(lines, options):
     Anchors on the last failure marker (failures usually report near the end);
     emits `[anchor - context_before, anchor + context_after]`, then caps to
     max_lines keeping the marker. With no marker, returns the tail. Returns
-    (window_lines, elided) where `elided` is True if any line was dropped.
+    (window_lines, trunc_head, trunc_tail) — whether lines were dropped before /
+    after the window (so the renderer can place a `…` marker on each cut side).
     """
     total = len(lines)
     if total <= options.max_lines:
-        return (lines, False)
+        return (lines, False, False)
 
     anchor = _last_marker_index(lines)
     if anchor < 0:
-        # No marker — trust the tail.
-        return (lines[total - options.max_lines:], True)
+        # No marker — trust the tail (head dropped, nothing after).
+        return (lines[total - options.max_lines:], True, False)
 
     start = anchor - options.context_before
     if start < 0:
@@ -204,12 +209,11 @@ def _window(lines, options):
     end = anchor + options.context_after + 1
     if end > total:
         end = total
-    window = lines[start:end]
 
     # Enforce max_lines, biasing toward keeping the marker (drop from the front).
-    if len(window) > options.max_lines:
-        window = window[len(window) - options.max_lines:]
-    return (window, True)
+    if end - start > options.max_lines:
+        start = end - options.max_lines
+    return (lines[start:end], start > 0, end < total)
 
 def extract_snippet_from_text(text, hit_cap, options):
     """Pure: turn raw log `text` into a SnippetResult via tail-with-error-anchor
@@ -219,12 +223,16 @@ def extract_snippet_from_text(text, hit_cap, options):
     lines = _clean_lines(text)
     if not lines:
         return _EMPTY
-    window, elided = _window(lines, options)
+    window, trunc_head, trunc_tail = _window(lines, options)
     if not window:
         return _EMPTY
+    # A byte-cap read drops the file's tail, so the window's tail is cut too.
+    trunc_tail = trunc_tail or hit_cap
     return SnippetResult(
         text = "\n".join(window),
-        truncated = elided or hit_cap,
+        truncated = trunc_head or trunc_tail,
+        trunc_head = trunc_head,
+        trunc_tail = trunc_tail,
         source = SnippetSource("log"),
     )
 
@@ -335,10 +343,12 @@ def extract_junit_failure_from_text(xml, options):
     lines = _clean_lines("\n".join(parts))
     if not lines:
         return _EMPTY
-    window, elided = _window(lines, options)
+    window, trunc_head, trunc_tail = _window(lines, options)
     return SnippetResult(
         text = "\n".join(window),
-        truncated = elided,
+        truncated = trunc_head or trunc_tail,
+        trunc_head = trunc_head,
+        trunc_tail = trunc_tail,
         source = SnippetSource("xml"),
     )
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/log_snippet.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/log_snippet.axl
@@ -226,6 +226,7 @@ def extract_snippet_from_text(text, hit_cap, options):
     window, trunc_head, trunc_tail = _window(lines, options)
     if not window:
         return _EMPTY
+
     # A byte-cap read drops the file's tail, so the window's tail is cut too.
     trunc_tail = trunc_tail or hit_cap
     return SnippetResult(

--- a/crates/aspect-cli/src/builtins/aspect/lib/log_snippet.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/log_snippet.axl
@@ -251,6 +251,30 @@ def _xml_unescape(s):
         .replace("&apos;", "'")
         .replace("&amp;", "&"))
 
+# Low-signal `<error>`/`<failure>` messages that Bazel SYNTHESIZES for tests
+# without native JUnit output (sh_test, cc_test, …) via tools/test/generate-xml.sh.
+# The real output lives in <system-out>, not the element — so when the JUnit
+# message is one of these AND the element has no body, we treat the XML as a miss
+# and fall back to the raw test.log (matched as a lowercased prefix).
+_SYNTHESIZED_JUNIT_PREFIXES = [
+    "exited with error code",
+    "test exited with",
+    "test did not complete",
+    "test was not completed",
+]
+
+def _is_low_signal_junit(header, body):
+    """True when a JUnit failure/error carries only a generic Bazel-synthesized
+    message and no body — the real diagnostic is in <system-out>, so the caller
+    should fall back to test.log."""
+    if body:
+        return False
+    low = header.lower().strip()
+    for p in _SYNTHESIZED_JUNIT_PREFIXES:
+        if low.startswith(p):
+            return True
+    return False
+
 def extract_junit_failure_from_text(xml, options):
     """Pure: emit the first JUnit `<failure>`/`<error>` message + body as a
     SnippetResult, or `none` on any parse miss (caller falls back to the log).
@@ -258,6 +282,10 @@ def extract_junit_failure_from_text(xml, options):
     Lightweight scan, not a real parser: find the first `<failure`/`<error`
     start-tag, read its `message`/`type` attrs, then capture body text up to the
     matching close tag (or self-closing `/>`). Windowed/capped like a log snippet.
+
+    Returns `none` for Bazel-synthesized low-signal failures (a generic "exited
+    with error code N" and an empty element) so the caller falls back to the raw
+    test.log, where the real output is — see `_is_low_signal_junit`.
     """
     if not xml:
         return _EMPTY
@@ -292,10 +320,13 @@ def extract_junit_failure_from_text(xml, options):
     else:
         header = message or typ
 
+    body = _xml_unescape(body).strip()
+    if _is_low_signal_junit(header, body):
+        return _EMPTY
+
     parts = []
     if header:
         parts.append(_xml_unescape(header.strip()))
-    body = _xml_unescape(body).strip()
     if body:
         parts.append(body)
     if not parts:

--- a/crates/axl-runtime/src/engine/std/fs.rs
+++ b/crates/axl-runtime/src/engine/std/fs.rs
@@ -571,6 +571,49 @@ pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
         Ok(heap.alloc_str(s.as_str()))
     }
 
+    /// Reads at most `max_bytes` bytes from the start of a file into a string,
+    /// or returns `""` on any I/O error (missing file, permission denied,
+    /// transient failure). Like `try_read_to_string`, the silent fall-through
+    /// lets callers degrade rather than fail the task.
+    ///
+    /// Only the capped prefix is read into memory — never the whole file — so a
+    /// multi-MB log can be summarized without spiking the heap. Non-UTF-8 bytes
+    /// are replaced (lossy), and the prefix may split a multi-byte sequence at
+    /// the cap; that final partial char is dropped rather than emitted as `\u{FFFD}`.
+    fn try_read_to_string_capped<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        #[starlark(require = pos)] path: values::StringValue,
+        #[starlark(require = pos)] max_bytes: i32,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<values::StringValue<'v>> {
+        use std::io::Read;
+        if max_bytes <= 0 {
+            return Ok(heap.alloc_str(""));
+        }
+        let cap = max_bytes as u64;
+        let s = match fs::File::open(path.as_str()) {
+            Ok(f) => {
+                let mut buf = Vec::new();
+                if f.take(cap).read_to_end(&mut buf).is_ok() {
+                    match String::from_utf8(buf) {
+                        Ok(valid) => valid,
+                        // Lossy decode, then drop a trailing replacement char that
+                        // a cap-split multi-byte sequence would have produced.
+                        Err(e) => {
+                            let valid_up_to = e.utf8_error().valid_up_to();
+                            let bytes = e.into_bytes();
+                            String::from_utf8_lossy(&bytes[..valid_up_to]).into_owned()
+                        }
+                    }
+                } else {
+                    String::new()
+                }
+            }
+            Err(_) => String::new(),
+        };
+        Ok(heap.alloc_str(s.as_str()))
+    }
+
     /// Opens a file for reading and returns it as a readable stream.
     ///
     /// The returned stream can be passed directly as the `data` argument to

--- a/examples/test_states/BUILD.bazel
+++ b/examples/test_states/BUILD.bazel
@@ -5,9 +5,15 @@ Use with:
     aspect dev test //examples/test_states/...
 
 Provides:
-  always_pass  — a test that always passes (sh_test exit 0)
-  always_fail  — a test that always fails (sh_test exit 1)
-  flaky_test   — a test that flips based on a counter file (simulated flaky)
+  always_pass     — a test that always passes (sh_test exit 0)
+  always_fail     — a test that always fails (sh_test exit 1)
+  flaky_test      — a test that flips based on a counter file (simulated flaky)
+  demo_test_fail  — a failing test with a realistic multi-line test.log, for
+                    demoing the inline test-log snippet on the status surfaces
+  demo_build_fail — a failing build action with realistic compiler-style stderr,
+                    for demoing the inline action-stderr snippet
+
+All but `always_pass` are tagged `manual` (opt-in only; never run with `//...`).
 """
 
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
@@ -30,4 +36,42 @@ sh_test(
     size = "small",
     srcs = ["flaky.sh"],
     tags = ["manual"],  # opt-in only; don't run with //...
+)
+
+# Demo failures for the inline failure-snippet surfaces (status checks,
+# Buildkite annotations, PR comment). Both are `manual` (opt-in only, never run
+# with `//...`) and emit realistic, multi-line output so the snippet windowing
+# has failure markers to anchor on. Run them explicitly to see snippets render:
+#
+#   aspect test //examples/test_states:demo_test_fail   # inline test.log snippet
+#   bazel build //examples/test_states:demo_build_fail  # inline action-stderr snippet
+
+sh_test(
+    name = "demo_test_fail",
+    size = "small",
+    srcs = ["demo_test_fail.sh"],
+    tags = ["manual"],
+)
+
+genrule(
+    name = "demo_build_fail",
+    outs = ["demo_build_fail.out"],
+    # Emits a realistic compiler-style error to stderr, then exits non-zero so
+    # the action fails and BES reports its stderr — exercising the action-stderr
+    # snippet path. `>&2` so it lands on the action's stderr, not stdout.
+    cmd = """(
+cat >&2 <<'ERR'
+INFO: From Compiling examples/test_states/widget.cc:
+examples/test_states/widget.cc: In function 'int Widget::total() const':
+examples/test_states/widget.cc:42:14: error: no matching function for call to 'sum(std::vector<Item>&)'
+   42 |   return sum(items_);
+      |          ~~~^~~~~~~~~
+examples/test_states/widget.cc:18:5: note: candidate: 'int sum(const std::vector<int>&)'
+   18 | int sum(const std::vector<int>& xs);
+      |     ^~~
+examples/test_states/widget.cc:18:5: note:   no known conversion for argument 1 from 'std::vector<Item>' to 'const std::vector<int>&'
+ERR
+exit 1
+)""",
+    tags = ["manual"],
 )

--- a/examples/test_states/demo_test_fail.sh
+++ b/examples/test_states/demo_test_fail.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Demo failure exercising the inline test-log snippet on the CI status surfaces.
+# Emits a realistic, multi-line pytest-style failure so the tail-with-error-anchor
+# windowing has markers to anchor on. Tagged `manual`; run explicitly via
+# `aspect test //examples/test_states:demo_test_fail`.
+set -u
+
+cat <<'LOG'
+============================= test session starts ==============================
+platform linux -- Python 3.11.4, pytest-7.4.0, pluggy-1.2.0
+collected 3 items
+
+tests/test_widget.py::test_render PASSED                                  [ 33%]
+tests/test_widget.py::test_serialize PASSED                               [ 66%]
+tests/test_widget.py::test_totals FAILED                                  [100%]
+
+=================================== FAILURES ===================================
+________________________________ test_totals __________________________________
+
+    def test_totals():
+        cart = Cart(items=[Item("apple", 2), Item("pear", 3)])
+>       assert cart.total() == 6
+E       assert 5 == 6
+E        +  where 5 = <Cart items=2>.total()
+
+tests/test_widget.py:42: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_widget.py::test_totals - assert 5 == 6
+========================= 1 failed, 2 passed in 0.07s ==========================
+LOG
+
+exit 1


### PR DESCRIPTION
## Summary

On a failure, the CI status surfaces (GitHub/GitLab status checks, Buildkite annotations, PR summary comments) today show *what* failed — failed test labels + kind + duration, failed action labels + mnemonics — plus links to the raw logs. To see *why* something failed, a user has to click through to the Aspect Web UI or the CI artifact. The old rosetta-driven Marvin v1 inlined failed build-action messages; it never inlined test logs.

This brings the surfaces to (and past) that parity: it **inlines a concise snippet of the actual failure output for both failed tests and failed build actions**, directly on the surfaces.

New `lib/log_snippet.axl` turns a log path into a bounded, cleaned snippet: it prefers a structured JUnit `test.xml` `<failure>`/`<error>` element when present (zero heuristics), otherwise applies **tail-with-error-anchor windowing** — strip ANSI/CR noise, anchor on the last failure marker, fall back to the tail — over a byte-capped prefix. Failed-action **stderr** (historically dropped to keep large inlined output off the Starlark heap) is now captured **by path only** (the BES `File.uri`, resolved via the existing `bb_clientd` helper) and read on demand at render time, so the bytes never land on the heap.

- **Status checks & Buildkite annotations** render snippets as collapsed `<details>` under each failure table via the shared `bazel_results` renderer. Snippets shed *first* in the existing 65 KB / 1 MiB size-cap trim ladder, so the failure tables users came for are never regressed.
- **PR summary comment** is a cross-job rollup (not a details body), so each job extracts its own snippets (only it can read its local log/stderr paths) and ships them in its status artifact. The writer applies **sticky + deterministic + hard-capped (5)** global selection persisted in the comment's state block, so the chosen snippets don't flip-flop as sibling jobs report in — an already-shown snippet is never evicted by a later-arriving one.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (in-tree module docstrings)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Failed tests and failed build actions now show an inline snippet of their output directly on CI status checks, Buildkite annotations, and the PR summary comment — no more clicking through to read the failure.

### Test plan

- New test cases added
  - `.aspect/axl.axl`: `test_log_snippet` + `test_bazel_render_snippets` (28 cases) — extraction, ANSI/CR stripping, marker-anchored windowing vs. tail fallback, byte cap, JUnit-first (incl. self-closing + entity unescape), missing-path degrade, and full `render_check_output` integration (inline test + action snippets, labeled `<details>`, off-by-default, budget-overflow note).
  - `github_status_comments_test.axl`: `_check_select_snippets` — deterministic order, sticky last-sorting-survives-contention, hard cap at 5, stale-key drop, malformed skip, a `render_body` integration for the `🔎 Failure output` section, and a regression test that `shown_snippets` survives the state-block round-trip.
- Covered by existing test cases (all 7 `aspect dev *-snapshots` suites stay green)
- Local verification: `aspect tests axl` → 824 passed; all 7 snapshot suites exit 0; `cargo test -p aspect-cli` → 40 passed. Rendered Markdown eyeballed on both the check surface and the PR comment.
- Remaining: exercise real build/test failures through live CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
