### PR TITLE
fix(tips): allow important tips to be silenced

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -412,16 +412,16 @@ def _check_collect_tip_rows(ctx):
     if subordinate_count != 5:
         fail("collect_tip_rows cap: expected 5 subordinate (suggestion+info), got %d" % subordinate_count)
 
-    # silence_hint: empty for important, non-empty for non-important.
-    # The rendered tip carries this `<sub>...</sub>` line as its
-    # silence-hint footer; an empty value suppresses the footer.
+    # silence_hint: non-empty for every severity (silencing is by id,
+    # regardless of severity). The rendered tip carries this
+    # `<sub>...</sub>` line as its silence-hint footer.
     rows = collect_tip_rows(ctx, [{"key": "t1", "tips": [
         {"id": "c", "severity": "important", "title": "C", "body": ""},
         {"id": "s", "severity": "suggestion", "title": "S", "body": ""},
     ]}])
     by_id = {r["id"]: r for r in rows}
-    if by_id["c"]["silence_hint"] != "":
-        fail("collect_tip_rows: important row must have empty silence_hint")
+    if "tips" not in by_id["c"]["silence_hint"] or "silence" not in by_id["c"]["silence_hint"]:
+        fail("collect_tip_rows: important row must reference the tips silence knob in silence_hint")
     if "tips" not in by_id["s"]["silence_hint"] or "silence" not in by_id["s"]["silence_hint"]:
         fail("collect_tip_rows: suggestion row must reference the tips silence knob in silence_hint")
 
@@ -1974,7 +1974,7 @@ def _test_impl(ctx):
                     make_build_passed(),
                     8000,
                     tips = [
-                        # 1 important — always shown, no silence footer.
+                        # 1 important — always shown (above the cap).
                         {
                             "id": "add-id-token-permission",
                             "severity": "important",

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -412,9 +412,8 @@ def _check_collect_tip_rows(ctx):
     if subordinate_count != 5:
         fail("collect_tip_rows cap: expected 5 subordinate (suggestion+info), got %d" % subordinate_count)
 
-    # silence_hint: non-empty for every severity (silencing is by id,
-    # regardless of severity). The rendered tip carries this
-    # `<sub>...</sub>` line as its silence-hint footer.
+    # silence_hint: non-empty whenever the tip has an id. The rendered
+    # tip carries this `<sub>...</sub>` line as its silence-hint footer.
     rows = collect_tip_rows(ctx, [{"key": "t1", "tips": [
         {"id": "c", "severity": "important", "title": "C", "body": ""},
         {"id": "s", "severity": "suggestion", "title": "S", "body": ""},

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -442,11 +442,10 @@ def severity_rank(severity):
     Unknown severities sort after `TIP_INFO`."""
     return _SEVERITY_ORDER.get(severity, 999)
 
-def silence_hint_line(id, severity):
+def silence_hint_line(id):
     """Markdown `<sub>` silence-hint footer naming the tip's id and the
     silence knob. Returns `""` for blank ids. Shared by the check-run
-    `TIPS_BLOCK` and PR-comment section so both stay aligned. `severity` is
-    currently unused but kept for call-site symmetry with `decorate_tip`."""
+    `TIPS_BLOCK` and PR-comment section so both stay aligned."""
     if not id:
         return ""
     return '<sub>_Silence by adding `"%s"` to `ctx.features["tips"].args.silence` in `.aspect/config.axl`, or pass `--tips:silence=%s` on the command line._</sub>' % (id, id)
@@ -487,7 +486,7 @@ def decorate_tip(t):
         "severity_label": severity_label(severity),
         "title": t.get("title", ""),
         "body_quoted": blockquote_body(t.get("body", "")),
-        "silence_hint": silence_hint_line(t.get("id", ""), severity),
+        "silence_hint": silence_hint_line(t.get("id", "")),
     }
 
 def strip_code_fences(body):
@@ -714,7 +713,7 @@ Tips = feature(
     args = {
         "silence": args.string_list(
             default = [],
-            description = "Tip ids to suppress for this task, regardless of severity. Append from config: `ctx.features[\"tips\"].args.silence.append(\"<id>\")`. Pass on CLI: `--tips:silence=<id>` (repeat for multiple).",
+            description = "Tip ids to suppress for this task. Append from config: `ctx.features[\"tips\"].args.silence.append(\"<id>\")`. Pass on CLI: `--tips:silence=<id>` (repeat for multiple).",
         ),
         "auto_print": args.boolean(
             default = True,

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -34,7 +34,6 @@ need to probe — the data flow just goes quiet.
 # Severity ordering (highest → lowest urgency)
 
     TIP_IMPORTANT   — action required; key features broken without it.
-                      Cannot be silenced; rendering omits the silence footer.
     TIP_WARNING     — degraded behavior; fix to restore full function.
     TIP_SUGGESTION  — improvement opportunity; works fine without it.
     TIP_INFO        — FYI.
@@ -224,7 +223,7 @@ def tip_replace(
 # `_body_src`, `vars`, `accumulate` (dict<name, list>) for re-rendering on
 # accumulation. Same-`(id, key)` re-emit replaces the stored tip
 # (accumulate unions onto the prior); silenced ids are dropped on
-# `add_tip` (unless TIP_IMPORTANT).
+# `add_tip`.
 #
 # When `Tips` isn't loaded the callable defaults are null-objects: `add` a
 # no-op, `collect` []. Emit sites don't probe — disabled propagates as zero
@@ -445,10 +444,10 @@ def severity_rank(severity):
 
 def silence_hint_line(id, severity):
     """Markdown `<sub>` silence-hint footer naming the tip's id and the
-    silence knob. Returns `""` for important tips (can't be silenced) and
-    blank ids. Shared by the check-run `TIPS_BLOCK` and PR-comment section
-    so both stay aligned."""
-    if not id or severity == TIP_IMPORTANT:
+    silence knob. Returns `""` for blank ids. Shared by the check-run
+    `TIPS_BLOCK` and PR-comment section so both stay aligned. `severity` is
+    currently unused but kept for call-site symmetry with `decorate_tip`."""
+    if not id:
         return ""
     return '<sub>_Silence by adding `"%s"` to `ctx.features["tips"].args.silence` in `.aspect/config.axl`, or pass `--tips:silence=%s` on the command line._</sub>' % (id, id)
 
@@ -518,8 +517,7 @@ def _print_tip(std, id, severity, title, body):
     <LABEL>:` prefix is severity-colored (see `_TERMINAL_TIP_COLOR`), the
     title bold-default so urgency reads without blending. Body + silence
     footer are prefixed with a colored `│ ` so the tip boundary is visible in
-    a stream of WARN/INFO lines. Code fences are stripped; the silence footer
-    is omitted for important tips."""
+    a stream of WARN/INFO lines. Code fences are stripped."""
     code = _TERMINAL_TIP_COLOR.get(severity, "1;36")  # default to INFO's cyan for unknown severities
     color_on = color_enabled(std)
 
@@ -536,9 +534,8 @@ def _print_tip(std, id, severity, title, body):
     if cleaned:
         for line in cleaned.split("\n"):
             print(bar if line == "" else bar + " " + line)
-    if severity != TIP_IMPORTANT:
-        print(bar)
-        print(bar + ' (Silence this tip with `--tips:silence=%s` or by adding it to `ctx.features["tips"].args.silence` in `.aspect/config.axl`.)' % id)
+    print(bar)
+    print(bar + ' (Silence this tip with `--tips:silence=%s` or by adding it to `ctx.features["tips"].args.silence` in `.aspect/config.axl`.)' % id)
 
 def blockquote_body(body):
     """Prefix every body line with `> ` (or `>` for blank) so it renders as a
@@ -651,7 +648,7 @@ def _tips_impl(ctx):
             _print_tip(call_ctx.std, stored["id"], stored["severity"], stored["title"], stored["body"])
 
     def _add(call_ctx, tip):
-        if tip["severity"] != TIP_IMPORTANT and tip["id"] in silenced:
+        if tip["id"] in silenced:
             return
 
         # Run the `tip_suggestion` chain: reject drops, replace rewrites.
@@ -717,7 +714,7 @@ Tips = feature(
     args = {
         "silence": args.string_list(
             default = [],
-            description = "Tip ids to suppress for this task. Important tips (severity=important) ignore this list — they signal key-feature breakages. Append from config: `ctx.features[\"tips\"].args.silence.append(\"<id>\")`. Pass on CLI: `--tips:silence=<id>` (repeat for multiple).",
+            description = "Tip ids to suppress for this task, regardless of severity. Append from config: `ctx.features[\"tips\"].args.silence.append(\"<id>\")`. Pass on CLI: `--tips:silence=<id>` (repeat for multiple).",
         ),
         "auto_print": args.boolean(
             default = True,

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -5,8 +5,8 @@ Covers the tip framework primitives directly:
                 replaces; distinct `key` coexists), `type`-driven
                 title/body (RAW / FORMAT `vars` / JINJA2 `vars` +
                 `accumulate`), within-task `accumulate` union,
-                severity guard, and `silenced_tips` short-circuit (by
-                `id`, across keys).
+                and `silenced_tips` short-circuit (by `id`, across keys
+                and severities).
   - `collect_tips_sorted` — severity ordering, insertion-order stability,
                             limit, surface allowlist.
   - `surfaces` / `combine_across_tasks` — storage + defaults on `add_tip`,
@@ -137,9 +137,8 @@ def _test_silenced_tips_short_circuits_add_tip(ctx):
     )
 
 def _test_silenced_tips_blocks_add(ctx):
-    """A non-important tip whose `id` is on the silence list never lands.
-    Mirrors how the suggestion-severity built-ins are gated, without
-    depending on any one built-in."""
+    """A tip whose `id` is on the silence list never lands. Mirrors how
+    the built-ins are gated, without depending on any one built-in."""
     _reset(ctx)
     tips._set_silenced_for_test(ctx, ["some-suggestion"])
     add_tip(ctx, id = "some-suggestion", severity = TIP_SUGGESTION, title = "T", body = "B")
@@ -149,18 +148,18 @@ def _test_silenced_tips_blocks_add(ctx):
         [],
     )
 
-def _test_important_tips_cannot_be_silenced(ctx):
-    """Important tips ignore `silenced_tips` — they signal a key-feature
-    breakage and must always reach the user. Verified both via direct
-    `add_tip(...)` and via the `tip_add_id_token_permission` built-in."""
+def _test_important_tips_can_be_silenced(ctx):
+    """Important tips honor `silenced_tips` like every other severity —
+    silencing is purely by `id`. Verified both via direct `add_tip(...)`
+    and via the `tip_add_id_token_permission` built-in."""
     _reset(ctx)
-    tips._set_silenced_for_test(ctx, ["unsuppressable", "add-id-token-permission"])
-    add_tip(ctx, id = "unsuppressable", severity = TIP_IMPORTANT, title = "T", body = "B")
+    tips._set_silenced_for_test(ctx, ["suppressable", "add-id-token-permission"])
+    add_tip(ctx, id = "suppressable", severity = TIP_IMPORTANT, title = "T", body = "B")
     tip_add_id_token_permission(ctx)
     _eq(
-        "important — silence list ignored",
+        "important — silence list honored",
         _ids(tips._inspect_for_test(ctx)),
-        ["unsuppressable", "add-id-token-permission"],
+        [],
     )
 
 def _test_add_tip_format(ctx):
@@ -452,12 +451,7 @@ def _test_builtin_tips_shape(ctx):
 
 def _test_silence_hint_line(ctx):
     _eq("silence_hint — empty id", silence_hint_line("", TIP_INFO), "")
-    _eq(
-        "silence_hint — important returns empty",
-        silence_hint_line("anything", TIP_IMPORTANT),
-        "",
-    )
-    for sev in (TIP_WARNING, TIP_SUGGESTION, TIP_INFO):
+    for sev in (TIP_IMPORTANT, TIP_WARNING, TIP_SUGGESTION, TIP_INFO):
         line = silence_hint_line("some-tip", sev)
         if "some-tip" not in line:
             fail("silence_hint %s: missing tip id: %r" % (sev, line))
@@ -669,11 +663,12 @@ def _test_decorate_tip(ctx):
     _eq("decorate_tip — title", decorated["title"], "T")
     _eq("decorate_tip — body_quoted prefixes each line", decorated["body_quoted"], "> line1\n> line2")
     if "tips" not in decorated["silence_hint"] or "silence" not in decorated["silence_hint"]:
-        fail("decorate_tip — non-important row missing silence_hint: %r" % decorated["silence_hint"])
+        fail("decorate_tip — row missing silence_hint: %r" % decorated["silence_hint"])
 
-    # Important: silence_hint should be blank.
+    # Important rows are silenceable too, so they carry a silence_hint.
     crit = decorate_tip({"id": "c", "severity": TIP_IMPORTANT, "title": "C", "body": ""})
-    _eq("decorate_tip — important silence_hint blank", crit["silence_hint"], "")
+    if "tips" not in crit["silence_hint"] or "silence" not in crit["silence_hint"]:
+        fail("decorate_tip — important row missing silence_hint: %r" % crit["silence_hint"])
 
 def _test_strip_code_fences(ctx):
     _eq("fences — empty body", strip_code_fences(""), "")
@@ -711,7 +706,7 @@ def _test_impl(ctx):
     _test_key_distinct(ctx)
     _test_silenced_tips_short_circuits_add_tip(ctx)
     _test_silenced_tips_blocks_add(ctx)
-    _test_important_tips_cannot_be_silenced(ctx)
+    _test_important_tips_can_be_silenced(ctx)
     _test_add_tip_format(ctx)
     _test_add_tip_raw_skips_interpolation(ctx)
     _test_add_tip_default_type_is_raw(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -5,8 +5,7 @@ Covers the tip framework primitives directly:
                 replaces; distinct `key` coexists), `type`-driven
                 title/body (RAW / FORMAT `vars` / JINJA2 `vars` +
                 `accumulate`), within-task `accumulate` union,
-                and `silenced_tips` short-circuit (by `id`, across keys
-                and severities).
+                and `silenced_tips` short-circuit (by `id`, across keys).
   - `collect_tips_sorted` — severity ordering, insertion-order stability,
                             limit, surface allowlist.
   - `surfaces` / `combine_across_tasks` — storage + defaults on `add_tip`,
@@ -149,7 +148,7 @@ def _test_silenced_tips_blocks_add(ctx):
     )
 
 def _test_important_tips_can_be_silenced(ctx):
-    """Important tips honor `silenced_tips` like every other severity —
+    """An important tip whose `id` is on the silence list never lands —
     silencing is purely by `id`. Verified both via direct `add_tip(...)`
     and via the `tip_add_id_token_permission` built-in."""
     _reset(ctx)
@@ -450,15 +449,14 @@ def _test_builtin_tips_shape(ctx):
             fail("aspect-api-token tip should not mention --scope=changed (App is only a fallback there)")
 
 def _test_silence_hint_line(ctx):
-    _eq("silence_hint — empty id", silence_hint_line("", TIP_INFO), "")
-    for sev in (TIP_IMPORTANT, TIP_WARNING, TIP_SUGGESTION, TIP_INFO):
-        line = silence_hint_line("some-tip", sev)
-        if "some-tip" not in line:
-            fail("silence_hint %s: missing tip id: %r" % (sev, line))
-        if "tips" not in line or "silence" not in line:
-            fail("silence_hint %s: missing tips/silence ref: %r" % (sev, line))
-        if not line.startswith("<sub>"):
-            fail("silence_hint %s: must wrap in <sub>: %r" % (sev, line))
+    _eq("silence_hint — empty id", silence_hint_line(""), "")
+    line = silence_hint_line("some-tip")
+    if "some-tip" not in line:
+        fail("silence_hint: missing tip id: %r" % line)
+    if "tips" not in line or "silence" not in line:
+        fail("silence_hint: missing tips/silence ref: %r" % line)
+    if not line.startswith("<sub>"):
+        fail("silence_hint: must wrap in <sub>: %r" % line)
 
 def _test_severity_rank(ctx):
     _eq("rank — important most urgent", severity_rank(TIP_IMPORTANT), 0)
@@ -665,7 +663,7 @@ def _test_decorate_tip(ctx):
     if "tips" not in decorated["silence_hint"] or "silence" not in decorated["silence_hint"]:
         fail("decorate_tip — row missing silence_hint: %r" % decorated["silence_hint"])
 
-    # Important rows are silenceable too, so they carry a silence_hint.
+    # Important rows are silenceable, so they carry a silence_hint.
     crit = decorate_tip({"id": "c", "severity": TIP_IMPORTANT, "title": "C", "body": ""})
     if "tips" not in crit["silence_hint"] or "silence" not in crit["silence_hint"]:
         fail("decorate_tip — important row missing silence_hint: %r" % crit["silence_hint"])

--- a/crates/aspect-cli/src/builtins/aspect/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/tips.axl
@@ -108,7 +108,7 @@ def add_tip(
     A tip is identified by `(id, key)`. Re-emitting the same `(id, key)`
     within a task replaces the stored content (accumulate fields ride
     along); a different `key` is a distinct tip. Silencing is always by
-    `id`: no-op if `id` is in the silence list AND `severity != TIP_IMPORTANT`.
+    `id`: no-op if `id` is in the silence list, regardless of severity.
 
     No-op overall when the `Tips` feature is disabled — the trait's
     `add` callable falls back to its null-object default.
@@ -119,8 +119,7 @@ def add_tip(
         with the same `(id, key)` are the same tip (re-emit replaces);
         `id` alone is what `--tips:silence=<id>` and the silence list match.
       severity: One of `TIP_IMPORTANT` / `TIP_WARNING` / `TIP_SUGGESTION` /
-        `TIP_INFO` — drives ordering, the emoji/label, and (for
-        `TIP_IMPORTANT`) immunity from silencing.
+        `TIP_INFO` — drives ordering and the emoji/label.
       title: Short headline, interpreted per `type`.
       body: Markdown body, interpreted per `type`.
       type: The interpolation engine for `title` / `body`:

--- a/crates/aspect-cli/src/builtins/aspect/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/tips.axl
@@ -108,7 +108,7 @@ def add_tip(
     A tip is identified by `(id, key)`. Re-emitting the same `(id, key)`
     within a task replaces the stored content (accumulate fields ride
     along); a different `key` is a distinct tip. Silencing is always by
-    `id`: no-op if `id` is in the silence list, regardless of severity.
+    `id`: no-op if `id` is in the silence list.
 
     No-op overall when the `Tips` feature is disabled — the trait's
     `add` callable falls back to its null-object default.


### PR DESCRIPTION
Important tips (`TIP_IMPORTANT`) were special-cased to be unsilenceable: they ignored the `tips:silence` list and rendered without the silence-hint footer on both the terminal and GitHub surfaces. That made it impossible to quiet an important tip that didn't apply to a given repo, even though every other severity could be silenced by `id`.

This backs out that special-casing. Important tips now silence by `id` like every other severity and carry the same silence hint everywhere. The only `TIP_IMPORTANT`-specific behavior left is ordering/emoji/label/color and the PR-summary display cap (which still shows important/warning above the cap — that's separate from silencing and unchanged).

Concretely: dropped the `severity != TIP_IMPORTANT` guard in `_add`, stopped suppressing the footer in `silence_hint_line` / `_print_tip`, and updated the docstrings and the `silence` arg description.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Important tips can now be silenced via `--tips:silence=<id>` or `ctx.features["tips"].args.silence`, like every other tip severity. Previously they were unsilenceable.

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
  - `cargo build -p aspect-cli`
  - `./target/debug/aspect-cli dev test-tips` — passes
  - `./target/debug/aspect-cli dev test-pr-comment-snapshots` — passes; the rendered important tip (`add-id-token-permission`) now shows the silence footer
