### PR TITLE
fix(github): deterministic PR change detection via synthesized merge SHA

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -500,17 +500,50 @@ def detect_merge_group_base_sha(std):
         return ""
     return (read_github_event(std).get("merge_group", {}) or {}).get("base_sha", "") or ""
 
-def head_is_synthesized_merge(std, parents):
+def detect_synthesized_merge_sha(std):
+    """The GitHub-synthesized PR merge commit SHA, or `""`.
+
+    On GHA `pull_request`, `GITHUB_SHA` *is* the `refs/pull/<n>/merge` commit
+    GitHub builds (head merged onto the base tip), so its first parent is the
+    base the PR is evaluated against. Returned so change detection can operate
+    on it by SHA, independent of what the user's checkout left at HEAD, of
+    `origin/*` freshness, and of `fetch-depth`.
+
+    `pull_request_target` is excluded: there `GITHUB_SHA` is the base branch
+    tip (the event runs in the base-repo context, not the merge), so it is not
+    a synthesized merge and its `parents[0]` is not the PR base. `""` off
+    `pull_request` (incl. `merge_group`, which carries its base directly via
+    `detect_merge_group_base_sha`)."""
+    env = std.env
+    if not env.var("GITHUB_ACTIONS"):
+        return ""
+    if (env.var("GITHUB_EVENT_NAME") or "") != "pull_request":
+        return ""
+    return env.var("GITHUB_SHA") or ""
+
+def head_is_synthesized_merge(std, parents, head_sha = ""):
     """True when HEAD is a CI-synthesized merge so `parents[0]` is a safe
     diff base. False for a developer's own merge and any non-merge HEAD.
 
     Trust rule differs by source (refs differ in developer-controllability):
 
       - GHA pull_request / pull_request_target: a workflow can checkout
-        `head.sha`, so the event alone doesn't prove a synthesized merge —
-        confirm `parents[0] == pull_request.base.sha` (GitHub merges head
-        onto exactly that base; a developer merge has parents[0] = prior
-        branch tip and falls through).
+        `head.sha`, so the event alone doesn't prove a synthesized merge.
+        HEAD is confirmed to be the GitHub-made `refs/pull/<n>/merge` ref
+        by EITHER:
+          (a) `head_sha` == the synthesized merge SHA
+              (`detect_synthesized_merge_sha`) — proves the default checkout
+              is in place. Holds even when the base branch advanced after the
+              merge ref was synthesized, which leaves `parents[0]` a newer
+              base tip than the event payload's `base.sha`. `pull_request`
+              only: on `pull_request_target` GITHUB_SHA is the base tip, not a
+              merge, so this branch never fires there.
+          (b) `parents[0] == pull_request.base.sha` — exact, but misses the
+              base-advance case above; used when `head_sha` isn't supplied and
+              the sole check on `pull_request_target`.
+        Either way GitHub makes the base the first parent, so `parents[0]`
+        is the base. A developer merge checked out via `ref: head.sha`
+        satisfies neither and falls through.
       - GHA merge_group: HEAD is the queue's `gh-readonly-queue` ref (not
         overridable), so ≥2 parents is always GitHub-made. parents[0] is
         NOT compared to `merge_group.base_sha` (that tracks the target
@@ -524,6 +557,9 @@ def head_is_synthesized_merge(std, parents):
     if env.var("GITHUB_ACTIONS"):
         event_name = env.var("GITHUB_EVENT_NAME") or ""
         if event_name in ("pull_request", "pull_request_target"):
+            merge_sha = detect_synthesized_merge_sha(std)
+            if head_sha and merge_sha and head_sha == merge_sha:
+                return True
             base = _pull_request_event_sha(std, "base")
             return base != "" and parents[0] == base
         return event_name == "merge_group"
@@ -754,10 +790,10 @@ def _git_cwd(ctx, cwd):
     """
     return cwd or ctx.std.env.current_dir()
 
-def _head_parents(ctx, cwd = None):
-    """HEAD's parent SHAs, or `[]` if unresolvable. `len >= 2` ⇒ merge commit.
+def _commit_parents(ctx, rev = "HEAD", cwd = None):
+    """`rev`'s parent SHAs, or `[]` if unresolvable. `len >= 2` ⇒ merge commit.
 
-    Reads via `git cat-file -p HEAD`, not `git log/rev-list --parents`:
+    Reads via `git cat-file -p <rev>`, not `git log/rev-list --parents`:
     those respect the `.git/shallow` overlay and return empty on a shallow
     checkout, though the raw object still encodes the parents. Bypassing the
     overlay makes merge-commit-first work on shallow PR checkouts (a targeted
@@ -769,7 +805,7 @@ def _head_parents(ctx, cwd = None):
     """
     process = ctx.std.process
     cwd = _git_cwd(ctx, cwd)
-    out = process.command("git").args(["cat-file", "-p", "HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
+    out = process.command("git").args(["cat-file", "-p", rev]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
     if not out.status.success:
         return []
     parents = []
@@ -781,6 +817,15 @@ def _head_parents(ctx, cwd = None):
         elif line == "":
             break  # end of header block; message follows
     return parents
+
+def _head_parents(ctx, cwd = None):
+    """HEAD's parent SHAs; see `_commit_parents`."""
+    return _commit_parents(ctx, rev = "HEAD", cwd = cwd)
+
+def _head_sha(ctx, cwd = None):
+    """`git rev-parse HEAD`, or `""` if unresolvable."""
+    out = ctx.std.process.command("git").args(["rev-parse", "HEAD"]).current_dir(_git_cwd(ctx, cwd)).stdout("piped").stderr("null").spawn().wait_with_output()
+    return out.stdout.strip() if out.status.success else ""
 
 def _ensure_local_sha(ctx, sha, cwd = None):
     """Ensure `sha` is in the local object store (shallow on-demand fetch
@@ -823,8 +868,7 @@ def _resolve_merge_base(ctx, base_ref, cwd = None):
     process = ctx.std.process
     cwd = _git_cwd(ctx, cwd)
 
-    head_out = process.command("git").args(["rev-parse", "HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
-    head_sha = head_out.stdout.strip() if head_out.status.success else ""
+    head_sha = _head_sha(ctx, cwd = cwd)
 
     head_on_base = False
     mb = process.command("git").args(["merge-base", "HEAD", base_ref]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
@@ -837,7 +881,7 @@ def _resolve_merge_base(ctx, base_ref, cwd = None):
 
     # HEAD^1 path (step 2): synthesized merge, or HEAD confirmed on base.
     parents = _head_parents(ctx, cwd = cwd)
-    synthesized = head_is_synthesized_merge(ctx.std, parents)
+    synthesized = head_is_synthesized_merge(ctx.std, parents, head_sha = head_sha)
     if synthesized or (len(parents) >= 1 and head_on_base):
         parent_sha = parents[0]
         if _ensure_local_sha(ctx, parent_sha, cwd = cwd):
@@ -870,27 +914,37 @@ def resolve_merge_base_for_test(ctx, base_ref, cwd):
     Production goes through `detect_changed_files`."""
     return _resolve_merge_base(ctx, base_ref, cwd = cwd)
 
-def _try_local_git_diff_from_base_sha(ctx, line_level, base_sha):
-    """Run `git diff <base_sha>` → `{files, skipped, source, unscoped}`,
-    or `None` on any failure (unfetchable SHA / `git diff` error).
+def _try_local_git_diff_from_base_sha(ctx, line_level, base_sha, head = "HEAD", cwd = None):
+    """Run `git diff <base_sha> <head>` → `{files, skipped, source,
+    unscoped}`, or `None` on any failure (unfetchable SHA / `git diff`
+    error). Two-dot (tree compare) — no merge-base / common history needed.
+
+    `head` defaults to the working-tree `HEAD`; the synthesized-merge path
+    passes an explicit merge SHA so the diff is independent of what the
+    user's checkout left at HEAD. Both `base_sha` and a non-HEAD `head`
+    are fetched on-demand by SHA (shallow-safe).
 
     `source` is a neutral `"local git diff <base>..<head>"`; callers
     append context. Used by every local-diff path in `detect_changed_files`.
     """
 
     process = ctx.std.process
-    cwd = ctx.std.env.current_dir()
+    cwd = _git_cwd(ctx, cwd)
 
-    # Shallow checkout may lack the SHA; depth-1 fetch on-demand.
-    if not _ensure_local_sha(ctx, base_sha):
+    # Shallow checkout may lack the SHA(s); depth-1 fetch on-demand.
+    if not _ensure_local_sha(ctx, base_sha, cwd = cwd):
+        return None
+    if head != "HEAD" and not _ensure_local_sha(ctx, head, cwd = cwd):
         return None
 
-    head_out = process.command("git").args(["rev-parse", "HEAD"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
-    head_sha = head_out.stdout.strip() if head_out.status.success else ""
-    source = "local git diff %s..%s" % (base_sha, head_sha) if head_sha else "local git diff %s..HEAD" % base_sha
+    source = "local git diff %s..%s" % (base_sha, head)
+
+    # Bare `git diff <base>` (base vs the working tree) for HEAD; an explicit
+    # `head` pins both diff endpoints.
+    head_args = [] if head == "HEAD" else [head]
 
     if line_level:
-        result = process.command("git").args(["diff", base_sha, "--unified=0"]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
+        result = process.command("git").args(["diff", base_sha] + head_args + ["--unified=0"]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
         if not result.status.success:
             return None
         parsed = _parse_local_diff_output(result.stdout)
@@ -898,11 +952,33 @@ def _try_local_git_diff_from_base_sha(ctx, line_level, base_sha):
             entry["hunk_lines"] = _widen_lines(entry["lines"], _HUNK_CONTEXT_LINES)
         return {"files": parsed, "skipped": [], "source": source, "unscoped": False}
 
-    out = process.command("git").args(["diff", "--diff-filter=d", "--name-only", base_sha]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
+    out = process.command("git").args(["diff", "--diff-filter=d", "--name-only", base_sha] + head_args).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
     if not out.status.success:
         return None
     names = [f for f in out.stdout.strip().split("\n") if f]
     return {"files": names, "skipped": [], "source": source, "unscoped": False}
+
+def _diff_synthesized_merge(ctx, line_level, merge_sha, cwd = None):
+    """Change set from the synthesized PR merge commit `merge_sha`, or `None`.
+
+    Fetches `merge_sha` by SHA, reads its `parents[0]` (the base GitHub merged
+    onto), and diffs `parents[0]` against the merge. Operating by SHA makes
+    this independent of HEAD, `origin/*` freshness, and `fetch-depth`;
+    git-only, so it works on fork PRs too. `None` when `merge_sha` is empty,
+    isn't a ≥2-parent commit, or the diff fails."""
+    if not merge_sha or not _ensure_local_sha(ctx, merge_sha, cwd = cwd):
+        return None
+    parents = _commit_parents(ctx, rev = merge_sha, cwd = cwd)
+    if len(parents) < 2:
+        return None
+    return _try_local_git_diff_from_base_sha(ctx, line_level, parents[0], head = merge_sha, cwd = cwd)
+
+def synthesized_merge_diff_for_test(ctx, line_level, merge_sha, cwd):
+    """Test seam for `_diff_synthesized_merge` against a scratch repo at `cwd`
+    with an explicit `merge_sha` (production reads it from the GHA env via
+    `detect_synthesized_merge_sha`). Production goes through
+    `detect_changed_files`."""
+    return _diff_synthesized_merge(ctx, line_level, merge_sha, cwd = cwd)
 
 def _parse_local_diff_output(output):
     """Parse `git diff --unified=0` into `[{file, lines, additions, deletions}]`:
@@ -1031,10 +1107,16 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
       4. `_resolve_merge_base(ctx, base_ref)` → diff against the merge-base.
          Covers Buildkite/CircleCI PR builds, overridden `ref:`, push-to-base,
          local dev.
-      5. PR Files API — only when steps 1-4 failed; costs App quota.
+      5. GHA synthesized merge by SHA (`_diff_synthesized_merge`):
+         deterministic and checkout-independent. The git-only guarantee for
+         GHA PRs; also covers fork PRs that can't reach the App-quota API.
+      6. PR Files API — only when steps 1-5 failed; costs App quota.
 
     Step 2 before 3 because GitLab merged_result/merge_train HEAD includes
     target updates beyond DIFF_BASE_SHA, so `HEAD^1..HEAD` is the right anchor.
+    Step 5 before 6 so fork PRs (no Aspect credentials) still resolve from git.
+    Step 2 is the same merge resolved via HEAD: a fetch-free fast path when the
+    checkout left HEAD at the merge, with step 5 the by-SHA backstop otherwise.
 
     `base_ref` for step 4: non-empty honored verbatim; empty (default
     sentinel) → `detect_ci_base_ref`, then `detect_default_branch_ref`,
@@ -1078,7 +1160,7 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
     # (2) merge-commit-first (see `head_is_synthesized_merge`); a developer's
     # own merge is rejected there and falls through to (4).
     parents = _head_parents(ctx)
-    if head_is_synthesized_merge(ctx.std, parents):
+    if head_is_synthesized_merge(ctx.std, parents, head_sha = _head_sha(ctx)):
         local = _try_local_git_diff_from_base_sha(ctx, line_level, parents[0])
         if local:
             local["source"] += " (HEAD is a CI-synthesized merge commit)"
@@ -1103,7 +1185,16 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
             local["source"] += " (%s)" % diff_base_source
             return local
 
-    # (5) PR Files API — only when steps 1-4 failed AND a PR context is
+    # (5) GitHub-synthesized merge by SHA — deterministic and
+    # checkout-independent; the git-only guarantee for GHA PRs (see
+    # `_diff_synthesized_merge`). Runs before the App-quota API so fork PRs
+    # resolve from git.
+    local = _diff_synthesized_merge(ctx, line_level, detect_synthesized_merge_sha(ctx.std))
+    if local:
+        local["source"] += " (GITHUB_SHA synthesized merge, fetched by SHA)"
+        return local
+
+    # (6) PR Files API — only when steps 1-5 failed AND a PR context is
     # detectable; otherwise degrade to `--scope=all`.
     pr, _ = detect_github_pr(ctx.std)
     if pr:

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -6,17 +6,21 @@ Covers:
     the PR context), `merge_group` (`detect_merge_group_base_sha`
     returns the queue base SHA), and `push` (neither fires; downstream
     falls back to local `git diff`).
+  - `detect_synthesized_merge_sha` — `GITHUB_SHA` on `pull_request`, `""`
+    elsewhere (notably `pull_request_target`, where it's the base tip).
   - `head_is_synthesized_merge` — the per-source gate that decides
     whether HEAD's first parent is a safe diff base, including the
-    PR-head-checkout and batched-merge_group cases.
+    PR-head-checkout, base-advance-race, `pull_request_target`-base-merge,
+    and batched-merge_group cases.
   - `list_pull_request_files` auth fallback + rate-limit bucketing.
 
 Most cases are env- and event-file-driven, so they stub `std` with a
 fake env (dict-backed) and a fake fs (path → content dict). The
-`_resolve_merge_base` integration section is the exception: it builds
-real scratch git repos with `git` subprocesses to exercise the
-merge-base / HEAD^1 diff-base resolution end to end (notably the
-developer-merge-commit case behind the reported under-scoping bug).
+integration section is the exception: it builds real scratch git repos
+with `git` subprocesses to exercise diff-base resolution end to end —
+`_resolve_merge_base` (merge-base / HEAD^1, incl. the developer-merge
+under-scoping case) and the synthesized-merge-by-SHA path
+(`synthesized_merge_diff_for_test`).
 
 Run with:
   aspect dev test-github-detect
@@ -28,10 +32,12 @@ load(
     "detect_commit_sha",
     "detect_github_pr",
     "detect_merge_group_base_sha",
+    "detect_synthesized_merge_sha",
     "github",
     "head_is_synthesized_merge",
     "read_github_event",
     "resolve_merge_base_for_test",
+    "synthesized_merge_diff_for_test",
 )
 load(
     "./gitlab_detect.axl",
@@ -84,6 +90,12 @@ def _expect_mg_sha(label, vars, files, expected):
     got = detect_merge_group_base_sha(_fake_std(vars, files))
     _eq(label, got, expected)
 
+# ── detect_synthesized_merge_sha ────────────────────────────────────
+
+def _expect_merge_sha(label, vars, expected):
+    got = detect_synthesized_merge_sha(_fake_std(vars, {}))
+    _eq(label, got, expected)
+
 # ── detect_commit_sha ───────────────────────────────────────────────
 
 def _expect_commit_sha(label, vars, files, expected):
@@ -92,8 +104,8 @@ def _expect_commit_sha(label, vars, files, expected):
 
 # ── head_is_synthesized_merge ───────────────────────────────────────
 
-def _expect_head_synthesized(label, vars, files, parents, expected):
-    got = head_is_synthesized_merge(_fake_std(vars, files), parents)
+def _expect_head_synthesized(label, vars, files, parents, expected, head_sha = ""):
+    got = head_is_synthesized_merge(_fake_std(vars, files), parents, head_sha = head_sha)
     _eq(label, got, expected)
 
 # ── read_github_event ───────────────────────────────────────────────
@@ -149,6 +161,37 @@ def _test_impl(ctx):
         pr_vars,
         pr_files,
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+
+    # detect_synthesized_merge_sha returns the GITHUB_SHA merge commit on
+    # `pull_request` (operated on by SHA in step 5), and "" elsewhere.
+    _expect_merge_sha(
+        "pull_request: detect_synthesized_merge_sha is GITHUB_SHA (the merge)",
+        pr_vars,
+        "ccccccccccccccccccccccccccccccccccccccccc",
+    )
+
+    # pull_request_target: GITHUB_SHA is the base branch tip, not a merge —
+    # excluded so a base tip that happens to be a merge isn't mistaken for one.
+    _expect_merge_sha(
+        "pull_request_target: detect_synthesized_merge_sha is empty (GITHUB_SHA is the base tip)",
+        {"GITHUB_ACTIONS": "true", "GITHUB_EVENT_NAME": "pull_request_target", "GITHUB_SHA": "deadbeef"},
+        "",
+    )
+    _expect_merge_sha(
+        "merge_group: detect_synthesized_merge_sha is empty (base carried directly)",
+        {"GITHUB_ACTIONS": "true", "GITHUB_EVENT_NAME": "merge_group", "GITHUB_SHA": "deadbeef"},
+        "",
+    )
+    _expect_merge_sha(
+        "push: detect_synthesized_merge_sha is empty",
+        {"GITHUB_ACTIONS": "true", "GITHUB_EVENT_NAME": "push", "GITHUB_SHA": "deadbeef"},
+        "",
+    )
+    _expect_merge_sha(
+        "off-CI: detect_synthesized_merge_sha is empty",
+        {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_SHA": "deadbeef"},
+        "",
     )
 
     # ── Merge queue — merge_group event ─────────────────────────────
@@ -232,6 +275,56 @@ def _test_impl(ctx):
         pr_files,
         [base],
         False,
+    )
+
+    # Base-advance race: on persistent runners reusing a clone, each job gets a
+    # fresh synthesized merge whose parents[0] is the CURRENT base tip — newer
+    # than the event payload's base.sha (snapshotted at PR-event time). The
+    # base.sha equality check then fails even though HEAD is genuinely the
+    # GitHub merge. `head_sha == GITHUB_SHA` confirms the merge ref directly and
+    # rescues the fast path; parents[0] (the newer base) is the correct diff base.
+    github_sha = pr_vars["GITHUB_SHA"]
+    newer_base = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    _expect_head_synthesized(
+        "pull_request: synthesized merge trusted via HEAD == GITHUB_SHA (parents[0] != stale base.sha)",
+        pr_vars,
+        pr_files,
+        [newer_base, head],
+        True,
+        head_sha = github_sha,
+    )
+
+    # Developer `ref: head.sha` checkout WITH head_sha supplied: HEAD is the PR
+    # head, not GITHUB_SHA's merge (GITHUB_SHA stays the synthesized merge on
+    # pull_request), and parents[0] is the prior tip — both signals reject.
+    _expect_head_synthesized(
+        "pull_request: developer head.sha checkout (HEAD != GITHUB_SHA, parents[0] != base) is rejected",
+        pr_vars,
+        pr_files,
+        [prior_tip, head],
+        False,
+        head_sha = head,
+    )
+
+    # pull_request_target: GITHUB_SHA is the base-branch tip, NOT a merge. When
+    # that tip is itself a merge commit (a prior PR's merge), the default
+    # checkout has HEAD == GITHUB_SHA — but its parents[0] is the prior base
+    # tip, not this PR's base. The `head_sha == GITHUB_SHA` branch must NOT
+    # fire here (detect_synthesized_merge_sha is `pull_request`-only); branch
+    # (b) `parents[0] == base.sha` then correctly rejects it.
+    prt_vars = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_EVENT_NAME": "pull_request_target",
+        "GITHUB_SHA": "ffffffffffffffffffffffffffffffffffffffff",
+        "GITHUB_EVENT_PATH": pr_event_path,
+    }
+    _expect_head_synthesized(
+        "pull_request_target: base tip is a merge, HEAD == GITHUB_SHA, parents[0] != base — rejected",
+        prt_vars,
+        pr_files,
+        [prior_tip, head],
+        False,
+        head_sha = "ffffffffffffffffffffffffffffffffffffffff",
     )
 
     # merge_group: the gh-readonly-queue ref is GitHub-controlled (not
@@ -988,6 +1081,43 @@ def _test_resolve_merge_base_integration(ctx):
         _changed_files(ctx, repo, diff_base),
         ["b1.txt"],
     )
+    ctx.std.fs.remove_dir_all(repo)
+
+    # (4) Synthesized-merge-by-SHA (step 5): the base-advance race that drove
+    # the `--scope=all` degradation. feature branches off main@B1, then main
+    # advances to B2 (touching base.txt), then GitHub builds the PR merge
+    # M = merge(B2, feature). The merge's own parents[0] (B2) is the base, so
+    # only the PR's file is in scope; diffing the stale event base.sha (B1)
+    # would wrongly include base.txt. HEAD is moved off M to prove the path
+    # reads parents[0] off M directly — no HEAD, origin/main, or merge-base.
+    repo, b0 = _init_repo(ctx)
+    _commit_file(ctx, repo, "b1.txt", "b1\n", "b1")
+    _git_ok(ctx, repo, ["checkout", "-q", "-b", "feature"])
+    _commit_file(ctx, repo, "feat.txt", "feat\n", "feat")
+    _git_ok(ctx, repo, ["checkout", "-q", "main"])
+    _commit_file(ctx, repo, "base.txt", "advanced\n", "b2")
+    _git_ok(ctx, repo, ["checkout", "-q", "-b", "prmerge"])
+    _git_ok(ctx, repo, ["merge", "-q", "--no-ff", "--no-edit", "feature"])
+    merge_sha = _git_ok(ctx, repo, ["rev-parse", "HEAD"])
+    _git_ok(ctx, repo, ["checkout", "-q", "feature"])
+
+    result = synthesized_merge_diff_for_test(ctx, False, merge_sha, repo)
+    _eq(
+        "synthesized-merge (filename) — only the PR's file in scope, not base.txt",
+        sorted(result["files"]),
+        ["feat.txt"],
+    )
+    line_result = synthesized_merge_diff_for_test(ctx, True, merge_sha, repo)
+    _eq(
+        "synthesized-merge (line-level) — only the PR's file in scope",
+        sorted([e["file"] for e in line_result["files"]]),
+        ["feat.txt"],
+    )
+
+    # A non-merge SHA (single parent) yields None — guards against treating a
+    # squash/rebase checkout's HEAD as a synthesized merge.
+    if synthesized_merge_diff_for_test(ctx, False, b0, repo) != None:
+        fail("synthesized-merge — single-parent SHA must yield None")
     ctx.std.fs.remove_dir_all(repo)
 
 github_detect_tests = task(


### PR DESCRIPTION
PR change detection on GitHub Actions could degrade to `--scope=all`, which forces `aspect lint` into `strategy=hard` and produces spurious failures. The synthesized-merge gate trusted the merge commit's `parents[0]` as the base only when it equaled the event payload's `pull_request.base.sha`. When the base branch advances after GitHub synthesizes the `refs/pull/<n>/merge` ref, the merge's `parents[0]` is a newer base tip than that (stale) `base.sha`, so the check fails and detection falls through to `merge-base HEAD origin/main` → `HEAD^1` → `fetch --depth=1` — all of which fail on a shallow or stale-`origin/*` clone (e.g. a persistent runner reusing a clone).

Runners don't perform checkout — users choose it, and we only recommend standard `actions/checkout` — so nothing about HEAD, `fetch-depth`, or `origin/*` is assumable. This makes detection deterministic and checkout-independent on GHA `pull_request`:

- **Fast path:** `head_is_synthesized_merge` also trusts when `head_sha` equals the synthesized merge SHA (`GITHUB_SHA`). Robust to a base-branch advance, and fetch-free when the checkout left HEAD at the merge.
- **Backstop:** a new resolution step operates on `GITHUB_SHA` **by SHA** rather than via HEAD — fetch the merge commit, read its `parents[0]` (the base GitHub merged onto), and `git diff <parents[0]> <GITHUB_SHA>`. It depends only on `GITHUB_SHA` and by-SHA fetches, so it resolves on any clone state. Git-only, so fork PRs (which can't reach the App-quota Files API) resolve here too — it runs before the API path.

Both key off the merge's own `parents[0]`, never the (possibly stale) event `base.sha`. Scoped to `pull_request` only; on `pull_request_target`, `GITHUB_SHA` is the base-branch tip rather than a merge, so it falls back to the existing `parents[0] == base.sha` check.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- PR change detection on GitHub Actions is now deterministic regardless of checkout configuration (shallow clones, reused runner clones, base-branch advances). Previously this could degrade to `--scope=all`, forcing `aspect lint` into `strategy=hard` and causing spurious failures. Fork PRs now get scoped detection from git alone, no credentials required.

### Test plan

- New test cases added
- Covered by existing test cases
- `cargo build -p aspect-cli && ./target/debug/aspect-cli dev test-github-detect` passes, covering `detect_synthesized_merge_sha` per event (`pull_request` / `pull_request_target` / `merge_group` / `push` / off-CI), the `head_is_synthesized_merge` fast-path / developer-override / `pull_request_target`-base-merge cases, and a scratch-repo integration test asserting the base-advance scenario scopes only the PR's file (filename and line-level), with a single-parent SHA yielding no result.
