### PR TITLE
ci: on PRs, build only the shell init preset workspace

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -292,6 +292,11 @@ jobs:
   # the generated workspace. Catches CLI-side breakage of the init renderer
   # against the live template. `--template-ref=main` tests the current template
   # tip; `init`'s default (latest release) is what end users get.
+  #
+  # Every preset is scaffolded on PRs (cheap, exercises the renderer for all of
+  # them), but the slow workspace build runs only for `shell` — the fastest
+  # preset and enough to smoke-test the generated build. Pushes to main build
+  # every preset.
   init-preset:
     runs-on: ubuntu-latest
     needs: [pre-build]
@@ -323,5 +328,6 @@ jobs:
         run: |
           aspect init "$RUNNER_TEMP/proj" --task-key init-${{ matrix.preset }} --preset='${{ matrix.preset }}' --name=my_project --template-ref=main
       - name: Build generated workspace
+        if: ${{ github.event_name != 'pull_request' || matrix.preset == 'shell' }}
         working-directory: ${{ runner.temp }}/proj
         run: aspect build --task-key init-${{ matrix.preset }} -- //...


### PR DESCRIPTION
The `init-preset` job scaffolds each template preset with the freshly-built `aspect init` and builds the generated workspace, to catch CLI-side breakage of the init renderer. Building all 12 generated workspaces on every PR is slow.

On PRs, keep scaffolding every preset (cheap — it exercises the renderer for all of them) but run the slow "Build generated workspace" step only for the `shell` preset, the fastest preset and enough to smoke-test that the generated workspace builds. Pushes to main still build every preset.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- `actionlint` and YAML parse clean on the changed job; the build step is gated by `if: github.event_name != 'pull_request' || matrix.preset == 'shell'`, so PRs build only `shell` while pushes to main build the full matrix.
