### PR TITLE
feat(workflows): attribute builds to a runner identity via x-identity

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -76,11 +76,17 @@ def _workflows_impl(ctx: FeatureContext):
     if environment.build_events != None:
         metadata_flags = get_build_metadata_flags(ctx.std)
 
+        # The runtime owns the BES connection, so send `x-identity` as sink
+        # metadata (the remote cache/RE path gets it via `--remote_header`).
+        bes_metadata = {}
+        if environment.runner and environment.runner.identity:
+            bes_metadata["x-identity"] = environment.runner.identity
+
         bessie_sinks = []
         if environment.build_events and environment.build_events.backend:
             bessie_sinks.append(bazel.build_events.grpc(
                 uri = environment.build_events.backend,
-                metadata = {},
+                metadata = bes_metadata,
                 max_retries = ctx.args.bes_max_retries,
                 retry_min_delay = ctx.args.bes_retry_min_delay,
                 retry_max_buffer_size = ctx.args.bes_retry_max_buffer_size,

--- a/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/environment.axl
@@ -23,6 +23,9 @@ BuildEvents = record(
 
 Runner = record(
     storage_path = field(str, default = DEFAULT_STORAGE_PATH),
+    # Opaque value sent verbatim as the `x-identity` header on the build's
+    # remote connections. "" when unset (no header sent).
+    identity = field(str, default = ""),
     product_version = field(str, default = ""),
     instance_id = field(str, default = ""),
     instance_name = field(str, default = ""),
@@ -266,6 +269,7 @@ def _read_runner(std) -> Runner | None:
     return Runner(
         account = std.env.var("ASPECT_WORKFLOWS_RUNNER_CLOUD_ACCOUNT") or "",
         aspect_launcher_version = std.env.var("ASPECT_WORKFLOWS_RUNNER_ASPECT_LAUNCHER_VERSION") or "",
+        identity = std.env.var("ASPECT_WORKFLOWS_RUNNER_IDENTITY") or "",
         az = std.env.var("ASPECT_WORKFLOWS_RUNNER_AZ") or "",
         bazel_root_dir = std.env.var("ASPECT_WORKFLOWS_RUNNER_BAZEL_ROOT_DIR") or (storage_path + "/bazel"),
         bin_dir = std.env.var("ASPECT_WORKFLOWS_RUNNER_BIN_DIR") or DEFAULT_BIN_DIR,
@@ -370,6 +374,12 @@ def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str) -
             build_flags.append("--remote_cache=" + remote_cache.endpoint)
         if remote_cache.bytestream_uri_prefix:
             build_flags.append("--remote_bytestream_uri_prefix=" + remote_cache.bytestream_uri_prefix)
+
+    # `--remote_header` is the shared header Bazel applies to both the remote
+    # cache and the executor channel, so gate on the identity alone: this also
+    # covers executor-only setups, and Bazel ignores the flag with no backend.
+    if runner.identity:
+        build_flags.append("--remote_header=x-identity=" + runner.identity)
 
     build_flags.append("--repository_cache=" + runner.repository_cache_dir)
 


### PR DESCRIPTION
On Aspect Workflows runners, read `ASPECT_WORKFLOWS_RUNNER_IDENTITY` and send it as the `x-identity` header on a build's remote connections:

- BES stream: as gRPC metadata on the runtime's `bazel.build_events.grpc(...)` sink.
- Remote cache / remote execution: as `--remote_header=x-identity=<id>`, the shared header Bazel applies to both the cache and the executor channel. Gated on the identity alone, so executor-only setups (`--remote_executor` with no remote cache) are covered; on a local build with no remote backend Bazel ignores the flag.

The value is opaque and passed through unparsed. When the env var is unset, no header is sent and behavior is unchanged.

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- `bazel build //:cli` (the AXL builtins are embedded in the binary, so this parses and type-checks the edited sources). The header is emitted only when the env var is set, so existing runners are unaffected.
