### PR TITLE
fix(change-detection): refresh origin/<base> before merge-base resolution

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -847,10 +847,47 @@ def _ensure_local_sha(ctx, sha, cwd = None):
     recheck = process.command("git").args(["cat-file", "-e", sha]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
     return recheck.status.success
 
+def _is_shallow_repo(ctx, cwd):
+    """True when `cwd` is a shallow clone (`git rev-parse
+    --is-shallow-repository`). False on full clones and on any error
+    (treat unknown as full — a full fetch is correctness-safe, just
+    slower)."""
+    out = ctx.std.process.command("git").args(["rev-parse", "--is-shallow-repository"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
+    return out.status.success and out.stdout.strip() == "true"
+
+def _refresh_remote_ref(ctx, base_ref, cwd):
+    """Best-effort refresh of the `origin/<branch>` remote-tracking ref
+    BEFORE merge-base resolution, so a persistent runner reusing a clone
+    doesn't compute the merge-base against a stale base tip (the
+    over-detection bug: a stale `origin/main` is a valid-but-old ancestor,
+    so `git merge-base` "succeeds" and the diff sweeps in every commit the
+    base advanced past since the last fetch).
+
+    Only fires for remote-tracking refs (`origin/<branch>`) — a bare local
+    ref has nothing to fetch. Depth-aware: a full clone gets a plain
+    `git fetch origin <branch>` (cheap incremental pull that also brings the
+    common history a correct merge-base needs); a shallow clone keeps
+    `--depth=1` to preserve its shallow contract (the by-SHA fallback in
+    `_resolve_merge_base` deepens further only if needed). Non-fatal: any
+    failure (offline, no `origin`, unknown branch) falls through to the
+    existing resolution against whatever refs are already local."""
+    if not base_ref.startswith("origin/"):
+        return
+    remote_ref = base_ref[len("origin/"):]
+    if not remote_ref:
+        return
+    args = ["fetch", "origin", remote_ref]
+    if _is_shallow_repo(ctx, cwd):
+        args = ["fetch", "--depth=1", "origin", remote_ref]
+    ctx.std.process.command("git").args(args).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
+
 def _resolve_merge_base(ctx, base_ref, cwd = None):
     """Resolve a diff-base SHA for local-git change detection, layered
     fallbacks. Returns `(sha, source)` or `("", reason)`.
 
+    0. `_refresh_remote_ref` — refresh `origin/<branch>` up-front so step 1
+       computes the merge-base against the CURRENT base tip, not a stale
+       remote-tracking ref left over on a reused (persistent-runner) clone.
     1. `git merge-base HEAD <base_ref>` — result gates step 2:
          - distinct SHA → use it.
          - == HEAD → HEAD is on `base_ref`; set `head_on_base`, fall through
@@ -867,6 +904,8 @@ def _resolve_merge_base(ctx, base_ref, cwd = None):
     """
     process = ctx.std.process
     cwd = _git_cwd(ctx, cwd)
+
+    _refresh_remote_ref(ctx, base_ref, cwd)
 
     head_sha = _head_sha(ctx, cwd = cwd)
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github.axl
@@ -847,47 +847,51 @@ def _ensure_local_sha(ctx, sha, cwd = None):
     recheck = process.command("git").args(["cat-file", "-e", sha]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
     return recheck.status.success
 
+def _remote_branch_of(base_ref):
+    """The `origin/<branch>` → `<branch>` name `git fetch origin` wants, or
+    `""` for a bare local ref (nothing on a remote to fetch). `origin/` with
+    no branch also yields `""`."""
+    if not base_ref.startswith("origin/"):
+        return ""
+    return base_ref[len("origin/"):]
+
 def _is_shallow_repo(ctx, cwd):
     """True when `cwd` is a shallow clone (`git rev-parse
-    --is-shallow-repository`). False on full clones and on any error
-    (treat unknown as full — a full fetch is correctness-safe, just
-    slower)."""
+    --is-shallow-repository`). False on full clones and on any error."""
     out = ctx.std.process.command("git").args(["rev-parse", "--is-shallow-repository"]).current_dir(cwd).stdout("piped").stderr("null").spawn().wait_with_output()
     return out.status.success and out.stdout.strip() == "true"
 
 def _refresh_remote_ref(ctx, base_ref, cwd):
     """Best-effort refresh of the `origin/<branch>` remote-tracking ref
     BEFORE merge-base resolution, so a persistent runner reusing a clone
-    doesn't compute the merge-base against a stale base tip (the
-    over-detection bug: a stale `origin/main` is a valid-but-old ancestor,
-    so `git merge-base` "succeeds" and the diff sweeps in every commit the
-    base advanced past since the last fetch).
+    doesn't compute the merge-base against a stale base tip — a stale
+    `origin/main` is a valid-but-old ancestor, so `git merge-base` succeeds
+    and the diff sweeps in every commit the base advanced past since the
+    last fetch (the over-detection bug).
 
-    Only fires for remote-tracking refs (`origin/<branch>`) — a bare local
-    ref has nothing to fetch. Depth-aware: a full clone gets a plain
-    `git fetch origin <branch>` (cheap incremental pull that also brings the
-    common history a correct merge-base needs); a shallow clone keeps
-    `--depth=1` to preserve its shallow contract (the by-SHA fallback in
-    `_resolve_merge_base` deepens further only if needed). Non-fatal: any
-    failure (offline, no `origin`, unknown branch) falls through to the
-    existing resolution against whatever refs are already local."""
-    if not base_ref.startswith("origin/"):
+    Full clones only. The refresh is a plain `git fetch origin <branch>`
+    that advances the ref while pulling the connecting history a correct
+    merge-base needs. Shallow clones are skipped entirely: a `--depth=1`
+    fetch would move the ref to a tip with no ancestry, breaking the
+    merge-base walk and discarding a stale-but-still-usable base — worse
+    than leaving the ref alone. Shallow checkouts fall through to the
+    existing `_resolve_merge_base` fallbacks unchanged.
+
+    Non-fatal: a failed fetch (offline, no `origin`, unknown branch) leaves
+    whatever refs are already local and resolution proceeds against them."""
+    remote_ref = _remote_branch_of(base_ref)
+    if not remote_ref or _is_shallow_repo(ctx, cwd):
         return
-    remote_ref = base_ref[len("origin/"):]
-    if not remote_ref:
-        return
-    args = ["fetch", "origin", remote_ref]
-    if _is_shallow_repo(ctx, cwd):
-        args = ["fetch", "--depth=1", "origin", remote_ref]
-    ctx.std.process.command("git").args(args).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
+    ctx.std.process.command("git").args(["fetch", "origin", remote_ref]).current_dir(cwd).stdout("null").stderr("null").spawn().wait_with_output()
 
 def _resolve_merge_base(ctx, base_ref, cwd = None):
     """Resolve a diff-base SHA for local-git change detection, layered
     fallbacks. Returns `(sha, source)` or `("", reason)`.
 
-    0. `_refresh_remote_ref` — refresh `origin/<branch>` up-front so step 1
-       computes the merge-base against the CURRENT base tip, not a stale
-       remote-tracking ref left over on a reused (persistent-runner) clone.
+    0. `_refresh_remote_ref` — refresh `origin/<branch>` up-front (full
+       clones only) so step 1 computes the merge-base against the CURRENT
+       base tip, not a stale remote-tracking ref left over on a reused
+       (persistent-runner) clone.
     1. `git merge-base HEAD <base_ref>` — result gates step 2:
          - distinct SHA → use it.
          - == HEAD → HEAD is on `base_ref`; set `head_on_base`, fall through
@@ -928,9 +932,9 @@ def _resolve_merge_base(ctx, base_ref, cwd = None):
                 return parent_sha, "git rev-parse HEAD^1 (CI-synthesized merge commit first parent)"
             return parent_sha, "git rev-parse HEAD^1 (HEAD on %s)" % base_ref
 
-    # `git fetch origin <ref>` wants the remote ref name; strip the
-    # `origin/` prefix off the local remote-tracking `base_ref`.
-    remote_ref = base_ref[len("origin/"):] if base_ref.startswith("origin/") else base_ref
+    # `git fetch origin <ref>` wants the branch name; a bare local `base_ref`
+    # is itself the branch name to try.
+    remote_ref = _remote_branch_of(base_ref) or base_ref
     fetch = process.command("git").args(["fetch", "--depth=1", "origin", remote_ref]).current_dir(cwd).stdout("null").stderr("piped").spawn().wait_with_output()
     if fetch.status.success:
         retry = process.command("git").args(["merge-base", "HEAD", base_ref]).current_dir(cwd).stdout("piped").stderr("piped").spawn().wait_with_output()
@@ -952,6 +956,12 @@ def resolve_merge_base_for_test(ctx, base_ref, cwd):
     """Test seam for `_resolve_merge_base` against a scratch repo at `cwd`.
     Production goes through `detect_changed_files`."""
     return _resolve_merge_base(ctx, base_ref, cwd = cwd)
+
+def refresh_remote_ref_for_test(ctx, base_ref, cwd):
+    """Test seam for `_refresh_remote_ref` against a scratch repo at `cwd`,
+    to assert the step-0 refresh in isolation from the rest of
+    `_resolve_merge_base`."""
+    _refresh_remote_ref(ctx, base_ref, cwd)
 
 def _try_local_git_diff_from_base_sha(ctx, line_level, base_sha, head = "HEAD", cwd = None):
     """Run `git diff <base_sha> <head>` → `{files, skipped, source,
@@ -1247,7 +1257,7 @@ def detect_changed_files(ctx, line_level = True, base_ref = "", merge_base = Non
         else:
             warn(ctx.std, "%s — falling back to the GitHub PR Files API (consumes GitHub App API quota). To avoid this on future runs, ensure `origin/%s` is fetchable from the working tree (e.g. `fetch-depth: 2` in `actions/checkout`, or `git fetch origin <base>` on Buildkite / CircleCI)." % (
                 _local_diff_exhausted_prefix(diff_base_source),
-                base_ref[len("origin/"):] if base_ref.startswith("origin/") else base_ref,
+                _remote_branch_of(base_ref) or base_ref,
             ))
             result = list_pull_request_files(ctx, token, pr["owner"], pr["repo"], pr["pr_number"], fallback_token = fallback, token_class = token_class)
             if result["success"]:

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -37,6 +37,7 @@ load(
     "github",
     "head_is_synthesized_merge",
     "read_github_event",
+    "refresh_remote_ref_for_test",
     "resolve_merge_base_for_test",
     "synthesized_merge_diff_for_test",
 )
@@ -1016,6 +1017,46 @@ def _init_repo(ctx):
     base_sha = _commit_file(ctx, repo, "base.txt", "base\n", "base")
     return repo, base_sha
 
+def _clone_with_stale_origin(ctx, depth = None):
+    """Build an `upstream` repo, advance its `main` one commit past the
+    clone point, then clone it so the clone's `origin/main` is pinned at
+    that tip. The caller advances `upstream` further (and forks the PR)
+    without re-fetching, leaving `origin/main` stale — the persistent-runner
+    state. `depth` (e.g. 1) makes a shallow clone. Returns
+    `(repo, upstream, stale_tip)`; both dirs are the caller's to remove."""
+    upstream, _ = _init_repo(ctx)
+    stale_tip = _commit_file(ctx, upstream, "old.txt", "old\n", "stale origin/main tip")
+    repo = ctx.std.fs.mkdtemp(prefix = "axl-github-detect-stale-base-test-")
+
+    # `--depth` is ignored for local-path clones; the `file://` transport is
+    # required to actually produce a shallow clone.
+    args = ["clone", "-q"]
+    source = upstream
+    if depth != None:
+        args += ["--depth=%d" % depth]
+        source = "file://" + upstream
+    _git_ok(ctx, repo, args + [source, "."])
+    if _git_ok(ctx, repo, ["rev-parse", "origin/main"]) != stale_tip:
+        fail("stale-base — clone's origin/main should start at the stale tip")
+    return repo, upstream, stale_tip
+
+def _branch_off_and_checkout(ctx, repo, upstream, branch, name, content):
+    """In `upstream`, fork `branch` off the current `main` tip, commit one
+    file, then check that PR head out in `repo` by SHA (fetched on demand) —
+    mirroring a runner that checks out the PR head without refreshing
+    `origin/main`. The PR-head fetch preserves `repo`'s shallowness (a
+    shallow runner checkout stays shallow). Returns the PR head SHA."""
+    _git_ok(ctx, upstream, ["checkout", "-q", "-b", branch])
+    _commit_file(ctx, upstream, name, content, "the PR's only change")
+    pr_tip = _git_ok(ctx, upstream, ["rev-parse", "HEAD"])
+    _git_ok(ctx, upstream, ["checkout", "-q", "main"])
+    fetch = ["fetch", "-q"]
+    if _git_ok(ctx, repo, ["rev-parse", "--is-shallow-repository"]) == "true":
+        fetch += ["--depth=1"]
+    _git_ok(ctx, repo, fetch + ["origin", pr_tip])
+    _git_ok(ctx, repo, ["checkout", "-q", pr_tip])
+    return pr_tip
+
 def _test_resolve_merge_base_integration(ctx):
     # (1) The reported bug: a developer's own merge of the base branch
     # into a feature branch. main: B0 → B1 (advances after branching).
@@ -1121,46 +1162,65 @@ def _test_resolve_merge_base_integration(ctx):
         fail("synthesized-merge — single-parent SHA must yield None")
     ctx.std.fs.remove_dir_all(repo)
 
-    # (5) Stale `origin/<base>` on a reused (persistent-runner) clone — the
-    # over-detection bug. A runner keeps `origin/main` from an earlier job;
-    # between jobs the base advances and a PR forks off the NEW tip. Without
-    # the up-front ref refresh, `git merge-base HEAD origin/main` "succeeds"
-    # against the stale tip (a valid-but-old ancestor), so the diff sweeps in
-    # every base commit landed since the last fetch. `_refresh_remote_ref`
-    # re-fetches `origin/main` first, so only the PR's file is in scope.
-    upstream, _u0 = _init_repo(ctx)
-    _commit_file(ctx, upstream, "old.txt", "old\n", "advance to stale tip")
-    stale_tip = _git_ok(ctx, upstream, ["rev-parse", "HEAD"])
-
-    clone = ctx.std.fs.mkdtemp(prefix = "axl-github-detect-stale-base-test-")
-    _git_ok(ctx, clone, ["clone", "-q", upstream, "."])
-    # Pin the local remote-tracking ref to the stale tip, then advance the
-    # upstream past it (and branch the PR off the NEW tip) without re-fetching.
-    if _git_ok(ctx, clone, ["rev-parse", "origin/main"]) != stale_tip:
-        fail("stale-base — clone's origin/main should start at the stale tip")
+    # (5) Stale `origin/<base>` on a reused full-clone (persistent-runner) —
+    # the over-detection bug. The runner keeps `origin/main` from an earlier
+    # job; between jobs the base advances and the PR forks off the NEW tip.
+    # Without the up-front refresh, `git merge-base HEAD origin/main`
+    # "succeeds" against the stale tip (a valid-but-old ancestor), so the diff
+    # sweeps in every base commit landed since the last fetch.
+    # `_refresh_remote_ref` re-fetches `origin/main` first, so the merge-base
+    # is the real fork point and only the PR's file is in scope.
+    repo, upstream, stale_tip = _clone_with_stale_origin(ctx)
     new_base = _commit_file(ctx, upstream, "moved.txt", "moved\n", "base advances past stale tip")
-    _git_ok(ctx, upstream, ["checkout", "-q", "-b", "feature"])
-    _commit_file(ctx, upstream, "pr.txt", "pr\n", "the PR's only change")
-    pr_tip = _git_ok(ctx, upstream, ["rev-parse", "HEAD"])
-
-    # The runner checks out the PR head by SHA (fetched on demand), leaving
-    # origin/main stale — exactly the silo build's state.
-    _git_ok(ctx, clone, ["fetch", "-q", "origin", pr_tip])
-    _git_ok(ctx, clone, ["checkout", "-q", pr_tip])
-    if _git_ok(ctx, clone, ["rev-parse", "origin/main"]) != stale_tip:
+    pr_tip = _branch_off_and_checkout(ctx, repo, upstream, "feature", "pr.txt", "pr\n")
+    if _git_ok(ctx, repo, ["rev-parse", "origin/main"]) != stale_tip:
         fail("stale-base — origin/main must still be stale before resolution")
 
-    diff_base, source = resolve_merge_base_for_test(ctx, "origin/main", clone)
-    _eq("stale-base — diff base is the refreshed merge-base (new base), not the stale tip", diff_base, new_base)
-    if diff_base == stale_tip:
-        fail("stale-base — diff base must not be the stale origin/main tip")
+    diff_base, _source = resolve_merge_base_for_test(ctx, "origin/main", repo)
+    _eq("stale-base (full clone) — diff base is the refreshed fork point, not the stale tip", diff_base, new_base)
     _eq(
-        "stale-base — only the PR's file in scope (not the base-advance commits)",
-        _changed_files(ctx, clone, diff_base),
+        "stale-base (full clone) — only the PR's file in scope (not the base-advance commits)",
+        _changed_files(ctx, repo, diff_base),
         ["pr.txt"],
     )
-    ctx.std.fs.remove_dir_all(clone)
+    if _git_ok(ctx, repo, ["rev-parse", "--is-shallow-repository"]) != "false":
+        fail("stale-base (full clone) — refresh must not convert a full clone to shallow")
+    ctx.std.fs.remove_dir_all(repo)
     ctx.std.fs.remove_dir_all(upstream)
+
+    # (6) The step-0 refresh itself, in isolation (`_refresh_remote_ref`).
+    #  - Full clone: advances a stale `origin/main` to the current tip while
+    #    staying full, so merge-base keeps a connected base.
+    #  - Shallow clone: skipped. A `--depth=1` fetch would move `origin/main`
+    #    to a tip with no connecting history, breaking the merge-base walk and
+    #    discarding the stale-but-still-usable base — so the ref is left alone
+    #    (the existing `_resolve_merge_base` fallbacks handle shallow as before).
+    repo, upstream, stale_tip = _clone_with_stale_origin(ctx)
+    moved = _commit_file(ctx, upstream, "moved.txt", "moved\n", "base advances")
+    refresh_remote_ref_for_test(ctx, "origin/main", repo)
+    _eq("refresh (full clone) — advances stale origin/main to the current tip", _git_ok(ctx, repo, ["rev-parse", "origin/main"]), moved)
+    if _git_ok(ctx, repo, ["rev-parse", "--is-shallow-repository"]) != "false":
+        fail("refresh (full clone) — must not convert a full clone to shallow")
+    ctx.std.fs.remove_dir_all(repo)
+    ctx.std.fs.remove_dir_all(upstream)
+
+    repo, upstream, stale_tip = _clone_with_stale_origin(ctx, depth = 1)
+    if _git_ok(ctx, repo, ["rev-parse", "--is-shallow-repository"]) != "true":
+        fail("refresh (shallow) — clone should be shallow")
+    _commit_file(ctx, upstream, "moved.txt", "moved\n", "base advances")
+    refresh_remote_ref_for_test(ctx, "origin/main", repo)
+    _eq("refresh (shallow) — skipped, origin/main left at the stale tip", _git_ok(ctx, repo, ["rev-parse", "origin/main"]), stale_tip)
+    ctx.std.fs.remove_dir_all(repo)
+    ctx.std.fs.remove_dir_all(upstream)
+
+    # (7) Bare local base ref (no `origin/` prefix) — refresh is a no-op
+    # (nothing on a remote to fetch) and resolution still finds the fork point.
+    repo, b0 = _init_repo(ctx)
+    _git_ok(ctx, repo, ["checkout", "-q", "-b", "feature"])
+    _commit_file(ctx, repo, "c1.txt", "c1\n", "c1")
+    diff_base, _source = resolve_merge_base_for_test(ctx, "main", repo)
+    _eq("bare-local-ref — diff base is the fork point", diff_base, b0)
+    ctx.std.fs.remove_dir_all(repo)
 
 github_detect_tests = task(
     name = "test-github-detect",

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -19,7 +19,8 @@ fake env (dict-backed) and a fake fs (path → content dict). The
 integration section is the exception: it builds real scratch git repos
 with `git` subprocesses to exercise diff-base resolution end to end —
 `_resolve_merge_base` (merge-base / HEAD^1, incl. the developer-merge
-under-scoping case) and the synthesized-merge-by-SHA path
+under-scoping case and the stale-`origin/<base>` over-detection case on
+reused persistent-runner clones) and the synthesized-merge-by-SHA path
 (`synthesized_merge_diff_for_test`).
 
 Run with:
@@ -1119,6 +1120,47 @@ def _test_resolve_merge_base_integration(ctx):
     if synthesized_merge_diff_for_test(ctx, False, b0, repo) != None:
         fail("synthesized-merge — single-parent SHA must yield None")
     ctx.std.fs.remove_dir_all(repo)
+
+    # (5) Stale `origin/<base>` on a reused (persistent-runner) clone — the
+    # over-detection bug. A runner keeps `origin/main` from an earlier job;
+    # between jobs the base advances and a PR forks off the NEW tip. Without
+    # the up-front ref refresh, `git merge-base HEAD origin/main` "succeeds"
+    # against the stale tip (a valid-but-old ancestor), so the diff sweeps in
+    # every base commit landed since the last fetch. `_refresh_remote_ref`
+    # re-fetches `origin/main` first, so only the PR's file is in scope.
+    upstream, _u0 = _init_repo(ctx)
+    _commit_file(ctx, upstream, "old.txt", "old\n", "advance to stale tip")
+    stale_tip = _git_ok(ctx, upstream, ["rev-parse", "HEAD"])
+
+    clone = ctx.std.fs.mkdtemp(prefix = "axl-github-detect-stale-base-test-")
+    _git_ok(ctx, clone, ["clone", "-q", upstream, "."])
+    # Pin the local remote-tracking ref to the stale tip, then advance the
+    # upstream past it (and branch the PR off the NEW tip) without re-fetching.
+    if _git_ok(ctx, clone, ["rev-parse", "origin/main"]) != stale_tip:
+        fail("stale-base — clone's origin/main should start at the stale tip")
+    new_base = _commit_file(ctx, upstream, "moved.txt", "moved\n", "base advances past stale tip")
+    _git_ok(ctx, upstream, ["checkout", "-q", "-b", "feature"])
+    _commit_file(ctx, upstream, "pr.txt", "pr\n", "the PR's only change")
+    pr_tip = _git_ok(ctx, upstream, ["rev-parse", "HEAD"])
+
+    # The runner checks out the PR head by SHA (fetched on demand), leaving
+    # origin/main stale — exactly the silo build's state.
+    _git_ok(ctx, clone, ["fetch", "-q", "origin", pr_tip])
+    _git_ok(ctx, clone, ["checkout", "-q", pr_tip])
+    if _git_ok(ctx, clone, ["rev-parse", "origin/main"]) != stale_tip:
+        fail("stale-base — origin/main must still be stale before resolution")
+
+    diff_base, source = resolve_merge_base_for_test(ctx, "origin/main", clone)
+    _eq("stale-base — diff base is the refreshed merge-base (new base), not the stale tip", diff_base, new_base)
+    if diff_base == stale_tip:
+        fail("stale-base — diff base must not be the stale origin/main tip")
+    _eq(
+        "stale-base — only the PR's file in scope (not the base-advance commits)",
+        _changed_files(ctx, clone, diff_base),
+        ["pr.txt"],
+    )
+    ctx.std.fs.remove_dir_all(clone)
+    ctx.std.fs.remove_dir_all(upstream)
 
 github_detect_tests = task(
     name = "test-github-detect",


### PR DESCRIPTION
## Summary

On a persistent CI runner that reuses a clone across jobs, the local `origin/<base>` remote-tracking ref can be stale — a prior job left it behind the current base tip, and the new job checks out the PR head by SHA without re-fetching the base branch. `_resolve_merge_base` then ran `git merge-base HEAD origin/main` against the stale ref. Because a stale tip is a *valid-but-old ancestor*, merge-base **succeeds** and returns it, so the resulting `git diff <stale-base>..HEAD` sweeps in every commit the base advanced past since the last fetch.

Observed in a 1-file PR that reported 92 changed files — exactly the files touched by the commits between the stale `origin/main` tip and the true merge-base.

The fix refreshes `origin/<base>` up-front in `_resolve_merge_base`, before the first merge-base, so resolution runs against the current base tip:

- **Full clones only.** A plain `git fetch origin <branch>` advances the ref while pulling the connecting history a correct merge-base needs.
- **Shallow clones are skipped.** A `--depth=1` fetch would move the ref to a tip with no ancestry, breaking the merge-base walk and discarding a stale-but-still-usable base; shallow checkouts fall through to the existing fallbacks unchanged.
- **Non-fatal** and scoped to `origin/<branch>` refs — offline / no `origin` / unknown branch / bare local ref all proceed as before.

`base_ref` itself is resolved (unchanged) from the PR/MR's actual target branch (`GITHUB_BASE_REF` / `BUILDKITE_PULL_REQUEST_BASE_BRANCH` / `CI_MERGE_REQUEST_TARGET_BRANCH_NAME`), so non-default base branches are refreshed correctly.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fixed over-detection of changed files on persistent CI runners, where a stale `origin/<base>` ref left from a previous job caused change detection to diff against an outdated base and scope in unrelated files.

### Test plan

- New test cases added (`test-github-detect`): stale-`origin/<base>` over-detection on a reused full clone, the shallow-clone skip, the full-clone refresh advancing the ref without un-fulling it, and the bare-local-ref no-op. Verified the over-detection case fails without the up-front refresh and passes with it.
