### PR TITLE
feat(status): per-failure repro commands + repro_flavors/fix_flavors controls

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -24,9 +24,9 @@ load(
     "extract_changed_dirs",
 )
 load("@aspect//lib/github.axl", "detect_commit_sha", "github")
+load("@aspect//lib/lifecycle.axl", "ReproFixCommand")
 load("@aspect//lib/log_snippet.axl", "SnippetOptions", "code_fence_for", "extract_junit_failure", "extract_snippet")
 load("@aspect//lib/path_glob.axl", "match_any", "match_path")
-load("@aspect//lib/lifecycle.axl", "ReproFixCommand")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "dedup_and_attribute", "patch_download_cmd", "task_cli_path")
 load("@aspect//lib/result_text.axl", "severity_for_status")
 load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
@@ -3296,6 +3296,7 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     r["bazel"]["failed_targets"] = [{"label": "//pkg:broken"}]
     r["bazel"]["target_kinds"] = {"//pkg:fail_test": "py_test", "//pkg:broken": "cc_library"}
     r["bazel"]["targets_total"] = 2
+
     # Combined repro (target == "") + per-failure repros (target set). The
     # producer + hook normally populate these; set directly for the render test.
     r["repro_commands"] = [
@@ -3320,6 +3321,7 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     tc = test_case(tc, "aspect test -- //pkg:fail_test" in out["text"], "render: per-failure aspect repro inline")
     tc = test_case(tc, "bazel test -- //pkg:fail_test" in out["text"], "render: per-failure vanilla repro inline")
     tc = test_case(tc, "aspect build -- //pkg:broken" in out["text"], "render: per-failure action repro inline")
+
     # The combined "🔁 Reproduce" section shows only the whole-run (target == "")
     # command; the per-failure ones don't double-render there.
     _repro_section = out["text"][out["text"].find("🔁 Reproduce"):] if "🔁 Reproduce" in out["text"] else ""

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3317,7 +3317,9 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     tc = test_case(tc, "❌ cc_library `//pkg:broken` failed to build:" in out["text"], "render: build snippet header (kind + label)")
 
     # Per-failure repro commands render inline beneath their failure's snippet,
-    # correlated by label (both flavors for the test, aspect for the action).
+    # under a "Reproduce with:" lead, correlated by label (both flavors for the
+    # test, aspect for the action).
+    tc = test_case(tc, "Reproduce with:" in out["text"], "render: per-failure repros lead with 'Reproduce with:'")
     tc = test_case(tc, "aspect test -- //pkg:fail_test" in out["text"], "render: per-failure aspect repro inline")
     tc = test_case(tc, "bazel test -- //pkg:fail_test" in out["text"], "render: per-failure vanilla repro inline")
     tc = test_case(tc, "aspect build -- //pkg:broken" in out["text"], "render: per-failure action repro inline")
@@ -3355,6 +3357,12 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     r2["bazel"]["targets_total"] = 3
     out2 = render_check_output(ctx, r2, "failed", render_ctx, links, snippet_options = SnippetOptions(max_lines = 15), max_snippets = 1)
     tc = test_case(tc, "more failure" in out2["text"] and "output not shown" in out2["text"], "render: budget overflow note shown")
+
+    # The overflow note renders BEFORE the <pre> table that lists the
+    # snippet-less labels (so the reader sees "output not shown" then the rows).
+    _ov = out2["text"].find("output not shown")
+    _tbl = out2["text"].find("<pre>", _ov)
+    tc = test_case(tc, _ov >= 0 and _tbl > _ov, "render: overflow note precedes the failures table")
 
     # Truncation markers: a long no-marker log keeps the tail and shows a leading
     # `…` for the dropped head (max_lines small forces windowing).

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3300,9 +3300,9 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     # producer + hook normally populate these; set directly for the render test.
     r["repro_commands"] = [
         ReproFixCommand(command = "aspect test -- //...", slug = "bazel-repro-aspect"),
-        ReproFixCommand(command = "aspect test -- //pkg:fail_test", slug = "bazel-repro-aspect-failure", target = "//pkg:fail_test"),
-        ReproFixCommand(command = "bazel test -- //pkg:fail_test", description = "vanilla bazel", slug = "bazel-repro-vanilla-bazel-failure", target = "//pkg:fail_test"),
-        ReproFixCommand(command = "aspect build -- //pkg:broken", slug = "bazel-repro-aspect-failure", target = "//pkg:broken"),
+        ReproFixCommand(command = "aspect test -- //pkg:fail_test", slug = "bazel-repro-aspect", target = "//pkg:fail_test"),
+        ReproFixCommand(command = "bazel test -- //pkg:fail_test", description = "vanilla bazel", slug = "bazel-repro-vanilla-bazel", target = "//pkg:fail_test"),
+        ReproFixCommand(command = "aspect build -- //pkg:broken", slug = "bazel-repro-aspect", target = "//pkg:broken"),
     ]
 
     out = render_check_output(ctx, r, "failed", render_ctx, links, snippet_options = opts, max_snippets = max_snips)

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3299,10 +3299,10 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     # Combined repro (target == "") + per-failure repros (target set). The
     # producer + hook normally populate these; set directly for the render test.
     r["repro_commands"] = [
-        ReproFixCommand(command = "aspect test -- //...", slug = "bazel-repro-aspect"),
-        ReproFixCommand(command = "aspect test -- //pkg:fail_test", slug = "bazel-repro-aspect", target = "//pkg:fail_test"),
-        ReproFixCommand(command = "bazel test -- //pkg:fail_test", description = "vanilla bazel", slug = "bazel-repro-vanilla-bazel", target = "//pkg:fail_test"),
-        ReproFixCommand(command = "aspect build -- //pkg:broken", slug = "bazel-repro-aspect", target = "//pkg:broken"),
+        ReproFixCommand(command = "aspect test -- //...", slug = "test-repro-aspect"),
+        ReproFixCommand(command = "aspect test -- //pkg:fail_test", slug = "test-repro-aspect", target = "//pkg:fail_test"),
+        ReproFixCommand(command = "bazel test -- //pkg:fail_test", description = "vanilla bazel", slug = "test-repro-vanilla-bazel", target = "//pkg:fail_test"),
+        ReproFixCommand(command = "aspect build -- //pkg:broken", slug = "build-repro-aspect", target = "//pkg:broken"),
     ]
 
     out = render_check_output(ctx, r, "failed", render_ctx, links, snippet_options = opts, max_snippets = max_snips)

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -26,6 +26,7 @@ load(
 load("@aspect//lib/github.axl", "detect_commit_sha", "github")
 load("@aspect//lib/log_snippet.axl", "SnippetOptions", "code_fence_for", "extract_junit_failure", "extract_snippet")
 load("@aspect//lib/path_glob.axl", "match_any", "match_path")
+load("@aspect//lib/lifecycle.axl", "ReproFixCommand")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "dedup_and_attribute", "patch_download_cmd", "task_cli_path")
 load("@aspect//lib/result_text.axl", "severity_for_status")
 load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
@@ -3295,6 +3296,14 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     r["bazel"]["failed_targets"] = [{"label": "//pkg:broken"}]
     r["bazel"]["target_kinds"] = {"//pkg:fail_test": "py_test", "//pkg:broken": "cc_library"}
     r["bazel"]["targets_total"] = 2
+    # Combined repro (target == "") + per-failure repros (target set). The
+    # producer + hook normally populate these; set directly for the render test.
+    r["repro_commands"] = [
+        ReproFixCommand(command = "aspect test -- //...", slug = "bazel-repro-aspect"),
+        ReproFixCommand(command = "aspect test -- //pkg:fail_test", slug = "bazel-repro-aspect-failure", target = "//pkg:fail_test"),
+        ReproFixCommand(command = "bazel test -- //pkg:fail_test", description = "vanilla bazel", slug = "bazel-repro-vanilla-bazel-failure", target = "//pkg:fail_test"),
+        ReproFixCommand(command = "aspect build -- //pkg:broken", slug = "bazel-repro-aspect-failure", target = "//pkg:broken"),
+    ]
 
     out = render_check_output(ctx, r, "failed", render_ctx, links, snippet_options = opts, max_snippets = max_snips)
     tc = test_case(tc, "FAILED: expected 1 got 2" in out["text"], "render: inlines failed-test log snippet")
@@ -3305,6 +3314,17 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     # for tests, "failed to build" for actions).
     tc = test_case(tc, "❌ py_test `//pkg:fail_test` failed in 3s:" in out["text"], "render: test snippet header (kind + label + duration)")
     tc = test_case(tc, "❌ cc_library `//pkg:broken` failed to build:" in out["text"], "render: build snippet header (kind + label)")
+
+    # Per-failure repro commands render inline beneath their failure's snippet,
+    # correlated by label (both flavors for the test, aspect for the action).
+    tc = test_case(tc, "aspect test -- //pkg:fail_test" in out["text"], "render: per-failure aspect repro inline")
+    tc = test_case(tc, "bazel test -- //pkg:fail_test" in out["text"], "render: per-failure vanilla repro inline")
+    tc = test_case(tc, "aspect build -- //pkg:broken" in out["text"], "render: per-failure action repro inline")
+    # The combined "🔁 Reproduce" section shows only the whole-run (target == "")
+    # command; the per-failure ones don't double-render there.
+    _repro_section = out["text"][out["text"].find("🔁 Reproduce"):] if "🔁 Reproduce" in out["text"] else ""
+    tc = test_case(tc, "aspect test -- //..." in _repro_section, "render: combined Reproduce shows whole-run command")
+    tc = test_case(tc, "//pkg:fail_test" not in _repro_section, "render: combined Reproduce excludes per-failure commands")
 
     # The snippet-shown labels are NOT also listed in the <pre> table (no dup).
     tc = test_case(tc, "<summary><code>//pkg:fail_test</code> output</summary>" not in out["text"], "render: no nested per-row <details>")

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -6,9 +6,9 @@ load("./bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_B
 load("./lib/artifacts.axl", "artifacts")
 load("./lib/bazel_flags.axl", "announce_bazel_args")
 load("./lib/bazel_runner.axl", "run_bazel_task")
-load("./lib/repro_commands.axl", "repro_flavor_args")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "TaskLifecycleTrait")
+load("./lib/repro_commands.axl", "repro_flavor_args")
 load("./lib/tips.axl", "tips")
 
 def _impl(ctx: TaskContext) -> int | TaskConclusion:

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -6,6 +6,7 @@ load("./bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_B
 load("./lib/artifacts.axl", "artifacts")
 load("./lib/bazel_flags.axl", "announce_bazel_args")
 load("./lib/bazel_runner.axl", "run_bazel_task")
+load("./lib/repro_commands.axl", "repro_flavor_args")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "TaskLifecycleTrait")
 load("./lib/tips.axl", "tips")
@@ -50,7 +51,7 @@ build = task(
             default = False,
             description = "Cancel any running Bazel invocation before starting the build.",
         ),
-    } | announce_bazel_args("the build"),
+    } | announce_bazel_args("the build") | repro_flavor_args(),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -840,7 +840,7 @@ def _collect_repro_fix_rows(sections):
                 for c in e.get(command_field, []) or []:
                     # Per-failure (target-set) commands render inline under their
                     # snippet, not in the combined Reproduce/Fix section.
-                    if not c.command or (getattr(c, "target", "") or ""):
+                    if not c.command or c.target:
                         continue
                     entries.append({
                         "kind": kind,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -171,6 +171,12 @@ _No tasks have reported yet._
 {% endif %}{{ s.snippet }}
 {% if s.trunc_tail %}…
 {% endif %}{{ s.fence }}
+{%- for r in s.repros %}
+```
+{% if r.description %}# {{ r.description }}
+{% endif %}{{ r.command }}
+```
+{%- endfor %}
 {% if s.task_label %}<sub>in {{ s.task_noun }} {{ s.task_label }}</sub>
 {% endif %}
 {% endmacro -%}
@@ -707,6 +713,10 @@ def _select_snippets(entries, shown_keys):
                     "kind": s.get("kind", ""),
                     "bucket": s.get("bucket", "test"),
                     "duration_ms": s.get("duration_ms", 0) or 0,
+                    # Per-failure repro commands [{command, description}] for this
+                    # label; rendered inline under the snippet. First contributor
+                    # wins (same label+content ⇒ same producer's repros).
+                    "repros": s.get("repros", []) or [],
                     "snippet": snippet_text,
                     "truncated": bool(s.get("truncated", False)),
                     "trunc_head": bool(s.get("trunc_head", False)),
@@ -828,7 +838,9 @@ def _collect_repro_fix_rows(sections):
                 kind = e.get("name", "") or ""
                 task_key = e.get("key", "") or kind
                 for c in e.get(command_field, []) or []:
-                    if not c.command:
+                    # Per-failure (target-set) commands render inline under their
+                    # snippet, not in the combined Reproduce/Fix section.
+                    if not c.command or (getattr(c, "target", "") or ""):
                         continue
                     entries.append({
                         "kind": kind,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -171,13 +171,16 @@ _No tasks have reported yet._
 {% endif %}{{ s.snippet }}
 {% if s.trunc_tail %}…
 {% endif %}{{ s.fence }}
-{%- for r in s.repros %}
+{% if s.task_label %}<sub>in {{ s.task_noun }} {{ s.task_label }}</sub>
+{% endif %}
+{%- if s.repros %}
+Reproduce with:
+{% for r in s.repros %}
 ```
 {% if r.description %}# {{ r.description }}
 {% endif %}{{ r.command }}
 ```
 {%- endfor %}
-{% if s.task_label %}<sub>in {{ s.task_noun }} {{ s.task_label }}</sub>
 {% endif %}
 {% endmacro -%}
 {% if build_snippets %}

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -735,7 +735,7 @@ def _check_state_serialize_round_trip():
     _eq("round-trip shown_repros", parsed["shown_repros"], state["shown_repros"])
     _eq("round-trip shown_fixes", parsed["shown_fixes"], state["shown_fixes"])
 
-def _snip(label, bucket = "test", text = "boom", truncated = False, kind = "", trunc_head = False, trunc_tail = False, duration_ms = 0):
+def _snip(label, bucket = "test", text = "boom", truncated = False, kind = "", trunc_head = False, trunc_tail = False, duration_ms = 0, repros = None):
     # kind defaults to the bucket word ("build"/"test") used in the header line.
     return {
         "label": label,
@@ -746,6 +746,7 @@ def _snip(label, bucket = "test", text = "boom", truncated = False, kind = "", t
         "trunc_tail": trunc_tail,
         "kind": kind or ("build" if bucket == "build" else "test"),
         "duration_ms": duration_ms,
+        "repros": repros or [],
     }
 
 def _entry_with_snippets(key, snippets):
@@ -834,7 +835,9 @@ def _check_select_snippets(ctx):
     prepared = prepare_for_render([failed_entry])
     snip_entry = _entry_with_snippets("test-task", [
         _snip("//pkg:broken", "build", "no member named 'foo'", kind = "genrule"),
-        _snip("//pkg:fail_test", "test", "FAILED: expected 1 got 2", kind = "sh_test", duration_ms = 149),
+        _snip("//pkg:fail_test", "test", "FAILED: expected 1 got 2", kind = "sh_test", duration_ms = 149,
+              repros = [{"command": "aspect test -- //pkg:fail_test", "description": ""},
+                        {"command": "bazel test -- //pkg:fail_test", "description": "vanilla bazel"}]),
         _snip("//pkg:slow_test", "timeout", "timed out after 60s", kind = "sh_test", duration_ms = 60000),
     ])
     sel_rows, _, _ = select_snippets([snip_entry], [])
@@ -872,6 +875,15 @@ def _check_select_snippets(ctx):
     )
     _eq("select: render includes snippet text", "FAILED: expected 1 got 2" in body, True)
     _eq("select: no per-row <details>", "<details open><summary>" not in body, True)
+    # Per-failure repros render inline beneath the snippet, both flavors, and
+    # before the contributing-task <sub> line.
+    _eq("select: per-failure aspect repro inline", "aspect test -- //pkg:fail_test" in body, True)
+    _eq("select: per-failure vanilla repro inline", "bazel test -- //pkg:fail_test" in body, True)
+    # The test snippet's repros sit between its fence-close and its <sub> line —
+    # the vanilla repro precedes the FIRST <sub> that follows the test snippet.
+    _ts = body.find("`//pkg:fail_test` failed in 149ms:")
+    _eq("select: repros render above the snippet's <sub> task line",
+        body.find("bazel test -- //pkg:fail_test", _ts) < body.find("<sub>in task test-task</sub>", _ts), True)
 
     # Overflow note lists the task holding the hidden failure (1 distinct dropped).
     over_snips = [_snip("//pkg:t%d" % i, "test", "boom %d" % i) for i in range(6)]

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -884,17 +884,20 @@ def _check_select_snippets(ctx):
     _eq("select: render includes snippet text", "FAILED: expected 1 got 2" in body, True)
     _eq("select: no per-row <details>", "<details open><summary>" not in body, True)
 
-    # Per-failure repros render inline beneath the snippet, both flavors, and
-    # before the contributing-task <sub> line.
+    # Per-failure repros render inline beneath the snippet, both flavors, under
+    # a "Reproduce with:" lead.
     _eq("select: per-failure aspect repro inline", "aspect test -- //pkg:fail_test" in body, True)
     _eq("select: per-failure vanilla repro inline", "bazel test -- //pkg:fail_test" in body, True)
+    _eq("select: repros lead with 'Reproduce with:'", "Reproduce with:" in body, True)
 
-    # The test snippet's repros sit between its fence-close and its <sub> line —
-    # the vanilla repro precedes the FIRST <sub> that follows the test snippet.
+    # Order within the test snippet block: contributing-task <sub> line first,
+    # then the "Reproduce with:" repros (so attribution sits right under the
+    # snippet and the actionable commands come last).
     _ts = body.find("`//pkg:fail_test` failed in 149ms:")
+    _sub = body.find("<sub>in task test-task</sub>", _ts)
     _eq(
-        "select: repros render above the snippet's <sub> task line",
-        body.find("bazel test -- //pkg:fail_test", _ts) < body.find("<sub>in task test-task</sub>", _ts),
+        "select: <sub> task line precedes the repros",
+        _sub < body.find("Reproduce with:", _ts) and body.find("Reproduce with:", _ts) < body.find("bazel test -- //pkg:fail_test", _ts),
         True,
     )
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -835,9 +835,17 @@ def _check_select_snippets(ctx):
     prepared = prepare_for_render([failed_entry])
     snip_entry = _entry_with_snippets("test-task", [
         _snip("//pkg:broken", "build", "no member named 'foo'", kind = "genrule"),
-        _snip("//pkg:fail_test", "test", "FAILED: expected 1 got 2", kind = "sh_test", duration_ms = 149,
-              repros = [{"command": "aspect test -- //pkg:fail_test", "description": ""},
-                        {"command": "bazel test -- //pkg:fail_test", "description": "vanilla bazel"}]),
+        _snip(
+            "//pkg:fail_test",
+            "test",
+            "FAILED: expected 1 got 2",
+            kind = "sh_test",
+            duration_ms = 149,
+            repros = [
+                {"command": "aspect test -- //pkg:fail_test", "description": ""},
+                {"command": "bazel test -- //pkg:fail_test", "description": "vanilla bazel"},
+            ],
+        ),
         _snip("//pkg:slow_test", "timeout", "timed out after 60s", kind = "sh_test", duration_ms = 60000),
     ])
     sel_rows, _, _ = select_snippets([snip_entry], [])
@@ -875,15 +883,20 @@ def _check_select_snippets(ctx):
     )
     _eq("select: render includes snippet text", "FAILED: expected 1 got 2" in body, True)
     _eq("select: no per-row <details>", "<details open><summary>" not in body, True)
+
     # Per-failure repros render inline beneath the snippet, both flavors, and
     # before the contributing-task <sub> line.
     _eq("select: per-failure aspect repro inline", "aspect test -- //pkg:fail_test" in body, True)
     _eq("select: per-failure vanilla repro inline", "bazel test -- //pkg:fail_test" in body, True)
+
     # The test snippet's repros sit between its fence-close and its <sub> line —
     # the vanilla repro precedes the FIRST <sub> that follows the test snippet.
     _ts = body.find("`//pkg:fail_test` failed in 149ms:")
-    _eq("select: repros render above the snippet's <sub> task line",
-        body.find("bazel test -- //pkg:fail_test", _ts) < body.find("<sub>in task test-task</sub>", _ts), True)
+    _eq(
+        "select: repros render above the snippet's <sub> task line",
+        body.find("bazel test -- //pkg:fail_test", _ts) < body.find("<sub>in task test-task</sub>", _ts),
+        True,
+    )
 
     # Overflow note lists the task holding the hidden failure (1 distinct dropped).
     over_snips = [_snip("//pkg:t%d" % i, "test", "boom %d" % i) for i in range(6)]

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -30,7 +30,7 @@ load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
 load("./lib/path_normalize.axl", "normalize_files_for_cwd")
-load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_prefix", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
 load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
@@ -248,6 +248,9 @@ def _emit_final(ctx, lifecycle, data, exit_code):
 
     _append_repro_command(ctx, data)
     _append_fix_commands(ctx, data)
+    # Honor the repro_flavors / fix_flavors controls (aspect | bazel | both).
+    data["repro_commands"] = filter_by_flavor(data["repro_commands"], ctx.args.repro_flavors)
+    data["fix_commands"] = filter_by_flavor(data["fix_commands"], ctx.args.fix_flavors)
 
     bookend = format_conclusion(status, data)
 
@@ -707,7 +710,7 @@ format = task(
             maximum = 4096,
             minimum = 0,
         ),
-    } | announce_bazel_args("the formatter build"),
+    } | announce_bazel_args("the formatter build") | repro_flavor_args(include_fix = True),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -249,7 +249,7 @@ def _emit_final(ctx, lifecycle, data, exit_code):
     _append_repro_command(ctx, data)
     _append_fix_commands(ctx, data)
 
-    # Honor the repro_flavors / fix_flavors controls (aspect | bazel | both).
+    # Honor the repro_flavors / fix_flavors controls (a list of aspect / bazel).
     data["repro_commands"] = filter_by_flavor(data["repro_commands"], ctx.args.repro_flavors)
     data["fix_commands"] = filter_by_flavor(data["fix_commands"], ctx.args.fix_flavors)
 

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -248,6 +248,7 @@ def _emit_final(ctx, lifecycle, data, exit_code):
 
     _append_repro_command(ctx, data)
     _append_fix_commands(ctx, data)
+
     # Honor the repro_flavors / fix_flavors controls (aspect | bazel | both).
     data["repro_commands"] = filter_by_flavor(data["repro_commands"], ctx.args.repro_flavors)
     data["fix_commands"] = filter_by_flavor(data["fix_commands"], ctx.args.fix_flavors)

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -381,6 +381,7 @@ def _emit_final(ctx, lifecycle, data, exit_code):
 
     _append_repro_command(ctx, data)
     _append_fix_commands(ctx, data)
+
     # Honor the repro_flavors / fix_flavors controls (aspect | bazel | both).
     data["repro_commands"] = filter_by_flavor(data["repro_commands"], ctx.args.repro_flavors)
     data["fix_commands"] = filter_by_flavor(data["fix_commands"], ctx.args.fix_flavors)

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -94,7 +94,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
-load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_prefix", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
 load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
@@ -381,6 +381,9 @@ def _emit_final(ctx, lifecycle, data, exit_code):
 
     _append_repro_command(ctx, data)
     _append_fix_commands(ctx, data)
+    # Honor the repro_flavors / fix_flavors controls (aspect | bazel | both).
+    data["repro_commands"] = filter_by_flavor(data["repro_commands"], ctx.args.repro_flavors)
+    data["fix_commands"] = filter_by_flavor(data["fix_commands"], ctx.args.fix_flavors)
 
     bookend = gazelle_conclusion(status, data)
 
@@ -744,7 +747,7 @@ gazelle = task(
             description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
             long = "bazel-startup-flag",
         ),
-    } | announce_bazel_args("the gazelle build"),
+    } | announce_bazel_args("the gazelle build") | repro_flavor_args(include_fix = True),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -382,7 +382,7 @@ def _emit_final(ctx, lifecycle, data, exit_code):
     _append_repro_command(ctx, data)
     _append_fix_commands(ctx, data)
 
-    # Honor the repro_flavors / fix_flavors controls (aspect | bazel | both).
+    # Honor the repro_flavors / fix_flavors controls (a list of aspect / bazel).
     data["repro_commands"] = filter_by_flavor(data["repro_commands"], ctx.args.repro_flavors)
     data["fix_commands"] = filter_by_flavor(data["fix_commands"], ctx.args.fix_flavors)
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -2689,7 +2689,13 @@ SNIPPET_MACRO = """{% macro failure_snippets(rows) %}
 {% endif %}{{ t.snippet }}
 {% if t.snippet_trunc_tail %}…
 {% endif %}{{ t.snippet_fence }}
-{% endif %}{%- endfor %}
+{% endif %}
+{%- for r in t.repros %}
+```
+{% if r.description %}# {{ r.description }}
+{% endif %}{{ r.command }}
+```
+{%- endfor %}{%- endfor %}
 {%- endmacro %}"""
 
 # Bazel-targets detail block: build failures (root + dep-broken),
@@ -3485,6 +3491,8 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
             if not entry.get("kind"):
                 entry["kind"] = target_kinds_map.get(original_label, "")
             entry["label"] = _truncate_label(original_label)
+            # Untruncated label, for correlating per-failure repro commands.
+            entry["_orig_label"] = original_label
             out.append(entry)
         return out
 
@@ -3639,6 +3647,8 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         mnemonics = a.get("mnemonics", []) or []
         row = {
             "label": _truncate_label(original_label),
+            # Untruncated label, for correlating per-failure repro commands.
+            "_orig_label": original_label,
             "kind": target_kinds_map.get(original_label, ""),
             "mnemonic": ", ".join(mnemonics),
         }
@@ -3691,6 +3701,25 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
     _decorate_snippet_verb(_build_failures_snippets, "failed to build", "")
     _decorate_snippet_verb(_failed_snippets, "failed", "in")
     _decorate_snippet_verb(_timeout_snippets, "timed out", "after")
+
+    # Per-failure repro commands (target-set entries in repro_commands, after the
+    # repro_fix_suggestion hook) attach to their snippet row, keyed by the
+    # untruncated label, and render inline beneath the snippet. Combined
+    # (target == "") entries stay in the "🔁 Reproduce" section (see
+    # repro_commands filtering below).
+    _repro_by_target = {}
+    for c in data.get("repro_commands", []) or []:
+        tgt = getattr(c, "target", "") or ""
+        if tgt:
+            _repro_by_target.setdefault(tgt, []).append({"command": c.command, "description": c.description})
+
+    def _attach_repros(rows):
+        for r in rows:
+            r["repros"] = _repro_by_target.get(r.get("_orig_label", ""), [])
+
+    _attach_repros(_build_failures_snippets)
+    _attach_repros(_failed_snippets)
+    _attach_repros(_timeout_snippets)
 
     # One global "more output not shown" note across the snippet-eligible buckets.
     # Only meaningful once at least one snippet rendered AND more failures remain.
@@ -3768,9 +3797,11 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         "snippets_overflow": str(_snippets_overflow) if _snippets_overflow > 0 else "",
         "snippets_overflow_plural": "s" if _snippets_overflow != 1 else "",
         # Producer-authored repro/fix lists (lib/repro_commands.axl); template
-        # emits the "🔁 Reproduce" / "🛠️ Fix" sections.
-        "repro_commands": list(data.get("repro_commands", []) or []),
-        "fix_commands": list(data.get("fix_commands", []) or []),
+        # emits the "🔁 Reproduce" / "🛠️ Fix" sections. Per-failure entries
+        # (target != "") render inline beneath their snippet, so the combined
+        # sections show only whole-run (target == "") commands.
+        "repro_commands": [c for c in (data.get("repro_commands", []) or []) if not (getattr(c, "target", "") or "")],
+        "fix_commands": [c for c in (data.get("fix_commands", []) or []) if not (getattr(c, "target", "") or "")],
         # Derived failures (dep broke, no own action error); collapsed list under
         # Build Failures. Count stringified (Jinja2 can't compare AXL ints).
         "derived_failures": _derived_table["rows"],
@@ -3954,10 +3985,11 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
 
     Returns a list of plain dicts (JSON-round-trippable through the artifact):
     `[{label, kind, bucket, snippet, truncated, trunc_head, trunc_tail,
-    duration_ms}]` (bucket is "build" | "test" | "timeout"; duration_ms is the
-    test wall time, 0 for build actions), capped at `max_per_task`. Empty when off
-    (max_per_task <= 0 / no options). The writer dedupes identical failures
-    across tasks and computes overflow from what it drops at render.
+    duration_ms, repros}]` (bucket is "build" | "test" | "timeout"; duration_ms
+    is the test wall time, 0 for build actions; repros is the per-failure repro
+    commands `[{command, description}]` for that label), capped at `max_per_task`.
+    Empty when off (max_per_task <= 0 / no options). The writer dedupes identical
+    failures across tasks and computes overflow from what it drops at render.
     """
     bz = data.get("bazel", {})
     if max_per_task <= 0 or snippet_options == None or std == None:
@@ -3965,6 +3997,15 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
 
     target_kinds = bz.get("target_kinds", {}) or {}
     test_details = bz.get("test_details", {}) or {}
+
+    # Per-failure repro commands (target-set entries, post-hook), keyed by label,
+    # shipped with each snippet so the writer renders them inline.
+    repro_by_target = {}
+    for c in data.get("repro_commands", []) or []:
+        tgt = getattr(c, "target", "") or ""
+        if tgt:
+            repro_by_target.setdefault(tgt, []).append({"command": c.command, "description": c.description})
+
     out = []
 
     def _take(label, kind, bucket, res, duration_ms = 0):
@@ -3981,6 +4022,7 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
             # Test wall time (ms); 0 for build actions (BES action timing is
             # unreliable and not captured). Rendered as "failed in <dur>".
             "duration_ms": duration_ms or 0,
+            "repros": repro_by_target.get(label, []),
         })
 
     # Build-action stderr first (precedence), then failed tests, then timeouts.

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -2750,12 +2750,15 @@ SNIPPET_MACRO = """{% macro failure_snippets(rows) %}
 {% if t.snippet_trunc_tail %}…
 {% endif %}{{ t.snippet_fence }}
 {% endif %}
-{%- for r in t.repros %}
+{%- if t.repros %}
+Reproduce with:
+{% for r in t.repros %}
 ```
 {% if r.description %}# {{ r.description }}
 {% endif %}{{ r.command }}
 ```
-{%- endfor %}{%- endfor %}
+{%- endfor %}
+{% endif %}{%- endfor %}
 {%- endmacro %}"""
 
 # Bazel-targets detail block: build failures (root + dep-broken),
@@ -2774,7 +2777,10 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 <details open>
 <summary>{{ build_failures_icon }} {{ build_failures_header }}</summary>
 {{ failure_snippets(build_failures_snippets) }}
-{% if build_failures %}<pre>
+{% if build_failures_snippet_overflow %}_+ {{ build_failures_snippet_overflow }} more failure{{ build_failures_snippet_overflow_plural }} — output not shown._
+
+{% endif %}
+{%- if build_failures %}<pre>
 {{- build_failures_table_head }}
 {{ build_failures_table_sep }}
 {%- for t in build_failures %}
@@ -2801,7 +2807,10 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 <details open>
 <summary>{{ failed_tests_icon }} {{ failed_tests_header }}</summary>
 {{ failure_snippets(failed_tests_snippets) }}
-{% if failed_tests %}<pre>
+{% if failed_tests_snippet_overflow %}_+ {{ failed_tests_snippet_overflow }} more failure{{ failed_tests_snippet_overflow_plural }} — output not shown._
+
+{% endif %}
+{%- if failed_tests %}<pre>
 {{- failed_tests_table_head }}
 {{ failed_tests_table_sep }}
 {%- for t in failed_tests %}
@@ -2815,7 +2824,10 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 <details open>
 <summary>{{ timeout_tests_icon }} {{ timeout_tests_header }}</summary>
 {{ failure_snippets(timeout_tests_snippets) }}
-{% if timeout_tests %}<pre>
+{% if timeout_tests_snippet_overflow %}_+ {{ timeout_tests_snippet_overflow }} more failure{{ timeout_tests_snippet_overflow_plural }} — output not shown._
+
+{% endif %}
+{%- if timeout_tests %}<pre>
 {{- timeout_tests_table_head }}
 {{ timeout_tests_table_sep }}
 {%- for t in timeout_tests %}
@@ -2823,10 +2835,6 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 {%- endfor %}</pre>
 {% endif %}
 </details>
-
-{% endif %}
-{%- if snippets_overflow %}
-_+ {{ snippets_overflow }} more failure{{ snippets_overflow_plural }} — output not shown._
 
 {% endif %}
 {%- if flaky_tests %}
@@ -3775,11 +3783,21 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
     _attach_repros(_failed_snippets)
     _attach_repros(_timeout_snippets)
 
-    # One global "more output not shown" note across the snippet-eligible buckets.
-    # Only meaningful once at least one snippet rendered AND more failures remain.
+    # Per-bucket "more output not shown" note. A failure with a rendered snippet
+    # is dropped from its bucket's <pre> table, so the table rows ARE the
+    # snippet-less failures — each bucket's overflow is just its table row count.
+    # Only framed as "output not shown" once snippets are on AND at least one
+    # rendered (otherwise the table is the normal full listing, not an overflow).
     _snippets_shown = (max_snippets - _snippet_budget[0]) if _snippets_enabled else 0
-    _snippet_eligible_total = build_failure_count + failed_test_count + timeout_test_count
-    _snippets_overflow = (_snippet_eligible_total - _snippets_shown) if _snippets_shown > 0 else 0
+    _overflow_active = _snippets_shown > 0
+
+    def _bucket_overflow(table):
+        n = len(table["rows"])
+        return n if (_overflow_active and n > 0) else 0
+
+    _build_failures_overflow_snip = _bucket_overflow(_build_failures_table)
+    _failed_tests_overflow_snip = _bucket_overflow(_failed_table)
+    _timeout_tests_overflow_snip = _bucket_overflow(_timeout_table)
 
     # Task timing: aligned <pre> (Phase | Description | Duration).
     _task_timing_rows_data = _build_task_timing_rows(task_phases, task_active, status)
@@ -3846,10 +3864,15 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         "build_failures_header": _bucket_header(_BUCKET_FAILED_TO_BUILD, build_failure_count),
         "build_failures_overflow": str(failed_actions_overflow) if failed_actions_overflow > 0 else "",
         "build_failures_icon": _BUCKET_ICONS[_BUCKET_FAILED_TO_BUILD],
-        # Inline-snippet overflow: failures past the shared snippet budget whose
-        # output isn't shown. "" when snippets are off or all fit.
-        "snippets_overflow": str(_snippets_overflow) if _snippets_overflow > 0 else "",
-        "snippets_overflow_plural": "s" if _snippets_overflow != 1 else "",
+        # Per-bucket inline-snippet overflow: failures in this bucket past the
+        # shared snippet budget (shown as table rows, output not inlined). The
+        # note renders inside the bucket, above its table. "" when none.
+        "build_failures_snippet_overflow": str(_build_failures_overflow_snip) if _build_failures_overflow_snip > 0 else "",
+        "build_failures_snippet_overflow_plural": "s" if _build_failures_overflow_snip != 1 else "",
+        "failed_tests_snippet_overflow": str(_failed_tests_overflow_snip) if _failed_tests_overflow_snip > 0 else "",
+        "failed_tests_snippet_overflow_plural": "s" if _failed_tests_overflow_snip != 1 else "",
+        "timeout_tests_snippet_overflow": str(_timeout_tests_overflow_snip) if _timeout_tests_overflow_snip > 0 else "",
+        "timeout_tests_snippet_overflow_plural": "s" if _timeout_tests_overflow_snip != 1 else "",
         # Producer-authored repro/fix lists (lib/repro_commands.axl); template
         # emits the "🔁 Reproduce" / "🛠️ Fix" sections. Per-failure entries
         # (target != "") render inline beneath their snippet, so the combined
@@ -4229,7 +4252,6 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
                       "), dropping inline snippet bodies from secondary failure buckets")
         _drop_snippets(details_data.get("failed_tests_snippets", []))
         _drop_snippets(details_data.get("timeout_tests_snippets", []))
-        details_data["snippets_overflow"] = ""
         details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
     if len(details_text) > _DETAILS_LIMIT and max_snippets > 0:

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -1046,23 +1046,15 @@ def _dedup_preserve_order(items):
             out.append(x)
     return out
 
-def repro_targets(data, original_targets):
-    """Pick the target list for a failing build/test task's repro command.
+def collapse_repro_targets(failed, original_targets):
+    """Collapse a failed-label list to a copy-pasteable target list for a repro.
 
-    Small failure sets (≤ `_REPRO_INLINE_MAX`) pass through verbatim. Larger
-    sets collapse to a common-root pattern when one exists, keeping any labels
-    the user named explicitly (wildcard patterns skip manual-tagged rules, so
-    explicit failures must not be lost). No usable collapse → `original_targets`.
-
-    Builds and tests share `failed_labels(data)` (action + target-level +
-    failed-test labels); derived consumers aren't subtracted — rebuilding them
-    is harmless once the root is fixed.
-
-    `original_targets` is the user's positional list (e.g. `ctx.args.targets`).
-    Output is always order-preserving deduped (the fallback is the one place a
-    duplicate can sneak in).
+    Small sets (≤ `_REPRO_INLINE_MAX`) pass through verbatim. Larger sets
+    collapse to a common-root pattern when one exists, keeping any labels the
+    user named explicitly (wildcard patterns skip manual-tagged rules, so
+    explicit failures must not be lost). No labels → `original_targets`; no
+    usable collapse → `original_targets`. Always order-preserving deduped.
     """
-    failed = failed_labels(data)
     if not failed:
         return _dedup_preserve_order(original_targets)
     if len(failed) <= _REPRO_INLINE_MAX:
@@ -1074,6 +1066,53 @@ def repro_targets(data, original_targets):
     explicit_in_original = {t: True for t in original_targets if _is_explicit_label(t)}
     explicit_failed = [l for l in failed if l in explicit_in_original]
     return explicit_failed + [root]
+
+def repro_targets(data, original_targets):
+    """Target list for a failing task's whole-run repro, over all failed labels
+    (action + target-level + failed-test). See `collapse_repro_targets`."""
+    return collapse_repro_targets(failed_labels(data), original_targets)
+
+def failed_labels_by_subcommand(data):
+    """Partition failed labels by the bazel subcommand that reproduces them:
+
+      "test"  — tests that built and then failed/timed out at test time.
+                `bazel test //x` reruns them.
+      "build" — build-action / target failures AND tests that failed to BUILD.
+                `bazel test //x` on these errors ("no test targets found" or a
+                build error with nothing to test), so they rerun with
+                `bazel build //x`.
+
+    Returns `{"build": [labels], "test": [labels]}`, each order-preserving
+    deduped. A label that both failed to build and is a test lands in "build"
+    (build-first precedence — you can't test what won't build)."""
+    build = []
+    test = []
+    build_seen = {}
+
+    def _add_build(lbl):
+        if lbl and lbl not in build_seen:
+            build_seen[lbl] = True
+            build.append(lbl)
+
+    for a in data["bazel"].get("failed_actions", []):
+        _add_build(a.get("label", ""))
+    for t in data["bazel"].get("failed_targets", []):
+        _add_build(t.get("label", ""))
+    for t in data["bazel"].get("failed_tests", []):
+        if t.get("status", "") == _TEST_STATUS_FAILED_TO_BUILD:
+            _add_build(t.get("label", ""))
+
+    test_seen = {}
+    for t in data["bazel"].get("failed_tests", []):
+        lbl = t.get("label", "")
+        # A test that failed to build is a build failure (above); a test also
+        # listed as a failed action/target likewise reruns via build.
+        if (t.get("status", "") != _TEST_STATUS_FAILED_TO_BUILD and
+            lbl and lbl not in build_seen and lbl not in test_seen):
+            test_seen[lbl] = True
+            test.append(lbl)
+
+    return {"build": build, "test": test}
 
 def compute_reproducer_command(data, task_name, max_chars = MAX_REPRO_CHARS):
     """Legacy helper preserved for test fixtures. New code should append

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -952,6 +952,26 @@ def failed_labels(data):
 
     return labels
 
+def _cmd_field(c, name):
+    """Read a ReproFixCommand field whether `c` is a record (producer/live) or a
+    dict (snapshot fixtures / JSON round-trip), defaulting to ""."""
+    if type(c) == "dict":
+        return c.get(name, "") or ""
+    return getattr(c, name, "") or ""
+
+def repro_by_target(repro_commands):
+    """Map untruncated failure label -> its per-failure repro commands
+    (`[{command, description}]`), built from the `target`-set entries in
+    `data["repro_commands"]`. Whole-run entries (`target == ""`) are skipped —
+    they render in the combined Reproduce section, not inline under a snippet.
+    """
+    out = {}
+    for c in repro_commands or []:
+        tgt = _cmd_field(c, "target")
+        if tgt:
+            out.setdefault(tgt, []).append({"command": _cmd_field(c, "command"), "description": _cmd_field(c, "description")})
+    return out
+
 # Above this many failing labels, collapse to a common-root pattern rather than
 # listing each. Tuned to stay under build_aspect_command's ~100-char soft wrap.
 _REPRO_INLINE_MAX = 10
@@ -3702,16 +3722,9 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
     _decorate_snippet_verb(_failed_snippets, "failed", "in")
     _decorate_snippet_verb(_timeout_snippets, "timed out", "after")
 
-    # Per-failure repro commands (target-set entries in repro_commands, after the
-    # repro_fix_suggestion hook) attach to their snippet row, keyed by the
-    # untruncated label, and render inline beneath the snippet. Combined
-    # (target == "") entries stay in the "🔁 Reproduce" section (see
-    # repro_commands filtering below).
-    _repro_by_target = {}
-    for c in data.get("repro_commands", []) or []:
-        tgt = getattr(c, "target", "") or ""
-        if tgt:
-            _repro_by_target.setdefault(tgt, []).append({"command": c.command, "description": c.description})
+    # Attach each failure's per-failure repro commands to its snippet row (keyed
+    # by untruncated label); they render inline beneath the snippet.
+    _repro_by_target = repro_by_target(data.get("repro_commands", []))
 
     def _attach_repros(rows):
         for r in rows:
@@ -3800,8 +3813,8 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         # emits the "🔁 Reproduce" / "🛠️ Fix" sections. Per-failure entries
         # (target != "") render inline beneath their snippet, so the combined
         # sections show only whole-run (target == "") commands.
-        "repro_commands": [c for c in (data.get("repro_commands", []) or []) if not (getattr(c, "target", "") or "")],
-        "fix_commands": [c for c in (data.get("fix_commands", []) or []) if not (getattr(c, "target", "") or "")],
+        "repro_commands": [c for c in (data.get("repro_commands", []) or []) if not _cmd_field(c, "target")],
+        "fix_commands": [c for c in (data.get("fix_commands", []) or []) if not _cmd_field(c, "target")],
         # Derived failures (dep broke, no own action error); collapsed list under
         # Build Failures. Count stringified (Jinja2 can't compare AXL ints).
         "derived_failures": _derived_table["rows"],
@@ -3998,13 +4011,9 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
     target_kinds = bz.get("target_kinds", {}) or {}
     test_details = bz.get("test_details", {}) or {}
 
-    # Per-failure repro commands (target-set entries, post-hook), keyed by label,
-    # shipped with each snippet so the writer renders them inline.
-    repro_by_target = {}
-    for c in data.get("repro_commands", []) or []:
-        tgt = getattr(c, "target", "") or ""
-        if tgt:
-            repro_by_target.setdefault(tgt, []).append({"command": c.command, "description": c.description})
+    # Per-failure repro commands keyed by label, shipped with each snippet so the
+    # PR-comment writer renders them inline.
+    _repros = repro_by_target(data.get("repro_commands", []))
 
     out = []
 
@@ -4022,7 +4031,7 @@ def extract_failure_snippets(std, data, snippet_options, max_per_task):
             # Test wall time (ms); 0 for build actions (BES action timing is
             # unreliable and not captured). Rendered as "failed in <dur>".
             "duration_ms": duration_ms or 0,
-            "repros": repro_by_target.get(label, []),
+            "repros": _repros.get(label, []),
         })
 
     # Build-action stderr first (precedence), then failed tests, then timeouts.

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -1105,6 +1105,7 @@ def failed_labels_by_subcommand(data):
     test_seen = {}
     for t in data["bazel"].get("failed_tests", []):
         lbl = t.get("label", "")
+
         # A test that failed to build is a build failure (above); a test also
         # listed as a failed action/target likewise reruns via build.
         if (t.get("status", "") != _TEST_STATUS_FAILED_TO_BUILD and
@@ -3550,6 +3551,7 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
             if not entry.get("kind"):
                 entry["kind"] = target_kinds_map.get(original_label, "")
             entry["label"] = _truncate_label(original_label)
+
             # Untruncated label, for correlating per-failure repro commands.
             entry["_orig_label"] = original_label
             out.append(entry)

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -8,7 +8,7 @@ Two task implementations live here:
     `compute_invocation_state`, `conclusion`, and skipped-bucket plumbing.
 """
 
-load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "aspect_web_ui_url", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "init_data", "process_event", "render_bes_url", "render_check_output", "repro_targets")
+load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "aspect_web_ui_url", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "failed_labels_by_subcommand", "init_data", "process_event", "render_bes_url", "render_check_output", "repro_targets")
 
 # Fake data builders
 
@@ -999,6 +999,33 @@ def _test_repro_targets_includes_target_failures(ctx):
         ["//pkg/broken:lib", "//pkg/analysis:bad", "//pkg/consumer:bin"],
     )
 
+def _test_failed_labels_by_subcommand(ctx):
+    """Classifier splits failures by the subcommand that reproduces them:
+    build-action / target failures and FailedToBuild tests → "build"; tests
+    that built then failed/timed out → "test". A `bazel test` on a build-only
+    target errors, so this split keeps build failures off the test repro."""
+    data = init_data()
+    data["bazel"]["failed_actions"] = [{"label": "//pkg:genrule", "mnemonics": ["Genrule"]}]
+    data["bazel"]["failed_targets"] = [{"label": "//pkg:genrule"}, {"label": "//pkg:lib"}]
+    data["bazel"]["failed_tests"] = [
+        {"label": "//pkg:a_test", "status": "failed"},
+        {"label": "//pkg:slow_test", "status": "timeout"},
+        {"label": "//pkg:wont_build_test", "status": "failed_to_build"},
+    ]
+    out = failed_labels_by_subcommand(data)
+    _eq("build bucket = actions + targets + failed_to_build test",
+        out["build"], ["//pkg:genrule", "//pkg:lib", "//pkg:wont_build_test"])
+    _eq("test bucket = built-then-failed tests only", out["test"], ["//pkg:a_test", "//pkg:slow_test"])
+
+def _test_failed_labels_by_subcommand_build_only(ctx):
+    """A build task (no test_summary) → empty test bucket, so no test repro."""
+    data = init_data()
+    data["bazel"]["failed_actions"] = [{"label": "//pkg:broken", "mnemonics": ["CppCompile"]}]
+    data["bazel"]["failed_targets"] = [{"label": "//pkg:broken"}]
+    out = failed_labels_by_subcommand(data)
+    _eq("build-only: build bucket", out["build"], ["//pkg:broken"])
+    _eq("build-only: empty test bucket", out["test"], [])
+
 def _test_repro_targets_preserves_explicit_label_through_collapse(ctx):
     """A failed label that the user named directly in the original
     command stays as an explicit entry alongside the collapse pattern —
@@ -1133,6 +1160,8 @@ _UNIT_TESTS = [
     _test_repro_targets_large_set_falls_back_when_no_common_root,
     _test_repro_targets_no_failures_falls_back,
     _test_repro_targets_includes_target_failures,
+    _test_failed_labels_by_subcommand,
+    _test_failed_labels_by_subcommand_build_only,
     _test_repro_targets_preserves_explicit_label_through_collapse,
     _test_repro_targets_collapse_with_only_wildcard_originals,
     _test_repro_targets_dedups_fallback_input,

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -8,7 +8,8 @@ Two task implementations live here:
     `compute_invocation_state`, `conclusion`, and skipped-bucket plumbing.
 """
 
-load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "aspect_web_ui_url", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "failed_labels_by_subcommand", "init_data", "process_event", "render_bes_url", "render_check_output", "repro_targets")
+load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "aspect_web_ui_url", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "failed_labels_by_subcommand", "init_data", "process_event", "render_bes_url", "render_check_output", "repro_by_target", "repro_targets")
+load("./lifecycle.axl", "ReproFixCommand")
 
 # Fake data builders
 
@@ -1029,6 +1030,38 @@ def _test_failed_labels_by_subcommand_build_only(ctx):
     _eq("build-only: build bucket", out["build"], ["//pkg:broken"])
     _eq("build-only: empty test bucket", out["test"], [])
 
+def _test_repro_by_target_groups_per_failure(ctx):
+    """`repro_by_target` keys per-failure (target-set) commands by label,
+    skips whole-run (target == "") entries, and tolerates both records
+    (producer/live) and dicts (snapshot / JSON round-trip)."""
+    commands = [
+        # Whole-run entries — excluded from the per-failure map.
+        ReproFixCommand(command = "aspect test -- //...", slug = "test-repro-aspect"),
+        # Per-failure: two flavors for one label (record form).
+        ReproFixCommand(command = "aspect test -- //a:t", slug = "test-repro-aspect", target = "//a:t"),
+        ReproFixCommand(command = "bazel test -- //a:t", description = "vanilla bazel", slug = "test-repro-vanilla-bazel", target = "//a:t"),
+        # Per-failure for a second label, dict form (post round-trip).
+        {"command": "aspect build -- //b:lib", "slug": "build-repro-aspect", "target": "//b:lib"},
+    ]
+    out = repro_by_target(commands)
+    _eq("two labels keyed", sorted(out.keys()), ["//a:t", "//b:lib"])
+    _eq("whole-run entry excluded", "//..." in out, False)
+    _eq(
+        "both flavors grouped under label",
+        [r["command"] for r in out["//a:t"]],
+        ["aspect test -- //a:t", "bazel test -- //a:t"],
+    )
+    _eq("vanilla description carried", out["//a:t"][1]["description"], "vanilla bazel")
+    _eq("dict entry tolerated", out["//b:lib"][0]["command"], "aspect build -- //b:lib")
+
+def _test_repro_by_target_empty_inputs(ctx):
+    _eq("None → empty map", repro_by_target(None), {})
+    _eq(
+        "no target-set entries → empty map",
+        repro_by_target([ReproFixCommand(command = "aspect test", slug = "test-repro-aspect")]),
+        {},
+    )
+
 def _test_repro_targets_preserves_explicit_label_through_collapse(ctx):
     """A failed label that the user named directly in the original
     command stays as an explicit entry alongside the collapse pattern —
@@ -1165,6 +1198,8 @@ _UNIT_TESTS = [
     _test_repro_targets_includes_target_failures,
     _test_failed_labels_by_subcommand,
     _test_failed_labels_by_subcommand_build_only,
+    _test_repro_by_target_groups_per_failure,
+    _test_repro_by_target_empty_inputs,
     _test_repro_targets_preserves_explicit_label_through_collapse,
     _test_repro_targets_collapse_with_only_wildcard_originals,
     _test_repro_targets_dedups_fallback_input,

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -1013,8 +1013,11 @@ def _test_failed_labels_by_subcommand(ctx):
         {"label": "//pkg:wont_build_test", "status": "failed_to_build"},
     ]
     out = failed_labels_by_subcommand(data)
-    _eq("build bucket = actions + targets + failed_to_build test",
-        out["build"], ["//pkg:genrule", "//pkg:lib", "//pkg:wont_build_test"])
+    _eq(
+        "build bucket = actions + targets + failed_to_build test",
+        out["build"],
+        ["//pkg:genrule", "//pkg:lib", "//pkg:wont_build_test"],
+    )
     _eq("test bucket = built-then-failed tests only", out["test"], ["//pkg:a_test", "//pkg:slow_test"])
 
 def _test_failed_labels_by_subcommand_build_only(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -17,7 +17,7 @@ load("./bazel_flags.axl", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "failed_labels", "init_data", "now_ms", "process_event", "repro_targets", bazel_conclusion = "conclusion")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
-load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "print_repro_and_fix", "task_cli_path")
+load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "flavor_allows", "print_repro_and_fix", "repro_prefix", "task_cli_path")
 load("./text.axl", "pluralize")
 load("../bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 
@@ -484,20 +484,40 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     if data.get("bazel_attempts"):
         archive_bazel_attempt(data, attempt + 1, invocation_status.code)
 
-    _repro_targets = repro_targets(data, targets)
-    _repro_cmd = build_aspect_command(task_cli_path(ctx.task), [], _repro_targets)
-    if _repro_cmd:
-        data["repro_commands"].append(ReproFixCommand(
-            command = _repro_cmd,
-            slug = "bazel-repro-aspect",
-        ))
+    _flavors = ctx.args.repro_flavors
+    _cli_path = task_cli_path(ctx.task)
 
-        # Alternate vanilla-bazel repro for users who don't have the Aspect CLI
-        # installed. Flags are intentionally omitted — best-effort, not faithful.
-        data["repro_commands"].append(ReproFixCommand(
-            command = build_bazel_command(command, _repro_targets),
+    def _add_repro(cmd, slug, description = "", target = ""):
+        """Append a repro command unless its flavor is suppressed (slug-derived)."""
+        if cmd and flavor_allows(_flavors, slug):
+            data["repro_commands"].append(ReproFixCommand(
+                command = cmd,
+                description = description,
+                slug = slug,
+                target = target,
+            ))
+
+    # Combined whole-run repro (Aspect CLI + vanilla-bazel alternate for users
+    # without it; vanilla flags intentionally omitted — best-effort, not faithful).
+    _repro_targets = repro_targets(data, targets)
+    _add_repro(build_aspect_command(_cli_path, [], _repro_targets), "bazel-repro-aspect")
+    _add_repro(build_bazel_command(command, _repro_targets), "bazel-repro-vanilla-bazel", description = "vanilla bazel")
+
+    # Per-failure repros: one targeted command per failing label, rendered inline
+    # beneath that failure's snippet (correlated by `target`). Single-label target
+    # list — no `repro_targets` collapsing. The `-failure` slugs keep the
+    # `-vanilla-bazel` suffix so flavor gating + suffix-match hooks still fire.
+    for _label in failed_labels(data):
+        _add_repro(
+            repro_prefix(ctx) + build_aspect_command(_cli_path, [], [_label]),
+            "bazel-repro-aspect-failure",
+            target = _label,
+        )
+        _add_repro(
+            build_bazel_command(command, [_label]),
+            "bazel-repro-vanilla-bazel-failure",
             description = "vanilla bazel",
-            slug = "bazel-repro-vanilla-bazel",
-        ))
+            target = _label,
+        )
 
     return _emit_terminal(ctx, lifecycle, command, data, invocation_status.code, targets = _repro_targets)

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -505,17 +505,18 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
 
     # Per-failure repros: one targeted command per failing label, rendered inline
     # beneath that failure's snippet (correlated by `target`). Single-label target
-    # list — no `repro_targets` collapsing. The `-failure` slugs keep the
-    # `-vanilla-bazel` suffix so flavor gating + suffix-match hooks still fire.
+    # list — no `repro_targets` collapsing. Same slugs as the combined commands:
+    # the `target` field is the per-failure marker, and reusing the slug keeps the
+    # documented `-vanilla-bazel` suffix so flavor gating + hook scoping still fire.
     for _label in failed_labels(data):
         _add_repro(
             repro_prefix(ctx) + build_aspect_command(_cli_path, [], [_label]),
-            "bazel-repro-aspect-failure",
+            "bazel-repro-aspect",
             target = _label,
         )
         _add_repro(
             build_bazel_command(command, [_label]),
-            "bazel-repro-vanilla-bazel-failure",
+            "bazel-repro-vanilla-bazel",
             description = "vanilla bazel",
             target = _label,
         )

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner.axl
@@ -14,10 +14,10 @@ applies uniformly to both tasks.
 
 load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "resolve_bazel_announce")
-load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "failed_labels", "init_data", "now_ms", "process_event", "repro_targets", bazel_conclusion = "conclusion")
+load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
-load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "flavor_allows", "print_repro_and_fix", "repro_prefix", "task_cli_path")
+load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "flavor_allows", "print_repro_and_fix", "repro_prefix")
 load("./text.axl", "pluralize")
 load("../bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 
@@ -485,7 +485,6 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
         archive_bazel_attempt(data, attempt + 1, invocation_status.code)
 
     _flavors = ctx.args.repro_flavors
-    _cli_path = task_cli_path(ctx.task)
 
     def _add_repro(cmd, slug, description = "", target = ""):
         """Append a repro command unless its flavor is suppressed (slug-derived)."""
@@ -497,28 +496,41 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
                 target = target,
             ))
 
-    # Combined whole-run repro (Aspect CLI + vanilla-bazel alternate for users
-    # without it; vanilla flags intentionally omitted — best-effort, not faithful).
-    _repro_targets = repro_targets(data, targets)
-    _add_repro(build_aspect_command(_cli_path, [], _repro_targets), "bazel-repro-aspect")
-    _add_repro(build_bazel_command(command, _repro_targets), "bazel-repro-vanilla-bazel", description = "vanilla bazel")
+    # Repros are keyed by the subcommand that REPRODUCES each failure, not by the
+    # task: a `test` task that hit a build-action failure (or a test that failed
+    # to build) reruns those via `build` — `bazel test //x` would error with "no
+    # test targets found". So a test run can emit both a `build` and a `test`
+    # combined repro. Slug = "<sub>-repro-aspect" / "<sub>-repro-vanilla-bazel".
+    _prefix = repro_prefix(ctx)
+    _by_sub = failed_labels_by_subcommand(data)
 
-    # Per-failure repros: one targeted command per failing label, rendered inline
-    # beneath that failure's snippet (correlated by `target`). Single-label target
-    # list — no `repro_targets` collapsing. Same slugs as the combined commands:
-    # the `target` field is the per-failure marker, and reusing the slug keeps the
-    # documented `-vanilla-bazel` suffix so flavor gating + hook scoping still fire.
-    for _label in failed_labels(data):
+    def _add_pair(subcommand, labels, target = ""):
+        if not labels:
+            return
         _add_repro(
-            repro_prefix(ctx) + build_aspect_command(_cli_path, [], [_label]),
-            "bazel-repro-aspect",
-            target = _label,
+            _prefix + build_aspect_command(subcommand, [], labels),
+            subcommand + "-repro-aspect",
+            target = target,
         )
         _add_repro(
-            build_bazel_command(command, [_label]),
-            "bazel-repro-vanilla-bazel",
+            _prefix + build_bazel_command(subcommand, labels),
+            subcommand + "-repro-vanilla-bazel",
             description = "vanilla bazel",
-            target = _label,
+            target = target,
         )
 
-    return _emit_terminal(ctx, lifecycle, command, data, invocation_status.code, targets = _repro_targets)
+    # Combined whole-run repro per subcommand (collapsed like the old single
+    # combined command; vanilla flags intentionally omitted — best-effort). Only
+    # for a subcommand with failures — `collapse_repro_targets` falls back to the
+    # user's whole target list when given none, which would mint a bogus repro.
+    for _sub in ("build", "test"):
+        if _by_sub[_sub]:
+            _add_pair(_sub, collapse_repro_targets(_by_sub[_sub], targets))
+
+    # Per-failure repros: one targeted command per failing label (single-label,
+    # no collapsing), `target` set so it renders inline beneath that snippet.
+    for _sub in ("build", "test"):
+        for _label in _by_sub[_sub]:
+            _add_pair(_sub, [_label], target = _label)
+
+    return _emit_terminal(ctx, lifecycle, command, data, invocation_status.code, targets = targets)

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -115,6 +115,13 @@ ReproFixCommand = record(
     # Stable kebab-case id ("lint-repro", …). Lets hooks scope by suggestion
     # type without parsing the command. Required.
     slug = field(str),
+    # Failure label this command targets, for the PER-FAILURE repro/fix commands
+    # rendered inline beneath a failure's snippet ("" for the whole-run / combined
+    # commands). Like `slug` it's identity: hooks rewrite command/description, never
+    # `target`, and `_apply_chain` carries it through. The combined Reproduce/Fix
+    # sections render only `target == ""` entries; `target`-set ones render only
+    # inline, correlated by label.
+    target = field(str, default = ""),
     # Idempotence flag flipped by `apply_repro_fix_hooks` after the entry
     # passes through `lifecycle.repro_fix_suggestion`, so each entry hooks at
     # most once. Producers leave `False`; user hooks must not read it.
@@ -317,9 +324,9 @@ def _apply_chain(ctx, info_base, command_kind, entry, handlers):
     """Run a `ReproFixCommand` entry through every handler in order.
 
     Returns the post-chain `ReproFixCommand` (`_hooked = True`), or `None`
-    on reject. Slug is carried through `replace` unchanged (hooks rewrite
-    commands, not identity). A fresh `ReproFixInfo` per handler so each sees
-    the prior's post-verdict state.
+    on reject. Slug and target are carried through `replace` unchanged (hooks
+    rewrite commands, not identity). A fresh `ReproFixInfo` per handler so each
+    sees the prior's post-verdict state.
     """
     command = entry.command
     description = entry.description
@@ -341,7 +348,7 @@ def _apply_chain(ctx, info_base, command_kind, entry, handlers):
                 command = verdict.command
             if verdict.description != None:
                 description = verdict.description
-    return ReproFixCommand(command = command, description = description, slug = slug, _hooked = True)
+    return ReproFixCommand(command = command, description = description, slug = slug, target = entry.target, _hooked = True)
 
 def dispatch_task_update(ctx, lifecycle, update):
     """Run any un-hooked repro/fix entries through

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -266,11 +266,14 @@ def apply_repro_fix_hooks(
       delivery: delivery-repro-local-preview
       bazel
        (build /
-        test):  bazel-repro-aspect
-                bazel-repro-vanilla-bazel
+        test):  build-repro-aspect, build-repro-vanilla-bazel
+                test-repro-aspect,  test-repro-vanilla-bazel
 
-    The bazel slugs recur once per failing target as PER-FAILURE entries (same
-    slug, `target` set to the label) in addition to the whole-run entry
+    The bazel slug names the subcommand that REPRODUCES the failure, not the
+    task: a `test` task with a build-action failure emits `build-repro-*` for it
+    (rerunning via `bazel build`, since `bazel test` on a non-test target errors).
+    Each bazel slug recurs once per failing target as a PER-FAILURE entry (same
+    slug, `target` set to the label) alongside the whole-run entry
     (`target == ""`); a hook scoping by slug catches both, and can read `target`
     to distinguish. Every "vanilla bazel for non-Aspect-CLI users" slug ends in
     `-vanilla-bazel`, so a hook can suffix-match across all producers.

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -269,7 +269,10 @@ def apply_repro_fix_hooks(
         test):  bazel-repro-aspect
                 bazel-repro-vanilla-bazel
 
-    Every "vanilla bazel for non-Aspect-CLI users" slug ends in
+    The bazel slugs recur once per failing target as PER-FAILURE entries (same
+    slug, `target` set to the label) in addition to the whole-run entry
+    (`target == ""`); a hook scoping by slug catches both, and can read `target`
+    to distinguish. Every "vanilla bazel for non-Aspect-CLI users" slug ends in
     `-vanilla-bazel`, so a hook can suffix-match across all producers.
 
     Args:

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -87,15 +87,14 @@ _SHELL_META = " \t\n\"'\\`$&|;<>()*?[]{}#!~"
 
 # `repro_flavors` / `fix_flavors` task-arg values: which command flavor(s) to
 # surface. Every "vanilla bazel for non-Aspect-CLI users" producer tags its
-# entry with a slug ending in `-vanilla-bazel` (or `-vanilla-bazel-failure` for
-# the per-failure variant); the Aspect-CLI entry's slug does not. So flavor can
-# be decided from the slug alone, uniformly across producers and surfaces.
+# entry with a slug ending in `-vanilla-bazel`; the Aspect-CLI entry's slug does
+# not. So flavor is decided from the slug alone, uniformly across producers and
+# surfaces.
 REPRO_FLAVOR_VALUES = ["aspect", "bazel", "both"]
 
 def is_vanilla_bazel_slug(slug):
-    """True for a vanilla-bazel command slug (suffix `-vanilla-bazel`, with or
-    without the `-failure` per-failure tag)."""
-    return slug.endswith("-vanilla-bazel") or slug.endswith("-vanilla-bazel-failure")
+    """True for a vanilla-bazel command slug (suffix `-vanilla-bazel`)."""
+    return slug.endswith("-vanilla-bazel")
 
 def flavor_allows(flavor, slug):
     """Whether a command with `slug` should be emitted under `flavor`

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -85,6 +85,58 @@ _DEFAULT_WRAP_AT = 100
 # contain spaces / parens / etc.
 _SHELL_META = " \t\n\"'\\`$&|;<>()*?[]{}#!~"
 
+# `repro_flavors` / `fix_flavors` task-arg values: which command flavor(s) to
+# surface. Every "vanilla bazel for non-Aspect-CLI users" producer tags its
+# entry with a slug ending in `-vanilla-bazel` (or `-vanilla-bazel-failure` for
+# the per-failure variant); the Aspect-CLI entry's slug does not. So flavor can
+# be decided from the slug alone, uniformly across producers and surfaces.
+REPRO_FLAVOR_VALUES = ["aspect", "bazel", "both"]
+
+def is_vanilla_bazel_slug(slug):
+    """True for a vanilla-bazel command slug (suffix `-vanilla-bazel`, with or
+    without the `-failure` per-failure tag)."""
+    return slug.endswith("-vanilla-bazel") or slug.endswith("-vanilla-bazel-failure")
+
+def flavor_allows(flavor, slug):
+    """Whether a command with `slug` should be emitted under `flavor`
+    (`"aspect"` | `"bazel"` | `"both"`). `"both"` keeps everything; otherwise
+    keep only the matching flavor. Unknown `flavor` (mis-set arg) → keep, so a
+    typo degrades to showing everything rather than hiding all repros."""
+    if flavor == "both" or flavor not in REPRO_FLAVOR_VALUES:
+        return True
+    return (flavor == "bazel") == is_vanilla_bazel_slug(slug)
+
+def _flavor_arg(long, noun):
+    return args.string(
+        default = "both",
+        values = REPRO_FLAVOR_VALUES,
+        long = long,
+        description = ("Which %s command flavor(s) to surface on the CLI and CI " +
+                       "status surfaces: `aspect` (Aspect CLI only), `bazel` (vanilla " +
+                       "bazel only), or `both` (default). Set from config: " +
+                       "`ctx.tasks[\"<task>\"].args.%s = \"aspect\"` in `.aspect/config.axl`; " +
+                       "pass on CLI: `--%s=aspect`.") % (noun, long.replace("-", "_"), long),
+    )
+
+def filter_by_flavor(commands, flavor):
+    """Return `commands` keeping only entries `flavor_allows` permits (by slug).
+    Convenience for producers that append many entries before gating; equivalent
+    to gating each `.append`. No-op for `flavor == "both"`."""
+    if flavor == "both" or flavor not in REPRO_FLAVOR_VALUES:
+        return commands
+    return [c for c in commands if flavor_allows(flavor, c.slug)]
+
+def repro_flavor_args(include_fix = False):
+    """`repro_flavors` (always) + `fix_flavors` (when `include_fix`) task args,
+    as a dict to splat into a task's `args = {...}`. Reuse on every repro/fix
+    producer so the control is identical task-to-task; the producer gates each
+    command append on `flavor_allows(ctx.args.repro_flavors, slug)` (and
+    `fix_flavors` for fix entries)."""
+    out = {"repro_flavors": _flavor_arg("repro-flavors", "reproduce")}
+    if include_fix:
+        out["fix_flavors"] = _flavor_arg("fix-flavors", "fix")
+    return out
+
 def _shell_quote(s):
     """Single-quote `s` for POSIX shells when it carries any shell-
     meta character; otherwise return it untouched so bazel labels
@@ -638,8 +690,8 @@ def rehydrate_commands(commands):
 
     Schema-tolerant: drops entries that aren't dicts or records, and
     falls back to `""` for missing optional fields (`description`,
-    `slug`) so a state block written by an older aspect-cli release
-    (predating the `slug` field) still round-trips cleanly. Entries
+    `slug`, `target`) so a state block written by an older aspect-cli
+    release (predating those fields) still round-trips cleanly. Entries
     that lack the required `command` field are also dropped.
 
     `None` / empty input → `[]`.
@@ -660,6 +712,7 @@ def rehydrate_commands(commands):
             command = cmd,
             description = c.get("description") or "",
             slug = c.get("slug") or "",
+            target = c.get("target") or "",
             _hooked = bool(c.get("_hooked", False)),
         ))
     return out

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -85,55 +85,64 @@ _DEFAULT_WRAP_AT = 100
 # contain spaces / parens / etc.
 _SHELL_META = " \t\n\"'\\`$&|;<>()*?[]{}#!~"
 
-# `repro_flavors` / `fix_flavors` task-arg values: which command flavor(s) to
-# surface. Every "vanilla bazel for non-Aspect-CLI users" producer tags its
-# entry with a slug ending in `-vanilla-bazel`; the Aspect-CLI entry's slug does
-# not. So flavor is decided from the slug alone, uniformly across producers and
-# surfaces.
-REPRO_FLAVOR_VALUES = ["aspect", "bazel", "both"]
+# Known command flavors for the `repro_flavors` / `fix_flavors` controls, and
+# the default (surface both). Every "vanilla bazel for non-Aspect-CLI users"
+# producer tags its entry with a slug ending in `-vanilla-bazel`; the Aspect-CLI
+# entry's slug does not. So a command's flavor is decided from its slug alone,
+# uniformly across producers and surfaces. The set is open — a user can list a
+# flavor name a custom `repro_fix_suggestion` hook understands; unknown names
+# simply don't match the built-in slugs.
+REPRO_FLAVORS = ["aspect", "bazel"]
 
 def is_vanilla_bazel_slug(slug):
     """True for a vanilla-bazel command slug (suffix `-vanilla-bazel`)."""
     return slug.endswith("-vanilla-bazel")
 
-def flavor_allows(flavor, slug):
-    """Whether a command with `slug` should be emitted under `flavor`
-    (`"aspect"` | `"bazel"` | `"both"`). `"both"` keeps everything; otherwise
-    keep only the matching flavor. Unknown `flavor` (mis-set arg) → keep, so a
-    typo degrades to showing everything rather than hiding all repros."""
-    if flavor == "both" or flavor not in REPRO_FLAVOR_VALUES:
-        return True
-    return (flavor == "bazel") == is_vanilla_bazel_slug(slug)
+def slug_flavor(slug):
+    """The flavor a command slug belongs to: `"bazel"` for the vanilla-bazel
+    variant (suffix `-vanilla-bazel`), else `"aspect"`."""
+    return "bazel" if is_vanilla_bazel_slug(slug) else "aspect"
 
-def _flavor_arg(long, noun):
-    return args.string(
-        default = "both",
-        values = REPRO_FLAVOR_VALUES,
-        long = long,
+def flavor_allows(flavors, slug):
+    """Whether a command with `slug` should be emitted given `flavors` — the
+    list of flavors the user opted into (`["aspect", "bazel"]` by default). Keep
+    the command iff its `slug_flavor` is in the list. An empty list (mis-set
+    arg) degrades to keep-all, so a misconfiguration shows everything rather
+    than hiding all repros."""
+    if not flavors:
+        return True
+    return slug_flavor(slug) in flavors
+
+def _flavor_arg(singular, noun):
+    return args.string_list(
+        default = REPRO_FLAVORS,
+        long = singular,
         description = ("Which %s command flavor(s) to surface on the CLI and CI " +
-                       "status surfaces: `aspect` (Aspect CLI only), `bazel` (vanilla " +
-                       "bazel only), or `both` (default). Set from config: " +
-                       "`ctx.tasks[\"<task>\"].args.%s = \"aspect\"` in `.aspect/config.axl`; " +
-                       "pass on CLI: `--%s=aspect`.") % (noun, long.replace("-", "_"), long),
+                       "status surfaces: `aspect` (Aspect CLI) and/or `bazel` (vanilla " +
+                       "bazel). Defaults to both. Repeat the flag to choose a subset, " +
+                       "e.g. `--%s=aspect`; set from config: " +
+                       "`ctx.tasks[\"<task>\"].args.%s = [\"aspect\"]` in `.aspect/config.axl`.") %
+                      (noun, singular, singular.replace("-", "_") + "s"),
     )
 
-def filter_by_flavor(commands, flavor):
+def filter_by_flavor(commands, flavors):
     """Return `commands` keeping only entries `flavor_allows` permits (by slug).
     Convenience for producers that append many entries before gating; equivalent
-    to gating each `.append`. No-op for `flavor == "both"`."""
-    if flavor == "both" or flavor not in REPRO_FLAVOR_VALUES:
+    to gating each `.append`. Keeps everything when `flavors` is empty."""
+    if not flavors:
         return commands
-    return [c for c in commands if flavor_allows(flavor, c.slug)]
+    return [c for c in commands if flavor_allows(flavors, c.slug)]
 
 def repro_flavor_args(include_fix = False):
     """`repro_flavors` (always) + `fix_flavors` (when `include_fix`) task args,
-    as a dict to splat into a task's `args = {...}`. Reuse on every repro/fix
-    producer so the control is identical task-to-task; the producer gates each
-    command append on `flavor_allows(ctx.args.repro_flavors, slug)` (and
-    `fix_flavors` for fix entries)."""
-    out = {"repro_flavors": _flavor_arg("repro-flavors", "reproduce")}
+    as a dict to splat into a task's `args = {...}`. Each is a string list of
+    flavors (CLI flag `--repro-flavor` / `--fix-flavor`, repeatable). Reuse on
+    every repro/fix producer so the control is identical task-to-task; the
+    producer gates each command append on `flavor_allows(ctx.args.repro_flavors,
+    slug)` (and `fix_flavors` for fix entries)."""
+    out = {"repro_flavors": _flavor_arg("repro-flavor", "reproduce")}
     if include_fix:
-        out["fix_flavors"] = _flavor_arg("fix-flavors", "fix")
+        out["fix_flavors"] = _flavor_arg("fix-flavor", "fix")
     return out
 
 def _shell_quote(s):

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -1093,9 +1093,8 @@ def _test_dispatch_skips_hook_when_lists_empty(_ctx):
 
 def _test_is_vanilla_bazel_slug(_ctx):
     _eq("vanilla slug", is_vanilla_bazel_slug("bazel-repro-vanilla-bazel"), True)
-    _eq("vanilla per-failure slug", is_vanilla_bazel_slug("bazel-repro-vanilla-bazel-failure"), True)
+    _eq("format vanilla fix slug", is_vanilla_bazel_slug("format-fix-vanilla-bazel"), True)
     _eq("aspect slug not vanilla", is_vanilla_bazel_slug("bazel-repro-aspect"), False)
-    _eq("aspect per-failure slug not vanilla", is_vanilla_bazel_slug("bazel-repro-aspect-failure"), False)
     _eq("lint-repro not vanilla", is_vanilla_bazel_slug("lint-repro"), False)
 
 def _test_flavor_allows(_ctx):
@@ -1125,10 +1124,22 @@ def _test_filter_by_flavor(_ctx):
     _eq("bazel → only vanilla", [c.slug for c in filter_by_flavor(cmds, "bazel")],
         ["bazel-repro-vanilla-bazel"])
 
+    # A multi-entry fix list (format/gazelle shape): aspect keeps the aspect
+    # fixes, drops the lone vanilla-bazel one; bazel keeps only it.
+    fixes = [
+        ReproFixCommand(command = "aspect format ...", slug = "format-fix"),
+        ReproFixCommand(command = "aspect format ... # rediscover", slug = "format-fix-rediscover"),
+        ReproFixCommand(command = "bazel run //tools/format ...", slug = "format-fix-vanilla-bazel"),
+    ]
+    _eq("aspect fixes → drop vanilla", [c.slug for c in filter_by_flavor(fixes, "aspect")],
+        ["format-fix", "format-fix-rediscover"])
+    _eq("bazel fixes → only vanilla", [c.slug for c in filter_by_flavor(fixes, "bazel")],
+        ["format-fix-vanilla-bazel"])
+
 def _test_target_round_trips_through_rehydrate(_ctx):
     # A per-failure command's target survives the JSON-dict round-trip the PR
     # comment artifact/state-block does (record → dict → rehydrate → record).
-    as_dict = {"command": "aspect test -- //foo:bar", "slug": "bazel-repro-aspect-failure", "target": "//foo:bar"}
+    as_dict = {"command": "aspect test -- //foo:bar", "slug": "bazel-repro-aspect", "target": "//foo:bar"}
     out = rehydrate_commands([as_dict])
     _eq("rehydrate count", len(out), 1)
     _eq("rehydrate preserves target", out[0].target, "//foo:bar")
@@ -1142,14 +1153,14 @@ def _test_hook_preserves_target(_ctx):
         return repro_fix_replace(command = "EDITED " + info.command)
     lifecycle = _fake_lifecycle([hook])
     data = {
-        "repro_commands": [ReproFixCommand(command = "aspect test -- //x", slug = "bazel-repro-aspect-failure", target = "//x")],
+        "repro_commands": [ReproFixCommand(command = "aspect test -- //x", slug = "bazel-repro-aspect", target = "//x")],
         "fix_commands": [],
     }
     apply_repro_fix_hooks(_fake_apply_ctx(), lifecycle, data, kind = "bazel_results", status = "failed")
     out = data["repro_commands"][0]
     _eq("hook rewrote command", out.command, "EDITED aspect test -- //x")
     _eq("hook preserved target", out.target, "//x")
-    _eq("hook preserved slug", out.slug, "bazel-repro-aspect-failure")
+    _eq("hook preserved slug", out.slug, "bazel-repro-aspect")
 
 _UNIT_TESTS = [
     _test_is_vanilla_bazel_slug,

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -1101,14 +1101,17 @@ def _test_flavor_allows(_ctx):
     # both → keep everything
     _eq("both keeps aspect", flavor_allows("both", "test-repro-aspect"), True)
     _eq("both keeps vanilla", flavor_allows("both", "test-repro-vanilla-bazel"), True)
+
     # aspect → only non-vanilla
     _eq("aspect keeps aspect slug", flavor_allows("aspect", "test-repro-aspect"), True)
     _eq("aspect drops vanilla slug", flavor_allows("aspect", "test-repro-vanilla-bazel"), False)
     _eq("aspect keeps lint-repro", flavor_allows("aspect", "lint-repro"), True)
+
     # bazel → only vanilla
     _eq("bazel drops aspect slug", flavor_allows("bazel", "test-repro-aspect"), False)
     _eq("bazel keeps vanilla slug", flavor_allows("bazel", "test-repro-vanilla-bazel"), True)
     _eq("bazel drops lint-repro (no vanilla variant)", flavor_allows("bazel", "lint-repro"), False)
+
     # unknown flavor (mis-set arg) degrades to keep-all
     _eq("unknown flavor keeps everything", flavor_allows("nonsense", "test-repro-vanilla-bazel"), True)
 
@@ -1117,12 +1120,21 @@ def _test_filter_by_flavor(_ctx):
         ReproFixCommand(command = "aspect test -- //a", slug = "test-repro-aspect"),
         ReproFixCommand(command = "bazel test -- //a", slug = "test-repro-vanilla-bazel"),
     ]
-    _eq("both → unchanged", [c.slug for c in filter_by_flavor(cmds, "both")],
-        ["test-repro-aspect", "test-repro-vanilla-bazel"])
-    _eq("aspect → only aspect", [c.slug for c in filter_by_flavor(cmds, "aspect")],
-        ["test-repro-aspect"])
-    _eq("bazel → only vanilla", [c.slug for c in filter_by_flavor(cmds, "bazel")],
-        ["test-repro-vanilla-bazel"])
+    _eq(
+        "both → unchanged",
+        [c.slug for c in filter_by_flavor(cmds, "both")],
+        ["test-repro-aspect", "test-repro-vanilla-bazel"],
+    )
+    _eq(
+        "aspect → only aspect",
+        [c.slug for c in filter_by_flavor(cmds, "aspect")],
+        ["test-repro-aspect"],
+    )
+    _eq(
+        "bazel → only vanilla",
+        [c.slug for c in filter_by_flavor(cmds, "bazel")],
+        ["test-repro-vanilla-bazel"],
+    )
 
     # A multi-entry fix list (format/gazelle shape): aspect keeps the aspect
     # fixes, drops the lone vanilla-bazel one; bazel keeps only it.
@@ -1131,10 +1143,16 @@ def _test_filter_by_flavor(_ctx):
         ReproFixCommand(command = "aspect format ... # rediscover", slug = "format-fix-rediscover"),
         ReproFixCommand(command = "bazel run //tools/format ...", slug = "format-fix-vanilla-bazel"),
     ]
-    _eq("aspect fixes → drop vanilla", [c.slug for c in filter_by_flavor(fixes, "aspect")],
-        ["format-fix", "format-fix-rediscover"])
-    _eq("bazel fixes → only vanilla", [c.slug for c in filter_by_flavor(fixes, "bazel")],
-        ["format-fix-vanilla-bazel"])
+    _eq(
+        "aspect fixes → drop vanilla",
+        [c.slug for c in filter_by_flavor(fixes, "aspect")],
+        ["format-fix", "format-fix-rediscover"],
+    )
+    _eq(
+        "bazel fixes → only vanilla",
+        [c.slug for c in filter_by_flavor(fixes, "bazel")],
+        ["format-fix-vanilla-bazel"],
+    )
 
 def _test_target_round_trips_through_rehydrate(_ctx):
     # A per-failure command's target survives the JSON-dict round-trip the PR
@@ -1143,6 +1161,7 @@ def _test_target_round_trips_through_rehydrate(_ctx):
     out = rehydrate_commands([as_dict])
     _eq("rehydrate count", len(out), 1)
     _eq("rehydrate preserves target", out[0].target, "//foo:bar")
+
     # Missing target → "" (older release / combined command).
     out2 = rehydrate_commands([{"command": "aspect test", "slug": "test-repro-aspect"}])
     _eq("rehydrate missing target → ''", out2[0].target, "")
@@ -1151,6 +1170,7 @@ def _test_hook_preserves_target(_ctx):
     # A replace verdict rewrites command but keeps target/slug identity.
     def hook(ctx, info):
         return repro_fix_replace(command = "EDITED " + info.command)
+
     lifecycle = _fake_lifecycle([hook])
     data = {
         "repro_commands": [ReproFixCommand(command = "aspect test -- //x", slug = "test-repro-aspect", target = "//x")],

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -854,14 +854,14 @@ def _test_slug_visible_to_hook(_ctx):
     parsing the command string."""
     data = {
         "repro_commands": [
-            ReproFixCommand(command = "aspect build -- //a:a", slug = "bazel-repro-aspect"),
-            ReproFixCommand(command = "bazel build -- //a:a", description = "vanilla bazel", slug = "bazel-repro-vanilla-bazel"),
+            ReproFixCommand(command = "aspect test -- //a:a", slug = "test-repro-aspect"),
+            ReproFixCommand(command = "bazel test -- //a:a", description = "vanilla bazel", slug = "test-repro-vanilla-bazel"),
         ],
         "fix_commands": [],
     }
 
     def reject_vanilla(ctx, info):
-        return REPRO_FIX_REJECT if info.slug == "bazel-repro-vanilla-bazel" else REPRO_FIX_ACCEPT
+        return REPRO_FIX_REJECT if info.slug == "test-repro-vanilla-bazel" else REPRO_FIX_ACCEPT
 
     apply_repro_fix_hooks(
         _fake_apply_ctx(),
@@ -872,7 +872,7 @@ def _test_slug_visible_to_hook(_ctx):
         exit_code = 1,
     )
     _eq("slug-based reject: vanilla dropped", len(data["repro_commands"]), 1)
-    _eq("slug-based reject: aspect kept", data["repro_commands"][0].slug, "bazel-repro-aspect")
+    _eq("slug-based reject: aspect kept", data["repro_commands"][0].slug, "test-repro-aspect")
 
 def _test_slug_preserved_through_replace(_ctx):
     """A `replace` verdict rewrites the command/description but
@@ -1092,37 +1092,37 @@ def _test_dispatch_skips_hook_when_lists_empty(_ctx):
     _eq("handler still called", handler_count[0], 1)
 
 def _test_is_vanilla_bazel_slug(_ctx):
-    _eq("vanilla slug", is_vanilla_bazel_slug("bazel-repro-vanilla-bazel"), True)
+    _eq("vanilla slug", is_vanilla_bazel_slug("test-repro-vanilla-bazel"), True)
     _eq("format vanilla fix slug", is_vanilla_bazel_slug("format-fix-vanilla-bazel"), True)
-    _eq("aspect slug not vanilla", is_vanilla_bazel_slug("bazel-repro-aspect"), False)
+    _eq("aspect slug not vanilla", is_vanilla_bazel_slug("test-repro-aspect"), False)
     _eq("lint-repro not vanilla", is_vanilla_bazel_slug("lint-repro"), False)
 
 def _test_flavor_allows(_ctx):
     # both → keep everything
-    _eq("both keeps aspect", flavor_allows("both", "bazel-repro-aspect"), True)
-    _eq("both keeps vanilla", flavor_allows("both", "bazel-repro-vanilla-bazel"), True)
+    _eq("both keeps aspect", flavor_allows("both", "test-repro-aspect"), True)
+    _eq("both keeps vanilla", flavor_allows("both", "test-repro-vanilla-bazel"), True)
     # aspect → only non-vanilla
-    _eq("aspect keeps aspect slug", flavor_allows("aspect", "bazel-repro-aspect"), True)
-    _eq("aspect drops vanilla slug", flavor_allows("aspect", "bazel-repro-vanilla-bazel"), False)
+    _eq("aspect keeps aspect slug", flavor_allows("aspect", "test-repro-aspect"), True)
+    _eq("aspect drops vanilla slug", flavor_allows("aspect", "test-repro-vanilla-bazel"), False)
     _eq("aspect keeps lint-repro", flavor_allows("aspect", "lint-repro"), True)
     # bazel → only vanilla
-    _eq("bazel drops aspect slug", flavor_allows("bazel", "bazel-repro-aspect"), False)
-    _eq("bazel keeps vanilla slug", flavor_allows("bazel", "bazel-repro-vanilla-bazel"), True)
+    _eq("bazel drops aspect slug", flavor_allows("bazel", "test-repro-aspect"), False)
+    _eq("bazel keeps vanilla slug", flavor_allows("bazel", "test-repro-vanilla-bazel"), True)
     _eq("bazel drops lint-repro (no vanilla variant)", flavor_allows("bazel", "lint-repro"), False)
     # unknown flavor (mis-set arg) degrades to keep-all
-    _eq("unknown flavor keeps everything", flavor_allows("nonsense", "bazel-repro-vanilla-bazel"), True)
+    _eq("unknown flavor keeps everything", flavor_allows("nonsense", "test-repro-vanilla-bazel"), True)
 
 def _test_filter_by_flavor(_ctx):
     cmds = [
-        ReproFixCommand(command = "aspect build -- //a", slug = "bazel-repro-aspect"),
-        ReproFixCommand(command = "bazel build -- //a", slug = "bazel-repro-vanilla-bazel"),
+        ReproFixCommand(command = "aspect test -- //a", slug = "test-repro-aspect"),
+        ReproFixCommand(command = "bazel test -- //a", slug = "test-repro-vanilla-bazel"),
     ]
     _eq("both → unchanged", [c.slug for c in filter_by_flavor(cmds, "both")],
-        ["bazel-repro-aspect", "bazel-repro-vanilla-bazel"])
+        ["test-repro-aspect", "test-repro-vanilla-bazel"])
     _eq("aspect → only aspect", [c.slug for c in filter_by_flavor(cmds, "aspect")],
-        ["bazel-repro-aspect"])
+        ["test-repro-aspect"])
     _eq("bazel → only vanilla", [c.slug for c in filter_by_flavor(cmds, "bazel")],
-        ["bazel-repro-vanilla-bazel"])
+        ["test-repro-vanilla-bazel"])
 
     # A multi-entry fix list (format/gazelle shape): aspect keeps the aspect
     # fixes, drops the lone vanilla-bazel one; bazel keeps only it.
@@ -1139,12 +1139,12 @@ def _test_filter_by_flavor(_ctx):
 def _test_target_round_trips_through_rehydrate(_ctx):
     # A per-failure command's target survives the JSON-dict round-trip the PR
     # comment artifact/state-block does (record → dict → rehydrate → record).
-    as_dict = {"command": "aspect test -- //foo:bar", "slug": "bazel-repro-aspect", "target": "//foo:bar"}
+    as_dict = {"command": "aspect test -- //foo:bar", "slug": "test-repro-aspect", "target": "//foo:bar"}
     out = rehydrate_commands([as_dict])
     _eq("rehydrate count", len(out), 1)
     _eq("rehydrate preserves target", out[0].target, "//foo:bar")
     # Missing target → "" (older release / combined command).
-    out2 = rehydrate_commands([{"command": "aspect test", "slug": "bazel-repro-aspect"}])
+    out2 = rehydrate_commands([{"command": "aspect test", "slug": "test-repro-aspect"}])
     _eq("rehydrate missing target → ''", out2[0].target, "")
 
 def _test_hook_preserves_target(_ctx):
@@ -1153,14 +1153,14 @@ def _test_hook_preserves_target(_ctx):
         return repro_fix_replace(command = "EDITED " + info.command)
     lifecycle = _fake_lifecycle([hook])
     data = {
-        "repro_commands": [ReproFixCommand(command = "aspect test -- //x", slug = "bazel-repro-aspect", target = "//x")],
+        "repro_commands": [ReproFixCommand(command = "aspect test -- //x", slug = "test-repro-aspect", target = "//x")],
         "fix_commands": [],
     }
     apply_repro_fix_hooks(_fake_apply_ctx(), lifecycle, data, kind = "bazel_results", status = "failed")
     out = data["repro_commands"][0]
     _eq("hook rewrote command", out.command, "EDITED aspect test -- //x")
     _eq("hook preserved target", out.target, "//x")
-    _eq("hook preserved slug", out.slug, "bazel-repro-aspect")
+    _eq("hook preserved slug", out.slug, "test-repro-aspect")
 
 _UNIT_TESTS = [
     _test_is_vanilla_bazel_slug,

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -7,7 +7,7 @@ tests on `Arguments`.
 """
 
 load("./lifecycle.axl", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixCommand", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "repro_fix_replace")
-load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "has_tools_bazel_wrapper", "rehydrate_commands", "repro_prefix", "subdir_prefix")
+load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "flavor_allows", "has_tools_bazel_wrapper", "is_vanilla_bazel_slug", "rehydrate_commands", "repro_prefix", "subdir_prefix")
 
 def _eq(label, got, want):
     if got != want:
@@ -1091,7 +1091,72 @@ def _test_dispatch_skips_hook_when_lists_empty(_ctx):
     _eq("hook not called when lists are empty", hook_count[0], 0)
     _eq("handler still called", handler_count[0], 1)
 
+def _test_is_vanilla_bazel_slug(_ctx):
+    _eq("vanilla slug", is_vanilla_bazel_slug("bazel-repro-vanilla-bazel"), True)
+    _eq("vanilla per-failure slug", is_vanilla_bazel_slug("bazel-repro-vanilla-bazel-failure"), True)
+    _eq("aspect slug not vanilla", is_vanilla_bazel_slug("bazel-repro-aspect"), False)
+    _eq("aspect per-failure slug not vanilla", is_vanilla_bazel_slug("bazel-repro-aspect-failure"), False)
+    _eq("lint-repro not vanilla", is_vanilla_bazel_slug("lint-repro"), False)
+
+def _test_flavor_allows(_ctx):
+    # both → keep everything
+    _eq("both keeps aspect", flavor_allows("both", "bazel-repro-aspect"), True)
+    _eq("both keeps vanilla", flavor_allows("both", "bazel-repro-vanilla-bazel"), True)
+    # aspect → only non-vanilla
+    _eq("aspect keeps aspect slug", flavor_allows("aspect", "bazel-repro-aspect"), True)
+    _eq("aspect drops vanilla slug", flavor_allows("aspect", "bazel-repro-vanilla-bazel"), False)
+    _eq("aspect keeps lint-repro", flavor_allows("aspect", "lint-repro"), True)
+    # bazel → only vanilla
+    _eq("bazel drops aspect slug", flavor_allows("bazel", "bazel-repro-aspect"), False)
+    _eq("bazel keeps vanilla slug", flavor_allows("bazel", "bazel-repro-vanilla-bazel"), True)
+    _eq("bazel drops lint-repro (no vanilla variant)", flavor_allows("bazel", "lint-repro"), False)
+    # unknown flavor (mis-set arg) degrades to keep-all
+    _eq("unknown flavor keeps everything", flavor_allows("nonsense", "bazel-repro-vanilla-bazel"), True)
+
+def _test_filter_by_flavor(_ctx):
+    cmds = [
+        ReproFixCommand(command = "aspect build -- //a", slug = "bazel-repro-aspect"),
+        ReproFixCommand(command = "bazel build -- //a", slug = "bazel-repro-vanilla-bazel"),
+    ]
+    _eq("both → unchanged", [c.slug for c in filter_by_flavor(cmds, "both")],
+        ["bazel-repro-aspect", "bazel-repro-vanilla-bazel"])
+    _eq("aspect → only aspect", [c.slug for c in filter_by_flavor(cmds, "aspect")],
+        ["bazel-repro-aspect"])
+    _eq("bazel → only vanilla", [c.slug for c in filter_by_flavor(cmds, "bazel")],
+        ["bazel-repro-vanilla-bazel"])
+
+def _test_target_round_trips_through_rehydrate(_ctx):
+    # A per-failure command's target survives the JSON-dict round-trip the PR
+    # comment artifact/state-block does (record → dict → rehydrate → record).
+    as_dict = {"command": "aspect test -- //foo:bar", "slug": "bazel-repro-aspect-failure", "target": "//foo:bar"}
+    out = rehydrate_commands([as_dict])
+    _eq("rehydrate count", len(out), 1)
+    _eq("rehydrate preserves target", out[0].target, "//foo:bar")
+    # Missing target → "" (older release / combined command).
+    out2 = rehydrate_commands([{"command": "aspect test", "slug": "bazel-repro-aspect"}])
+    _eq("rehydrate missing target → ''", out2[0].target, "")
+
+def _test_hook_preserves_target(_ctx):
+    # A replace verdict rewrites command but keeps target/slug identity.
+    def hook(ctx, info):
+        return repro_fix_replace(command = "EDITED " + info.command)
+    lifecycle = _fake_lifecycle([hook])
+    data = {
+        "repro_commands": [ReproFixCommand(command = "aspect test -- //x", slug = "bazel-repro-aspect-failure", target = "//x")],
+        "fix_commands": [],
+    }
+    apply_repro_fix_hooks(_fake_apply_ctx(), lifecycle, data, kind = "bazel_results", status = "failed")
+    out = data["repro_commands"][0]
+    _eq("hook rewrote command", out.command, "EDITED aspect test -- //x")
+    _eq("hook preserved target", out.target, "//x")
+    _eq("hook preserved slug", out.slug, "bazel-repro-aspect-failure")
+
 _UNIT_TESTS = [
+    _test_is_vanilla_bazel_slug,
+    _test_flavor_allows,
+    _test_filter_by_flavor,
+    _test_target_round_trips_through_rehydrate,
+    _test_hook_preserves_target,
     _test_returns_empty_when_no_explicit,
     _test_includes_only_explicit_pairs,
     _test_preserves_input_pair_order,

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -7,7 +7,7 @@ tests on `Arguments`.
 """
 
 load("./lifecycle.axl", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixCommand", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "repro_fix_replace")
-load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "flavor_allows", "has_tools_bazel_wrapper", "is_vanilla_bazel_slug", "rehydrate_commands", "repro_prefix", "subdir_prefix")
+load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "flavor_allows", "has_tools_bazel_wrapper", "is_vanilla_bazel_slug", "rehydrate_commands", "repro_prefix", "slug_flavor", "subdir_prefix")
 
 def _eq(label, got, want):
     if got != want:
@@ -1097,23 +1097,29 @@ def _test_is_vanilla_bazel_slug(_ctx):
     _eq("aspect slug not vanilla", is_vanilla_bazel_slug("test-repro-aspect"), False)
     _eq("lint-repro not vanilla", is_vanilla_bazel_slug("lint-repro"), False)
 
+def _test_slug_flavor(_ctx):
+    _eq("vanilla slug → bazel", slug_flavor("test-repro-vanilla-bazel"), "bazel")
+    _eq("aspect slug → aspect", slug_flavor("test-repro-aspect"), "aspect")
+    _eq("plain slug → aspect", slug_flavor("lint-repro"), "aspect")
+
 def _test_flavor_allows(_ctx):
-    # both → keep everything
-    _eq("both keeps aspect", flavor_allows("both", "test-repro-aspect"), True)
-    _eq("both keeps vanilla", flavor_allows("both", "test-repro-vanilla-bazel"), True)
+    # `flavors` is a list of opted-in flavors.
+    both = ["aspect", "bazel"]
+    _eq("both keeps aspect", flavor_allows(both, "test-repro-aspect"), True)
+    _eq("both keeps vanilla", flavor_allows(both, "test-repro-vanilla-bazel"), True)
 
-    # aspect → only non-vanilla
-    _eq("aspect keeps aspect slug", flavor_allows("aspect", "test-repro-aspect"), True)
-    _eq("aspect drops vanilla slug", flavor_allows("aspect", "test-repro-vanilla-bazel"), False)
-    _eq("aspect keeps lint-repro", flavor_allows("aspect", "lint-repro"), True)
+    # ["aspect"] → only non-vanilla
+    _eq("aspect keeps aspect slug", flavor_allows(["aspect"], "test-repro-aspect"), True)
+    _eq("aspect drops vanilla slug", flavor_allows(["aspect"], "test-repro-vanilla-bazel"), False)
+    _eq("aspect keeps lint-repro", flavor_allows(["aspect"], "lint-repro"), True)
 
-    # bazel → only vanilla
-    _eq("bazel drops aspect slug", flavor_allows("bazel", "test-repro-aspect"), False)
-    _eq("bazel keeps vanilla slug", flavor_allows("bazel", "test-repro-vanilla-bazel"), True)
-    _eq("bazel drops lint-repro (no vanilla variant)", flavor_allows("bazel", "lint-repro"), False)
+    # ["bazel"] → only vanilla
+    _eq("bazel drops aspect slug", flavor_allows(["bazel"], "test-repro-aspect"), False)
+    _eq("bazel keeps vanilla slug", flavor_allows(["bazel"], "test-repro-vanilla-bazel"), True)
+    _eq("bazel drops lint-repro (no vanilla variant)", flavor_allows(["bazel"], "lint-repro"), False)
 
-    # unknown flavor (mis-set arg) degrades to keep-all
-    _eq("unknown flavor keeps everything", flavor_allows("nonsense", "test-repro-vanilla-bazel"), True)
+    # Empty list (mis-set arg) degrades to keep-all.
+    _eq("empty list keeps everything", flavor_allows([], "test-repro-vanilla-bazel"), True)
 
 def _test_filter_by_flavor(_ctx):
     cmds = [
@@ -1122,18 +1128,23 @@ def _test_filter_by_flavor(_ctx):
     ]
     _eq(
         "both → unchanged",
-        [c.slug for c in filter_by_flavor(cmds, "both")],
+        [c.slug for c in filter_by_flavor(cmds, ["aspect", "bazel"])],
         ["test-repro-aspect", "test-repro-vanilla-bazel"],
     )
     _eq(
         "aspect → only aspect",
-        [c.slug for c in filter_by_flavor(cmds, "aspect")],
+        [c.slug for c in filter_by_flavor(cmds, ["aspect"])],
         ["test-repro-aspect"],
     )
     _eq(
         "bazel → only vanilla",
-        [c.slug for c in filter_by_flavor(cmds, "bazel")],
+        [c.slug for c in filter_by_flavor(cmds, ["bazel"])],
         ["test-repro-vanilla-bazel"],
+    )
+    _eq(
+        "empty list → unchanged",
+        [c.slug for c in filter_by_flavor(cmds, [])],
+        ["test-repro-aspect", "test-repro-vanilla-bazel"],
     )
 
     # A multi-entry fix list (format/gazelle shape): aspect keeps the aspect
@@ -1145,12 +1156,12 @@ def _test_filter_by_flavor(_ctx):
     ]
     _eq(
         "aspect fixes → drop vanilla",
-        [c.slug for c in filter_by_flavor(fixes, "aspect")],
+        [c.slug for c in filter_by_flavor(fixes, ["aspect"])],
         ["format-fix", "format-fix-rediscover"],
     )
     _eq(
         "bazel fixes → only vanilla",
-        [c.slug for c in filter_by_flavor(fixes, "bazel")],
+        [c.slug for c in filter_by_flavor(fixes, ["bazel"])],
         ["format-fix-vanilla-bazel"],
     )
 
@@ -1184,6 +1195,7 @@ def _test_hook_preserves_target(_ctx):
 
 _UNIT_TESTS = [
     _test_is_vanilla_bazel_slug,
+    _test_slug_flavor,
     _test_flavor_allows,
     _test_filter_by_flavor,
     _test_target_round_trips_through_rehydrate,

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -28,7 +28,7 @@ load("./lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_ch
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("./lib/lint_results.axl", "detect_lint_tool", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
-load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "print_repro_and_fix", "repro_prefix", "task_cli_path")
+load("./lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "flavor_allows", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
 load("./lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics")
 load("./lib/tar.axl", "tar_create")
 load("./lib/text.axl", "pluralize")
@@ -1001,11 +1001,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     targets = list(ctx.args.targets)
     task_path = task_cli_path(ctx.task)
     prefix = repro_prefix(ctx)
-    data["repro_commands"].append(ReproFixCommand(
-        command = prefix + build_aspect_command(task_path, repro_flags, targets),
-        slug = "lint-repro",
-    ))
-    if data["lint"]["suggestions"]:
+    if flavor_allows(ctx.args.repro_flavors, "lint-repro"):
+        data["repro_commands"].append(ReproFixCommand(
+            command = prefix + build_aspect_command(task_path, repro_flags, targets),
+            slug = "lint-repro",
+        ))
+    if data["lint"]["suggestions"] and flavor_allows(ctx.args.fix_flavors, "lint-fix"):
         data["fix_commands"].append(ReproFixCommand(
             command = prefix + build_aspect_command(task_path, [("--fix", None)] + repro_flags, targets),
             slug = "lint-fix",
@@ -1104,7 +1105,7 @@ lint = task(
             default = ["..."],
             description = "Bazel target patterns to lint. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory. Pass multiple patterns to combine includes and excludes; when any pattern is hyphen-led, separate them from flags with `--` (e.g. `aspect lint -- //... -//experimental/...`).",
         ),
-    } | announce_bazel_args("the lint build"),
+    } | announce_bazel_args("the lint build") | repro_flavor_args(include_fix = True),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -8,6 +8,7 @@ load("./lib/bazel_flags.axl", "announce_bazel_args")
 load("./lib/bazel_runner.axl", "run_bazel_task")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "TaskLifecycleTrait")
+load("./lib/repro_commands.axl", "repro_flavor_args")
 load("./lib/tips.axl", "tips")
 
 # Where `--combined_report=lcov` writes the merged LCOV report, relative to
@@ -149,7 +150,7 @@ test = task(
             default = False,
             description = "Cancel any running Bazel invocation before starting the test.",
         ),
-    } | announce_bazel_args("the test"),
+    } | announce_bazel_args("the test") | repro_flavor_args(),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/examples/test_states/BUILD.bazel
+++ b/examples/test_states/BUILD.bazel
@@ -50,7 +50,7 @@ sh_test(
     name = "demo_test_fail",
     size = "small",
     srcs = ["demo_test_fail.sh"],
-    tags = ["manual"],
+    tags = ["manual"],  # opt-in only; don't run with //...
 )
 
 genrule(
@@ -73,5 +73,5 @@ examples/test_states/widget.cc:18:5: note:   no known conversion for argument 1 
 ERR
 exit 1
 )""",
-    tags = ["manual"],
+    tags = ["manual"],  # opt-in only; don't run with //...
 )


### PR DESCRIPTION
On a failed CI build, the status surfaces already inline a snippet of each failure's output. This PR adds a **targeted repro command directly beneath each failure's snippet** — a dev reading the snippet for `//foo:bar_test` now sees `aspect test -- //foo:bar_test` (and the vanilla `bazel test -- //foo:bar_test`) right there, instead of hand-editing the whole-run command down. The combined "🔁 Reproduce" section stays for re-running everything.

Repro commands are keyed by the subcommand that actually **reproduces** each failure, not by the task. A `test` task that hit a build-action failure (or a test that failed to *build*) reruns those via `bazel build` — `bazel test //x` on a non-test target errors with "no test targets found". So a single test run can surface both a `build` and a `test` combined repro, each with the right per-failure commands underneath.

Two new task args, `repro_flavors` and `fix_flavors`, select which command flavor(s) to surface — a list of `aspect` / `bazel`, defaulting to both, set via a repeatable `--repro-flavor` / `--fix-flavor` flag. Gated at the producer, so all surfaces and the CLI printout honor the control for free.

## How it fits together

- **`ReproFixCommand.target`** (new field) correlates a per-failure command to its failure label; whole-run commands carry `target == ""`. Preserved through the `repro_fix_suggestion` hook chain like `slug`.
- **`failed_labels_by_subcommand(data)`** partitions failures into `build` (actions + targets + failed-to-build tests) and `test` (built-then-failed) buckets.
- **`repro_by_target(...)`** maps each failing label to its per-failure commands; the renderers attach them to snippet rows (correlated by untruncated label) so they appear inline under the snippet on the GitHub status check, the PR/MR comment, and the Buildkite annotation.
- **`flavor_allows` / `filter_by_flavor`** gate emission by slug against the opted-in flavor list (`-vanilla-bazel` suffix ⇒ the bazel flavor), so suppressed flavors are never produced.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- CI status surfaces now show a per-failure repro command (Aspect CLI + vanilla `bazel`) directly beneath each failure's inline output snippet, routed to the correct `build`/`test` subcommand.
- New `repro_flavors` / `fix_flavors` task args (a list of `aspect` / `bazel`, default both; repeatable `--repro-flavor` / `--fix-flavor` flag) control which command flavor is surfaced on status checks, annotations, and PR/MR comments.

### Test plan

- Covered by existing test cases
- New test cases added
  - `failed_labels_by_subcommand` build/test partitioning (incl. build-only task) and `repro_by_target` per-failure correlation (record + dict inputs, whole-run exclusion) in `bazel_results_test.axl`
  - `is_vanilla_bazel_slug`, `flavor_allows`, `filter_by_flavor`, `target` round-trip + hook preservation in `repro_commands_test.axl`
  - per-failure inline repro rendering + combined-section exclusion in the `.aspect/axl.axl` render suite and `github_status_comments_test.axl`
- Full local regression green: `aspect tests axl`, `test-repro-commands` / `test-bazel-results` / `test-bazel-runner`, all snapshot suites, `cargo test -p aspect-cli`
- Verified end-to-end on live CI (GitHub PR comment + status checks): a `test` run with both a build-action and a test failure emits `aspect build -- …` and `aspect test -- …`, and the build target is never placed on `aspect test`.
