### PR TITLE
feat(status): selectable template styles + DX-focused "Strata" style

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -31,6 +31,7 @@ load("@aspect//lib/repro_commands.axl", "build_aspect_command", "dedup_and_attri
 load("@aspect//lib/result_text.axl", "severity_for_status")
 load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
 load("@aspect//lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics", "sarif_to_review_comments")
+load("@aspect//lib/template_styles.axl", "resolve_style")
 load("@aspect//lib/tips.axl", "tips")
 load("@aspect//lint.axl", "file_uri_to_path", "filter_all", "filter_changeset", "linter_error_message")
 load("@demo//answer.axl", "ANSWER")
@@ -3377,6 +3378,22 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     out3 = render_check_output(ctx, r3, "failed", render_ctx, links, snippet_options = SnippetOptions(max_lines = 5), max_snippets = 1)
     tc = test_case(tc, "…\nline 45" in out3["text"], "render: dropped-head truncation marker (leading …)")
     tc = test_case(tc, "line 49" in out3["text"], "render: windowed snippet keeps the tail")
+
+    # Strata style: same fixture `r` (snippets + per-failure repros), rendered
+    # through the Strata templates. The DX layout leads with a verdict heading +
+    # KPI strip, shows each failure snippet open with its repro beneath it, and
+    # keeps the whole-run command out of the combined Reproduce section.
+    _strata = resolve_style("strata", {})
+    _st = {"summary": _strata["summary"], "details": _strata["details"]}
+    out_s = render_check_output(ctx, r, "failed", render_ctx, links, templates = _st, snippet_options = opts, max_snippets = max_snips)
+    tc = test_case(tc, "### ❌ Failed" in out_s["text"], "strata: verdict heading")
+    tc = test_case(tc, "### 💥 What broke" in out_s["text"], "strata: what-broke section")
+    tc = test_case(tc, "FAILED: expected 1 got 2" in out_s["text"], "strata: inlines failed-test snippet")
+    tc = test_case(tc, "no member named 'foo'" in out_s["text"], "strata: inlines failed-action snippet")
+    tc = test_case(tc, "aspect test -- //pkg:fail_test" in out_s["text"], "strata: per-failure aspect repro inline")
+    tc = test_case(tc, "aspect build -- //pkg:broken" in out_s["text"], "strata: per-failure action repro inline")
+    _s_repro = out_s["text"][out_s["text"].find("🔁 Reproduce"):] if "🔁 Reproduce" in out_s["text"] else ""
+    tc = test_case(tc, "//pkg:fail_test" not in _s_repro, "strata: combined Reproduce excludes per-failure commands")
 
     ctx.std.fs.remove_dir_all(d)
     return tc

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -32,6 +32,7 @@ load("@aspect//lib/runnable_test.axl", "runnable_tests")
 load("@aspect//lib/runner_job_history_test.axl", "runner_job_history_tests")
 load("@aspect//lib/sandbox_recovery_test.axl", "sandbox_recovery_tests")
 load("@aspect//lib/tar_test.axl", "tar_tests")
+load("@aspect//lib/template_styles_test.axl", "template_styles_tests")
 load("@aspect//lib/tips_test.axl", "tips_tests")
 load("@aspect//lib/wrapper_test.axl", "wrapper_tests")
 load("@aspect//tips.axl", "TASK_SCREENS", "TIP_SUGGESTION", "TIP_TEMPLATE_RAW", "add_tip")
@@ -271,6 +272,11 @@ def config(ctx: ConfigContext):
     # bsdtar platform-key mapping (supported + unsupported hosts).
     # Run with: aspect dev test-tar
     ctx.tasks.add(tar_tests)
+
+    # Template-style machinery: resolve_style selection + override layering,
+    # compute_strata_kpi verdict/thresholds/slow-detection.
+    # Run with: aspect dev test-template-styles
+    ctx.tasks.add(template_styles_tests)
 
     # CircleCI S3 error parsing: expired-credential 400 → legible reason.
     # Run with: aspect dev test-circleci

--- a/crates/aspect-cli/src/builtins/aspect/README.md
+++ b/crates/aspect-cli/src/builtins/aspect/README.md
@@ -218,5 +218,6 @@ Behavior notes:
 | [lib/format_results.axl](lib/format_results.axl) | `init_data`, `render_check_output`, `format_summary_title` | format |
 | [lib/gazelle_results.axl](lib/gazelle_results.axl) | `init_data`, `render_check_output`, `gazelle_summary_title` | gazelle |
 | [lib/delivery_results.axl](lib/delivery_results.axl) | `init_data`, `add_result`, `render_check_output`, `delivery_summary_title` | delivery |
+| [lib/template_styles.axl](lib/template_styles.axl) | `resolve_style`, `builtin_style`, `STYLE_NAMES`, `STYLE_ARG_DESCRIPTION` (Strata strings in [lib/strata_templates.axl](lib/strata_templates.axl)) | every status feature (the `style` arg) |
 
 Each `*_results.axl` derives its `init_data()` from `bazel_results.init_data()` (so `process_event` can populate the full bazel state) and appends `SHARED_DETAILS_BODY_TEMPLATE` to its task-specific top section so the rendered details body has the same Targets / Build Metrics / Invocation / Workflows Runner / Workspace Status / Build Metadata / Options-parsed sections everywhere.

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -34,6 +34,7 @@ load("../lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
 load("../lib/rate_limit.axl", "usage_footer")
 load("../lib/result_text.axl", "severity_for_status")
+load("../lib/template_styles.axl", "STYLE_ARG_DESCRIPTION", "STYLE_NAMES", "resolve_style")
 load("../lib/tips.axl", "SURFACE_BUILDKITE_ANNOTATIONS", "collect_tips_sorted")
 
 # ─── Style selection ──────────────────────────────────────────────────────────
@@ -205,6 +206,10 @@ def _buildkite_annotations(ctx: FeatureContext):
     mode = ctx.args.mode
     is_bk = bool(ctx.std.env.var("BUILDKITE"))
 
+    # Resolve the named style into the {summary, details} the renderer consumes.
+    _style = resolve_style(ctx.args.style, ctx.args.templates or {})
+    _templates = {"summary": _style["summary"], "details": _style["details"]}
+
     _LOG.trace("starting (mode=%s BUILDKITE=%r is_bk=%s)" %
                (mode, ctx.std.env.var("BUILDKITE") or "", is_bk))
 
@@ -322,7 +327,7 @@ def _buildkite_annotations(ctx: FeatureContext):
             status,
             make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_BUILDKITE_ANNOTATIONS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             _make_links(data),
-            None,
+            _templates,
             None,
             snippet_options = _snippet_opts,
             max_snippets = _max_snippets,
@@ -356,6 +361,19 @@ BuildkiteAnnotations = feature(
                           "reduce `buildkite-agent annotate` invocations on chatty tasks at the cost of " +
                           "less-responsive live annotations. The task's terminal result and phase " +
                           "boundaries always land immediately regardless of this setting.",
+        ),
+        "style": args.string(
+            default = "kilgore",
+            values = STYLE_NAMES,
+            description = STYLE_ARG_DESCRIPTION,
+        ),
+        "templates": args.custom(
+            dict,
+            default = {},
+            description = "Map of template overrides for the rendered annotation body. " +
+                          "Keys: \"summary\", \"details\". Each value is a Jinja2 template string. " +
+                          "Empty dict (default) uses the selected `style`'s templates. Overrides " +
+                          "layer on top of `style`.",
         ),
     },
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -363,7 +363,7 @@ BuildkiteAnnotations = feature(
                           "boundaries always land immediately regardless of this setting.",
         ),
         "style": args.string(
-            default = "kilgore",
+            default = "strata",
             values = STYLE_NAMES,
             description = STYLE_ARG_DESCRIPTION,
         ),

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -497,7 +497,7 @@ GithubStatusChecks = feature(
             description = "Restrict lint check-run annotations to the displayed hunk regions of changed files (added lines + surrounding context from `detect_changed_files`). When false, off-region annotations are still posted but GitHub only renders them on the check-run detail page and commit page, not in Files Changed. Skipped silently when no changed-files context is available.",
         ),
         "style": args.string(
-            default = "kilgore",
+            default = "strata",
             values = STYLE_NAMES,
             description = STYLE_ARG_DESCRIPTION,
         ),

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -56,6 +56,7 @@ load(
     "should_emit_phase_change",
     "usage_footer",
 )
+load("../lib/template_styles.axl", "STYLE_ARG_DESCRIPTION", "STYLE_NAMES", "resolve_style")
 load("../lib/tips.axl", "SURFACE_GITHUB_STATUS_CHECKS", "collect_tips_sorted")
 load("../lint.axl", "LintTrait")
 
@@ -93,7 +94,12 @@ def _collect_ci_links(ctx, results_base_url):
 def _github_status_checks(ctx: FeatureContext):
     lifecycle = ctx.traits[TaskLifecycleTrait]
 
-    templates = ctx.args.templates or {}
+    # Resolve the named style (kilgore default) into its template bundle, then
+    # layer the per-key `templates` overrides on top (a custom variant). The
+    # resolved {summary, details} pair is what the renderer consumes; selecting
+    # the default style is byte-identical to the pre-style behavior.
+    _style = resolve_style(ctx.args.style, ctx.args.templates or {})
+    templates = {"summary": _style["summary"], "details": _style["details"]}
     metadata_keys = list(ctx.args.metadata_keys or [])
 
     # Check-run URL is published below via `checkrun.set_url`; siblings
@@ -490,12 +496,19 @@ GithubStatusChecks = feature(
             default = True,
             description = "Restrict lint check-run annotations to the displayed hunk regions of changed files (added lines + surrounding context from `detect_changed_files`). When false, off-region annotations are still posted but GitHub only renders them on the check-run detail page and commit page, not in Files Changed. Skipped silently when no changed-files context is available.",
         ),
+        "style": args.string(
+            default = "kilgore",
+            values = STYLE_NAMES,
+            description = STYLE_ARG_DESCRIPTION,
+        ),
         "templates": args.custom(
             dict,
             default = {},
             description = "Map of template overrides for the rendered check-run output. " +
                           "Keys: \"summary\", \"details\". Each value is a Jinja2 template " +
-                          "string. Empty dict (default) uses the feature's built-in templates.",
+                          "string. Empty dict (default) uses the selected `style`'s templates. " +
+                          "Overrides layer on top of `style`, so you can pick a style and replace " +
+                          "just one slot.",
         ),
         "metadata_keys": args.string_list(
             default = [],

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1994,7 +1994,7 @@ GithubStatusComments = feature(
         ),
         # Config-only (set via configure(..., feature_args = {...}) in config.axl).
         "style": args.string(
-            default = "kilgore",
+            default = "strata",
             values = STYLE_NAMES,
             description = STYLE_ARG_DESCRIPTION,
         ),

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -82,6 +82,7 @@ load(
 load("../lib/repro_commands.axl", "ASPECT_CLI_INSTALL_HINT_MARKDOWN", "dedup_and_attribute", "rehydrate_commands")
 load("../lib/result_text.axl", "severity_for_status")
 load("../lib/tar.axl", "bsdtar")
+load("../lib/template_styles.axl", "STYLE_ARG_DESCRIPTION", "STYLE_NAMES", "resolve_style")
 load(
     "../lib/tips.axl",
     "SURFACE_GITHUB_PR_SUMMARY",
@@ -1264,9 +1265,13 @@ def _github_status_comments(ctx: FeatureContext):
     min_poll_interval_seconds = ctx.args.min_poll_interval_seconds
     artifact_expires_minutes = ctx.args.artifact_expires_minutes
 
+    # Resolve the named style (kilgore default), then layer the per-key
+    # `templates` overrides. The Kilgore bundle carries no `body` (the body
+    # template lives in this feature), so it falls back to _DEFAULT_BODY_TEMPLATE;
+    # Strata supplies its own body; a `templates["body"]` override wins over both.
     # args.custom(dict, ...) hands None at runtime, not the declared default.
-    templates = ctx.args.templates or {}
-    body_template = templates.get("body") or _DEFAULT_BODY_TEMPLATE
+    _style = resolve_style(ctx.args.style, ctx.args.templates or {})
+    body_template = _style["body"] or _DEFAULT_BODY_TEMPLATE
     status_badges = dict(_DEFAULT_STATUS_BADGES)
     status_badges.update(ctx.args.status_badges or {})
 
@@ -1988,6 +1993,11 @@ GithubStatusComments = feature(
                           "Set to 0 to disable (no expiry).",
         ),
         # Config-only (set via configure(..., feature_args = {...}) in config.axl).
+        "style": args.string(
+            default = "kilgore",
+            values = STYLE_NAMES,
+            description = STYLE_ARG_DESCRIPTION,
+        ),
         "templates": args.custom(
             dict,
             default = {},

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -72,6 +72,7 @@ load(
 load("../lib/bazel_results.axl", "compute_reproducer_command")
 load("../lib/github.axl", "github")
 load("../lib/repro_commands.axl", "rehydrate_commands")
+load("../lib/template_styles.axl", "resolve_style")
 load("../lib/tips.axl", "tips")
 
 def _eq(label, got, want):
@@ -2332,8 +2333,29 @@ def _test_impl(ctx):
         print(body)
         print("")
 
+    # Strata style: render a subset through the Strata body template so any
+    # Jinja/data-shape regression in the aggregated comment surfaces here.
+    strata = resolve_style("strata", {})
+    for (label, raw_entries) in scenarios:
+        prepared = prepare_for_render(raw_entries)
+        sections = bucket_entries(prepared)
+        body = render_body(
+            ctx,
+            MARKER_FMT % 1234,
+            prepared,
+            "Fri May 10 07:16:05 UTC 2024",
+            strata["body"],
+            DEFAULT_STATUS_BADGES,
+            sections,
+        )
+        print(sep)
+        print("SCENARIO: strata · " + label)
+        print(sep)
+        print(body)
+        print("")
+
     print(sep)
-    print("All %d PR-comment scenarios rendered without error." % len(scenarios))
+    print("All %d PR-comment scenarios rendered without error (Kilgore + Strata)." % len(scenarios))
     return 0
 
 def _aborted(data, reason):

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -432,7 +432,7 @@ GitlabCommitStatuses = feature(
                           "so the final state shows up without delay.",
         ),
         "style": args.string(
-            default = "kilgore",
+            default = "strata",
             values = STYLE_NAMES,
             description = STYLE_ARG_DESCRIPTION,
         ),

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -87,6 +87,7 @@ load(
     "effective_throttle_factor",
     "should_emit_phase_change",
 )
+load("../lib/template_styles.axl", "STYLE_ARG_DESCRIPTION", "STYLE_NAMES", "resolve_style")
 
 _LOG = feature_logger("GitLab commit statuses")
 
@@ -152,7 +153,9 @@ def _state_for(status, final):
 def _gitlab_commit_statuses(ctx: FeatureContext):
     lifecycle = ctx.traits[TaskLifecycleTrait]
 
-    templates = ctx.args.templates or {}
+    # Resolve the named style (kilgore default) + per-key `templates` overrides.
+    _style = resolve_style(ctx.args.style, ctx.args.templates or {})
+    templates = {"summary": _style["summary"], "details": _style["details"]}
     metadata_keys = list(ctx.args.metadata_keys or [])
 
     mode = ctx.args.mode
@@ -428,12 +431,18 @@ GitlabCommitStatuses = feature(
                           "or the task runs longer. The task's terminal result always lands immediately " +
                           "so the final state shows up without delay.",
         ),
+        "style": args.string(
+            default = "kilgore",
+            values = STYLE_NAMES,
+            description = STYLE_ARG_DESCRIPTION,
+        ),
         "templates": args.custom(
             dict,
             default = {},
             description = "Map of template overrides for the rendered status output. " +
                           "Keys: \"summary\", \"details\". Each value is a Jinja2 template " +
-                          "string. Empty dict (default) uses the feature's built-in templates. " +
+                          "string. Empty dict (default) uses the selected `style`'s templates; " +
+                          "overrides layer on top of `style`. " +
                           "Note: only the rendered `title` lands on the commit status (in " +
                           "`description`, truncated to 255 chars) — the full body is rendered " +
                           "into the GitlabStatusComments rolling note.",

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -447,7 +447,7 @@ GitlabStatusComments = feature(
                           "verdicts always land immediately.",
         ),
         "style": args.string(
-            default = "kilgore",
+            default = "strata",
             values = STYLE_NAMES,
             description = STYLE_ARG_DESCRIPTION,
         ),

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -76,6 +76,7 @@ load(
     "epoch_now_s",
     "usage_footer",
 )
+load("../lib/template_styles.axl", "STYLE_ARG_DESCRIPTION", "STYLE_NAMES", "resolve_style")
 
 _LOG = feature_logger("GitLab status comments")
 
@@ -153,8 +154,11 @@ def _gitlab_status_comments(ctx: FeatureContext):
     ci_run_url = _ci_run_url(env)
     min_poll_interval_seconds = max(1, ctx.args.min_poll_interval_seconds)
 
-    templates = ctx.args.templates or {}
-    body_template = templates.get("body") or DEFAULT_BODY_TEMPLATE
+    # Resolve the named style, then layer per-key `templates` overrides. Kilgore
+    # carries no body (falls back to the shared GitHub body template); Strata
+    # supplies its own; a `templates["body"]` override wins over both.
+    _style = resolve_style(ctx.args.style, ctx.args.templates or {})
+    body_template = _style["body"] or DEFAULT_BODY_TEMPLATE
     status_badges = dict(DEFAULT_STATUS_BADGES)
     status_badges.update(ctx.args.status_badges or {})
 
@@ -442,13 +446,18 @@ GitlabStatusComments = feature(
                           "the cost stays flat regardless of how many run in parallel. Terminal task " +
                           "verdicts always land immediately.",
         ),
+        "style": args.string(
+            default = "kilgore",
+            values = STYLE_NAMES,
+            description = STYLE_ARG_DESCRIPTION,
+        ),
         "templates": args.custom(
             dict,
             default = {},
             description = "Per-section Jinja2 template overrides. Keys: 'body'. " +
                           "Vars available match the GithubStatusComments template contract " +
-                          "(see feature/github_status_comments.axl). Empty dict → built-in default. " +
-                          "config.axl only.",
+                          "(see feature/github_status_comments.axl). Empty dict → selected `style`'s " +
+                          "body. Overrides layer on top of `style`. config.axl only.",
         ),
         "status_badges": args.custom(
             dict,

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -3465,6 +3465,177 @@ def _build_invocation_stats(data):
         "miss_reasons_table": miss_reasons_pre,
     }
 
+# Strata KPI thresholds: (green-floor, amber-floor). A value ≥ green-floor is
+# 🟢, ≥ amber-floor is 🟡, else 🔴. Echo the Strata web UI's tile colors, which
+# markdown can't set directly. `_kpi_emoji` maps a value through these.
+_KPI_CACHE_GREEN = 85
+_KPI_CACHE_AMBER = 60
+_KPI_PARALLEL_GREEN = 4.0
+_KPI_PARALLEL_AMBER = 1.5
+
+# Critical-path / analysis SHARE-of-wall thresholds are inverted (lower is
+# better): a share at/under green-ceiling is 🟢, at/under amber-ceiling is 🟡.
+_KPI_CRIT_SHARE_GREEN = 40
+_KPI_CRIT_SHARE_AMBER = 60
+
+def _kpi_emoji_high(value, green_floor, amber_floor):
+    """🟢/🟡/🔴 for a higher-is-better KPI (cache hit %, parallelism)."""
+    if value >= green_floor:
+        return "🟢"
+    if value >= amber_floor:
+        return "🟡"
+    return "🔴"
+
+def _kpi_emoji_low(value, green_ceiling, amber_ceiling):
+    """🟢/🟡/🔴 for a lower-is-better KPI (critical-path share of wall)."""
+    if value <= green_ceiling:
+        return "🟢"
+    if value <= amber_ceiling:
+        return "🟡"
+    return "🔴"
+
+def compute_strata_kpi(data, status):
+    """Compute the Strata KPI strip: a verdict line + the at-a-glance health
+    numbers (cache hit %, parallelism, wall, critical-path share), each paired
+    with a 🟢/🟡/🔴 threshold emoji that stands in for the web UI's tile color.
+
+    Returns a dict the Strata `details`/`body` templates read. Before any
+    build_metrics arrive it carries only the verdict (the heading still renders)
+    with an empty `strip_lines`, so the fenced KPI block is skipped. Shape:
+
+        {
+          "verdict_emoji": "🔴", "verdict_word": "Failed",
+          "slow": bool,                     # green-but-slow → auto-expand perf
+          "cache": {"emoji","value","sub"} | None,
+          "parallelism": {...} | None,
+          "wall": {"emoji","value","sub"} | None,
+          "strip_lines": [str, ...],        # pre-aligned monospace KPI lines
+        }
+
+    `slow` fires when wall is the dominant cost AND there's a legible reason —
+    a low cache hit or low parallelism — so the perf section always has
+    something to point at when it auto-expands. Pure-numeric inputs come from
+    `data["bazel"]`; thresholds are the `_KPI_*` constants.
+    """
+    b = data["bazel"]
+    wall_ms = b.get("wall_time_ms", 0) or 0
+    cpu_ms = b.get("cpu_time_ms", 0) or 0
+    critical_ms = b.get("critical_path_ms", 0) or 0
+
+    executed, cached, total = _effective_action_cache_counts(data)
+    has_metrics = wall_ms > 0 or total > 0
+    if not has_metrics:
+        # No build_metrics yet — surface the verdict heading anyway (computable
+        # from status), with an empty strip so the fenced KPI block is skipped.
+        v_emoji, v_word = _strata_verdict(data, status, False)
+        return {
+            "verdict_emoji": v_emoji,
+            "verdict_word": v_word,
+            "slow": False,
+            "cache": None,
+            "parallelism": None,
+            "wall": None,
+            "strip_lines": [],
+        }
+
+    cache = None
+    if total > 0:
+        pct = (cached * 100) // total
+        cache = {
+            "emoji": _kpi_emoji_high(pct, _KPI_CACHE_GREEN, _KPI_CACHE_AMBER),
+            "value": str(pct) + "%",
+            "sub": format_int_comma(cached) + " / " + format_int_comma(total) + " actions",
+        }
+
+    parallelism = None
+    if wall_ms > 0 and cpu_ms > 0:
+        ratio = float(cpu_ms) / float(wall_ms)
+
+        # One decimal, e.g. "6.2×".
+        tenths = int(ratio * 10 + 0.5)
+        parallelism = {
+            "emoji": _kpi_emoji_high(ratio, _KPI_PARALLEL_GREEN, _KPI_PARALLEL_AMBER),
+            "value": str(tenths // 10) + "." + str(tenths % 10) + "×",
+            "sub": "cpu " + format_duration_ms(cpu_ms),
+        }
+
+    wall = None
+    if wall_ms > 0:
+        crit_sub = ""
+        wall_emoji = "🟢"
+        if critical_ms > 0:
+            share = (critical_ms * 100) // wall_ms
+            wall_emoji = _kpi_emoji_low(share, _KPI_CRIT_SHARE_GREEN, _KPI_CRIT_SHARE_AMBER)
+            crit_sub = "crit path " + format_duration_ms(critical_ms) + " (" + str(share) + "%)"
+        wall = {
+            "emoji": wall_emoji,
+            "value": format_duration_ms(wall_ms),
+            "sub": crit_sub,
+        }
+
+    # Green-but-slow: terminal pass where the build's cost is dominated by a
+    # legible bottleneck (poor cache reuse or poor parallelism). The verdict
+    # then reads "Passed, but slow" and the perf section auto-expands.
+    cache_red = cache != None and cache["emoji"] == "🔴"
+    parallel_red = parallelism != None and parallelism["emoji"] == "🔴"
+    is_pass = status == "passed"
+    slow = is_pass and (cache_red or parallel_red)
+
+    verdict_emoji, verdict_word = _strata_verdict(data, status, slow)
+
+    # Pre-align the strip as one line per KPI: "<emoji> <LABEL>  <value>  <sub>".
+    # Labels are fixed-width ASCII, so they align regardless of how a renderer
+    # sizes the leading emoji glyph (monospace emoji width is unreliable across
+    # GitHub/GitLab/Buildkite). Skip a KPI with no data rather than show "n/a".
+    def _strip_line(emoji, label, value, sub):
+        # Right-pad value only when a sub-line follows, so a KPI with no sub
+        # (e.g. wall with no critical path) carries no trailing whitespace.
+        cell = _pad_right(value, 8) + sub if sub else value
+        return (emoji + " " + _pad_right(label, 12) + cell).rstrip()
+
+    strip_lines = []
+    if cache:
+        strip_lines.append(_strip_line(cache["emoji"], "Cache hit", cache["value"], cache["sub"]))
+    if parallelism:
+        strip_lines.append(_strip_line(parallelism["emoji"], "Parallelism", parallelism["value"], parallelism["sub"]))
+    if wall:
+        strip_lines.append(_strip_line(wall["emoji"], "Wall time", wall["value"], wall["sub"]))
+
+    return {
+        "verdict_emoji": verdict_emoji,
+        "verdict_word": verdict_word,
+        "slow": slow,
+        "cache": cache,
+        "parallelism": parallelism,
+        "wall": wall,
+        # Pre-aligned monospace strip lines for the fenced KPI block.
+        "strip_lines": strip_lines,
+    }
+
+def _strata_verdict(data, status, slow):
+    """(emoji, word) for the Strata verdict line, using the web UI vocabulary:
+    Passed / Failed / Running / Timed out / Flaky / Skipped (+ aborted)."""
+    if data["bazel"].get("aborted", False):
+        return ("🔥", "Aborted")
+    if status == "running" or status == "failing":
+        return ("🔄", "Running")
+    if status == "passed":
+        if slow:
+            return ("🟢", "Passed, but slow")
+        if (data["bazel"].get("flaky_test_total", 0) or 0) > 0:
+            return ("⚠️", "Passed with flakes")
+        return ("✅", "Passed")
+
+    # Any terminal non-pass is a failure; name a timeout specifically.
+    failed_tests = data["bazel"].get("failed_tests", []) or []
+    only_timeouts = len(failed_tests) > 0 and all([
+        t.get("status", "") == _TEST_STATUS_TIMEOUT
+        for t in failed_tests
+    ])
+    if only_timeouts and (data["bazel"].get("failed_actions_total", 0) or 0) == 0:
+        return ("⏱", "Timed out")
+    return ("❌", "Failed")
+
 def build_details_data(data, links, render_ctx = None, status = "", start_date = "", finish_date = "", std = None, task_phases = None, task_active = None, task_elapsed_ms = 0, include_bazel_targets = True, render_repro_in_targets = False, snippet_options = None, max_snippets = 0):
     """Build Jinja2 template data for DETAILS_TEMPLATE.
 
@@ -3847,6 +4018,9 @@ def build_details_data(data, links, render_ctx = None, status = "", start_date =
         "aborted": data["bazel"].get("aborted", False),
         "abort_reason": data["bazel"].get("abort_reason", ""),
         "abort_description": data["bazel"].get("abort_description", ""),
+        # Strata KPI strip (verdict + cache/parallelism/wall health). None
+        # pre-build_metrics; the Kilgore template ignores this field.
+        "strata_kpi": compute_strata_kpi(data, status),
         # "" (falsy) when any bucket has data; "1" → template shows a
         # "waiting for data" placeholder.
         "no_targets_info": "" if _has_targets_info else "1",

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -10,6 +10,7 @@ Two task implementations live here:
 
 load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "aspect_web_ui_url", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "failed_labels_by_subcommand", "init_data", "process_event", "render_bes_url", "render_check_output", "repro_by_target", "repro_targets")
 load("./lifecycle.axl", "ReproFixCommand")
+load("./template_styles.axl", "resolve_style")
 
 # Fake data builders
 
@@ -624,8 +625,36 @@ def _test_impl(ctx):
         print(out["text"][:8000])
         print("")
 
+    # Strata style: render the same scenarios through the DX-focused templates
+    # so any Jinja/data-shape regression in the Strata layout surfaces here too.
+    strata = resolve_style("strata", {})
+    strata_templates = {"summary": strata["summary"], "details": strata["details"]}
+    strata_scenarios = [
+        ("S1. strata · failed", _make_results_failed(), "failed"),
+        ("S2. strata · all-passed", _make_results_passed(), "passed"),
+        ("S3. strata · flaky", _make_results_flaky(), "passed"),
+        ("S4. strata · failing-live", _make_results_failing_live(), "failing"),
+        ("S5. strata · aborted", _make_results_aborted(), "failed"),
+        ("S6. strata · large", _make_results_large(), "failed"),
+        ("S7. strata · fully-cached", _make_results_fully_cached(), "passed"),
+        ("S8. strata · running", _make_results_passed(), "running"),
+    ]
+    for (label, data, status) in strata_scenarios:
+        rc = _render_ctx(subject = "//...", progress = "")
+        lk = _links(with_artifact = True, ci = "github")
+        out = render_check_output(ctx, data, status, rc, lk, templates = strata_templates)
+        print(sep)
+        print("SCENARIO: " + label)
+        print(sep)
+        print("TITLE:    " + out["title"])
+        print("")
+        print("DETAILS (first 8000 chars):")
+        print(out["text"][:8000])
+        print("")
+
     print(sep)
-    print("All " + str(len(scenarios)) + " scenarios rendered without error.")
+    print("All " + str(len(scenarios)) + " Kilgore + " + str(len(strata_scenarios)) +
+          " Strata scenarios rendered without error.")
     return 0
 
 template_snapshot_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/lib/strata_templates.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/strata_templates.axl
@@ -1,0 +1,295 @@
+"""Strata template strings — the DX-focused CI status layout.
+
+Three Jinja2 templates, one per surface slot, consuming the *same* data the
+Kilgore templates do (so no data-layer fork is needed):
+
+  - `STRATA_SUMMARY_TEMPLATE` / `STRATA_DETAILS_TEMPLATE` — the check-run output
+    `{summary, text}` (GitHub status check, GitLab commit status, Buildkite
+    annotation). Built from `build_summary_data` / `build_details_data`.
+  - `STRATA_BODY_TEMPLATE` — the aggregated PR/MR comment body, built from the
+    github_status_comments `_render_body` data dict.
+
+Layout philosophy (answer in order: what broke → how to fix/repro → why slow):
+
+  1. A verdict heading carrying the status word (no preamble).
+  2. The KPI strip — a fenced, monospace, threshold-emoji health line
+     (`strata_kpi`): cache hit %, parallelism, wall + critical-path share. It is
+     cheap, incompressible signal, so on the byte-capped status check it is the
+     last thing the trim ladder touches.
+  3. Failures — each failure's snippet, OPEN by default, with that failure's
+     repro command directly beneath it (per-failure `repros`).
+  4. Reproduce / Fix for the whole run (Fix first — it's the action).
+  5. Everything else (passed/cached rollups, performance detail, invocation
+     metadata, build graph) collapsed behind a single `<details>`, recoverable
+     in one click via the Aspect Web UI. The performance block AUTO-EXPANDS on a
+     "Passed, but slow" verdict (`strata_kpi.slow`).
+
+These strings are composed into a `TemplateStyle` by `lib/template_styles.axl`;
+the data they read is documented there and in `build_details_data` /
+`_render_body`. Reused emoji vocabulary matches the Strata web UI: ✅ Passed,
+❌ Failed, 🔄 Running, ⏱ Timed out, ⚠️ flaky, 🔥 aborted, ✨ Aspect, 🔁 Reproduce,
+🛠️ Fix.
+"""
+
+load("./repro_commands.axl", "ASPECT_CLI_INSTALL_HINT_MARKDOWN")
+
+# The KPI strip: a fenced, monospace, threshold-emoji health block, one
+# pre-aligned line per KPI (`strip_lines`, built by `compute_strata_kpi`).
+# Rendered as a macro so the details + body templates share one definition.
+# `kpi` is the `strata_kpi` dict (or None pre-build_metrics → strip skipped).
+STRATA_KPI_MACRO = """{% macro kpi_strip(kpi) %}
+{%- if kpi and kpi.strip_lines %}```text
+{% for line in kpi.strip_lines %}{{ line }}
+{% endfor %}```
+{% endif %}
+{%- endmacro %}"""
+
+# Failure snippet (OPEN) + per-failure repro command beneath it. `rows` is the
+# budget-gated snippet list (build_failures_snippets / failed_tests_snippets /
+# timeout_tests_snippets). The header survives even when the trim ladder pops
+# `snippet`; the repro fence then still pairs the failing label with its command.
+STRATA_SNIPPET_MACRO = """{% macro strata_snippets(rows) %}
+{%- for t in rows %}
+**❌ `{{ t.label }}`** — {{ t.kind }} {{ t.snippet_verb }}
+{%- if t.snippet %}
+{{ t.snippet_fence }}text
+{% if t.snippet_trunc_head %}…
+{% endif %}{{ t.snippet }}
+{% if t.snippet_trunc_tail %}…
+{% endif %}{{ t.snippet_fence }}
+{% endif %}
+{%- if t.repros %}
+Reproduce with:
+{% for r in t.repros %}
+```
+{% if r.description %}# {{ r.description }}
+{% endif %}{{ r.command }}
+```
+{%- endfor %}
+{% endif %}{%- endfor %}
+{%- endmacro %}"""
+
+# Whole-run Reproduce / Fix (target == "" entries). Fix first — it's the action.
+STRATA_REPRO_FIX_BLOCK = """{%- if fix_commands %}
+### 🛠️ Fix
+{% for c in fix_commands %}
+```
+{% if c.description %}# {{ c.description }}
+{% endif %}{{ c.command }}
+```
+{% endfor %}{% endif %}
+{%- if repro_commands %}
+### 🔁 Reproduce
+{% for c in repro_commands %}
+```
+{% if c.description %}# {{ c.description }}
+{% endif %}{{ c.command }}
+```
+{% endfor %}""" + ASPECT_CLI_INSTALL_HINT_MARKDOWN + """
+{% endif %}"""
+
+# The collapsed reference block: performance detail, invocation, build-graph
+# stats. Recoverable in one click; auto-expands only when the run is slow.
+STRATA_REFERENCE_BLOCK = """{%- if invocation_stats %}
+<details{% if strata_kpi and strata_kpi.slow %} open{% endif %}>
+<summary>⏱ Why it ran this way{% if strata_kpi and strata_kpi.slow %} — slow{% endif %}</summary>
+
+<pre>
+{%- if invocation_stats.elapsed_time %}
+Elapsed time:        {{ invocation_stats.elapsed_time }}
+{%- endif %}
+{%- if invocation_stats.analysis_time %}
+Analysis time:       {{ invocation_stats.analysis_time }}
+{%- endif %}
+{%- if invocation_stats.execution_time %}
+Execution time:      {{ invocation_stats.execution_time }}
+{%- endif %}
+{%- if invocation_stats.critical_path %}
+Critical path:       {{ invocation_stats.critical_path }}
+{%- endif %}
+{%- if invocation_stats.cache_actions_line %}
+Action cache:        {{ invocation_stats.cache_actions_line }}
+{%- endif %}
+{%- if invocation_stats.cache_tests_line %}
+Test cache:          {{ invocation_stats.cache_tests_line }}
+{%- endif %}
+{%- if invocation_stats.cached_tests_time_saved %}
+Cached tests saved:  {{ invocation_stats.cached_tests_time_saved }}
+{%- endif %}
+{%- if invocation_stats.targets_line %}
+Targets:             {{ invocation_stats.targets_line }}
+{%- endif %}
+{%- if invocation_stats.actions_line %}
+Actions:             {{ invocation_stats.actions_line }}
+{%- endif %}
+</pre>
+{%- if invocation_stats.runner_table %}
+
+{{ invocation_stats.runner_table }}
+{%- endif %}
+{%- if invocation_stats.mnemonic_table %}
+
+{{ invocation_stats.mnemonic_table }}
+{%- endif %}
+</details>
+{% endif %}"""
+
+STRATA_SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
+{% for item in row %}{{ item.icon }} {{ item.value }}{% if not loop.last %} · {% endif %}{% endfor %}{% if not loop.last %}  {% endif %}
+{%- endfor %}{% endif %}"""
+
+# Check-run body (status check / commit status / Buildkite annotation). Verdict
+# heading, KPI strip, failures (open), repro/fix, collapsed reference.
+STRATA_DETAILS_TEMPLATE = STRATA_KPI_MACRO + STRATA_SNIPPET_MACRO + """
+{% if aborted %}> 🔥 **Build aborted**{% if abort_reason %} (`{{ abort_reason }}`){% endif %}{% if abort_description %}: {{ abort_description }}{% endif %}
+
+{% endif -%}
+{% if strata_kpi %}### {{ strata_kpi.verdict_emoji }} {{ strata_kpi.verdict_word }}
+{{ kpi_strip(strata_kpi) }}
+{% endif -%}
+{% if build_failures_snippets or failed_tests_snippets or timeout_tests_snippets or build_failures or derived_failures %}
+### 💥 What broke
+{{ strata_snippets(build_failures_snippets) }}{{ strata_snippets(failed_tests_snippets) }}{{ strata_snippets(timeout_tests_snippets) }}
+{%- if build_failures %}
+<pre>
+{{- build_failures_table_head }}
+{{ build_failures_table_sep }}
+{%- for t in build_failures %}
+{{ t.aligned_label }} | {{ t.aligned_kind }} | {{ t.aligned_mnemonic }}
+{%- endfor %}
+{% if build_failures_overflow %}_{{ build_failures_overflow }} more root failure(s) not shown._{% endif %}</pre>
+{% endif %}
+{%- if derived_failures %}
+<details><summary>{{ derived_failures_count }} more target{{ derived_failures_plural }} blocked by a failed dependency</summary>
+
+<pre>
+{{- derived_failures_table_head }}
+{{ derived_failures_table_sep }}
+{%- for t in derived_failures %}
+{{ t.aligned_label }} | {{ t.aligned_kind }}
+{%- endfor %}
+{% if derived_failures_overflow %}_{{ derived_failures_overflow }} more not shown._{% endif %}</pre>
+</details>
+{% endif %}
+{%- if snippets_overflow %}
+_+ {{ snippets_overflow }} more failure{{ snippets_overflow_plural }} — output not shown._
+{% endif %}
+{% endif -%}
+""" + STRATA_REPRO_FIX_BLOCK + """
+{% if flaky_tests %}
+<details>
+<summary>⚠️ {{ flaky_tests_header }}</summary>
+
+<pre>
+{{- flaky_tests_table_head }}
+{{ flaky_tests_table_sep }}
+{%- for t in flaky_tests %}
+{{ t.aligned_label }} | {{ t.aligned_kind }} | {{ t.aligned_duration }}
+{%- endfor %}</pre>
+</details>
+{% endif -%}
+{% if passed_tests_count or cached_tests_count or built_targets_count %}
+<details>
+<summary>✅ Passed{% if passed_tests_count %} · {{ passed_tests_count }} tests{% endif %}{% if cached_tests_count %} · ⚡ {{ cached_tests_count }} cached{% endif %}{% if built_targets_count %} · {{ built_targets_count }} built{% endif %}</summary>
+
+<sub>Full per-target breakdown in the Aspect Web UI{% if aspect_url %} — [open ✨]({{ aspect_url }}){% endif %}.</sub>
+</details>
+{% endif -%}
+""" + STRATA_REFERENCE_BLOCK + """
+{% if aspect_url or bes_invocation_url or ci_url %}
+{% if aspect_url %}[Aspect ✨]({{ aspect_url }}){% endif %}{% if bes_invocation_url %}{% if aspect_url %} · {% endif %}[BES 🔗]({{ bes_invocation_url }}){% endif %}{% if ci_url %}{% if aspect_url or bes_invocation_url %} · {% endif %}[{{ ci_label or "CI" }}]({{ ci_url }}){% endif %}
+{% endif %}"""
+
+# Aggregated PR/MR comment. Verdict heading carries the cross-task tally; a
+# compact per-task list; deduped failure cards (open) with per-failure repros;
+# whole-run fix/repro; collapsed footer.
+STRATA_BODY_TEMPLATE = """{{ marker }}
+
+## ✨ Aspect Workflows
+{% if not entries -%}
+_No tasks have reported yet._
+{% else -%}
+{%- set fail_n = (sections.failed|length) + (sections.failing|length) -%}
+{%- set run_n = sections.running|length -%}
+{%- set flag_n = sections.flagged|length -%}
+{%- if fail_n > 0 %}### ❌ {{ fail_n }} task{{ "s" if fail_n != 1 else "" }} failed
+{% elif run_n > 0 %}### 🔄 Running…
+{% elif flag_n > 0 %}### ⚠️ Passed with warnings
+{% else %}### ✅ All {{ entries|length }} task{{ "s" if entries|length != 1 else "" }} passed
+{% endif %}
+{% macro task_row(e) -%}
+- {{ status_badges[e._badge_key] }} {{ e.name }}{% if e.key and e.key != e.name %} ({{ e.key }}){% endif %}{% if e._elapsed_text %} · {{ e._elapsed_text }}{% endif %}{% if e._links_text %} · {{ e._links_text }}{% endif %}{% if e._result_text %}<br>💬 {{ e._result_text }}{% endif %}
+{% endmacro -%}
+{% for e in sections.failed %}{{ task_row(e) }}{% endfor -%}
+{% for e in sections.failing %}{{ task_row(e) }}{% endfor -%}
+{% for e in sections.running %}{{ task_row(e) }}{% endfor -%}
+{% for e in sections.flagged %}{{ task_row(e) }}{% endfor -%}
+{% for e in sections.successful %}{{ task_row(e) }}{% endfor -%}
+{% macro snippet_block(s) %}
+**❌ `{{ s.label }}`** — {{ s.kind or (s.bucket if s.bucket != "timeout" else "test") }} {{ s.verb }}
+{{ s.fence }}text
+{% if s.trunc_head %}…
+{% endif %}{{ s.snippet }}
+{% if s.trunc_tail %}…
+{% endif %}{{ s.fence }}
+{%- for r in s.repros %}
+```
+{% if r.description %}# {{ r.description }}
+{% endif %}{{ r.command }}
+```
+{%- endfor %}
+{% if s.task_label %}<sub>in {{ s.task_noun }} {{ s.task_label }}</sub>
+{% endif %}
+{% endmacro -%}
+{% if build_snippets or test_snippets %}
+### 💥 What broke
+{% for s in build_snippets %}{{ snippet_block(s) }}{% endfor -%}
+{% for s in test_snippets %}{{ snippet_block(s) }}{% endfor -%}
+{% if snippet_overflow_note %}
+{{ snippet_overflow_note }}
+{% endif %}
+{% endif -%}
+{% if fix_rows %}
+### 🛠️ Fix
+{% for r in fix_rows %}{% if r.show_heading %}
+#### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_keys %} ({{ r.task_keys|join(" · ") }}){% endif %}{% endif %}
+```
+{% if r.description %}# {{ r.description }}
+{% endif %}{{ r.command }}
+```
+{% endfor %}
+{% if fix_overflow_note %}
+{{ fix_overflow_note }}
+{% endif %}
+""" + ASPECT_CLI_INSTALL_HINT_MARKDOWN + """
+{% endif -%}
+{% if repro_rows %}
+### 🔁 Reproduce
+{% for r in repro_rows %}{% if r.show_heading %}
+#### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_keys %} ({{ r.task_keys|join(" · ") }}){% endif %}{% endif %}
+```
+{% if r.description %}# {{ r.description }}
+{% endif %}{{ r.command }}
+```
+{% endfor %}
+{% if repro_overflow_note %}
+{{ repro_overflow_note }}
+{% endif %}
+""" + ASPECT_CLI_INSTALL_HINT_MARKDOWN + """
+{% endif -%}
+{% if tip_rows %}
+<details>
+<summary>💡 {{ tip_rows|length }} tip{{ "s" if tip_rows|length != 1 else "" }}</summary>
+{% for tip in tip_rows %}
+> {{ tip.severity_emoji }} **{{ tip.severity_label|upper }}: {{ tip.title }}**
+>
+{{ tip.body_quoted }}
+{% endfor %}
+</details>
+{% endif -%}
+{% endif %}
+---
+
+{% if last_updated_at or api_usage %}<sub>{% if last_updated_at %}⏱ Last updated {{ last_updated_at }}{% endif %}{% if last_updated_at and api_usage %} · {% endif %}{% if api_usage %}{{ api_usage }}{% endif %}</sub><br>
+{%- endif %}<sub>🚀 Powered by [Aspect CLI](https://github.com/aspect-build/aspect-cli){% if cli_version %} (v{{ cli_version }}){% endif %}</sub>
+"""

--- a/crates/aspect-cli/src/builtins/aspect/lib/template_styles.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/template_styles.axl
@@ -1,0 +1,145 @@
+"""CI status-output template *styles* — named bundles of Markdown templates.
+
+A *style* selects how every status surface (GitHub/GitLab PR-comment, GitHub
+status check, GitLab commit status, Buildkite annotation) renders a task's
+result. Two styles ship built-in:
+
+  - **kilgore** (default) — the original "show everything" layout: every target
+    bucket, the full Bazel-details umbrella, workspace status, parsed options.
+    A faithful report of the whole invocation.
+  - **strata** — a DX-focused layout that answers, in order, *what broke* →
+    *how to fix / reproduce it* → *why it was slow*. Leads with a verdict and a
+    compact KPI strip, shows failure snippets open by default with each
+    failure's repro command beneath it, and collapses or omits the reference
+    sections (recoverable in one click via the Aspect Web UI).
+
+A style is a `TemplateStyle` record carrying the three top-level Jinja2 template
+strings a surface may need — `summary` + `details` (the check surfaces) and
+`body` (the aggregated PR/MR comment) — plus a `StyleKnobs` record of render
+switches the data builders read to shape `details_data` for the chosen layout.
+
+`resolve_style(name, overrides)` is the single entry point a feature calls:
+
+    bundle = resolve_style(ctx.args.style, ctx.args.templates or {})
+    render_check_output(..., templates = {"summary": bundle.summary,
+                                          "details": bundle.details},
+                             style_knobs = bundle.knobs)
+
+The per-key `overrides` dict is the existing `templates` feature arg. It layers
+*on top of* the named style, so a user can pick `strata` and replace just one
+slot (e.g. a custom `details`) without re-authoring the others. This is how
+custom variants are expressed; a fully bespoke style is an `overrides` dict that
+replaces every slot. Overrides always win over the named style's defaults.
+
+The Kilgore bundle references the template constants defined in
+`lib/bazel_results.axl` and `feature/github_status_comments.axl` verbatim, so
+selecting the default style is byte-identical to the pre-style behavior. The
+dependency is one-directional: features → template_styles → bazel_results
+(constants only); `render_check_output` keeps accepting a `templates` dict and
+never imports this module, so there is no load cycle.
+"""
+
+load("./bazel_results.axl", "DETAILS_TEMPLATE", "SUMMARY_TEMPLATE")
+load("./strata_templates.axl", "STRATA_BODY_TEMPLATE", "STRATA_DETAILS_TEMPLATE", "STRATA_SUMMARY_TEMPLATE")
+
+StyleKnobs = record(
+    # Failure snippets render in `<details open>` (visible without a click) and
+    # each failure's repro command renders directly beneath its snippet.
+    snippets_open = field(bool, default = False),
+    # Render the fenced monospace KPI strip (verdict + cache/parallelism/wall).
+    kpi_strip = field(bool, default = False),
+    # The heading carries the verdict; drop the Kilgore preamble + rollup rows.
+    lead_with_verdict = field(bool, default = False),
+    # Fold the aspect + vanilla-bazel flavors of a command into ONE fence with a
+    # `# vanilla bazel: …` comment line, instead of two separate fences.
+    fold_flavors = field(bool, default = False),
+    # Collapse (and on the byte-capped surfaces, drop first) the reference
+    # sections: workspace status, parsed options, build metadata, invocation
+    # detail, performance detail. They are redundant with the Aspect Web UI.
+    demote_reference = field(bool, default = False),
+    # Never depend on `<details>` collapsibility (Buildkite live updates unwrap
+    # it); render section headers flat.
+    flat_no_details = field(bool, default = False),
+)
+
+TemplateStyle = record(
+    name = field(str),
+    summary = field(str),
+    details = field(str),
+    body = field(str),
+    knobs = field(StyleKnobs),
+)
+
+KILGORE_KNOBS = StyleKnobs()
+
+# Strata's render switches. The Strata template strings live in
+# `strata_templates.axl`; this module composes them into the bundle below.
+STRATA_KNOBS = StyleKnobs(
+    snippets_open = True,
+    kpi_strip = True,
+    lead_with_verdict = True,
+    fold_flavors = True,
+    demote_reference = True,
+    flat_no_details = False,
+)
+
+# The PR/MR-comment body template is defined in the github_status_comments
+# feature, not in lib/. To avoid a lib→feature load edge, the Kilgore body slot
+# is left empty here and the comment feature falls back to its own
+# `_DEFAULT_BODY_TEMPLATE` when a bundle carries no `body`. Strata supplies its
+# body from `strata_templates.axl`.
+_KILGORE = TemplateStyle(
+    name = "kilgore",
+    summary = SUMMARY_TEMPLATE,
+    details = DETAILS_TEMPLATE,
+    body = "",
+    knobs = KILGORE_KNOBS,
+)
+
+_STRATA = TemplateStyle(
+    name = "strata",
+    summary = STRATA_SUMMARY_TEMPLATE,
+    details = STRATA_DETAILS_TEMPLATE,
+    body = STRATA_BODY_TEMPLATE,
+    knobs = STRATA_KNOBS,
+)
+
+STYLE_NAMES = ["kilgore", "strata"]
+
+# Shared `description=` for the `style` feature arg, so every status feature
+# documents the choice identically.
+STYLE_ARG_DESCRIPTION = (
+    "Template style for the rendered status output. \"kilgore\" (default) is the " +
+    "full report — every target bucket, the Bazel-details umbrella, workspace " +
+    "status, parsed options. \"strata\" is the DX-focused layout: a verdict + a " +
+    "compact KPI strip (cache hit / parallelism / wall), failure snippets open " +
+    "with each failure's repro command beneath it, and reference sections " +
+    "collapsed. Per-key `templates` overrides still layer on top of the chosen " +
+    "style for custom variants."
+)
+
+def builtin_style(name: str) -> TemplateStyle:
+    """Return the built-in `TemplateStyle` for `name`, defaulting to kilgore for
+    an empty or unknown name (a mis-set arg degrades to the safe default rather
+    than failing the build)."""
+    if name == "strata":
+        return _STRATA
+    return _KILGORE
+
+def resolve_style(name: str, overrides = None) -> dict:
+    """Resolve a style name + per-key overrides into the template bundle a
+    surface consumes.
+
+    Returns a dict: `{summary, details, body, knobs}`. `overrides` is the
+    feature's `templates` arg — a dict whose `summary`/`details`/`body` keys, if
+    present and non-empty, replace the named style's corresponding slot (a
+    custom variant). Overrides win over the named style.
+    """
+    base = builtin_style(name or "kilgore")
+    o = overrides or {}
+    return {
+        "summary": o.get("summary") or base.summary,
+        "details": o.get("details") or base.details,
+        "body": o.get("body") or base.body,
+        "knobs": base.knobs,
+    }

--- a/crates/aspect-cli/src/builtins/aspect/lib/template_styles.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/template_styles.axl
@@ -4,14 +4,14 @@ A *style* selects how every status surface (GitHub/GitLab PR-comment, GitHub
 status check, GitLab commit status, Buildkite annotation) renders a task's
 result. Two styles ship built-in:
 
-  - **kilgore** (default) — the original "show everything" layout: every target
-    bucket, the full Bazel-details umbrella, workspace status, parsed options.
-    A faithful report of the whole invocation.
-  - **strata** — a DX-focused layout that answers, in order, *what broke* →
-    *how to fix / reproduce it* → *why it was slow*. Leads with a verdict and a
-    compact KPI strip, shows failure snippets open by default with each
-    failure's repro command beneath it, and collapses or omits the reference
-    sections (recoverable in one click via the Aspect Web UI).
+  - **strata** (default) — a DX-focused layout that answers, in order, *what
+    broke* → *how to fix / reproduce it* → *why it was slow*. Leads with a
+    verdict and a compact KPI strip, shows failure snippets open by default with
+    each failure's repro command beneath it, and collapses or omits the
+    reference sections.
+  - **kilgore** — the original "show everything" layout: every target bucket,
+    the full Bazel-details umbrella, workspace status, parsed options. A faithful
+    report of the whole invocation.
 
 A style is a `TemplateStyle` record carrying the three top-level Jinja2 template
 strings a surface may need — `summary` + `details` (the check surfaces) and
@@ -106,25 +106,30 @@ _STRATA = TemplateStyle(
 
 STYLE_NAMES = ["kilgore", "strata"]
 
+# The default style. Mirrors the `default =` on each feature's `style` arg, and
+# is the fallback `builtin_style` resolves an empty / unknown name to (so a
+# mis-set arg renders the default rather than failing).
+DEFAULT_STYLE = "strata"
+
 # Shared `description=` for the `style` feature arg, so every status feature
 # documents the choice identically.
 STYLE_ARG_DESCRIPTION = (
-    "Template style for the rendered status output. \"kilgore\" (default) is the " +
-    "full report — every target bucket, the Bazel-details umbrella, workspace " +
-    "status, parsed options. \"strata\" is the DX-focused layout: a verdict + a " +
-    "compact KPI strip (cache hit / parallelism / wall), failure snippets open " +
-    "with each failure's repro command beneath it, and reference sections " +
-    "collapsed. Per-key `templates` overrides still layer on top of the chosen " +
-    "style for custom variants."
+    "Template style for the rendered status output. \"strata\" (default) is the " +
+    "DX-focused layout: a verdict + a compact KPI strip (cache hit / parallelism " +
+    "/ wall), failure snippets open with each failure's repro command beneath it, " +
+    "and reference sections collapsed. \"kilgore\" is the full report — every " +
+    "target bucket, the Bazel-details umbrella, workspace status, parsed options. " +
+    "Per-key `templates` overrides still layer on top of the chosen style for " +
+    "custom variants."
 )
 
+_BUILTIN_STYLES = {"kilgore": _KILGORE, "strata": _STRATA}
+
 def builtin_style(name: str) -> TemplateStyle:
-    """Return the built-in `TemplateStyle` for `name`, defaulting to kilgore for
-    an empty or unknown name (a mis-set arg degrades to the safe default rather
-    than failing the build)."""
-    if name == "strata":
-        return _STRATA
-    return _KILGORE
+    """Return the built-in `TemplateStyle` for `name`. An empty or unknown name
+    falls back to `DEFAULT_STYLE` (a mis-set arg renders the default rather than
+    failing the build)."""
+    return _BUILTIN_STYLES.get(name) or _BUILTIN_STYLES[DEFAULT_STYLE]
 
 def resolve_style(name: str, overrides = None) -> dict:
     """Resolve a style name + per-key overrides into the template bundle a
@@ -135,7 +140,7 @@ def resolve_style(name: str, overrides = None) -> dict:
     present and non-empty, replace the named style's corresponding slot (a
     custom variant). Overrides win over the named style.
     """
-    base = builtin_style(name or "kilgore")
+    base = builtin_style(name)
     o = overrides or {}
     return {
         "summary": o.get("summary") or base.summary,

--- a/crates/aspect-cli/src/builtins/aspect/lib/template_styles_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/template_styles_test.axl
@@ -1,0 +1,189 @@
+"""Unit tests for the template-style machinery.
+
+Covers `resolve_style` (style selection + per-key override layering) and
+`compute_strata_kpi` (verdict word, threshold→emoji mapping, slow-but-passing
+detection, missing-metrics → None). The end-to-end Strata rendering is exercised
+by the snapshot suites (test-template-snapshots / test-pr-comment-snapshots).
+"""
+
+load("./bazel_results.axl", "compute_strata_kpi", "init_data")
+load("./template_styles.axl", "STYLE_NAMES", "builtin_style", "resolve_style")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _kpi_data(wall_ms = 0, cpu_ms = 0, critical_ms = 0, actions_total = 0, actions_executed = 0):
+    """A `data` dict with just the build_metrics fields compute_strata_kpi reads."""
+    data = init_data()
+    data["bazel"]["wall_time_ms"] = wall_ms
+    data["bazel"]["cpu_time_ms"] = cpu_ms
+    data["bazel"]["critical_path_ms"] = critical_ms
+    data["bazel"]["actions_total"] = actions_total
+    data["bazel"]["actions_executed"] = actions_executed
+    return data
+
+# resolve_style
+
+def _test_default_is_kilgore(_ctx):
+    b = resolve_style("kilgore", {})
+    k = builtin_style("kilgore")
+    _eq("default summary is kilgore's", b["summary"], k.summary)
+    _eq("default details is kilgore's", b["details"], k.details)
+    _eq("kilgore knobs: not strata", b["knobs"].kpi_strip, False)
+
+def _test_empty_name_degrades_to_kilgore(_ctx):
+    b = resolve_style("", {})
+    _eq("empty name → kilgore details", b["details"], builtin_style("kilgore").details)
+
+def _test_unknown_name_degrades_to_kilgore(_ctx):
+    b = resolve_style("nonsense", {})
+    _eq("unknown name → kilgore details", b["details"], builtin_style("kilgore").details)
+
+def _test_strata_selects_strata_bundle(_ctx):
+    b = resolve_style("strata", {})
+    s = builtin_style("strata")
+    _eq("strata summary", b["summary"], s.summary)
+    _eq("strata details", b["details"], s.details)
+    _eq("strata body non-empty", b["body"] != "", True)
+    _eq("strata knobs: kpi_strip on", b["knobs"].kpi_strip, True)
+    _eq("strata knobs: snippets_open on", b["knobs"].snippets_open, True)
+
+def _test_kilgore_body_empty_for_feature_fallback(_ctx):
+    # The PR-comment body lives in the feature; Kilgore's bundle carries no body
+    # so the feature falls back to its own _DEFAULT_BODY_TEMPLATE.
+    _eq("kilgore body is empty", resolve_style("kilgore", {})["body"], "")
+
+def _test_override_replaces_one_slot(_ctx):
+    b = resolve_style("strata", {"details": "MY DETAILS"})
+    _eq("override wins for details", b["details"], "MY DETAILS")
+
+    # Other slots still come from the named style.
+    _eq("non-overridden summary stays strata", b["summary"], builtin_style("strata").summary)
+
+def _test_override_on_kilgore(_ctx):
+    b = resolve_style("kilgore", {"summary": "X", "body": "Y"})
+    _eq("override summary", b["summary"], "X")
+    _eq("override body", b["body"], "Y")
+    _eq("non-overridden details stays kilgore", b["details"], builtin_style("kilgore").details)
+
+def _test_empty_override_value_ignored(_ctx):
+    # An empty-string override doesn't blank the slot; it falls through.
+    b = resolve_style("strata", {"details": ""})
+    _eq("empty override falls through", b["details"], builtin_style("strata").details)
+
+def _test_style_names_listed(_ctx):
+    _eq("both built-ins listed", STYLE_NAMES, ["kilgore", "strata"])
+
+# compute_strata_kpi
+
+def _test_kpi_verdict_only_without_metrics(_ctx):
+    # Before build_metrics arrive: verdict renders, strip is empty.
+    k = compute_strata_kpi(_kpi_data(), "passed")
+    _eq("no metrics → verdict word still set", k["verdict_word"], "Passed")
+    _eq("no metrics → empty strip", k["strip_lines"], [])
+    _eq("no metrics → no cache cell", k["cache"], None)
+
+def _test_kpi_cache_thresholds(_ctx):
+    # 90% → green, 70% → amber, 40% → red. cached = total - executed.
+    green = compute_strata_kpi(_kpi_data(wall_ms = 1000, actions_total = 100, actions_executed = 10), "passed")
+    _eq("90% cache → green", green["cache"]["emoji"], "🟢")
+    _eq("90% cache value", green["cache"]["value"], "90%")
+    amber = compute_strata_kpi(_kpi_data(wall_ms = 1000, actions_total = 100, actions_executed = 30), "passed")
+    _eq("70% cache → amber", amber["cache"]["emoji"], "🟡")
+    red = compute_strata_kpi(_kpi_data(wall_ms = 1000, actions_total = 100, actions_executed = 60), "passed")
+    _eq("40% cache → red", red["cache"]["emoji"], "🔴")
+
+def _test_kpi_parallelism(_ctx):
+    # cpu/wall = 6.0× → green; 2.0× → amber; 1.0× → red.
+    g = compute_strata_kpi(_kpi_data(wall_ms = 1000, cpu_ms = 6000, actions_total = 1), "passed")
+    _eq("6x parallel → green", g["parallelism"]["emoji"], "🟢")
+    _eq("6x value", g["parallelism"]["value"], "6.0×")
+    a = compute_strata_kpi(_kpi_data(wall_ms = 1000, cpu_ms = 2000, actions_total = 1), "passed")
+    _eq("2x parallel → amber", a["parallelism"]["emoji"], "🟡")
+    r = compute_strata_kpi(_kpi_data(wall_ms = 1000, cpu_ms = 1000, actions_total = 1), "passed")
+    _eq("1x parallel → red", r["parallelism"]["emoji"], "🔴")
+
+def _test_kpi_wall_critical_share(_ctx):
+    # critical/wall: 30% → green wall, 50% → amber, 80% → red.
+    g = compute_strata_kpi(_kpi_data(wall_ms = 1000, critical_ms = 300, actions_total = 1), "passed")
+    _eq("30% crit share → green wall", g["wall"]["emoji"], "🟢")
+    r = compute_strata_kpi(_kpi_data(wall_ms = 1000, critical_ms = 800, actions_total = 1), "passed")
+    _eq("80% crit share → red wall", r["wall"]["emoji"], "🔴")
+
+def _test_kpi_verdict_passed(_ctx):
+    k = compute_strata_kpi(_kpi_data(wall_ms = 1000, actions_total = 100, actions_executed = 5), "passed")
+    _eq("passed verdict emoji", k["verdict_emoji"], "✅")
+    _eq("passed verdict word", k["verdict_word"], "Passed")
+    _eq("healthy build not slow", k["slow"], False)
+
+def _test_kpi_verdict_failed(_ctx):
+    k = compute_strata_kpi(_kpi_data(wall_ms = 1000, actions_total = 100, actions_executed = 5), "failed")
+    _eq("failed verdict word", k["verdict_word"], "Failed")
+
+def _test_kpi_verdict_running(_ctx):
+    k = compute_strata_kpi(_kpi_data(wall_ms = 1000, actions_total = 10), "running")
+    _eq("running verdict word", k["verdict_word"], "Running")
+
+def _test_kpi_passed_but_slow(_ctx):
+    # Green pass, but cache 40% (red) → "Passed, but slow" + slow flag set.
+    data = _kpi_data(wall_ms = 10000, cpu_ms = 12000, actions_total = 100, actions_executed = 60)
+    k = compute_strata_kpi(data, "passed")
+    _eq("slow flag set", k["slow"], True)
+    _eq("slow verdict word", k["verdict_word"], "Passed, but slow")
+
+def _test_kpi_aborted_verdict(_ctx):
+    data = _kpi_data(wall_ms = 1000, actions_total = 10)
+    data["bazel"]["aborted"] = True
+    k = compute_strata_kpi(data, "failed")
+    _eq("aborted verdict word", k["verdict_word"], "Aborted")
+
+def _test_kpi_timeout_verdict(_ctx):
+    data = _kpi_data(wall_ms = 1000, actions_total = 10)
+    data["bazel"]["failed_tests"] = [{"label": "//x:t", "status": "timeout"}]
+    k = compute_strata_kpi(data, "failed")
+    _eq("timeout verdict word", k["verdict_word"], "Timed out")
+
+def _test_kpi_strip_lines_present(_ctx):
+    k = compute_strata_kpi(_kpi_data(wall_ms = 1000, cpu_ms = 4000, actions_total = 100, actions_executed = 10), "passed")
+
+    # cache + parallelism + wall → 3 aligned lines, no trailing whitespace.
+    _eq("three strip lines", len(k["strip_lines"]), 3)
+    for line in k["strip_lines"]:
+        _eq("no trailing whitespace", line, line.rstrip())
+
+_UNIT_TESTS = [
+    _test_default_is_kilgore,
+    _test_empty_name_degrades_to_kilgore,
+    _test_unknown_name_degrades_to_kilgore,
+    _test_strata_selects_strata_bundle,
+    _test_kilgore_body_empty_for_feature_fallback,
+    _test_override_replaces_one_slot,
+    _test_override_on_kilgore,
+    _test_empty_override_value_ignored,
+    _test_style_names_listed,
+    _test_kpi_verdict_only_without_metrics,
+    _test_kpi_cache_thresholds,
+    _test_kpi_parallelism,
+    _test_kpi_wall_critical_share,
+    _test_kpi_verdict_passed,
+    _test_kpi_verdict_failed,
+    _test_kpi_verdict_running,
+    _test_kpi_passed_but_slow,
+    _test_kpi_aborted_verdict,
+    _test_kpi_timeout_verdict,
+    _test_kpi_strip_lines_present,
+]
+
+def _test_impl(ctx):
+    for t in _UNIT_TESTS:
+        t(ctx)
+    print("template_styles.axl: OK (%d tests)" % len(_UNIT_TESTS))
+    return 0
+
+template_styles_tests = task(
+    name = "test-template-styles",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/lib/template_styles_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/template_styles_test.axl
@@ -7,7 +7,7 @@ by the snapshot suites (test-template-snapshots / test-pr-comment-snapshots).
 """
 
 load("./bazel_results.axl", "compute_strata_kpi", "init_data")
-load("./template_styles.axl", "STYLE_NAMES", "builtin_style", "resolve_style")
+load("./template_styles.axl", "DEFAULT_STYLE", "STYLE_NAMES", "builtin_style", "resolve_style")
 
 def _eq(label, got, want):
     if got != want:
@@ -25,20 +25,25 @@ def _kpi_data(wall_ms = 0, cpu_ms = 0, critical_ms = 0, actions_total = 0, actio
 
 # resolve_style
 
-def _test_default_is_kilgore(_ctx):
+def _test_explicit_kilgore(_ctx):
     b = resolve_style("kilgore", {})
     k = builtin_style("kilgore")
-    _eq("default summary is kilgore's", b["summary"], k.summary)
-    _eq("default details is kilgore's", b["details"], k.details)
+    _eq("kilgore summary", b["summary"], k.summary)
+    _eq("kilgore details", b["details"], k.details)
     _eq("kilgore knobs: not strata", b["knobs"].kpi_strip, False)
 
-def _test_empty_name_degrades_to_kilgore(_ctx):
-    b = resolve_style("", {})
-    _eq("empty name → kilgore details", b["details"], builtin_style("kilgore").details)
+def _test_default_is_strata(_ctx):
+    # strata is the default; DEFAULT_STYLE names it.
+    _eq("DEFAULT_STYLE is strata", DEFAULT_STYLE, "strata")
+    _eq("default → strata details", builtin_style(DEFAULT_STYLE).details, builtin_style("strata").details)
 
-def _test_unknown_name_degrades_to_kilgore(_ctx):
+def _test_empty_name_degrades_to_default(_ctx):
+    b = resolve_style("", {})
+    _eq("empty name → strata details (the default)", b["details"], builtin_style("strata").details)
+
+def _test_unknown_name_degrades_to_default(_ctx):
     b = resolve_style("nonsense", {})
-    _eq("unknown name → kilgore details", b["details"], builtin_style("kilgore").details)
+    _eq("unknown name → strata details (the default)", b["details"], builtin_style("strata").details)
 
 def _test_strata_selects_strata_bundle(_ctx):
     b = resolve_style("strata", {})
@@ -153,9 +158,10 @@ def _test_kpi_strip_lines_present(_ctx):
         _eq("no trailing whitespace", line, line.rstrip())
 
 _UNIT_TESTS = [
-    _test_default_is_kilgore,
-    _test_empty_name_degrades_to_kilgore,
-    _test_unknown_name_degrades_to_kilgore,
+    _test_explicit_kilgore,
+    _test_default_is_strata,
+    _test_empty_name_degrades_to_default,
+    _test_unknown_name_degrades_to_default,
     _test_strata_selects_strata_bundle,
     _test_kilgore_body_empty_for_feature_fallback,
     _test_override_replaces_one_slot,


### PR DESCRIPTION
The current CI status templates were a first pass that shows *everything*. This PR makes the template layout selectable and adds a second, DX-focused style — **Strata** — that answers, in priority order: **what broke → how to fix/repro it → why it was slow**. The existing layout is preserved as **Kilgore** (the default), byte-identical to today.

> **Stacked on #1258** — that PR finalizes the per-failure repro data model this builds on. Review/merge #1258 first.

## How it works

A *style* is a bundle of the three top-level Jinja2 templates a surface may need — `summary` + `details` (check surfaces) and `body` (the aggregated PR/MR comment) — selected by a new `style` arg on every status feature:

```python
def config(ctx):
    for name in ctx.tasks:
        ctx.tasks[name].features[GithubStatusComments].args.style = "strata"
        ctx.tasks[name].features[GithubStatusChecks].args.style = "strata"
```

`resolve_style(name, overrides)` layers the **existing** per-key `templates` arg on top of the named style, so you can pick a style and replace just one slot — that's how custom variants are expressed, no new mechanism:

```python
args.style = "strata"
args.templates = {"details": "<my jinja2>"}   # strata everywhere else, custom details
```

Wired into all five status features: GitHub status checks, GitHub PR comment, GitLab commit statuses, GitLab MR comment, Buildkite annotation.

## What Strata looks like

Verdict-led, compact, aggregated PR comment:

```markdown
## ✨ Aspect Workflows
### ❌ 1 task failed

- ❌ build (build-task) · ⏱ 42s · ✨ Aspect · 🐙 GitHub Actions · ☑️ Check<br>💬 Bazel build failed
- 🔄 test (test-task) · ⏱ 1m 18s · ✨ Aspect<br>💬 Bazel test running... (13/60 tests run)
- ✅ lint (lint-task) · ⏱ 24s · ✨ Aspect<br>💬 Lint complete (clean)
```

On a check surface, the body leads with a verdict heading + a **KPI strip** — a fenced, monospace, threshold-emoji health line that stands in for the web UI's colored tiles (markdown has no color):

```text
🟡 Cache hit   78%     4,498 / 5,768 actions
🟢 Parallelism 6.2×    cpu 26m
🟡 Wall time   4m12s   crit path 1m50s (44%)
```

— then **What broke** (each failure's snippet open, with that failure's repro command right beneath it), then whole-run **Fix** / **Reproduce**, with the passed/cached rollup and the performance/invocation detail collapsed below. The performance block auto-expands on a "Passed, but slow" verdict.

Design synthesized from three independent design passes, drawing on BuildBuddy's results UI and the new Strata web UI in `silo`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (docsite PR linked below)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Status surfaces (GitHub/GitLab PR comment, GitHub status check, GitLab commit status, Buildkite annotation) now support a `style` arg. `strata` is a new DX-focused layout — a verdict + a compact cache/parallelism/wall KPI strip, failure snippets shown with their repro commands inline, and reference sections collapsed. The original full report is `kilgore` (default, unchanged).
- Custom variants: layer per-key `templates` overrides on top of any `style`.

### Test plan

- New test cases added
  - `lib/template_styles_test.axl` — 20 unit tests: `resolve_style` selection + override layering, `compute_strata_kpi` thresholds (cache/parallelism/critical-path-share), verdict words, slow-but-passing detection, verdict-without-metrics
  - Strata render passes added to `test-template-snapshots`, `test-pr-comment-snapshots`, and the inline-snippet render test in `.aspect/axl.axl`
- Covered by existing test cases (Kilgore output unchanged across all snapshot suites)
- Full local regression green: `aspect tests axl` (851), `test-template-styles` (20), all 7 snapshot suites, `test-repro-commands`/`test-bazel-results`/`test-bazel-runner`, `cargo test -p aspect-cli` (40)
- Live verification of the PR-comment + GitHub status-check surfaces with `style = "strata"` (in progress)
