### PR TITLE
ci: port Buildkite-only tests (runner-smoke, axl-tests, bazelrc-e2e, test-flags) to GHA

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -71,10 +71,18 @@ steps:
     command: |
       echo "--- :bazel: aspect build //crates/aspect-launcher //crates/aspect-cli"
       ASPECT_DEBUG=1 aspect build --task-key build-bk-axl-tests-bootstrap //crates/aspect-launcher //crates/aspect-cli
-      # Use cquery to get the actual output paths (handles platform transitions on Linux)
+      # Use cquery to get the actual output paths (handles platform transitions on Linux),
+      # then copy both binaries to stable target/ci/ paths IMMEDIATELY. A later
+      # build (or the second cquery below) can redirect the bazel-out symlink, so
+      # pointing $$LAUNCHER/$$CLI straight at the cquery'd bazel-out path races and
+      # dies with a 127 "No such file" on first use (mirrors bootstrap.sh, which
+      # stabilizes the cli the same way).
       WORKSPACE_ROOT=$$(pwd)
-      LAUNCHER=$$WORKSPACE_ROOT/$$(bazel $$BAZEL_STARTUP_OPTS cquery $$BAZEL_BUILD_OPTS --output=files //crates/aspect-launcher)
-      CLI=$$WORKSPACE_ROOT/$$(bazel $$BAZEL_STARTUP_OPTS cquery $$BAZEL_BUILD_OPTS --output=files //crates/aspect-cli)
+      mkdir -p target/ci
+      cp -f "$$(bazel $$BAZEL_STARTUP_OPTS cquery $$BAZEL_BUILD_OPTS --output=files //crates/aspect-launcher)" target/ci/aspect-launcher
+      cp -f "$$(bazel $$BAZEL_STARTUP_OPTS cquery $$BAZEL_BUILD_OPTS --output=files //crates/aspect-cli)" target/ci/aspect-cli
+      LAUNCHER=$$WORKSPACE_ROOT/target/ci/aspect-launcher
+      CLI=$$WORKSPACE_ROOT/target/ci/aspect-cli
       echo "--- :aspect: aspect demo template-demo"
       $$LAUNCHER demo template-demo
       echo "--- :aspect: aspect user nested user=task"
@@ -140,8 +148,9 @@ steps:
       echo "--- :aspect: aspect dev test-runner-job-history"
       $$LAUNCHER dev test-runner-job-history
       echo "--- :aspect: aspect tests axl"
-      # Run AXL tests last — cancel tests may kill the Bazel server,
-      # which invalidates bazel-out paths used by $$LAUNCHER above.
+      # Run AXL tests last — cancel tests may kill the Bazel server. $$LAUNCHER /
+      # $$CLI are stable target/ci/ copies (not bazel-out paths), so that's
+      # harmless here.
       $$LAUNCHER tests axl
   - key: bazelrc-e2e
     depends_on:

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -487,13 +487,14 @@ jobs:
   # THIS commit and invoke it directly — exactly like Buildkite's `$LAUNCHER`.
   #
   # We build via `aspect` (which self-configures the runner's output base + remote
-  # cache, so the dev tree pre-build already populated is a cache hit) and resolve
-  # the binaries with `aspect cquery --output=files` (handles Linux platform
-  # transitions). We copy the launcher to a stable path immediately: a later
-  # `aspect`/`bazel` build can redirect the bazel-out symlink, which is what makes
-  # the raw cquery'd path go stale (Buildkite hit exactly that — a 127 "No such
-  # file" on the launcher). The CLI is already stabilized at target/ci/aspect-cli
-  # by install-prebuilt-aspect-cli, which is also what the launcher resolves.
+  # cache, so the dev tree pre-build already populated is a cache hit), then copy
+  # the launcher from its bazel-bin path to a stable target/ci/ path immediately:
+  # a later `aspect`/`bazel` build can redirect the bazel-out symlink, which is
+  # what makes a raw bazel-out path go stale (Buildkite hit exactly that — a 127
+  # "No such file" on the launcher). The launcher is a host-config binary, so the
+  # bazel-bin convenience symlink resolves it directly (no platform transition for
+  # this target). The CLI is already stabilized at target/ci/aspect-cli by
+  # install-prebuilt-aspect-cli, which is also what the launcher resolves.
   axl-tests:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
@@ -509,10 +510,11 @@ jobs:
           echo "--- build the dev launcher (= Buildkite's \$LAUNCHER)"
           aspect build --task-key axl-tests-gha-bootstrap //crates/aspect-launcher
           # Copy to a stable path NOW, before any later build redirects bazel-out.
-          # (cquery stdout is just the file path; drop any stderr progress lines.)
+          # The launcher is a host-config binary, so the bazel-bin convenience
+          # symlink resolves it directly (no cquery needed / no platform
+          # transition for this target). Fail loudly if the path moves.
           mkdir -p target/ci
-          launcher_out=$(aspect cquery --output=files //crates/aspect-launcher 2>/dev/null)
-          cp -f "$launcher_out" target/ci/aspect-launcher
+          cp -f bazel-bin/crates/aspect-launcher/aspect-launcher target/ci/aspect-launcher
           LAUNCHER="$GITHUB_WORKSPACE/target/ci/aspect-launcher"
           CLI="$GITHUB_WORKSPACE/target/ci/aspect-cli"
           # Fail loudly if we somehow didn't get the unstamped dev launcher — the
@@ -586,68 +588,13 @@ jobs:
           # which invalidates bazel-out paths. We use the stabilized $LAUNCHER /
           # $CLI copies above, so that's harmless here.
           "$LAUNCHER" tests axl
-  # bazelrc e2e: assert `aspect` and bare `bazel` start the SAME Bazel server
-  # (no server restart between them => identical startup flags). Ported from the
-  # Buildkite `bazelrc-e2e` step.
-  #
-  # The bare `bazel info` calls only target the same server as `aspect` if they
-  # share `aspect`'s computed --output_base/--output_user_root. Buildkite gets
-  # those via bootstrap.sh's $BAZEL_STARTUP_OPTS; here bootstrap.sh did NOT run
-  # (we install the prebuilt CLI instead), so $GITHUB_ENV never received them.
-  # We recompute them inline, mirroring bootstrap.sh + environment.axl's
-  # get_bazelrc_flags. `aspect` itself always injects these on a Workflows runner
-  # regardless, so only the bare `bazel` invocations need the explicit opts.
-  bazelrc-e2e:
-    runs-on: [self-hosted, aspect-workflows, aspect-default]
-    needs: [pre-build]
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
-        with:
-          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
-      - name: bazelrc e2e (no server restart)
-        run: |
-          # Recompute the Workflows-runner startup opts that bootstrap.sh would
-          # have exported, so bare `bazel info` hits aspect's output base.
-          # Held in an array so the flags word-split into separate args cleanly.
-          STORAGE_PATH="${ASPECT_WORKFLOWS_RUNNER_STORAGE_PATH:-/mnt/ephemeral}"
-          REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | sed 's|.*/||' | sed 's|[^a-zA-Z0-9._-]|_|g')
-          SUBDIR=$(basename "${GITHUB_WORKSPACE}" | sed 's|[^a-zA-Z0-9._-]|_|g')
-          if [ -n "${REPO_NAME}" ]; then
-            OUTPUT_USER_ROOT="${STORAGE_PATH}/bazel/${REPO_NAME}/${SUBDIR}"
-            OUTPUT_BASE="${STORAGE_PATH}/output/${REPO_NAME}/${SUBDIR}"
-          else
-            OUTPUT_USER_ROOT="${STORAGE_PATH}/bazel/${SUBDIR}"
-            OUTPUT_BASE="${STORAGE_PATH}/output/${SUBDIR}"
-          fi
-          STARTUP_OPTS=(--nohome_rc --nosystem_rc "--output_user_root=${OUTPUT_USER_ROOT}" "--output_base=${OUTPUT_BASE}")
-          echo "Startup opts: ${STARTUP_OPTS[*]}"
-
-          echo "--- Warm up Bazel server"
-          bazel "${STARTUP_OPTS[@]}" test --config=ci -c dbg //crates/bazelrc:bazelrc_test
-          BEFORE_PID=$(bazel "${STARTUP_OPTS[@]}" info server_pid)
-          echo "server_pid: $BEFORE_PID"
-          echo "--- bazel info (before aspect)"
-          bazel "${STARTUP_OPTS[@]}" info
-          echo "--- aspect test //crates/bazelrc:bazelrc_test"
-          aspect test --task-key bazelrc-e2e-gha //crates/bazelrc:bazelrc_test
-          AFTER_PID=$(bazel "${STARTUP_OPTS[@]}" info server_pid)
-          echo "--- bazel info (after aspect)"
-          bazel "${STARTUP_OPTS[@]}" info
-          # Intentionally no $SERVER_LOG cat or $OUTPUT_BASE artifact uploads.
-          # This repo is public, so the job log and artifact tab are
-          # world-readable. java.log / command.log / jvm.out / cmdline can capture
-          # `--announce_rc` output and error messages that quote flag values
-          # verbatim (--remote_header=, --action_env=TOKEN=, URL creds …) — none
-          # of which go through the Rust BES redactor.
-          if [ "$BEFORE_PID" != "$AFTER_PID" ]; then
-            echo "::error::Bazel server was restarted (PID $BEFORE_PID -> $AFTER_PID)"
-            echo "This means aspect produced different startup flags than bazel."
-            exit 1
-          fi
-          echo "OK: server PID unchanged ($BEFORE_PID)"
+  # NOTE: the Buildkite `bazelrc-e2e` step is intentionally NOT ported here. It
+  # asserts that bare `bazel` and `aspect` start the SAME Bazel server (identical
+  # startup flags, no server thrash). On a GitHub Actions Workflows runner `bazel`
+  # resolves to the stable Aspect launcher rather than vanilla bazel, so the
+  # bare-bazel-vs-aspect comparison the test depends on can't be reconstructed
+  # (and the launcher injects BES/remote-cache config that hangs on flush). It
+  # stays a Buildkite-only test on main.
   # Smoke-tests the new test-task flags. Ported from the Buildkite
   # `test-flags-task` step. `--target-pattern-file` is forwarded to Bazel
   # verbatim, so the assertion is just that aspect resolves the file and the run

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -489,8 +489,8 @@ jobs:
   # We build via `aspect` (self-configures the runner's output base + remote cache,
   # so the dev tree pre-build already populated is a cache hit), force the binary
   # local with --remote_download_toplevel (the runner defaults to minimal downloads
-  # over a FUSE cache, else it never lands in the workspace), resolve its path with
-  # cquery, and copy to a stable target/ci/ path immediately — a later build can
+  # over a FUSE cache, else it never lands in the workspace), then copy it from the
+  # bazel-bin symlink to a stable target/ci/ path immediately — a later build can
   # redirect bazel-out, which is what makes a raw bazel-out path go stale (Buildkite
   # hit exactly that — a 127 "No such file" on the launcher). The CLI is already
   # stabilized at target/ci/aspect-cli by install-prebuilt-aspect-cli, which is also
@@ -515,12 +515,21 @@ jobs:
           aspect build --task-key axl-tests-gha-bootstrap \
             --bazel-flag=--remote_download_toplevel \
             //crates/aspect-launcher
-          # Resolve the output path with cquery (config-agnostic — k8-fastbuild here,
-          # not the cli's k8-dbg) and copy to a stable target/ci/ path immediately,
-          # before any later build redirects bazel-out. Fail loudly if it's missing.
+          # Copy to a stable target/ci/ path immediately, before any later build
+          # redirects bazel-out. The launcher goes through a config transition, so
+          # we rely on the bazel-bin convenience symlink (which Bazel keeps pointed
+          # at the transitioned output) and fall back to a bazel-out scan. NOTE:
+          # `aspect cquery` does NOT exist (aspect-cli has no cquery verb), so we
+          # resolve the path directly rather than querying.
           mkdir -p target/ci
-          launcher_out=$(aspect cquery --output=files //crates/aspect-launcher)
-          test -f "$launcher_out" || { echo "::error::launcher not materialized locally: '$launcher_out'"; exit 1; }
+          launcher_out=bazel-bin/crates/aspect-launcher/aspect-launcher
+          if [ ! -f "$launcher_out" ]; then
+            # Bazel-out paths are alphanumeric; -t picks the newest transitioned dir.
+            # shellcheck disable=SC2012
+            launcher_out=$(ls -t bazel-out/*/bin/crates/aspect-launcher/aspect-launcher 2>/dev/null | head -n1)
+          fi
+          test -n "$launcher_out" && test -f "$launcher_out" || { echo "::error::dev launcher binary not found locally after build"; exit 1; }
+          echo "launcher binary: $launcher_out"
           cp -f "$launcher_out" target/ci/aspect-launcher
           LAUNCHER="$GITHUB_WORKSPACE/target/ci/aspect-launcher"
           CLI="$GITHUB_WORKSPACE/target/ci/aspect-cli"

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -416,3 +416,241 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Cache Diff Task (ASPECT_DEBUG=1)
         run: ASPECT_DEBUG=1 aspect cache diff --task-key cache-diff-gha-debug
+  # Workflows runner smoke test: the freshly-built CLI starts, prints version /
+  # help, and the runner injects the expected ASPECT_WORKFLOWS_* environment.
+  # Runs on a self-hosted runner because the ASPECT_WORKFLOWS_RUNNER_* values it
+  # dumps only exist there. Ported from the Buildkite `runner-smoke` step (which
+  # only runs on main); kept here so PRs catch CLI-startup / env-plumbing breakage.
+  runner-smoke:
+    runs-on: [self-hosted, aspect-workflows, aspect-default]
+    needs: [pre-build]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+      - name: Runner smoke test
+        run: |
+          aspect --version
+          aspect version
+          aspect help
+          echo "ASPECT_* env var names present:"
+          env | grep -o '^ASPECT_[^=]*' | sort | sed 's/^/  /'
+          echo "ASPECT_WORKFLOWS_* values:"
+          for var in \
+            ASPECT_WORKFLOWS_BES_BACKEND \
+            ASPECT_WORKFLOWS_BES_RESULTS_URL \
+            ASPECT_WORKFLOWS_DELIVERY_API_ENDPOINT \
+            ASPECT_WORKFLOWS_REMOTE_BYTESTREAM_URI_PREFIX \
+            ASPECT_WORKFLOWS_REMOTE_CACHE \
+            ASPECT_WORKFLOWS_RUNNER \
+            ASPECT_WORKFLOWS_RUNNER_ASPECT_LAUNCHER_VERSION \
+            ASPECT_WORKFLOWS_RUNNER_AZ \
+            ASPECT_WORKFLOWS_RUNNER_BAZEL_ROOT_DIR \
+            ASPECT_WORKFLOWS_RUNNER_BIN_DIR \
+            ASPECT_WORKFLOWS_RUNNER_CI_AGENT_VERSION \
+            ASPECT_WORKFLOWS_RUNNER_CLOUD_ACCOUNT \
+            ASPECT_WORKFLOWS_RUNNER_CLOUD_PROVIDER \
+            ASPECT_WORKFLOWS_RUNNER_DATA_DIR \
+            ASPECT_WORKFLOWS_RUNNER_HAS_NVME_STORAGE \
+            ASPECT_WORKFLOWS_RUNNER_IMAGE_ID \
+            ASPECT_WORKFLOWS_RUNNER_INSTANCE_ID \
+            ASPECT_WORKFLOWS_RUNNER_INSTANCE_NAME \
+            ASPECT_WORKFLOWS_RUNNER_INSTANCE_TYPE \
+            ASPECT_WORKFLOWS_RUNNER_GROUP_NAME \
+            ASPECT_WORKFLOWS_RUNNER_GROUP_QUEUE \
+            ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE \
+            ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR \
+            ASPECT_WORKFLOWS_RUNNER_LAST_HEALTH_CHECK_FILE \
+            ASPECT_WORKFLOWS_RUNNER_RESOURCE_TYPE \
+            ASPECT_WORKFLOWS_RUNNER_OUTPUT_ROOT_DIR \
+            ASPECT_WORKFLOWS_RUNNER_REGION \
+            ASPECT_WORKFLOWS_RUNNER_REPOSITORY_CACHE_DIR \
+            ASPECT_WORKFLOWS_RUNNER_STORAGE_PATH \
+            ASPECT_WORKFLOWS_RUNNER_VERSION \
+            ASPECT_WORKFLOWS_RUNNER_WARMING_CACHE_VERSION_FILE \
+            ASPECT_WORKFLOWS_RUNNER_WARMING_COMPLETE_MARKER_FILE \
+            ASPECT_WORKFLOWS_RUNNER_WARMING_ENABLED \
+          ; do
+            val=$(printenv "$var") && echo "  $var=$val" || true
+          done
+  # AXL test suite + CLI/launcher end-to-end smoke. Ported from the Buildkite
+  # `axl-tests` step. Unlike Buildkite (which cquery's the just-built launcher /
+  # cli out of bazel-out), the prebuilt CLI is already installed at
+  # `target/ci/aspect-cli` by install-prebuilt-aspect-cli, and the stable
+  # `aspect` launcher on PATH resolves it via .aspect/version.axl. So we invoke
+  # `aspect` directly (= Buildkite's $LAUNCHER) and the raw binary at
+  # target/ci/aspect-cli (= Buildkite's $CLI) without the build + cquery dance.
+  axl-tests:
+    runs-on: [self-hosted, aspect-workflows, aspect-default]
+    needs: [pre-build]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+      - name: AXL Tests
+        run: |
+          CLI="$GITHUB_WORKSPACE/target/ci/aspect-cli"
+          echo "--- aspect demo template-demo"
+          aspect demo template-demo
+          echo "--- aspect user nested user-task"
+          aspect user nested user-task --run_count 5
+          echo "--- aspect user user-task-man"
+          aspect user user-task-man
+          echo "--- aspect user user-task-added-by-config"
+          aspect user user-task-added-by-config
+          echo "--- aspect user user-task-subdir (in crates/aspect-cli)"
+          (
+            cd crates/aspect-cli
+            aspect user user-task-subdir
+          )
+          echo "--- aspect run smoke (//examples/deliverable)"
+          aspect run //examples/deliverable:py_deliverable
+          aspect run //examples/deliverable:sh_deliverable -- forwarded-arg
+          echo "--- aspect help"
+          aspect help
+          echo "--- aspect launcher --version"
+          aspect --version
+          echo "--- aspect-cli --version"
+          "$CLI" --version
+          echo "--- aspect version"
+          aspect version
+          echo "--- invalid task-id"
+          aspect build --task-id not-a-uuid //... && echo "ERROR: --task-id should reject non-UUID" && exit 1 || true
+          echo "--- invalid task-key"
+          aspect build --task-key "bad key!" //... && echo "ERROR: --task-key should reject invalid chars" && exit 1 || true
+          echo "--- aspect dev test-template-snapshots"
+          aspect dev test-template-snapshots
+          echo "--- aspect dev test-lint-template-snapshots"
+          aspect dev test-lint-template-snapshots
+          echo "--- aspect dev test-lint-annotation-plan"
+          aspect dev test-lint-annotation-plan
+          echo "--- aspect dev test-format-template-snapshots"
+          aspect dev test-format-template-snapshots
+          echo "--- aspect dev test-gazelle-template-snapshots"
+          aspect dev test-gazelle-template-snapshots
+          echo "--- aspect dev test-delivery-template-snapshots"
+          aspect dev test-delivery-template-snapshots
+          echo "--- aspect dev test-bk-annotation-snapshots"
+          aspect dev test-bk-annotation-snapshots
+          echo "--- aspect dev test-pr-comment-snapshots"
+          aspect dev test-pr-comment-snapshots
+          echo "--- aspect dev test-github-detect"
+          aspect dev test-github-detect
+          echo "--- aspect dev test-gitlab-detect"
+          aspect dev test-gitlab-detect
+          echo "--- aspect dev test-gitlab-client"
+          aspect dev test-gitlab-client
+          echo "--- aspect dev test-tips"
+          aspect dev test-tips
+          echo "--- aspect dev test-rate-limit"
+          aspect dev test-rate-limit
+          echo "--- aspect dev test-runner-job-history"
+          aspect dev test-runner-job-history
+          echo "--- aspect tests axl"
+          # Run AXL tests last — cancel tests may kill the Bazel server,
+          # which invalidates bazel-out paths used above.
+          aspect tests axl
+  # bazelrc e2e: assert `aspect` and bare `bazel` start the SAME Bazel server
+  # (no server restart between them => identical startup flags). Ported from the
+  # Buildkite `bazelrc-e2e` step.
+  #
+  # The bare `bazel info` calls only target the same server as `aspect` if they
+  # share `aspect`'s computed --output_base/--output_user_root. Buildkite gets
+  # those via bootstrap.sh's $BAZEL_STARTUP_OPTS; here bootstrap.sh did NOT run
+  # (we install the prebuilt CLI instead), so $GITHUB_ENV never received them.
+  # We recompute them inline, mirroring bootstrap.sh + environment.axl's
+  # get_bazelrc_flags. `aspect` itself always injects these on a Workflows runner
+  # regardless, so only the bare `bazel` invocations need the explicit opts.
+  bazelrc-e2e:
+    runs-on: [self-hosted, aspect-workflows, aspect-default]
+    needs: [pre-build]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+      - name: bazelrc e2e (no server restart)
+        run: |
+          # Recompute the Workflows-runner startup opts that bootstrap.sh would
+          # have exported, so bare `bazel info` hits aspect's output base.
+          # Held in an array so the flags word-split into separate args cleanly.
+          STORAGE_PATH="${ASPECT_WORKFLOWS_RUNNER_STORAGE_PATH:-/mnt/ephemeral}"
+          REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | sed 's|.*/||' | sed 's|[^a-zA-Z0-9._-]|_|g')
+          SUBDIR=$(basename "${GITHUB_WORKSPACE}" | sed 's|[^a-zA-Z0-9._-]|_|g')
+          if [ -n "${REPO_NAME}" ]; then
+            OUTPUT_USER_ROOT="${STORAGE_PATH}/bazel/${REPO_NAME}/${SUBDIR}"
+            OUTPUT_BASE="${STORAGE_PATH}/output/${REPO_NAME}/${SUBDIR}"
+          else
+            OUTPUT_USER_ROOT="${STORAGE_PATH}/bazel/${SUBDIR}"
+            OUTPUT_BASE="${STORAGE_PATH}/output/${SUBDIR}"
+          fi
+          STARTUP_OPTS=(--nohome_rc --nosystem_rc "--output_user_root=${OUTPUT_USER_ROOT}" "--output_base=${OUTPUT_BASE}")
+          echo "Startup opts: ${STARTUP_OPTS[*]}"
+
+          echo "--- Warm up Bazel server"
+          bazel "${STARTUP_OPTS[@]}" test --config=ci -c dbg //crates/bazelrc:bazelrc_test
+          BEFORE_PID=$(bazel "${STARTUP_OPTS[@]}" info server_pid)
+          echo "server_pid: $BEFORE_PID"
+          echo "--- bazel info (before aspect)"
+          bazel "${STARTUP_OPTS[@]}" info
+          echo "--- aspect test //crates/bazelrc:bazelrc_test"
+          aspect test --task-key bazelrc-e2e-gha //crates/bazelrc:bazelrc_test
+          AFTER_PID=$(bazel "${STARTUP_OPTS[@]}" info server_pid)
+          echo "--- bazel info (after aspect)"
+          bazel "${STARTUP_OPTS[@]}" info
+          # Intentionally no $SERVER_LOG cat or $OUTPUT_BASE artifact uploads.
+          # This repo is public, so the job log and artifact tab are
+          # world-readable. java.log / command.log / jvm.out / cmdline can capture
+          # `--announce_rc` output and error messages that quote flag values
+          # verbatim (--remote_header=, --action_env=TOKEN=, URL creds …) — none
+          # of which go through the Rust BES redactor.
+          if [ "$BEFORE_PID" != "$AFTER_PID" ]; then
+            echo "::error::Bazel server was restarted (PID $BEFORE_PID -> $AFTER_PID)"
+            echo "This means aspect produced different startup flags than bazel."
+            exit 1
+          fi
+          echo "OK: server PID unchanged ($BEFORE_PID)"
+  # Smoke-tests the new test-task flags. Ported from the Buildkite
+  # `test-flags-task` step. `--target-pattern-file` is forwarded to Bazel
+  # verbatim, so the assertion is just that aspect resolves the file and the run
+  # completes. `--coverage` is exercised against an sh_test rather than a
+  # rust_test: toolchains_llvm_bootstrapped 0.5.2 (pinned in MODULE.bazel) ships
+  # without libclang_rt.profile.a, so any rust_test under --collect_code_coverage
+  # fails CppLink (upstream hermeticbuild/hermetic-llvm#318, fixed in #468 — not
+  # in 0.5.2 yet). sh_test has no coverage instrumentation so this exercises flag
+  # plumbing + the "report not found" warning path rather than an LCOV payload.
+  test-flags-task:
+    runs-on: [self-hosted, aspect-workflows, aspect-default]
+    needs: [pre-build]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+      - name: Test Task — new flags
+        run: |
+          echo "--- aspect test --target-pattern-file"
+          PATTERNS=$(mktemp)
+          echo "# smoke: targets forwarded via --target_pattern_file" > "$PATTERNS"
+          echo "//examples/test_states:always_pass" >> "$PATTERNS"
+          aspect test --task-key test-gha-target-pattern-file --target-pattern-file="$PATTERNS"
+          rm -f "$PATTERNS"
+
+          echo "--- aspect test --coverage (+ --coverage-report + --coverage-tool)"
+          REPORT=$(mktemp)
+          aspect test --task-key test-gha-coverage \
+            --coverage \
+            --coverage-report="$REPORT" \
+            --coverage-tool=cat --coverage-tool-arg='{report}' \
+            //examples/test_states:always_pass
+          rm -f "$REPORT"

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -477,12 +477,23 @@ jobs:
             val=$(printenv "$var") && echo "  $var=$val" || true
           done
   # AXL test suite + CLI/launcher end-to-end smoke. Ported from the Buildkite
-  # `axl-tests` step. Unlike Buildkite (which cquery's the just-built launcher /
-  # cli out of bazel-out), the prebuilt CLI is already installed at
-  # `target/ci/aspect-cli` by install-prebuilt-aspect-cli, and the stable
-  # `aspect` launcher on PATH resolves it via .aspect/version.axl. So we invoke
-  # `aspect` directly (= Buildkite's $LAUNCHER) and the raw binary at
-  # target/ci/aspect-cli (= Buildkite's $CLI) without the build + cquery dance.
+  # `axl-tests` step.
+  #
+  # `aspect tests axl` asserts (under CI) that it was launched by the
+  # just-built, UNSTAMPED launcher: ASPECT_LAUNCHER_VERSION == "0.0.0-dev" and
+  # the launcher resolved the CLI via local("target/ci/aspect-cli")
+  # (.aspect/axl.axl:3393-3405). The stable `aspect` launcher that setup-aspect /
+  # the runner provides is release-stamped, so we must build the launcher from
+  # THIS commit and invoke it directly — exactly like Buildkite's `$LAUNCHER`.
+  #
+  # We build via `aspect` (which self-configures the runner's output base + remote
+  # cache, so the dev tree pre-build already populated is a cache hit) and resolve
+  # the binaries with `aspect cquery --output=files` (handles Linux platform
+  # transitions). We copy the launcher to a stable path immediately: a later
+  # `aspect`/`bazel` build can redirect the bazel-out symlink, which is what makes
+  # the raw cquery'd path go stale (Buildkite hit exactly that — a 127 "No such
+  # file" on the launcher). The CLI is already stabilized at target/ci/aspect-cli
+  # by install-prebuilt-aspect-cli, which is also what the launcher resolves.
   axl-tests:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
@@ -495,67 +506,86 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: AXL Tests
         run: |
+          echo "--- build the dev launcher (= Buildkite's \$LAUNCHER)"
+          aspect build --task-key axl-tests-gha-bootstrap //crates/aspect-launcher
+          # Copy to a stable path NOW, before any later build redirects bazel-out.
+          # (cquery stdout is just the file path; drop any stderr progress lines.)
+          mkdir -p target/ci
+          launcher_out=$(aspect cquery --output=files //crates/aspect-launcher 2>/dev/null)
+          cp -f "$launcher_out" target/ci/aspect-launcher
+          LAUNCHER="$GITHUB_WORKSPACE/target/ci/aspect-launcher"
           CLI="$GITHUB_WORKSPACE/target/ci/aspect-cli"
+          # Fail loudly if we somehow didn't get the unstamped dev launcher — the
+          # `aspect tests axl` suite asserts ASPECT_LAUNCHER_VERSION == 0.0.0-dev,
+          # and a silent fallback to the runner's stable launcher would be cryptic.
+          launcher_version=$("$LAUNCHER" --version)
+          echo "dev launcher: $launcher_version"
+          case "$launcher_version" in
+            *0.0.0-dev*) ;;
+            *) echo "::error::expected an unstamped 0.0.0-dev launcher, got: $launcher_version"; exit 1 ;;
+          esac
+
           echo "--- aspect demo template-demo"
-          aspect demo template-demo
+          "$LAUNCHER" demo template-demo
           echo "--- aspect user nested user-task"
-          aspect user nested user-task --run_count 5
+          "$LAUNCHER" user nested user-task --run_count 5
           echo "--- aspect user user-task-man"
-          aspect user user-task-man
+          "$LAUNCHER" user user-task-man
           echo "--- aspect user user-task-added-by-config"
-          aspect user user-task-added-by-config
+          "$LAUNCHER" user user-task-added-by-config
           echo "--- aspect user user-task-subdir (in crates/aspect-cli)"
           (
             cd crates/aspect-cli
-            aspect user user-task-subdir
+            "$LAUNCHER" user user-task-subdir
           )
           echo "--- aspect run smoke (//examples/deliverable)"
-          aspect run //examples/deliverable:py_deliverable
-          aspect run //examples/deliverable:sh_deliverable -- forwarded-arg
+          "$LAUNCHER" run //examples/deliverable:py_deliverable
+          "$LAUNCHER" run //examples/deliverable:sh_deliverable -- forwarded-arg
           echo "--- aspect help"
-          aspect help
-          echo "--- aspect launcher --version"
-          aspect --version
+          "$LAUNCHER" help
+          echo "--- aspect-launcher --version"
+          "$LAUNCHER" --version
           echo "--- aspect-cli --version"
           "$CLI" --version
           echo "--- aspect version"
-          aspect version
+          "$LAUNCHER" version
           echo "--- invalid task-id"
-          aspect build --task-id not-a-uuid //... && echo "ERROR: --task-id should reject non-UUID" && exit 1 || true
+          "$LAUNCHER" build --task-id not-a-uuid //... && echo "ERROR: --task-id should reject non-UUID" && exit 1 || true
           echo "--- invalid task-key"
-          aspect build --task-key "bad key!" //... && echo "ERROR: --task-key should reject invalid chars" && exit 1 || true
+          "$LAUNCHER" build --task-key "bad key!" //... && echo "ERROR: --task-key should reject invalid chars" && exit 1 || true
           echo "--- aspect dev test-template-snapshots"
-          aspect dev test-template-snapshots
+          "$LAUNCHER" dev test-template-snapshots
           echo "--- aspect dev test-lint-template-snapshots"
-          aspect dev test-lint-template-snapshots
+          "$LAUNCHER" dev test-lint-template-snapshots
           echo "--- aspect dev test-lint-annotation-plan"
-          aspect dev test-lint-annotation-plan
+          "$LAUNCHER" dev test-lint-annotation-plan
           echo "--- aspect dev test-format-template-snapshots"
-          aspect dev test-format-template-snapshots
+          "$LAUNCHER" dev test-format-template-snapshots
           echo "--- aspect dev test-gazelle-template-snapshots"
-          aspect dev test-gazelle-template-snapshots
+          "$LAUNCHER" dev test-gazelle-template-snapshots
           echo "--- aspect dev test-delivery-template-snapshots"
-          aspect dev test-delivery-template-snapshots
+          "$LAUNCHER" dev test-delivery-template-snapshots
           echo "--- aspect dev test-bk-annotation-snapshots"
-          aspect dev test-bk-annotation-snapshots
+          "$LAUNCHER" dev test-bk-annotation-snapshots
           echo "--- aspect dev test-pr-comment-snapshots"
-          aspect dev test-pr-comment-snapshots
+          "$LAUNCHER" dev test-pr-comment-snapshots
           echo "--- aspect dev test-github-detect"
-          aspect dev test-github-detect
+          "$LAUNCHER" dev test-github-detect
           echo "--- aspect dev test-gitlab-detect"
-          aspect dev test-gitlab-detect
+          "$LAUNCHER" dev test-gitlab-detect
           echo "--- aspect dev test-gitlab-client"
-          aspect dev test-gitlab-client
+          "$LAUNCHER" dev test-gitlab-client
           echo "--- aspect dev test-tips"
-          aspect dev test-tips
+          "$LAUNCHER" dev test-tips
           echo "--- aspect dev test-rate-limit"
-          aspect dev test-rate-limit
+          "$LAUNCHER" dev test-rate-limit
           echo "--- aspect dev test-runner-job-history"
-          aspect dev test-runner-job-history
+          "$LAUNCHER" dev test-runner-job-history
           echo "--- aspect tests axl"
           # Run AXL tests last — cancel tests may kill the Bazel server,
-          # which invalidates bazel-out paths used above.
-          aspect tests axl
+          # which invalidates bazel-out paths. We use the stabilized $LAUNCHER /
+          # $CLI copies above, so that's harmless here.
+          "$LAUNCHER" tests axl
   # bazelrc e2e: assert `aspect` and bare `bazel` start the SAME Bazel server
   # (no server restart between them => identical startup flags). Ported from the
   # Buildkite `bazelrc-e2e` step.

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -486,15 +486,15 @@ jobs:
   # the runner provides is release-stamped, so we must build the launcher from
   # THIS commit and invoke it directly — exactly like Buildkite's `$LAUNCHER`.
   #
-  # We build via `aspect` (which self-configures the runner's output base + remote
-  # cache, so the dev tree pre-build already populated is a cache hit), then copy
-  # the launcher from its bazel-bin path to a stable target/ci/ path immediately:
-  # a later `aspect`/`bazel` build can redirect the bazel-out symlink, which is
-  # what makes a raw bazel-out path go stale (Buildkite hit exactly that — a 127
-  # "No such file" on the launcher). The launcher is a host-config binary, so the
-  # bazel-bin convenience symlink resolves it directly (no platform transition for
-  # this target). The CLI is already stabilized at target/ci/aspect-cli by
-  # install-prebuilt-aspect-cli, which is also what the launcher resolves.
+  # We build via `aspect` (self-configures the runner's output base + remote cache,
+  # so the dev tree pre-build already populated is a cache hit), force the binary
+  # local with --remote_download_toplevel (the runner defaults to minimal downloads
+  # over a FUSE cache, else it never lands in the workspace), resolve its path with
+  # cquery, and copy to a stable target/ci/ path immediately — a later build can
+  # redirect bazel-out, which is what makes a raw bazel-out path go stale (Buildkite
+  # hit exactly that — a 127 "No such file" on the launcher). The CLI is already
+  # stabilized at target/ci/aspect-cli by install-prebuilt-aspect-cli, which is also
+  # what the launcher resolves.
   axl-tests:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
@@ -508,13 +508,20 @@ jobs:
       - name: AXL Tests
         run: |
           echo "--- build the dev launcher (= Buildkite's \$LAUNCHER)"
-          aspect build --task-key axl-tests-gha-bootstrap //crates/aspect-launcher
-          # Copy to a stable path NOW, before any later build redirects bazel-out.
-          # The launcher is a host-config binary, so the bazel-bin convenience
-          # symlink resolves it directly (no cquery needed / no platform
-          # transition for this target). Fail loudly if the path moves.
+          # --remote_download_toplevel forces the binary onto local disk: the
+          # Workflows runner defaults to --remote_download_outputs=minimal (bb_clientd
+          # FUSE cache), so without it the output stays remote and never lands in the
+          # workspace (mirrors what bootstrap.sh does for //:cli).
+          aspect build --task-key axl-tests-gha-bootstrap \
+            --bazel-flag=--remote_download_toplevel \
+            //crates/aspect-launcher
+          # Resolve the output path with cquery (config-agnostic — k8-fastbuild here,
+          # not the cli's k8-dbg) and copy to a stable target/ci/ path immediately,
+          # before any later build redirects bazel-out. Fail loudly if it's missing.
           mkdir -p target/ci
-          cp -f bazel-bin/crates/aspect-launcher/aspect-launcher target/ci/aspect-launcher
+          launcher_out=$(aspect cquery --output=files //crates/aspect-launcher)
+          test -f "$launcher_out" || { echo "::error::launcher not materialized locally: '$launcher_out'"; exit 1; }
+          cp -f "$launcher_out" target/ci/aspect-launcher
           LAUNCHER="$GITHUB_WORKSPACE/target/ci/aspect-launcher"
           CLI="$GITHUB_WORKSPACE/target/ci/aspect-cli"
           # Fail loudly if we somehow didn't get the unstamped dev launcher — the


### PR DESCRIPTION
The Buildkite pipeline only runs on `main` (to reduce cost), so any test that lives **only** there is a regression risk on PRs — it can break and we won't find out until after landing. This moves the four Buildkite steps that had no GitHub Actions equivalent into `ci-workflows.yaml` so PRs exercise them too.

Ported steps (all `needs: [pre-build]` on the self-hosted `aspect-workflows` runner — they need the remote cache / warm Bazel server, and `runner-smoke` needs the runner-only env):

| Job | Covers |
|---|---|
| `runner-smoke` | CLI startup (`--version`/`version`/`help`) + the injected `ASPECT_WORKFLOWS_*` env |
| `axl-tests` | `aspect tests axl`, all `aspect dev test-*` snapshot/detect tests, `demo`/`user`/`run` smoke, invalid `--task-id`/`--task-key` rejection |
| `bazelrc-e2e` | `aspect` and bare `bazel` start the **same** Bazel server (no restart ⇒ identical startup flags) |
| `test-flags-task` | `aspect test` `--target-pattern-file` and `--coverage` (`--coverage-report`/`--coverage-tool`) plumbing |

The Buildkite pipeline is **unchanged**: it keeps these as the main-only regression net, re-testing on landed commits what already passed on GitHub Actions.

**Adaptations from the Buildkite source** (these aren't blind copies):
- `axl-tests` drops Buildkite's `bazel build //crates/aspect-launcher //crates/aspect-cli` + `cquery` dance. In GHA the prebuilt binary is already at `target/ci/aspect-cli` (via `install-prebuilt-aspect-cli`) and the stable `aspect` launcher resolves it through `.aspect/version.axl`, so `$LAUNCHER` → `aspect` and `$CLI` → `$GITHUB_WORKSPACE/target/ci/aspect-cli`.
- `bazelrc-e2e` recomputes the runner's `--output_base`/`--output_user_root` inline (mirroring `bootstrap.sh` + `environment.axl`). `bootstrap.sh` only exports `$BAZEL_STARTUP_OPTS` to `$GITHUB_ENV` within the pre-build job, which these jobs don't run — so without recomputing, bare `bazel info` would hit a different server than `aspect` and the test would falsely fail. Held in a bash array for clean word-splitting.
- `--task-key` values renamed `*-bk-*` → `*-gha-*` to match this file's convention.

`force-targets-input` was intentionally **not** ported — it's a Buildkite UI-input mechanism, not a test; GHA already handles force-targets via the `force_targets` field on `dispatch-delivery` → `ci-workflows-delivery.yaml`.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added (the four ported CI jobs themselves — they'll run on this PR)
- Validated locally with `actionlint` + `shellcheck`: zero findings on the new code (only the pre-existing `aspect-workflows`/`aspect-default` custom-runner-label warnings that fire on every self-hosted job in the file)
