### PR TITLE
fix(lint): lazy-init existing_markers in GitHub _lint_end (fixes KeyError)

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
@@ -775,7 +775,14 @@ def _github_lint_impl(ctx: FeatureContext):
                 # Errors streamed in _lint_report; post remaining warnings/notes
                 # (severity-sorted, capped to leftover budget). Patch suggestion
                 # comments join the same buffer for shared cap/dedup logic.
-                #
+
+                # Lazy-init existing markers for prior-run dedup. _lint_report
+                # only sets this when it streams a batch with errors; a run with
+                # no streamed errors (warnings/notes or patch suggestions only)
+                # reaches here with the key still unset.
+                if "existing_markers" not in gh:
+                    gh["existing_markers"] = _get_existing_markers(ctx, gh, ctx.task.key)
+
                 # "annotations" = no PR comments: patches go through
                 # _build_suggestion_comments independently of the destination
                 # filter, so gate them here too (SARIF comments are already empty).


### PR DESCRIPTION
The GitHub lint-comment reporter crashes with `Key "existing_markers" was not found` (at [github_lint_comments.axl:800](crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl#L800)) whenever a lint run reaches `_lint_end` without `_lint_report` having first streamed a batch that contained **errors**.

`_lint_report` lazily initializes `gh["existing_markers"]` — the prior-run dedup map — but only on the path that streams an error batch. A run that produces **only warnings/notes**, or **only patch suggestions** (which surface exclusively in `_lint_end`), leaves the key unset, and `_lint_end`'s dedup read then blows up. This surfaced as a red `lint-task` on CI.

The fix adds the same lazy-init guard at the top of `_lint_end`'s non-stale branch, before the first read:

```python
if "existing_markers" not in gh:
    gh["existing_markers"] = _get_existing_markers(ctx, gh, ctx.task.key)
```

This mirrors the guard already present in `_lint_report` ([line 582](crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl#L582)) and in the GitLab sibling `gitlab_lint_comments.axl` (which guards in both its stream and end paths). Unrelated to the CI-workflows port in #1260; filed separately as requested.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (internal lint-reporter behavior; no user-facing docs cover it)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fixed a crash (`Key "existing_markers" was not found`) when posting GitHub PR lint comments on runs that produced only warnings/notes or only patch suggestions.

### Test plan

- Covered by existing test cases
