### PR TITLE
feat(axl): add current_dir for query/info

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -364,7 +364,7 @@ def test_large_bes(ctx: TaskContext, tc: int, temp_dir: str) -> int:
         "//...",
         flags = ["--noremote_accept_cached"],
         build_events = [iter],
-        current_dir = "./examples/large_bes",
+        directory = "./examples/large_bes",
     )
 
     # Iterate through all build events - this would hang before the fix

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -344,7 +344,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         ctx.args.formatter_target,
         build_events = build_events,
         flags = r.flags,
-        current_dir = ctx.std.env.aspect_root_dir(),
+        directory = ctx.std.env.aspect_root_dir(),
         announce_version = announce_version,
         announce_command = announce_command,
     )

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -486,7 +486,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         ctx.args.gazelle_target,
         build_events = build_events,
         flags = r.flags,
-        current_dir = ctx.std.env.bazel_root_dir(),
+        directory = ctx.std.env.bazel_root_dir(),
         announce_version = announce_version,
         announce_command = announce_command,
     )

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -755,7 +755,7 @@ impl Build {
         startup_flags: Vec<String>,
         stdout: Stdio,
         stderr: Stdio,
-        current_dir: Option<String>,
+        directory: Option<String>,
         announce: AnnounceSpawn,
         rt: AsyncRuntime,
     ) -> Result<Build, std::io::Error> {
@@ -777,8 +777,8 @@ impl Build {
         cmd.arg(verb);
         cmd.args(flags);
 
-        if let Some(current_dir) = current_dir {
-            cmd.current_dir(current_dir);
+        if let Some(directory) = directory {
+            cmd.current_dir(directory);
         }
 
         // File sinks share the BES reader's raw-bytes path (preserves

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -378,7 +378,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     /// * `stdio` - Shorthand: set both `stdout` and `stderr` from a single
     ///   `Stdio` bundle (typically `ctx.std.io`). Cannot be combined with
     ///   `stdout`/`stderr`.
-    /// * `current_dir` - Working directory for the Bazel invocation.
+    /// * `directory` - Working directory for the Bazel invocation; selects
+    ///   the workspace / server (used for git-worktree execution).
     /// * `announce_version` - Print an `INFO: Bazel <version>` line before
     ///   spawning. Resolved from the `--announce-bazel-version` task flag.
     /// * `announce_command` - Print an `INFO: Spawning: <command>` line (the
@@ -432,7 +433,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named)] stdout: Option<NoneOr<Writable>>,
         #[starlark(require = named)] stderr: Option<NoneOr<Writable>>,
         #[starlark(require = named, default = NoneOr::None)] stdio: NoneOr<StdStdio>,
-        #[starlark(require = named, default = NoneOr::None)] current_dir: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] directory: NoneOr<String>,
         #[starlark(require = named, default = false)] announce_version: bool,
         #[starlark(require = named, default = false)] announce_command: bool,
         eval: &mut Evaluator<'v, '_, '_>,
@@ -456,7 +457,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             resolved_startup_flags,
             stdout,
             stderr,
-            current_dir.into_option(),
+            directory.into_option(),
             build::AnnounceSpawn {
                 version: announce_version,
                 command: announce_command,
@@ -492,7 +493,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     /// * `stdio` - Shorthand: set both `stdout` and `stderr` from a single
     ///   `Stdio` bundle (typically `ctx.std.io`). Cannot be combined with
     ///   `stdout`/`stderr`.
-    /// * `current_dir` - Working directory for the Bazel invocation.
+    /// * `directory` - Working directory for the Bazel invocation; selects
+    ///   the workspace / server (used for git-worktree execution).
     /// * `announce_version` - Print an `INFO: Bazel <version>` line before
     ///   spawning. Resolved from the `--announce-bazel-version` task flag.
     /// * `announce_command` - Print an `INFO: Spawning: <command>` line (the
@@ -544,7 +546,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named)] stdout: Option<NoneOr<Writable>>,
         #[starlark(require = named)] stderr: Option<NoneOr<Writable>>,
         #[starlark(require = named, default = NoneOr::None)] stdio: NoneOr<StdStdio>,
-        #[starlark(require = named, default = NoneOr::None)] current_dir: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] directory: NoneOr<String>,
         #[starlark(require = named, default = false)] announce_version: bool,
         #[starlark(require = named, default = false)] announce_command: bool,
         eval: &mut Evaluator<'v, '_, '_>,
@@ -568,7 +570,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             resolved_startup_flags,
             stdout,
             stderr,
-            current_dir.into_option(),
+            directory.into_option(),
             build::AnnounceSpawn {
                 version: announce_version,
                 command: announce_command,
@@ -593,6 +595,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///   its own `.bazelrc`.
     /// * `flags` - Per-call command extras appended after the rc expansion.
     ///   Same `str | (str, version-constraint)` shape as `build` / `test`.
+    /// * `directory` - Working directory for the query; selects the
+    ///   workspace / server. Used for git-worktree-scoped discovery.
     /// * `announce_version` / `announce_command` - Mirror the build/test
     ///   spawn disclosure.
     ///
@@ -609,6 +613,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named, default = UnpackList::default())] flags: UnpackList<
             Either<values::StringValue<'v>, (values::StringValue<'v>, values::StringValue<'v>)>,
         >,
+        #[starlark(require = named, default = NoneOr::None)] directory: NoneOr<String>,
         #[starlark(require = named, default = false)] announce_version: bool,
         #[starlark(require = named, default = false)] announce_command: bool,
     ) -> anyhow::Result<query::Query> {
@@ -625,6 +630,7 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             &expr,
             &startup,
             &command_flags,
+            directory.into_option(),
             build::AnnounceSpawn {
                 version: announce_version,
                 command: announce_command,
@@ -638,7 +644,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     /// with a non-zero code.
     ///
     /// # Arguments
-    /// * `workdir`: workspace root to run `bazel info` in (default: inferred from ctx)
+    /// * `directory`: working directory to run `bazel info` in; selects the
+    ///   workspace / server (default: the parent process cwd).
     ///
     /// **Examples**
     ///
@@ -648,12 +655,18 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///     print(info["output_base"])
     ///     print(info["execution_root"])
     /// ```
-    fn info<'v>(this: values::Value<'v>) -> anyhow::Result<SmallMap<String, String>> {
+    fn info<'v>(
+        this: values::Value<'v>,
+        #[starlark(require = named, default = NoneOr::None)] directory: NoneOr<String>,
+    ) -> anyhow::Result<SmallMap<String, String>> {
         let startup_flags = read_startup_flags(this)?;
 
         let mut cmd = bazel_command();
         cmd.args(&startup_flags);
         cmd.arg("info");
+        if let Some(dir) = directory.into_option() {
+            cmd.current_dir(dir);
+        }
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::null());
         cmd.stdin(Stdio::null());

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -161,6 +161,7 @@ pub fn run(
     expr: &str,
     startup_flags: &[String],
     flags: &[String],
+    current_dir: Option<String>,
     announce: super::build::AnnounceSpawn,
 ) -> anyhow::Result<Query> {
     let mut cmd = super::bazel_command();
@@ -169,6 +170,9 @@ pub fn run(
     cmd.arg(expr);
     cmd.args(flags);
     cmd.arg("--output=streamed_proto");
+    if let Some(dir) = current_dir {
+        cmd.current_dir(dir);
+    }
     let out = temp_dir().join("query.bin");
     let _ = fs::remove_file(&out);
     let errfile_path = temp_dir().join("query.err");

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -161,7 +161,7 @@ pub fn run(
     expr: &str,
     startup_flags: &[String],
     flags: &[String],
-    current_dir: Option<String>,
+    directory: Option<String>,
     announce: super::build::AnnounceSpawn,
 ) -> anyhow::Result<Query> {
     let mut cmd = super::bazel_command();
@@ -170,7 +170,7 @@ pub fn run(
     cmd.arg(expr);
     cmd.args(flags);
     cmd.arg("--output=streamed_proto");
-    if let Some(dir) = current_dir {
+    if let Some(dir) = directory {
         cmd.current_dir(dir);
     }
     let out = temp_dir().join("query.bin");


### PR DESCRIPTION
Align `query` / `info` with `build` / `test` by giving them a `current_dir` argument.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
