### PR TITLE
test(axl): warm repo cache before cancel tests to avoid lock hang

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -521,6 +521,15 @@ def test_query_flags(ctx: TaskContext, tc: int) -> int:
     return tc
 
 def test_cancel_invocation(ctx: TaskContext, tc: int) -> int:
+    # Warm up loading/analysis to completion FIRST so the cancelled --nobuild
+    # builds below never get SIGINT'd mid-repository-fetch. On a cold repo cache
+    # (GHA Workflows runners, unlike Buildkite's warm shared cache) a build
+    # cancelled during repo fetching can strand the Bazel 9 "repo contents cache"
+    # lock, so the next invocation hangs on "could not acquire lock on repo
+    # contents cache". Running the same target to completion here fetches the
+    # repos and releases that lock cleanly before any cancellation.
+    ctx.bazel.build("//crates/aspect-cli:aspect-cli", flags = ["--nobuild"]).wait()
+
     # Test 1: Server-wide cancel_invocation when no build is running
     cancellation3 = ctx.bazel.cancel_invocation()
     tc = test_case(tc, type(cancellation3.busy) == "bool", "cancel_invocation().busy should be a bool")


### PR DESCRIPTION
Follow-up to #1262 — the ported `aspect tests axl` job intermittently **hangs** on GitHub Actions in the cancellation suite:

```
wait() on server-wide cancellation should return True ... OK
Bazel caught interrupt signal; cancelling pending invocation.
ERROR: could not acquire lock on repo contents cache
```

### Cause

`test_cancel_invocation` starts `build //crates/aspect-cli --nobuild` and SIGINTs it. On a **cold** repo cache (GHA Workflows runners), that `--nobuild` build is still **fetching repositories** when cancelled, so it strands the Bazel 9 *repo contents cache* lock — and the next invocation blocks on `could not acquire lock on repo contents cache`. `wait()` only polls the command lock (`is_server_busy`), not the finer-grained repo-contents lock, so it returns `True` before that lock is released.

Buildkite doesn't hit this because its shared `--repository_cache` is already warm, so `--nobuild` does no fetching when cancelled.

### Fix

Reproduce Buildkite's warm state: run the same `//crates/aspect-cli --nobuild` target **to completion once** at the top of `test_cancel_invocation`, fetching the repos and releasing the lock cleanly **before** any cancellation lands. The subsequent cancelled builds then only do loading/analysis on already-fetched repos, so no fetch lock is held at SIGINT time.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases (the `axl-tests` job exercises `test_cancel_invocation`)
- Verified locally that `.aspect/axl.axl` still parses/loads (the dev launcher lists tasks without error)
