### PR TITLE
feat(cli): task kind/name identity model + --task: flag namespace

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -2777,16 +2777,17 @@ def test_repro_commands_lib(tc: int) -> int:
     tc = test_case(tc, lines[0] == "aspect lint \\", "build_aspect_command: no-targets flag-overflow wraps head (got %r)" % lines[0])
     tc = test_case(tc, not lines[-1].endswith("\\"), "build_aspect_command: no-targets last flag has no trailing ` \\` (got %r)" % lines[-1])
 
-    # task_cli_path: bare task (no group).
-    bare = struct(group = [], name = "lint")
+    # task_cli_path uses the task kind (the runnable command), not the
+    # per-invocation --task:name.
+    bare = struct(group = [], kind = "lint")
     tc = test_case(tc, task_cli_path(bare) == "lint", "task_cli_path: bare task")
 
     # task_cli_path: single group level.
-    nested = struct(group = ["utils"], name = "format")
+    nested = struct(group = ["utils"], kind = "format")
     tc = test_case(tc, task_cli_path(nested) == "utils format", "task_cli_path: single group")
 
     # task_cli_path: multi-level group nesting.
-    deep = struct(group = ["utils", "frontend"], name = "format")
+    deep = struct(group = ["utils", "frontend"], kind = "format")
     tc = test_case(tc, task_cli_path(deep) == "utils frontend format", "task_cli_path: nested groups")
 
     # dedup_and_attribute: same (kind, command, description) → one row,

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -9,7 +9,6 @@ load(
     "@aspect//lib/build_metadata.axl",
     "detect_vcs_from_host",
     "parse_git_remote_url",
-    "task_display_name",
     "version_gte",
     "version_tuple",
 )
@@ -300,18 +299,26 @@ def test_stream(ctx: TaskContext, tc: int, temp_dir: str) -> int:
 def test_task_info(ctx: TaskContext, tc: int) -> int:
     info = ctx.task
 
-    # name should be the symbol name "axl" (no explicit name= was given)
-    tc = test_case(tc, type(info.name) == "string", "ctx.task.name should be a string")
-    tc = test_case(tc, info.name == "axl", "ctx.task.name should equal the symbol name 'axl'")
+    # kind should be the symbol name "axl" (no explicit kind= was given)
+    tc = test_case(tc, type(info.kind) == "string", "ctx.task.kind should be a string")
+    tc = test_case(tc, info.kind == "axl", "ctx.task.kind should equal the symbol name 'axl'")
+
+    # display_kind: Title-Cased kind ("axl" → "Axl") unless display_kind= given
+    tc = test_case(tc, type(info.display_kind) == "string", "ctx.task.display_kind should be a string")
+    tc = test_case(tc, info.display_kind == "Axl", "ctx.task.display_kind should be Title-Cased kind 'Axl'")
 
     # group should be the list declared in task(group=[...])
     tc = test_case(tc, type(info.group) == "list", "ctx.task.group should be a list")
     tc = test_case(tc, len(info.group) == 1, "ctx.task.group should have one entry")
     tc = test_case(tc, info.group[0] == "tests", "ctx.task.group[0] should be 'tests'")
 
-    # key: non-empty string (auto-generated when --task-key not set)
-    tc = test_case(tc, type(info.key) == "string", "ctx.task.key should be a string")
-    tc = test_case(tc, len(info.key) > 0, "ctx.task.key should be non-empty")
+    # name: non-empty string (defaults to "<kind>-<suffix>" when --task-name not set)
+    tc = test_case(tc, type(info.name) == "string", "ctx.task.name should be a string")
+    tc = test_case(tc, len(info.name) > 0, "ctx.task.name should be non-empty")
+
+    # display_name: non-empty string (defaults to the name verbatim)
+    tc = test_case(tc, type(info.display_name) == "string", "ctx.task.display_name should be a string")
+    tc = test_case(tc, len(info.display_name) > 0, "ctx.task.display_name should be non-empty")
 
     # id: UUID v4 format (36 chars, dashes at positions 8/13/18/23)
     tc = test_case(tc, type(info.id) == "string", "ctx.task.id should be a string")
@@ -1978,19 +1985,6 @@ def test_build_metadata_lib(tc: int) -> int:
     tc = test_case(tc, version_gte("6.0.0", "5.99.99"), "version_gte: major greater")
     tc = test_case(tc, not version_gte("5.17.99", "5.18.0"), "version_gte: less")
     tc = test_case(tc, version_gte("5.18.0-rc1", "5.18.0"), "version_gte: pre-release tolerant (treated equal)")
-
-    # task_display_name
-    cases = [
-        ("test", "Test", "single-word"),
-        ("build", "Build", "single-word"),
-        ("my-task", "My Task", "kebab → Title Case"),
-        ("my_task", "My Task", "snake → Title Case"),
-        ("github-status", "Github Status", "kebab title-case"),
-        ("", "", "empty"),
-    ]
-    for (input, expected, desc) in cases:
-        got = task_display_name(input)
-        tc = test_case(tc, got == expected, "task_display_name: %s → %r (got %r)" % (desc, expected, got))
 
     return tc
 

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -303,9 +303,9 @@ def test_task_info(ctx: TaskContext, tc: int) -> int:
     tc = test_case(tc, type(info.kind) == "string", "ctx.task.kind should be a string")
     tc = test_case(tc, info.kind == "axl", "ctx.task.kind should equal the symbol name 'axl'")
 
-    # display_kind: Title-Cased kind ("axl" → "Axl") unless display_kind= given
-    tc = test_case(tc, type(info.display_kind) == "string", "ctx.task.display_kind should be a string")
-    tc = test_case(tc, info.display_kind == "Axl", "ctx.task.display_kind should be Title-Cased kind 'Axl'")
+    # friendly_kind: Title-Cased kind ("axl" → "Axl") unless friendly_kind= given
+    tc = test_case(tc, type(info.friendly_kind) == "string", "ctx.task.friendly_kind should be a string")
+    tc = test_case(tc, info.friendly_kind == "Axl", "ctx.task.friendly_kind should be Title-Cased kind 'Axl'")
 
     # group should be the list declared in task(group=[...])
     tc = test_case(tc, type(info.group) == "list", "ctx.task.group should be a list")
@@ -316,9 +316,9 @@ def test_task_info(ctx: TaskContext, tc: int) -> int:
     tc = test_case(tc, type(info.name) == "string", "ctx.task.name should be a string")
     tc = test_case(tc, len(info.name) > 0, "ctx.task.name should be non-empty")
 
-    # display_name: non-empty string (defaults to the name verbatim)
-    tc = test_case(tc, type(info.display_name) == "string", "ctx.task.display_name should be a string")
-    tc = test_case(tc, len(info.display_name) > 0, "ctx.task.display_name should be non-empty")
+    # friendly_name: non-empty string (defaults to the name verbatim)
+    tc = test_case(tc, type(info.friendly_name) == "string", "ctx.task.friendly_name should be a string")
+    tc = test_case(tc, len(info.friendly_name) > 0, "ctx.task.friendly_name should be non-empty")
 
     # id: UUID v4 format (36 chars, dashes at positions 8/13/18/23)
     tc = test_case(tc, type(info.id) == "string", "ctx.task.id should be a string")

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -736,8 +736,8 @@ def test_template_rendering(ctx: TaskContext, tc: int) -> int:
     tc = test_case(tc, "summary" in out, "render_check_output returns a dict with 'summary'")
     tc = test_case(tc, "text" in out, "render_check_output returns a dict with 'text'")
 
-    # New title format: "<status_emoji> <task_name> <subject> · <state>"
-    # (task name optional). In these tests no render_ctx["task_name"]
+    # Title format: "<status_emoji> <task_kind> <subject> · <state>"
+    # (kind optional). In these tests no render_ctx["task_kind"]
     # is set, so title is "<emoji> <subject> · <state>".
     tc = test_case(tc, "Tests passed" in out["title"], "passed title has Tests passed state: " + out["title"])
     tc = test_case(tc, "//..." in out["title"], "passed title contains target pattern: " + out["title"])
@@ -808,7 +808,7 @@ def test_template_rendering(ctx: TaskContext, tc: int) -> int:
     tc = test_case(tc, "Tests passed (cached)" in title_cached, "all-cached title: " + title_cached)
 
     # With target pattern + task name
-    title_tn = summary_title(r5, "passed", target_pattern = "//foo/...", task_name = "test")
+    title_tn = summary_title(r5, "passed", target_pattern = "//foo/...", task_kind = "test")
     tc = test_case(tc, "test //foo/..." in title_tn, "title contains task name and subject: " + title_tn)
 
     # Long target pattern is truncated
@@ -2272,15 +2272,15 @@ def test_detect_ci(ctx: TaskContext, tc: int) -> int:
 def test_artifacts_lib(ctx: TaskContext, tc: int) -> int:
     """Coverage for lib/artifacts.axl: artifact_name."""
     cases = [
-        # (ci, task_name, task_key, filename, expected, desc)
+        # (ci, task_kind, task_name, filename, expected, desc)
         ("github", "test", "my-build", "profile.gz", "test.my-build.profile.gz", "github → flat dotted"),
         ("buildkite", "test", "my-build", "profile.gz", "test/my-build/profile.gz", "buildkite → path"),
         ("gitlab", "test", "my-build", "profile.gz", "test/my-build/profile.gz", "gitlab → path"),
         ("circleci", "test", "my-build", "profile.gz", "test/my-build/profile.gz", "circleci → path"),
         ("github", "lint", "lint-gha", "format.patch", "lint.lint-gha.format.patch", "github format.patch"),
     ]
-    for (ci, task_name, task_key, filename, expected, desc) in cases:
-        got = artifact_name(ci, task_name, task_key, filename)
+    for (ci, task_kind, task_name, filename, expected, desc) in cases:
+        got = artifact_name(ci, task_kind, task_name, filename)
         tc = test_case(tc, got == expected, "artifact_name: %s → %r (got %r)" % (desc, expected, got))
     return tc
 
@@ -2491,71 +2491,71 @@ def test_fmt_elapsed(tc: int) -> int:
 def test_summary_title(tc: int) -> int:
     """Coverage for bazel_results.summary_title — GitHub check title.
 
-    Title shape: "<status_emoji> <task_name> <subject> · <state>".
+    Title shape: "<status_emoji> <task_kind> <subject> · <state>".
     Leading emoji is derived from `status` via `emoji_for_status`.
     """
 
     # status="passed" + no buckets → state empty → emoji + task + subject
     r = init_data()
-    title = summary_title(r, "passed", target_pattern = "//...", task_name = "build")
+    title = summary_title(r, "passed", target_pattern = "//...", task_kind = "build")
     tc = test_case(tc, title == "✅ build //...", "summary_title: empty data, passed → emoji+task+subject (got %r)" % title)
 
     # status="running" → "Running..." with running emoji
     r = init_data()
-    title = summary_title(r, "running", target_pattern = "//...", task_name = "test")
+    title = summary_title(r, "running", target_pattern = "//...", task_kind = "test")
     tc = test_case(tc, title == "🔄 test //... · Running...", "summary_title: running → Running... (got %r)" % title)
 
     # status="failing" also counts as in-progress.
-    title = summary_title(r, "failing", target_pattern = "//foo", task_name = "test")
+    title = summary_title(r, "failing", target_pattern = "//foo", task_kind = "test")
     tc = test_case(tc, title == "❌ test //foo · Running...", "summary_title: failing → Running... + ❌ (got %r)" % title)
 
     # passed_test_total > 0, all cached → "Tests passed (cached)"
     r = init_data()
     r["bazel"]["passed_test_total"] = 5
     r["bazel"]["cached_test_total"] = 5
-    title = summary_title(r, "passed", target_pattern = "//...", task_name = "test")
+    title = summary_title(r, "passed", target_pattern = "//...", task_kind = "test")
     tc = test_case(tc, title == "✅ test //... · Tests passed (cached)", "summary_title: all cached (got %r)" % title)
 
     # Not all cached → "Tests passed".
     r = init_data()
     r["bazel"]["passed_test_total"] = 5
     r["bazel"]["cached_test_total"] = 2
-    title = summary_title(r, "passed", target_pattern = "//...", task_name = "test")
+    title = summary_title(r, "passed", target_pattern = "//...", task_kind = "test")
     tc = test_case(tc, title == "✅ test //... · Tests passed", "summary_title: partial cached (got %r)" % title)
 
     # failed_tests with status=failed → "Tests failed", and emoji is failed
     r = init_data()
     r["bazel"]["failed_tests"] = [{"label": "//a:t", "status": "failed"}]
-    title = summary_title(r, "failed", target_pattern = "//...", task_name = "test")
+    title = summary_title(r, "failed", target_pattern = "//...", task_kind = "test")
     tc = test_case(tc, title == "❌ test //... · Tests failed", "summary_title: failed test (got %r)" % title)
 
     # flaky_test_total + status="warning" → warning emoji + "Tests flaky"
     r = init_data()
     r["bazel"]["flaky_test_total"] = 1
-    title = summary_title(r, "warning", target_pattern = "//...", task_name = "test")
+    title = summary_title(r, "warning", target_pattern = "//...", task_kind = "test")
     tc = test_case(tc, title == "⚠️ test //... · Tests flaky", "summary_title: flaky terminal (got %r)" % title)
 
     # failed_targets (build failure) → "Failed to build"
     r = init_data()
     r["bazel"]["failed_targets"] = [{"label": "//a:b"}]
-    title = summary_title(r, "failed", target_pattern = "//...", task_name = "build")
+    title = summary_title(r, "failed", target_pattern = "//...", task_kind = "build")
     tc = test_case(tc, title == "❌ build //... · Failed to build", "summary_title: failed target (got %r)" % title)
 
     # aborted status uses the 🔥 emoji.
     r = init_data()
     r["bazel"]["aborted"] = True
     r["bazel"]["passed_test_total"] = 99
-    title = summary_title(r, "aborted", target_pattern = "//...", task_name = "test")
+    title = summary_title(r, "aborted", target_pattern = "//...", task_kind = "test")
     tc = test_case(tc, title == "🔥 test //... · Invocation disconnected", "summary_title: aborted (got %r)" % title)
 
-    # Empty task_name → leading emoji + subject only.
+    # Empty task_kind → leading emoji + subject only.
     r = init_data()
     r["bazel"]["passed_test_total"] = 1
     title = summary_title(r, "passed", target_pattern = "//foo")
     tc = test_case(tc, title == "✅ //foo · Tests passed", "summary_title: empty task name → emoji + subject (got %r)" % title)
 
     # Empty target_pattern → no subject; emoji + task + state.
-    title = summary_title(r, "passed", task_name = "test")
+    title = summary_title(r, "passed", task_kind = "test")
     tc = test_case(tc, title == "✅ test · Tests passed", "summary_title: empty subject (got %r)" % title)
 
     # Both empty → emoji + state.
@@ -2564,7 +2564,7 @@ def test_summary_title(tc: int) -> int:
 
     # Long subject is truncated.
     long_target = "//" + "x" * 200
-    title = summary_title(r, "passed", target_pattern = long_target, task_name = "build")
+    title = summary_title(r, "passed", target_pattern = long_target, task_kind = "build")
     tc = test_case(tc, "…" in title, "summary_title: long subject gets ellipsis truncation (got %r)" % title)
     tc = test_case(tc, title.startswith("✅ build //"), "summary_title: still starts with emoji+task+subject prefix")
     tc = test_case(tc, len(title) <= 160, "summary_title: respects 160 char hard limit (len=%d)" % len(title))
@@ -2662,11 +2662,11 @@ def test_compute_repro(tc: int) -> int:
     tc = test_case(tc, cmd == "aspect test //a:t1 //b:t2", "compute_reproducer_command: joins failed test labels (got %r)" % cmd)
     tc = test_case(tc, total == 2, "compute_reproducer_command: total = failed test count")
 
-    # task_name is the user's task name — non-{build,test} names are surfaced verbatim.
+    # task_kind is the task's command — non-{build,test} kinds are surfaced verbatim.
     r = init_data()
     r["bazel"]["failed_targets"] = [{"label": "//x:y"}]
     cmd, _ = compute_reproducer_command(r, "ci")
-    tc = test_case(tc, cmd == "aspect ci //x:y", "compute_reproducer_command: uses task_name as the subcommand (got %r)" % cmd)
+    tc = test_case(tc, cmd == "aspect ci //x:y", "compute_reproducer_command: uses task_kind as the subcommand (got %r)" % cmd)
 
     # Long label list is truncated at MAX_REPRO_CHARS but total still reflects all.
     r = init_data()
@@ -2791,31 +2791,31 @@ def test_repro_commands_lib(tc: int) -> int:
     tc = test_case(tc, task_cli_path(deep) == "utils frontend format", "task_cli_path: nested groups")
 
     # dedup_and_attribute: same (kind, command, description) → one row,
-    # both task_keys listed; first-seen order preserved.
+    # both task_names listed; first-seen order preserved.
     rows = dedup_and_attribute([
-        {"kind": "build", "task_key": "build-gha", "command": "aspect build -- //...", "description": ""},
-        {"kind": "build", "task_key": "build-gha-debug", "command": "aspect build -- //...", "description": ""},
+        {"kind": "build", "task_name": "build-gha", "command": "aspect build -- //...", "description": ""},
+        {"kind": "build", "task_name": "build-gha-debug", "command": "aspect build -- //...", "description": ""},
     ])
     tc = test_case(tc, len(rows) == 1, "dedup_and_attribute: identical (kind,cmd,desc) collapse to one row")
-    tc = test_case(tc, rows[0]["task_keys"] == ["build-gha", "build-gha-debug"], "dedup_and_attribute: task_keys preserve first-seen order")
+    tc = test_case(tc, rows[0]["task_names"] == ["build-gha", "build-gha-debug"], "dedup_and_attribute: task_names preserve first-seen order")
 
     # dedup_and_attribute: different kinds with same command stay split.
     rows = dedup_and_attribute([
-        {"kind": "build", "task_key": "a", "command": "aspect build -- //...", "description": ""},
-        {"kind": "test", "task_key": "b", "command": "aspect build -- //...", "description": ""},
+        {"kind": "build", "task_name": "a", "command": "aspect build -- //...", "description": ""},
+        {"kind": "test", "task_name": "b", "command": "aspect build -- //...", "description": ""},
     ])
     tc = test_case(tc, len(rows) == 2, "dedup_and_attribute: different kinds stay split even with same command")
 
     # dedup_and_attribute: different descriptions stay split.
     rows = dedup_and_attribute([
-        {"kind": "format", "task_key": "a", "command": "aspect format ...", "description": "First 20 of 47"},
-        {"kind": "format", "task_key": "a", "command": "aspect format ...", "description": ""},
+        {"kind": "format", "task_name": "a", "command": "aspect format ...", "description": "First 20 of 47"},
+        {"kind": "format", "task_name": "a", "command": "aspect format ...", "description": ""},
     ])
     tc = test_case(tc, len(rows) == 2, "dedup_and_attribute: different descriptions stay split")
 
     # dedup_and_attribute: empty command rows are dropped.
     rows = dedup_and_attribute([
-        {"kind": "build", "task_key": "a", "command": "", "description": ""},
+        {"kind": "build", "task_name": "a", "command": "", "description": ""},
     ])
     tc = test_case(tc, rows == [], "dedup_and_attribute: empty commands are dropped")
 

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -312,13 +312,12 @@ def test_task_info(ctx: TaskContext, tc: int) -> int:
     tc = test_case(tc, len(info.group) == 1, "ctx.task.group should have one entry")
     tc = test_case(tc, info.group[0] == "tests", "ctx.task.group[0] should be 'tests'")
 
-    # name: non-empty string (defaults to "<kind>-<suffix>" when --task-name not set)
+    # name: non-empty string (defaults to "<kind>-<suffix>" when --task:name not set)
     tc = test_case(tc, type(info.name) == "string", "ctx.task.name should be a string")
     tc = test_case(tc, len(info.name) > 0, "ctx.task.name should be non-empty")
 
-    # friendly_name: non-empty string (defaults to the name verbatim)
-    tc = test_case(tc, type(info.friendly_name) == "string", "ctx.task.friendly_name should be a string")
-    tc = test_case(tc, len(info.friendly_name) > 0, "ctx.task.friendly_name should be non-empty")
+    # friendly_name: defaults to the name verbatim (no --task:friendly-name set)
+    tc = test_case(tc, info.friendly_name == info.name, "ctx.task.friendly_name should default to the name")
 
     # id: UUID v4 format (36 chars, dashes at positions 8/13/18/23)
     tc = test_case(tc, type(info.id) == "string", "ctx.task.id should be a string")

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -43,7 +43,7 @@ def _user_task_impl(ctx: TaskContext) -> int:
     return 0
 
 _user_task = task(
-    name = "user-task-added-by-config",
+    kind = "user-task-added-by-config",
     group = ["user"],
     implementation = _user_task_impl,
     args = {},

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -85,7 +85,7 @@ def _buildifier_repro_fix(ctx: TaskContext, info: ReproFixInfo) -> ReproFixSugge
     """Rewrite buildifier `aspect ...` suggestions to `bazel ...`. The
     `tools/bazel` wrapper makes them interchangeable here; suggest the wrapper
     form so contributors use the checked-in Bazel. Buildifier-only."""
-    if info.task_name != "buildifier":
+    if info.task_kind != "buildifier":
         return REPRO_FIX_ACCEPT
     return repro_fix_replace(
         command = info.command.replace("aspect buildifier", "bazel buildifier", 1),

--- a/.aspect/modules/demo/template_demo.axl
+++ b/.aspect/modules/demo/template_demo.axl
@@ -50,7 +50,7 @@ deep: {{address.nested.deep}}
     return 0
 
 template_demo = task(
-    name = "template-demo",
+    kind = "template-demo",
     group = ["demo"],
     implementation = _impl,
     args = {},

--- a/.aspect/user/user-task-manual.axl
+++ b/.aspect/user/user-task-manual.axl
@@ -3,7 +3,7 @@ def _impl(ctx: TaskContext) -> int:
     return 0
 
 user_task_manual = task(
-    name = "user-task-man",
+    kind = "user-task-man",
     group = ["user"],
     implementation = _impl,
     args = {},

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The [`aspect-build/bazel-examples`](https://github.com/aspect-build/bazel-exampl
 `aspect <task>` posts task results to three surfaces:
 
 - **PR task summary comment** — a single comment summarising every task in the pipeline.
-- **GitHub Status Checks** — one check per `aspect <task>` invocation, named by `--task-key`.
+- **GitHub Status Checks** — one check per `aspect <task>` invocation, named by `--task-name`.
 - **Buildkite annotations** _(when running on Buildkite)_ — one annotation per `aspect <task>` invocation, rendered at the top of the build page.
 
 Live links to each, from real runs of this repo's own CI: [What `aspect <task>` reports back](https://aspect.build/docs/cli/tasks-ci#what-aspect-%3Ctask%3E-reports-back).

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The [`aspect-build/bazel-examples`](https://github.com/aspect-build/bazel-exampl
 `aspect <task>` posts task results to three surfaces:
 
 - **PR task summary comment** — a single comment summarising every task in the pipeline.
-- **GitHub Status Checks** — one check per `aspect <task>` invocation, named by `--task-name`.
+- **GitHub Status Checks** — one check per `aspect <task>` invocation, named by `--task:name`.
 - **Buildkite annotations** _(when running on Buildkite)_ — one annotation per `aspect <task>` invocation, rendered at the top of the build page.
 
 Live links to each, from real runs of this repo's own CI: [What `aspect <task>` reports back](https://aspect.build/docs/cli/tasks-ci#what-aspect-%3Ctask%3E-reports-back).

--- a/crates/aspect-cli/.aspect/user-task-subdir.axl
+++ b/crates/aspect-cli/.aspect/user-task-subdir.axl
@@ -3,7 +3,7 @@ def _impl(ctx: TaskContext) -> int:
     return 0
 
 user_task = task(
-    name = "user-task-subdir",
+    kind = "user-task-subdir",
     group = ["user"],
     implementation = _impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
+++ b/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
@@ -92,7 +92,7 @@ setup_phase(ctx, lifecycle, subject, …)          # FIRST thing in every _impl
        └─ BuildkiteAnnotations inits → posts the first "info" annotation
   └─ hc_trait.health_check                        # Workflows env table / server health check
 bazel_trait.build_start
-  └─ Workflows prints `--- :bazel: Running bazel <task> [<task-key>] <targets>`
+  └─ Workflows prints `--- :bazel: Running bazel <task> [<task-name>] <targets>`
 events = bazel.build_events.iterator()           # create handle BEFORE the spawn
 ctx.bazel.build(..., build_events = [events])    # runtime subscribes pre-spawn
 data["sink_invocation_id"] = build.sink_invocation_id

--- a/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
+++ b/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
@@ -122,8 +122,8 @@ def _run_probe(ctx: TaskContext, patterns: list, rc, announce_version: bool, ann
     or `None` if Bazel failed unexpectedly (no gRPC log — its captured stderr is
     surfaced first). Bazel's own stdout/stderr are hidden: the expected
     require-cached denials are noise, the signal is the log."""
-    log_path = "/tmp/aspect-cache-diff-grpc-{}.bin".format(ctx.task.key)
-    err_path = "/tmp/aspect-cache-diff-probe-{}.log".format(ctx.task.key)
+    log_path = "/tmp/aspect-cache-diff-grpc-{}.bin".format(ctx.task.name)
+    err_path = "/tmp/aspect-cache-diff-probe-{}.log".format(ctx.task.name)
 
     dummy = None
     flags = [
@@ -198,7 +198,7 @@ def _build_missing_non_test(ctx: TaskContext, patterns: list, rc, announce_versi
     """precise pre-pass: execute + upload the missing non-test actions on the
     default (incremental) output base. Bazel output hidden; surfaced + False
     returned on a hard build failure (a real broken target, not a cache miss)."""
-    err_path = "/tmp/aspect-cache-diff-build-{}.log".format(ctx.task.key)
+    err_path = "/tmp/aspect-cache-diff-build-{}.log".format(ctx.task.name)
     _t = time.monotonic()
     status = ctx.bazel.build(
         rc = rc,

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -360,7 +360,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
     `should_surface_phase2_stderr`). The gRPC log uploads per
     `ctx.args.upload_grpc_log`. Uploads no-op off-CI.
     """
-    repo_dir = "/tmp/aspect_delivery_" + ctx.task.key
+    repo_dir = "/tmp/aspect_delivery_" + ctx.task.name
     _write_aspect_repo(ctx, repo_dir)
 
     # `--inject_repository` only registers the repo in the bzlmod graph; under
@@ -410,7 +410,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
         # flag — used post-wait to tell a declared opt-out from a real
         # phase-2 key drift. Local-action-cache hits aren't logged (per
         # spawn.proto), the same blind spot aquery has; accepted.
-        phase1_execlog_path = _EXECLOG_PATH.format(ctx.task.key)
+        phase1_execlog_path = _EXECLOG_PATH.format(ctx.task.name)
         phase1_execlog_sinks = list(bazel_trait.execution_log_sinks)
         phase1_execlog_sinks.append(bazel.execution_log.file(path = phase1_execlog_path))
 
@@ -518,7 +518,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
         phase = Phase(name = "checksum", description = "Checksum delivery digests", emoji = "💯"),
     )
     _t_phase2 = time.monotonic()
-    log_path = _GRPC_LOG_PATH.format(ctx.task.key)
+    log_path = _GRPC_LOG_PATH.format(ctx.task.name)
 
     # Phase 2 needs a remote executor endpoint: DeliveryHash is `no-local`, so
     # Bazel requires one even though require-cached means it never executes
@@ -546,7 +546,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
 
     # Redirect stderr to a file: require-cached failures are noisy-but-expected;
     # the actionable signal is the gRPC log below. The file is the escape hatch.
-    phase2_log_path = _PHASE2_LOG_PATH.format(ctx.task.key)
+    phase2_log_path = _PHASE2_LOG_PATH.format(ctx.task.name)
     phase2_status = ctx.bazel.build(
         flags = phase2_flags,
         stdout = None,
@@ -987,10 +987,10 @@ def _delivery_impl(ctx):
 
     # Change-detection prefix: --task-key, optionally extended by --salt.
     if ctx.args.salt:
-        prefix = ctx.task.key + ":" + ctx.args.salt
+        prefix = ctx.task.name + ":" + ctx.args.salt
         prefix_source = "--task-key + --salt"
     else:
-        prefix = ctx.task.key
+        prefix = ctx.task.name
         prefix_source = "--task-key"
 
     # Surface the salt-augmented prefix so the "KEY" column shows
@@ -1233,7 +1233,7 @@ def _delivery_impl(ctx):
         # Redirect stderr to a file: phase-3 re-materializes artifacts (OCI
         # layers, runfiles) and its progress looks like redundant rebuilds;
         # the log is the escape hatch on real failure.
-        phase3_log_path = _PHASE3_LOG_PATH.format(ctx.task.key)
+        phase3_log_path = _PHASE3_LOG_PATH.format(ctx.task.name)
         phase3_events = bazel.build_events.iterator()
         build = ctx.bazel.build(
             flags = phase3_flags,
@@ -1308,7 +1308,7 @@ def _delivery_impl(ctx):
             pending_count += 1
             mnemonics = non_hermetic_misses.get(apparent_label(label), [])
             if mnemonics:
-                msg = "no digest: non-cacheable upstream action(s) ({}); likely non-hermetic. Phase-2 raw log: {}".format(", ".join(mnemonics), _PHASE2_LOG_PATH.format(ctx.task.key))
+                msg = "no digest: non-cacheable upstream action(s) ({}); likely non-hermetic. Phase-2 raw log: {}".format(", ".join(mnemonics), _PHASE2_LOG_PATH.format(ctx.task.name))
             else:
                 msg = "no output_sha (not in grpc log; target may be an alias — use the actual target label)"
             rows.append((label, "WARN", "warn", msg, "-", "-"))
@@ -1530,7 +1530,7 @@ def _delivery_impl(ctx):
     return _emit_final(ctx, lifecycle, data, exit_code = exit_code)
 
 delivery = task(
-    name = "delivery",
+    kind = "delivery",
     summary = "Build and deliver binary targets. Targets are built with stamping and delivered exactly once per commit unless forced; change detection skips targets whose outputs haven't changed since the last delivery.",
     description = """Build and deliver binary targets. Targets are built with stamping and delivered exactly once per commit unless forced; change detection skips targets whose outputs haven't changed since the last delivery.
 

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -30,7 +30,7 @@ Three orthogonal flags shape every invocation:
   --track-state={true,false}      default true — record/query delivery state
 
 `selective` uses change detection (only candidates not yet delivered for the
-`--task-key[:--salt]` prefix); `always` skips it and treats every resolved
+`--task:name[:--salt]` prefix); `always` skips it and treats every resolved
 target as a candidate (legacy `only_on_change: false`; `--force-target`
 redundant here). `--track-state=true` records this run's digests/deliveries
 and queries prior ones; since change detection builds on it,
@@ -985,13 +985,13 @@ def _delivery_impl(ctx):
     data["delivery"]["commit_sha"] = commit_sha
     data["delivery"]["build_url"] = build_url
 
-    # Change-detection prefix: --task-key, optionally extended by --salt.
+    # Change-detection prefix: the task name, optionally extended by --salt.
     if ctx.args.salt:
         prefix = ctx.task.name + ":" + ctx.args.salt
-        prefix_source = "--task-key + --salt"
+        prefix_source = "--task:name + --salt"
     else:
         prefix = ctx.task.name
-        prefix_source = "--task-key"
+        prefix_source = "--task:name"
 
     # Surface the salt-augmented prefix so the "KEY" column shows
     # `<prefix>:<hash>` (the change-detection identity); the raw output_sha is
@@ -1550,7 +1550,7 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         ),
         "query": args.string(
             default = "",
-            description = "Bazel query expression to select candidate delivery targets (takes precedence over positional targets). Candidates are only delivered when change detection finds them new for the --task-key[:--salt] prefix — this does not force re-delivery. Targets tagged `manual` ARE included if they match the query expression (e.g. `attr(tags, scheduled_deliverable, //...)` resolves manual-tagged targets); the `manual` tag only excludes from wildcard target patterns like `//...:all`, not from attribute-filtered queries.",
+            description = "Bazel query expression to select candidate delivery targets (takes precedence over positional targets). Candidates are only delivered when change detection finds them new for the --task:name[:--salt] prefix — this does not force re-delivery. Targets tagged `manual` ARE included if they match the query expression (e.g. `attr(tags, scheduled_deliverable, //...)` resolves manual-tagged targets); the `manual` tag only excludes from wildcard target patterns like `//...:all`, not from attribute-filtered queries.",
         ),
         "limit": args.int(
             default = 0,
@@ -1577,7 +1577,7 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         ),
         "salt": args.string(
             default = "",
-            description = "Additional string appended to --task-key to scope change detection (task-key:salt). Useful for scoping delivery to a specific environment or pipeline variant without changing --task-key.",
+            description = "Additional string appended to --task:name to scope change detection (task-name:salt). Useful for scoping delivery to a specific environment or pipeline variant without changing --task:name.",
         ),
         "force_targets": args.string_list(
             long = "force-target",
@@ -1587,7 +1587,7 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         "mode": args.string(
             default = "selective",
             values = ["selective", "always"],
-            description = "Delivery model. 'selective' (default): only run candidates that haven't already been delivered for this --task-key[:--salt] prefix (uses change detection). 'always': skip change detection entirely and run every resolved target — closest analogue to legacy always-deliver behavior. Combine with --dry-run for a preview and/or --track-state=false for environments without a state backend.",
+            description = "Delivery model. 'selective' (default): only run candidates that haven't already been delivered for this --task:name[:--salt] prefix (uses change detection). 'always': skip change detection entirely and run every resolved target — closest analogue to legacy always-deliver behavior. Combine with --dry-run for a preview and/or --track-state=false for environments without a state backend.",
         ),
         "dry_run": args.boolean(
             default = False,

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -258,7 +258,7 @@ def _buildkite_annotations(ctx: FeatureContext):
         # task_update is the Setup phase mark, which carries a `kind`, so the
         # normal render emits the initial annotation.
         _state["_started_ms"] = now_ms(ctx)
-        _state["_task_name"] = ctx.task.kind
+        _state["_task_kind"] = ctx.task.kind
         _state["_triggered_by"] = (ctx.std.env.var("BUILDKITE_BUILD_CREATOR") or
                                    ctx.std.env.var("BUILDKITE_PIPELINE_NAME") or "")
         _state["_context_id"] = "aspect-%s" % ctx.task.name

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -137,16 +137,16 @@ def _format_body(out, kind, status, task_label = "", final = False):
         body = body[:_ANNOTATION_SIZE_LIMIT - 64] + "\n\n_… annotation truncated (1 MiB limit)._"
     return body
 
-def _task_label(task_key):
-    """`:aspect: task <code>task-key</code>` — the leading pill that
+def _task_label(task_name):
+    """`:aspect: task <code>task-name</code>` — the leading pill that
     prefixes the title.
 
     The `:aspect:` emoji marks the annotation as Aspect's, the literal
-    "task" scopes it to a single task (not the step), and the key
-    disambiguates multi-task steps. Task *name* lives in the title
+    "task" scopes it to a single task (not the step), and the per-invocation
+    name disambiguates multi-task steps. The task *kind* lives in the title
     next to the pill so duplicating it here would add noise.
     """
-    return ":aspect: task <code>%s</code>" % task_key
+    return ":aspect: task <code>%s</code>" % task_name
 
 # ─── Annotation I/O ───────────────────────────────────────────────────────────
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -258,16 +258,16 @@ def _buildkite_annotations(ctx: FeatureContext):
         # task_update is the Setup phase mark, which carries a `kind`, so the
         # normal render emits the initial annotation.
         _state["_started_ms"] = now_ms(ctx)
-        _state["_task_name"] = ctx.task.name
+        _state["_task_name"] = ctx.task.kind
         _state["_triggered_by"] = (ctx.std.env.var("BUILDKITE_BUILD_CREATOR") or
                                    ctx.std.env.var("BUILDKITE_PIPELINE_NAME") or "")
-        _state["_context_id"] = "aspect-%s-%s" % (ctx.task.name, ctx.task.key)
-        _state["_task_label"] = _task_label(ctx.task.key)
+        _state["_context_id"] = "aspect-%s" % ctx.task.name
+        _state["_task_label"] = _task_label(ctx.task.name)
 
         subject = _state.get("_subject", "")
         subject_str = (" " + subject) if subject else ""
-        _LOG.trace("aspect/%s (%s)%s (ctx=%s)" %
-                   (ctx.task.name, ctx.task.key, subject_str, _state["_context_id"]))
+        _LOG.trace("aspect/%s%s (ctx=%s)" %
+                   (ctx.task.name, subject_str, _state["_context_id"]))
 
     def _task_update(ctx, update):
         # Latch the subject before init/render: `setup_phase` sets it on the

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations_test.axl
@@ -94,7 +94,7 @@ def _bk_links():
         "testlogs_label_urls": {},
     }
 
-def _render_ctx(subject, task_name):
+def _render_ctx(subject, task_kind):
     """Build the render_ctx via the real `make_render_ctx` (not hand-rolled)
     so the test exercises the same wiring as the live BK feature. `subject`
     is the task subject (target pattern); pass "" for the empty-subject case,
@@ -106,7 +106,7 @@ def _render_ctx(subject, task_name):
         "_started_ms": 1744630000000,
         "_ended_ms": 1744630004500,
         "_progress": "",
-        "_task_name": task_name,
+        "_task_kind": task_kind,
     }
     return make_render_ctx(state)
 
@@ -120,7 +120,7 @@ _RENDERERS = {
 
 def _test_impl(ctx):
     scenarios = [
-        # (label,                                       kind,                data,                               status,    final, subject,      task_name)
+        # (label,                                       kind,                data,                               status,    final, subject,      task_kind)
         ("1. build-passed", "bazel_results", _make_build_passed(), "passed", True, "//...", "build"),
         ("2. test-failed", "bazel_results", _make_test_failed(), "failed", True, "//...", "test"),
         ("3. lint-passed-clean", "lint_results", _make_lint_passed_clean(), "passed", True, "//...", "lint"),
@@ -154,9 +154,9 @@ def _test_impl(ctx):
 
     sep = "=" * 70
 
-    for (label, kind, data, status, final, subject, task_name) in scenarios:
+    for (label, kind, data, status, final, subject, task_kind) in scenarios:
         renderer = _RENDERERS[kind]
-        rc = _render_ctx(subject, task_name)
+        rc = _render_ctx(subject, task_kind)
         out = renderer(ctx, data, status, rc, _bk_links(), None, None)
 
         # Mirror the live wiring: include a `:aspect: task <code>key</code>`

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations_test.axl
@@ -166,7 +166,7 @@ def _test_impl(ctx):
         body = format_body(out, kind, status, task_label = task_label, final = final)
         style = severity_for_status(status)
 
-        context_id = "aspect-%s-%s" % (task_name, "local-test")
+        context_id = "aspect-%s" % "local-test"
 
         print(sep)
         print("SCENARIO: " + label)
@@ -186,7 +186,7 @@ def _test_impl(ctx):
     return 0
 
 bk_annotation_snapshot_tests = task(
-    name = "test-bk-annotation-snapshots",
+    kind = "test-bk-annotation-snapshots",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/feature/circleci_test_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/circleci_test_results.axl
@@ -127,7 +127,7 @@ def _circleci_test_results_impl(ctx: FeatureContext) -> None:
         staging = ctx.std.fs.mkdtemp(prefix = "aspect-circleci-tr-", parent = tmpdir)
         sources = _staged_archive_sources(ctx, entries, staging, cached_as_skipped)
 
-        archive = tmpdir + "/" + ctx.task.key + "-circleci-test-results.tar.gz"
+        archive = tmpdir + "/" + ctx.task.name + "-circleci-test-results.tar.gz"
         if not tar_create(ctx, archive, _build_mtree(sources)):
             warn(ctx.std, "CircleCI test results: failed to build the JUnit archive; skipping upload.")
             ctx.std.fs.remove_dir_all(staging)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
@@ -564,7 +564,7 @@ def _github_lint_impl(ctx: FeatureContext):
         # in priority/stable order, not per-file arrival order.
         if gh and gh["stale"]:
             return
-        comments = _build_comments(ctx, filepath, run_id, ctx.task.key, destination = destination)
+        comments = _build_comments(ctx, filepath, run_id, ctx.task.name, destination = destination)
         state["all_comments_count"] += len(comments)
 
         cap_exhausted = bool(gh) and state["posted"] >= max_pr_comments
@@ -580,7 +580,7 @@ def _github_lint_impl(ctx: FeatureContext):
 
         # Lazy-init existing markers on first stream for prior-run dedup.
         if "existing_markers" not in gh:
-            gh["existing_markers"] = _get_existing_markers(ctx, gh, ctx.task.key)
+            gh["existing_markers"] = _get_existing_markers(ctx, gh, ctx.task.name)
 
         # Errors stream now; everything else buffers for _lint_end.
         errors_in_batch = [c for c in comments if c.get("_severity") == "error"]
@@ -596,7 +596,7 @@ def _github_lint_impl(ctx: FeatureContext):
         # dupes don't consume budget; count only new postable comments.
         new_only = []
         for c in ready:
-            marker = lc_extract_marker(c.get("body", ""), task_key = ctx.task.key)
+            marker = lc_extract_marker(c.get("body", ""), task_key = ctx.task.name)
             if marker and marker in gh["existing_markers"]:
                 continue
             new_only.append(c)
@@ -612,7 +612,7 @@ def _github_lint_impl(ctx: FeatureContext):
             new_only = new_only[:remaining_budget]
 
         before = len(gh["existing_markers"])
-        errors = _post_individually(ctx, gh, new_only, gh["existing_markers"], ctx.task.key)
+        errors = _post_individually(ctx, gh, new_only, gh["existing_markers"], ctx.task.name)
         state["posted"] += len(gh["existing_markers"]) - before
         state["errors"].extend(errors)
 
@@ -647,7 +647,7 @@ def _github_lint_impl(ctx: FeatureContext):
         `_tool`, `_file` for the `_lint_end` bookkeeping that fills lint_trait.suggestions.
         """
         comments = []
-        task_key = ctx.task.key
+        task_key = ctx.task.name
 
         # Index diagnostics by (file, line, tool) for correlation. `tool` keeps
         # the match same-linter; case-folded since the BES mnemonic ("ShellCheck")
@@ -781,7 +781,7 @@ def _github_lint_impl(ctx: FeatureContext):
                 # no streamed errors (warnings/notes or patch suggestions only)
                 # reaches here with the key still unset.
                 if "existing_markers" not in gh:
-                    gh["existing_markers"] = _get_existing_markers(ctx, gh, ctx.task.key)
+                    gh["existing_markers"] = _get_existing_markers(ctx, gh, ctx.task.name)
 
                 # "annotations" = no PR comments: patches go through
                 # _build_suggestion_comments independently of the destination
@@ -794,7 +794,7 @@ def _github_lint_impl(ctx: FeatureContext):
 
                 # Intra-run dedup by marker (within-run dupes; the existing-markers
                 # check below handles prior-run dupes).
-                non_errors = _dedup_by_marker(non_errors, ctx.task.key)
+                non_errors = _dedup_by_marker(non_errors, ctx.task.name)
 
                 # No diff-region pre-filter (see _lint_report); out-of-hunk 422s
                 # are tolerated via _post_individually's error collection.
@@ -803,7 +803,7 @@ def _github_lint_impl(ctx: FeatureContext):
                 deduped_skipped = 0
                 new_only = []
                 for c in non_errors:
-                    marker = lc_extract_marker(c.get("body", ""), task_key = ctx.task.key)
+                    marker = lc_extract_marker(c.get("body", ""), task_key = ctx.task.name)
                     if marker and marker in gh["existing_markers"]:
                         deduped_skipped += 1
                         continue
@@ -824,7 +824,7 @@ def _github_lint_impl(ctx: FeatureContext):
                 # 4. Post.
                 if new_only:
                     before = len(gh["existing_markers"])
-                    errors = _post_individually(ctx, gh, new_only, gh["existing_markers"], ctx.task.key)
+                    errors = _post_individually(ctx, gh, new_only, gh["existing_markers"], ctx.task.name)
                     state["posted"] += len(gh["existing_markers"]) - before
                     state["errors"].extend(errors)
                     outcome = "posted %d new comment(s)" % (len(gh["existing_markers"]) - before)
@@ -839,7 +839,7 @@ def _github_lint_impl(ctx: FeatureContext):
                 # keeps them desired.
                 suggestion_markers = []
                 for c in suggestion_comments:
-                    m = lc_extract_marker(c.get("body", ""), task_key = ctx.task.key)
+                    m = lc_extract_marker(c.get("body", ""), task_key = ctx.task.name)
                     if m:
                         suggestion_markers.append(m)
 
@@ -874,7 +874,7 @@ def _github_lint_impl(ctx: FeatureContext):
                     if path and line:
                         lint_trait.comment_urls[(path, line)] = _files_changed_url(url)
 
-                _cleanup_comments(ctx, gh, relevant_diagnostics, run_id, ctx.task.key, suggestion_markers, destination = destination)
+                _cleanup_comments(ctx, gh, relevant_diagnostics, run_id, ctx.task.name, suggestion_markers, destination = destination)
 
                 if state["dropped_due_to_cap"] > 0:
                     # Per-severity breakdown (known levels in priority order, rest "other").

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -186,7 +186,7 @@ def _github_status_checks(ctx: FeatureContext):
 
         # No `task_update.kind` yet — pick by task name, fall back to
         # bazel_results.
-        initial_kind = kind_for_task(ctx.task.name)
+        initial_kind = kind_for_task(ctx.task.kind)
         initial_renderer = renderer_for_kind(initial_kind) or renderer_for_kind("bazel_results")
         initial_output = initial_renderer.render(
             ctx,
@@ -198,9 +198,9 @@ def _github_status_checks(ctx: FeatureContext):
             metadata_keys,
         )
 
-        # Match the CLI invocation name so the Checks-tab row reads as a
-        # command, not a heading.
-        check_name = "aspect / %s (%s)" % (ctx.task.name, ctx.task.key)
+        # Use the per-invocation task name so the Checks-tab row is unique
+        # when the same kind runs more than once in a pipeline.
+        check_name = "aspect / %s" % ctx.task.name
         result = github.status_checks.create(ctx, token, owner, repo, sha, check_name)
         if not result["success"]:
             _LOG.warn(ctx.std, "Failed to create check run: %s" % result.get("error", "unknown error"))
@@ -279,8 +279,8 @@ def _github_status_checks(ctx: FeatureContext):
         # has no .task; `make_render_ctx` reads it), then create the check run.
         subject = _state.get("_subject", "")
         subject_str = (" " + subject) if subject else ""
-        _LOG.trace("aspect/%s (%s)%s" % (ctx.task.name, ctx.task.key, subject_str))
-        _state["_task_name"] = ctx.task.name
+        _LOG.trace("aspect/%s%s" % (ctx.task.name, subject_str))
+        _state["_task_name"] = ctx.task.kind
         _create_check_run(ctx)
 
     def _lint_annotation_plan(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -280,7 +280,7 @@ def _github_status_checks(ctx: FeatureContext):
         subject = _state.get("_subject", "")
         subject_str = (" " + subject) if subject else ""
         _LOG.trace("aspect/%s%s" % (ctx.task.name, subject_str))
-        _state["_task_name"] = ctx.task.kind
+        _state["_task_kind"] = ctx.task.kind
         _create_check_run(ctx)
 
     def _lint_annotation_plan(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -22,7 +22,7 @@ test.log / action-stderr paths; sibling writers can't read them) on its
 terminal update and ships them in its status artifact under `failure_snippets`.
 The writer picks which to show across all tasks via `_select_snippets`, which
 first DEDUPES by `(label, snippet)` \342\200\224 the same target failing in several jobs
-collapses to one snippet attributed to all of them (`task_keys`) rather than
+collapses to one snippet attributed to all of them (`task_names`) rather than
 rendering N identical copies \342\200\224 then sticky-selects (an already-shown snippet is
 never evicted by a later-arriving one), deterministic fill, hard-capped at
 `_MAX_COMMENT_SNIPPETS`. The chosen keys persist in the state block so selection
@@ -43,11 +43,9 @@ Body-template variables:
     started_at     \342\200\224 Earliest sibling-task start time, UTC.
     status_badges  \342\200\224 {badge_key -> label}.
     rollup         \342\200\224 {error, warning, running, passed, aborted} counts.
-    entries        \342\200\224 per-task entry dicts, alphabetical by (job, name, key).
-                     NOTE: for back-compat the wire fields are inverted vs.
-                     today's vocabulary - `entry.name` holds the task *kind*
-                     (the command) and `entry.key` holds the per-invocation
-                     task *name*. Rows render as `<name> [<kind>]`.
+    entries        \342\200\224 per-task entry dicts, alphabetical by (job, kind, name).
+                     `entry.kind` is the task kind (the command); `entry.name`
+                     is the per-invocation name. Rows render as `<name> [<kind>]`.
     build_snippets / test_snippets / repro_rows / fix_rows \342\200\224 selected items per section.
     *_overflow_note \342\200\224 "N more not shown" line for each capped section.
 """
@@ -159,7 +157,7 @@ _No tasks have reported yet._
 ## {{ icon }} {{ items|length }} {{ label }} task{{ "s" if items|length != 1 else "" }}
 
 {% for e in items -%}
-- {{ status_badges[e._badge_key] }} {{ e.key or e.name }}{% if e.key and e.key != e.name %} [{{ e.name }}]{% endif %}{% if e._elapsed_text %} · {{ e._elapsed_text }}{% endif %}{% if e._links_text %} · {{ e._links_text }}{% endif %}{% if e._result_text %}<br>💬 {{ e._result_text }}{% endif %}
+- {{ status_badges[e._badge_key] }} {{ e.name or e.kind }}{% if e.name and e.name != e.kind %} [{{ e.kind }}]{% endif %}{% if e._elapsed_text %} · {{ e._elapsed_text }}{% endif %}{% if e._links_text %} · {{ e._links_text }}{% endif %}{% if e._result_text %}<br>💬 {{ e._result_text }}{% endif %}
 {% endfor -%}
 {% endif -%}
 {% endmacro -%}
@@ -205,7 +203,7 @@ Reproduce with:
 >
 {{ tip.body_quoted }}
 >
-> <sub>_Surfaced by: {{ tip.task_keys|join(", ") }}_</sub>{% if tip.silence_hint %}
+> <sub>_Surfaced by: {{ tip.task_names|join(", ") }}_</sub>{% if tip.silence_hint %}
 >
 > {{ tip.silence_hint }}{% endif %}
 
@@ -213,7 +211,7 @@ Reproduce with:
 {% if fix_rows %}
 ## 🛠️ Fix
 {% for r in fix_rows %}{% if r.show_heading %}
-#### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_keys %} ({{ r.task_keys|join(" · ") }}){% endif %}{% endif %}
+#### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_names %} ({{ r.task_names|join(" · ") }}){% endif %}{% endif %}
 ```
 {% if r.description %}# {{ r.description }}
 {% endif %}{{ r.command }}
@@ -227,7 +225,7 @@ Reproduce with:
 {% if repro_rows %}
 ## 🔁 Reproduce
 {% for r in repro_rows %}{% if r.show_heading %}
-#### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_keys %} ({{ r.task_keys|join(" · ") }}){% endif %}{% endif %}
+#### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_names %} ({{ r.task_names|join(" · ") }}){% endif %}{% endif %}
 ```
 {% if r.description %}# {{ r.description }}
 {% endif %}{{ r.command }}
@@ -358,8 +356,8 @@ def _prepare_for_render(entries):
         e["_result_text"] = _result_cell_text(e)
     return sorted(entries, key = lambda e: (
         e.get("job", ""),
+        e.get("kind", ""),
         e.get("name", ""),
-        e.get("key", ""),
     ))
 
 def _run_attempt_int(entry):
@@ -391,18 +389,18 @@ def _collapse_by(entries, key_of, rank_of):
             best[k] = e
     return list(best.values())
 
-def _union_entries_by_name_key(primary, fallback):
-    """`primary` plus `fallback` entries whose `(name, key)` isn't in
+def _union_entries_by_kind_name(primary, fallback):
+    """`primary` plus `fallback` entries whose `(kind, name)` isn't in
     `primary` (primary wins; fallback fills gaps), preserving order."""
-    primary_keys = {(e.get("name", ""), e.get("key", "")): True for e in primary}
+    primary_keys = {(e.get("kind", ""), e.get("name", "")): True for e in primary}
     return list(primary) + [
         e
         for e in fallback
-        if (e.get("name", ""), e.get("key", "")) not in primary_keys
+        if (e.get("kind", ""), e.get("name", "")) not in primary_keys
     ]
 
 def _dedup_by_run_attempt(entries):
-    """Collapse `(name, key, job)` to the highest `run_attempt`.
+    """Collapse `(kind, name, job)` to the highest `run_attempt`.
 
     The artifacts API has no `attempt_number` filter, so a re-run's
     listing returns every prior attempt; without this a task that
@@ -412,7 +410,7 @@ def _dedup_by_run_attempt(entries):
     upstream order when callers feed newest-first)."""
     return _collapse_by(
         entries,
-        lambda e: (e.get("name", ""), e.get("key", ""), e.get("job", "")),
+        lambda e: (e.get("kind", ""), e.get("name", ""), e.get("job", "")),
         _run_attempt_int,
     )
 
@@ -423,11 +421,11 @@ def _dedup_for_display(entries):
     Defense-in-depth: `_merge_state` already produces unique rows. Guards
     a snapshot briefly carrying two rows for one task in one run_id
     (eventual-consistency blip). `workflow_run_id` is in the key so
-    distinct concurrent workflows sharing a `(job, name, key)` survive.
+    distinct concurrent workflows sharing a `(job, kind, name)` survive.
     Display copy only; persisted state untouched."""
     return _collapse_by(
         entries,
-        lambda e: (e.get("workflow_run_id", ""), e.get("job", ""), e.get("name", ""), e.get("key", "")),
+        lambda e: (e.get("workflow_run_id", ""), e.get("job", ""), e.get("kind", ""), e.get("name", "")),
         _run_attempt_int,
     )
 
@@ -678,7 +676,7 @@ def _select_snippets(entries, shown_keys):
     Identical failures are DEDUPED across tasks first: the same target failing
     in several jobs (e.g. a build target built by build-gha, build-gha-debug and
     the test task) collapses to ONE snippet attributed to all of them
-    (`task_keys`), rather than rendering the same output N times and crowding out
+    (`task_names`), rather than rendering the same output N times and crowding out
     distinct failures. The dedup identity is `(label, snippet)` — same target AND
     same output.
 
@@ -694,17 +692,17 @@ def _select_snippets(entries, shown_keys):
     `entries` are merged per-task dicts (each may carry `failure_snippets`).
     `shown_keys` is the persisted list of dedup keys shown so
     far. Returns `(snippet_rows, new_shown_keys, overflow)` where snippet_rows are
-    render dicts `{label, kind, bucket, snippet, truncated, fence, task_keys}` and
+    render dicts `{label, kind, bucket, snippet, truncated, fence, task_names}` and
     `overflow` is `{total, by_task}` over DISTINCT (deduped) failures not shown —
     `total` is the global count, `by_task` attributes the not-shown to the tasks
     that hold them (a hidden failure shared by N tasks counts once per task)."""
 
     # Dedup available snippets by (label, snippet) across tasks, unioning the
-    # contributing task_keys (first-seen order).
+    # contributing task names (first-seen order).
     available = {}
     order = []
     for e in entries:
-        task_key = e.get("key", "") or e.get("name", "")
+        task_name = e.get("name", "") or e.get("kind", "")
         for s in e.get("failure_snippets", []) or []:
             if type(s) != "dict":
                 continue
@@ -731,12 +729,12 @@ def _select_snippets(entries, shown_keys):
                     # Fence sized past any backtick run so log content can't close
                     # the code block early (CommonMark fence-injection guard).
                     "fence": code_fence_for(snippet_text),
-                    "task_keys": [task_key] if task_key else [],
+                    "task_names": [task_name] if task_name else [],
                     "_key": key,
                 }
                 order.append(key)
-            elif task_key and task_key not in slot["task_keys"]:
-                slot["task_keys"].append(task_key)
+            elif task_name and task_name not in slot["task_names"]:
+                slot["task_names"].append(task_name)
 
     # Deterministic candidate order — (bucket_rank, label) — fed to the shared
     # sticky+capped core. Dedup key (label+content) is the sticky identity.
@@ -757,7 +755,7 @@ def _select_snippets(entries, shown_keys):
     return (rows, new_shown, overflow)
 
 def _by_task_overflow(dropped):
-    """Build `{total, tasks}` for dropped rows that each carry `task_keys`.
+    """Build `{total, tasks}` for dropped rows that each carry `task_names`.
     `total` = number of distinct dropped (deduped) items; `tasks` = the set of
     tasks that hold at least one hidden item, sorted. Per-task COUNTS would
     double-count a deduped item shared by N tasks (sum > total), so we list the
@@ -767,17 +765,17 @@ def _by_task_overflow(dropped):
     total = 0
     for r in dropped:
         total += 1
-        for tk in r.get("task_keys", []) or []:
-            if tk and tk not in seen:
-                seen[tk] = True
-                tasks.append(tk)
+        for tn in r.get("task_names", []) or []:
+            if tn and tn not in seen:
+                seen[tn] = True
+                tasks.append(tn)
     return {"total": total, "tasks": sorted(tasks)}
 
 def _split_snippet_rows(rows):
     """Partition selected snippet rows into (build, test) groups, decorating each
     with the render fields the template needs:
 
-      `task_label` — `task_keys` joined; rendered "in <task_noun> <task_label>"
+      `task_label` — `task_names` joined; rendered "in <task_noun> <task_label>"
                      small below the snippet.
       `task_noun`  — "task" / "tasks" for the small-text line.
       `verb`       — the header tail: "failed to build" (build), "failed" /
@@ -791,9 +789,9 @@ def _split_snippet_rows(rows):
     test_rows = []
     for r in rows:
         row = dict(r)
-        tks = r.get("task_keys", []) or []
-        row["task_label"] = ", ".join(tks)
-        row["task_noun"] = "task" if len(tks) == 1 else "tasks"
+        tns = r.get("task_names", []) or []
+        row["task_label"] = ", ".join(tns)
+        row["task_noun"] = "task" if len(tns) == 1 else "tasks"
         dur = r.get("duration_ms", 0) or 0
         dur_str = (" in " + format_duration_ms(dur)) if dur > 0 else ""
         bucket = r.get("bucket")
@@ -822,7 +820,7 @@ _RANK_EMOJI = {3: "❌", 2: "⚠️", 1: "🔄", 0: "✅"}
 
 def _collect_repro_fix_rows(sections):
     """Return `(repro_rows, fix_rows)` for the template, each row
-    `{"kind", "command", "description", "task_keys": [...], "severity_emoji"}`.
+    `{"kind", "command", "description", "task_names": [...], "severity_emoji"}`.
 
     Scope: repro = non-passing (failed/failing/flagged); fix = every
     contributor (so format/gazelle advertise fixes even on green). Dedup
@@ -830,20 +828,20 @@ def _collect_repro_fix_rows(sections):
     contributors. Sorted most-severe first, first-seen tiebreak.
     """
 
-    # task_key → highest severity rank across buckets it appears in.
+    # task name → highest severity rank across buckets it appears in.
     task_rank = {}
     for bucket, rank in _BUCKET_SEVERITY_RANK.items():
         for e in sections.get(bucket, []) or []:
-            tk = e.get("key", "") or e.get("name", "")
-            if tk:
-                task_rank[tk] = max(task_rank.get(tk, -1), rank)
+            tn = e.get("name", "") or e.get("kind", "")
+            if tn:
+                task_rank[tn] = max(task_rank.get(tn, -1), rank)
 
     def _gather(buckets, command_field):
         entries = []
         for bucket in buckets:
             for e in sections.get(bucket, []) or []:
-                kind = e.get("name", "") or ""
-                task_key = e.get("key", "") or kind
+                kind = e.get("kind", "") or ""
+                task_name = e.get("name", "") or kind
                 for c in e.get(command_field, []) or []:
                     # Per-failure (target-set) commands render inline under their
                     # snippet, not in the combined Reproduce/Fix section.
@@ -851,13 +849,13 @@ def _collect_repro_fix_rows(sections):
                         continue
                     entries.append({
                         "kind": kind,
-                        "task_key": task_key,
+                        "task_name": task_name,
                         "command": c.command,
                         "description": c.description,
                     })
         rows = dedup_and_attribute(entries)
         for r in rows:
-            ranks = [task_rank.get(tk, 0) for tk in r["task_keys"]] or [0]
+            ranks = [task_rank.get(tn, 0) for tn in r["task_names"]] or [0]
             r["_rank"] = max(ranks)
             r["severity_emoji"] = _RANK_EMOJI.get(r["_rank"], "")
 
@@ -881,11 +879,11 @@ def _command_key(kind, command, description):
 
 def _finalize_command_rows(rows):
     """Set `show_heading` on the FINAL (post-selection) row order: collapse
-    consecutive repeated `(kind, task_keys)` headings — a task may contribute
+    consecutive repeated `(kind, task_names)` headings — a task may contribute
     multiple commands (e.g. `aspect …` + `bazel …`)."""
     prev_heading_key = None
     for r in rows:
-        heading_key = (r["kind"], tuple(r["task_keys"]))
+        heading_key = (r["kind"], tuple(r["task_names"]))
         r["show_heading"] = heading_key != prev_heading_key
         prev_heading_key = heading_key
     return rows
@@ -909,7 +907,7 @@ def _ordered_unique(values):
 def _combine_across(ctx, contributors):
     """Collapse a same-`(id, key)` group into one row, unioning across tasks.
 
-    `contributors` is `[(tip, task_key)]`. JINJA2 `accumulate` fields are
+    `contributors` is `[(tip, task_name)]`. JINJA2 `accumulate` fields are
     unioned (first-seen) and re-rendered against `vars` + merged lists;
     title/body are newest-wins (last contributor); attributed to all."""
     tips_ = [t for t, _ in contributors]
@@ -926,7 +924,7 @@ def _combine_across(ctx, contributors):
             row["title"] = ctx.template.jinja2(row["_title_src"], data = data)
         if row.get("_body_src"):
             row["body"] = ctx.template.jinja2(row["_body_src"], data = data)
-    row["_task_keys"] = _ordered_unique([k for _, k in contributors])
+    row["_task_names"] = _ordered_unique([n for _, n in contributors])
     return row
 
 def _latest(contributors):
@@ -936,11 +934,11 @@ def _latest(contributors):
     distinct = _ordered_unique([(t.get("title", ""), t.get("body", "")) for t, _ in contributors])
     if len(distinct) == 1:
         row = dict(contributors[0][0])
-        row["_task_keys"] = _ordered_unique([k for _, k in contributors])
+        row["_task_names"] = _ordered_unique([n for _, n in contributors])
         return row
-    tip, task_key = contributors[-1]
+    tip, task_name = contributors[-1]
     row = dict(tip)
-    row["_task_keys"] = [task_key] if task_key else []
+    row["_task_names"] = [task_name] if task_name else []
     return row
 
 def _collect_tip_rows(ctx, entries):
@@ -957,11 +955,11 @@ def _collect_tip_rows(ctx, entries):
 
     Caps: important/warning always surface; suggestion+info capped at
     `_MAX_SUBORDINATE_TIPS`. Returns `decorate_tip` rows + sorted
-    `task_keys`."""
+    `task_names`."""
     groups = {}
     insertion_order = []
     for e in entries:
-        task_key = e.get("key", "") or e.get("name", "")
+        task_name = e.get("name", "") or e.get("kind", "")
         for tip in e.get("tips", []) or []:
             if not tip.get("id"):
                 continue
@@ -971,7 +969,7 @@ def _collect_tip_rows(ctx, entries):
             if identity not in groups:
                 groups[identity] = []
                 insertion_order.append(identity)
-            groups[identity].append((tip, task_key))
+            groups[identity].append((tip, task_name))
 
     rows = []
     for identity in insertion_order:
@@ -987,7 +985,7 @@ def _collect_tip_rows(ctx, entries):
     out = []
     for r in selected:
         decorated = decorate_tip(r)
-        decorated["task_keys"] = sorted(r["_task_keys"])
+        decorated["task_names"] = sorted(r["_task_names"])
         out.append(decorated)
     return out
 
@@ -1207,7 +1205,7 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
         if refreshed == None:
             entries.extend(snapshot)
         else:
-            entries.extend(_union_entries_by_name_key(refreshed, snapshot))
+            entries.extend(_union_entries_by_kind_name(refreshed, snapshot))
 
     # Deterministic order so the serialized block is byte-stable across
     # writers; else alternating ownership flips order each cycle and
@@ -1216,8 +1214,8 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
     entries = sorted(entries, key = lambda e: (
         str(e.get("workflow_run_id", "")),
         str(e.get("job", "")),
-        str(e.get("key", "")),
         str(e.get("name", "")),
+        str(e.get("kind", "")),
         str(e.get("run_attempt", "")),
     ))
 
@@ -1310,8 +1308,8 @@ def _github_status_comments(ctx: FeatureContext):
         # Prefer the per-job URL to drop the reviewer on the failing job's logs.
         link_url = _state.get("_ci_link_url") or ci_run_url
         payload = {
+            "kind": _state["_task_kind"],
             "name": _state["_task_name"],
-            "key": _state["_task_key"],
             "job": job_name,
             "run_attempt": run_attempt,
             "status": _state.get("_status", "running"),
@@ -1340,7 +1338,7 @@ def _github_status_comments(ctx: FeatureContext):
         `delete_artifact` quiets benign 404s via `_should_quiet_delete_log`."""
         if "_workdir" not in _state:
             _state["_workdir"] = ctx.std.fs.mkdtemp(prefix = "aspect-ci-status-")
-        _state["_my_artifact_name"] = _ARTIFACT_PREFIX + job_name + "-" + _state["_task_key"] + "-" + run_attempt
+        _state["_my_artifact_name"] = _ARTIFACT_PREFIX + job_name + "-" + _state["_task_name"] + "-" + run_attempt
 
         payload = _own_payload(ctx)
         payload_str = json.encode(payload)
@@ -1442,7 +1440,7 @@ def _github_status_comments(ctx: FeatureContext):
             seen[aname] = entry
 
             if is_own_swarm:
-                # Artifact name (stable per `(job, task_key, run_attempt)`)
+                # Artifact name (stable per `(job, task_name, run_attempt)`)
                 # is the `sibling_id`, so a re-upload overwrites its prior
                 # slice. Absent field (older producers) → ingest no-ops.
                 ingest_sibling_observations(
@@ -1721,8 +1719,8 @@ def _github_status_comments(ctx: FeatureContext):
     def _init(ctx):
         # One-time init on first task_update: cache task identity (FeatureContext
         # has no ctx.task) for the artifact name, then authenticate for `_publish`.
-        _state["_task_name"] = ctx.task.kind
-        _state["_task_key"] = ctx.task.name
+        _state["_task_kind"] = ctx.task.kind
+        _state["_task_name"] = ctx.task.name
 
         # Anchor for the time-based throttle in `_task_update`.
         _state["_task_started_at"] = monotonic()

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -44,6 +44,10 @@ Body-template variables:
     status_badges  \342\200\224 {badge_key -> label}.
     rollup         \342\200\224 {error, warning, running, passed, aborted} counts.
     entries        \342\200\224 per-task entry dicts, alphabetical by (job, name, key).
+                     NOTE: for back-compat the wire fields are inverted vs.
+                     today's vocabulary - `entry.name` holds the task *kind*
+                     (the command) and `entry.key` holds the per-invocation
+                     task *name*. Rows render as `<name> [<kind>]`.
     build_snippets / test_snippets / repro_rows / fix_rows \342\200\224 selected items per section.
     *_overflow_note \342\200\224 "N more not shown" line for each capped section.
 """
@@ -155,7 +159,7 @@ _No tasks have reported yet._
 ## {{ icon }} {{ items|length }} {{ label }} task{{ "s" if items|length != 1 else "" }}
 
 {% for e in items -%}
-- {{ status_badges[e._badge_key] }} {{ e.name }}{% if e.key and e.key != e.name %} ({{ e.key }}){% endif %}{% if e._elapsed_text %} · {{ e._elapsed_text }}{% endif %}{% if e._links_text %} · {{ e._links_text }}{% endif %}{% if e._result_text %}<br>💬 {{ e._result_text }}{% endif %}
+- {{ status_badges[e._badge_key] }} {{ e.key or e.name }}{% if e.key and e.key != e.name %} [{{ e.name }}]{% endif %}{% if e._elapsed_text %} · {{ e._elapsed_text }}{% endif %}{% if e._links_text %} · {{ e._links_text }}{% endif %}{% if e._result_text %}<br>💬 {{ e._result_text }}{% endif %}
 {% endfor -%}
 {% endif -%}
 {% endmacro -%}

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -129,7 +129,7 @@ _TERMINAL_SETTLE_DELAY_MS = 5000
 #   "running" — in flight, no warning
 #   "passed"  — terminal clean
 #   "aborted" — Bazel aborted (timeout, OOM, ctrl-c)
-# Emoji-only, prefixed to the task name (`✅ build (build-gha)`),
+# Emoji-only, prefixed to the task row (`✅ build-gha [build]`),
 # effectively replacing the per-kind icon; the rollup line spells out
 # counts in words for screen readers.
 _DEFAULT_STATUS_BADGES = {

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1717,8 +1717,8 @@ def _github_status_comments(ctx: FeatureContext):
     def _init(ctx):
         # One-time init on first task_update: cache task identity (FeatureContext
         # has no ctx.task) for the artifact name, then authenticate for `_publish`.
-        _state["_task_name"] = ctx.task.name
-        _state["_task_key"] = ctx.task.key
+        _state["_task_name"] = ctx.task.kind
+        _state["_task_key"] = ctx.task.name
 
         # Anchor for the time-based throttle in `_task_update`.
         _state["_task_started_at"] = monotonic()

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1996,9 +1996,9 @@ GithubStatusComments = feature(
             description = "Per-section Jinja2 template overrides. Keys: 'body'. " +
                           "Vars available to 'body': marker, started_at, status_badges, rollup " +
                           "(dict with error/warning/running/passed/aborted counts), entries " +
-                          "(alphabetical by (job, name, key); each decorated with _severity, " +
+                          "(alphabetical by (job, kind, name); each decorated with _severity, " +
                           "_badge_key, _links_text, _elapsed_text, _result_text plus " +
-                          "the raw {name, key, job, run_attempt, status, kind, elapsed_ms, " +
+                          "the raw {kind, name, job, run_attempt, status, elapsed_ms, " +
                           "ci_run_url, aspect_url, check_run_url, current_phase, progress, " +
                           "failed_in_phase, repro_commands, fix_commands, …}), and `repro_rows` / " +
                           "`fix_rows` (deduped across siblings via dedup_and_attribute). " +

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -2351,7 +2351,7 @@ def _delivery_partial(data, total):
     return data
 
 pr_comment_snapshot_tests = task(
-    name = "test-pr-comment-snapshots",
+    kind = "test-pr-comment-snapshots",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -297,8 +297,8 @@ def _delivery_compact(status, data):
     return ""
 
 def _entry(
-        name,
-        key,
+        task_kind,
+        task_name,
         job,
         kind,
         status,
@@ -330,7 +330,7 @@ def _entry(
     # `rehydrate_commands` so the fixture matches what the production
     # read path would deliver to the renderer (records, not raw dicts).
     if not data.get("repro_commands"):
-        repro, _ = compute_reproducer_command(data, name)
+        repro, _ = compute_reproducer_command(data, task_kind)
         if repro:
             data = dict(data)
             data["repro_commands"] = rehydrate_commands([
@@ -358,8 +358,8 @@ def _entry(
             "body": _body_for(kind, status, data),
             "stream": "",
         }
-    payload["name"] = name
-    payload["key"] = key
+    payload["kind"] = task_kind
+    payload["name"] = task_name
     payload["job"] = job
     payload["run_attempt"] = "1"
     payload["status"] = status
@@ -377,20 +377,20 @@ def _check_collect_tip_rows(ctx):
     # Dedup + attribution: same (id, key) with identical content from two
     # tasks merges into one row with both task keys in alphabetical order.
     rows = collect_tip_rows(ctx, [
-        {"key": "lint-task", "tips": [
+        {"name": "lint-task", "tips": [
             {"id": "x", "severity": "suggestion", "title": "T", "body": "B"},
         ]},
-        {"key": "build-task", "tips": [
+        {"name": "build-task", "tips": [
             {"id": "x", "severity": "suggestion", "title": "T", "body": "B"},
         ]},
     ])
     if len(rows) != 1:
         fail("collect_tip_rows dedup: expected 1 row, got %d" % len(rows))
-    if rows[0]["task_keys"] != ["build-task", "lint-task"]:
-        fail("collect_tip_rows attribution: expected [build-task, lint-task], got %r" % rows[0]["task_keys"])
+    if rows[0]["task_names"] != ["build-task", "lint-task"]:
+        fail("collect_tip_rows attribution: expected [build-task, lint-task], got %r" % rows[0]["task_names"])
 
     # Severity sort: important first, then warning, then suggestion, then info.
-    rows = collect_tip_rows(ctx, [{"key": "t1", "tips": [
+    rows = collect_tip_rows(ctx, [{"name": "t1", "tips": [
         {"id": "i", "severity": "info", "title": "I", "body": ""},
         {"id": "c", "severity": "important", "title": "C", "body": ""},
         {"id": "s", "severity": "suggestion", "title": "S", "body": ""},
@@ -407,7 +407,7 @@ def _check_collect_tip_rows(ctx):
         [{"id": "s%d" % i, "severity": "suggestion", "title": "S", "body": ""} for i in range(4)] +
         [{"id": "i%d" % i, "severity": "info", "title": "I", "body": ""} for i in range(4)]
     )
-    rows = collect_tip_rows(ctx, [{"key": "t1", "tips": big}])
+    rows = collect_tip_rows(ctx, [{"name": "t1", "tips": big}])
     important_count = len([r for r in rows if r["severity_label"] == "Important"])
     warning_count = len([r for r in rows if r["severity_label"] == "Warning"])
     subordinate_count = len([r for r in rows if r["severity_label"] in ("Tip", "Info")])
@@ -420,7 +420,7 @@ def _check_collect_tip_rows(ctx):
 
     # silence_hint: non-empty whenever the tip has an id. The rendered
     # tip carries this `<sub>...</sub>` line as its silence-hint footer.
-    rows = collect_tip_rows(ctx, [{"key": "t1", "tips": [
+    rows = collect_tip_rows(ctx, [{"name": "t1", "tips": [
         {"id": "c", "severity": "important", "title": "C", "body": ""},
         {"id": "s", "severity": "suggestion", "title": "S", "body": ""},
     ]}])
@@ -437,7 +437,7 @@ def _check_collect_tip_rows(ctx):
     title_tmpl = "Grant {% if scopes|length == 1 %}`{{ scopes[0] }}`{% else %}{{ scopes|length }} scopes{% endif %}"
     body_tmpl = "{{ endpoints|length }} calls fell back:\n{% for e in endpoints %}- {{ e }}\n{% endfor %}"
     rows = collect_tip_rows(ctx, [
-        {"key": "build-task", "tips": [{
+        {"name": "build-task", "tips": [{
             "id": "sample-scope-tip",
             "severity": "warning",
             "title": "Grant `actions: read`",
@@ -448,7 +448,7 @@ def _check_collect_tip_rows(ctx):
             "_body_src": body_tmpl,
             "accumulate": {"scopes": ["actions: read"], "endpoints": ["/a/jobs"]},
         }]},
-        {"key": "test-task", "tips": [{
+        {"name": "test-task", "tips": [{
             "id": "sample-scope-tip",
             "severity": "warning",
             "title": "Grant `pull-requests: read`",
@@ -468,15 +468,15 @@ def _check_collect_tip_rows(ctx):
         fail("combine: body missing an endpoint: %r" % rows[0]["body_quoted"])
     if "3 calls" not in rows[0]["body_quoted"]:
         fail("combine: body not re-rendered with merged count: %r" % rows[0]["body_quoted"])
-    if rows[0]["task_keys"] != ["build-task", "test-task"]:
-        fail("combine: task_keys merge wrong: %r" % rows[0]["task_keys"])
+    if rows[0]["task_names"] != ["build-task", "test-task"]:
+        fail("combine: task_names merge wrong: %r" % rows[0]["task_names"])
 
     # ── Surface gate + (id, key) grouping + combine vs latest ─────────
 
     # Surface gate: a tip whose `surfaces` omits the PR summary is
     # dropped from the rollup even though it reached the aggregator.
     rows = collect_tip_rows(ctx, [
-        {"key": "build-task", "tips": [{
+        {"name": "build-task", "tips": [{
             "id": "task-only-tip",
             "severity": "info",
             "title": "Only on task screens",
@@ -490,7 +490,7 @@ def _check_collect_tip_rows(ctx):
 
     # An empty `surfaces` list means all surfaces — eligible for the rollup.
     rows = collect_tip_rows(ctx, [
-        {"key": "build-task", "tips": [{"id": "everywhere-tip", "severity": "info", "title": "Everywhere", "body": "b", "type": "raw", "surfaces": []}]},
+        {"name": "build-task", "tips": [{"id": "everywhere-tip", "severity": "info", "title": "Everywhere", "body": "b", "type": "raw", "surfaces": []}]},
     ])
     if len(rows) != 1:
         fail("surface gate: empty surfaces must be eligible, got %d rows" % len(rows))
@@ -498,44 +498,44 @@ def _check_collect_tip_rows(ctx):
     # combine=False (default), identical content across tasks → one row
     # attributed to both.
     rows = collect_tip_rows(ctx, [
-        {"key": "build-task", "tips": [{"id": "static", "severity": "info", "title": "Same", "body": "Same body", "type": "raw"}]},
-        {"key": "test-task", "tips": [{"id": "static", "severity": "info", "title": "Same", "body": "Same body", "type": "raw"}]},
+        {"name": "build-task", "tips": [{"id": "static", "severity": "info", "title": "Same", "body": "Same body", "type": "raw"}]},
+        {"name": "test-task", "tips": [{"id": "static", "severity": "info", "title": "Same", "body": "Same body", "type": "raw"}]},
     ])
     if len(rows) != 1:
         fail("latest-identical: expected 1 row, got %d" % len(rows))
-    if rows[0]["task_keys"] != ["build-task", "test-task"]:
-        fail("latest-identical: expected both task keys, got %r" % rows[0]["task_keys"])
+    if rows[0]["task_names"] != ["build-task", "test-task"]:
+        fail("latest-identical: expected both task keys, got %r" % rows[0]["task_names"])
 
     # combine=False, divergent content across tasks → latest task's
     # content wins, attributed to that task.
     rows = collect_tip_rows(ctx, [
-        {"key": "build-task", "tips": [{"id": "dyn", "severity": "info", "title": "Built //a", "body": "b1", "type": "raw"}]},
-        {"key": "test-task", "tips": [{"id": "dyn", "severity": "info", "title": "Built //b", "body": "b2", "type": "raw"}]},
+        {"name": "build-task", "tips": [{"id": "dyn", "severity": "info", "title": "Built //a", "body": "b1", "type": "raw"}]},
+        {"name": "test-task", "tips": [{"id": "dyn", "severity": "info", "title": "Built //b", "body": "b2", "type": "raw"}]},
     ])
     if len(rows) != 1:
         fail("latest-divergent: expected 1 row, got %d" % len(rows))
-    if rows[0]["title"] != "Built //b" or rows[0]["task_keys"] != ["test-task"]:
-        fail("latest-divergent: expected latest task to win, got title=%r keys=%r" % (rows[0]["title"], rows[0]["task_keys"]))
+    if rows[0]["title"] != "Built //b" or rows[0]["task_names"] != ["test-task"]:
+        fail("latest-divergent: expected latest task to win, got title=%r keys=%r" % (rows[0]["title"], rows[0]["task_names"]))
 
     # Distinct `key` under the same `id` → separate rows, each attributed
     # to its own task. (The "same tip, different subjects" use case.)
     rows = collect_tip_rows(ctx, [
-        {"key": "build-task", "tips": [{"id": "flaky", "key": "//a", "severity": "warning", "title": "Flaky //a", "body": "b", "type": "raw"}]},
-        {"key": "test-task", "tips": [{"id": "flaky", "key": "//b", "severity": "warning", "title": "Flaky //b", "body": "b", "type": "raw"}]},
+        {"name": "build-task", "tips": [{"id": "flaky", "key": "//a", "severity": "warning", "title": "Flaky //a", "body": "b", "type": "raw"}]},
+        {"name": "test-task", "tips": [{"id": "flaky", "key": "//b", "severity": "warning", "title": "Flaky //b", "body": "b", "type": "raw"}]},
     ])
     if len(rows) != 2:
         fail("distinct-key: expected 2 rows, got %d" % len(rows))
     by_title = {r["title"]: r for r in rows}
-    if by_title["Flaky //a"]["task_keys"] != ["build-task"]:
-        fail("distinct-key: //a mis-attributed: %r" % by_title["Flaky //a"]["task_keys"])
-    if by_title["Flaky //b"]["task_keys"] != ["test-task"]:
-        fail("distinct-key: //b mis-attributed: %r" % by_title["Flaky //b"]["task_keys"])
+    if by_title["Flaky //a"]["task_names"] != ["build-task"]:
+        fail("distinct-key: //a mis-attributed: %r" % by_title["Flaky //a"]["task_names"])
+    if by_title["Flaky //b"]["task_names"] != ["test-task"]:
+        fail("distinct-key: //b mis-attributed: %r" % by_title["Flaky //b"]["task_names"])
 
     # combine=False: same id, same key, different content from two tasks
     # collapses to ONE row (latest), not two — distinctness needs a key.
     rows = collect_tip_rows(ctx, [
-        {"key": "build-task", "tips": [{"id": "nokey", "severity": "info", "title": "Built //a", "body": "b1", "type": "raw"}]},
-        {"key": "test-task", "tips": [{"id": "nokey", "severity": "info", "title": "Built //b", "body": "b2", "type": "raw"}]},
+        {"name": "build-task", "tips": [{"id": "nokey", "severity": "info", "title": "Built //a", "body": "b1", "type": "raw"}]},
+        {"name": "test-task", "tips": [{"id": "nokey", "severity": "info", "title": "Built //b", "body": "b2", "type": "raw"}]},
     ])
     if len(rows) != 1:
         fail("no-key-collapse: same (id, '') must be one row, got %d" % len(rows))
@@ -543,10 +543,10 @@ def _check_collect_tip_rows(ctx):
     # combine=True if ANY contributor opts in: the group merges into one
     # row even when another contributor left it False.
     rows = collect_tip_rows(ctx, [
-        {"key": "build-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "_title_src": "T", "_body_src": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["a"]}}]},
-        {"key": "test-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "combine_across_tasks": True, "_title_src": "T", "_body_src": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["b"]}}]},
+        {"name": "build-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "_title_src": "T", "_body_src": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["a"]}}]},
+        {"name": "test-task", "tips": [{"id": "scope", "severity": "info", "title": "T", "body": "b", "type": "jinja2", "combine_across_tasks": True, "_title_src": "T", "_body_src": "{% for s in scopes %}{{ s }} {% endfor %}", "accumulate": {"scopes": ["b"]}}]},
     ])
-    if len(rows) != 1 or rows[0]["task_keys"] != ["build-task", "test-task"]:
+    if len(rows) != 1 or rows[0]["task_names"] != ["build-task", "test-task"]:
         fail("combine-any: a single combine_across_tasks contributor must merge the group, got %r" % rows)
     if "a" not in rows[0]["body_quoted"] or "b" not in rows[0]["body_quoted"]:
         fail("combine-any: scopes not unioned across tasks: %r" % rows[0]["body_quoted"])
@@ -560,8 +560,8 @@ def _check_dedup_by_run_attempt():
     # 2 is the terminal "passed". One entry per (name, key, job)
     # survives, with the higher run_attempt's payload.
     out = dedup_by_run_attempt([
-        {"name": "format", "key": "format-gha", "job": "format-task", "run_attempt": "1", "status": "running"},
-        {"name": "format", "key": "format-gha", "job": "format-task", "run_attempt": "2", "status": "passed"},
+        {"kind": "format", "name": "format-gha", "job": "format-task", "run_attempt": "1", "status": "running"},
+        {"kind": "format", "name": "format-gha", "job": "format-task", "run_attempt": "2", "status": "passed"},
     ])
     if len(out) != 1:
         fail("dedup_by_run_attempt rerun: expected 1 entry, got %d: %r" % (len(out), out))
@@ -571,24 +571,24 @@ def _check_dedup_by_run_attempt():
     # Different `job` → NOT collapsed (matrix-style: same task surfaced
     # by two distinct yaml jobs is two legitimate rows).
     out = dedup_by_run_attempt([
-        {"name": "test", "key": "test-gha", "job": "cpu-test", "run_attempt": "1", "status": "passed"},
-        {"name": "test", "key": "test-gha", "job": "gpu-test", "run_attempt": "1", "status": "passed"},
+        {"kind": "test", "name": "test-gha", "job": "cpu-test", "run_attempt": "1", "status": "passed"},
+        {"kind": "test", "name": "test-gha", "job": "gpu-test", "run_attempt": "1", "status": "passed"},
     ])
     if len(out) != 2:
         fail("dedup_by_run_attempt matrix: expected 2 distinct rows, got %d: %r" % (len(out), out))
 
     # Numeric ordering, not lexicographic: "10" > "9".
     out = dedup_by_run_attempt([
-        {"name": "x", "key": "x", "job": "j", "run_attempt": "9", "status": "running"},
-        {"name": "x", "key": "x", "job": "j", "run_attempt": "10", "status": "passed"},
+        {"kind": "x", "name": "x", "job": "j", "run_attempt": "9", "status": "running"},
+        {"kind": "x", "name": "x", "job": "j", "run_attempt": "10", "status": "passed"},
     ])
     if out[0]["run_attempt"] != "10":
         fail("dedup_by_run_attempt numeric: expected '10' to win over '9', got %r" % out[0])
 
     # Missing / non-numeric run_attempt defaults to 1.
     out = dedup_by_run_attempt([
-        {"name": "y", "key": "y", "job": "j", "status": "running"},
-        {"name": "y", "key": "y", "job": "j", "run_attempt": "2", "status": "passed"},
+        {"kind": "y", "name": "y", "job": "j", "status": "running"},
+        {"kind": "y", "name": "y", "job": "j", "run_attempt": "2", "status": "passed"},
     ])
     if out[0].get("run_attempt") != "2":
         fail("dedup_by_run_attempt missing-attempt: expected attempt-2 to win, got %r" % out[0])
@@ -714,8 +714,8 @@ def _check_state_serialize_round_trip():
             {"run_id": "200", "workflow_name": "ci-workflows"},
         ],
         "entries": [
-            {"name": "build", "key": "build", "workflow_run_id": "100"},
-            {"name": "lint", "key": "lint", "workflow_run_id": "200"},
+            {"kind": "build", "name": "build", "workflow_run_id": "100"},
+            {"kind": "lint", "name": "lint", "workflow_run_id": "200"},
         ],
         "shown_snippets": [snippet_key("//pkg:a", "boom a"), snippet_key("//pkg:b", "boom b")],
         "shown_repros": ["test\x00aspect test //pkg:a\x00"],
@@ -749,8 +749,8 @@ def _snip(label, bucket = "test", text = "boom", truncated = False, kind = "", t
         "repros": repros or [],
     }
 
-def _entry_with_snippets(key, snippets):
-    return {"name": key, "key": key, "failure_snippets": snippets}
+def _entry_with_snippets(name, snippets):
+    return {"kind": name, "name": name, "failure_snippets": snippets}
 
 def _check_select_snippets(ctx):
     """_select_snippets: dedup-by-(label,content) across tasks, sticky,
@@ -776,7 +776,7 @@ def _check_select_snippets(ctx):
     _eq("select: identical failure deduped to one row", len(rows_dup), 1)
     _eq(
         "select: deduped row attributes all contributing tasks",
-        rows_dup[0]["task_keys"],
+        rows_dup[0]["task_names"],
         ["build-gha", "build-gha-debug", "test-gha"],
     )
     _eq("select: deduped → no overflow", overflow_dup["total"], 0)
@@ -993,8 +993,8 @@ def _check_by_task_overflow():
     of tasks holding hidden items (no per-task counts — they'd double-count a
     deduped item shared by N tasks). Shared by snippets and repro/fix commands."""
     dropped = [
-        {"command": "x", "task_keys": ["task-a", "task-b"]},
-        {"command": "y", "task_keys": ["task-b"]},
+        {"command": "x", "task_names": ["task-a", "task-b"]},
+        {"command": "y", "task_names": ["task-b"]},
     ]
     of = by_task_overflow(dropped)
     _eq("by_task_overflow: total counts distinct dropped items", of["total"], 2)
@@ -1039,7 +1039,7 @@ def _check_parse_state_missing_terminator():
 def _check_merge_state_first_writer():
     """First writer (existing_state=None) → state lists only our slot
     and our entries."""
-    my_entries = [{"name": "build", "key": "build", "workflow_run_id": "100"}]
+    my_entries = [{"kind": "build", "name": "build", "workflow_run_id": "100"}]
     new = merge_state(None, "abc", "100", "ci-gha", my_entries, {})
     _eq("merge — first writer head_sha", new["head_sha"], "abc")
     _eq("merge — first writer workflow_runs", new["workflow_runs"], [{"run_id": "100", "workflow_name": "ci-gha"}])
@@ -1055,13 +1055,13 @@ def _check_merge_state_two_workflows_with_fresh_refresh():
         "last_upsert_epoch_s": 1699999000,
         "workflow_runs": [{"run_id": "200", "workflow_name": "ci-workflows"}],
         "entries": [
-            {"name": "lint", "key": "lint", "workflow_run_id": "200", "status": "running"},
+            {"kind": "lint", "name": "lint", "workflow_run_id": "200", "status": "running"},
         ],
     }
     fresh_b_entries = [
-        {"name": "lint", "key": "lint", "workflow_run_id": "200", "status": "passed"},
+        {"kind": "lint", "name": "lint", "workflow_run_id": "200", "status": "passed"},
     ]
-    a_entries = [{"name": "build", "key": "build", "workflow_run_id": "100"}]
+    a_entries = [{"kind": "build", "name": "build", "workflow_run_id": "100"}]
     new = merge_state(existing, "abc", "100", "ci-gha", a_entries, {"200": fresh_b_entries})
     _eq("merge — two slots count", len(new["workflow_runs"]), 2)
     _eq(
@@ -1081,10 +1081,10 @@ def _check_merge_state_falls_back_to_snapshot_when_refresh_missing():
         "head_sha": "abc",
         "workflow_runs": [{"run_id": "200", "workflow_name": "ci-workflows"}],
         "entries": [
-            {"name": "lint", "key": "lint", "workflow_run_id": "200", "status": "passed"},
+            {"kind": "lint", "name": "lint", "workflow_run_id": "200", "status": "passed"},
         ],
     }
-    a_entries = [{"name": "build", "key": "build", "workflow_run_id": "100"}]
+    a_entries = [{"kind": "build", "name": "build", "workflow_run_id": "100"}]
     new = merge_state(existing, "abc", "100", "ci-gha", a_entries, {})
     _eq("merge — fallback entries count", len(new["entries"]), 2)
     by_name = {e["name"]: e for e in new["entries"]}
@@ -1103,16 +1103,16 @@ def _check_merge_state_per_task_union_with_snapshot():
         "head_sha": "abc",
         "workflow_runs": [{"run_id": "200", "workflow_name": "ci-b"}],
         "entries": [
-            {"name": "lint", "key": "lint", "workflow_run_id": "200", "status": "running"},
-            {"name": "test", "key": "test", "workflow_run_id": "200", "status": "running"},
-            {"name": "build", "key": "build", "workflow_run_id": "200", "status": "running"},
+            {"kind": "lint", "name": "lint", "workflow_run_id": "200", "status": "running"},
+            {"kind": "test", "name": "test", "workflow_run_id": "200", "status": "running"},
+            {"kind": "build", "name": "build", "workflow_run_id": "200", "status": "running"},
         ],
     }
 
     # Refresh returned only `lint` (with updated status). `test` and
     # `build` were briefly invisible in the listing.
     partial_refresh = [
-        {"name": "lint", "key": "lint", "workflow_run_id": "200", "status": "passed"},
+        {"kind": "lint", "name": "lint", "workflow_run_id": "200", "status": "passed"},
     ]
     new = merge_state(existing, "abc", "100", "ci-a", [], {"200": partial_refresh})
     by_name = {e["name"]: e for e in new["entries"]}
@@ -1129,7 +1129,7 @@ def _check_merge_state_empty_refresh_keeps_snapshot():
         "head_sha": "abc",
         "workflow_runs": [{"run_id": "200", "workflow_name": "ci-b"}],
         "entries": [
-            {"name": "lint", "key": "lint", "workflow_run_id": "200", "status": "passed"},
+            {"kind": "lint", "name": "lint", "workflow_run_id": "200", "status": "passed"},
         ],
     }
     new = merge_state(existing, "abc", "100", "ci-a", [], {"200": []})
@@ -1147,7 +1147,7 @@ def _check_merge_state_replaces_own_slot():
         ],
         "entries": [],
     }
-    my_entries = [{"name": "build", "key": "build", "workflow_run_id": "100"}]
+    my_entries = [{"kind": "build", "name": "build", "workflow_run_id": "100"}]
     new = merge_state(existing, "abc", "100", "ci-gha", my_entries, {})
     runs_by_rid = {r["run_id"]: r for r in new["workflow_runs"]}
     _eq("merge — own slot has current workflow_name", runs_by_rid["100"]["workflow_name"], "ci-gha")
@@ -1165,11 +1165,11 @@ def _check_merge_state_drops_orphan_snapshot_entries():
             {"run_id": "200", "workflow_name": "ci-b"},
         ],
         "entries": [
-            {"name": "ghost", "key": "ghost", "workflow_run_id": "999"},
-            {"name": "lint", "key": "lint", "workflow_run_id": "200"},
+            {"kind": "ghost", "name": "ghost", "workflow_run_id": "999"},
+            {"kind": "lint", "name": "lint", "workflow_run_id": "200"},
         ],
     }
-    my_entries = [{"name": "build", "key": "build", "workflow_run_id": "100"}]
+    my_entries = [{"kind": "build", "name": "build", "workflow_run_id": "100"}]
     new = merge_state(existing, "abc", "100", "ci-a", my_entries, {})
     names = sorted([e["name"] for e in new["entries"]])
     _eq("merge — orphan snapshot entry dropped", names, ["build", "lint"])
@@ -1201,13 +1201,13 @@ def _check_merge_state_entries_sorted():
     block is byte-stable across writers — even when each writer
     discovers its swarm in a different artifact-id order."""
     my_entries = [
-        {"name": "z", "key": "z", "job": "j", "workflow_run_id": "100", "run_attempt": "1"},
-        {"name": "a", "key": "a", "job": "j", "workflow_run_id": "100", "run_attempt": "1"},
+        {"kind": "z", "name": "z", "job": "j", "workflow_run_id": "100", "run_attempt": "1"},
+        {"kind": "a", "name": "a", "job": "j", "workflow_run_id": "100", "run_attempt": "1"},
     ]
     refreshed = {
         "200": [
-            {"name": "y", "key": "y", "job": "k", "workflow_run_id": "200", "run_attempt": "1"},
-            {"name": "b", "key": "b", "job": "k", "workflow_run_id": "200", "run_attempt": "1"},
+            {"kind": "y", "name": "y", "job": "k", "workflow_run_id": "200", "run_attempt": "1"},
+            {"kind": "b", "name": "b", "job": "k", "workflow_run_id": "200", "run_attempt": "1"},
         ],
     }
     existing = {
@@ -1216,8 +1216,8 @@ def _check_merge_state_entries_sorted():
         "entries": [],
     }
     new = merge_state(existing, "abc", "100", "ci-a", my_entries, refreshed)
-    keys = [e["key"] for e in new["entries"]]
-    _eq("merge — entries sorted by (run_id, job, key, ...)", keys, ["a", "z", "b", "y"])
+    names = [e["name"] for e in new["entries"]]
+    _eq("merge — entries sorted by (run_id, job, name, ...)", names, ["a", "z", "b", "y"])
 
 def _check_parse_state_validates_field_types():
     """Wrong-shape payload (valid base64 JSON but unexpected field types)
@@ -1249,7 +1249,7 @@ def _check_parse_state_filters_non_dict_rows():
             42,
         ],
         "entries": [
-            {"name": "build", "key": "build"},
+            {"kind": "build", "name": "build"},
             None,
             ["this list element should be dropped"],
         ],
@@ -1263,7 +1263,7 @@ def _check_parse_state_filters_non_dict_rows():
     _eq(
         "parse_state — entries filtered to dicts",
         parsed["entries"],
-        [{"name": "build", "key": "build"}],
+        [{"kind": "build", "name": "build"}],
     )
 
 def _check_merge_state_drops_stale_push():
@@ -1272,9 +1272,9 @@ def _check_merge_state_drops_stale_push():
     existing = {
         "head_sha": "old",
         "workflow_runs": [{"run_id": "200", "workflow_name": "ci-workflows"}],
-        "entries": [{"name": "lint", "key": "lint", "workflow_run_id": "200"}],
+        "entries": [{"kind": "lint", "name": "lint", "workflow_run_id": "200"}],
     }
-    my_entries = [{"name": "build", "key": "build", "workflow_run_id": "100"}]
+    my_entries = [{"kind": "build", "name": "build", "workflow_run_id": "100"}]
     new = merge_state(existing, "new", "100", "ci-gha", my_entries, {})
     _eq("merge — stale-push drops slots", new["workflow_runs"], [{"run_id": "100", "workflow_name": "ci-gha"}])
     _eq("merge — stale-push drops entries", new["entries"], my_entries)
@@ -1294,13 +1294,13 @@ def _check_merge_state_evicts_superseded_workflow_run():
             {"run_id": "500", "workflow_name": "ci-workflows"},
         ],
         "entries": [
-            {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "status": "passed"},
-            {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "500", "status": "passed"},
+            {"kind": "test", "name": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "status": "passed"},
+            {"kind": "lint", "name": "lint", "job": "lint", "workflow_run_id": "500", "status": "passed"},
         ],
     }
 
     # We are a newer run (run_id 999) of "ci-gha".
-    my_entries = [{"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "999", "status": "running"}]
+    my_entries = [{"kind": "test", "name": "cpu", "job": "test (cpu)", "workflow_run_id": "999", "status": "running"}]
     new = merge_state(existing, "abc", "999", "ci-gha", my_entries, {})
 
     rids = sorted([r["run_id"] for r in new["workflow_runs"]])
@@ -1308,7 +1308,7 @@ def _check_merge_state_evicts_superseded_workflow_run():
 
     # The stale run_id=100 snapshot entry must not survive — only our
     # live row + the distinct sibling workflow's row.
-    keyed = {(e["name"], e["key"], e.get("workflow_run_id", "")): e for e in new["entries"]}
+    keyed = {(e["kind"], e["name"], e.get("workflow_run_id", "")): e for e in new["entries"]}
     if ("test", "cpu", "100") in keyed:
         fail("merge — stale superseded entry should be dropped, got %r" % new["entries"])
     _eq("merge — our live row survives", keyed[("test", "cpu", "999")]["status"], "running")
@@ -1325,8 +1325,8 @@ def _check_merge_state_evicts_superseded_sibling_run():
             {"run_id": "700", "workflow_name": "ci-workflows"},
         ],
         "entries": [
-            {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "300", "status": "running"},
-            {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "700", "status": "passed"},
+            {"kind": "lint", "name": "lint", "job": "lint", "workflow_run_id": "300", "status": "running"},
+            {"kind": "lint", "name": "lint", "job": "lint", "workflow_run_id": "700", "status": "passed"},
         ],
     }
     new = merge_state(existing, "abc", "999", "ci-gha", [], {})
@@ -1347,12 +1347,12 @@ def _check_merge_state_losing_rerun_does_not_resurrect():
             {"run_id": "999", "workflow_name": "ci-gha"},
         ],
         "entries": [
-            {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "999", "status": "running"},
+            {"kind": "test", "name": "cpu", "job": "test (cpu)", "workflow_run_id": "999", "status": "running"},
         ],
     }
 
     # We are the older run 100; our entries are stale.
-    my_entries = [{"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "status": "passed"}]
+    my_entries = [{"kind": "test", "name": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "status": "passed"}]
     new = merge_state(existing, "abc", "100", "ci-gha", my_entries, {})
 
     rids = [r["run_id"] for r in new["workflow_runs"]]
@@ -1382,8 +1382,8 @@ def _check_dedup_for_display_collapses_exact_duplicates():
     guarding against a snapshot that briefly carries two rows for one
     task within a single run_id."""
     out = dedup_for_display([
-        {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "run_attempt": "1", "status": "running"},
-        {"name": "test", "key": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "run_attempt": "2", "status": "passed"},
+        {"kind": "test", "name": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "run_attempt": "1", "status": "running"},
+        {"kind": "test", "name": "cpu", "job": "test (cpu)", "workflow_run_id": "100", "run_attempt": "2", "status": "passed"},
     ])
     if len(out) != 1:
         fail("dedup_for_display: expected 1 row, got %d: %r" % (len(out), out))
@@ -1394,8 +1394,8 @@ def _check_dedup_for_display_keeps_distinct_jobs():
     jobs / distinct workflows with different job names) and must not
     collapse."""
     out = dedup_for_display([
-        {"name": "test", "key": "t", "job": "test (cpu)", "workflow_run_id": "100"},
-        {"name": "test", "key": "t", "job": "test (gpu)", "workflow_run_id": "100"},
+        {"kind": "test", "name": "t", "job": "test (cpu)", "workflow_run_id": "100"},
+        {"kind": "test", "name": "t", "job": "test (gpu)", "workflow_run_id": "100"},
     ])
     _eq("dedup_for_display — distinct jobs kept", len(out), 2)
 
@@ -1405,8 +1405,8 @@ def _check_dedup_for_display_keeps_distinct_workflows():
     render — `workflow_run_id` is part of the display identity, so they
     are not collapsed into one row."""
     out = dedup_for_display([
-        {"name": "test", "key": "test", "job": "test", "workflow_run_id": "100", "status": "passed"},
-        {"name": "test", "key": "test", "job": "test", "workflow_run_id": "200", "status": "running"},
+        {"kind": "test", "name": "test", "job": "test", "workflow_run_id": "100", "status": "passed"},
+        {"kind": "test", "name": "test", "job": "test", "workflow_run_id": "200", "status": "running"},
     ])
     _eq("dedup_for_display — distinct workflows both kept", len(out), 2)
 
@@ -1421,15 +1421,15 @@ def _check_rerun_renders_each_task_once(ctx):
         "head_sha": "abc",
         "workflow_runs": [{"run_id": "100", "workflow_name": "ci-gha"}],
         "entries": [
-            {"name": "test", "key": "cpu-test", "job": "test (cpu-test)", "workflow_run_id": "100", "status": "passed"},
-            {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "100", "status": "passed"},
+            {"kind": "test", "name": "cpu-test", "job": "test (cpu-test)", "workflow_run_id": "100", "status": "passed"},
+            {"kind": "lint", "name": "lint", "job": "lint", "workflow_run_id": "100", "status": "passed"},
         ],
     }
 
     # We are a newer run (999) of the same workflow with the same tasks.
     my_entries = [
-        {"name": "test", "key": "cpu-test", "job": "test (cpu-test)", "workflow_run_id": "999", "status": "passed"},
-        {"name": "lint", "key": "lint", "job": "lint", "workflow_run_id": "999", "status": "passed"},
+        {"kind": "test", "name": "cpu-test", "job": "test (cpu-test)", "workflow_run_id": "999", "status": "passed"},
+        {"kind": "lint", "name": "lint", "job": "lint", "workflow_run_id": "999", "status": "passed"},
     ]
     new = merge_state(existing, "abc", "999", "ci-gha", my_entries, {})
 
@@ -1458,8 +1458,8 @@ def _check_render_body_emits_state_block(ctx):
         "workflow_runs": [{"run_id": "100", "workflow_name": "ci-gha"}],
         "entries": [
             {
+                "kind": "build",
                 "name": "build",
-                "key": "build",
                 "job": "ci",
                 "status": "running",
                 "workflow_run_id": "100",
@@ -1492,10 +1492,9 @@ def _check_render_body_no_state_block_when_state_none(ctx):
     that don't need cross-workflow merge) suppresses the state block."""
     entries = [
         {
-            "name": "build",
-            "key": "build",
-            "job": "ci",
             "kind": "build",
+            "name": "build",
+            "job": "ci",
             "status": "running",
             "elapsed_ms": 1000,
         },
@@ -1530,10 +1529,9 @@ def _check_repro_dedup_consecutive_headings(ctx):
     # boundary; do the same here so we exercise the production code path.
     entries = [
         {
-            "name": "buildifier",
-            "key": "buildifier-task",
+            "kind": "buildifier",
+            "name": "buildifier-task",
             "job": "ci",
-            "kind": "format",
             "status": "failed",
             "elapsed_ms": 1000,
             "repro_commands": rehydrate_commands([

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -1512,6 +1512,28 @@ def _check_render_body_no_state_block_when_state_none(ctx):
     )
     _eq("render_body — no state block when state is None", parse_state(body), None)
 
+def _check_row_renders_name_and_kind(ctx):
+    """Per-task rows lead with the invocation name; the kind is bracketed
+    only when it differs from the name (`<name> [<kind>]`). When name == kind
+    (the common single-invocation case) the bracket is omitted."""
+    entries = [
+        {"kind": "delivery", "name": "delivery-gha-debug", "job": "deliver", "status": "passed", "elapsed_ms": 1000},
+        {"kind": "lint", "name": "lint", "job": "lint", "status": "passed", "elapsed_ms": 1000},
+    ]
+    prepared = prepare_for_render(entries)
+    body = render_body(
+        ctx,
+        MARKER_FMT % 42,
+        prepared,
+        "2026-01-01 00:00:00 UTC",
+        DEFAULT_BODY_TEMPLATE,
+        DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared),
+    )
+    _eq("row — name != kind renders '<name> [<kind>]'", "delivery-gha-debug [delivery]" in body, True)
+    _eq("row — name == kind omits the bracket", "lint [lint]" in body, False)
+    _eq("row — name == kind still renders the name", "✅ lint ·" in body, True)
+
 def _check_repro_dedup_consecutive_headings(ctx):
     """Two fix commands from the same task collapse to one heading.
 
@@ -1607,6 +1629,7 @@ def _test_impl(ctx):
     _check_merge_state_entries_sorted()
     _check_render_body_emits_state_block(ctx)
     _check_render_body_no_state_block_when_state_none(ctx)
+    _check_row_renders_name_and_kind(ctx)
     _check_select_snippets(ctx)
     _check_select_sticky()
     _check_by_task_overflow()

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments_test.axl
@@ -1445,7 +1445,7 @@ def _check_rerun_renders_each_task_once(ctx):
         sections,
         state = new,
     )
-    _eq("rerun render — 'test (cpu-test)' appears once", body.count("test (cpu-test)"), 1)
+    _eq("rerun render — 'cpu-test [test]' appears once", body.count("cpu-test [test]"), 1)
     _eq("rerun render — 'lint' row appears once", body.count("✅ lint"), 1)
     _eq("rerun render — two task rows total", body.count("<br>💬"), 2)
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -274,12 +274,12 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         # `ctx` is a TaskContext here, so `ctx.task` is in scope.
         subject = _state.get("_subject", "")
         subject_str = (" " + subject) if subject else ""
-        _LOG.trace("aspect/%s (%s)%s" % (ctx.task.name, ctx.task.key, subject_str))
-        _state["_task_name"] = ctx.task.name
+        _LOG.trace("aspect/%s%s" % (ctx.task.name, subject_str))
+        _state["_task_name"] = ctx.task.kind
 
-        # Per-task name shown in the MR's status badge column. Matches
-        # the CLI invocation shape so the row reads as a command.
-        _state["_status_name"] = "aspect / %s (%s)" % (ctx.task.name, ctx.task.key)
+        # Per-invocation name shown in the MR's status badge column; unique
+        # when the same kind runs more than once in a pipeline.
+        _state["_status_name"] = "aspect / %s" % ctx.task.name
         _state["_status"] = "running"
         _state["_started_ms"] = now_ms(ctx)
         _state["_triggered_by"] = _detect_triggered_by(ctx.std.env)
@@ -291,7 +291,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         # Initial "pending" — the task hasn't started producing data
         # yet, so we surface a placeholder rather than waiting for the
         # first BES tick. Reviewers see the row appear immediately.
-        initial_kind = kind_for_task(ctx.task.name)
+        initial_kind = kind_for_task(ctx.task.kind)
         initial_renderer = renderer_for_kind(initial_kind) or renderer_for_kind("bazel_results")
         initial_links = dict(_ci_links_base)
         apply_artifact_links(ctx, initial_links)

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -275,7 +275,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         subject = _state.get("_subject", "")
         subject_str = (" " + subject) if subject else ""
         _LOG.trace("aspect/%s%s" % (ctx.task.name, subject_str))
-        _state["_task_name"] = ctx.task.kind
+        _state["_task_kind"] = ctx.task.kind
 
         # Per-invocation name shown in the MR's status badge column; unique
         # when the same kind runs more than once in a pipeline.

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
@@ -554,20 +554,20 @@ def _gitlab_lint_impl(ctx: FeatureContext):
         gl["changed_lines"] = {f["file"]: f.get("hunk_lines") or f["lines"] for f in lint_trait.changed_files}
 
     def _lint_report(ctx, filepath):
-        comments = _build_comments(ctx, filepath, run_id, ctx.task.key, destination = destination)
+        comments = _build_comments(ctx, filepath, run_id, ctx.task.name, destination = destination)
         state["all_comments"].extend(comments)
         if "existing_markers" not in gl:
-            gl["existing_markers"] = _get_existing_markers(ctx, gl, ctx.task.key)
+            gl["existing_markers"] = _get_existing_markers(ctx, gl, ctx.task.name)
         errors_in_batch = [c for c in comments if c.get("_severity") == "error"]
         if not errors_in_batch:
             return
         remaining = max_pr_comments - state["posted"]
         if remaining <= 0:
             return
-        new_only = [c for c in errors_in_batch if not (extract_marker(c.get("body", ""), task_key = ctx.task.key) in gl["existing_markers"])]
+        new_only = [c for c in errors_in_batch if not (extract_marker(c.get("body", ""), task_key = ctx.task.name) in gl["existing_markers"])]
         new_only = new_only[:remaining]
         before = len(gl["existing_markers"])
-        errs = _post_comments(ctx, gl, new_only, gl["existing_markers"], ctx.task.key)
+        errs = _post_comments(ctx, gl, new_only, gl["existing_markers"], ctx.task.name)
         state["posted"] += len(gl["existing_markers"]) - before
         state["errors"].extend(errs)
 
@@ -576,24 +576,24 @@ def _gitlab_lint_impl(ctx: FeatureContext):
 
     def _lint_end(ctx, relevant_diagnostics):
         if "existing_markers" not in gl:
-            gl["existing_markers"] = _get_existing_markers(ctx, gl, ctx.task.key)
-        suggestion_comments = [] if destination == "annotations" else _build_suggestion_comments(ctx, run_id, ctx.task.key, relevant_diagnostics, state["pending_patches"])
+            gl["existing_markers"] = _get_existing_markers(ctx, gl, ctx.task.name)
+        suggestion_comments = [] if destination == "annotations" else _build_suggestion_comments(ctx, run_id, ctx.task.name, relevant_diagnostics, state["pending_patches"])
         non_errors = [c for c in state["all_comments"] if c.get("_severity") != "error"] + suggestion_comments
-        non_errors = _dedup_by_marker(non_errors, ctx.task.key)
+        non_errors = _dedup_by_marker(non_errors, ctx.task.name)
         new_only = []
         for c in non_errors:
-            marker = extract_marker(c.get("body", ""), task_key = ctx.task.key)
+            marker = extract_marker(c.get("body", ""), task_key = ctx.task.name)
             if marker and marker in gl["existing_markers"]:
                 continue
             new_only.append(c)
         remaining = max_pr_comments - state["posted"]
         if remaining > 0:
             before = len(gl["existing_markers"])
-            errs = _post_comments(ctx, gl, new_only[:remaining], gl["existing_markers"], ctx.task.key)
+            errs = _post_comments(ctx, gl, new_only[:remaining], gl["existing_markers"], ctx.task.name)
             state["posted"] += len(gl["existing_markers"]) - before
             state["errors"].extend(errs)
-        suggestion_markers = [m for m in [extract_marker(c.get("body", ""), task_key = ctx.task.key) for c in suggestion_comments] if m]
-        _cleanup_and_resolve(ctx, gl, relevant_diagnostics, run_id, ctx.task.key, suggestion_markers, destination)
+        suggestion_markers = [m for m in [extract_marker(c.get("body", ""), task_key = ctx.task.name) for c in suggestion_comments] if m]
+        _cleanup_and_resolve(ctx, gl, relevant_diagnostics, run_id, ctx.task.name, suggestion_markers, destination)
         if trace.enabled:
             trace.log("gitlab lint comment summary:")
             trace.log("posted comments:  %s" % state["posted"])

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -385,10 +385,9 @@ def _gitlab_status_comments(ctx: FeatureContext):
             _state["_current_phase"] = update.progress.body
 
         base = dict(subset)
-        base["name"] = ctx.task.kind
-        base["key"] = ctx.task.name
+        base["kind"] = ctx.task.kind
+        base["name"] = ctx.task.name
         base["status"] = status
-        base["kind"] = update.kind or ""
         base["ci_run_url"] = ci_run_url
         _state["_own_base"] = base
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -385,8 +385,8 @@ def _gitlab_status_comments(ctx: FeatureContext):
             _state["_current_phase"] = update.progress.body
 
         base = dict(subset)
-        base["name"] = ctx.task.name
-        base["key"] = ctx.task.key
+        base["name"] = ctx.task.kind
+        base["key"] = ctx.task.name
         base["status"] = status
         base["kind"] = update.kind or ""
         base["ci_run_url"] = ci_run_url

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -639,7 +639,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             phase = Phase(name = "apply", description = "Apply gazelle patch", emoji = "📦"),
         )
         tmp = ctx.std.env.temp_dir()
-        patch_path = tmp + "/gazelle-" + ctx.task.key + ".patch"
+        patch_path = tmp + "/gazelle-" + ctx.task.name + ".patch"
         ctx.std.fs.write(patch_path, diff_stdout)
         apply_result = ctx.std.process.command("git").args(["apply", "-p0", patch_path]) \
             .current_dir(ctx.std.env.aspect_root_dir()) \

--- a/crates/aspect-cli/src/builtins/aspect/helpers_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/helpers_test.axl
@@ -37,7 +37,7 @@ def _test_impl(ctx):
     return 0
 
 helpers_facade_tests = task(
-    name = "test-helpers",
+    kind = "test-helpers",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/init.axl
+++ b/crates/aspect-cli/src/builtins/aspect/init.axl
@@ -197,7 +197,7 @@ def _impl(ctx):
 # NB: --preset has no static `values=` list — valid presets are read at runtime
 # from the template's template-config.json (preset_flags fails on an unknown name).
 init = task(
-    name = "init",
+    kind = "init",
     summary = "Scaffold a new Bazel project from the Aspect Workflows template.",
     implementation = _impl,
     args = {

--- a/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
@@ -133,7 +133,7 @@ def _upload_file(ctx, kind, name, path):
     if not ctx.std.fs.exists(path):
         warn(ctx.std, "Artifact upload (%s) failed: file not found: %s" % (name, path))
         return ""
-    full_name = artifact_name(detect_ci(ctx.std.env), ctx.task.name, ctx.task.key, name)
+    full_name = artifact_name(detect_ci(ctx.std.env), ctx.task.kind, ctx.task.name, name)
     result = uploader.upload_file(ctx, path, full_name)
     if not result["success"]:
         for err in result.get("errors") or ["unknown error"]:
@@ -158,8 +158,8 @@ def _upload(ctx, kind, name, content):
         return ""
     tmpdir = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR") or ctx.std.env.temp_dir()
 
-    # ctx.task.key keeps concurrent same-task-different-key runs from colliding.
-    tmppath = tmpdir + "/" + ctx.task.key + "-" + name
+    # ctx.task.name keeps concurrent same-task-different-key runs from colliding.
+    tmppath = tmpdir + "/" + ctx.task.name + "-" + name
     ctx.std.fs.write(tmppath, content)
     url = _upload_file(ctx, kind, name, tmppath)
     ctx.std.fs.remove_file(tmppath)
@@ -188,15 +188,15 @@ artifacts = struct(
 
 # Artifact naming convention per CI platform
 
-def artifact_name(ci, task_name, task_key, filename):
+def artifact_name(ci, task_kind, task_name, filename):
     """Format an artifact name per CI conventions.
 
-    Buildkite/CircleCI/GitLab group via path-style `task_name/task_key/
-    filename`; GitHub Actions needs flat `task_name.task_key.filename`.
+    Buildkite/CircleCI/GitLab group via path-style `task_kind/task_name/
+    filename`; GitHub Actions needs flat `task_kind.task_name.filename`.
     """
     if ci == "github":
-        return task_name + "." + task_key + "." + filename
-    return task_name + "/" + task_key + "/" + filename
+        return task_kind + "." + task_name + "." + filename
+    return task_kind + "/" + task_name + "/" + filename
 
 # GitLab CI uploader (inline — no separate lib needed)
 
@@ -676,7 +676,7 @@ def _artifact_upload_impl(ctx: FeatureContext):
             return
         _collect_test_files(ctx, event, upload_test_logs, test_entries, skipped_files)
         if len(test_entries) >= test_group["last_count"] + _BATCH_SIZE:
-            name = artifact_name(ci, ctx.task.name, ctx.task.key, "testlogs")
+            name = artifact_name(ci, ctx.task.kind, ctx.task.name, "testlogs")
             if uploader.upload_testlogs(ctx, test_group, test_entries, name):
                 _publish_testlogs()
 
@@ -687,7 +687,7 @@ def _artifact_upload_impl(ctx: FeatureContext):
                 info(ctx.std, "Artifact upload skipped: " + reason)
             else:
                 if upload_testlogs:
-                    name = artifact_name(ci, ctx.task.name, ctx.task.key, "testlogs")
+                    name = artifact_name(ci, ctx.task.kind, ctx.task.name, "testlogs")
 
                     # final=True publishes plain `{name}`; rolling-delete
                     # still reaps the prior partial via prev_ref.

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_flags_test.axl
@@ -213,7 +213,7 @@ def _test_impl(ctx):
     return 0
 
 bazel_flags_tests = task(
-    name = "test-bazel-flags",
+    kind = "test-bazel-flags",
     group = ["dev"],
     implementation = _test_impl,
     # The helpers exercised here read CLI args off `ctx.args`. Declare

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -1145,8 +1145,8 @@ def summary_title(data, status, target_pattern = "", task_name = ""):
         data:           dict from init_data()
         status:         "running" | "failing" | "passed" | "failed" | "warning" | "aborted"
         target_pattern: subject (e.g. "//..." for a build/test task)
-        task_name:      raw task identifier (`ctx.task.name`) — the
-                        lowercase string declared on `task(name=...)`.
+        task_name:      raw task kind (`ctx.task.kind`) — the lowercase
+                        string declared on `task(kind=...)`.
 
     Returns:
         str — max 160 chars (GitHub check title limit)

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results.axl
@@ -1115,7 +1115,7 @@ def failed_labels_by_subcommand(data):
 
     return {"build": build, "test": test}
 
-def compute_reproducer_command(data, task_name, max_chars = MAX_REPRO_CHARS):
+def compute_reproducer_command(data, task_kind, max_chars = MAX_REPRO_CHARS):
     """Legacy helper preserved for test fixtures. New code should append
     `{"command", "description"}` entries to `data["repro_commands"]`
     directly via `lib/repro_commands.axl::build_aspect_command`.
@@ -1123,14 +1123,14 @@ def compute_reproducer_command(data, task_name, max_chars = MAX_REPRO_CHARS):
     Returns `(command, total)` from the deduped failure-label set.
     """
     labels = failed_labels(data)
-    cmd, _ = _repro_with_prefix("aspect " + task_name, labels, max_chars)
+    cmd, _ = _repro_with_prefix("aspect " + task_kind, labels, max_chars)
     return (cmd, len(labels))
 
 # GitHub check-run title cap. Subject within is capped tighter at SUBJECT_TITLE_MAX.
 _TITLE_MAX_LEN = 160
 
-def summary_title(data, status, target_pattern = "", task_name = ""):
-    """Build the check run title in the form '<status_emoji> <task_name> <subject> · <state>'.
+def summary_title(data, status, target_pattern = "", task_kind = ""):
+    """Build the check run title in the form '<status_emoji> <task_kind> <subject> · <state>'.
 
     Mirrors Aspect Web UI conventions — see _BUCKET_INVOCATION_LABELS
     for the state vocabulary and compute_invocation_state for priority rules.
@@ -1145,7 +1145,7 @@ def summary_title(data, status, target_pattern = "", task_name = ""):
         data:           dict from init_data()
         status:         "running" | "failing" | "passed" | "failed" | "warning" | "aborted"
         target_pattern: subject (e.g. "//..." for a build/test task)
-        task_name:      raw task kind (`ctx.task.kind`) — the lowercase
+        task_kind:      the task kind (`ctx.task.kind`) — the lowercase
                         string declared on `task(kind=...)`.
 
     Returns:
@@ -1157,8 +1157,8 @@ def summary_title(data, status, target_pattern = "", task_name = ""):
 
     # `{icon} {task} {subject}` is the "what"; state clause follows after `·`.
     front_parts = []
-    if task_name:
-        front_parts.append(icon + " " + task_name)
+    if task_kind:
+        front_parts.append(icon + " " + task_kind)
     else:
         front_parts.append(icon)
     if subject:
@@ -3158,17 +3158,17 @@ def build_summary_data(ctx, data, status, render_ctx, links, metadata_keys, run_
     if status in ("running", "failing", "failed"):
         last_update = render_ctx.get("progress", "") or ""
     elif status in ("passed", "warning"):
-        name = render_ctx.get("task_name", "") or "task"
+        kind = render_ctx.get("task_kind", "") or "task"
 
-        # "<name> task complete" not "<name> complete": "test complete" reads as
+        # "<kind> task complete" not "<kind> complete": "test complete" reads as
         # "the test passed", but "test task complete" means the task finished.
         # `warning` joins `passed` (terminal, non-fatal) so the row isn't blank.
-        last_update = name + " task complete"
+        last_update = kind + " task complete"
         if complete_suffix:
             last_update = last_update + " · " + complete_suffix
     elif status == "aborted":
-        name = render_ctx.get("task_name", "") or "task"
-        last_update = name + " task aborted"
+        kind = render_ctx.get("task_kind", "") or "task"
+        last_update = kind + " task aborted"
     else:
         last_update = ""
 
@@ -4365,13 +4365,13 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         trace.log(details_text[:5000])
 
     target_pattern = render_ctx.get("subject", "") if render_ctx else ""
-    task_name = render_ctx.get("task_name", "") if render_ctx else ""
+    task_kind = render_ctx.get("task_kind", "") if render_ctx else ""
     return {
         "title": summary_title(
             data,
             status,
             target_pattern = target_pattern,
-            task_name = task_name,
+            task_kind = task_kind,
         ),
         "summary": summary_text,
         "text": details_text,

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -455,14 +455,14 @@ def _make_results_large():
 
 # Shared render context and links
 
-def _render_ctx(subject = "//...", task_name = "test", progress = ""):
+def _render_ctx(subject = "//...", task_kind = "test", progress = ""):
     return {
         "triggered_by": "ci-bot (workflow_dispatch)",
         "subject": subject,
         "started_ms": 1744630000000,
         "ended_ms": 1744630002200,
         "progress": progress,
-        "task_name": task_name,
+        "task_kind": task_kind,
     }
 
 def _links(with_artifact = False, ci = "github"):

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_results_test.axl
@@ -629,7 +629,7 @@ def _test_impl(ctx):
     return 0
 
 template_snapshot_tests = task(
-    name = "test-template-snapshots",
+    kind = "test-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,
     args = {},
@@ -1212,7 +1212,7 @@ def _unit_test_impl(ctx):
     return 0
 
 bazel_results_unit_tests = task(
-    name = "test-bazel-results",
+    kind = "test-bazel-results",
     group = ["dev"],
     implementation = _unit_test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/bazel_runner_test.axl
@@ -94,7 +94,7 @@ def _test_impl(ctx):
     return 0
 
 bazel_runner_tests = task(
-    name = "test-bazel-runner",
+    kind = "test-bazel-runner",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/build_metadata.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/build_metadata.axl
@@ -489,39 +489,47 @@ def get_task_metadata_flags(ctx):
 
     Two schemas by detected runner version:
       pre-5.18 / off-runner (legacy Web UI):
-        ASPECT_TASK_NAME = <display>, ASPECT_TASK_ID = <UUID>
+        ASPECT_TASK_NAME = <friendly_kind>, ASPECT_TASK_ID = <UUID>
       5.18.0+ (split schema):
-        ASPECT_TASK_DISPLAY_NAME = <display>, ASPECT_TASK_NAME = <kind>,
-        ASPECT_TASK_KIND = <kind>, ASPECT_TASK_ID = <UUID>
+        ASPECT_TASK_KIND = <kind>, ASPECT_TASK_FRIENDLY_KIND = <friendly_kind>,
+        ASPECT_TASK_NAME = <name>, ASPECT_TASK_FRIENDLY_NAME = <friendly_name>,
+        ASPECT_TASK_ID = <UUID>
 
-    `ASPECT_TASK_NAME` carries the task *kind* (the command) for Web UI
-    back-compat; `ASPECT_TASK_KIND` is the explicit kind alias. The legacy
-    `ASPECT_TASK_KEY` field is no longer emitted.
+    `ASPECT_TASK_KIND`/`ASPECT_TASK_FRIENDLY_KIND` describe the task kind (the
+    command and its friendly label); `ASPECT_TASK_NAME`/`ASPECT_TASK_FRIENDLY_NAME`
+    describe this particular invocation (`--task:name` / `--task:friendly-name`,
+    explicit or generated). The legacy `ASPECT_TASK_KEY` field is no longer
+    emitted.
 
     Off a Workflows runner (ASPECT_WORKFLOWS_RUNNER_VERSION unset) → legacy form
     so check runs against non-Aspect backends stay readable.
     """
     task = ctx.task
     kind = task.kind or ""
+    friendly_kind = task.friendly_kind or ""
+    name = task.name or ""
+    friendly_name = task.friendly_name or ""
     uuid = task.id or ""
-    display_name = task.display_name or ""
 
     runner_version = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_VERSION") or ""
     new_schema = bool(runner_version) and version_gte(runner_version, _TASK_METADATA_NEW_SCHEMA_MIN_VERSION)
 
     flags = []
     if new_schema:
-        if display_name:
-            flags.append("--build_metadata=ASPECT_TASK_DISPLAY_NAME=" + display_name)
         if kind:
-            flags.append("--build_metadata=ASPECT_TASK_NAME=" + kind)
             flags.append("--build_metadata=ASPECT_TASK_KIND=" + kind)
+        if friendly_kind:
+            flags.append("--build_metadata=ASPECT_TASK_FRIENDLY_KIND=" + friendly_kind)
+        if name:
+            flags.append("--build_metadata=ASPECT_TASK_NAME=" + name)
+        if friendly_name:
+            flags.append("--build_metadata=ASPECT_TASK_FRIENDLY_NAME=" + friendly_name)
         if uuid:
             flags.append("--build_metadata=ASPECT_TASK_ID=" + uuid)
     else:
-        # Legacy: NAME = display name, ID = UUID.
-        if display_name:
-            flags.append("--build_metadata=ASPECT_TASK_NAME=" + display_name)
+        # Legacy: NAME = friendly label of the kind, ID = UUID.
+        if friendly_kind:
+            flags.append("--build_metadata=ASPECT_TASK_NAME=" + friendly_kind)
         if uuid:
             flags.append("--build_metadata=ASPECT_TASK_ID=" + uuid)
     return flags

--- a/crates/aspect-cli/src/builtins/aspect/lib/build_metadata.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/build_metadata.axl
@@ -480,8 +480,8 @@ def version_gte(a, b):
     return version_tuple(a) >= version_tuple(b)
 
 # Runner version at which the Web UI adopts the split
-# DISPLAY_NAME/NAME/KIND/ID schema. Below it we emit the legacy two-field
-# form (NAME=display, ID=UUID).
+# KIND/FRIENDLY_KIND/NAME/FRIENDLY_NAME/ID schema. Below it we emit the
+# legacy two-field form (NAME=friendly_kind, ID=UUID).
 _TASK_METADATA_NEW_SCHEMA_MIN_VERSION = "5.18.0"
 
 def get_task_metadata_flags(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/lib/build_metadata.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/build_metadata.axl
@@ -479,19 +479,9 @@ def version_gte(a, b):
     """Semver-ish '>=' comparison. Handles "5.18.0" >= "5.18.0"."""
     return version_tuple(a) >= version_tuple(b)
 
-def task_display_name(task_name):
-    """Title-Case a raw task name ("my-task"/"my_task" → "My Task"). Used for
-    ASPECT_TASK_DISPLAY_NAME (Web UI task-list). Check-run / BK titles use the
-    raw lowercase name, so this needn't match those surfaces."""
-    if not task_name:
-        return task_name
-    if "/" in task_name:
-        task_name = task_name.rsplit("/", 1)[-1]
-    words = [w.capitalize() for w in task_name.replace("_", "-").split("-") if w]
-    return " ".join(words) if words else task_name
-
-# Runner version at which the Web UI adopts the split DISPLAY_NAME/NAME/KEY/ID
-# schema. Below it we emit the legacy two-field form (NAME=display, ID=key).
+# Runner version at which the Web UI adopts the split
+# DISPLAY_NAME/NAME/KIND/ID schema. Below it we emit the legacy two-field
+# form (NAME=display, ID=UUID).
 _TASK_METADATA_NEW_SCHEMA_MIN_VERSION = "5.18.0"
 
 def get_task_metadata_flags(ctx):
@@ -499,19 +489,22 @@ def get_task_metadata_flags(ctx):
 
     Two schemas by detected runner version:
       pre-5.18 / off-runner (legacy Web UI):
-        ASPECT_TASK_NAME = <display>, ASPECT_TASK_ID = <key>
+        ASPECT_TASK_NAME = <display>, ASPECT_TASK_ID = <UUID>
       5.18.0+ (split schema):
-        ASPECT_TASK_DISPLAY_NAME = <display>, ASPECT_TASK_NAME = <raw>,
-        ASPECT_TASK_KEY = <key>, ASPECT_TASK_ID = <UUID>
+        ASPECT_TASK_DISPLAY_NAME = <display>, ASPECT_TASK_NAME = <kind>,
+        ASPECT_TASK_KIND = <kind>, ASPECT_TASK_ID = <UUID>
+
+    `ASPECT_TASK_NAME` carries the task *kind* (the command) for Web UI
+    back-compat; `ASPECT_TASK_KIND` is the explicit kind alias. The legacy
+    `ASPECT_TASK_KEY` field is no longer emitted.
 
     Off a Workflows runner (ASPECT_WORKFLOWS_RUNNER_VERSION unset) → legacy form
     so check runs against non-Aspect backends stay readable.
     """
     task = ctx.task
-    name = task.name or ""
-    key = task.key or ""
+    kind = task.kind or ""
     uuid = task.id or ""
-    display_name = task_display_name(name)
+    display_name = task.display_name or ""
 
     runner_version = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_VERSION") or ""
     new_schema = bool(runner_version) and version_gte(runner_version, _TASK_METADATA_NEW_SCHEMA_MIN_VERSION)
@@ -520,18 +513,17 @@ def get_task_metadata_flags(ctx):
     if new_schema:
         if display_name:
             flags.append("--build_metadata=ASPECT_TASK_DISPLAY_NAME=" + display_name)
-        if name:
-            flags.append("--build_metadata=ASPECT_TASK_NAME=" + name)
-        if key:
-            flags.append("--build_metadata=ASPECT_TASK_KEY=" + key)
+        if kind:
+            flags.append("--build_metadata=ASPECT_TASK_NAME=" + kind)
+            flags.append("--build_metadata=ASPECT_TASK_KIND=" + kind)
         if uuid:
             flags.append("--build_metadata=ASPECT_TASK_ID=" + uuid)
     else:
-        # Legacy: NAME = display name, ID = task key.
+        # Legacy: NAME = display name, ID = UUID.
         if display_name:
             flags.append("--build_metadata=ASPECT_TASK_NAME=" + display_name)
-        if key:
-            flags.append("--build_metadata=ASPECT_TASK_ID=" + key)
+        if uuid:
+            flags.append("--build_metadata=ASPECT_TASK_ID=" + uuid)
     return flags
 
 # Public entry point

--- a/crates/aspect-cli/src/builtins/aspect/lib/buildkite.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/buildkite.axl
@@ -89,7 +89,7 @@ def _resolve_artifact_url(ctx, name):
     # `--format "%i\n"` emits one artifact UUID per line. `--build`
     # defaults to BUILDKITE_BUILD_ID so the search is already scoped
     # to this build, and our artifact paths embed
-    # `task_name/task_key/<filename>` so the query is unique per upload.
+    # `task_kind/task_name/<filename>` so the query is unique per upload.
     artifact_id = ""
     for line in out.stdout.split("\n"):
         line = line.strip()

--- a/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
@@ -144,7 +144,7 @@ def make_render_ctx(state, tips = None, api_usage = "", last_updated_at = ""):
 
     Reads from `state` — the feature-private dict the caller maintains
     across hook calls. Expected slots: `_triggered_by`, `_subject`,
-    `_started_ms`, `_ended_ms`, `_progress`, `_task_name`.
+    `_started_ms`, `_ended_ms`, `_progress`, `_task_kind`.
 
     `subject` is the task's target patterns / formatter target / etc.,
     rendered in the title. Empty when the task hasn't supplied one (e.g. a
@@ -173,7 +173,7 @@ def make_render_ctx(state, tips = None, api_usage = "", last_updated_at = ""):
         "started_ms": state.get("_started_ms", 0),
         "ended_ms": state.get("_ended_ms", 0),
         "progress": state.get("_progress", ""),
-        "task_name": state.get("_task_name", ""),
+        "task_kind": state.get("_task_kind", ""),
         "tips": tips or [],
         "api_usage": api_usage or "",
         "last_updated_at": last_updated_at or "",

--- a/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/check_dispatch.axl
@@ -11,7 +11,7 @@ Split here, not in the features:
 
   RENDERERS                  Per-kind init + render dispatch table.
   renderer_for_kind(kind)
-  kind_for_task(task_name)   Initial kind to use before the first
+  kind_for_task(task_kind)   Initial kind to use before the first
                              task_update has fired.
   to_display_name(name)      snake_case → CamelCase task display name.
   make_render_ctx(state)     Build the render_ctx dict the per-kind
@@ -103,12 +103,13 @@ def renderer_for_kind(kind):
     """Return the Renderer struct for `kind`, or None if unknown."""
     return RENDERERS.get(kind, None)
 
-def kind_for_task(task_name):
-    """Best-guess initial kind for a task before any task_update has fired.
+def kind_for_task(task_kind):
+    """Best-guess initial renderer kind for a task before any task_update
+    has fired.
 
-    Falls back to "bazel_results" for unknown task names.
+    Falls back to "bazel_results" for unknown task kinds.
     """
-    return _TASK_KIND_DEFAULTS.get(task_name, "bazel_results")
+    return _TASK_KIND_DEFAULTS.get(task_kind, "bazel_results")
 
 # Per-surface inline-snippet budgets (max snippets shown + per-snippet line cap).
 # Status checks / BK annotations are glanceable and bump the surface size caps

--- a/crates/aspect-cli/src/builtins/aspect/lib/ci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/ci_test.axl
@@ -215,7 +215,7 @@ def _test_impl(ctx):
     return 0
 
 ci_tests = task(
-    name = "test-ci",
+    kind = "test-ci",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/circleci_test.axl
@@ -319,7 +319,7 @@ def _test_impl(ctx):
     return 0
 
 circleci_tests = task(
-    name = "test-circleci",
+    kind = "test-circleci",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
@@ -180,7 +180,7 @@ def delivery_summary_title(data, status, target_pattern = "", task_name = ""):
       - all delivered / skipped → "N delivered, M skipped"
       - "Running..." while running
 
-    `task_name` comes from the producer's `task(name=…)`. The leading
+    `task_name` comes from the producer's `task(kind=…)`. The leading
     emoji is the status verdict via `emoji_for_status`. Defaults to
     "delivery" when no name is provided.
     """

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
@@ -167,7 +167,7 @@ def build_manifest(data):
 
 # ─── Title ────────────────────────────────────────────────────────────────────
 
-def delivery_summary_title(data, status, target_pattern = "", task_name = ""):
+def delivery_summary_title(data, status, target_pattern = "", task_kind = ""):
     """Compute the check-run title.
 
     "✅ delivery //apps/... · 12 delivered" — status emoji + raw task
@@ -180,11 +180,11 @@ def delivery_summary_title(data, status, target_pattern = "", task_name = ""):
       - all delivered / skipped → "N delivered, M skipped"
       - "Running..." while running
 
-    `task_name` comes from the producer's `task(kind=…)`. The leading
+    `task_kind` comes from the producer's `task(kind=…)`. The leading
     emoji is the status verdict via `emoji_for_status`. Defaults to
     "delivery" when no name is provided.
     """
-    display = emoji_for_status(status) + " " + (task_name or "delivery")
+    display = emoji_for_status(status) + " " + (task_kind or "delivery")
     target = truncate_for_title(target_pattern or data.get("target_pattern", ""))
     base = display + ((" " + target) if target else "")
 
@@ -313,8 +313,8 @@ def _truncate(s, max_len):
 def _outcome_table(diags, outcome, prefix):
     """Render a small table per outcome: label, key, context.
 
-    `prefix` is the salt-augmented change-detection prefix (`task_key`
-    optionally extended by `:salt`); each row's key is rendered as
+    `prefix` is the salt-augmented change-detection prefix (the task
+    name optionally extended by `:salt`); each row's key is rendered as
     `<prefix>:<output_sha[:12]>` so two runs collide iff they would resolve
     to the same deliveryd record.
 
@@ -544,7 +544,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
     target_pattern = render_ctx.get("subject", "") if render_ctx else ""
-    task_name = render_ctx.get("task_name", "") if render_ctx else ""
+    task_kind = render_ctx.get("task_kind", "") if render_ctx else ""
     if not target_pattern:
         target_pattern = data.get("target_pattern", "")
     return {
@@ -552,7 +552,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             data,
             status,
             target_pattern = target_pattern,
-            task_name = task_name,
+            task_kind = task_kind,
         ),
         "summary": summary_text,
         "text": details_text,

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results.axl
@@ -84,7 +84,7 @@ def init_data():
         "ci_host": "",  # deliveryd CI label: "bk" | "gh" | "circle" | …
         "build_url": "",  # CI job URL the delivery was performed from
         "commit_sha": "",  # commit being delivered
-        "prefix": "",  # task.key — delivery namespace
+        "prefix": "",  # task name — delivery namespace
         "deliveries": [],  # see add_result() for the per-entry schema.
 
         # Run-shape flags surfaced in the check-run / annotation summary so a

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results_test.axl
@@ -383,7 +383,7 @@ def _check_long_subject_title_is_capped(ctx):
         fail("title unexpectedly long (%d chars): %r" % (len(title), title))
 
 delivery_template_snapshot_tests = task(
-    name = "test-delivery-template-snapshots",
+    kind = "test-delivery-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,
     args = {},
@@ -575,7 +575,7 @@ def _unit_test_impl(ctx):
     return 0
 
 delivery_results_unit_tests = task(
-    name = "test-delivery-results",
+    kind = "test-delivery-results",
     group = ["dev"],
     implementation = _unit_test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/delivery_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/delivery_results_test.axl
@@ -254,14 +254,14 @@ def _make_build_failed():
 
 # ─── Test harness ─────────────────────────────────────────────────────────────
 
-def _render_ctx(subject = "//apps/...", task_name = "delivery", progress = ""):
+def _render_ctx(subject = "//apps/...", task_kind = "delivery", progress = ""):
     return {
         "triggered_by": "Greg Magolan (workflow_dispatch)",
         "subject": subject,
         "started_ms": 1744630000000,
         "ended_ms": 1744630012500,
         "progress": progress,
-        "task_name": task_name,
+        "task_kind": task_kind,
     }
 
 def _links(ci = "buildkite", with_manifest = False):

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
@@ -63,7 +63,7 @@ def init_data():
 
 # ─── Title ────────────────────────────────────────────────────────────────────
 
-def format_summary_title(data, status, target_pattern = "", task_name = ""):
+def format_summary_title(data, status, target_pattern = "", task_kind = ""):
     """Compute the check-run title.
 
     "✅ format //tools/format:format · Passed"
@@ -72,7 +72,7 @@ def format_summary_title(data, status, target_pattern = "", task_name = ""):
     "✅ format //tools/format:format · No files to format"
     "🔄 format //tools/format:format · Running..."
 
-    `task_name` is the raw task kind (`ctx.task.kind`) — the lowercase
+    `task_kind` is the raw task kind (`ctx.task.kind`) — the lowercase
     string the user declared on `task(kind="...")`. The
     leading emoji comes from the task's *current status* via
     `emoji_for_status` so the icon mirrors the verdict at a glance
@@ -84,7 +84,7 @@ def format_summary_title(data, status, target_pattern = "", task_name = ""):
     tasks in one build (e.g. `format` + `buildifier-only` running on
     different `format_multirun`s) collapse to identical titles.
     """
-    display = emoji_for_status(status) + " " + (task_name or "format")
+    display = emoji_for_status(status) + " " + (task_kind or "format")
     target = target_pattern or data["format"].get("formatter_target", "") or ""
     base = display + ((" " + target) if target else "")
 
@@ -377,14 +377,14 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             details_data["has_overflow"] = missing > 0
             details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
-    task_name = render_ctx.get("task_name", "") if render_ctx else ""
+    task_kind = render_ctx.get("task_kind", "") if render_ctx else ""
     target_pattern = render_ctx.get("subject", "") if render_ctx else ""
     return {
         "title": format_summary_title(
             data,
             status,
             target_pattern = target_pattern,
-            task_name = task_name,
+            task_kind = task_kind,
         ),
         "summary": summary_text,
         "text": details_text,

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results.axl
@@ -72,8 +72,8 @@ def format_summary_title(data, status, target_pattern = "", task_name = ""):
     "✅ format //tools/format:format · No files to format"
     "🔄 format //tools/format:format · Running..."
 
-    `task_name` is the raw task identifier (`ctx.task.name`) — the
-    lowercase string the user declared on `task(name="...")`. The
+    `task_name` is the raw task kind (`ctx.task.kind`) — the lowercase
+    string the user declared on `task(kind="...")`. The
     leading emoji comes from the task's *current status* via
     `emoji_for_status` so the icon mirrors the verdict at a glance
     (✅/⚠️/❌/🔄/🔥). Defaults to "format" when no name is provided.

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
@@ -296,7 +296,7 @@ def _test_impl(ctx):
     return 0
 
 format_template_snapshot_tests = task(
-    name = "test-format-template-snapshots",
+    kind = "test-format-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_results_test.axl
@@ -200,14 +200,14 @@ def _make_failing_with_drift():
 
 # ─── Test harness ─────────────────────────────────────────────────────────────
 
-def _render_ctx(task_name = "format"):
+def _render_ctx(task_kind = "format"):
     return {
         "triggered_by": "Greg Magolan (pull_request)",
         "subject": "",
         "started_ms": 1744630000000,
         "ended_ms": 1744630003200,
         "progress": "",
-        "task_name": task_name,
+        "task_kind": task_kind,
     }
 
 def _links(ci = "github"):

--- a/crates/aspect-cli/src/builtins/aspect/lib/format_spawn_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/format_spawn_test.axl
@@ -71,7 +71,7 @@ def _test_impl(ctx):
     return 0
 
 format_spawn_tests = task(
-    name = "test-format-spawn",
+    kind = "test-format-spawn",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
@@ -161,7 +161,7 @@ def gazelle_summary_title(data, status, target_pattern = "", task_name = ""):
     "❌ gazelle //tools/gazelle:gazelle · Apply error"
     "🔄 gazelle //tools/gazelle:gazelle · Running..."
 
-    `task_name` comes from the producer's `task(name=…)`. The leading
+    `task_name` comes from the producer's `task(kind=…)`. The leading
     emoji is the status verdict via `emoji_for_status`. Defaults to
     "gazelle" when no name is provided.
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results.axl
@@ -152,7 +152,7 @@ def dedupe_subtrees(dirs):
 
 # ─── Title ────────────────────────────────────────────────────────────────────
 
-def gazelle_summary_title(data, status, target_pattern = "", task_name = ""):
+def gazelle_summary_title(data, status, target_pattern = "", task_kind = ""):
     """Compute the check-run title.
 
     "❌ gazelle //tools/gazelle:gazelle · 5 BUILD files out of date"
@@ -161,7 +161,7 @@ def gazelle_summary_title(data, status, target_pattern = "", task_name = ""):
     "❌ gazelle //tools/gazelle:gazelle · Apply error"
     "🔄 gazelle //tools/gazelle:gazelle · Running..."
 
-    `task_name` comes from the producer's `task(kind=…)`. The leading
+    `task_kind` comes from the producer's `task(kind=…)`. The leading
     emoji is the status verdict via `emoji_for_status`. Defaults to
     "gazelle" when no name is provided.
 
@@ -170,7 +170,7 @@ def gazelle_summary_title(data, status, target_pattern = "", task_name = ""):
     their target in the title and lets multiple gazelle tasks in one
     build (e.g. prebuilt + from-source) render distinct titles.
     """
-    display = emoji_for_status(status) + " " + (task_name or "gazelle")
+    display = emoji_for_status(status) + " " + (task_kind or "gazelle")
     target = target_pattern or data["gazelle"].get("gazelle_target", "") or ""
     base = display + ((" " + target) if target else "")
 
@@ -433,14 +433,14 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             details_data["has_overflow"] = missing > 0
             details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
-    task_name = render_ctx.get("task_name", "") if render_ctx else ""
+    task_kind = render_ctx.get("task_kind", "") if render_ctx else ""
     target_pattern = render_ctx.get("subject", "") if render_ctx else ""
     return {
         "title": gazelle_summary_title(
             data,
             status,
             target_pattern = target_pattern,
-            task_name = task_name,
+            task_kind = task_kind,
         ),
         "summary": summary_text,
         "text": details_text,

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
@@ -311,7 +311,7 @@ def _test_impl(ctx):
     return 0
 
 gazelle_template_snapshot_tests = task(
-    name = "test-gazelle-template-snapshots",
+    kind = "test-gazelle-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gazelle_results_test.axl
@@ -213,14 +213,14 @@ def _make_failing_with_drift():
 
 # ─── Test harness ─────────────────────────────────────────────────────────────
 
-def _render_ctx(task_name = "gazelle"):
+def _render_ctx(task_kind = "gazelle"):
     return {
         "triggered_by": "Greg Magolan (pull_request)",
         "subject": "",
         "started_ms": 1744630000000,
         "ended_ms": 1744630005800,
         "progress": "",
-        "task_name": task_name,
+        "task_kind": task_kind,
     }
 
 def _links(ci = "github"):

--- a/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/github_detect_test.axl
@@ -1223,7 +1223,7 @@ def _test_resolve_merge_base_integration(ctx):
     ctx.std.fs.remove_dir_all(repo)
 
 github_detect_tests = task(
-    name = "test-github-detect",
+    kind = "test-github-detect",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_detect_test.axl
@@ -231,7 +231,7 @@ def _test_impl(ctx):
     return 0
 
 gitlab_detect_tests = task(
-    name = "test-gitlab-detect",
+    kind = "test-gitlab-detect",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_features_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_features_test.axl
@@ -90,7 +90,7 @@ def _test_impl(ctx):
     return 0
 
 gitlab_features_tests = task(
-    name = "test-gitlab-features",
+    kind = "test-gitlab-features",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_lint_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_lint_comments_test.axl
@@ -137,7 +137,7 @@ def _test_impl(ctx):
     return 0
 
 gitlab_lint_comments_tests = task(
-    name = "test-gitlab-lint-comments",
+    kind = "test-gitlab-lint-comments",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/gitlab_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/gitlab_test.axl
@@ -306,7 +306,7 @@ def _test_impl(ctx):
     return 0
 
 gitlab_client_tests = task(
-    name = "test-gitlab-client",
+    kind = "test-gitlab-client",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/health_check_ready_test.axl
@@ -279,7 +279,7 @@ def _test_impl(ctx):
     return 0
 
 health_check_ready_tests = task(
-    name = "test-health-check-ready",
+    kind = "test-health-check-ready",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/init_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/init_test.axl
@@ -176,7 +176,7 @@ def _test_impl(ctx):
     return 0
 
 init_tests = task(
-    name = "test-init",
+    kind = "test-init",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -141,8 +141,9 @@ ReproFixAction = enum("accept", "reject", "replace")
 # returns a `ReproFixSuggestion` verdict. Typed fields cover most
 # decisions; `extras` / `data` are escape hatches.
 ReproFixInfo = record(
-    # Task identity. `task_path` is the joined `<group...> <name>`
-    # ("aspect lint"); `task_name` / `task_group` are the parts.
+    # Task identity. `task_path` is the joined `<group...> <kind>`
+    # ("aspect lint"); `task_name` carries the task *kind* (the command)
+    # and `task_group` the group segments.
     task_path = field(str),
     task_name = field(str),
     task_group = field(list[str]),

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -142,10 +142,10 @@ ReproFixAction = enum("accept", "reject", "replace")
 # decisions; `extras` / `data` are escape hatches.
 ReproFixInfo = record(
     # Task identity. `task_path` is the joined `<group...> <kind>`
-    # ("aspect lint"); `task_name` carries the task *kind* (the command)
-    # and `task_group` the group segments.
+    # ("aspect lint"); `task_kind` is the task kind (the command) and
+    # `task_group` the group segments.
     task_path = field(str),
-    task_name = field(str),
+    task_kind = field(str),
     task_group = field(list[str]),
     # Task result kind ("lint_results" | "bazel_results" | …). Matches
     # `TaskUpdate.kind` so hooks route by the surface-template key.
@@ -298,7 +298,7 @@ def apply_repro_fix_hooks(
 
     info_base = {
         "task_path": " ".join(list(ctx.task.group) + [ctx.task.kind]),
-        "task_name": ctx.task.kind,
+        "task_kind": ctx.task.kind,
         "task_group": list(ctx.task.group),
         "kind": kind,
         "status": status,

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -296,8 +296,8 @@ def apply_repro_fix_hooks(
         return
 
     info_base = {
-        "task_path": " ".join(list(ctx.task.group) + [ctx.task.name]),
-        "task_name": ctx.task.name,
+        "task_path": " ".join(list(ctx.task.group) + [ctx.task.kind]),
+        "task_name": ctx.task.kind,
         "task_group": list(ctx.task.group),
         "kind": kind,
         "status": status,

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_comments_test.axl
@@ -41,7 +41,7 @@ def _test_impl(ctx):
     return 0
 
 lint_comments_tests = task(
-    name = "test-lint-comments",
+    kind = "test-lint-comments",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results.axl
@@ -151,14 +151,14 @@ def _recount(data):
     data["lint"]["counts_by_severity"] = by_sev
     data["lint"]["counts_by_tool"] = by_tool
 
-def lint_summary_title(data, status, target_pattern = "", task_name = ""):
+def lint_summary_title(data, status, target_pattern = "", task_kind = ""):
     """Compute the check-run title, e.g. "⚠️ lint //... · 3 errors, 8 warnings",
     "✅ lint //... · Passed", "❌ lint //... · Build failed", "🔄 ... · Running...".
 
-    Leading emoji is the status verdict (emoji_for_status). `task_name` defaults
+    Leading emoji is the status verdict (emoji_for_status). `task_kind` defaults
     to "lint".
     """
-    display = emoji_for_status(status) + " " + (task_name or "lint")
+    display = emoji_for_status(status) + " " + (task_kind or "lint")
     target = target_pattern or data.get("target_pattern", "")
     base = display + ((" " + target) if target else "")
 
@@ -865,7 +865,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         details_text = ctx.template.jinja2(details_tmpl, data = details_data)
 
     target_pattern = render_ctx.get("subject", "") if render_ctx else ""
-    task_name = render_ctx.get("task_name", "") if render_ctx else ""
+    task_kind = render_ctx.get("task_kind", "") if render_ctx else ""
     if not target_pattern:
         target_pattern = data.get("target_pattern", "")
     return {
@@ -873,7 +873,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             data,
             status,
             target_pattern = target_pattern,
-            task_name = task_name,
+            task_kind = task_kind,
         ),
         "summary": summary_text,
         "text": details_text,

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
@@ -357,14 +357,14 @@ def _make_results_annotations_changed_regions():
 
 # ─── Test harness ─────────────────────────────────────────────────────────────
 
-def _render_ctx(subject = "//...", task_name = "lint"):
+def _render_ctx(subject = "//...", task_kind = "lint"):
     return {
         "triggered_by": "Greg Magolan (workflow_dispatch)",
         "subject": subject,
         "started_ms": 1744630000000,
         "ended_ms": 1744630004500,
         "progress": "",
-        "task_name": task_name,
+        "task_kind": task_kind,
     }
 
 def _links(with_artifact = False, ci = "github"):

--- a/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lint_results_test.axl
@@ -687,7 +687,7 @@ def _check_fix_renders_before_reproduce(ctx):
         fail("Fix block must render before Reproduce (fix@%d, repro@%d)" % (fix_at, repro_at))
 
 lint_template_snapshot_tests = task(
-    name = "test-lint-template-snapshots",
+    kind = "test-lint-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,
     args = {},
@@ -762,7 +762,7 @@ def _test_lint_annotation_plan(ctx):
     return 0
 
 lint_annotation_plan_tests = task(
-    name = "test-lint-annotation-plan",
+    kind = "test-lint-annotation-plan",
     group = ["dev"],
     implementation = _test_lint_annotation_plan,
     args = {},
@@ -836,7 +836,7 @@ def _test_linter_rows(ctx):
     return 0
 
 linter_rows_tests = task(
-    name = "test-lint-linter-rows",
+    kind = "test-lint-linter-rows",
     group = ["dev"],
     implementation = _test_linter_rows,
     args = {},
@@ -892,7 +892,7 @@ def _test_detect_lint_tool(ctx):
     return 0
 
 detect_lint_tool_tests = task(
-    name = "test-lint-detect-tool",
+    kind = "test-lint-detect-tool",
     group = ["dev"],
     implementation = _test_detect_lint_tool,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/path_normalize_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/path_normalize_test.axl
@@ -140,7 +140,7 @@ def _test_impl(ctx):
     return 0
 
 path_normalize_tests = task(
-    name = "test-path-normalize",
+    kind = "test-path-normalize",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit.axl
@@ -184,7 +184,7 @@ def _new_state():
 def _path(ctx):
     # `<job-tmpdir>/rate_limit/<pid>.json`. Each task is its own process, so
     # the pid is a per-task id available from any ctx flavor (unlike
-    # `ctx.task.key`). Swarm aggregation flows through
+    # `ctx.task.name`). Swarm aggregation flows through
     # `export_observations` / `ingest_sibling_observations`, not this file.
     base = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR") or ctx.std.env.temp_dir()
     return base + "/rate_limit/" + str(ctx.std.process.id()) + ".json"

--- a/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/rate_limit_test.axl
@@ -1168,7 +1168,7 @@ def _test_impl(ctx):
     return 0
 
 rate_limit_tests = task(
-    name = "test-rate-limit",
+    kind = "test-rate-limit",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/remote_executor_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/remote_executor_test.axl
@@ -48,7 +48,7 @@ def _test_impl(ctx):
     return 0
 
 remote_executor_tests = task(
-    name = "test-remote-executor",
+    kind = "test-remote-executor",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -161,12 +161,14 @@ def _shell_quote(s):
     return "'" + s.replace("'", "'\\''") + "'"
 
 def task_cli_path(task):
-    """Return the task's CLI invocation path — `<group...> <name>`.
+    """Return the task's CLI invocation path — `<group...> <kind>`.
 
-    Pass `ctx.task` (or anything with `.group: list[str]` and `.name:
+    Uses the task *kind* (the command name), not the per-invocation
+    `--task:name`, so the rendered `aspect <path>` is actually runnable.
+    Pass `ctx.task` (or anything with `.group: list[str]` and `.kind:
     str`) and feed the result to `build_aspect_command`.
     """
-    return " ".join(list(task.group) + [task.name])
+    return " ".join(list(task.group) + [task.kind])
 
 def explicit_flags(ctx, pairs):
     """Convert `[(arg_name, flag_name), ...]` into the subset of

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands.axl
@@ -40,7 +40,7 @@ commands that faithfully encode the invocation.
 `dedup_and_attribute(entries)` is what status surfaces use to merge
 the per-task lists into a single rolled-up view across tasks: two
 contributions of the same `(command, description)` collapse into one
-row that lists every contributing task_key.
+row that lists every contributing task name.
 
 `apply_repro_fix_hooks` and `dispatch_task_update` live in
 `lib/lifecycle.axl` next to `TaskLifecycleTrait`. The framework runs
@@ -525,15 +525,15 @@ def _join_continued(lines):
     return "\n".join(out)
 
 def dedup_and_attribute(entries):
-    """Collapse `{kind, task_key, command, description}` entries across tasks.
+    """Collapse `{kind, task_name, command, description}` entries across tasks.
 
     Two entries dedup when `(kind, command, description)` matches
     exactly. Commands differing only by target subset stay separate;
     different task kinds (build vs test, lint vs format, …) also stay
     separate even when the literal command is the same. Output
-    preserves first-seen order for both rows and their `task_keys`.
+    preserves first-seen order for both rows and their `task_names`.
 
-    Returns one `{"kind", "command", "description", "task_keys"}` dict
+    Returns one `{"kind", "command", "description", "task_names"}` dict
     per unique `(kind, command, description)` triple. `kind` is the
     empty string when no entry provided one.
     """
@@ -543,7 +543,7 @@ def dedup_and_attribute(entries):
         command = e.get("command", "") or ""
         description = e.get("description", "") or ""
         kind = e.get("kind", "") or ""
-        task_key = e.get("task_key", "") or ""
+        task_name = e.get("task_name", "") or ""
         if not command:
             continue
         k = (kind, command, description)
@@ -552,14 +552,14 @@ def dedup_and_attribute(entries):
                 "kind": kind,
                 "command": command,
                 "description": description,
-                "task_keys": [],
+                "task_names": [],
                 "_seen": {},
             }
             order.append(k)
         slot = by_key[k]
-        if task_key and task_key not in slot["_seen"]:
-            slot["_seen"][task_key] = True
-            slot["task_keys"].append(task_key)
+        if task_name and task_name not in slot["_seen"]:
+            slot["_seen"][task_name] = True
+            slot["task_names"].append(task_name)
 
     out = []
     for k in order:
@@ -568,7 +568,7 @@ def dedup_and_attribute(entries):
             "kind": slot["kind"],
             "command": slot["command"],
             "description": slot["description"],
-            "task_keys": slot["task_keys"],
+            "task_names": slot["task_names"],
         })
     return out
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -586,7 +586,7 @@ def _test_overflow_comments_never_carry_continuation(_ctx):
 
 def _fake_apply_ctx():
     """Build a fake `ctx` with the fields `apply_repro_fix_hooks` reads —
-    just `ctx.task.name` and `ctx.task.group`. Std/env are not touched."""
+    just `ctx.task.kind` and `ctx.task.group`. Std/env are not touched."""
     return struct(task = struct(name = "lint", group = ["aspect"]))
 
 def _fake_lifecycle(handlers):
@@ -1283,7 +1283,7 @@ def _test_impl(ctx):
     return 0
 
 repro_commands_tests = task(
-    name = "test-repro-commands",
+    kind = "test-repro-commands",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -783,7 +783,7 @@ def _test_info_exposes_typed_fields(_ctx):
     def capture(ctx, info):
         seen.append({
             "task_path": info.task_path,
-            "task_name": info.task_name,
+            "task_kind": info.task_kind,
             "kind": info.kind,
             "command_kind": info.command_kind.value,
             "status": info.status,
@@ -810,8 +810,8 @@ def _test_info_exposes_typed_fields(_ctx):
         extras = {"aspects": ["//tools/lint:eslint"]},
     )
     _eq("info: 2 entries seen (1 repro + 1 fix)", len(seen), 2)
-    _eq("info: task_path composed from group+name", seen[0]["task_path"], "aspect lint")
-    _eq("info: task_name", seen[0]["task_name"], "lint")
+    _eq("info: task_path composed from group+kind", seen[0]["task_path"], "aspect lint")
+    _eq("info: task_kind", seen[0]["task_kind"], "lint")
     _eq("info: kind", seen[0]["kind"], "lint_results")
     _eq("info: command_kind for repro", seen[0]["command_kind"], "repro")
     _eq("info: command_kind for fix", seen[1]["command_kind"], "fix")

--- a/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/repro_commands_test.axl
@@ -587,7 +587,7 @@ def _test_overflow_comments_never_carry_continuation(_ctx):
 def _fake_apply_ctx():
     """Build a fake `ctx` with the fields `apply_repro_fix_hooks` reads —
     just `ctx.task.kind` and `ctx.task.group`. Std/env are not touched."""
-    return struct(task = struct(name = "lint", group = ["aspect"]))
+    return struct(task = struct(kind = "lint", group = ["aspect"]))
 
 def _fake_lifecycle(handlers):
     """Build a fake `lifecycle` with the single attribute the helper

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -643,7 +643,7 @@ def _test_impl(ctx):
     return 0
 
 runnable_tests = task(
-    name = "test-runnable",
+    kind = "test-runnable",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history.axl
@@ -5,18 +5,18 @@ historical Rosetta behavior.
 
 File format (line-per-task, opaque to the consumer):
 
-    [<human-readable date>] <task-URL> <task-path> <task-key>\\n
+    [<human-readable date>] <task-URL> <task-path> <task-name>\\n
 
 Vigor reads the file, counts non-empty lines, and prints the latest 10
 verbatim. The date is rendered for humans (no parsing on the read
 side); we still match Rosetta's `new Date().toString()` shape closely
 so a single status check can mix Rosetta-era and AXL-era entries
 without visual jank. The trailing `<task-path>` (colon-separated
-group + name, e.g. `dev:test-runner-job-history`) and `<task-key>`
-fields are AXL-era additions — Rosetta wrote only `[<date>] <URL>`,
-and its reader regex strips the bracket prefix and treats the rest as
-the dedup key, so the extra trailing fields are forwards-compatible
-on both sides.
+group + kind, e.g. `dev:test-runner-job-history`) and `<task-name>`
+(the per-invocation name) fields are AXL-era additions — Rosetta wrote
+only `[<date>] <URL>`, and its reader regex strips the bracket prefix
+and treats the rest as the dedup key, so the extra trailing fields are
+forwards-compatible on both sides.
 
 Plumbing:
 
@@ -34,7 +34,7 @@ whether or not the runner history file write succeeds.
 
 Dedup: skip the append when the post-`] ` portion already appears as
 a line tail in the file. The dedup key is the full
-`<URL> <task-path> <task-key>` triple, so the same (job, task, key)
+`<URL> <task-path> <task-name>` triple, so the same (job, kind, name)
 tuple appearing across multiple aspect-cli invocations on a warm
 runner won't bloat the file. Different tasks on the same job land as
 distinct rows — an improvement over Rosetta's URL-only dedup, which
@@ -50,8 +50,8 @@ load("./ci.axl", "resolve_build_url")
 _HISTORY_PATH_ENV = "ASPECT_WORKFLOWS_RUNNER_JOB_HISTORY_FILE"
 
 def _task_path(ctx):
-    """Colon-separated invocation path: `<group>:<name>`, or just `<name>`
-    when the task has no group. Mirrors the `aspect <group> <name>` CLI
+    """Colon-separated invocation path: `<group>:<kind>`, or just `<kind>`
+    when the task has no group. Mirrors the `aspect <group> <kind>` CLI
     shape (`aspect build` → `build`, `aspect dev test-foo` → `dev:test-foo`).
     """
     groups = ctx.task.group

--- a/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history.axl
@@ -56,8 +56,8 @@ def _task_path(ctx):
     """
     groups = ctx.task.group
     if not groups:
-        return ctx.task.name
-    return ":".join(groups + [ctx.task.name])
+        return ctx.task.kind
+    return ":".join(groups + [ctx.task.kind])
 
 def _format_date(ctx):
     """Human-readable timestamp for the `[<date>]` prefix.
@@ -135,7 +135,7 @@ def append_runner_job_history(ctx):
     if not task_url:
         return False
 
-    dedup_key = "%s %s %s" % (task_url, _task_path(ctx), ctx.task.key)
+    dedup_key = "%s %s %s" % (task_url, _task_path(ctx), ctx.task.name)
     if dedup_key in _existing_dedup_keys(ctx, path):
         return False
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runner_job_history_test.axl
@@ -340,7 +340,7 @@ def _test_impl(ctx):
     return 0
 
 runner_job_history_tests = task(
-    name = "test-runner-job-history",
+    kind = "test-runner-job-history",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/sandbox_recovery_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/sandbox_recovery_test.axl
@@ -192,7 +192,7 @@ def _test_impl(ctx):
     return 0
 
 sandbox_recovery_tests = task(
-    name = "test-sandbox-recovery",
+    kind = "test-sandbox-recovery",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/tar_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tar_test.axl
@@ -45,7 +45,7 @@ def _test_impl(ctx):
     return 0
 
 tar_tests = task(
-    name = "test-tar",
+    kind = "test-tar",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -165,7 +165,8 @@ TipAction = enum("accept", "reject", "replace")
 # + content + policy so the hook can scope and rewrite. Fires on every
 # `add_tip`, including accumulate re-emits.
 TipInfo = record(
-    # Task identity for hooks that scope by task.
+    # Task identity for hooks that scope by task. `task_name` carries the
+    # task *kind* (the command); `task_path` is the joined group + kind.
     task_path = field(str),
     task_name = field(str),
     task_group = field(list[str]),

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -574,8 +574,8 @@ def apply_tip_suggestion_hooks(ctx, tip: dict) -> dict | None:
 
     out = dict(tip)
     info_base = {
-        "task_path": " ".join(list(ctx.task.group) + [ctx.task.name]),
-        "task_name": ctx.task.name,
+        "task_path": " ".join(list(ctx.task.group) + [ctx.task.kind]),
+        "task_name": ctx.task.kind,
         "task_group": list(ctx.task.group),
     }
     for handler in handlers:

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips.axl
@@ -165,10 +165,10 @@ TipAction = enum("accept", "reject", "replace")
 # + content + policy so the hook can scope and rewrite. Fires on every
 # `add_tip`, including accumulate re-emits.
 TipInfo = record(
-    # Task identity for hooks that scope by task. `task_name` carries the
-    # task *kind* (the command); `task_path` is the joined group + kind.
+    # Task identity for hooks that scope by task. `task_kind` is the task
+    # kind (the command); `task_path` is the joined group + kind.
     task_path = field(str),
-    task_name = field(str),
+    task_kind = field(str),
     task_group = field(list[str]),
 
     # The tip about to be stored. For JINJA2 tips `title`/`body` are EMPTY
@@ -477,7 +477,7 @@ def decorate_tip(t):
     """Project a stored tip into the render-shape consumed by the surface
     templates (`TIPS_BLOCK` in `bazel_results.axl`, the `## 💡 Tips` section
     in `feature/github_status_comments.axl`) — single source of truth so both
-    stay aligned. The PR-comment aggregator adds a `task_keys` list for its
+    stay aligned. The PR-comment aggregator adds a `task_names` list for its
     "Surfaced by:" footer."""
     severity = t.get("severity")
     return {
@@ -576,7 +576,7 @@ def apply_tip_suggestion_hooks(ctx, tip: dict) -> dict | None:
     out = dict(tip)
     info_base = {
         "task_path": " ".join(list(ctx.task.group) + [ctx.task.kind]),
-        "task_name": ctx.task.kind,
+        "task_kind": ctx.task.kind,
         "task_group": list(ctx.task.group),
     }
     for handler in handlers:

--- a/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/tips_test.axl
@@ -735,7 +735,7 @@ def _test_impl(ctx):
     return 0
 
 tips_tests = task(
-    name = "test-tips",
+    kind = "test-tips",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/lib/wrapper_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/wrapper_test.axl
@@ -166,7 +166,7 @@ def _test_impl(ctx):
     return 0
 
 wrapper_tests = task(
-    name = "test-wrapper",
+    kind = "test-wrapper",
     group = ["dev"],
     implementation = _test_impl,
     args = {},

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -1308,6 +1308,32 @@ mod tests {
         assert_eq!(dispatch.task_uuid.as_deref(), Some(uuid));
     }
 
+    #[test]
+    fn dispatch_parses_timing_summary() {
+        let t = stub_task("greet", &[], SmallMap::new());
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let root = cmd.build("0.0.0").expect("build ok");
+
+        let parse = |args: &[&str]| {
+            let matches = root.clone().try_get_matches_from(args);
+            matches.map(|m| cmd.dispatch(m).expect("dispatch ok").timing)
+        };
+
+        assert_eq!(
+            parse(&["aspect", "greet", "--task:timing-summary=short"]).unwrap(),
+            TimingMode::Short
+        );
+        // Default flows from the flag's default_value, not Default::default().
+        assert_eq!(parse(&["aspect", "greet"]).unwrap(), TimingMode::Detailed);
+        // Invalid level is rejected by the value parser at parse time.
+        assert!(parse(&["aspect", "greet", "--task:timing-summary=verbose"]).is_err());
+    }
+
     // ── Override merge (no heap path: no overrides applied) ────────────────
 
     #[test]

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -5,7 +5,7 @@
 //! * [`Cmd`] — value-passing input. Holds task & feature trait objects plus
 //!   filesystem context. `build()` produces the Clap [`Command`]. `dispatch()`
 //!   turns parsed [`ArgMatches`] into a [`Dispatch`].
-//! * [`Dispatch`] — carries `task_id`, `task_key`, `task_uuid`, and the parsed
+//! * [`Dispatch`] — carries `task_id`, `task_name`, `task_display_name`, `task_uuid`, and the parsed
 //!   matches. `task_args(...)` and `feature_args(...)` produce the merged
 //!   runtime [`Arguments`] for a given task or feature.
 //!
@@ -61,7 +61,8 @@ pub struct Cmd<'a, 'v> {
 /// Carries the parsed CLI state needed to execute the selected task and its features.
 pub struct Dispatch {
     pub task_id: usize,
-    pub task_key: String,
+    pub task_name: String,
+    pub task_display_name: Option<String>,
     pub task_uuid: Option<String>,
     pub timing: TimingMode,
     matches: ArgMatches,
@@ -101,12 +102,28 @@ impl<'a, 'v> Cmd<'a, 'v> {
                     .help("Print version"),
             )
             .arg(
+                ClapArg::new("task-name")
+                    .long("task-name")
+                    .value_name("NAME")
+                    .global(true)
+                    .value_parser(parse_task_name)
+                    .help("A short name uniquely identifying this task invocation. Allowed characters: A-Za-z0-9, _, -. Useful when the same task runs multiple times in one pipeline (e.g. 'backend', 'frontend'). Defaults to '<kind>-<suffix>' if not set."),
+            )
+            .arg(
+                ClapArg::new("task-display-name")
+                    .long("task-display-name")
+                    .value_name("DISPLAY_NAME")
+                    .global(true)
+                    .help("A human-readable label for this task invocation, shown on status surfaces. Defaults to --task-name."),
+            )
+            .arg(
                 ClapArg::new("task-key")
                     .long("task-key")
                     .value_name("KEY")
                     .global(true)
-                    .value_parser(parse_task_key)
-                    .help("A short key identifying this task invocation. Allowed characters: A-Za-z0-9, _, -. Useful when the same task runs multiple times in one pipeline (e.g. 'backend', 'frontend'). Auto-generated if not set."),
+                    .hide(true)
+                    .value_parser(parse_task_name)
+                    .help("Deprecated alias for --task-name; will be removed in a future release."),
             )
             .arg(
                 ClapArg::new("task-id")
@@ -144,11 +161,31 @@ impl<'a, 'v> Cmd<'a, 'v> {
         let task_id = *leaf
             .get_one::<usize>(TASK_ID_KEY)
             .ok_or(CmdError::NoTaskSelected)?;
-        let task_key = leaf
+        // Resolution order: --task-name wins; the deprecated --task-key is
+        // accepted as an alias and always warns; otherwise the name defaults
+        // to the task kind (the deepest selected subcommand name).
+        let explicit_name = leaf
+            .get_one::<String>("task-name")
+            .filter(|s| !s.is_empty())
+            .cloned();
+        let deprecated_key = leaf
             .get_one::<String>("task-key")
             .filter(|s| !s.is_empty())
-            .cloned()
-            .unwrap_or_else(generate_task_key);
+            .cloned();
+        if deprecated_key.is_some() {
+            eprintln!(
+                "\x1b[1;33mWARNING:\x1b[0m --task-key is deprecated; use --task-name instead. \
+                 --task-key will be removed in a future release."
+            );
+        }
+        let task_name = explicit_name.or(deprecated_key).unwrap_or_else(|| {
+            // Default to `<kind>-<friendly-suffix>` so repeated invocations of
+            // the same kind in one pipeline don't collide. (PR2 will prefer a
+            // detected CI job name over the random suffix.)
+            let kind = leaf_command_name(&matches).unwrap_or_default();
+            format!("{}-{}", kind, generate_name_suffix())
+        });
+        let task_display_name = leaf.get_one::<String>("task-display-name").cloned();
         let task_uuid = leaf.get_one::<String>("task-id").cloned();
         let timing = leaf
             .get_one::<TimingMode>("timing")
@@ -156,7 +193,8 @@ impl<'a, 'v> Cmd<'a, 'v> {
             .unwrap_or_default();
         Ok(Dispatch {
             task_id,
-            task_key,
+            task_name,
+            task_display_name,
             task_uuid,
             timing,
             matches,
@@ -650,17 +688,17 @@ fn task_command(
     feature_blocks: &[FeatureBlock],
     cli_header: &str,
 ) -> Command {
-    let name = task.name();
-    let display_name = task.display_name();
-    let display = if !display_name.is_empty() {
-        display_name
+    let kind = task.kind();
+    let display_kind = task.display_kind();
+    let display = if !display_kind.is_empty() {
+        display_kind
     } else {
-        to_display_name(&name)
+        to_display_name(&kind)
     };
 
     let context_line = format!(
         "\x1b[3m{}\x1b[0m task defined in \x1b[3m{}\x1b[0m",
-        name, label,
+        kind, label,
     );
     let about = if task.summary().is_empty() {
         context_line.clone()
@@ -678,7 +716,7 @@ fn task_command(
         Some(format!("{}\n\n{}", body, context_line))
     };
 
-    let mut cmd = Command::new(name)
+    let mut cmd = Command::new(kind)
         .about(about)
         .display_order(TASK_COMMAND_DISPLAY_ORDER)
         .arg(
@@ -748,7 +786,7 @@ impl Tree {
         let group = task.group().clone();
         if group.len() > MAX_TASK_GROUPS {
             return Err(CmdError::TooManyGroups(
-                task.name(),
+                task.kind(),
                 label.to_owned(),
                 MAX_TASK_GROUPS,
             ));
@@ -756,14 +794,14 @@ impl Tree {
         // A top-level `get` task is unreachable: `main` routes `aspect get` to
         // the credential helper before task parsing. Reject it rather than let
         // it silently never run. Nested under a group it is reachable and fine.
-        if group.is_empty() && task.name() == crate::credential_helper::GET_COMMAND {
+        if group.is_empty() && task.kind() == crate::credential_helper::GET_COMMAND {
             return Err(CmdError::ReservedName(
-                task.name(),
+                task.kind(),
                 label.to_owned(),
                 crate::credential_helper::GET_COMMAND.to_owned(),
             ));
         }
-        self.insert_at(&task.name(), &group[..], &group[..], label, cmd)
+        self.insert_at(&task.kind(), &group[..], &group[..], label, cmd)
     }
 
     fn insert_at(
@@ -887,7 +925,19 @@ fn deepest_subcommand(matches: &ArgMatches) -> Option<&ArgMatches> {
     Some(leaf)
 }
 
-fn parse_task_key(s: &str) -> Result<String, String> {
+/// The deepest selected subcommand's name — the task kind (`build`, `test`, …),
+/// used as the default task name when neither `--task-name` nor `--task-key`
+/// is given.
+fn leaf_command_name(matches: &ArgMatches) -> Option<String> {
+    let (mut name, mut leaf) = matches.subcommand()?;
+    while let Some((next_name, next)) = leaf.subcommand() {
+        name = next_name;
+        leaf = next;
+    }
+    Some(name.to_owned())
+}
+
+fn parse_task_name(s: &str) -> Result<String, String> {
     if s.chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
@@ -898,6 +948,14 @@ fn parse_task_key(s: &str) -> Result<String, String> {
             s
         ))
     }
+}
+
+/// A friendly random suffix (e.g. "fluffy-parakeet") appended to the task kind
+/// to form a default `--task-name`. Falls back to a short UUID fragment.
+fn generate_name_suffix() -> String {
+    names::Generator::with_naming(names::Name::Plain)
+        .next()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()[..8].to_string())
 }
 
 fn parse_task_uuid(s: &str) -> Result<String, String> {
@@ -913,12 +971,6 @@ fn parse_task_uuid(s: &str) -> Result<String, String> {
 
 fn parse_timing_mode(s: &str) -> Result<TimingMode, String> {
     s.parse::<TimingMode>()
-}
-
-fn generate_task_key() -> String {
-    names::Generator::with_naming(names::Name::Plain)
-        .next()
-        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()[..8].to_string())
 }
 
 fn help_text(description: &Option<String>) -> Resettable<StyledStr> {
@@ -966,13 +1018,13 @@ mod tests {
         fn description(&self) -> &String {
             empty_string()
         }
-        fn display_name(&self) -> String {
+        fn display_kind(&self) -> String {
             String::new()
         }
         fn group(&self) -> &Vec<String> {
             &self.group
         }
-        fn name(&self) -> String {
+        fn kind(&self) -> String {
             self.name.clone()
         }
         fn path(&self) -> &PathBuf {
@@ -1144,16 +1196,16 @@ mod tests {
         };
         let root = cmd.build("0.0.0").expect("build ok");
         let matches = root
-            .try_get_matches_from(["aspect", "greet", "--task-key=smoke"])
+            .try_get_matches_from(["aspect", "greet", "--task-name=smoke"])
             .expect("parse ok");
         let dispatch = cmd.dispatch(matches).expect("dispatch ok");
         assert_eq!(dispatch.task_id, 0);
-        assert_eq!(dispatch.task_key, "smoke");
+        assert_eq!(dispatch.task_name, "smoke");
         assert!(dispatch.task_uuid.is_none());
     }
 
     #[test]
-    fn dispatch_auto_generates_task_key_when_absent() {
+    fn dispatch_defaults_task_name_to_kind_with_suffix_when_absent() {
         let t = stub_task("greet", &[], SmallMap::new());
         let cmd = Cmd {
             tasks: vec![&t],
@@ -1166,7 +1218,30 @@ mod tests {
             .try_get_matches_from(["aspect", "greet"])
             .expect("parse ok");
         let dispatch = cmd.dispatch(matches).expect("dispatch ok");
-        assert!(!dispatch.task_key.is_empty());
+        // Auto-named as `<kind>-<suffix>`; the suffix is random so assert the prefix.
+        assert!(
+            dispatch.task_name.starts_with("greet-"),
+            "expected greet-<suffix>, got {}",
+            dispatch.task_name
+        );
+        assert!(dispatch.task_name.len() > "greet-".len());
+    }
+
+    #[test]
+    fn dispatch_accepts_deprecated_task_key() {
+        let t = stub_task("greet", &[], SmallMap::new());
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let root = cmd.build("0.0.0").expect("build ok");
+        let matches = root
+            .try_get_matches_from(["aspect", "greet", "--task-key=legacy"])
+            .expect("parse ok");
+        let dispatch = cmd.dispatch(matches).expect("dispatch ok");
+        assert_eq!(dispatch.task_name, "legacy");
     }
 
     // ── Override merge (no heap path: no overrides applied) ────────────────

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -5,7 +5,7 @@
 //! * [`Cmd`] — value-passing input. Holds task & feature trait objects plus
 //!   filesystem context. `build()` produces the Clap [`Command`]. `dispatch()`
 //!   turns parsed [`ArgMatches`] into a [`Dispatch`].
-//! * [`Dispatch`] — carries `task_id`, `task_name`, `task_display_name`, `task_uuid`, and the parsed
+//! * [`Dispatch`] — carries `task_id`, `task_name`, `task_friendly_name`, `task_uuid`, and the parsed
 //!   matches. `task_args(...)` and `feature_args(...)` produce the merged
 //!   runtime [`Arguments`] for a given task or feature.
 //!
@@ -62,7 +62,7 @@ pub struct Cmd<'a, 'v> {
 pub struct Dispatch {
     pub task_id: usize,
     pub task_name: String,
-    pub task_display_name: Option<String>,
+    pub task_friendly_name: Option<String>,
     pub task_uuid: Option<String>,
     pub timing: TimingMode,
     matches: ArgMatches,
@@ -102,19 +102,19 @@ impl<'a, 'v> Cmd<'a, 'v> {
                     .help("Print version"),
             )
             .arg(
-                ClapArg::new("task-name")
-                    .long("task-name")
+                ClapArg::new("task:name")
+                    .long("task:name")
                     .value_name("NAME")
                     .global(true)
                     .value_parser(parse_task_name)
                     .help("A short name uniquely identifying this task invocation. Allowed characters: A-Za-z0-9, _, -. Useful when the same task runs multiple times in one pipeline (e.g. 'backend', 'frontend'). Defaults to '<kind>-<suffix>' if not set."),
             )
             .arg(
-                ClapArg::new("task-display-name")
-                    .long("task-display-name")
-                    .value_name("DISPLAY_NAME")
+                ClapArg::new("task:friendly-name")
+                    .long("task:friendly-name")
+                    .value_name("FRIENDLY_NAME")
                     .global(true)
-                    .help("A human-readable label for this task invocation, shown on status surfaces. Defaults to --task-name."),
+                    .help("A human-readable label for this task invocation, shown on status surfaces. Defaults to --task:name."),
             )
             .arg(
                 ClapArg::new("task-key")
@@ -123,24 +123,24 @@ impl<'a, 'v> Cmd<'a, 'v> {
                     .global(true)
                     .hide(true)
                     .value_parser(parse_task_name)
-                    .help("Deprecated alias for --task-name; will be removed in a future release."),
+                    .help("Deprecated alias for --task:name; will be removed in a future release."),
             )
             .arg(
-                ClapArg::new("task-id")
-                    .long("task-id")
+                ClapArg::new("task:id")
+                    .long("task:id")
                     .value_name("UUID")
                     .global(true)
                     .value_parser(parse_task_uuid)
                     .help("A UUID uniquely identifying this task invocation. Auto-generated if not set."),
             )
             .arg(
-                ClapArg::new("timing")
-                    .long("timing")
+                ClapArg::new("task:timing-summary")
+                    .long("task:timing-summary")
                     .value_name("LEVEL")
                     .global(true)
                     .value_parser(parse_timing_mode)
                     .default_value("detailed")
-                    .help("Verbosity of the phase-timing breakdown trailing the task completion line: 'total' (no breakdown — total only), 'summary' (inline phases), or 'detailed' (multi-line with descriptions; default). Tasks that don't opt into phases see only the total regardless of this setting."),
+                    .help("Verbosity of the phase-timing breakdown trailing the task completion line: 'none' (no timing summary), 'total' (total only), 'short' (inline phases), or 'detailed' (multi-line with descriptions; default). Tasks that don't opt into phases see only the total regardless of this setting."),
             )
             .subcommand(Command::new("version").about("Print version").hide(true))
             .subcommand(
@@ -161,11 +161,11 @@ impl<'a, 'v> Cmd<'a, 'v> {
         let task_id = *leaf
             .get_one::<usize>(TASK_ID_KEY)
             .ok_or(CmdError::NoTaskSelected)?;
-        // Resolution order: --task-name wins; the deprecated --task-key is
+        // Resolution order: --task:name wins; the deprecated --task-key is
         // accepted as an alias and always warns; otherwise the name defaults
         // to the task kind (the deepest selected subcommand name).
         let explicit_name = leaf
-            .get_one::<String>("task-name")
+            .get_one::<String>("task:name")
             .filter(|s| !s.is_empty())
             .cloned();
         let deprecated_key = leaf
@@ -174,7 +174,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
             .cloned();
         if deprecated_key.is_some() {
             eprintln!(
-                "\x1b[1;33mWARNING:\x1b[0m --task-key is deprecated; use --task-name instead. \
+                "\x1b[1;33mWARNING:\x1b[0m --task-key is deprecated; use --task:name instead. \
                  --task-key will be removed in a future release."
             );
         }
@@ -185,16 +185,16 @@ impl<'a, 'v> Cmd<'a, 'v> {
             let kind = leaf_command_name(&matches).unwrap_or_default();
             format!("{}-{}", kind, generate_name_suffix())
         });
-        let task_display_name = leaf.get_one::<String>("task-display-name").cloned();
-        let task_uuid = leaf.get_one::<String>("task-id").cloned();
+        let task_friendly_name = leaf.get_one::<String>("task:friendly-name").cloned();
+        let task_uuid = leaf.get_one::<String>("task:id").cloned();
         let timing = leaf
-            .get_one::<TimingMode>("timing")
+            .get_one::<TimingMode>("task:timing-summary")
             .copied()
             .unwrap_or_default();
         Ok(Dispatch {
             task_id,
             task_name,
-            task_display_name,
+            task_friendly_name,
             task_uuid,
             timing,
             matches,
@@ -689,9 +689,9 @@ fn task_command(
     cli_header: &str,
 ) -> Command {
     let kind = task.kind();
-    let display_kind = task.display_kind();
-    let display = if !display_kind.is_empty() {
-        display_kind
+    let friendly_kind = task.friendly_kind();
+    let display = if !friendly_kind.is_empty() {
+        friendly_kind
     } else {
         to_display_name(&kind)
     };
@@ -926,7 +926,7 @@ fn deepest_subcommand(matches: &ArgMatches) -> Option<&ArgMatches> {
 }
 
 /// The deepest selected subcommand's name — the task kind (`build`, `test`, …),
-/// used as the default task name when neither `--task-name` nor `--task-key`
+/// used as the default task name when neither `--task:name` nor `--task-key`
 /// is given.
 fn leaf_command_name(matches: &ArgMatches) -> Option<String> {
     let (mut name, mut leaf) = matches.subcommand()?;
@@ -951,7 +951,7 @@ fn parse_task_name(s: &str) -> Result<String, String> {
 }
 
 /// A friendly random suffix (e.g. "fluffy-parakeet") appended to the task kind
-/// to form a default `--task-name`. Falls back to a short UUID fragment.
+/// to form a default `--task:name`. Falls back to a short UUID fragment.
 fn generate_name_suffix() -> String {
     names::Generator::with_naming(names::Name::Plain)
         .next()
@@ -1018,7 +1018,7 @@ mod tests {
         fn description(&self) -> &String {
             empty_string()
         }
-        fn display_kind(&self) -> String {
+        fn friendly_kind(&self) -> String {
             String::new()
         }
         fn group(&self) -> &Vec<String> {
@@ -1196,7 +1196,7 @@ mod tests {
         };
         let root = cmd.build("0.0.0").expect("build ok");
         let matches = root
-            .try_get_matches_from(["aspect", "greet", "--task-name=smoke"])
+            .try_get_matches_from(["aspect", "greet", "--task:name=smoke"])
             .expect("parse ok");
         let dispatch = cmd.dispatch(matches).expect("dispatch ok");
         assert_eq!(dispatch.task_id, 0);

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -1244,6 +1244,70 @@ mod tests {
         assert_eq!(dispatch.task_name, "legacy");
     }
 
+    #[test]
+    fn dispatch_task_name_wins_over_deprecated_task_key() {
+        let t = stub_task("greet", &[], SmallMap::new());
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let root = cmd.build("0.0.0").expect("build ok");
+        let matches = root
+            .try_get_matches_from(["aspect", "greet", "--task:name=winner", "--task-key=loser"])
+            .expect("parse ok");
+        let dispatch = cmd.dispatch(matches).expect("dispatch ok");
+        assert_eq!(dispatch.task_name, "winner");
+    }
+
+    #[test]
+    fn dispatch_extracts_friendly_name() {
+        let t = stub_task("greet", &[], SmallMap::new());
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let root = cmd.build("0.0.0").expect("build ok");
+        let with = root
+            .clone()
+            .try_get_matches_from(["aspect", "greet", "--task:friendly-name=My Build"])
+            .expect("parse ok");
+        assert_eq!(
+            cmd.dispatch(with).expect("dispatch ok").task_friendly_name,
+            Some("My Build".to_owned())
+        );
+        let without = root
+            .try_get_matches_from(["aspect", "greet"])
+            .expect("parse ok");
+        assert!(
+            cmd.dispatch(without)
+                .expect("dispatch ok")
+                .task_friendly_name
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn dispatch_extracts_task_uuid() {
+        let t = stub_task("greet", &[], SmallMap::new());
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let uuid = "12345678-1234-1234-1234-123456789abc";
+        let root = cmd.build("0.0.0").expect("build ok");
+        let matches = root
+            .try_get_matches_from(["aspect", "greet", "--task:id", uuid])
+            .expect("parse ok");
+        let dispatch = cmd.dispatch(matches).expect("dispatch ok");
+        assert_eq!(dispatch.task_uuid.as_deref(), Some(uuid));
+    }
+
     // ── Override merge (no heap path: no overrides applied) ────────────────
 
     #[test]

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -186,7 +186,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                 .execute_tasks_with_args(
                     dispatch.task_id,
                     dispatch.task_name.clone(),
-                    dispatch.task_display_name.clone(),
+                    dispatch.task_friendly_name.clone(),
                     dispatch.task_uuid.clone(),
                     dispatch.timing,
                     |t, h| dispatch.task_args(t, h),

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -166,7 +166,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
             // implementations run so any diagnostic output from feature
             // initialization (auth WARNINGs, tip blocks, etc.) is
             // framed by the header.
-            mpe.print_running_task_header(dispatch.task_id, &dispatch.task_key)
+            mpe.print_running_task_header(dispatch.task_id, &dispatch.task_name)
                 .map_err(anyhow::Error::from)?;
 
             // Phase 3: run enabled feature impls.
@@ -185,7 +185,8 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
             let exit = mpe
                 .execute_tasks_with_args(
                     dispatch.task_id,
-                    dispatch.task_key.clone(),
+                    dispatch.task_name.clone(),
+                    dispatch.task_display_name.clone(),
                     dispatch.task_uuid.clone(),
                     dispatch.timing,
                     |t, h| dispatch.task_args(t, h),

--- a/crates/axl-runtime/src/engine/names.rs
+++ b/crates/axl-runtime/src/engine/names.rs
@@ -232,9 +232,22 @@ mod tests {
     //! End-to-end checks that task(), feature(), and trait() naming validation
     //! fires through the AXL eval stack.
     use crate::axl_check;
+    use crate::engine::names::to_display_name;
 
     fn eval(code: &str) -> Result<(), String> {
         axl_check!(code).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn to_display_name_title_cases_every_word() {
+        // The default for `ctx.task.friendly_kind` (Title-Cased kind).
+        assert_eq!(to_display_name("axl"), "Axl");
+        assert_eq!(to_display_name("bazel_query"), "Bazel Query");
+        assert_eq!(
+            to_display_name("github-status-checks"),
+            "Github Status Checks"
+        );
+        assert_eq!(to_display_name(""), "");
     }
 
     fn eval_err(code: &str) -> String {

--- a/crates/axl-runtime/src/engine/names.rs
+++ b/crates/axl-runtime/src/engine/names.rs
@@ -256,12 +256,12 @@ ValidFeature = feature(implementation = _impl)
 "#;
 
     #[test]
-    fn task_valid_explicit_name() {
+    fn task_valid_explicit_kind() {
         assert!(
             eval(
                 r#"
 def _impl(ctx): pass
-T = task(implementation = _impl, args = {}, name = "my-task")
+T = task(implementation = _impl, args = {}, kind = "my-task")
 "#
             )
             .is_ok()
@@ -269,11 +269,11 @@ T = task(implementation = _impl, args = {}, name = "my-task")
     }
 
     #[test]
-    fn task_name_underscore_rejected() {
+    fn task_kind_underscore_rejected() {
         let err = eval_err(
             r#"
 def _impl(ctx): pass
-T = task(implementation = _impl, args = {}, name = "bad_name")
+T = task(implementation = _impl, args = {}, kind = "bad_name")
 "#,
         );
         assert!(
@@ -284,11 +284,11 @@ T = task(implementation = _impl, args = {}, name = "bad_name")
     }
 
     #[test]
-    fn task_name_uppercase_rejected() {
+    fn task_kind_uppercase_rejected() {
         let err = eval_err(
             r#"
 def _impl(ctx): pass
-T = task(implementation = _impl, args = {}, name = "BadName")
+T = task(implementation = _impl, args = {}, kind = "BadName")
 "#,
         );
         assert!(
@@ -299,11 +299,11 @@ T = task(implementation = _impl, args = {}, name = "BadName")
     }
 
     #[test]
-    fn task_name_leading_digit_rejected() {
+    fn task_kind_leading_digit_rejected() {
         let err = eval_err(
             r#"
 def _impl(ctx): pass
-T = task(implementation = _impl, args = {}, name = "1task")
+T = task(implementation = _impl, args = {}, kind = "1task")
 "#,
         );
         assert!(

--- a/crates/axl-runtime/src/engine/task.rs
+++ b/crates/axl-runtime/src/engine/task.rs
@@ -43,9 +43,9 @@ pub trait TaskLike<'v> {
     fn summary(&self) -> &String;
     /// Extended description shown only in `--help`, after the summary. Empty means omit.
     fn description(&self) -> &String;
-    /// The task kind's display label (Title-Cased kind, or the `display_kind=`
+    /// The task kind's display label (Title-Cased kind, or the `friendly_kind=`
     /// kwarg). Distinct from the per-invocation display name set at runtime.
-    fn display_kind(&self) -> String;
+    fn friendly_kind(&self) -> String;
     fn group(&self) -> &Vec<String>;
     /// The task kind — the command being run (e.g. `build`, `test`, `lint`),
     /// derived from the snake_case export variable (or the `kind=` kwarg).
@@ -132,7 +132,7 @@ pub struct Task<'v> {
     pub(super) args: SmallMap<String, Arg>,
     pub(super) summary: String,
     pub(super) description: String,
-    pub(super) display_kind: RefCell<String>,
+    pub(super) friendly_kind: RefCell<String>,
     pub(super) group: Vec<String>,
     pub(super) kind: RefCell<String>,
     pub(super) traits: Vec<values::Value<'v>>,
@@ -155,8 +155,8 @@ impl<'v> Task<'v> {
     pub fn description(&self) -> &String {
         &self.description
     }
-    pub fn display_kind(&self) -> String {
-        self.display_kind.borrow().clone()
+    pub fn friendly_kind(&self) -> String {
+        self.friendly_kind.borrow().clone()
     }
     pub fn group(&self) -> &Vec<String> {
         &self.group
@@ -199,7 +199,7 @@ impl<'v> Task<'v> {
             args: frozen.args.clone(),
             summary: frozen.summary.clone(),
             description: frozen.description.clone(),
-            display_kind: RefCell::new(frozen.display_kind.clone()),
+            friendly_kind: RefCell::new(frozen.friendly_kind.clone()),
             group: frozen.group.clone(),
             kind: RefCell::new(frozen.kind.clone()),
             traits,
@@ -219,8 +219,8 @@ impl<'v> TaskLike<'v> for Task<'v> {
     fn description(&self) -> &String {
         &self.description
     }
-    fn display_kind(&self) -> String {
-        self.display_kind.borrow().clone()
+    fn friendly_kind(&self) -> String {
+        self.friendly_kind.borrow().clone()
     }
     fn group(&self) -> &Vec<String> {
         &self.group
@@ -259,9 +259,9 @@ impl<'v> StarlarkValue<'v> for Task<'v> {
         if kind.is_empty() {
             *kind = kebab;
         }
-        let mut display_kind = self.display_kind.borrow_mut();
-        if display_kind.is_empty() {
-            *display_kind = to_display_name(&kind);
+        let mut friendly_kind = self.friendly_kind.borrow_mut();
+        if friendly_kind.is_empty() {
+            *friendly_kind = to_display_name(&kind);
         }
         Ok(())
     }
@@ -304,7 +304,7 @@ impl<'v> values::Freeze for Task<'v> {
             r#impl: frozen_impl,
             summary: self.summary,
             description: self.description,
-            display_kind: self.display_kind.into_inner(),
+            friendly_kind: self.friendly_kind.into_inner(),
             group: self.group,
             kind: self.kind.into_inner(),
             traits: frozen_traits?,
@@ -322,7 +322,7 @@ pub struct FrozenTask {
     pub(super) args: SmallMap<String, Arg>,
     pub(super) summary: String,
     pub(super) description: String,
-    pub(super) display_kind: String,
+    pub(super) friendly_kind: String,
     pub(super) group: Vec<String>,
     pub(super) kind: String,
     pub(super) traits: Vec<values::FrozenValue>,
@@ -377,8 +377,8 @@ impl<'v> TaskLike<'v> for FrozenTask {
     fn description(&self) -> &String {
         &self.description
     }
-    fn display_kind(&self) -> String {
-        self.display_kind.clone()
+    fn friendly_kind(&self) -> String {
+        self.friendly_kind.clone()
     }
     fn group(&self) -> &Vec<String> {
         &self.group
@@ -415,14 +415,14 @@ impl StarlarkCallableParamSpec for TaskImpl {
     }
 }
 
-/// Validate `kind`/`group` and resolve `display_kind` per the rules shared by
+/// Validate `kind`/`group` and resolve `friendly_kind` per the rules shared by
 /// `task()` and `task.alias(...)`.
 ///
 /// - `group` length is capped at `MAX_TASK_GROUPS`.
 /// - `kind`, when non-empty, must match `[a-z][a-z0-9-]*`. An empty `kind`
 ///   defers naming to `export_as` (which fills from the variable name).
 /// - Each `group` element must match the same pattern as `kind`.
-/// - The returned `display_kind` is `display_kind` verbatim if non-empty,
+/// - The returned `friendly_kind` is `friendly_kind` verbatim if non-empty,
 ///   then a Title-Case derivation of `kind` if `kind` is non-empty, else
 ///   empty (deferred until `export_as` populates `kind`).
 ///
@@ -432,7 +432,7 @@ fn resolve_task_metadata(
     context: &str,
     kind: &str,
     group: &[String],
-    display_kind: String,
+    friendly_kind: String,
 ) -> anyhow::Result<String> {
     if group.len() > MAX_TASK_GROUPS {
         return Err(anyhow::anyhow!(
@@ -447,8 +447,8 @@ fn resolve_task_metadata(
     for g in group {
         validate_command_name(g, "group").map_err(|e| anyhow::anyhow!(e))?;
     }
-    Ok(if !display_kind.is_empty() {
-        display_kind
+    Ok(if !friendly_kind.is_empty() {
+        friendly_kind
     } else if !kind.is_empty() {
         to_display_name(kind)
     } else {
@@ -458,7 +458,7 @@ fn resolve_task_metadata(
 
 /// Build a fresh `Task<'v>` that aliases `base`. The alias shares the base's
 /// `implementation` callable and `traits` vector and inherits nothing else —
-/// `name`, `group`, `summary`, `description`, and `display_kind` come from
+/// `name`, `group`, `summary`, `description`, and `friendly_kind` come from
 /// the alias's own kwargs. An empty `name` defers naming to `export_as`.
 ///
 /// `defaults` may overlay new defaults onto any arg present on `base`; see
@@ -468,12 +468,12 @@ fn build_alias<'v>(
     defaults: UnpackDictEntries<String, Value<'v>>,
     summary: String,
     description: String,
-    display_kind: String,
+    friendly_kind: String,
     group: Vec<String>,
     kind: String,
     eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
 ) -> anyhow::Result<Task<'v>> {
-    let display_kind = resolve_task_metadata("task.alias", &kind, &group, display_kind)?;
+    let friendly_kind = resolve_task_metadata("task.alias", &kind, &group, friendly_kind)?;
 
     let mut overlaid = base.args().clone();
     for (k, v) in defaults.entries {
@@ -508,7 +508,7 @@ fn build_alias<'v>(
         r#impl: base.implementation(),
         summary,
         description,
-        display_kind: RefCell::new(display_kind),
+        friendly_kind: RefCell::new(friendly_kind),
         group,
         kind: RefCell::new(kind),
         traits: base.trait_values(),
@@ -564,7 +564,7 @@ fn task_methods(builder: &mut MethodsBuilder) {
         defaults: UnpackDictEntries<String, Value<'v>>,
         #[starlark(require = named, default = String::new())] summary: String,
         #[starlark(require = named, default = String::new())] description: String,
-        #[starlark(require = named, default = String::new())] display_kind: String,
+        #[starlark(require = named, default = String::new())] friendly_kind: String,
         #[starlark(require = named, default = UnpackList::default())] group: UnpackList<String>,
         #[starlark(require = named, default = String::new())] kind: String,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
@@ -580,7 +580,7 @@ fn task_methods(builder: &mut MethodsBuilder) {
             defaults,
             summary,
             description,
-            display_kind,
+            friendly_kind,
             group.items,
             kind,
             eval,
@@ -618,7 +618,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
     ///
     /// - `summary` — one-liner shown in the task list; falls back to `"<name> task defined in <file>"`.
     /// - `description` — extended prose shown in `--help` (replaces summary in that view).
-    /// - `display_kind` — Title Case label for help section headings; auto-derived from the kind.
+    /// - `friendly_kind` — Title Case label for help section headings; auto-derived from the kind.
     ///
     /// ## Aliases
     ///
@@ -653,13 +653,13 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         args: values::dict::UnpackDictEntries<String, Value<'v>>,
         #[starlark(require = named, default = String::new())] summary: String,
         #[starlark(require = named, default = String::new())] description: String,
-        #[starlark(require = named, default = String::new())] display_kind: String,
+        #[starlark(require = named, default = String::new())] friendly_kind: String,
         #[starlark(require = named, default = UnpackList::default())] group: UnpackList<String>,
         #[starlark(require = named, default = String::new())] kind: String,
         #[starlark(require = named, default = UnpackList::default())] traits: UnpackList<Value<'v>>,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<Task<'v>> {
-        let display_kind = resolve_task_metadata("task", &kind, &group.items, display_kind)?;
+        let friendly_kind = resolve_task_metadata("task", &kind, &group.items, friendly_kind)?;
 
         // Parse and validate args.
         let mut args_ = SmallMap::new();
@@ -705,7 +705,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             r#impl: implementation.0,
             summary,
             description,
-            display_kind: RefCell::new(display_kind),
+            friendly_kind: RefCell::new(friendly_kind),
             group: group.items,
             kind: RefCell::new(kind),
             traits: all_traits,

--- a/crates/axl-runtime/src/engine/task.rs
+++ b/crates/axl-runtime/src/engine/task.rs
@@ -458,8 +458,8 @@ fn resolve_task_metadata(
 
 /// Build a fresh `Task<'v>` that aliases `base`. The alias shares the base's
 /// `implementation` callable and `traits` vector and inherits nothing else —
-/// `name`, `group`, `summary`, `description`, and `friendly_kind` come from
-/// the alias's own kwargs. An empty `name` defers naming to `export_as`.
+/// `kind`, `group`, `summary`, `description`, and `friendly_kind` come from
+/// the alias's own kwargs. An empty `kind` defers naming to `export_as`.
 ///
 /// `defaults` may overlay new defaults onto any arg present on `base`; see
 /// `Arg::with_default` for the per-variant validation rules.
@@ -599,7 +599,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
     /// (`axl_add` → `axl-add`). Use `kind = "explicit-kind"` to override it.
     /// Kinds must match `[a-z][a-z0-9-]*`. (The per-invocation task *name* — the
     /// unique identity of one run — is a separate concept set at runtime via
-    /// `--task-name`; see `ctx.task`.)
+    /// `--task:name`; see `ctx.task`.)
     ///
     /// ## Args
     ///

--- a/crates/axl-runtime/src/engine/task.rs
+++ b/crates/axl-runtime/src/engine/task.rs
@@ -43,9 +43,13 @@ pub trait TaskLike<'v> {
     fn summary(&self) -> &String;
     /// Extended description shown only in `--help`, after the summary. Empty means omit.
     fn description(&self) -> &String;
-    fn display_name(&self) -> String;
+    /// The task kind's display label (Title-Cased kind, or the `display_kind=`
+    /// kwarg). Distinct from the per-invocation display name set at runtime.
+    fn display_kind(&self) -> String;
     fn group(&self) -> &Vec<String>;
-    fn name(&self) -> String;
+    /// The task kind — the command being run (e.g. `build`, `test`, `lint`),
+    /// derived from the snake_case export variable (or the `kind=` kwarg).
+    fn kind(&self) -> String;
     /// Absolute path to the .axl file the task was defined in.
     fn path(&self) -> &PathBuf;
     /// `Arguments` value carrying config.axl overrides for this task.
@@ -128,9 +132,9 @@ pub struct Task<'v> {
     pub(super) args: SmallMap<String, Arg>,
     pub(super) summary: String,
     pub(super) description: String,
-    pub(super) display_name: RefCell<String>,
+    pub(super) display_kind: RefCell<String>,
     pub(super) group: Vec<String>,
-    pub(super) name: RefCell<String>,
+    pub(super) kind: RefCell<String>,
     pub(super) traits: Vec<values::Value<'v>>,
     pub(super) path: PathBuf,
     /// Mutable override store for `ctx.tasks["k"].args.foo = ...`.
@@ -151,14 +155,14 @@ impl<'v> Task<'v> {
     pub fn description(&self) -> &String {
         &self.description
     }
-    pub fn display_name(&self) -> String {
-        self.display_name.borrow().clone()
+    pub fn display_kind(&self) -> String {
+        self.display_kind.borrow().clone()
     }
     pub fn group(&self) -> &Vec<String> {
         &self.group
     }
-    pub fn name(&self) -> String {
-        self.name.borrow().clone()
+    pub fn kind(&self) -> String {
+        self.kind.borrow().clone()
     }
     pub fn traits(&self) -> &[values::Value<'v>] {
         &self.traits
@@ -195,9 +199,9 @@ impl<'v> Task<'v> {
             args: frozen.args.clone(),
             summary: frozen.summary.clone(),
             description: frozen.description.clone(),
-            display_name: RefCell::new(frozen.display_name.clone()),
+            display_kind: RefCell::new(frozen.display_kind.clone()),
             group: frozen.group.clone(),
-            name: RefCell::new(frozen.name.clone()),
+            kind: RefCell::new(frozen.kind.clone()),
             traits,
             path: frozen.path.clone(),
             overrides,
@@ -215,14 +219,14 @@ impl<'v> TaskLike<'v> for Task<'v> {
     fn description(&self) -> &String {
         &self.description
     }
-    fn display_name(&self) -> String {
-        self.display_name.borrow().clone()
+    fn display_kind(&self) -> String {
+        self.display_kind.borrow().clone()
     }
     fn group(&self) -> &Vec<String> {
         &self.group
     }
-    fn name(&self) -> String {
-        self.name.borrow().clone()
+    fn kind(&self) -> String {
+        self.kind.borrow().clone()
     }
     fn path(&self) -> &PathBuf {
         &self.path
@@ -251,13 +255,13 @@ impl<'v> StarlarkValue<'v> for Task<'v> {
         let kebab = to_command_name(variable_name);
         validate_command_name(&kebab, "task")
             .map_err(|e| starlark::Error::new_other(anyhow::anyhow!(e)))?;
-        let mut name = self.name.borrow_mut();
-        if name.is_empty() {
-            *name = kebab;
+        let mut kind = self.kind.borrow_mut();
+        if kind.is_empty() {
+            *kind = kebab;
         }
-        let mut display_name = self.display_name.borrow_mut();
-        if display_name.is_empty() {
-            *display_name = to_display_name(&name);
+        let mut display_kind = self.display_kind.borrow_mut();
+        if display_kind.is_empty() {
+            *display_kind = to_display_name(&kind);
         }
         Ok(())
     }
@@ -300,9 +304,9 @@ impl<'v> values::Freeze for Task<'v> {
             r#impl: frozen_impl,
             summary: self.summary,
             description: self.description,
-            display_name: self.display_name.into_inner(),
+            display_kind: self.display_kind.into_inner(),
             group: self.group,
-            name: self.name.into_inner(),
+            kind: self.kind.into_inner(),
             traits: frozen_traits?,
             path: self.path,
             overrides: self.overrides.freeze(freezer)?,
@@ -318,9 +322,9 @@ pub struct FrozenTask {
     pub(super) args: SmallMap<String, Arg>,
     pub(super) summary: String,
     pub(super) description: String,
-    pub(super) display_name: String,
+    pub(super) display_kind: String,
     pub(super) group: Vec<String>,
-    pub(super) name: String,
+    pub(super) kind: String,
     pub(super) traits: Vec<values::FrozenValue>,
     pub(super) path: PathBuf,
     pub(super) overrides: values::FrozenValue,
@@ -373,14 +377,14 @@ impl<'v> TaskLike<'v> for FrozenTask {
     fn description(&self) -> &String {
         &self.description
     }
-    fn display_name(&self) -> String {
-        self.display_name.clone()
+    fn display_kind(&self) -> String {
+        self.display_kind.clone()
     }
     fn group(&self) -> &Vec<String> {
         &self.group
     }
-    fn name(&self) -> String {
-        self.name.clone()
+    fn kind(&self) -> String {
+        self.kind.clone()
     }
     fn path(&self) -> &PathBuf {
         &self.path
@@ -411,24 +415,24 @@ impl StarlarkCallableParamSpec for TaskImpl {
     }
 }
 
-/// Validate `name`/`group` and resolve `display_name` per the rules shared by
+/// Validate `kind`/`group` and resolve `display_kind` per the rules shared by
 /// `task()` and `task.alias(...)`.
 ///
 /// - `group` length is capped at `MAX_TASK_GROUPS`.
-/// - `name`, when non-empty, must match `[a-z][a-z0-9-]*`. An empty `name`
+/// - `kind`, when non-empty, must match `[a-z][a-z0-9-]*`. An empty `kind`
 ///   defers naming to `export_as` (which fills from the variable name).
-/// - Each `group` element must match the same pattern as `name`.
-/// - The returned `display_name` is `display_name` verbatim if non-empty,
-///   then a Title-Case derivation of `name` if `name` is non-empty, else
-///   empty (deferred until `export_as` populates `name`).
+/// - Each `group` element must match the same pattern as `kind`.
+/// - The returned `display_kind` is `display_kind` verbatim if non-empty,
+///   then a Title-Case derivation of `kind` if `kind` is non-empty, else
+///   empty (deferred until `export_as` populates `kind`).
 ///
 /// `context` is the user-facing identifier used in error messages — typically
 /// `"task"` or `"task.alias"`.
 fn resolve_task_metadata(
     context: &str,
-    name: &str,
+    kind: &str,
     group: &[String],
-    display_name: String,
+    display_kind: String,
 ) -> anyhow::Result<String> {
     if group.len() > MAX_TASK_GROUPS {
         return Err(anyhow::anyhow!(
@@ -437,16 +441,16 @@ fn resolve_task_metadata(
             MAX_TASK_GROUPS,
         ));
     }
-    if !name.is_empty() {
-        validate_command_name(name, context).map_err(|e| anyhow::anyhow!(e))?;
+    if !kind.is_empty() {
+        validate_command_name(kind, context).map_err(|e| anyhow::anyhow!(e))?;
     }
     for g in group {
         validate_command_name(g, "group").map_err(|e| anyhow::anyhow!(e))?;
     }
-    Ok(if !display_name.is_empty() {
-        display_name
-    } else if !name.is_empty() {
-        to_display_name(name)
+    Ok(if !display_kind.is_empty() {
+        display_kind
+    } else if !kind.is_empty() {
+        to_display_name(kind)
     } else {
         String::new()
     })
@@ -454,7 +458,7 @@ fn resolve_task_metadata(
 
 /// Build a fresh `Task<'v>` that aliases `base`. The alias shares the base's
 /// `implementation` callable and `traits` vector and inherits nothing else —
-/// `name`, `group`, `summary`, `description`, and `display_name` come from
+/// `name`, `group`, `summary`, `description`, and `display_kind` come from
 /// the alias's own kwargs. An empty `name` defers naming to `export_as`.
 ///
 /// `defaults` may overlay new defaults onto any arg present on `base`; see
@@ -464,12 +468,12 @@ fn build_alias<'v>(
     defaults: UnpackDictEntries<String, Value<'v>>,
     summary: String,
     description: String,
-    display_name: String,
+    display_kind: String,
     group: Vec<String>,
-    name: String,
+    kind: String,
     eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
 ) -> anyhow::Result<Task<'v>> {
-    let display_name = resolve_task_metadata("task.alias", &name, &group, display_name)?;
+    let display_kind = resolve_task_metadata("task.alias", &kind, &group, display_kind)?;
 
     let mut overlaid = base.args().clone();
     for (k, v) in defaults.entries {
@@ -477,7 +481,7 @@ fn build_alias<'v>(
             return Err(anyhow::anyhow!(
                 "task.alias defaults[{:?}]: no such arg on aliased task `{}`",
                 k,
-                base.name(),
+                base.kind(),
             ));
         };
         let next = existing.with_default(&k, v, eval.heap())?;
@@ -489,7 +493,7 @@ fn build_alias<'v>(
     // `summary` and stays uncluttered. When the user supplied a `summary` but
     // no `description`, seed the description from the summary so the user's
     // text isn't displaced by the hint in the per-task help view.
-    let alias_hint = format!("(alias of `{}`)", base.name());
+    let alias_hint = format!("(alias of `{}`)", base.kind());
     let description = match (description.is_empty(), summary.is_empty()) {
         (true, true) => alias_hint,
         (true, false) => format!("{}\n\n{}", summary, alias_hint),
@@ -504,9 +508,9 @@ fn build_alias<'v>(
         r#impl: base.implementation(),
         summary,
         description,
-        display_name: RefCell::new(display_name),
+        display_kind: RefCell::new(display_kind),
         group,
-        name: RefCell::new(name),
+        kind: RefCell::new(kind),
         traits: base.trait_values(),
         path: Env::current_script_path(eval)?,
         overrides,
@@ -525,9 +529,9 @@ fn task_methods(builder: &mut MethodsBuilder) {
     ///
     /// ## Naming
     ///
-    /// Assign the result to a **snake_case** variable; the CLI command name is
-    /// derived from the variable. The base task's name is never inherited.
-    /// Use `name = "explicit-name"` to override.
+    /// Assign the result to a **snake_case** variable; the task kind (CLI
+    /// command name) is derived from the variable. The base task's kind is
+    /// never inherited. Use `kind = "explicit-kind"` to override.
     ///
     /// ## Constraints
     ///
@@ -560,9 +564,9 @@ fn task_methods(builder: &mut MethodsBuilder) {
         defaults: UnpackDictEntries<String, Value<'v>>,
         #[starlark(require = named, default = String::new())] summary: String,
         #[starlark(require = named, default = String::new())] description: String,
-        #[starlark(require = named, default = String::new())] display_name: String,
+        #[starlark(require = named, default = String::new())] display_kind: String,
         #[starlark(require = named, default = UnpackList::default())] group: UnpackList<String>,
-        #[starlark(require = named, default = String::new())] name: String,
+        #[starlark(require = named, default = String::new())] kind: String,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<Task<'v>> {
         let base = try_as_task(this).ok_or_else(|| {
@@ -576,9 +580,9 @@ fn task_methods(builder: &mut MethodsBuilder) {
             defaults,
             summary,
             description,
-            display_name,
+            display_kind,
             group.items,
-            name,
+            kind,
             eval,
         )
     }
@@ -590,10 +594,12 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
     ///
     /// ## Naming
     ///
-    /// Assign the result to a **snake_case** variable. The CLI command name is derived
-    /// automatically by converting `_` to `-` (`axl_add` → `axl-add`).
-    /// Use `name = "explicit-name"` to override.
-    /// Command names must match `[a-z][a-z0-9-]*`.
+    /// Assign the result to a **snake_case** variable. The task *kind* (the CLI
+    /// command name) is derived automatically by converting `_` to `-`
+    /// (`axl_add` → `axl-add`). Use `kind = "explicit-kind"` to override it.
+    /// Kinds must match `[a-z][a-z0-9-]*`. (The per-invocation task *name* — the
+    /// unique identity of one run — is a separate concept set at runtime via
+    /// `--task-name`; see `ctx.task`.)
     ///
     /// ## Args
     ///
@@ -612,7 +618,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
     ///
     /// - `summary` — one-liner shown in the task list; falls back to `"<name> task defined in <file>"`.
     /// - `description` — extended prose shown in `--help` (replaces summary in that view).
-    /// - `display_name` — Title Case name for help section headings; auto-derived from command name.
+    /// - `display_kind` — Title Case label for help section headings; auto-derived from the kind.
     ///
     /// ## Aliases
     ///
@@ -647,13 +653,13 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         args: values::dict::UnpackDictEntries<String, Value<'v>>,
         #[starlark(require = named, default = String::new())] summary: String,
         #[starlark(require = named, default = String::new())] description: String,
-        #[starlark(require = named, default = String::new())] display_name: String,
+        #[starlark(require = named, default = String::new())] display_kind: String,
         #[starlark(require = named, default = UnpackList::default())] group: UnpackList<String>,
-        #[starlark(require = named, default = String::new())] name: String,
+        #[starlark(require = named, default = String::new())] kind: String,
         #[starlark(require = named, default = UnpackList::default())] traits: UnpackList<Value<'v>>,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<Task<'v>> {
-        let display_name = resolve_task_metadata("task", &name, &group.items, display_name)?;
+        let display_kind = resolve_task_metadata("task", &kind, &group.items, display_kind)?;
 
         // Parse and validate args.
         let mut args_ = SmallMap::new();
@@ -699,9 +705,9 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             r#impl: implementation.0,
             summary,
             description,
-            display_name: RefCell::new(display_name),
+            display_kind: RefCell::new(display_kind),
             group: group.items,
-            name: RefCell::new(name),
+            kind: RefCell::new(kind),
             traits: all_traits,
             path: Env::current_script_path(eval)?,
             overrides,
@@ -898,11 +904,11 @@ buildifier = base.alias(defaults = {"opt": 42})
     }
 
     #[test]
-    fn alias_invalid_name_rejected() {
+    fn alias_invalid_kind_rejected() {
         assert_eval_err_contains(
             r#"
 base = task(implementation = _impl)
-aliased = base.alias(name = "Bad-Name")
+aliased = base.alias(kind = "Bad-Kind")
 "#,
             "task.alias",
         );

--- a/crates/axl-runtime/src/engine/task_info.rs
+++ b/crates/axl-runtime/src/engine/task_info.rs
@@ -290,7 +290,7 @@ impl<'v> StarlarkValue<'v> for TaskInfo {
 #[starlark_module]
 fn task_info_methods(registry: &mut MethodsBuilder) {
     /// The kind of task — the command being run (e.g. `build`, `test`, `lint`).
-    /// Derived from the snake_case export variable (or the `task(name=...)`
+    /// Derived from the snake_case export variable (or the `task(kind=...)`
     /// kwarg). Use `name` for the unique identity of this particular invocation.
     #[starlark(attribute)]
     fn kind<'v>(this: Value<'v>) -> anyhow::Result<String> {

--- a/crates/axl-runtime/src/engine/task_info.rs
+++ b/crates/axl-runtime/src/engine/task_info.rs
@@ -184,8 +184,13 @@ impl TaskPhase {
 
 /// Per-invocation task metadata exposed to AXL as `ctx.task`.
 ///
-/// In addition to identity fields (name, group, key, id), `TaskInfo`
-/// owns the task's timing state and a phase log. AXL marks phase
+/// In addition to identity fields (kind, display_kind, group, name,
+/// display_name, id), `TaskInfo` owns the task's timing state and a phase
+/// log. The `kind` is the command being run (`build`, `test`, …) and
+/// `display_kind` its human label (from `task(display_kind=...)`); the
+/// `name` is the unique identity of *this* invocation (set via
+/// `--task-name`, else auto-named) and `display_name` its human label
+/// (from `--task-display-name`). AXL marks phase
 /// boundaries via `ctx.task.phase(name, description=, emoji=,
 /// display_name=)` (or via the higher-level `task_update(...,
 /// phase=Phase(...))` wrapper in `lib/lifecycle.axl`); the runtime
@@ -197,9 +202,11 @@ impl TaskPhase {
 #[derive(Debug, ProvidesStaticType, Display, NoSerialize, Allocative)]
 #[display("<TaskInfo>")]
 pub struct TaskInfo {
-    pub name: String,
+    pub kind: String,
+    pub display_kind: String,
     pub group: Vec<String>,
-    pub task_key: String,
+    pub name: String,
+    pub display_name: String,
     pub task_id: String,
 
     #[allocative(skip)]
@@ -214,11 +221,20 @@ impl TaskInfo {
     /// Construct a fresh TaskInfo, stamping `started_at` to now. The
     /// `started_at` field is the authoritative bookend for total task
     /// wall time and the "init" phase synthesis on first `phase()` call.
-    pub fn new(name: String, group: Vec<String>, task_key: String, task_id: String) -> Self {
+    pub fn new(
+        kind: String,
+        display_kind: String,
+        group: Vec<String>,
+        name: String,
+        display_name: String,
+        task_id: String,
+    ) -> Self {
         Self {
-            name,
+            kind,
+            display_kind,
             group,
-            task_key,
+            name,
+            display_name,
             task_id,
             started_at: Instant::now(),
             phases: RefCell::new(Vec::new()),
@@ -273,13 +289,46 @@ impl<'v> StarlarkValue<'v> for TaskInfo {
 
 #[starlark_module]
 fn task_info_methods(registry: &mut MethodsBuilder) {
-    /// The name of the task.
+    /// The kind of task — the command being run (e.g. `build`, `test`, `lint`).
+    /// Derived from the snake_case export variable (or the `task(name=...)`
+    /// kwarg). Use `name` for the unique identity of this particular invocation.
+    #[starlark(attribute)]
+    fn kind<'v>(this: Value<'v>) -> anyhow::Result<String> {
+        let info = this
+            .downcast_ref::<TaskInfo>()
+            .ok_or_else(|| anyhow::anyhow!("kind: receiver is not a TaskInfo"))?;
+        Ok(info.kind.clone())
+    }
+
+    /// The human-readable display label for the task kind. Set via
+    /// `task(display_kind=...)`; defaults to a Title-Cased form of `kind`.
+    #[starlark(attribute)]
+    fn display_kind<'v>(this: Value<'v>) -> anyhow::Result<String> {
+        let info = this
+            .downcast_ref::<TaskInfo>()
+            .ok_or_else(|| anyhow::anyhow!("display_kind: receiver is not a TaskInfo"))?;
+        Ok(info.display_kind.clone())
+    }
+
+    /// A short name uniquely identifying this task invocation. Set via
+    /// `--task-name` on the CLI; defaults to `<kind>-<suffix>` so repeated
+    /// invocations of the same kind in one pipeline stay distinct.
     #[starlark(attribute)]
     fn name<'v>(this: Value<'v>) -> anyhow::Result<String> {
         let info = this
             .downcast_ref::<TaskInfo>()
             .ok_or_else(|| anyhow::anyhow!("name: receiver is not a TaskInfo"))?;
         Ok(info.name.clone())
+    }
+
+    /// The human-readable display label for this invocation. Set via
+    /// `--task-display-name`; defaults to `name` verbatim.
+    #[starlark(attribute)]
+    fn display_name<'v>(this: Value<'v>) -> anyhow::Result<String> {
+        let info = this
+            .downcast_ref::<TaskInfo>()
+            .ok_or_else(|| anyhow::anyhow!("display_name: receiver is not a TaskInfo"))?;
+        Ok(info.display_name.clone())
     }
 
     /// The group(s) this task belongs to.
@@ -291,18 +340,8 @@ fn task_info_methods(registry: &mut MethodsBuilder) {
         Ok(info.group.clone())
     }
 
-    /// A short human-readable key identifying this task invocation.
-    /// Set via --task-key on the CLI, or auto-generated as a friendly name (e.g. "fluffy-parakeet").
-    #[starlark(attribute)]
-    fn key<'v>(this: Value<'v>) -> anyhow::Result<String> {
-        let info = this
-            .downcast_ref::<TaskInfo>()
-            .ok_or_else(|| anyhow::anyhow!("key: receiver is not a TaskInfo"))?;
-        Ok(info.task_key.clone())
-    }
-
     /// A globally unique UUID v4 for this task invocation.
-    /// Always auto-generated; use key for a short human-readable discriminator.
+    /// Always auto-generated; use name for a short human-readable discriminator.
     #[starlark(attribute)]
     fn id<'v>(this: Value<'v>) -> anyhow::Result<String> {
         let info = this

--- a/crates/axl-runtime/src/engine/task_info.rs
+++ b/crates/axl-runtime/src/engine/task_info.rs
@@ -184,13 +184,13 @@ impl TaskPhase {
 
 /// Per-invocation task metadata exposed to AXL as `ctx.task`.
 ///
-/// In addition to identity fields (kind, display_kind, group, name,
-/// display_name, id), `TaskInfo` owns the task's timing state and a phase
+/// In addition to identity fields (kind, friendly_kind, group, name,
+/// friendly_name, id), `TaskInfo` owns the task's timing state and a phase
 /// log. The `kind` is the command being run (`build`, `test`, …) and
-/// `display_kind` its human label (from `task(display_kind=...)`); the
+/// `friendly_kind` its human label (from `task(friendly_kind=...)`); the
 /// `name` is the unique identity of *this* invocation (set via
-/// `--task-name`, else auto-named) and `display_name` its human label
-/// (from `--task-display-name`). AXL marks phase
+/// `--task:name`, else auto-named) and `friendly_name` its human label
+/// (from `--task:friendly-name`). AXL marks phase
 /// boundaries via `ctx.task.phase(name, description=, emoji=,
 /// display_name=)` (or via the higher-level `task_update(...,
 /// phase=Phase(...))` wrapper in `lib/lifecycle.axl`); the runtime
@@ -203,10 +203,10 @@ impl TaskPhase {
 #[display("<TaskInfo>")]
 pub struct TaskInfo {
     pub kind: String,
-    pub display_kind: String,
+    pub friendly_kind: String,
     pub group: Vec<String>,
     pub name: String,
-    pub display_name: String,
+    pub friendly_name: String,
     pub task_id: String,
 
     #[allocative(skip)]
@@ -223,18 +223,18 @@ impl TaskInfo {
     /// wall time and the "init" phase synthesis on first `phase()` call.
     pub fn new(
         kind: String,
-        display_kind: String,
+        friendly_kind: String,
         group: Vec<String>,
         name: String,
-        display_name: String,
+        friendly_name: String,
         task_id: String,
     ) -> Self {
         Self {
             kind,
-            display_kind,
+            friendly_kind,
             group,
             name,
-            display_name,
+            friendly_name,
             task_id,
             started_at: Instant::now(),
             phases: RefCell::new(Vec::new()),
@@ -301,17 +301,17 @@ fn task_info_methods(registry: &mut MethodsBuilder) {
     }
 
     /// The human-readable display label for the task kind. Set via
-    /// `task(display_kind=...)`; defaults to a Title-Cased form of `kind`.
+    /// `task(friendly_kind=...)`; defaults to a Title-Cased form of `kind`.
     #[starlark(attribute)]
-    fn display_kind<'v>(this: Value<'v>) -> anyhow::Result<String> {
+    fn friendly_kind<'v>(this: Value<'v>) -> anyhow::Result<String> {
         let info = this
             .downcast_ref::<TaskInfo>()
-            .ok_or_else(|| anyhow::anyhow!("display_kind: receiver is not a TaskInfo"))?;
-        Ok(info.display_kind.clone())
+            .ok_or_else(|| anyhow::anyhow!("friendly_kind: receiver is not a TaskInfo"))?;
+        Ok(info.friendly_kind.clone())
     }
 
     /// A short name uniquely identifying this task invocation. Set via
-    /// `--task-name` on the CLI; defaults to `<kind>-<suffix>` so repeated
+    /// `--task:name` on the CLI; defaults to `<kind>-<suffix>` so repeated
     /// invocations of the same kind in one pipeline stay distinct.
     #[starlark(attribute)]
     fn name<'v>(this: Value<'v>) -> anyhow::Result<String> {
@@ -321,14 +321,14 @@ fn task_info_methods(registry: &mut MethodsBuilder) {
         Ok(info.name.clone())
     }
 
-    /// The human-readable display label for this invocation. Set via
-    /// `--task-display-name`; defaults to `name` verbatim.
+    /// The human-readable label for this invocation. Set via
+    /// `--task:friendly-name`; defaults to `name` verbatim.
     #[starlark(attribute)]
-    fn display_name<'v>(this: Value<'v>) -> anyhow::Result<String> {
+    fn friendly_name<'v>(this: Value<'v>) -> anyhow::Result<String> {
         let info = this
             .downcast_ref::<TaskInfo>()
-            .ok_or_else(|| anyhow::anyhow!("display_name: receiver is not a TaskInfo"))?;
-        Ok(info.display_name.clone())
+            .ok_or_else(|| anyhow::anyhow!("friendly_name: receiver is not a TaskInfo"))?;
+        Ok(info.friendly_name.clone())
     }
 
     /// The group(s) this task belongs to.

--- a/crates/axl-runtime/src/engine/task_map.rs
+++ b/crates/axl-runtime/src/engine/task_map.rs
@@ -36,11 +36,11 @@ pub fn task_key(group: &[String], name: &str) -> String {
 
 fn task_key_of(value: Value<'_>) -> Option<String> {
     if let Some(t) = value.downcast_ref::<Task>() {
-        Some(task_key(t.group(), &t.name()))
+        Some(task_key(t.group(), &t.kind()))
     } else {
         value
             .downcast_ref::<FrozenTask>()
-            .map(|t| task_key(&t.group, &t.name))
+            .map(|t| task_key(&t.group, &t.kind))
     }
 }
 

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -357,14 +357,18 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
     pub fn print_running_task_header(
         &self,
         task_index: usize,
-        task_key: &str,
+        task_name: &str,
     ) -> Result<(), EvalError> {
         let task = *self.tasks().get(task_index).ok_or_else(|| {
             EvalError::UnknownError(anyhow!("task index {} out of range", task_index))
         })?;
         let (verb_seq, reset) = running_verb_color();
-        let key_suffix = if on_recognized_ci() {
-            format!(" [{}]", task_key)
+        // Show the task name only when it differs from the kind — i.e. when a
+        // `--task-name` (or the deprecated `--task-key`) was set or auto-named,
+        // so repeated kinds in one pipeline read distinctly. A bare local run
+        // (name == kind) shows just the kind.
+        let name_suffix = if task_name != task.kind() {
+            format!(" [{}]", task_name)
         } else {
             String::new()
         };
@@ -379,8 +383,8 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
                 "--- :aspect: {}Running{} `{}` task{}",
                 verb_seq,
                 reset,
-                task.name(),
-                key_suffix
+                task.kind(),
+                name_suffix
             );
         } else {
             // 🎬 (clapper board) pairs with the closing ✅ / ⚠️ / ❌ as
@@ -389,8 +393,8 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
                 "→ 🎬 {}Running{} `{}` task{}",
                 verb_seq,
                 reset,
-                task.name(),
-                key_suffix
+                task.kind(),
+                name_suffix
             );
         }
         Ok(())
@@ -454,7 +458,7 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         skip_all,
         err,
         fields(
-            task_key = %task_key,
+            task_name = %task_name,
             task = tracing::field::Empty,
             task_id = tracing::field::Empty,
             exit_code = tracing::field::Empty,
@@ -463,7 +467,8 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
     pub fn execute_tasks_with_args(
         &mut self,
         task_index: usize,
-        task_key: String,
+        task_name: String,
+        task_display_name: Option<String>,
         task_id: Option<String>,
         timing: TimingMode,
         args_builder: impl FnOnce(&dyn TaskLike<'v>, Heap<'v>) -> Arguments<'v>,
@@ -477,14 +482,25 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         let task_args = args_builder(task, heap);
 
         let span = tracing::Span::current();
-        span.record("task", task.name());
+        span.record("task", task.kind());
         span.record("task_id", task_id.as_str());
 
-        // Capture name early — `task_info` is moved into TaskContext below
+        // Resolve the per-invocation display name: explicit --task-display-name,
+        // else the task name verbatim.
+        let task_display_name = task_display_name.unwrap_or_else(|| task_name.clone());
+
+        // Capture the kind early — `task_info` is moved into TaskContext below
         // and is no longer accessible from the closing announcement after
         // the eval returns.
-        let task_name = task.name();
-        let task_info = TaskInfo::new(task.name(), task.group().clone(), task_key, task_id);
+        let task_kind = task.kind();
+        let task_info = TaskInfo::new(
+            task.kind(),
+            task.display_kind(),
+            task.group().clone(),
+            task_name,
+            task_display_name,
+            task_id,
+        );
 
         // The opening `→ 🎬 Running …` (or BK `--- :aspect: Running …`)
         // header is printed by `print_running_task_header` BEFORE phase
@@ -604,7 +620,7 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
                 verdict.color,
                 verdict.verb,
                 reset,
-                task_name,
+                task_kind,
                 exit_suffix,
                 duration,
                 conclusion_suffix,
@@ -618,7 +634,7 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
                 verdict.color,
                 verdict.verb,
                 reset,
-                task_name,
+                task_kind,
                 exit_suffix,
                 duration,
                 conclusion_suffix,

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -1032,7 +1032,10 @@ mod tests {
     fn phase_breakdown_empty_for_none_and_total() {
         let phases = [phase("setup", "🔧", 2), phase("build", "🔨", 3)];
         assert_eq!(render_phase_breakdown(&phases, TimingMode::None, false), "");
-        assert_eq!(render_phase_breakdown(&phases, TimingMode::Total, false), "");
+        assert_eq!(
+            render_phase_breakdown(&phases, TimingMode::Total, false),
+            ""
+        );
     }
 
     #[test]
@@ -1040,7 +1043,10 @@ mod tests {
         let phases = [phase("setup", "🔧", 2), phase("build", "🔨", 3)];
         let out = render_phase_breakdown(&phases, TimingMode::Short, false);
         assert!(out.starts_with(" — "), "Short form is inline; got: {out}");
-        assert!(out.contains(" · "), "Short form joins phases with ·; got: {out}");
+        assert!(
+            out.contains(" · "),
+            "Short form joins phases with ·; got: {out}"
+        );
     }
 
     #[test]

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -363,11 +363,11 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
             EvalError::UnknownError(anyhow!("task index {} out of range", task_index))
         })?;
         let (verb_seq, reset) = running_verb_color();
-        // Show the task name only when it differs from the kind — i.e. when a
-        // `--task-name` (or the deprecated `--task-key`) was set or auto-named,
-        // so repeated kinds in one pipeline read distinctly. A bare local run
-        // (name == kind) shows just the kind.
-        let name_suffix = if task_name != task.kind() {
+        // On CI, append the per-invocation name so repeated kinds in one
+        // pipeline read distinctly and the header matches the check name. A
+        // bare local run shows just the kind — the auto `<kind>-<suffix>` name
+        // would be noise there.
+        let name_suffix = if on_recognized_ci() && task_name != task.kind() {
             format!(" [{}]", task_name)
         } else {
             String::new()
@@ -578,13 +578,7 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
 
         let failed = matches!(exit_code, Some(code) if code != 0);
         let breakdown = render_phase_breakdown(&phases, timing, failed);
-        // `--task:timing-summary=none` drops the timing entirely (no "in 46.8s"
-        // and no breakdown); every other level keeps the total.
-        let timing_segment = if timing == TimingMode::None {
-            String::new()
-        } else {
-            format!(" in {}", format_duration(elapsed))
-        };
+        let timing_segment = render_timing_segment(timing, elapsed);
         let conclusion_suffix = if conclusion.is_empty() {
             String::new()
         } else {
@@ -819,6 +813,19 @@ impl std::str::FromStr for TimingMode {
     }
 }
 
+/// Render the `" in <duration>"` segment of the task completion line.
+///
+/// Empty for `TimingMode::None` (no timing summary at all); every other
+/// level keeps the total. The leading space lets it concatenate after the
+/// `task` token.
+fn render_timing_segment(mode: TimingMode, elapsed: std::time::Duration) -> String {
+    if mode == TimingMode::None {
+        String::new()
+    } else {
+        format!(" in {}", format_duration(elapsed))
+    }
+}
+
 /// Render the phase breakdown that trails the runtime's "→ Completed"
 /// / "→ Failed" line.
 ///
@@ -974,7 +981,9 @@ fn display_width(s: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{TimingMode, display_width, render_phase_breakdown};
+    use super::{
+        TimingMode, display_width, format_duration, render_phase_breakdown, render_timing_segment,
+    };
     use crate::engine::task_info::PhaseRecord;
     use std::time::Duration;
 
@@ -987,6 +996,51 @@ mod tests {
             emoji: emoji.to_string(),
             display_name: String::new(),
         }
+    }
+
+    #[test]
+    fn timing_mode_from_str_parses_all_levels() {
+        assert_eq!("none".parse::<TimingMode>(), Ok(TimingMode::None));
+        assert_eq!("total".parse::<TimingMode>(), Ok(TimingMode::Total));
+        assert_eq!("short".parse::<TimingMode>(), Ok(TimingMode::Short));
+        assert_eq!("detailed".parse::<TimingMode>(), Ok(TimingMode::Detailed));
+    }
+
+    #[test]
+    fn timing_mode_from_str_rejects_invalid() {
+        let err = "verbose".parse::<TimingMode>().unwrap_err();
+        assert!(
+            err.contains("none, total, short, detailed"),
+            "error should list valid levels, got: {err}"
+        );
+    }
+
+    #[test]
+    fn timing_segment_suppressed_for_none() {
+        let d = Duration::from_secs(5);
+        assert_eq!(render_timing_segment(TimingMode::None, d), "");
+        for mode in [TimingMode::Total, TimingMode::Short, TimingMode::Detailed] {
+            assert_eq!(
+                render_timing_segment(mode, d),
+                format!(" in {}", format_duration(d)),
+                "{mode:?} should keep the total"
+            );
+        }
+    }
+
+    #[test]
+    fn phase_breakdown_empty_for_none_and_total() {
+        let phases = [phase("setup", "🔧", 2), phase("build", "🔨", 3)];
+        assert_eq!(render_phase_breakdown(&phases, TimingMode::None, false), "");
+        assert_eq!(render_phase_breakdown(&phases, TimingMode::Total, false), "");
+    }
+
+    #[test]
+    fn phase_breakdown_short_is_inline() {
+        let phases = [phase("setup", "🔧", 2), phase("build", "🔨", 3)];
+        let out = render_phase_breakdown(&phases, TimingMode::Short, false);
+        assert!(out.starts_with(" — "), "Short form is inline; got: {out}");
+        assert!(out.contains(" · "), "Short form joins phases with ·; got: {out}");
     }
 
     #[test]

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -468,7 +468,7 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         &mut self,
         task_index: usize,
         task_name: String,
-        task_display_name: Option<String>,
+        task_friendly_name: Option<String>,
         task_id: Option<String>,
         timing: TimingMode,
         args_builder: impl FnOnce(&dyn TaskLike<'v>, Heap<'v>) -> Arguments<'v>,
@@ -485,9 +485,9 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         span.record("task", task.kind());
         span.record("task_id", task_id.as_str());
 
-        // Resolve the per-invocation display name: explicit --task-display-name,
+        // Resolve the per-invocation friendly name: explicit --task:friendly-name,
         // else the task name verbatim.
-        let task_display_name = task_display_name.unwrap_or_else(|| task_name.clone());
+        let task_friendly_name = task_friendly_name.unwrap_or_else(|| task_name.clone());
 
         // Capture the kind early — `task_info` is moved into TaskContext below
         // and is no longer accessible from the closing announcement after
@@ -495,10 +495,10 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         let task_kind = task.kind();
         let task_info = TaskInfo::new(
             task.kind(),
-            task.display_kind(),
+            task.friendly_kind(),
             task.group().clone(),
             task_name,
-            task_display_name,
+            task_friendly_name,
             task_id,
         );
 
@@ -576,9 +576,15 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
             tracing::error!(exit_code = code as i64, "task exited with non-zero status");
         }
 
-        let duration = format_duration(elapsed);
         let failed = matches!(exit_code, Some(code) if code != 0);
         let breakdown = render_phase_breakdown(&phases, timing, failed);
+        // `--task:timing-summary=none` drops the timing entirely (no "in 46.8s"
+        // and no breakdown); every other level keeps the total.
+        let timing_segment = if timing == TimingMode::None {
+            String::new()
+        } else {
+            format!(" in {}", format_duration(elapsed))
+        };
         let conclusion_suffix = if conclusion.is_empty() {
             String::new()
         } else {
@@ -614,7 +620,7 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
             }
             let bookend_marker = if unclean { "+++" } else { "---" };
             eprintln!(
-                "{} {} {}{}{} · `{}` task{} in {}{}{}",
+                "{} {} {}{}{} · `{}` task{}{}{}{}",
                 bookend_marker,
                 verdict.bk_shortcode,
                 verdict.color,
@@ -622,21 +628,21 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
                 reset,
                 task_kind,
                 exit_suffix,
-                duration,
+                timing_segment,
                 conclusion_suffix,
                 breakdown,
             );
         } else {
             eprintln!();
             eprintln!(
-                "→ {} {}{}{} `{}` task{} in {}{}{}",
+                "→ {} {}{}{} `{}` task{}{}{}{}",
                 verdict.glyph,
                 verdict.color,
                 verdict.verb,
                 reset,
                 task_kind,
                 exit_suffix,
-                duration,
+                timing_segment,
                 conclusion_suffix,
                 breakdown,
             );
@@ -773,17 +779,20 @@ fn format_duration(d: std::time::Duration) -> String {
 /// even at 0ms — those are intentional boundaries.
 const INIT_PHASE_HIDE_THRESHOLD_MS: u128 = 50;
 
-/// Verbosity for the phase breakdown trailing the runtime's
+/// Verbosity for the timing summary trailing the runtime's
 /// "→ ✅ Passed" / "→ ⚠️ Flagged" / "→ ❌ Failed" line. Driven by the
-/// top-level `--timing` CLI flag.
+/// top-level `--task:timing-summary` CLI flag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TimingMode {
-    /// Total only. Same as the pre-phase output.
+    /// No timing summary at all — not even the total.
+    /// `→ ✅ Passed `lint` task`
+    None,
+    /// Total only.
     /// `→ ✅ Passed `lint` task in 46.8s`
     Total,
     /// Total + inline phase breakdown.
     /// `→ ✅ Passed `lint` task in 46.8s — 🌱 Init 0.2s · 🔍 Detect 1.2s · ...`
-    Summary,
+    Short,
     /// Total + multi-line breakdown with descriptions. Default.
     Detailed,
 }
@@ -798,11 +807,12 @@ impl std::str::FromStr for TimingMode {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "none" => Ok(TimingMode::None),
             "total" => Ok(TimingMode::Total),
-            "summary" => Ok(TimingMode::Summary),
+            "short" => Ok(TimingMode::Short),
             "detailed" => Ok(TimingMode::Detailed),
             other => Err(format!(
-                "invalid timing mode {:?}; expected one of: total, summary, detailed",
+                "invalid timing mode {:?}; expected one of: none, total, short, detailed",
                 other
             )),
         }
@@ -812,10 +822,10 @@ impl std::str::FromStr for TimingMode {
 /// Render the phase breakdown that trails the runtime's "→ Completed"
 /// / "→ Failed" line.
 ///
-/// Returns `""` for `Total` mode, or for any mode when `phases` is
-/// empty (task didn't opt into phases).
+/// Returns `""` for `None`/`Total` mode, or for any mode when `phases`
+/// is empty (task didn't opt into phases).
 ///
-/// `Summary` returns a leading-space-and-em-dash inline form so it
+/// `Short` returns a leading-space-and-em-dash inline form so it
 /// concatenates cleanly after the duration. `Detailed` returns a
 /// leading newline plus indented per-phase lines.
 ///
@@ -826,7 +836,7 @@ impl std::str::FromStr for TimingMode {
 /// On success or a non-failed exit, `interrupted` is treated as a
 /// normal completed entry.
 fn render_phase_breakdown(phases: &[PhaseRecord], mode: TimingMode, failed: bool) -> String {
-    if phases.is_empty() || mode == TimingMode::Total {
+    if phases.is_empty() || mode == TimingMode::None || mode == TimingMode::Total {
         return String::new();
     }
     // Suppress the synthetic `init` phase when it's negligible. The
@@ -843,7 +853,7 @@ fn render_phase_breakdown(phases: &[PhaseRecord], mode: TimingMode, failed: bool
     }
     // Prefix the caller-supplied `Phase(emoji=...)` when present; an empty
     // emoji stays bare. The Detailed branch aligns columns by `display_width`
-    // (which counts the emoji as two cells); Summary mode has no columns.
+    // (which counts the emoji as two cells); Short mode has no columns.
     let phase_label = |p: &PhaseRecord| -> String {
         let name = if p.display_name.is_empty() {
             titlecase(&p.name)
@@ -866,8 +876,8 @@ fn render_phase_breakdown(phases: &[PhaseRecord], mode: TimingMode, failed: bool
         }
     };
     match mode {
-        TimingMode::Total => unreachable!(),
-        TimingMode::Summary => {
+        TimingMode::None | TimingMode::Total => unreachable!(),
+        TimingMode::Short => {
             let parts: Vec<String> = visible.iter().map(|p| format_phase(p)).collect();
             format!(" — {}", parts.join(" · "))
         }

--- a/crates/axl-runtime/src/test.rs
+++ b/crates/axl-runtime/src/test.rs
@@ -174,6 +174,7 @@ impl EvalBuilder {
                     task_index,
                     "_test".to_string(),
                     None,
+                    None,
                     crate::eval::TimingMode::default(),
                     |_t, _h| Arguments::new(),
                 )

--- a/docs/design.md
+++ b/docs/design.md
@@ -52,7 +52,7 @@ Task execution occurs when a user explicitly invokes a task (e.g., `aspect run <
 - `ctx.http()` — HTTP client (get, post, download with integrity checking)
 - `ctx.template` — template rendering
 - `ctx.traits[TraitType]` — frozen trait data (read-only, as configured)
-- `ctx.task` — task metadata (kind, display_kind, name, display_name, group, id)
+- `ctx.task` — task metadata (kind, friendly_kind, name, friendly_name, group, id)
 
 Task execution is inherently non-deterministic. It interacts with the outside world — building code, fetching URLs, writing files, running processes. The determinism guarantee applies only to evaluation; execution is where real work happens.
 
@@ -109,7 +109,7 @@ Use `name = "explicit-name"` to override the derived command name. Command names
 |---|---|---|
 | `summary` | Task list and `--help` header | One line. Falls back to `"<name> task defined in <file>"`. |
 | `description` | `--help` header only | Extended prose. Replaces `summary` in `--help` when set. |
-| `display_name` | Help section headings | Title Case. Auto-derived from command name (`axl-add` → `Axl Add`). |
+| `friendly_kind` | Help section headings | Title Case. Auto-derived from the kind (`axl-add` → `Axl Add`). |
 
 #### CLI arguments
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -52,7 +52,7 @@ Task execution occurs when a user explicitly invokes a task (e.g., `aspect run <
 - `ctx.http()` — HTTP client (get, post, download with integrity checking)
 - `ctx.template` — template rendering
 - `ctx.traits[TraitType]` — frozen trait data (read-only, as configured)
-- `ctx.task` — task metadata (name, group)
+- `ctx.task` — task metadata (kind, display_kind, name, display_name, group, id)
 
 Task execution is inherently non-deterministic. It interacts with the outside world — building code, fetching URLs, writing files, running processes. The determinism guarantee applies only to evaluation; execution is where real work happens.
 
@@ -142,7 +142,7 @@ def _impl(ctx: FeatureContext):
         event = "success" if exit_code == 0 else "failure"
         channel = channels.get(event)
         if channel:
-            slack.post(channel, "Build %s: %s" % (task_ctx.task.name, event))
+            slack.post(channel, "Build %s: %s" % (task_ctx.task.kind, event))
 
     bazel_trait.build_end.append(_on_build_end)
 

--- a/tools/bazel.md
+++ b/tools/bazel.md
@@ -72,7 +72,7 @@ Bazel is the closed set. The wrapper classifies each flag against the embedded B
 The rules:
 
 1. A recognized Bazel flag is wrapped: `--keep_going` → `--bazel-flag=--keep_going`; `--config=ci` → `--bazel-flag=--config=ci`; `--config ci` → `--bazel-flag=--config=ci` (next token consumed and glued with `=`); `-c opt` → `--bazel-flag=-c=opt`.
-2. Anything else passes through unchanged: aspect globals (`--task-name`, `--timing`), feature flags (`--artifact-upload:enabled`), and unrecognized flags — including a typo or a brand-new Bazel flag not yet in the lists, which simply goes to aspect until you add it.
+2. Anything else passes through unchanged: aspect globals (`--task:name`, `--task:timing-summary`), feature flags (`--artifact-upload:enabled`), and unrecognized flags — including a typo or a brand-new Bazel flag not yet in the lists, which simply goes to aspect until you add it.
 3. After `--`, everything passes through verbatim (positional targets, `run` arguments, etc.).
 4. Flags **before the verb** get the same classification, except Bazel flags wrap as `--bazel-startup-flag=…` (which aspect accepts as a post-verb flag, so they're moved after the verb). Aspect global flags stay in front of the verb.
 

--- a/tools/bazel.md
+++ b/tools/bazel.md
@@ -72,7 +72,7 @@ Bazel is the closed set. The wrapper classifies each flag against the embedded B
 The rules:
 
 1. A recognized Bazel flag is wrapped: `--keep_going` → `--bazel-flag=--keep_going`; `--config=ci` → `--bazel-flag=--config=ci`; `--config ci` → `--bazel-flag=--config=ci` (next token consumed and glued with `=`); `-c opt` → `--bazel-flag=-c=opt`.
-2. Anything else passes through unchanged: aspect globals (`--task-key`, `--timing`), feature flags (`--artifact-upload:enabled`), and unrecognized flags — including a typo or a brand-new Bazel flag not yet in the lists, which simply goes to aspect until you add it.
+2. Anything else passes through unchanged: aspect globals (`--task-name`, `--timing`), feature flags (`--artifact-upload:enabled`), and unrecognized flags — including a typo or a brand-new Bazel flag not yet in the lists, which simply goes to aspect until you add it.
 3. After `--`, everything passes through verbatim (positional targets, `run` arguments, etc.).
 4. Flags **before the verb** get the same classification, except Bazel flags wrap as `--bazel-startup-flag=…` (which aspect accepts as a post-verb flag, so they're moved after the verb). Aspect global flags stay in front of the verb.
 


### PR DESCRIPTION
Realigns task identity vocabulary with how users think about it, and namespaces the per-task CLI flags.

## Task identity

Two paired concepts, each with a machine value and a human label:

| | Machine | Friendly label |
|---|---|---|
| **Kind** — the command being run (`build`, `test`, …) | `ctx.task.kind` | `ctx.task.friendly_kind` |
| **Name** — the unique identity of one invocation | `ctx.task.name` | `ctx.task.friendly_name` |

Kind and its label are set at definition time via `task(kind=…, friendly_kind=…)`. Name and its label are set at runtime via `--task:name` / `--task:friendly-name`. Previously the code called the kind the "name" and the per-invocation discriminator the "key" — backwards from intuition.

## CLI flags

Per-task flags are namespaced under `--task:`:

- `--task:name` — unique name for this invocation (strict `[A-Za-z0-9_-]`). Defaults to `<kind>-<suffix>` (e.g. `test-fluffy-parakeet`) so repeated invocations of the same kind in one pipeline don't collide.
- `--task:friendly-name` — human label shown on status surfaces. Defaults to the name.
- `--task:id` — invocation UUID.
- `--task:timing-summary` — verbosity of the task-completion timing line: `none` / `total` / `short` (inline phases) / `detailed` (default), in the spirit of Bazel's `--test_summary`.

`--task-key` remains as a deprecated alias for `--task:name` (warns; removed in a future release).

## Status surfaces & build metadata

- CI check names and status rows show the task name, not `kind (name)`. The PR-summary comment renders each row as `<name> [<kind>]` (collapsing to `<name>` when name == kind).
- `--build_metadata` emits `ASPECT_TASK_KIND`, `ASPECT_TASK_FRIENDLY_KIND`, `ASPECT_TASK_NAME` (the per-invocation name), `ASPECT_TASK_FRIENDLY_NAME`, and `ASPECT_TASK_ID`. The unused `ASPECT_TASK_KEY` is dropped.

Docs are updated in a companion PR on `aspect-build/site` (#1202).

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes — the AXL surface is hard-renamed (no aliases): `ctx.task.name`/`.key` → `ctx.task.kind`/`.name`, `ctx.task.display_*` → `ctx.task.friendly_*`, the `task(name=…, display_name=…)` kwargs → `task(kind=…, friendly_kind=…)`, and the `ReproFixInfo`/`TipInfo` hook field `task_name` → `task_kind`. CLI flags move under `--task:`; the old `--task-key` keeps working with a deprecation warning.
- Suggested release notes appear below: yes

### Suggested release notes

- Task identity is now `kind`/`friendly_kind` (the command + its label) and `name`/`friendly_name` (the per-invocation identity + its label). `ctx.task.name` now means the per-invocation name; the command is `ctx.task.kind`. Task definitions use `task(kind=…, friendly_kind=…)`.
- Per-task CLI flags are namespaced under `--task:` — `--task:name`, `--task:friendly-name`, `--task:id`, `--task:timing-summary` (with a new `none` level). `--task-key` is deprecated in favor of `--task:name`.
- CI check names and the PR summary comment show the task name instead of `kind (name)`.
- `--build_metadata` now emits `ASPECT_TASK_KIND` / `ASPECT_TASK_FRIENDLY_KIND` / `ASPECT_TASK_FRIENDLY_NAME` and no longer emits `ASPECT_TASK_KEY`.

### Test plan

- Covered by existing test cases
- New test cases added: dispatch flag resolution (`--task:name` precedence over `--task-key`, `--task:friendly-name`, `--task:id`, `--task:timing-summary` parsing); `TimingMode` parsing + `render_timing_segment`/`render_phase_breakdown`; `to_display_name`; `ctx.task.kind`/`friendly_kind`/`name`/`friendly_name`; PR-summary `<name> [<kind>]` row rendering; `task_cli_path` uses the kind.
- `cargo test -p axl-runtime -p aspect-cli` (313 passed) + AXL builtin self-tests (`aspect tests axl`) + all `aspect dev test-*` suites (snapshots, status comments, repro commands).
