### PR TITLE
fix(bk): expand the failing/flagged phase section on Buildkite

### DIFF
--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -584,14 +584,22 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
             // it here (before the closing bookend opens its own section) targets
             // that phase. We can't know a phase will fail/flag when its `---`
             // header is printed, so this is the only point where the verdict is
-            // known and the offending section is still current. The closing
-            // bookend below then opens the timing-summary section, which BK
-            // leaves expanded as the last one.
-            if failed || flagged {
+            // known and the offending section is still current.
+            //
+            // `^^^ +++` counts as an explicit expansion, which defeats BK's
+            // "auto-expand the last collapsed `---` group when nothing is
+            // explicitly expanded" rule — so the timing-summary bookend below
+            // would collapse. Open it with `+++` on this path so both the
+            // failing phase and the summary stay expanded. On a clean run we
+            // keep `---` and let the auto-expand handle the summary.
+            let unclean = failed || flagged;
+            if unclean {
                 eprintln!("^^^ +++");
             }
+            let bookend_marker = if unclean { "+++" } else { "---" };
             eprintln!(
-                "--- {} {}{}{} · `{}` task{} in {}{}{}",
+                "{} {} {}{}{} · `{}` task{} in {}{}{}",
+                bookend_marker,
                 verdict.bk_shortcode,
                 verdict.color,
                 verdict.verb,
@@ -646,8 +654,11 @@ fn run_deferred<'v>(context: Value<'v>, eval: &mut Evaluator<'v, '_, '_>) {
 ///   exit non-0       → ❌ Failed   (bold red)
 ///
 /// Off Buildkite the runtime emits `→ <glyph> <verb> …`; on BK it
-/// emits `--- <bk_shortcode> <verb> · …` so the closing line lands as
-/// its own collapsible section header.
+/// emits `<marker> <bk_shortcode> <verb> · …` so the closing line lands
+/// as its own collapsible section header — `+++` (expanded) on a
+/// failed/flagged verdict so the timing summary stays open alongside the
+/// expanded failing phase, else `---` (collapsed, auto-expanded by BK as
+/// the last group).
 struct Verdict<'a> {
     /// BK emoji shortcode (e.g. `:white_check_mark:`); used in the
     /// `--- :<shortcode>: <verb> …` BK section header.

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -577,6 +577,19 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
             .unwrap_or(false);
         let verdict = Verdict::pick(exit_code, flagged, &bold_green, &bold_yellow, &bold_red);
         if on_bk {
+            // On a non-clean verdict, retroactively expand the section that is
+            // still open — the last phase the task emitted, i.e. the one that
+            // failed or got flagged. BK's `^^^ +++` expands the currently-open
+            // section regardless of how its `---` header declared it; emitting
+            // it here (before the closing bookend opens its own section) targets
+            // that phase. We can't know a phase will fail/flag when its `---`
+            // header is printed, so this is the only point where the verdict is
+            // known and the offending section is still current. The closing
+            // bookend below then opens the timing-summary section, which BK
+            // leaves expanded as the last one.
+            if failed || flagged {
+                eprintln!("^^^ +++");
+            }
             eprintln!(
                 "--- {} {}{}{} · `{}` task{} in {}{}{}",
                 verdict.bk_shortcode,


### PR DESCRIPTION
On Buildkite, each task phase opens a collapsed `--- <phase>` section, and the closing timing-summary bookend opens its own section — which BK leaves expanded because it's the last one. On a non-clean verdict, the section users actually want open (the phase that failed or got flagged) stayed collapsed, because we can't predict a phase's outcome when its `---` header is first printed.

The fix emits BK's `^^^ +++` directive (expand the currently-open section) right before the closing bookend when the verdict is `failed` or `flagged`. At that point the currently-open section is the last phase the task emitted — the offending one — so it expands retroactively. `close_active_phase()` only closes the logical phase in `TaskInfo` and prints nothing, so the BK section is still current. The bookend then opens the timing-summary section as before.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

On Buildkite, the phase section that failed (or was flagged) is now automatically expanded in the build log, instead of staying collapsed.

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  - Run a task that fails on Buildkite (e.g. a failing `aspect test`). The collapsed phase section that produced the failure now renders expanded; a clean run is unchanged.
