### PR TITLE
fix(artifacts): upload all test logs under runs_per_test / sharding

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -2290,14 +2290,15 @@ def test_artifacts_lib(ctx: TaskContext, tc: int) -> int:
         tc = test_case(tc, got == expected, "artifact_name: %s → %r (got %r)" % (desc, expected, got))
 
     # testlog_dest_dir — runs_per_test / sharding / retries must not collide.
+    # Bazel numbers run/shard/attempt one-based; (1, 1, 1) is the lone result.
     dest_cases = [
         # (label, run, shard, attempt, expected, desc)
-        ("//pkg:net_test", 0, 0, 0, "pkg/net_test", "single run → label path unchanged"),
-        ("//pkg:net_test", 1, 0, 0, "pkg/net_test/run_1", "runs_per_test → run subdir"),
-        ("//pkg:net_test", 2, 0, 0, "pkg/net_test/run_2", "second run distinct from first"),
-        ("//pkg:net_test", 0, 3, 0, "pkg/net_test/shard_3", "sharded test → shard subdir"),
-        ("//pkg:net_test", 0, 0, 2, "pkg/net_test/attempt_2", "flaky retry → attempt subdir"),
-        ("//pkg:net_test", 2, 3, 1, "pkg/net_test/run_2_shard_3_attempt_1", "run+shard+attempt combined"),
+        ("//pkg:net_test", 1, 1, 1, "pkg/net_test", "single run → label path unchanged"),
+        ("//pkg:net_test", 0, 0, 0, "pkg/net_test", "unset ids → label path unchanged"),
+        ("//pkg:net_test", 2, 1, 1, "pkg/net_test/run_2", "runs_per_test → run subdir"),
+        ("//pkg:net_test", 1, 3, 1, "pkg/net_test/shard_3", "sharded test → shard subdir"),
+        ("//pkg:net_test", 1, 1, 2, "pkg/net_test/attempt_2", "flaky retry → attempt subdir"),
+        ("//pkg:net_test", 2, 3, 4, "pkg/net_test/run_2_shard_3_attempt_4", "run+shard+attempt combined"),
     ]
     for (label, run, shard, attempt, expected, desc) in dest_cases:
         got = testlog_dest_dir(label, run, shard, attempt)

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3,7 +3,7 @@ Exercise axl
 """
 
 load("@aspect//delivery.axl", delivery_count_unexplained_unresolved = "count_unexplained_unresolved", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
-load("@aspect//lib/artifacts.axl", "artifact_name")
+load("@aspect//lib/artifacts.axl", "artifact_name", "testlog_dest_dir")
 load("@aspect//lib/bazel_results.axl", "compute_reproducer_command", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
 load(
     "@aspect//lib/build_metadata.axl",
@@ -2288,6 +2288,20 @@ def test_artifacts_lib(ctx: TaskContext, tc: int) -> int:
     for (ci, task_name, task_key, filename, expected, desc) in cases:
         got = artifact_name(ci, task_name, task_key, filename)
         tc = test_case(tc, got == expected, "artifact_name: %s → %r (got %r)" % (desc, expected, got))
+
+    # testlog_dest_dir — runs_per_test / sharding / retries must not collide.
+    dest_cases = [
+        # (label, run, shard, attempt, expected, desc)
+        ("//pkg:net_test", 0, 0, 0, "pkg/net_test", "single run → label path unchanged"),
+        ("//pkg:net_test", 1, 0, 0, "pkg/net_test/run_1", "runs_per_test → run subdir"),
+        ("//pkg:net_test", 2, 0, 0, "pkg/net_test/run_2", "second run distinct from first"),
+        ("//pkg:net_test", 0, 3, 0, "pkg/net_test/shard_3", "sharded test → shard subdir"),
+        ("//pkg:net_test", 0, 0, 2, "pkg/net_test/attempt_2", "flaky retry → attempt subdir"),
+        ("//pkg:net_test", 2, 3, 1, "pkg/net_test/run_2_shard_3_attempt_1", "run+shard+attempt combined"),
+    ]
+    for (label, run, shard, attempt, expected, desc) in dest_cases:
+        got = testlog_dest_dir(label, run, shard, attempt)
+        tc = test_case(tc, got == expected, "testlog_dest_dir: %s → %r (got %r)" % (desc, expected, got))
     return tc
 
 def test_detect_build_url(ctx: TaskContext, tc: int) -> int:

--- a/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
@@ -360,7 +360,12 @@ def _upload_testlogs_buildkite(ctx, group, entries, name):
 
 def _upload_testlogs_per_file(ctx, provider, group, entries, name):
     """Per-file upload — CircleCI. Records each per-(label, filename) URL
-    into group['label_urls'] so output can link files separately."""
+    into group['label_urls'] so output can link files separately.
+
+    The results table renders one log/xml link per test label, so for
+    runs_per_test / sharded targets (many files share a basename) the first
+    uploaded URL wins; all runs are still uploaded under distinct dest paths.
+    """
     count = len(entries)
     if count == 0 or count == group["last_count"]:
         return False
@@ -381,7 +386,7 @@ def _upload_testlogs_per_file(ctx, provider, group, entries, name):
             if url and url.startswith("http"):
                 fname = entry["dest"].rsplit("/", 1)[-1]
                 files = label_urls.setdefault(entry["label"], {})
-                files[fname] = url
+                files.setdefault(fname, url)
             group["last_count"] += 1
             any_success = True
         else:
@@ -519,6 +524,29 @@ def _should_collect_test(strategy, status, cached_locally):
         return status in _NOT_PASSED_STATUSES
     return False
 
+def testlog_dest_dir(label, run, shard, attempt):
+    """Destination directory for a test_result's output files.
+
+    runs_per_test / sharding / flaky retries emit one test_result event per
+    (run, shard, attempt), each carrying its own test.log/test.xml under the
+    same label. Without a distinguishing dest segment they collide — an
+    archive entry overwrites, a per-file URL overwrites, a symlink fails — and
+    only one run's logs survive. Append a `run_N`/`shard_N`/`attempt_N` subdir
+    whenever any is set (>0); a lone run/shard/attempt leaves the path
+    unchanged so single-run uploads keep their historical layout.
+    """
+    label_path = label.lstrip("/").replace(":", "/")
+    if not (run or shard or attempt):
+        return label_path
+    parts = []
+    if run:
+        parts.append("run_" + str(run))
+    if shard:
+        parts.append("shard_" + str(shard))
+    if attempt:
+        parts.append("attempt_" + str(attempt))
+    return label_path + "/" + "_".join(parts)
+
 def _collect_test_files(ctx, event, strategy, test_entries, skipped_files):
     """Append testlog entries (+ skip reasons) from a test_result BES
     event into the closure-private lists.
@@ -537,7 +565,12 @@ def _collect_test_files(ctx, event, strategy, test_entries, skipped_files):
         return
 
     label = event.id.label
-    label_path = label.lstrip("/").replace(":", "/")
+    dest_dir = testlog_dest_dir(
+        label,
+        bes_get(event.id, "run", 0) or 0,
+        bes_get(event.id, "shard", 0) or 0,
+        bes_get(event.id, "attempt", 0) or 0,
+    )
 
     for file in (bes_get(payload, "test_action_output", None) or []):
         raw_uri = file.file
@@ -550,7 +583,7 @@ def _collect_test_files(ctx, event, strategy, test_entries, skipped_files):
         if not ctx.std.fs.exists(src):
             skipped_files.append({"label": label, "name": file.name, "reason": "not found", "raw": src})
             continue
-        test_entries.append({"src": src, "dest": label_path + "/" + file.name, "label": label})
+        test_entries.append({"src": src, "dest": dest_dir + "/" + file.name, "label": label})
 
 def _new_test_group():
     """Fresh per-group upload state. Field semantics: see the upload

--- a/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/artifacts.axl
@@ -531,20 +531,23 @@ def testlog_dest_dir(label, run, shard, attempt):
     (run, shard, attempt), each carrying its own test.log/test.xml under the
     same label. Without a distinguishing dest segment they collide — an
     archive entry overwrites, a per-file URL overwrites, a symlink fails — and
-    only one run's logs survive. Append a `run_N`/`shard_N`/`attempt_N` subdir
-    whenever any is set (>0); a lone run/shard/attempt leaves the path
-    unchanged so single-run uploads keep their historical layout.
+    only one run's logs survive.
+
+    Bazel numbers these one-based, so the single / first / unsharded result
+    arrives as (1, 1, 1). Append a `run_N`/`shard_N`/`attempt_N` subdir only
+    for the components that exceed 1, leaving the common single-run test at
+    its historical flat `<label>/` path.
     """
     label_path = label.lstrip("/").replace(":", "/")
-    if not (run or shard or attempt):
-        return label_path
     parts = []
-    if run:
+    if run > 1:
         parts.append("run_" + str(run))
-    if shard:
+    if shard > 1:
         parts.append("shard_" + str(shard))
-    if attempt:
+    if attempt > 1:
         parts.append("attempt_" + str(attempt))
+    if not parts:
+        return label_path
     return label_path + "/" + "_".join(parts)
 
 def _collect_test_files(ctx, event, strategy, test_entries, skipped_files):


### PR DESCRIPTION
## Summary

When `--runs_per_test > 1` (and likewise for sharded or flaky-retried tests), AXL uploaded only one of the failing test logs. If 3 of 10 runs failed, only one `test.log` reached the artifact store.

Root cause: Bazel emits one `TestResult` BEP event per `(run, shard, attempt)`, each carrying its own `test.log`/`test.xml`, but `_collect_test_files` keyed each upload entry's destination on the **label alone** (`pkg/foo_test/test.log`). Every run produced the identical destination, so all four upload strategies collapsed them to one — the tar/zip archive entry overwrote, the Buildkite symlink collided, and the CircleCI per-file URL overwrote.

The fix derives the destination directory from `(label, run, shard, attempt)` via a new `testlog_dest_dir` helper: a `run_N`/`shard_N`/`attempt_N` subdir is appended whenever any is set, so each run's logs upload to a distinct path. Single-run uploads keep their existing layout. Because every strategy keys off this destination, one change fixes all CI providers.

The CircleCI results-table link map (one log/xml link per test row) now records the first uploaded URL per filename rather than letting later runs clobber it; all runs are still uploaded under distinct paths.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fixed test log upload to capture all failing runs when `--runs_per_test`, test sharding, or flaky retries produce multiple `TestResult` events for one target.

### Test plan

- New test cases added: `testlog_dest_dir` cases in `.aspect/axl.axl` (`tests axl`) covering single-run, runs_per_test, sharding, retries, and the combined case.
- Covered by existing test cases: `dev test-template-snapshots` and the per-file URL render tests.
