### PR TITLE
fix(delivery): upgrade --remote_download_outputs=minimal to toplevel for phase 3

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -351,12 +351,13 @@ def _surface_phase_stderr(ctx, phase, log_path):
     artifacts.upload_file(ctx, "delivery_phase{}_log".format(phase), "phase{}-stderr.log".format(phase), log_path)
 
 def _base_flag_overridden(rc, flag: str) -> bool:
-    """Whether the active run command already sets `flag` such that the
-    delivery base default should be dropped.
+    """Whether the active run command already sets `flag`, so the matching
+    `LOCAL_SPAWN_BASE_FLAGS` default should be dropped.
 
-    For most flags any user-set value overrides the default. The exception is
+    `rc.flag_value` reports the value from either `--flag=v` or `--flag v`, so
+    both CLI/rc forms are handled. Any value counts as an override, except
     `--remote_download_outputs`: only `toplevel`/`all` put the top-level binary
-    on disk, so a user `=minimal` is treated as not overriding (the `=toplevel`
+    on disk, so a user `=minimal` is not treated as an override (the `=toplevel`
     default still wins) to keep the phase-3 runfiles download working."""
     name = flag.split("=", 1)[0]
     value = rc.flag_value(name, command = "build")
@@ -1224,18 +1225,10 @@ def _delivery_impl(ctx):
         # defined" (the task's own expanded_flags already went through this).
         release_flags = expand_config_flags(ctx, bazel_trait, ctx.args.release_bazel_flags)
 
-        # LOCAL_SPAWN_BASE_FLAGS are delivery defaults the rc/user override (a
-        # repo's `build --remote_download_outputs=all` must win over the default
-        # `toplevel`). Per-call extras win over the rc, so apply each base flag
-        # only when the active run command doesn't already set it — that's a
-        # default the rc overrides, not an override of the rc.
-        #
-        # `--remote_download_outputs` is the exception: a user value is honored
-        # only when it's sufficient to put the top-level binary on disk
-        # (`toplevel`/`all`). A user `=minimal` leaves the binary remote and
-        # breaks the runfiles download, so the `=toplevel` default must still
-        # win — drop the base flag only for the sufficient values, not for any
-        # user-set value.
+        # LOCAL_SPAWN_BASE_FLAGS are delivery defaults the active run command
+        # may override (a repo's `build --remote_download_outputs=all` must win
+        # over the default `toplevel`); drop each one the rc already sets. See
+        # `_base_flag_overridden` for the `--remote_download_outputs` carve-out.
         base_defaults = [
             f
             for f in LOCAL_SPAWN_BASE_FLAGS

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -139,7 +139,7 @@ load("@aspect//lib/health_check.axl", "HealthCheckTrait")
 load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("@aspect//lib/remote_executor.axl", "start_dummy_executor", "stop_dummy_executor")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "apparent_label", "runnable")
+load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "apparent_label", "download_outputs_sufficient", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
 load("@aspect//lib/tips.axl", "tips")
 load("@bazel//proto/remote_logging.axl", "remote_logging")
@@ -349,6 +349,22 @@ def _surface_phase_stderr(ctx, phase, log_path):
         return
     ctx.std.io.stderr.write(ctx.std.fs.read_to_string(log_path))
     artifacts.upload_file(ctx, "delivery_phase{}_log".format(phase), "phase{}-stderr.log".format(phase), log_path)
+
+def _base_flag_overridden(rc, flag: str) -> bool:
+    """Whether the active run command already sets `flag` such that the
+    delivery base default should be dropped.
+
+    For most flags any user-set value overrides the default. The exception is
+    `--remote_download_outputs`: only `toplevel`/`all` put the top-level binary
+    on disk, so a user `=minimal` is treated as not overriding (the `=toplevel`
+    default still wins) to keep the phase-3 runfiles download working."""
+    name = flag.split("=", 1)[0]
+    value = rc.flag_value(name, command = "build")
+    if value == None:
+        return False
+    if name == "--remote_download_outputs":
+        return download_outputs_sufficient(value)
+    return True
 
 def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, user_remote_executor_uri, ansi, data):
     """Run phase 1 (build) + phase 2 (digest extraction); return
@@ -1213,10 +1229,17 @@ def _delivery_impl(ctx):
         # `toplevel`). Per-call extras win over the rc, so apply each base flag
         # only when the active run command doesn't already set it — that's a
         # default the rc overrides, not an override of the rc.
+        #
+        # `--remote_download_outputs` is the exception: a user value is honored
+        # only when it's sufficient to put the top-level binary on disk
+        # (`toplevel`/`all`). A user `=minimal` leaves the binary remote and
+        # breaks the runfiles download, so the `=toplevel` default must still
+        # win — drop the base flag only for the sufficient values, not for any
+        # user-set value.
         base_defaults = [
             f
             for f in LOCAL_SPAWN_BASE_FLAGS
-            if rc.flag_value(f.split("=", 1)[0], command = "build") == None
+            if not _base_flag_overridden(rc, f)
         ]
 
         # Phase 3 flag order (last-wins): active run command, then the per-call

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -139,7 +139,7 @@ load("@aspect//lib/health_check.axl", "HealthCheckTrait")
 load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("@aspect//lib/remote_executor.axl", "start_dummy_executor", "stop_dummy_executor")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "apparent_label", "download_outputs_sufficient", "runnable")
+load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "apparent_label", "download_outputs_sufficient", "effective_download_outputs", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
 load("@aspect//lib/tips.axl", "tips")
 load("@bazel//proto/remote_logging.axl", "remote_logging")
@@ -350,22 +350,19 @@ def _surface_phase_stderr(ctx, phase, log_path):
     ctx.std.io.stderr.write(ctx.std.fs.read_to_string(log_path))
     artifacts.upload_file(ctx, "delivery_phase{}_log".format(phase), "phase{}-stderr.log".format(phase), log_path)
 
-def _base_flag_overridden(rc, flag: str) -> bool:
-    """Whether the active run command already sets `flag`, so the matching
-    `LOCAL_SPAWN_BASE_FLAGS` default should be dropped.
+def _base_flag_satisfied(rc, flag: str) -> bool:
+    """Whether the active run command already satisfies a `LOCAL_SPAWN_BASE_FLAGS`
+    default, so phase 3 need not inject it.
 
-    `rc.flag_value` reports the value from either `--flag=v` or `--flag v`, so
-    both CLI/rc forms are handled. Any value counts as an override, except
-    `--remote_download_outputs`: only `toplevel`/`all` put the top-level binary
-    on disk, so a user `=minimal` is not treated as an override (the `=toplevel`
-    default still wins) to keep the phase-3 runfiles download working."""
-    name = flag.split("=", 1)[0]
-    value = rc.flag_value(name, command = "build")
-    if value == None:
-        return False
-    if name == "--remote_download_outputs":
-        return download_outputs_sufficient(value)
-    return True
+    `--remote_download_outputs=toplevel` carries the only non-trivial policy:
+    phase 3 must materialize the top-level binary on disk, so the default is
+    satisfied only when the rc resolves to a sufficient mode (`toplevel`/`all`)
+    — across every flag form, including the `--remote_download_*` aliases. A
+    user `=minimal` is not sufficient, so the `=toplevel` default still applies.
+    Any other base flag is satisfied once the rc sets it at all."""
+    if flag.startswith("--remote_download_outputs="):
+        return download_outputs_sufficient(effective_download_outputs(rc.expand(command = "build")))
+    return rc.flag_value(flag.split("=", 1)[0], command = "build") != None
 
 def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, user_remote_executor_uri, ansi, data):
     """Run phase 1 (build) + phase 2 (digest extraction); return
@@ -1226,13 +1223,13 @@ def _delivery_impl(ctx):
         release_flags = expand_config_flags(ctx, bazel_trait, ctx.args.release_bazel_flags)
 
         # LOCAL_SPAWN_BASE_FLAGS are delivery defaults the active run command
-        # may override (a repo's `build --remote_download_outputs=all` must win
-        # over the default `toplevel`); drop each one the rc already sets. See
-        # `_base_flag_overridden` for the `--remote_download_outputs` carve-out.
+        # may override (a repo's `--remote_download_outputs=all` must win over
+        # the default `toplevel`); inject only those the rc doesn't already
+        # satisfy. See `_base_flag_satisfied` for the download-outputs policy.
         base_defaults = [
             f
             for f in LOCAL_SPAWN_BASE_FLAGS
-            if not _base_flag_overridden(rc, f)
+            if not _base_flag_satisfied(rc, f)
         ]
 
         # Phase 3 flag order (last-wins): active run command, then the per-call

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -17,14 +17,16 @@ LOCAL_SPAWN_FLAGS = [
     "--build_runfile_links",
 ]
 
-# Default `--remote_download_outputs` value for a task that immediately
-# spawns the built binary. Inject these via the `bazel_base_flags` path
-# (i.e. BEFORE user flags / rc expansion) so a user who needs `=all` —
-# e.g. an older Bazel version or a misbehaving rule set that won't run
-# without dependency outputs materialized — can override via the command
-# line or `.bazelrc`. `=toplevel` is the minimum that puts the binary
-# itself on disk so we can spawn it; `=minimal` would leave it remote
-# and break the spawn.
+# Default `--remote_download_outputs` value for a task that immediately spawns
+# the built binary. `=toplevel` is the minimum that puts the binary itself on
+# disk so we can spawn it; `=minimal` would leave it remote and break the spawn.
+# A user who needs `=all` — an older Bazel, or a rule set that won't run without
+# dependency outputs materialized — can still override.
+#
+# run/format/gazelle inject these via `bazel_base_flags` (BEFORE user flags), so
+# Bazel's last-wins lets the user override. Delivery injects them per-call
+# (AFTER the rc) and instead gates each on `_base_flag_satisfied`, so a user
+# `=minimal` is upgraded to `=toplevel` rather than silently winning.
 LOCAL_SPAWN_BASE_FLAGS = [
     "--remote_download_outputs=toplevel",
 ]
@@ -33,16 +35,56 @@ LOCAL_SPAWN_BASE_FLAGS = [
 # on disk; `minimal` is excluded on purpose (see `download_outputs_sufficient`).
 _DOWNLOAD_OUTPUTS_SUFFICIENT = ["toplevel", "all"]
 
+# Bazel's no-value expansion aliases for `--remote_download_outputs`, mapped to
+# the value they expand to. Bazel expands these internally, so they never reach
+# `rc.flag_value("--remote_download_outputs")` — `effective_download_outputs`
+# must match them directly to see a user's mode. (Per the Bazel command-line
+# reference: https://bazel.build/reference/command-line-reference.)
+_DOWNLOAD_OUTPUTS_ALIASES = {
+    "--remote_download_minimal": "minimal",
+    "--remote_download_toplevel": "toplevel",
+    "--remote_download_all": "all",
+}
+
 def download_outputs_sufficient(value: str | None) -> bool:
-    """Whether a `--remote_download_outputs=<value>` already puts the top-level
+    """Whether a `--remote_download_outputs` value already puts the top-level
     binary on disk, so the spawn/delivery `=toplevel` default need not override
     it.
 
     `toplevel`/`all` are sufficient; `minimal` is not — it leaves the binary
     remote and breaks the spawn, so a `=minimal` must be upgraded to `toplevel`
-    rather than respected. `None` (flag unset) is not sufficient: the default
+    rather than respected. `None` (mode unset) is not sufficient: the default
     applies."""
     return value in _DOWNLOAD_OUTPUTS_SUFFICIENT
+
+def effective_download_outputs(flags: list) -> str | None:
+    """The `--remote_download_outputs` mode an ordered Bazel flag list resolves
+    to (`minimal`/`toplevel`/`all`), or `None` if unset.
+
+    Resolves every form Bazel accepts — the canonical
+    `--remote_download_outputs=<mode>`, its two-token `--remote_download_outputs
+    <mode>`, and the no-value aliases (`--remote_download_all`, …) — honoring
+    last-wins across them, so a later `--remote_download_all` beats an earlier
+    `--remote_download_outputs=minimal` and vice versa. `flags` items are the
+    `str` / `(flag, version_condition)` shapes `RunCommand.expand` yields."""
+    mode = None
+    expect_value = False
+    for f in flags:
+        flag = f[0] if type(f) == "tuple" else f
+        if expect_value:
+            # Token after a bare `--remote_download_outputs`; a leading `-`
+            # means the flag had no value (next is its own flag).
+            expect_value = False
+            if not flag.startswith("-"):
+                mode = flag
+                continue
+        if flag == "--remote_download_outputs":
+            expect_value = True
+        elif flag.startswith("--remote_download_outputs="):
+            mode = flag.split("=", 1)[1]
+        elif flag in _DOWNLOAD_OUTPUTS_ALIASES:
+            mode = _DOWNLOAD_OUTPUTS_ALIASES[flag]
+    return mode
 
 # Named modes accepted by `--run-in=<choice>` on tasks that spawn a
 # built binary.

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -29,21 +29,19 @@ LOCAL_SPAWN_BASE_FLAGS = [
     "--remote_download_outputs=toplevel",
 ]
 
-# Values of `--remote_download_outputs` that already put the top-level
-# binary on disk, so a user-set value is honored as-is. `minimal` is
-# absent on purpose: it leaves the binary remote and breaks the spawn, so
-# it must be upgraded to the `toplevel` default rather than respected.
+# `--remote_download_outputs` values that already put the top-level binary
+# on disk; `minimal` is excluded on purpose (see `download_outputs_sufficient`).
 _DOWNLOAD_OUTPUTS_SUFFICIENT = ["toplevel", "all"]
 
 def download_outputs_sufficient(value: str | None) -> bool:
-    """Whether a user-set `--remote_download_outputs=<value>` already puts the
-    top-level binary on disk, so the delivery/spawn `=toplevel` default need
-    not override it.
+    """Whether a `--remote_download_outputs=<value>` already puts the top-level
+    binary on disk, so the spawn/delivery `=toplevel` default need not override
+    it.
 
-    `toplevel`/`all` are sufficient; `minimal` is not (it leaves the binary
-    remote and breaks the spawn), so a `=minimal` must be upgraded to
-    `toplevel` rather than respected. None (flag unset) is not sufficient —
-    the default applies."""
+    `toplevel`/`all` are sufficient; `minimal` is not — it leaves the binary
+    remote and breaks the spawn, so a `=minimal` must be upgraded to `toplevel`
+    rather than respected. `None` (flag unset) is not sufficient: the default
+    applies."""
     return value in _DOWNLOAD_OUTPUTS_SUFFICIENT
 
 # Named modes accepted by `--run-in=<choice>` on tasks that spawn a

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -29,6 +29,23 @@ LOCAL_SPAWN_BASE_FLAGS = [
     "--remote_download_outputs=toplevel",
 ]
 
+# Values of `--remote_download_outputs` that already put the top-level
+# binary on disk, so a user-set value is honored as-is. `minimal` is
+# absent on purpose: it leaves the binary remote and breaks the spawn, so
+# it must be upgraded to the `toplevel` default rather than respected.
+_DOWNLOAD_OUTPUTS_SUFFICIENT = ["toplevel", "all"]
+
+def download_outputs_sufficient(value: str | None) -> bool:
+    """Whether a user-set `--remote_download_outputs=<value>` already puts the
+    top-level binary on disk, so the delivery/spawn `=toplevel` default need
+    not override it.
+
+    `toplevel`/`all` are sufficient; `minimal` is not (it leaves the binary
+    remote and breaks the spawn), so a `=minimal` must be upgraded to
+    `toplevel` rather than respected. None (flag unset) is not sufficient —
+    the default applies."""
+    return value in _DOWNLOAD_OUTPUTS_SUFFICIENT
+
 # Named modes accepted by `--run-in=<choice>` on tasks that spawn a
 # built binary.
 _RUN_IN_NAMED_MODES = ["runfiles", "cwd", "bazel-root", "aspect-root", "git-root"]

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -63,8 +63,10 @@ def effective_download_outputs(flags: list) -> str | None:
 
     Resolves every form Bazel accepts — the canonical
     `--remote_download_outputs=<mode>`, its two-token `--remote_download_outputs
-    <mode>`, and the no-value aliases (`--remote_download_all`, …) — honoring
-    last-wins across them, so a later `--remote_download_all` beats an earlier
+    <mode>` (a `.bazelrc` line shell-tokenizes into two options; `--bazel-flag`
+    stores its value verbatim so the CLI can't produce this form), and the
+    no-value aliases (`--remote_download_all`, …) — honoring last-wins across
+    them, so a later `--remote_download_all` beats an earlier
     `--remote_download_outputs=minimal` and vice versa. `flags` items are the
     `str` / `(flag, version_condition)` shapes `RunCommand.expand` yields."""
     mode = None

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,7 +1,7 @@
 """Unit tests for lib/runnable.axl: apparent_label normalization, BES matching,
 entrypoint selection (passes 1–3), and runfiles directory detection."""
 
-load("./runnable.axl", "apparent_label", "resolve_run_in", "runnable")
+load("./runnable.axl", "apparent_label", "download_outputs_sufficient", "resolve_run_in", "runnable")
 
 def _eq(label, got, want):
     if got != want:
@@ -575,6 +575,24 @@ def _test_run_in_relative_dotdot(_ctx):
         "/here/../sub",
     )
 
+# download_outputs_sufficient — which user `--remote_download_outputs` values
+# already put the top-level binary on disk (so the spawn/delivery `=toplevel`
+# default need not override them).
+
+def _test_download_outputs_toplevel_sufficient(_ctx):
+    _eq("toplevel is sufficient", download_outputs_sufficient("toplevel"), True)
+
+def _test_download_outputs_all_sufficient(_ctx):
+    _eq("all is sufficient", download_outputs_sufficient("all"), True)
+
+def _test_download_outputs_minimal_insufficient(_ctx):
+    """The regression: `=minimal` leaves the binary remote, so it must be
+    upgraded to the `=toplevel` default, not respected."""
+    _eq("minimal is insufficient", download_outputs_sufficient("minimal"), False)
+
+def _test_download_outputs_unset_insufficient(_ctx):
+    _eq("unset (None) is insufficient", download_outputs_sufficient(None), False)
+
 _UNIT_TESTS = [
     _test_local_label_with_colon,
     _test_local_label_without_colon,
@@ -626,6 +644,10 @@ _UNIT_TESTS = [
     _test_run_in_absolute_path,
     _test_run_in_relative_dot,
     _test_run_in_relative_dotdot,
+    _test_download_outputs_toplevel_sufficient,
+    _test_download_outputs_all_sufficient,
+    _test_download_outputs_minimal_insufficient,
+    _test_download_outputs_unset_insufficient,
     _test_runfiles_workspace_dir_uses_bes_workspace_name,
     _test_runfiles_workspace_dir_non_default_workspace,
     _test_runfiles_workspace_dir_default_when_no_workspace_config,

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,5 +1,6 @@
 """Unit tests for lib/runnable.axl: apparent_label normalization, BES matching,
-entrypoint selection (passes 1–3), and runfiles directory detection."""
+entrypoint selection (passes 1–3), runfiles directory detection, `--run-in`
+cwd resolution, and `--remote_download_outputs` sufficiency."""
 
 load("./runnable.axl", "apparent_label", "download_outputs_sufficient", "resolve_run_in", "runnable")
 

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,8 +1,8 @@
 """Unit tests for lib/runnable.axl: apparent_label normalization, BES matching,
 entrypoint selection (passes 1–3), runfiles directory detection, `--run-in`
-cwd resolution, and `--remote_download_outputs` sufficiency."""
+cwd resolution, and `--remote_download_outputs` resolution/sufficiency."""
 
-load("./runnable.axl", "apparent_label", "download_outputs_sufficient", "resolve_run_in", "runnable")
+load("./runnable.axl", "apparent_label", "download_outputs_sufficient", "effective_download_outputs", "resolve_run_in", "runnable")
 
 def _eq(label, got, want):
     if got != want:
@@ -594,6 +594,61 @@ def _test_download_outputs_minimal_insufficient(_ctx):
 def _test_download_outputs_unset_insufficient(_ctx):
     _eq("unset (None) is insufficient", download_outputs_sufficient(None), False)
 
+# effective_download_outputs — resolve the `--remote_download_outputs` mode
+# from an ordered flag list across every form Bazel accepts (canonical `=`,
+# two-token, and `--remote_download_*` aliases), honoring last-wins.
+
+def _test_effective_download_outputs_unset(_ctx):
+    _eq("no download flag → None", effective_download_outputs(["--jobs=4", "--stamp"]), None)
+
+def _test_effective_download_outputs_canonical_eq(_ctx):
+    _eq("--remote_download_outputs=minimal", effective_download_outputs(["--remote_download_outputs=minimal"]), "minimal")
+
+def _test_effective_download_outputs_two_token(_ctx):
+    _eq(
+        "two-token --remote_download_outputs all",
+        effective_download_outputs(["--remote_download_outputs", "all"]),
+        "all",
+    )
+
+def _test_effective_download_outputs_bare_flag_no_value(_ctx):
+    """A bare `--remote_download_outputs` followed by another flag has no value."""
+    _eq(
+        "bare flag then another flag → None",
+        effective_download_outputs(["--remote_download_outputs", "--jobs=4"]),
+        None,
+    )
+
+def _test_effective_download_outputs_alias_all(_ctx):
+    _eq("--remote_download_all alias", effective_download_outputs(["--remote_download_all"]), "all")
+
+def _test_effective_download_outputs_alias_minimal(_ctx):
+    _eq("--remote_download_minimal alias", effective_download_outputs(["--remote_download_minimal"]), "minimal")
+
+def _test_effective_download_outputs_alias_beats_earlier_canonical(_ctx):
+    """The Codex regression: a later `--remote_download_all` alias must beat an
+    earlier canonical `--remote_download_outputs=minimal`."""
+    _eq(
+        "alias wins last over canonical",
+        effective_download_outputs(["--remote_download_outputs=minimal", "--remote_download_all"]),
+        "all",
+    )
+
+def _test_effective_download_outputs_canonical_beats_earlier_alias(_ctx):
+    _eq(
+        "canonical wins last over alias",
+        effective_download_outputs(["--remote_download_all", "--remote_download_outputs=minimal"]),
+        "minimal",
+    )
+
+def _test_effective_download_outputs_version_tuple(_ctx):
+    """`expand` may yield `(flag, version_condition)` tuples — read the flag."""
+    _eq(
+        "tuple-form flag",
+        effective_download_outputs([("--remote_download_outputs=toplevel", ">=8")]),
+        "toplevel",
+    )
+
 _UNIT_TESTS = [
     _test_local_label_with_colon,
     _test_local_label_without_colon,
@@ -649,6 +704,15 @@ _UNIT_TESTS = [
     _test_download_outputs_all_sufficient,
     _test_download_outputs_minimal_insufficient,
     _test_download_outputs_unset_insufficient,
+    _test_effective_download_outputs_unset,
+    _test_effective_download_outputs_canonical_eq,
+    _test_effective_download_outputs_two_token,
+    _test_effective_download_outputs_bare_flag_no_value,
+    _test_effective_download_outputs_alias_all,
+    _test_effective_download_outputs_alias_minimal,
+    _test_effective_download_outputs_alias_beats_earlier_canonical,
+    _test_effective_download_outputs_canonical_beats_earlier_alias,
+    _test_effective_download_outputs_version_tuple,
     _test_runfiles_workspace_dir_uses_bes_workspace_name,
     _test_runfiles_workspace_dir_non_default_workspace,
     _test_runfiles_workspace_dir_default_when_no_workspace_config,


### PR DESCRIPTION
`aspect delivery`'s phase 3 ("download runfiles") injects `--remote_download_outputs=toplevel` as a default the active run command may override, so a repo that needs `=all` (older Bazel, or a rule set that won't run without dependency outputs materialized) still wins. That override check dropped the default for *any* user-set value — which also suppressed the required upgrade from a user-set `=minimal`, leaving the top-level binary remote and breaking the runfiles download delivery depends on.

The gate is now value-aware. Delivery resolves the effective `--remote_download_outputs` mode from the fully expanded flag list (`effective_download_outputs`), matching every form Bazel accepts — canonical `--remote_download_outputs=<mode>`, the two-token form, and the no-value aliases (`--remote_download_all` / `--remote_download_toplevel` / `--remote_download_minimal`) — with last-wins across them. The `=toplevel` default is kept only when that mode is insufficient: a user `=minimal` is upgraded to `=toplevel`, while a user `=all` / `toplevel` (in any form) is respected.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Fixed `aspect delivery` failing to download runfiles when `--remote_download_outputs=minimal` is set in the user's flags or `.bazelrc`; the phase-3 download now upgrades to `=toplevel`, while a user-set `=all`/`toplevel` (including the `--remote_download_*` aliases) is still respected.

### Test plan

- New unit tests in `lib/runnable_test.axl` cover `effective_download_outputs` (canonical, two-token, and alias forms with last-wins) and `download_outputs_sufficient`
- Covered by existing test cases (delivery template snapshots; full `aspect tests axl` suite)
