### PR TITLE
feat(bk): let users mark phases auto-expanded on Buildkite

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -23,6 +23,7 @@ load("@aspect//lib/gitlab_lint_comments_test.axl", "gitlab_lint_comments_tests")
 load("@aspect//lib/gitlab_test.axl", "gitlab_client_tests")
 load("@aspect//lib/health_check_ready_test.axl", "health_check_ready_tests")
 load("@aspect//lib/init_test.axl", "init_tests")
+load("@aspect//lib/lifecycle_test.axl", "lifecycle_tests")
 load("@aspect//lib/lint_comments_test.axl", "lint_comments_tests")
 load("@aspect//lib/lint_results_test.axl", "detect_lint_tool_tests", "lint_annotation_plan_tests", "lint_template_snapshot_tests", "linter_rows_tests")
 load("@aspect//lib/rate_limit_test.axl", "rate_limit_tests")
@@ -205,6 +206,9 @@ def config(ctx: ConfigContext):
     ctx.features[CircleCITestResults].args.upload_test_results = "all"
     ctx.features[CircleCITestResults].args.cached_as_skipped = True
 
+    # Expand test phase by default
+    ctx.features[BuildkiteAnnotations].args.expand_phases = ["test"]
+
     # Silence tips via the Tips feature args (append ids to suppress):
     # ctx.features["tips"].args.silence.append("some-tip-id")
 
@@ -279,6 +283,11 @@ def config(ctx: ConfigContext):
     # Cross-CI URL helpers (lib/ci.axl): host detection, build URL, per-job cache.
     # Run with: aspect dev test-ci
     ctx.tasks.add(ci_tests)
+
+    # Buildkite phase-section expansion (lib/lifecycle.axl): Phase.expanded +
+    # BuildkiteAnnotations.expanded_phases → `+++`/`---` marker resolution.
+    # Run with: aspect dev test-lifecycle
+    ctx.tasks.add(lifecycle_tests)
 
     # @aspect//helpers.axl facade: re-exports resolve to the real helpers.
     # Run with: aspect dev test-helpers

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -13,10 +13,12 @@ Only runs when `BUILDKITE` env is set — skips silently in local dev.
 
 Usage in `.aspect/config.axl`:
 
-    load("@aspect_workflows//:lib.axl", "BuildkiteAnnotations")
+    load("@aspect//feature/buildkite_annotations.axl", "BuildkiteAnnotations")
 
     def config(ctx):
-        ctx.features[BuildkiteAnnotations].enabled = True
+        ctx.features[BuildkiteAnnotations].args.enabled = True
+        # Open the build + test phase log sections by default (else collapsed).
+        ctx.features[BuildkiteAnnotations].args.expand_phases = ["build", "test"]
 """
 
 load("../lib/bazel_results.axl", "format_run_date", "html_escape", "now_ms", "render_bes_url", "resolve_aspect_url")
@@ -31,7 +33,7 @@ load(
 )
 load("../lib/ci.axl", "resolve_build_url")
 load("../lib/environment.axl", "feature_logger", "workflows_results_url")
-load("../lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
+load("../lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate", "publish_expanded_phases")
 load("../lib/rate_limit.axl", "usage_footer")
 load("../lib/result_text.axl", "severity_for_status")
 load("../lib/tips.axl", "SURFACE_BUILDKITE_ANNOTATIONS", "collect_tips_sorted")
@@ -217,6 +219,13 @@ def _buildkite_annotations(ctx: FeatureContext):
 
     # mode == "always" falls through
 
+    # Publish which phases should render as expanded (`+++`) BK sections.
+    # Independent of the `buildkite-agent annotate` probe below — phase section
+    # headers are printed by the task lifecycle, not by this feature — so set it
+    # before the probe can early-return. No-op off Buildkite (the section
+    # emitter is itself BK-gated), so it's safe under any `mode`.
+    publish_expanded_phases(ctx, ctx.args.expand_phases)
+
     # Probe buildkite-agent — on a Workflows runner it always exists,
     # so this is a clean rc check; elsewhere `.spawn()` raises before
     # we ever get the rc.
@@ -356,6 +365,18 @@ BuildkiteAnnotations = feature(
                           "reduce `buildkite-agent annotate` invocations on chatty tasks at the cost of " +
                           "less-responsive live annotations. The task's terminal result and phase " +
                           "boundaries always land immediately regardless of this setting.",
+        ),
+        "expand_phases": args.string_list(
+            default = [],
+            long = "buildkite-annotations:expand-phase",
+            description = "Phase id (e.g. \"build\", \"test\") whose Buildkite log section is open by " +
+                          "default; repeat the flag to name several " +
+                          "(--buildkite-annotations:expand-phase=build --buildkite-annotations:expand-phase=test). " +
+                          "A named phase's `--- ` collapsed header is emitted as an expanded `+++` header " +
+                          "instead, regardless of the task's own `Phase.expanded`. Note BK auto-expands " +
+                          "only the last collapsed section when none is explicitly expanded, so expanding " +
+                          "an earlier phase suppresses that auto-expansion of the closing timing-summary " +
+                          "section. Empty (default) leaves each phase's own `Phase.expanded`.",
         ),
     },
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -499,6 +499,7 @@ GithubStatusChecks = feature(
         ),
         "metadata_keys": args.string_list(
             default = [],
+            long = "github-status-checks:metadata-key",
             description = "Additional BES build_metadata keys to surface in the check run summary, " +
                           "beyond the built-in set (BRANCH, COMMIT_SHA, TAG, COMMIT_MESSAGE). Use " +
                           "[\"*\"] to show ALL metadata keys from the BES stream. Users inject " +

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -440,6 +440,7 @@ GitlabCommitStatuses = feature(
         ),
         "metadata_keys": args.string_list(
             default = [],
+            long = "gitlab-commit-statuses:metadata-key",
             description = "Additional BES build_metadata keys to surface in the render-context (used " +
                           "by sibling features like GitlabStatusComments). Use [\"*\"] for all keys.",
         ),

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle.axl
@@ -99,7 +99,22 @@ Phase = record(
 
     # Display-label override; wins over titlecase(name) when non-empty.
     display_name = field(str, default = ""),
+
+    # When True, this phase's Buildkite section header is emitted expanded
+    # (`+++`) instead of collapsed (`---`), so the section is open by default
+    # in the BK log. The `--buildkite-annotations:expand-phase` user flag can
+    # force a phase expanded regardless of this field — see
+    # `_emit_bk_phase_section`. No effect off Buildkite.
+    expanded = field(bool, default = False),
 )
+
+# Env channel by which the `BuildkiteAnnotations` feature publishes its
+# user-configured expanded phases (the repeatable
+# `--buildkite-annotations:expand-phase` flag) to `_emit_bk_phase_section`,
+# which runs later in the task `_impl`. Comma-separated phase ids. The feature
+# evaluates before `_impl`, so an env var is the process-wide channel (same
+# pattern as `ci.axl`'s job-URL cache). Empty / unset → no overrides.
+_BK_EXPANDED_PHASES_ENV = "ASPECT_BK_EXPANDED_PHASES"
 
 # A single repro / fix command suggestion. Stored in
 # `data["repro_commands"]` / `data["fix_commands"]` and surfaced to every
@@ -433,11 +448,46 @@ def _strip_ansi(text):
 # emoji still get a section marker.
 _ASPECT_BK_SHORTCODE = ":aspect:"
 
+def publish_expanded_phases(ctx, phase_names: list) -> None:
+    """Record `phase_names` as the phases whose Buildkite section headers should
+    be emitted expanded (`+++`), read later by `_emit_bk_phase_section` during the
+    task `_impl`. Called by the `BuildkiteAnnotations` feature from its config.
+
+    Stored in `_BK_EXPANDED_PHASES_ENV` (comma-separated) since the feature runs
+    before `_impl` and an env var is the process-wide channel between the two.
+    The list is written verbatim each call (an empty list clears the channel)
+    so the value always reflects the current run's resolved config."""
+    ctx.std.env.set_var(_BK_EXPANDED_PHASES_ENV, ",".join([n for n in phase_names if n]))
+
+def bk_phase_section_marker(ctx, phase) -> str:
+    """Resolve `phase`'s Buildkite section-header marker: `"+++"` (expanded) or
+    `"---"` (collapsed).
+
+    Expanded when the producer set `Phase.expanded = True`, OR when the phase id
+    (`phase.name`) was passed to `--buildkite-annotations:expand-phase` (published
+    via `_BK_EXPANDED_PHASES_ENV`). The flag can thus force a phase open even when
+    the task left `Phase.expanded = False`; neither can force a phase *collapsed*
+    against the other (it's a union)."""
+    if phase.expanded:
+        return "+++"
+    configured = ctx.std.env.var(_BK_EXPANDED_PHASES_ENV) or ""
+    if configured:
+        for name in configured.split(","):
+            if name.strip() == phase.name:
+                return "+++"
+    return "---"
+
 def _emit_bk_phase_section(ctx, phase, progress_styles = None):
-    """Emit a per-phase BK section header `--- <emoji> <Phase> · <cli>`
+    """Emit a per-phase BK section header `<marker> <emoji> <Phase> · <cli>`
     (1:1 AXL-phase → BK collapsible section). The `<cli>` mirrors the live
     `→` print (`progress_styles.stream`, falling back to `.body`).
-    `phase.emoji` → `:aspect:`, `phase.display_name` → titlecase(name)."""
+    `phase.emoji` → `:aspect:`, `phase.display_name` → titlecase(name).
+
+    `<marker>` is `+++` (expanded) when `bk_phase_section_marker` resolves it for
+    this phase — either `Phase.expanded` or a `--buildkite-annotations:expand-phase`
+    entry — else `---` (collapsed). Note BK only auto-expands the last collapsed
+    `---` group when no group is explicitly expanded, so a `+++` here suppresses
+    that auto-expansion of a later section (e.g. the closing bookend)."""
     if not ctx.std.env.var("BUILDKITE"):
         return
     label = phase.display_name or _titlecase_phase(phase.name)
@@ -449,7 +499,8 @@ def _emit_bk_phase_section(ctx, phase, progress_styles = None):
         cli = progress_styles.stream or progress_styles.body
         if cli:
             suffix = " · " + cli
-    print("--- " + (phase.emoji or _ASPECT_BK_SHORTCODE) + " " + label + suffix)
+    marker = bk_phase_section_marker(ctx, phase)
+    print(marker + " " + (phase.emoji or _ASPECT_BK_SHORTCODE) + " " + label + suffix)
 
 def _titlecase_phase(phase):
     """Title-case a phase id (underscores → spaces, first char upper).

--- a/crates/aspect-cli/src/builtins/aspect/lib/lifecycle_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/lifecycle_test.axl
@@ -1,0 +1,73 @@
+"""Tests for `lib/lifecycle.axl`'s Buildkite phase-section expansion.
+
+Covers `bk_phase_section_marker` + `publish_expanded_phases` — the logic
+deciding whether a phase's BK section header is emitted expanded (`+++`) or
+collapsed (`---`):
+
+  - `Phase.expanded = True` → `+++`.
+  - A `--buildkite-annotations:expand-phase` entry (published via
+    `publish_expanded_phases`) → `+++`, matched on the phase id.
+  - Neither → `---`.
+  - The two are a union: config can force a phase open, but cannot force one
+    that the producer marked `expanded = True` back to collapsed.
+
+These exercise real `ctx.std.env` (no env-mocking layer in AXL), so the
+subtest snapshots and restores the channel env var it touches.
+
+Run with:
+  aspect dev test-lifecycle
+"""
+
+load("./lifecycle.axl", "Phase", "bk_phase_section_marker", "publish_expanded_phases")
+
+_ENV_KEY = "ASPECT_BK_EXPANDED_PHASES"
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _test_marker(ctx):
+    prior = ctx.std.env.var(_ENV_KEY)
+    ctx.std.env.remove_var(_ENV_KEY)
+
+    build = Phase(name = "build")
+    test = Phase(name = "test")
+    build_expanded = Phase(name = "build", expanded = True)
+
+    # No config, no Phase.expanded → collapsed.
+    _eq("default collapsed", bk_phase_section_marker(ctx, build), "---")
+
+    # Phase.expanded wins on its own.
+    _eq("Phase.expanded → expanded", bk_phase_section_marker(ctx, build_expanded), "+++")
+
+    # Config names the phase → expanded; an unnamed phase stays collapsed.
+    publish_expanded_phases(ctx, ["build"])
+    _eq("config match → expanded", bk_phase_section_marker(ctx, build), "+++")
+    _eq("config miss → collapsed", bk_phase_section_marker(ctx, test), "---")
+
+    # Whitespace around configured ids is tolerated.
+    publish_expanded_phases(ctx, [" build ", "test"])
+    _eq("config whitespace tolerated", bk_phase_section_marker(ctx, build), "+++")
+    _eq("config second entry matches", bk_phase_section_marker(ctx, test), "+++")
+
+    # Empty list clears the channel → back to Phase.expanded only.
+    publish_expanded_phases(ctx, [])
+    _eq("cleared config → collapsed", bk_phase_section_marker(ctx, build), "---")
+    _eq("cleared config, Phase.expanded still wins", bk_phase_section_marker(ctx, build_expanded), "+++")
+
+    if prior == None:
+        ctx.std.env.remove_var(_ENV_KEY)
+    else:
+        ctx.std.env.set_var(_ENV_KEY, prior)
+
+def _test_impl(ctx):
+    _test_marker(ctx)
+    print("lifecycle.axl: OK (1 section)")
+    return 0
+
+lifecycle_tests = task(
+    kind = "test-lifecycle",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)


### PR DESCRIPTION
Builds on the section-expansion work in #1266 (which expands the *failing* phase). Users asked to also have specific **passing** phases open by default in the Buildkite log.

Adds two ways to emit a phase's BK section header as expanded (`+++`) instead of collapsed (`---`):

- **`Phase.expanded`** — a producer marks a phase's section open when emitting the phase boundary.
- **`--buildkite-annotations:expand-phase`** — a repeatable user flag naming phase ids that forces those phases open regardless of the task's own `Phase.expanded`. The feature publishes the list to the section emitter (which runs later, inside the task `_impl`) via the `ASPECT_BK_EXPANDED_PHASES` env channel — the same process-wide feature→task channel pattern already used by `lib/ci.axl`'s job-URL cache.

The arg key is `expand_phases` with an explicit `long` override carrying the full `buildkite-annotations:expand-phase` flag, so the repeatable flag reads in the singular while the config arg key stays plural. While here, the same singular-flag convention is applied to the existing repeatable `metadata_keys` args: `--github-status-checks:metadata-key` and `--gitlab-commit-statuses:metadata-key`.

`bk_phase_section_marker` resolves the marker as the union of the two knobs. Per [BK's docs](https://buildkite.com/docs/pipelines/configure/managing-log-output#expanded-groups), only the last collapsed `---` group auto-expands when nothing is explicitly expanded, so expanding an earlier phase suppresses the auto-expansion of the closing timing-summary section — documented on both knobs.

## Usage

Expand the `test` phase by default, two ways:

**In `.aspect/config.axl`:**

```python
load("@aspect//feature/buildkite_annotations.axl", "BuildkiteAnnotations")

def config(ctx):
    ctx.features[BuildkiteAnnotations].args.expand_phases = ["test"]
```

**On the command line** (repeat the flag, one phase per occurrence):

```bash
aspect test //... --buildkite-annotations:expand-phase=test
```

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

On Buildkite, you can now keep chosen phase log sections open by default — set `BuildkiteAnnotations.args.expand_phases` in `.aspect/config.axl` or pass the repeatable `--buildkite-annotations:expand-phase=<phase>` flag, or mark a phase `expanded` when emitting it.

### Test plan

- New test cases added: `lib/lifecycle_test.axl` (`aspect dev test-lifecycle`) covers `Phase.expanded`, config-match/miss, whitespace tolerance, clearing, and the union precedence.
- Manual testing: `aspect build --help` shows `--buildkite-annotations:expand-phase`, `--github-status-checks:metadata-key`, and `--gitlab-commit-statuses:metadata-key` with the correct feature prefixes.
- Covered by existing test cases: `aspect dev test-bk-annotation-snapshots` and `aspect dev test-ci` still pass.
