### PR TITLE
fix: inject args and env for runnable.axl

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -139,7 +139,7 @@ load("@aspect//lib/health_check.axl", "HealthCheckTrait")
 load("@aspect//lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("@aspect//lib/remote_executor.axl", "start_dummy_executor", "stop_dummy_executor")
 load("@aspect//lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "repro_prefix", "task_cli_path")
-load("@aspect//lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "apparent_label", "download_outputs_sufficient", "effective_download_outputs", "runnable")
+load("@aspect//lib/runnable.axl", "apparent_label", "runnable")
 load("@aspect//lib/text.axl", "pluralize")
 load("@aspect//lib/tips.axl", "tips")
 load("@bazel//proto/remote_logging.axl", "remote_logging")
@@ -349,20 +349,6 @@ def _surface_phase_stderr(ctx, phase, log_path):
         return
     ctx.std.io.stderr.write(ctx.std.fs.read_to_string(log_path))
     artifacts.upload_file(ctx, "delivery_phase{}_log".format(phase), "phase{}-stderr.log".format(phase), log_path)
-
-def _base_flag_satisfied(rc, flag: str) -> bool:
-    """Whether the active run command already satisfies a `LOCAL_SPAWN_BASE_FLAGS`
-    default, so phase 3 need not inject it.
-
-    `--remote_download_outputs=toplevel` carries the only non-trivial policy:
-    phase 3 must materialize the top-level binary on disk, so the default is
-    satisfied only when the rc resolves to a sufficient mode (`toplevel`/`all`)
-    — across every flag form, including the `--remote_download_*` aliases. A
-    user `=minimal` is not sufficient, so the `=toplevel` default still applies.
-    Any other base flag is satisfied once the rc sets it at all."""
-    if flag.startswith("--remote_download_outputs="):
-        return download_outputs_sufficient(effective_download_outputs(rc.expand(command = "build")))
-    return rc.flag_value(flag.split("=", 1)[0], command = "build") != None
 
 def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, user_remote_executor_uri, ansi, data):
     """Run phase 1 (build) + phase 2 (digest extraction); return
@@ -1114,7 +1100,10 @@ def _delivery_impl(ctx):
 
     _print_header(ansi, endpoint, ci_host, commit_sha, prefix, prefix_source, build_url, rc.expand(command = "build"), targets, forced_targets, mode, dry_run, track_state)
 
-    run_tracker = runnable(ctx, targets)
+    # `rc=` opts into the runinfo aspect so the deliverables spawned in phase 3
+    # replay their `args` attribute + env the way `bazel run` does. The aspect
+    # rides phase 3 (the build feeding `.event`) via `run_tracker.flags`.
+    run_tracker = runnable(ctx, targets, rc = rc)
 
     _t_total = time.monotonic()
 
@@ -1222,23 +1211,18 @@ def _delivery_impl(ctx):
         # defined" (the task's own expanded_flags already went through this).
         release_flags = expand_config_flags(ctx, bazel_trait, ctx.args.release_bazel_flags)
 
-        # LOCAL_SPAWN_BASE_FLAGS are delivery defaults the active run command
-        # may override (a repo's `--remote_download_outputs=all` must win over
-        # the default `toplevel`); inject only those the rc doesn't already
-        # satisfy. See `_base_flag_satisfied` for the download-outputs policy.
-        base_defaults = [
-            f
-            for f in LOCAL_SPAWN_BASE_FLAGS
-            if not _base_flag_satisfied(rc, f)
-        ]
-
-        # Phase 3 flag order (last-wins): active run command, then the per-call
-        # extras below. release_flags are `--release-bazel-flag`s (e.g. `--stamp`,
-        # `--config=release`) rc-config-expanded; LOCAL_SPAWN_FLAGS are mandatory
-        # and last; `--noremote_upload_local_results` keeps release artifacts out
-        # of the shared remote cache (delivery-specific). base_defaults lead so a
-        # release flag could still override them.
-        phase3_flags = base_defaults + list(release_flags) + LOCAL_SPAWN_FLAGS + [
+        # Phase 3 flag order (last-wins): active run command, then these per-call
+        # extras. `run_tracker.flags` carries every flag needed to build-then-spawn
+        # the deliverables (mandatory spawn flags, the runinfo aspect so each
+        # deliverable's `args`/env replay like `bazel run`, and the
+        # `--remote_download_outputs=toplevel` floor that upgrades a user `=minimal`).
+        # release_flags (`--release-bazel-flag`s like `--stamp`, `--config=release`)
+        # come AFTER so a release that *raises* the floor — e.g. `=all` for a rule
+        # set that won't run without dependency outputs materialized — still wins
+        # over `=toplevel` (the floor is a minimum, not a ceiling).
+        # `--noremote_upload_local_results` keeps release artifacts out of the
+        # shared remote cache (delivery-specific).
+        phase3_flags = run_tracker.flags + list(release_flags) + [
             "--noremote_upload_local_results",
         ]
         _t_download = time.monotonic()

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -31,7 +31,7 @@ load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskL
 load("./lib/path_glob.axl", "match_any")
 load("./lib/path_normalize.axl", "normalize_files_for_cwd")
 load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
-load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
+load("./lib/runnable.axl", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
 
@@ -308,10 +308,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # Single pre-task setup phase (status surface, rc parse, health checks);
     # returns resolved flags (a failed health check fails the task inside).
-    setup_phase(ctx, lifecycle, ctx.args.formatter_target, "format_results", data, hc_trait, bazel_trait, bazel_base_flags = LOCAL_SPAWN_BASE_FLAGS)
+    rc = setup_phase(ctx, lifecycle, ctx.args.formatter_target, "format_results", data, hc_trait, bazel_trait)
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
-    r = runnable(ctx, [ctx.args.formatter_target])
+    # `rc=` opts into the runinfo aspect: `r.flags` captures the formatter's
+    # executable + `args` attribute + env so `r.spawn` replays them ahead of the
+    # changed-file list.
+    r = runnable(ctx, [ctx.args.formatter_target], rc = rc)
 
     # Pass build_event_sinks (carries the Aspect backend gRPC sink in CI) so the
     # "✨ Aspect Workflows" link resolves to a real record, not a 404.
@@ -340,7 +343,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     build = ctx.bazel.build(
         ctx.args.formatter_target,
         build_events = build_events,
-        flags = LOCAL_SPAWN_FLAGS,
+        flags = r.flags,
         current_dir = ctx.std.env.aspect_root_dir(),
         announce_version = announce_version,
         announce_command = announce_command,

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -95,7 +95,7 @@ load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
 load("./lib/path_glob.axl", "match_any")
 load("./lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
-load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "runnable")
+load("./lib/runnable.axl", "runnable")
 load("./lib/text.axl", "pluralize")
 load("./lib/tips.axl", "tips")
 
@@ -442,7 +442,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # Single pre-task setup phase (status surface, rc parse, health checks);
     # returns resolved flags (a failed health check fails the task inside).
-    setup_phase(ctx, lifecycle, ctx.args.gazelle_target, "gazelle_results", data, hc_trait, bazel_trait, bazel_base_flags = LOCAL_SPAWN_BASE_FLAGS)
+    rc = setup_phase(ctx, lifecycle, ctx.args.gazelle_target, "gazelle_results", data, hc_trait, bazel_trait)
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
     # Resolve dirs before the build: gazelle needs them when spawned, the no-op
@@ -454,7 +454,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data["gazelle"]["no_changed_dirs"] = True
         return _emit_final(ctx, lifecycle, data, 0)
 
-    r = runnable(ctx, [ctx.args.gazelle_target])
+    # `rc=` opts into the runinfo aspect: `r.flags` captures the gazelle
+    # target's executable (the sh_binary, not its `-runner.bash` helper), its
+    # `args` attribute, and its env so `r.spawn` resolves and replays them.
+    r = runnable(ctx, [ctx.args.gazelle_target], rc = rc)
 
     # See format.axl for why the trait sinks need to be plumbed in.
     events = bazel.build_events.iterator()
@@ -482,7 +485,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     build = ctx.bazel.build(
         ctx.args.gazelle_target,
         build_events = build_events,
-        flags = LOCAL_SPAWN_FLAGS,
+        flags = r.flags,
         current_dir = ctx.std.env.bazel_root_dir(),
         announce_version = announce_version,
         announce_command = announce_command,
@@ -548,14 +551,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if not ep:
         _emit_final(ctx, lifecycle, data, 1)
         fail("Failed to determine the gazelle target's entrypoint.")
-
-    # Upstream gazelle() (from-source) emits both a `<name>` sh_binary and an
-    # inner `<name>-runner.bash`; determine_entrypoint may surface either (BES
-    # ordering). The runner script's $0-relative runfiles lookup wants
-    # `<name>-runner.bash.runfiles`, but bazel creates `<name>.runfiles`.
-    # Stripping the suffix points at the sh_binary, whose runfiles resolve.
-    if ep.path.endswith("-runner.bash"):
-        ep = struct(path = ep.path[:-len("-runner.bash")], runfiles_dir = ep.runfiles_dir)
 
     # Diff phase: -mode=diff yields the verdict + patch without touching the
     # tree. The wrapper hardcodes `-mode fix`; our appended `-mode=diff` wins

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable.axl
@@ -2,33 +2,19 @@ load("./bazel_results.axl", "bes_get")
 
 _DEFAULT_WORKSPACE_NAME = "_main"
 
-# Mandatory Bazel flags for a task that immediately spawns the built binary
-# (format, gazelle, run, delivery phase 3). Append these LAST so they win
-# over any user rc / `--bazel-flag` value that would flip them: the spawn
-# cannot work without them.
+# Mandatory Bazel flags every spawn build needs: BES must report artifacts as
+# local paths and the runfiles tree must be materialized so the binary runs.
+# Private — callers never assemble spawn flags by hand; `runnable().flags`
+# bundles these with the runinfo aspect and the download floor.
 #
 #   --experimental_build_event_upload_strategy=local: BES reports artifacts
 #       as local file:// paths so we can locate the binary on disk;
 #       the remote strategy yields bytestream:// URIs, which aren't paths.
 #   --build_runfile_links: materializes the runfiles tree so the binary's
 #       wrappers and data deps resolve at runtime.
-LOCAL_SPAWN_FLAGS = [
+_LOCAL_SPAWN_FLAGS = [
     "--experimental_build_event_upload_strategy=local",
     "--build_runfile_links",
-]
-
-# Default `--remote_download_outputs` value for a task that immediately spawns
-# the built binary. `=toplevel` is the minimum that puts the binary itself on
-# disk so we can spawn it; `=minimal` would leave it remote and break the spawn.
-# A user who needs `=all` — an older Bazel, or a rule set that won't run without
-# dependency outputs materialized — can still override.
-#
-# run/format/gazelle inject these via `bazel_base_flags` (BEFORE user flags), so
-# Bazel's last-wins lets the user override. Delivery injects them per-call
-# (AFTER the rc) and instead gates each on `_base_flag_satisfied`, so a user
-# `=minimal` is upgraded to `=toplevel` rather than silently winning.
-LOCAL_SPAWN_BASE_FLAGS = [
-    "--remote_download_outputs=toplevel",
 ]
 
 # `--remote_download_outputs` values that already put the top-level binary
@@ -46,10 +32,159 @@ _DOWNLOAD_OUTPUTS_ALIASES = {
     "--remote_download_all": "all",
 }
 
+# Injected-aspect repo / output-group / file-suffix names. The aspect writes
+# one `<name>.aspect_runinfo.json` per runnable target carrying everything
+# `bazel run` reconstructs but no provider exposes: the executable
+# (runfiles-relative short_path), the expanded+tokenized `args` attribute, and
+# the `RunEnvironmentInfo` env. `determine_entrypoint` reads it back.
+_RUNINFO_REPO = "aspect_runinfo"
+_RUNINFO_OUTPUT_GROUP = "aspect_runinfo"
+_RUNINFO_JSON_SUFFIX = ".aspect_runinfo.json"
+
+# The injected aspect, materialized verbatim into a temp repo. `_tokenize` is a
+# Starlark port of Bazel's ShellUtils.tokenize (ShellUtils.java:90-143); the
+# args pipeline mirrors RunfilesSupport.java:608 — location-expand over `data`,
+# Make-var expand, then shell-tokenize — so the captured argv matches `bazel
+# run` byte-for-byte. Backslashes are doubled for the AXL string literal.
+_RUNINFO_BZL = """_BS = '\\\\'
+
+def _tokenize(s):
+    tokens = []
+    token = ""
+    active = False
+    i = 0
+    n = len(s)
+    for _ in range(n + 1):
+        if i >= n:
+            break
+        c = s[i]
+        i += 1
+        if c == "'":
+            active = True
+            closed = False
+            for _ in range(n + 1):
+                if i >= n:
+                    break
+                d = s[i]
+                i += 1
+                if d == "'":
+                    closed = True
+                    break
+                token += d
+            if not closed:
+                fail("tokenize: unterminated single quote in: " + s)
+        elif c == '"':
+            active = True
+            closed = False
+            for _ in range(n + 1):
+                if i >= n:
+                    break
+                d = s[i]
+                i += 1
+                if d == '"':
+                    closed = True
+                    break
+                if d == _BS:
+                    if i >= n:
+                        fail("tokenize: trailing backslash in: " + s)
+                    e = s[i]
+                    i += 1
+                    if e == '"' or e == _BS:
+                        token += e
+                    else:
+                        token += _BS + e
+                else:
+                    token += d
+            if not closed:
+                fail("tokenize: unterminated double quote in: " + s)
+        elif c == " " or c == "\\t":
+            if active:
+                tokens.append(token)
+                token = ""
+                active = False
+        elif c == _BS:
+            if i >= n:
+                fail("tokenize: trailing backslash in: " + s)
+            token += s[i]
+            i += 1
+            active = True
+        else:
+            token += c
+            active = True
+    if active:
+        tokens.append(token)
+    return tokens
+
+def _expand_and_tokenize_args(ctx, target):
+    raw = getattr(ctx.rule.attr, "args", None)
+    if not raw:
+        return []
+    lookup = getattr(ctx.rule.attr, "data", []) + [target]
+    out = []
+    for a in raw:
+        a = ctx.expand_location(a, lookup)
+        a = ctx.expand_make_variables("args", a, {})
+        out.extend(_tokenize(a))
+    return out
+
+def _runinfo_aspect_impl(target, ctx):
+    files_to_run = target[DefaultInfo].files_to_run
+    if files_to_run == None or files_to_run.executable == None:
+        return []
+
+    env = {}
+    inherited = []
+    if RunEnvironmentInfo in target:
+        rei = target[RunEnvironmentInfo]
+        env = rei.environment
+        inherited = rei.inherited_environment
+
+    info = struct(
+        executable = files_to_run.executable.short_path,
+        args = _expand_and_tokenize_args(ctx, target),
+        environment = env,
+        inherited_environment = inherited,
+    )
+
+    out = ctx.actions.declare_file(target.label.name + ".aspect_runinfo.json")
+    ctx.actions.write(out, json.encode(info))
+    return [OutputGroupInfo(aspect_runinfo = depset([out]))]
+
+runinfo = aspect(implementation = _runinfo_aspect_impl)
+"""
+
+def _write_runinfo_repo(ctx, repo_dir: str):
+    ctx.std.fs.create_dir_all(repo_dir)
+    ctx.std.fs.write(repo_dir + "/REPO.bazel", "")
+    ctx.std.fs.write(repo_dir + "/BUILD.bazel", "")
+    ctx.std.fs.write(repo_dir + "/runinfo.bzl", _RUNINFO_BZL)
+
+def _runinfo_aspect_flags(ctx, rc) -> list[str]:
+    """Materialize the runinfo aspect into a temp injectable repo and return the
+    Bazel flags that apply it to the top-level run target(s).
+
+    Folded into `runnable(rc=...)` so spawn tasks never assemble it by hand.
+    The temp repo is namespaced by `ctx.task.name`. `rc` selects the injection
+    flag: `--inject_repository` only registers the repo in the bzlmod graph, so
+    under WORKSPACE mode (`--enable_bzlmod=false`) the repo is invisible and
+    `@aspect_runinfo` fails to resolve — `--override_repository` injects in both
+    modes. Mirrors `delivery._get_output_shas`.
+    """
+    repo_dir = "/tmp/aspect_runinfo_" + ctx.task.name
+    _write_runinfo_repo(ctx, repo_dir)
+    if rc.bool_flag("--enable_bzlmod", command = "build") == False:
+        inject = "--override_repository=" + _RUNINFO_REPO + "=" + repo_dir
+    else:
+        inject = "--inject_repository=" + _RUNINFO_REPO + "=" + repo_dir
+    return [
+        "--aspects=@" + _RUNINFO_REPO + "//:runinfo.bzl%runinfo",
+        "--output_groups=+" + _RUNINFO_OUTPUT_GROUP,
+        inject,
+    ]
+
 def download_outputs_sufficient(value: str | None) -> bool:
     """Whether a `--remote_download_outputs` value already puts the top-level
-    binary on disk, so the spawn/delivery `=toplevel` default need not override
-    it.
+    binary on disk, so the spawn `=toplevel` default need not override it.
 
     `toplevel`/`all` are sufficient; `minimal` is not — it leaves the binary
     remote and breaks the spawn, so a `=minimal` must be upgraded to `toplevel`
@@ -87,6 +222,15 @@ def effective_download_outputs(flags: list) -> str | None:
         elif flag in _DOWNLOAD_OUTPUTS_ALIASES:
             mode = _DOWNLOAD_OUTPUTS_ALIASES[flag]
     return mode
+
+def _download_floor_flags(rc) -> list[str]:
+    """`--remote_download_outputs=toplevel` when `rc` resolves below `toplevel`
+    (unset or `minimal`), else empty. Bundled into `runnable().flags` so it wins
+    last; skipped when the user already asked for `toplevel`/`all` so an upward
+    override stands."""
+    if download_outputs_sufficient(effective_download_outputs(rc.expand(command = "build"))):
+        return []
+    return ["--remote_download_outputs=toplevel"]
 
 # Named modes accepted by `--run-in=<choice>` on tasks that spawn a
 # built binary.
@@ -241,6 +385,8 @@ def _process_bes(state: struct, event):
             for og in (bes_get(event.payload, "output_group", None) or []):
                 if og.name == "default":
                     state.target_fileset[label_key] = og.file_sets
+                elif og.name == _RUNINFO_OUTPUT_GROUP:
+                    state.runinfo_fileset[label_key] = og.file_sets
     elif event.kind == "workspace_config":
         # WorkspaceConfig.local_exec_root is "<output_base>/execroot/<workspace_name>".
         # Its basename is the canonical repo name Bazel uses inside runfiles trees.
@@ -292,12 +438,44 @@ def _get_default_outputs(state: struct, target: str) -> list[str]:
         return []
     return _collect_fileset_paths(state, state.target_fileset[target])
 
+def _read_runinfo(state: struct, target_key: str) -> struct | None:
+    """Parse the `aspect_runinfo` JSON the injected aspect wrote for `target_key`.
+
+    Returns `struct(executable, args, environment, inherited_environment)` —
+    `executable` the runfiles-relative short_path of the binary, `args` the
+    expanded+tokenized `args` attribute, and the `RunEnvironmentInfo` env split.
+    `None` when the aspect didn't run for this target (no injection, or a
+    non-runnable target the aspect skipped) or when `ctx` is absent (unit tests).
+    """
+    if state.ctx == None or target_key not in state.runinfo_fileset:
+        return None
+    for path in _collect_fileset_paths(state, state.runinfo_fileset[target_key]):
+        if not path.endswith(_RUNINFO_JSON_SUFFIX):
+            continue
+        parsed = json.try_decode(state.ctx.std.fs.read_to_string(path), None)
+        if parsed == None:
+            continue
+        return struct(
+            executable = parsed.get("executable", ""),
+            args = parsed.get("args", []),
+            environment = parsed.get("environment", {}),
+            inherited_environment = parsed.get("inherited_environment", []),
+        )
+    return None
+
 def _determine_entrypoint(state: struct, target: str) -> struct | None:
     """Resolve `target` to an executable path and runfiles directory.
 
-    Returns `struct(path, runfiles_dir, runfiles_workspace_dir)` or
-    `None` when the target produced no BES `target_completed` event or
-    its default output group has no selectable executable.
+    Returns `struct(path, runfiles_dir, runfiles_workspace_dir, args,
+    environment, inherited_environment)` or `None` when the target produced no
+    BES `target_completed` event or its default output group has no selectable
+    executable.
+
+    `args` / `environment` / `inherited_environment` come from the injected
+    `runinfo` aspect (see `runinfo_aspect_flags`): the expanded+tokenized `args`
+    attribute and the target's `RunEnvironmentInfo` env, for `_spawn` to replay
+    the way `bazel run` does. They are empty when the aspect didn't run — e.g.
+    `delivery`, which doesn't inject it, and the unit tests.
 
     `runfiles_dir` is the resolved runfiles directory path (e.g.
     `…/format.runfiles`), or `None` when no `<entrypoint>.runfiles`
@@ -308,12 +486,15 @@ def _determine_entrypoint(state: struct, target: str) -> struct | None:
     or `None` when `runfiles_dir` is `None`. Pre-joined here so consumers
     don't have to know the canonical workspace name.
 
-    Entrypoint selection — three passes over the default-output-group files:
+    Entrypoint selection:
+      0. When the `runinfo` aspect ran, match its `files_to_run.executable`
+         short_path basename — authoritative, so it supersedes the heuristics.
       1. Exact match on `target_name`.
       2. `target_name + EXT` for each extension in `_SCRIPT_EXTENSIONS`
          (.sh, .bash, .exe, .bat).
       3. First file with the executable bit set —
          last-resort for any remaining non-standard output name.
+    Passes 1–3 are the fallback for callers that don't inject the aspect.
 
     Runfiles detection — Bazel names the runfiles dir after the
     executable FILE (including any extension), not the target label:
@@ -323,7 +504,7 @@ def _determine_entrypoint(state: struct, target: str) -> struct | None:
     https://github.com/bazelbuild/bazel/blob/9.0.0rc1/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java#L83-L84
 
     Detection checks `<entrypoint>.runfiles` on disk, materialized
-    by `--build_runfile_links` (included in `LOCAL_SPAWN_FLAGS`).
+    by `--build_runfile_links` (included in `r.flags`).
     """
     target = apparent_label(target, state.current_package)
     if target not in state.target_fileset:
@@ -335,11 +516,20 @@ def _determine_entrypoint(state: struct, target: str) -> struct | None:
     if not candidates:
         return None
 
+    runinfo = _read_runinfo(state, target)
+
     entrypoint = None
-    for c in candidates:
-        if c.rsplit("/", 1)[-1] == target_name:
-            entrypoint = c
-            break
+    if runinfo != None and runinfo.executable:
+        exe_name = runinfo.executable.rsplit("/", 1)[-1]
+        for c in candidates:
+            if c.rsplit("/", 1)[-1] == exe_name:
+                entrypoint = c
+                break
+    if entrypoint == None:
+        for c in candidates:
+            if c.rsplit("/", 1)[-1] == target_name:
+                entrypoint = c
+                break
     if entrypoint == None:
         for ext in _SCRIPT_EXTENSIONS:
             for c in candidates:
@@ -368,10 +558,22 @@ def _determine_entrypoint(state: struct, target: str) -> struct | None:
         path = entrypoint,
         runfiles_dir = runfiles_dir,
         runfiles_workspace_dir = runfiles_workspace_dir,
+        args = runinfo.args if runinfo != None else [],
+        environment = runinfo.environment if runinfo != None else {},
+        inherited_environment = runinfo.inherited_environment if runinfo != None else [],
     )
 
 def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture: bool = False, cwd: str | None = None) -> std.process.Child:
-    """Spawn `ep.path` with `args` in the Bazel runfiles environment.
+    """Spawn `ep.path` in the Bazel runfiles environment.
+
+    The argv is `ep.args + args`: the target's `args` attribute (expanded and
+    tokenized by the `runinfo` aspect) precedes the caller's forwarded args,
+    matching `bazel run` (RunCommand.java:913-914). `ep.args` is empty when the
+    aspect didn't run, so this is a no-op for those callers.
+
+    Applies the target's `RunEnvironmentInfo` env (`ep.environment`) first so the
+    runfiles/BUILD_* vars below win on conflict; `ep.inherited_environment` names
+    are already covered by the spawned process inheriting our environment.
 
     Always sets BUILD_WORKSPACE_DIRECTORY / BUILD_WORKING_DIRECTORY so tool
     wrappers can locate the workspace, and the four ASPECT_* variables for
@@ -393,15 +595,17 @@ def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture
     arguments against the user's cwd.
     """
     effective_cwd = cwd or ep.runfiles_workspace_dir or ctx.std.env.current_dir()
-    cmd = ctx.std.process.command(ep.path) \
-        .current_dir(effective_cwd) \
+    cmd = ctx.std.process.command(ep.path).current_dir(effective_cwd)
+    for k, v in (getattr(ep, "environment", {}) or {}).items():
+        cmd = cmd.env(k, v)
+    cmd = cmd \
         .env("BUILD_WORKSPACE_DIRECTORY", ctx.std.env.bazel_root_dir()) \
         .env("BUILD_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
         .env("ASPECT_WORKING_DIRECTORY", ctx.std.env.current_dir()) \
         .env("ASPECT_ROOT_DIRECTORY", ctx.std.env.aspect_root_dir()) \
         .env("ASPECT_BAZEL_ROOT_DIRECTORY", ctx.std.env.bazel_root_dir()) \
         .env("ASPECT_GIT_ROOT_DIRECTORY", ctx.std.env.git_root_dir() or "") \
-        .args(args)
+        .args(getattr(ep, "args", []) + list(args))
     if ep.runfiles_dir:
         cmd = cmd \
             .env("RUNFILES_DIR", ep.runfiles_dir) \
@@ -412,20 +616,38 @@ def _spawn(ctx: TaskContext, state: struct, ep: struct, args: list[str], capture
         cmd = cmd.stdout("piped").stderr("piped")
     return cmd.spawn()
 
-def runnable(ctx, targets: list[str]) -> struct:
+def runnable(ctx, targets: list[str], rc = None) -> struct:
     """Build a BES event tracker that resolves entrypoints for `targets`.
+
+    Pass the active `RunCommand` as `rc` (the value `setup_phase` returns) to opt
+    into the `runinfo` aspect: `flags` then carries the aspect injection too. Omit
+    `rc` (unit tests) for the BES-only heuristic with no aspect.
 
     Feed BES events via `.event(event)` as they arrive from the build. Once the
     build completes, query results per target through the returned struct:
 
-      determine_entrypoint(target) → struct(path, runfiles_dir, runfiles_workspace_dir) | None
+      flags → list[str]
+          The single, complete `flags=` to pass to `ctx.bazel.build` — every
+          load-bearing flag for building-then-running the targets: the mandatory
+          spawn flags, plus (when `rc` is given) the `runinfo` aspect injection
+          and the `--remote_download_outputs` floor (forced up to `toplevel` only
+          when `rc` resolves below it, so the binary lands on disk while an upward
+          `=all` override still stands). Callers pass `flags = r.flags` and
+          assemble no spawn constants by hand. A caller with its own non-spawn
+          extras (e.g. `delivery`'s release flags) places those before `r.flags`
+          so the load-bearing flags win.
+
+      determine_entrypoint(target) → struct(path, runfiles_dir, runfiles_workspace_dir, args, environment, inherited_environment) | None
           Best executable output for `target` from its BES default output group,
           or None if no BES data was received for it. `runfiles_dir` is the
           resolved runfiles directory (e.g. `…/format.runfiles`), or `None`
           when no `<entrypoint>.runfiles` directory exists on disk.
           `runfiles_workspace_dir` is `runfiles_dir + "/" + <workspace>` (the
           cwd `bazel run` uses; usually `…/format.runfiles/_main`), or `None`
-          when `runfiles_dir` is `None`.
+          when `runfiles_dir` is `None`. `args` / `environment` /
+          `inherited_environment` carry the `runinfo` aspect's capture (empty
+          when the caller didn't inject it — i.e. constructed `runnable` without
+          `rc`, or built without `r.flags`).
 
       get_default_outputs(target) → list[str]
           Absolute paths of every file in `target`'s default output group,
@@ -436,10 +658,12 @@ def runnable(ctx, targets: list[str]) -> struct:
           responsible for materializing what it intends to read.
 
       spawn(ep, args, capture=False, cwd=None) → Child
-          Spawn `ep.path` with Bazel runfiles environment variables set.
-          `cwd` defaults to `ep.runfiles_dir/<workspace>` when a runfiles tree
-          is present (matching `bazel run`), falling back to the aspect
-          invocation directory when there is no runfiles tree. Pass an
+          Spawn `ep.path` with Bazel runfiles environment variables set. The
+          target's `args` attribute (`ep.args`) is prepended before `args`, and
+          its `RunEnvironmentInfo` env (`ep.environment`) is applied, matching
+          `bazel run`. `cwd` defaults to `ep.runfiles_dir/<workspace>` when a
+          runfiles tree is present (matching `bazel run`), falling back to the
+          aspect invocation directory when there is no runfiles tree. Pass an
           explicit `cwd` to override — e.g. the resolved value from `--run-in=<choice>`.
     """
     current_package = _current_package(ctx) if ctx else ""
@@ -449,12 +673,18 @@ def runnable(ctx, targets: list[str]) -> struct:
         targets = {apparent_label(t, current_package): t for t in targets},
         filesets = {},
         target_fileset = {},
+        runinfo_fileset = {},
         # Single-element list so `_process_bes` can mutate it (struct fields are
         # otherwise read-only after construction).
         workspace_name = [""],
     )
 
+    flags = list(_LOCAL_SPAWN_FLAGS)
+    if rc != None:
+        flags = flags + _runinfo_aspect_flags(ctx, rc) + _download_floor_flags(rc)
+
     return struct(
+        flags = flags,
         event = lambda event: _process_bes(state, event),
         determine_entrypoint = lambda target: _determine_entrypoint(state, target),
         get_default_outputs = lambda target: _get_default_outputs(state, target),

--- a/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lib/runnable_test.axl
@@ -1,6 +1,5 @@
 """Unit tests for lib/runnable.axl: apparent_label normalization, BES matching,
-entrypoint selection (passes 1–3), runfiles directory detection, `--run-in`
-cwd resolution, and `--remote_download_outputs` resolution/sufficiency."""
+entrypoint selection (passes 1–3), and runfiles directory detection."""
 
 load("./runnable.axl", "apparent_label", "download_outputs_sufficient", "effective_download_outputs", "resolve_run_in", "runnable")
 
@@ -343,15 +342,18 @@ def _test_pass3_skips_non_executable(ctx):
 # Filesystem detection tests — exercise `<entrypoint>.runfiles` discovery on
 # disk with a minimal mock ctx.
 
-def _make_mock_ctx(existing_paths, executable_paths = None):
+def _make_mock_ctx(existing_paths, executable_paths = None, file_contents = None):
     """Minimal TaskContext mock for filesystem detection tests.
 
     existing_paths: absolute paths that `std.fs.exists()` returns True for.
     executable_paths: absolute paths that `std.fs.metadata().executable` is True
         for. None means "every path is executable" — the right default for tests
         that don't exercise pass-3's executable-bit check.
+    file_contents: path → contents for `std.fs.read_to_string()` (the runinfo
+        JSON reads). None / missing path → empty string.
     """
     is_executable = (lambda path: True) if executable_paths == None else (lambda path: path in executable_paths)
+    contents = file_contents or {}
     return struct(
         std = struct(
             env = struct(
@@ -361,7 +363,22 @@ def _make_mock_ctx(existing_paths, executable_paths = None):
             fs = struct(
                 exists = lambda path: path in existing_paths,
                 metadata = lambda path: struct(executable = is_executable(path)),
+                read_to_string = lambda path: contents.get(path, ""),
             ),
+        ),
+    )
+
+def _make_runinfo_target_event(bes_label, default_set_id, runinfo_set_id):
+    """target_completed event carrying both the `default` and `aspect_runinfo`
+    output groups (the latter written by the injected runinfo aspect)."""
+    return struct(
+        kind = "target_completed",
+        id = struct(label = bes_label),
+        payload = struct(
+            output_group = [
+                struct(name = "default", file_sets = [struct(id = default_set_id)]),
+                struct(name = "aspect_runinfo", file_sets = [struct(id = runinfo_set_id)]),
+            ],
         ),
     )
 
@@ -576,9 +593,154 @@ def _test_run_in_relative_dotdot(_ctx):
         "/here/../sub",
     )
 
+# runinfo aspect integration — when the injected aspect's JSON is present,
+# `determine_entrypoint` selects the exact `files_to_run` executable (pass 0)
+# and attaches the replayed `args` / `environment`.
+
+_RUNINFO_JSON = '{"executable": "_main/tools/format/format_real", "args": ["--config", "x"], "environment": {"FOO": "1"}, "inherited_environment": ["HOME"]}'
+
+def _test_runinfo_selects_executable_over_heuristic(ctx):
+    """Pass 0 picks the file whose basename matches the aspect's executable
+    short_path, even when a different file matches the target name (pass 1)."""
+    mock = _make_mock_ctx(
+        existing_paths = [],
+        file_contents = {"/out/bin/tools/format/format.aspect_runinfo.json": _RUNINFO_JSON},
+    )
+    r = runnable(mock, ["//tools/format:format"])
+
+    # `format` matches the target name (pass 1), `format_real` matches the
+    # aspect's executable — pass 0 must win.
+    r.event(_make_fileset_event("def", [
+        "/out/bin/tools/format/format",
+        "/out/bin/tools/format/format_real",
+    ]))
+    r.event(_make_fileset_event("ri", ["/out/bin/tools/format/format.aspect_runinfo.json"]))
+    r.event(_make_runinfo_target_event("//tools/format:format", "def", "ri"))
+    ep = r.determine_entrypoint("//tools/format:format")
+    if ep == None:
+        fail("runinfo-pass0: expected entrypoint, got None")
+    _eq("runinfo-pass0: executable", ep.path, "/out/bin/tools/format/format_real")
+
+def _test_runinfo_attaches_args_and_env(ctx):
+    """The expanded args + RunEnvironmentInfo env flow onto the entrypoint."""
+    mock = _make_mock_ctx(
+        existing_paths = [],
+        file_contents = {"/out/bin/tools/format/format.aspect_runinfo.json": _RUNINFO_JSON},
+    )
+    r = runnable(mock, ["//tools/format:format"])
+    r.event(_make_fileset_event("def", ["/out/bin/tools/format/format_real"]))
+    r.event(_make_fileset_event("ri", ["/out/bin/tools/format/format.aspect_runinfo.json"]))
+    r.event(_make_runinfo_target_event("//tools/format:format", "def", "ri"))
+    ep = r.determine_entrypoint("//tools/format:format")
+    _eq("runinfo-args", ep.args, ["--config", "x"])
+    _eq("runinfo-env", ep.environment, {"FOO": "1"})
+    _eq("runinfo-inherited", ep.inherited_environment, ["HOME"])
+
+def _test_no_runinfo_yields_empty_args_env(ctx):
+    """Without the aspect (no aspect_runinfo group), args/env default to empty
+    and the heuristic still resolves the entrypoint."""
+    r = runnable(None, ["//tools/format:format"])
+    r.event(_make_fileset_event("s1", ["/out/bin/tools/format/format"]))
+    r.event(_make_target_event("//tools/format:format", "s1"))
+    ep = r.determine_entrypoint("//tools/format:format")
+    if ep == None:
+        fail("no-runinfo: expected entrypoint, got None")
+    _eq("no-runinfo: path", ep.path, "/out/bin/tools/format/format")
+    _eq("no-runinfo: args empty", ep.args, [])
+    _eq("no-runinfo: env empty", ep.environment, {})
+    _eq("no-runinfo: inherited empty", ep.inherited_environment, [])
+
+# flags — runinfo injection + the --remote_download_outputs floor.
+# Exercised through `runnable(rc=...).flags`; the helpers are private.
+
+def _make_flags_ctx():
+    """ctx mock sufficient for `runnable().flags`: writes the temp aspect
+    repo (no-op fs) and carries a task key for the repo path."""
+    return struct(
+        task = struct(name = "testkey"),
+        std = struct(
+            env = struct(
+                bazel_root_dir = lambda: "/ws",
+                current_dir = lambda: "/ws",
+            ),
+            fs = struct(
+                create_dir_all = lambda path: None,
+                write = lambda path, content: None,
+            ),
+        ),
+    )
+
+def _make_rc(flags, bzlmod = None):
+    """Mock RunCommand: `expand` returns the ordered build flags, `bool_flag`
+    returns the `--enable_bzlmod` tri-state."""
+    return struct(
+        expand = lambda command = None: flags,
+        bool_flag = lambda name, command = None: bzlmod,
+    )
+
+_FLOOR = "--remote_download_outputs=toplevel"
+
+def _test_download_floor_forced_when_unset(ctx):
+    r = runnable(_make_flags_ctx(), ["//a:b"], rc = _make_rc([]))
+    if _FLOOR not in r.flags:
+        fail("unset → floor forces toplevel; got %r" % r.flags)
+
+def _test_download_floor_forced_when_minimal(ctx):
+    r = runnable(_make_flags_ctx(), ["//a:b"], rc = _make_rc(["--remote_download_outputs=minimal"]))
+    if _FLOOR not in r.flags:
+        fail("minimal → forced up to toplevel; got %r" % r.flags)
+
+def _test_download_floor_forced_when_minimal_alias(ctx):
+    r = runnable(_make_flags_ctx(), ["//a:b"], rc = _make_rc(["--remote_download_minimal"]))
+    if _FLOOR not in r.flags:
+        fail("minimal alias → forced up; got %r" % r.flags)
+
+def _test_download_floor_skips_when_all(ctx):
+    r = runnable(_make_flags_ctx(), ["//a:b"], rc = _make_rc(["--remote_download_outputs=all"]))
+    if _FLOOR in r.flags:
+        fail("all → upward override must stand, no floor flag; got %r" % r.flags)
+
+def _test_download_floor_skips_when_toplevel_alias(ctx):
+    r = runnable(_make_flags_ctx(), ["//a:b"], rc = _make_rc(["--remote_download_toplevel"]))
+    if _FLOOR in r.flags:
+        fail("toplevel alias already satisfies floor; got %r" % r.flags)
+
+def _test_download_floor_two_token_all(ctx):
+    r = runnable(_make_flags_ctx(), ["//a:b"], rc = _make_rc(["--remote_download_outputs", "all"]))
+    if _FLOOR in r.flags:
+        fail("two-token =all → floor skipped; got %r" % r.flags)
+
+def _test_download_floor_alias_last_wins(ctx):
+    # canonical =all, then a later minimal alias → effective minimal → forced up.
+    r = runnable(_make_flags_ctx(), ["//a:b"], rc = _make_rc(["--remote_download_outputs=all", "--remote_download_minimal"]))
+    if _FLOOR not in r.flags:
+        fail("alias last-wins (minimal) → forced up; got %r" % r.flags)
+
+def _test_flags_inject_repo_by_default(ctx):
+    r = runnable(_make_flags_ctx(), ["//a:b"], rc = _make_rc([]))
+    joined = " ".join(r.flags)
+    if "--inject_repository=aspect_runinfo=" not in joined:
+        fail("default → inject_repository; got %r" % r.flags)
+    if "--aspects=@aspect_runinfo//:runinfo.bzl%runinfo" not in r.flags:
+        fail("missing runinfo aspect flag; got %r" % r.flags)
+
+def _test_flags_override_repo_in_workspace_mode(ctx):
+    r = runnable(_make_flags_ctx(), ["//a:b"], rc = _make_rc([], bzlmod = False))
+    if "--override_repository=aspect_runinfo=" not in " ".join(r.flags):
+        fail("workspace mode → override_repository; got %r" % r.flags)
+
+def _test_flags_no_rc_is_spawn_flags_only(ctx):
+    r = runnable(None, ["//a:b"])
+    if _FLOOR in r.flags:
+        fail("no rc → no floor; got %r" % r.flags)
+    if "aspect_runinfo" in " ".join(r.flags):
+        fail("no rc → no aspect injection; got %r" % r.flags)
+    if "--build_runfile_links" not in r.flags:
+        fail("flags must always carry the mandatory spawn flags; got %r" % r.flags)
+
 # download_outputs_sufficient — which user `--remote_download_outputs` values
-# already put the top-level binary on disk (so the spawn/delivery `=toplevel`
-# default need not override them).
+# already put the top-level binary on disk (so the spawn `=toplevel` default
+# need not override them).
 
 def _test_download_outputs_toplevel_sufficient(_ctx):
     _eq("toplevel is sufficient", download_outputs_sufficient("toplevel"), True)
@@ -626,8 +788,8 @@ def _test_effective_download_outputs_alias_minimal(_ctx):
     _eq("--remote_download_minimal alias", effective_download_outputs(["--remote_download_minimal"]), "minimal")
 
 def _test_effective_download_outputs_alias_beats_earlier_canonical(_ctx):
-    """The Codex regression: a later `--remote_download_all` alias must beat an
-    earlier canonical `--remote_download_outputs=minimal`."""
+    """A later `--remote_download_all` alias must beat an earlier canonical
+    `--remote_download_outputs=minimal`."""
     _eq(
         "alias wins last over canonical",
         effective_download_outputs(["--remote_download_outputs=minimal", "--remote_download_all"]),
@@ -700,6 +862,27 @@ _UNIT_TESTS = [
     _test_run_in_absolute_path,
     _test_run_in_relative_dot,
     _test_run_in_relative_dotdot,
+    _test_runfiles_workspace_dir_uses_bes_workspace_name,
+    _test_runfiles_workspace_dir_non_default_workspace,
+    _test_runfiles_workspace_dir_default_when_no_workspace_config,
+    _test_get_default_outputs_unknown_target_returns_empty,
+    _test_get_default_outputs_single_fileset,
+    _test_get_default_outputs_walks_nested_filesets,
+    _test_get_default_outputs_apparent_label_normalization,
+    _test_get_default_outputs_strips_file_uri_prefix,
+    _test_runinfo_selects_executable_over_heuristic,
+    _test_runinfo_attaches_args_and_env,
+    _test_no_runinfo_yields_empty_args_env,
+    _test_download_floor_forced_when_unset,
+    _test_download_floor_forced_when_minimal,
+    _test_download_floor_forced_when_minimal_alias,
+    _test_download_floor_skips_when_all,
+    _test_download_floor_skips_when_toplevel_alias,
+    _test_download_floor_two_token_all,
+    _test_download_floor_alias_last_wins,
+    _test_flags_inject_repo_by_default,
+    _test_flags_override_repo_in_workspace_mode,
+    _test_flags_no_rc_is_spawn_flags_only,
     _test_download_outputs_toplevel_sufficient,
     _test_download_outputs_all_sufficient,
     _test_download_outputs_minimal_insufficient,
@@ -713,14 +896,6 @@ _UNIT_TESTS = [
     _test_effective_download_outputs_alias_beats_earlier_canonical,
     _test_effective_download_outputs_canonical_beats_earlier_alias,
     _test_effective_download_outputs_version_tuple,
-    _test_runfiles_workspace_dir_uses_bes_workspace_name,
-    _test_runfiles_workspace_dir_non_default_workspace,
-    _test_runfiles_workspace_dir_default_when_no_workspace_config,
-    _test_get_default_outputs_unknown_target_returns_empty,
-    _test_get_default_outputs_single_fileset,
-    _test_get_default_outputs_walks_nested_filesets,
-    _test_get_default_outputs_apparent_label_normalization,
-    _test_get_default_outputs_strips_file_uri_prefix,
 ]
 
 def _test_impl(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -9,7 +9,7 @@ load("./lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_bui
 load("./lib/environment.axl", "error")
 load("./lib/health_check.axl", "HealthCheckTrait")
 load("./lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
-load("./lib/runnable.axl", "LOCAL_SPAWN_BASE_FLAGS", "LOCAL_SPAWN_FLAGS", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
+load("./lib/runnable.axl", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
 load("./lib/tips.axl", "tips")
 
 def _terminal_status(data, exit_code):
@@ -79,10 +79,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # ultimately invokes `ctx.bazel.build`, which spawns a literal `bazel
     # build`. The `run:` rc section can contain options Bazel's `build` command
     # rejects as unrecognized (e.g. `--script_path`).
-    setup_phase(ctx, lifecycle, target, "bazel_results", data, hc_trait, bazel_trait, "build", bazel_base_flags = LOCAL_SPAWN_BASE_FLAGS)
+    rc = setup_phase(ctx, lifecycle, target, "bazel_results", data, hc_trait, bazel_trait, "build")
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
-    r = runnable(ctx, [target])
+    # `rc=` opts into the runinfo aspect: `r.flags` then carries the spawn
+    # flags + aspect injection that capture the executable, the `args` attribute,
+    # and the target env so `r.spawn` replays them the way `bazel run` does.
+    r = runnable(ctx, [target], rc = rc)
     events = bazel.build_events.iterator()
     build_events = [events] + list(bazel_trait.build_event_sinks)
 
@@ -105,7 +108,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     build = ctx.bazel.build(
         target,
         build_events = build_events,
-        flags = LOCAL_SPAWN_FLAGS,
+        flags = r.flags,
         announce_version = announce_version,
         announce_command = announce_command,
     )

--- a/crates/bazelrc/src/lib.rs
+++ b/crates/bazelrc/src/lib.rs
@@ -978,38 +978,32 @@ fn runcommand_methods(registry: &mut starlark::environment::MethodsBuilder) {
 
     /// Expand all `--config=` flags for `command` into the fully-resolved flag
     /// list, compatible with `ctx.bazel.build(flags=...)`.
+    ///
+    /// Version-gated options are filtered to the run command's resolved Bazel
+    /// version (same as `flag_value` / `resolve_for_command`), so the result
+    /// reflects what Bazel actually receives — an option gated to a different
+    /// version is dropped rather than reported as active.
     fn expand<'v>(
         this: &BazelRC,
         #[starlark(require = named)] command: String,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<Vec<Value<'v>>> {
-        let skip: Vec<&str> = this
-            .skip_config_if_missing
-            .iter()
-            .map(String::as_str)
-            .collect();
-        let opts = this
-            .expand_configs(&command, &skip)
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        let opts = this.applicable_options(&command, None)?;
         Ok(opts.iter().map(|opt| alloc_flag(eval, opt)).collect())
     }
 
     /// Expand `--config=` flags for `command`, split into
     /// `(startup_flags, flags)` where `common`-section options are rendered as
     /// `--default_override=0:common=...` startup-side entries.
+    ///
+    /// Like `expand`, the command flags are filtered to the resolved Bazel
+    /// version so version-gated options report accurately.
     fn expand_all<'v>(
         this: &BazelRC,
         #[starlark(require = named)] command: String,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<(Vec<Value<'v>>, Vec<Value<'v>>)> {
-        let skip: Vec<&str> = this
-            .skip_config_if_missing
-            .iter()
-            .map(String::as_str)
-            .collect();
-        let opts = this
-            .expand_configs(&command, &skip)
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        let opts = this.applicable_options(&command, None)?;
 
         let startup: Vec<Value<'v>> = this
             .raw_options("startup")


### PR DESCRIPTION
Built a runinfo aspect that replays each target's executable, args attribute, and RunEnvironmentInfo env so aspect run/format/gazelle/delivery match bazel run byte-for-byte, exposed it through a single load-bearing runnable().flags attribute (with a --remote_download_outputs floor that upgrades minimal→toplevel), and cleaned up the call sites so no command hand-assembles spawn flags.

---

### Changes are visible to end-users: yes


- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`aspect run` and `runnable.axl` now supports `env` and `args` of runnable targets. 

### Test plan

- Covered by existing test cases
- New test cases added
