### PR TITLE
test(axl-docgen): smoke-test axl-api-watch notification

### DIFF
--- a/crates/axl-docgen/api_surface.golden
+++ b/crates/axl-docgen/api_surface.golden
@@ -3,7 +3,6 @@
 @bazel//grpc.Status(*, code: int, message: str) -> grpc.Status
 @bazel//grpc.grpc: struct(Code = struct(ABORTED = int, ALREADY_EXISTS = int, CANCELLED = int, DATA_LOSS = int, DEADLINE_EXCEEDED = int, FAILED_PRECONDITION = int, INTERNAL = int, INVALID_ARGUMENT = int, NOT_FOUND = int, OK = int, OUT_OF_RANGE = int, PERMISSION_DENIED = int, RESOURCE_EXHAUSTED = int, UNAUTHENTICATED = int, UNAVAILABLE = int, UNIMPLEMENTED = int, UNKNOWN = int), Server = function, Status = function)
 @std//base64.base64: struct(decode = function, decode_url = function, encode = function, encode_url = function)
-@std//hash.blake2b() -> typing.Any
 @std//hash.blake2s() -> typing.Any
 @std//hash.md5() -> typing.Any
 @std//hash.sha1() -> typing.Any


### PR DESCRIPTION
## Purpose

End-to-end smoke test of the `axl-api-watch` workflow (now that the `SLACK_API_SURFACE_WEBHOOK_URL` secret is set).

This deletes one line (`@std//hash.blake2b`) from the committed `api_surface.golden`. The line is **not** actually gone from the API — only from the snapshot.

## What happens on merge (the watcher runs on push to main, not on this PR)

1. `axl-api-watch` dumps the live surface (still has `blake2b`).
2. Diff vs the doctored golden → non-empty → `changed=true`.
3. Posts the diff to **#aspect-cli**. ✅ (the thing we're verifying)
4. Auto-commits the corrected golden, restoring the deleted line (self-heal).

So merging this should produce exactly one Slack ping and one `chore(axl): refresh API surface snapshot` bot commit on main. No real API change; no manual cleanup.

## Note

The notification fires **after merge** (trigger is `push` to `main`), not on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)