### PR TITLE
fix(axl-docgen): don't advance API-surface baseline on failed diff/notify

### DIFF
--- a/.github/workflows/axl-api-watch.yml
+++ b/.github/workflows/axl-api-watch.yml
@@ -84,13 +84,20 @@ jobs:
           | curl -sS -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK_URL"
       # Advance the baseline: cache the surface just rendered so the next run
       # diffs against it. Saved under the current SHA's key; the next run finds
-      # it via the restore-keys prefix. Runs even when unchanged so the cache
-      # entry's 7-day idle eviction timer keeps resetting.
+      # it via the restore-keys prefix.
+      #
+      # No `always()` — these inherit the default `success()` guard ON PURPOSE.
+      # If the diff or restore step failed, or a drift was detected but the
+      # Notify step failed (cache-service outage, webhook/network error), the
+      # job is in a failed state and these steps are skipped, so the baseline is
+      # NOT advanced. The next run then re-detects the same drift and re-alerts,
+      # rather than silently swallowing the break by moving the baseline past an
+      # un-notified change. An unchanged run leaves Notify skipped (not failed),
+      # so the save still runs and refreshes the cache (resetting its idle
+      # eviction timer).
       - name: Save current surface as new baseline
-        if: always()
         run: cp /tmp/surface.new /tmp/surface.prev
       - name: Cache new baseline
-        if: always()
         uses: actions/cache/save@v4
         with:
           path: /tmp/surface.prev


### PR DESCRIPTION
## Problem (review feedback on #1280)

The cache-save steps used `if: always()`, which GitHub runs even after prior step failures. So if a drift is detected but the **diff/restore fails or the Slack notify fails** (cache-service outage, webhook/network error), the baseline was still advanced to the current surface. The next run would diff against the already-changed surface and **never post the API break** — a silent, permanent swallowed alert, with the run staying green.

## Fix

Drop `always()` from both save steps so they inherit the default `success()` guard:

- diff/restore fails → saves skipped → baseline holds.
- drift detected + Notify **fails** → job failed → saves skipped → **next run re-detects and re-alerts**.
- changed=false → Notify *skipped* (not failed) → saves still run, cache refreshes (resets idle-eviction timer).

No complex gate expression needed — `success()` already encodes exactly the intended condition.

## Honest limit

Doesn't close the case where the cache *soft-misses* during an outage (returns empty without erroring) — indistinguishable from a legitimate first-run seed, so a break could still be swallowed then. Gating on step success only catches hard failures. Acceptably rare; full closure isn't worth the complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)