### PR TITLE
fix(bootstrap): set x-identity remote header for pre-build BES stream

### DIFF
--- a/.aspect/bootstrap.sh
+++ b/.aspect/bootstrap.sh
@@ -20,6 +20,11 @@ BAZEL_REMOTE_FLAGS=""
 [ -n "${ASPECT_WORKFLOWS_BES_RESULTS_URL:-}" ] && BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --bes_results_url=${ASPECT_WORKFLOWS_BES_RESULTS_URL}"
 [ -n "${ASPECT_WORKFLOWS_REMOTE_CACHE:-}" ] && BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --remote_cache=${ASPECT_WORKFLOWS_REMOTE_CACHE}"
 [ -n "${ASPECT_WORKFLOWS_REMOTE_BYTESTREAM_URI_PREFIX:-}" ] && BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --remote_bytestream_uri_prefix=${ASPECT_WORKFLOWS_REMOTE_BYTESTREAM_URI_PREFIX}"
+# x-identity authenticates the runner to the remote cache, executor, AND BES
+# backend — without it the pre-build's BES stream is rejected. Bazel applies
+# --remote_header to all three channels, so gate on the identity alone (mirrors
+# get_bazelrc_flags in crates/aspect-cli/src/builtins/aspect/lib/environment.axl).
+[ -n "${ASPECT_WORKFLOWS_RUNNER_IDENTITY:-}" ] && BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --remote_header=x-identity=${ASPECT_WORKFLOWS_RUNNER_IDENTITY}"
 
 # --build_metadata flags for the pre-build invocation. Only set when we're
 # forwarding events to a BES backend (the Aspect Web UI or similar) —

--- a/.aspect/bootstrap.sh
+++ b/.aspect/bootstrap.sh
@@ -302,7 +302,11 @@ export DISABLE_PLUGINS_FLAG
 export LOCK_VERSION_FLAG
 
 echo "Startup opts: ${BAZEL_STARTUP_OPTS}"
-echo "Build opts: ${BAZEL_BUILD_OPTS}"
+# Redact x-identity header values before echoing — the runner identity is an
+# auth credential, and the CLI's own log redaction treats remote_header/
+# bes_header values as secrets (crates/axl-runtime/src/engine/bazel/stream/
+# redaction.rs). The exported BAZEL_BUILD_OPTS keeps the real value.
+echo "Build opts: $(printf '%s' "${BAZEL_BUILD_OPTS}" | sed 's/x-identity=[^ ]*/x-identity=<REDACTED>/g')"
 
 if [ -f /etc/bazel.bazelrc ]; then
     echo "/etc/bazel.bazelrc exists ($(wc -l </etc/bazel.bazelrc) lines)"

--- a/.aspect/bootstrap.sh
+++ b/.aspect/bootstrap.sh
@@ -20,11 +20,16 @@ BAZEL_REMOTE_FLAGS=""
 [ -n "${ASPECT_WORKFLOWS_BES_RESULTS_URL:-}" ] && BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --bes_results_url=${ASPECT_WORKFLOWS_BES_RESULTS_URL}"
 [ -n "${ASPECT_WORKFLOWS_REMOTE_CACHE:-}" ] && BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --remote_cache=${ASPECT_WORKFLOWS_REMOTE_CACHE}"
 [ -n "${ASPECT_WORKFLOWS_REMOTE_BYTESTREAM_URI_PREFIX:-}" ] && BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --remote_bytestream_uri_prefix=${ASPECT_WORKFLOWS_REMOTE_BYTESTREAM_URI_PREFIX}"
-# x-identity authenticates the runner to the remote cache, executor, AND BES
-# backend — without it the pre-build's BES stream is rejected. Bazel applies
-# --remote_header to all three channels, so gate on the identity alone (mirrors
-# get_bazelrc_flags in crates/aspect-cli/src/builtins/aspect/lib/environment.axl).
-[ -n "${ASPECT_WORKFLOWS_RUNNER_IDENTITY:-}" ] && BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --remote_header=x-identity=${ASPECT_WORKFLOWS_RUNNER_IDENTITY}"
+# x-identity authenticates the runner to the backend. Bazel scopes headers per
+# channel: --remote_header covers the remote cache and executor gRPC channels
+# but NOT the BES channel, which needs its own --bes_header. Set both so the
+# cache/executor and the pre-build's BES stream all authenticate. Gate on the
+# identity alone (mirrors get_bazelrc_flags in
+# crates/aspect-cli/src/builtins/aspect/lib/environment.axl).
+if [ -n "${ASPECT_WORKFLOWS_RUNNER_IDENTITY:-}" ]; then
+    BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --remote_header=x-identity=${ASPECT_WORKFLOWS_RUNNER_IDENTITY}"
+    BAZEL_REMOTE_FLAGS="${BAZEL_REMOTE_FLAGS} --bes_header=x-identity=${ASPECT_WORKFLOWS_RUNNER_IDENTITY}"
+fi
 
 # --build_metadata flags for the pre-build invocation. Only set when we're
 # forwarding events to a BES backend (the Aspect Web UI or similar) —


### PR DESCRIPTION
The CI pre-build step in `.aspect/bootstrap.sh` runs vanilla `bazel build //:cli` and streams a Build Event Stream to the Aspect backend when `ASPECT_WORKFLOWS_BES_BACKEND` is set. But it never sent the `x-identity` remote header the backend uses to authenticate the stream, so the pre-build's BES upload was unauthenticated.

The AXL task path already handles this in `get_bazelrc_flags` ([environment.axl](crates/aspect-cli/src/builtins/aspect/lib/environment.axl)), which appends `--remote_header=x-identity=<identity>` gating on the runner identity alone (Bazel applies `--remote_header` to the remote cache, executor, and BES channels alike).

This PR mirrors that in the bootstrap script: when `ASPECT_WORKFLOWS_RUNNER_IDENTITY` is set, add `--remote_header=x-identity=<identity>` to `BAZEL_REMOTE_FLAGS`. That flows into `BAZEL_BUILD_OPTS` for the `bazel build //:cli` invocation and persists to later pipeline steps via `GITHUB_ENV`.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  - On a Workflows runner with `ASPECT_WORKFLOWS_BES_BACKEND` and `ASPECT_WORKFLOWS_RUNNER_IDENTITY` set, source `.aspect/bootstrap.sh` and confirm the `bazel build //:cli` invocation includes `--remote_header=x-identity=<identity>` (echoed in "Build opts") and the BES stream is accepted by the backend.
