### PR TITLE
feat(cli): move feature flags out of task --help into `aspect feature`

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -349,6 +349,7 @@ def _buildkite_annotations(ctx: FeatureContext):
     lifecycle.task_update.append(_task_update)
 
 BuildkiteAnnotations = feature(
+    summary = "Post live task status as Buildkite annotations.",
     implementation = _buildkite_annotations,
     # Gated on BUILDKITE at runtime; safe to enable everywhere.
     enabled = True,

--- a/crates/aspect-cli/src/builtins/aspect/feature/circleci_test_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/circleci_test_results.axl
@@ -158,8 +158,7 @@ def _circleci_test_results_impl(ctx: FeatureContext) -> None:
 
 CircleCITestResults = feature(
     display_name = "CircleCI Test Results",
-    summary = "Upload Bazel JUnit test results to CircleCI's Tests tab and Test Insights. " +
-              "Separate from artifact upload so it can be toggled independently.",
+    summary = "Upload Bazel JUnit results to CircleCI's Tests tab.",
     implementation = _circleci_test_results_impl,
     args = {
         "upload_test_results": args.string(

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
@@ -926,6 +926,7 @@ def _github_lint_impl(ctx: FeatureContext):
     lint_trait.lint_end.append(_lint_end)
 
 GithubLintComments = feature(
+    summary = "Post lint diagnostics as GitHub PR review comments.",
     implementation = _github_lint_impl,
     args = {
         "max_pr_comments": args.int(

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -467,6 +467,7 @@ def _github_status_checks(ctx: FeatureContext):
     lifecycle.task_update.append(_task_update)
 
 GithubStatusChecks = feature(
+    summary = "Report live task status as GitHub check runs.",
     implementation = _github_status_checks,
     enabled = True,
     args = {

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1963,6 +1963,7 @@ DEFAULT_STATUS_BADGES = _DEFAULT_STATUS_BADGES
 MARKER_FMT = _MARKER_FMT
 
 GithubStatusComments = feature(
+    summary = "Post live task status as a GitHub PR comment.",
     implementation = _github_status_comments,
     enabled = True,
     args = {

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -411,6 +411,7 @@ def truncate_description(text):
 DESCRIPTION_MAX = _DESCRIPTION_MAX
 
 GitlabCommitStatuses = feature(
+    summary = "Report live task status as GitLab commit statuses.",
     implementation = _gitlab_commit_statuses,
     enabled = True,
     args = {

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
@@ -606,6 +606,7 @@ def _gitlab_lint_impl(ctx: FeatureContext):
     lint_trait.lint_end.append(_lint_end)
 
 GitlabLintComments = feature(
+    summary = "Post lint diagnostics as GitLab MR discussions.",
     implementation = _gitlab_lint_impl,
     enabled = True,
     args = {

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -423,6 +423,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
 MARKER_FMT = _MARKER_FMT
 
 GitlabStatusComments = feature(
+    summary = "Post live task status as a GitLab MR comment.",
     implementation = _gitlab_status_comments,
     enabled = True,
     args = {

--- a/crates/aspect-cli/src/builtins/aspect/feature/telemetry.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/telemetry.axl
@@ -216,9 +216,7 @@ def _telemetry_impl(ctx: FeatureContext):
 
 Telemetry = feature(
     display_name = "Telemetry",
-    summary = "Register OTLP exporters. Imports endpoints from OTEL_EXPORTER_OTLP_* " +
-              "env vars by default and accepts additional endpoints (with optional " +
-              "headers) via the --telemetry:endpoint flag.",
+    summary = "Register OTLP exporters for traces and metrics.",
     implementation = _telemetry_impl,
     args = {
         # Toggles the env-var import. Kept separate from `enabled` so when

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -102,12 +102,7 @@ def _workflows_impl(ctx: FeatureContext):
 
 Workflows = feature(
     display_name = "Aspect Workflows",
-    summary = "CI-aware Bazel configuration for Aspect Workflows. Wires BES " +
-              "forwarding, build metadata, health checks, and CI-host quirks " +
-              "(GitHub runner tracking, Buildkite section markers, color " +
-              "forcing). Today this only fully works on Aspect Workflows " +
-              "runners; the CI-host branches for buildkite/github are partial " +
-              "and may grow into general-CI support later.",
+    summary = "CI-aware Bazel configuration for Aspect Workflows runners.",
     implementation = _workflows_impl,
     args = {
         # BES sink retry/buffer/timeout knobs. Forwarded verbatim to

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/artifacts.axl
@@ -753,7 +753,7 @@ def _artifact_upload_impl(ctx: FeatureContext):
 
 ArtifactUpload = feature(
     display_name = "Artifact Upload",
-    summary = "Automatically upload build artifacts to CI. Supports GitHub Actions, Buildkite, CircleCI, and GitLab.",
+    summary = "Upload build artifacts to CI (GitHub, Buildkite, CircleCI, GitLab).",
     implementation = _artifact_upload_impl,
     args = {
         # All uploads opt-in: a CI artifact is downloadable by anyone with

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/tips.axl
@@ -708,7 +708,7 @@ def _tips_impl(ctx):
 
 Tips = feature(
     display_name = "Tips",
-    summary = "Collect and surface non-fatal tips (suggestions / warnings / important notices) on each task. Disable with `--tips:enabled=false`, or in `.aspect/config.axl` set `ctx.features[Tips].enabled = False` after `load(\"@aspect//feature/tips.axl\", \"Tips\")`.",
+    summary = "Collect and surface non-fatal tips on each task.",
     implementation = _tips_impl,
     enabled = True,
     args = {

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -235,11 +235,12 @@ impl<'a, 'v> Cmd<'a, 'v> {
     /// feature's flags — the section that used to live inline in each task's
     /// `--help`. An unknown name lists the valid ones on stderr and exits 2.
     pub fn print_feature_help(&self, version: &str, name: Option<&str>) -> ExitCode {
-        let blocks: Vec<(&dyn FeatureLike<'_>, FeatureBlock)> = self
+        let mut blocks: Vec<(&dyn FeatureLike<'_>, FeatureBlock)> = self
             .features
             .iter()
             .filter_map(|f| feature_block(*f).map(|b| (*f, b)))
             .collect();
+        blocks.sort_by(|(a, _), (b, _)| a.name().cmp(&b.name()));
 
         match name {
             None => {

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -35,10 +35,13 @@ use starlark::values::{Heap, Value, ValueLike};
 use thiserror::Error;
 
 const TASK_ID_KEY: &str = "@@@$'__AXL_TASK_ID__'$@@@";
-/// Reserved top-level command: `main` routes `aspect feature ...` to the
-/// feature-help renderer before task parsing, so a top-level task of this kind
-/// would be unreachable.
+/// `aspect feature [<name>]`: routed to the feature-help renderer in `main`.
 const FEATURE_COMMAND: &str = "feature";
+/// Top-level command names `main` intercepts before task parsing; a top-level
+/// task of any of these kinds would be unreachable, so it is rejected at build
+/// time (see `Tree::insert`). Reachable when nested under a group.
+const RESERVED_TOP_LEVEL_COMMANDS: &[&str] =
+    &[FEATURE_COMMAND, crate::credential_helper::GET_COMMAND];
 const TASK_COMMAND_DISPLAY_ORDER: usize = 0;
 const TASK_GROUP_DISPLAY_ORDER: usize = 1;
 
@@ -244,9 +247,8 @@ impl<'a, 'v> Cmd<'a, 'v> {
     /// Render `aspect feature [<name>]` and return the process exit code.
     ///
     /// With no name, lists every active feature (keyed by the kebab slug the
-    /// user passes back in) and its summary. With a name, prints just that
-    /// feature's flags — the section that used to live inline in each task's
-    /// `--help`. An unknown name lists the valid ones on stderr and exits 2.
+    /// user passes back in). With a name, prints just that feature's flags. An
+    /// unknown name lists the valid ones on stderr and exits 2.
     pub fn print_feature_help(&self, version: &str, name: Option<&str>) -> ExitCode {
         let mut blocks: Vec<(&dyn FeatureLike<'_>, FeatureBlock)> = self
             .features
@@ -257,69 +259,25 @@ impl<'a, 'v> Cmd<'a, 'v> {
 
         match name {
             None => {
-                let header = banner::line(version);
-                let width = blocks
-                    .iter()
-                    .map(|(f, _)| f.name().len())
-                    .max()
-                    .unwrap_or(0);
-                let mut out = format!("{header}\n\n\x1b[1;4mFeatures:\x1b[0m\n");
-                for (feat, _) in &blocks {
-                    let slug = feat.name();
-                    let pad = " ".repeat(width - slug.len() + 2);
-                    out.push_str(&format!(
-                        "  \x1b[1m{}\x1b[0m{}{}\n",
-                        slug,
-                        pad,
-                        feat.summary()
-                    ));
-                }
-                out.push_str("\nRun `aspect feature <NAME>` to see a feature's flags.\n");
-                print!("{out}");
+                print!("{}", render_feature_list(version, &blocks));
                 ExitCode::SUCCESS
             }
-            Some(name) => {
-                let Some((feat, block)) = blocks.iter().find(|(f, _)| f.name() == name) else {
+            Some(name) => match blocks.iter().find(|(f, _)| f.name() == name) {
+                Some((feat, block)) => {
+                    render_feature_detail(version, *feat, block, self.aspect_root, self.modules)
+                        .print_help()
+                        .ok();
+                    ExitCode::SUCCESS
+                }
+                None => {
                     let valid: Vec<String> = blocks.iter().map(|(f, _)| f.name()).collect();
                     eprintln!(
-                        "\x1b[1;31merror:\x1b[0m unknown feature {name:?}. \
-                         Valid features: {}",
+                        "\x1b[1;31merror:\x1b[0m unknown feature {name:?}. Valid features: {}",
                         valid.join(", ")
                     );
-                    return ExitCode::from(2);
-                };
-                let header = banner::line(version);
-                let label = defined_in_label(feat.path(), self.aspect_root, self.modules);
-                let context = format!(
-                    "\x1b[3m{}\x1b[0m feature defined in \x1b[3m{}\x1b[0m",
-                    feat.export_name().unwrap_or_default(),
-                    label
-                );
-                let body = if !feat.description().is_empty() {
-                    feat.description().clone()
-                } else if !feat.summary().is_empty() {
-                    feat.summary().clone()
-                } else {
-                    String::new()
-                };
-                let about = if body.is_empty() {
-                    context
-                } else {
-                    format!("{body}\n\n{context}")
-                };
-                let mut cmd = Command::new(format!("feature {name}"))
-                    .no_binary_name(true)
-                    .disable_help_flag(true)
-                    .help_template(format!("{header}\n\n{about}\n\n{{all-args}}"));
-                for (arg_name, arg) in block.args.iter() {
-                    cmd = cmd.arg(
-                        arg_to_clap(Scope::Feature(&block.prefix), arg_name, arg)
-                            .help_heading(block.heading.clone()),
-                    );
+                    ExitCode::from(2)
                 }
-                cmd.print_help().ok();
-                ExitCode::SUCCESS
-            }
+            },
         }
     }
 }
@@ -780,6 +738,72 @@ fn feature_block(feat: &dyn FeatureLike<'_>) -> Option<FeatureBlock> {
     })
 }
 
+// ── `aspect feature` rendering ─────────────────────────────────────────────
+
+/// Render the `aspect feature` listing: one row per feature, keyed by the
+/// kebab slug the user passes to `aspect feature <name>`, with its summary.
+fn render_feature_list(version: &str, blocks: &[(&dyn FeatureLike<'_>, FeatureBlock)]) -> String {
+    let width = blocks
+        .iter()
+        .map(|(f, _)| f.name().len())
+        .max()
+        .unwrap_or(0);
+    let mut out = format!("{}\n\n\x1b[1;4mFeatures:\x1b[0m\n", banner::line(version));
+    for (feat, _) in blocks {
+        let slug = feat.name();
+        let pad = " ".repeat(width - slug.len() + 2);
+        out.push_str(&format!(
+            "  \x1b[1m{}\x1b[0m{}{}\n",
+            slug,
+            pad,
+            feat.summary()
+        ));
+    }
+    out.push_str("\nRun `aspect feature <NAME>` to see a feature's flags.\n");
+    out
+}
+
+/// Build the `aspect feature <name>` help command: the feature's prose (or its
+/// "defined in" line when it has none) above its flags, rendered with the same
+/// clap formatting the flags used to get inline in each task's `--help`.
+fn render_feature_detail(
+    version: &str,
+    feat: &dyn FeatureLike<'_>,
+    block: &FeatureBlock,
+    aspect_root: &Path,
+    modules: &[Mod],
+) -> Command {
+    let context = format!(
+        "\x1b[3m{}\x1b[0m feature defined in \x1b[3m{}\x1b[0m",
+        feat.export_name().unwrap_or_default(),
+        defined_in_label(feat.path(), aspect_root, modules),
+    );
+    let body = if !feat.description().is_empty() {
+        feat.description()
+    } else {
+        feat.summary()
+    };
+    let about = if body.is_empty() {
+        context
+    } else {
+        format!("{body}\n\n{context}")
+    };
+    let mut cmd = Command::new(format!("feature {}", feat.name()))
+        .no_binary_name(true)
+        .disable_help_flag(true)
+        .help_template(format!(
+            "{}\n\n{about}\n\n{{all-args}}",
+            banner::line(version)
+        ));
+    for (arg_name, arg) in block.args.iter() {
+        cmd = cmd.arg(
+            arg_to_clap(Scope::Feature(&block.prefix), arg_name, arg)
+                .help_heading(block.heading.clone()),
+        );
+    }
+    cmd
+}
+
 // ── Per-task subcommand assembly ───────────────────────────────────────────
 
 fn task_command(
@@ -891,24 +915,14 @@ impl Tree {
                 MAX_TASK_GROUPS,
             ));
         }
-        // A top-level `get` task is unreachable: `main` routes `aspect get` to
-        // the credential helper before task parsing. Reject it rather than let
-        // it silently never run. Nested under a group it is reachable and fine.
-        if group.is_empty() && task.kind() == crate::credential_helper::GET_COMMAND {
+        // `main` routes these top-level commands before task parsing, so a
+        // top-level task of the same kind would never run. Reject it rather than
+        // let it silently disappear; nested under a group it is reachable.
+        if group.is_empty() && RESERVED_TOP_LEVEL_COMMANDS.contains(&task.kind().as_str()) {
             return Err(CmdError::ReservedName(
                 task.kind(),
                 label.to_owned(),
-                crate::credential_helper::GET_COMMAND.to_owned(),
-            ));
-        }
-        // A top-level `feature` task is unreachable: `main` routes
-        // `aspect feature ...` to the feature-help renderer before task parsing.
-        // Nested under a group it is reachable and fine.
-        if group.is_empty() && task.kind() == FEATURE_COMMAND {
-            return Err(CmdError::ReservedName(
                 task.kind(),
-                label.to_owned(),
-                FEATURE_COMMAND.to_owned(),
             ));
         }
         self.insert_at(&task.kind(), &group[..], &group[..], label, cmd)
@@ -1178,6 +1192,7 @@ mod tests {
         name: String,
         export_name: String,
         display_name: String,
+        summary: String,
         args: SmallMap<String, Arg>,
         path: PathBuf,
     }
@@ -1190,7 +1205,7 @@ mod tests {
             Some(self.export_name.clone())
         }
         fn summary(&self) -> &String {
-            empty_string()
+            &self.summary
         }
         fn description(&self) -> &String {
             empty_string()
@@ -1216,6 +1231,10 @@ mod tests {
     /// the CamelCase export name (e.g. `"ArtifactUpload"`); name/display_name are
     /// derived to match production (`artifact-upload` / `Artifact Upload`).
     fn stub_feature(identifier: &str) -> StubFeature {
+        stub_feature_with_summary(identifier, "")
+    }
+
+    fn stub_feature_with_summary(identifier: &str, summary: &str) -> StubFeature {
         let mut args: SmallMap<String, Arg> = SmallMap::new();
         args.insert(
             "enabled".to_owned(),
@@ -1231,6 +1250,7 @@ mod tests {
             name: axl_runtime::engine::names::to_command_name(identifier),
             export_name: identifier.to_owned(),
             display_name: axl_runtime::engine::names::camel_to_display_name(identifier),
+            summary: summary.to_owned(),
             args,
             path: PathBuf::from("/repo/feature/artifact_upload.axl"),
         }
@@ -1430,7 +1450,40 @@ mod tests {
     }
 
     #[test]
-    fn print_feature_help_renders_named_feature() {
+    fn feature_list_is_sorted_by_slug_with_summaries() {
+        let tips = stub_feature_with_summary("Tips", "Collect tips.");
+        let au = stub_feature_with_summary("ArtifactUpload", "Upload artifacts.");
+        let blocks: Vec<(&dyn FeatureLike, FeatureBlock)> = [&au, &tips]
+            .iter()
+            .map(|f| (*f as &dyn FeatureLike, feature_block(*f).unwrap()))
+            .collect();
+        let mut sorted = blocks;
+        sorted.sort_by(|(a, _), (b, _)| a.name().cmp(&b.name()));
+        let out = render_feature_list("1.2.3", &sorted);
+        let au_at = out.find("artifact-upload").expect("artifact-upload listed");
+        let tips_at = out.find("tips").expect("tips listed");
+        assert!(au_at < tips_at, "rows should be alphabetical by slug");
+        assert!(out.contains("Upload artifacts."), "summary missing");
+        assert!(out.contains("aspect feature <NAME>"), "footer missing");
+    }
+
+    #[test]
+    fn feature_detail_renders_flags_and_defined_in_line() {
+        let f = stub_feature("ArtifactUpload");
+        let block = feature_block(&f).unwrap();
+        let help = render_feature_detail("1.2.3", &f, &block, Path::new("/repo"), &[])
+            .render_help()
+            .to_string();
+        assert!(help.contains("Artifact Upload Options"), "heading missing");
+        assert!(help.contains("artifact-upload:enabled"), "flag missing");
+        assert!(
+            help.contains("ArtifactUpload feature defined in"),
+            "defined-in line missing"
+        );
+    }
+
+    #[test]
+    fn print_feature_help_exit_codes() {
         let f = stub_feature("ArtifactUpload");
         let cmd = Cmd {
             tasks: vec![],
@@ -1438,11 +1491,14 @@ mod tests {
             aspect_root: Path::new("/repo"),
             modules: &[],
         };
-        // No panic; lists the feature when unnamed and renders flags when named.
         assert_eq!(cmd.print_feature_help("0.0.0", None), ExitCode::SUCCESS);
         assert_eq!(
             cmd.print_feature_help("0.0.0", Some("artifact-upload")),
             ExitCode::SUCCESS
+        );
+        assert_eq!(
+            cmd.print_feature_help("0.0.0", Some("nope")),
+            ExitCode::from(2)
         );
     }
 

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -834,8 +834,7 @@ fn task_command(
     // appended to the help template below).
     for block in feature_blocks {
         for (arg_name, arg) in block.args.iter() {
-            let clap_arg =
-                arg_to_clap(Scope::Feature(&block.prefix), arg_name, arg).hide(true);
+            let clap_arg = arg_to_clap(Scope::Feature(&block.prefix), arg_name, arg).hide(true);
             cmd = cmd.arg(clap_arg);
         }
     }
@@ -848,8 +847,7 @@ fn task_command(
         Some(h) => format!("{h}\n"),
         None => "{about-with-newline}".to_string(),
     };
-    let feature_footer =
-        "\x1b[2mFeature flags are accepted here but hidden. \
+    let feature_footer = "\x1b[2mFeature flags are accepted here but hidden. \
          Run `aspect feature` to list features and their flags.\x1b[0m";
     cmd = cmd.help_template(format!(
         "{cli_header}\n\n{about_block}\n{{usage-heading}} {{usage}}\n\n{{all-args}}\n\n{feature_footer}"

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -154,13 +154,26 @@ impl<'a, 'v> Cmd<'a, 'v> {
                     .help("Verbosity of the phase-timing breakdown trailing the task completion line: 'none' (no timing summary), 'total' (total only), 'short' (inline phases), or 'detailed' (multi-line with descriptions; default). Tasks that don't opt into phases see only the total regardless of this setting."),
             )
             .subcommand(
+                // `feature` is not a task: its parsing exists only so `main`
+                // can route to `Cmd::print_feature_help`. Disable clap's auto
+                // help flag (otherwise `feature --help` renders clap's own
+                // help, leaking the global `--task:*` args) and accept a no-op
+                // `-h`/`--help` so it falls through to our renderer instead.
                 Command::new("feature")
                     .about("List features and show a feature's flags")
                     .hide(true)
+                    .disable_help_flag(true)
                     .arg(
                         ClapArg::new("name")
                             .value_name("NAME")
                             .required(false),
+                    )
+                    .arg(
+                        ClapArg::new("help")
+                            .short('h')
+                            .long("help")
+                            .action(ArgAction::SetTrue)
+                            .hide(true),
                     ),
             )
             .subcommand(Command::new("version").about("Print version").hide(true))

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -851,7 +851,7 @@ fn task_command(
         "\x1b[2mFeature flags are accepted here but hidden. \
          Run `aspect feature` to list features and their flags.\x1b[0m";
     cmd = cmd.help_template(format!(
-        "{cli_header}\n\n{about_block}\n{{usage-heading}} {{usage}}\n\n{{all-args}}\n{feature_footer}"
+        "{cli_header}\n\n{about_block}\n{{usage-heading}} {{usage}}\n\n{{all-args}}\n\n{feature_footer}"
     ));
     cmd
 }

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -4,7 +4,9 @@
 //!
 //! * [`Cmd`] — value-passing input. Holds task & feature trait objects plus
 //!   filesystem context. `build()` produces the Clap [`Command`]. `dispatch()`
-//!   turns parsed [`ArgMatches`] into a [`Dispatch`].
+//!   turns parsed [`ArgMatches`] into a [`Dispatch`]. `print_feature_help()`
+//!   renders `aspect feature [<name>]`, the discovery surface for feature flags
+//!   (which are hidden from each task's `--help`).
 //! * [`Dispatch`] — carries `task_id`, `task_name`, `task_friendly_name`, `task_uuid`, and the parsed
 //!   matches. `task_args(...)` and `feature_args(...)` produce the merged
 //!   runtime [`Arguments`] for a given task or feature.
@@ -13,6 +15,7 @@
 
 use std::collections::BTreeMap;
 use std::path::Path;
+use std::process::ExitCode;
 
 use axl_runtime::banner;
 use axl_runtime::engine::arg::Arg;
@@ -32,6 +35,10 @@ use starlark::values::{Heap, Value, ValueLike};
 use thiserror::Error;
 
 const TASK_ID_KEY: &str = "@@@$'__AXL_TASK_ID__'$@@@";
+/// Reserved top-level command: `main` routes `aspect feature ...` to the
+/// feature-help renderer before task parsing, so a top-level task of this kind
+/// would be unreachable.
+const FEATURE_COMMAND: &str = "feature";
 const TASK_COMMAND_DISPLAY_ORDER: usize = 0;
 const TASK_GROUP_DISPLAY_ORDER: usize = 1;
 
@@ -78,7 +85,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
         let feature_blocks: Vec<FeatureBlock> = self
             .features
             .iter()
-            .filter_map(|f| feature_block(*f, self.aspect_root, self.modules))
+            .filter_map(|f| feature_block(*f))
             .collect();
 
         let cli_header = banner::line(version);
@@ -146,6 +153,16 @@ impl<'a, 'v> Cmd<'a, 'v> {
                     .default_value("detailed")
                     .help("Verbosity of the phase-timing breakdown trailing the task completion line: 'none' (no timing summary), 'total' (total only), 'short' (inline phases), or 'detailed' (multi-line with descriptions; default). Tasks that don't opt into phases see only the total regardless of this setting."),
             )
+            .subcommand(
+                Command::new("feature")
+                    .about("List features and show a feature's flags")
+                    .hide(true)
+                    .arg(
+                        ClapArg::new("name")
+                            .value_name("NAME")
+                            .required(false),
+                    ),
+            )
             .subcommand(Command::new("version").about("Print version").hide(true))
             .subcommand(
                 Command::new("help")
@@ -153,7 +170,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
                     .hide(true),
             )
             .help_template(format!(
-                "{cli_header}\n\n{{about-with-newline}}\n{{usage-heading}} {{usage}}\n\n\x1b[1;4mTasks:\x1b[0m\n{{subcommands}}{group_section}\n\x1b[1;4mCommands:\x1b[0m\n  \x1b[1mversion\x1b[0m  Print version\n  \x1b[1mhelp\x1b[0m     Print this message or the help of the given subcommand(s)\n\n\x1b[1;4mOptions:\x1b[0m\n{{options}}"
+                "{cli_header}\n\n{{about-with-newline}}\n{{usage-heading}} {{usage}}\n\n\x1b[1;4mTasks:\x1b[0m\n{{subcommands}}{group_section}\n\x1b[1;4mCommands:\x1b[0m\n  \x1b[1mfeature\x1b[0m  List features and their flags\n  \x1b[1mversion\x1b[0m  Print version\n  \x1b[1mhelp\x1b[0m     Print this message or the help of the given subcommand(s)\n\n\x1b[1;4mOptions:\x1b[0m\n{{options}}"
             ));
 
         tree.attach(root, version)
@@ -209,6 +226,87 @@ impl<'a, 'v> Cmd<'a, 'v> {
             timing,
             matches,
         })
+    }
+
+    /// Render `aspect feature [<name>]` and return the process exit code.
+    ///
+    /// With no name, lists every active feature (keyed by the kebab slug the
+    /// user passes back in) and its summary. With a name, prints just that
+    /// feature's flags — the section that used to live inline in each task's
+    /// `--help`. An unknown name lists the valid ones on stderr and exits 2.
+    pub fn print_feature_help(&self, version: &str, name: Option<&str>) -> ExitCode {
+        let blocks: Vec<(&dyn FeatureLike<'_>, FeatureBlock)> = self
+            .features
+            .iter()
+            .filter_map(|f| feature_block(*f).map(|b| (*f, b)))
+            .collect();
+
+        match name {
+            None => {
+                let header = banner::line(version);
+                let width = blocks
+                    .iter()
+                    .map(|(f, _)| f.name().len())
+                    .max()
+                    .unwrap_or(0);
+                let mut out = format!("{header}\n\n\x1b[1;4mFeatures:\x1b[0m\n");
+                for (feat, _) in &blocks {
+                    let slug = feat.name();
+                    let pad = " ".repeat(width - slug.len() + 2);
+                    out.push_str(&format!(
+                        "  \x1b[1m{}\x1b[0m{}{}\n",
+                        slug,
+                        pad,
+                        feat.summary()
+                    ));
+                }
+                out.push_str("\nRun `aspect feature <NAME>` to see a feature's flags.\n");
+                print!("{out}");
+                ExitCode::SUCCESS
+            }
+            Some(name) => {
+                let Some((feat, block)) = blocks.iter().find(|(f, _)| f.name() == name) else {
+                    let valid: Vec<String> = blocks.iter().map(|(f, _)| f.name()).collect();
+                    eprintln!(
+                        "\x1b[1;31merror:\x1b[0m unknown feature {name:?}. \
+                         Valid features: {}",
+                        valid.join(", ")
+                    );
+                    return ExitCode::from(2);
+                };
+                let header = banner::line(version);
+                let label = defined_in_label(feat.path(), self.aspect_root, self.modules);
+                let context = format!(
+                    "\x1b[3m{}\x1b[0m feature defined in \x1b[3m{}\x1b[0m",
+                    feat.export_name().unwrap_or_default(),
+                    label
+                );
+                let body = if !feat.description().is_empty() {
+                    feat.description().clone()
+                } else if !feat.summary().is_empty() {
+                    feat.summary().clone()
+                } else {
+                    String::new()
+                };
+                let about = if body.is_empty() {
+                    context
+                } else {
+                    format!("{body}\n\n{context}")
+                };
+                let mut cmd = Command::new(format!("feature {name}"))
+                    .no_binary_name(true)
+                    .disable_help_flag(true)
+                    .help_template(format!("{header}\n\n{about}\n\n{{all-args}}"));
+                for (arg_name, arg) in block.args.iter() {
+                    cmd = cmd.arg(
+                        arg_to_clap(Scope::Feature(&block.prefix), arg_name, arg)
+                            .help_heading(block.heading.clone()),
+                    );
+                }
+                cmd.print_help().ok();
+                ExitCode::SUCCESS
+            }
+        }
     }
 }
 
@@ -614,20 +712,19 @@ fn stringify_value(v: Value<'_>) -> String {
     }
 }
 
-// ── Per-feature help block (built once, applied to every task command) ─────
+// ── Per-feature help block ─────────────────────────────────────────────────
+//
+// Built once per feature. Each task command registers these args hidden (so
+// they parse but don't clutter `--help`); `aspect feature [<name>]` renders
+// them for discovery via `Cmd::print_feature_help`.
 
 struct FeatureBlock {
     args: Vec<(String, Arg)>,
     heading: String,
-    description_line: String,
     prefix: String,
 }
 
-fn feature_block(
-    feat: &dyn FeatureLike<'_>,
-    aspect_root: &Path,
-    modules: &[Mod],
-) -> Option<FeatureBlock> {
+fn feature_block(feat: &dyn FeatureLike<'_>) -> Option<FeatureBlock> {
     let mut args: Vec<(String, Arg)> = feat
         .args()
         .iter()
@@ -661,30 +758,10 @@ fn feature_block(
         }
     }
 
-    let identifier = feat.export_name().unwrap_or_default();
-    let label = defined_in_label(feat.path(), aspect_root, modules);
     let heading = format!("{} Options", feat.display_name());
-    let context = format!(
-        "\x1b[3m{}\x1b[0m feature defined in \x1b[3m{}\x1b[0m",
-        identifier, label
-    );
-    let body = if !feat.description().is_empty() {
-        feat.description().clone()
-    } else if !feat.summary().is_empty() {
-        feat.summary().clone()
-    } else {
-        String::new()
-    };
-    let desc_text = if body.is_empty() {
-        context
-    } else {
-        format!("{}\n\n      {}", body, context)
-    };
-    let description_line = format!("\x1b[0m      {}\n\x1b[8m", desc_text);
     Some(FeatureBlock {
         args,
         heading,
-        description_line,
         prefix: feat.name(),
     })
 }
@@ -751,15 +828,13 @@ fn task_command(
         cmd = cmd.arg(clap_arg);
     }
 
+    // Feature flags stay parseable on the task command but are hidden from
+    // `--help`; `aspect feature [<name>]` surfaces them instead (see the footer
+    // appended to the help template below).
     for block in feature_blocks {
-        let full_heading = if block.description_line.is_empty() {
-            block.heading.clone()
-        } else {
-            format!("{}:\n{}", block.heading, block.description_line)
-        };
         for (arg_name, arg) in block.args.iter() {
-            let clap_arg = arg_to_clap(Scope::Feature(&block.prefix), arg_name, arg)
-                .help_heading(full_heading.clone());
+            let clap_arg =
+                arg_to_clap(Scope::Feature(&block.prefix), arg_name, arg).hide(true);
             cmd = cmd.arg(clap_arg);
         }
     }
@@ -772,8 +847,11 @@ fn task_command(
         Some(h) => format!("{h}\n"),
         None => "{about-with-newline}".to_string(),
     };
+    let feature_footer =
+        "\x1b[2mFeature flags are accepted here but hidden. \
+         Run `aspect feature` to list features and their flags.\x1b[0m";
     cmd = cmd.help_template(format!(
-        "{cli_header}\n\n{about_block}\n{{usage-heading}} {{usage}}\n\n{{all-args}}"
+        "{cli_header}\n\n{about_block}\n{{usage-heading}} {{usage}}\n\n{{all-args}}\n{feature_footer}"
     ));
     cmd
 }
@@ -809,6 +887,16 @@ impl Tree {
                 task.kind(),
                 label.to_owned(),
                 crate::credential_helper::GET_COMMAND.to_owned(),
+            ));
+        }
+        // A top-level `feature` task is unreachable: `main` routes
+        // `aspect feature ...` to the feature-help renderer before task parsing.
+        // Nested under a group it is reachable and fine.
+        if group.is_empty() && task.kind() == FEATURE_COMMAND {
+            return Err(CmdError::ReservedName(
+                task.kind(),
+                label.to_owned(),
+                FEATURE_COMMAND.to_owned(),
             ));
         }
         self.insert_at(&task.kind(), &group[..], &group[..], label, cmd)
@@ -1074,6 +1162,68 @@ mod tests {
         }
     }
 
+    struct StubFeature {
+        name: String,
+        export_name: String,
+        display_name: String,
+        args: SmallMap<String, Arg>,
+        path: PathBuf,
+    }
+
+    impl<'v> FeatureLike<'v> for StubFeature {
+        fn name(&self) -> String {
+            self.name.clone()
+        }
+        fn export_name(&self) -> Option<String> {
+            Some(self.export_name.clone())
+        }
+        fn summary(&self) -> &String {
+            empty_string()
+        }
+        fn description(&self) -> &String {
+            empty_string()
+        }
+        fn display_name(&self) -> String {
+            self.display_name.clone()
+        }
+        fn args(&self) -> &SmallMap<String, Arg> {
+            &self.args
+        }
+        fn path(&self) -> &PathBuf {
+            &self.path
+        }
+        fn overrides(&self) -> Value<'v> {
+            FrozenValue::new_none().to_value()
+        }
+        fn implementation(&self) -> Value<'v> {
+            unimplemented!("test stub")
+        }
+    }
+
+    /// Builds a feature carrying a single `enabled` boolean arg. `identifier` is
+    /// the CamelCase export name (e.g. `"ArtifactUpload"`); name/display_name are
+    /// derived to match production (`artifact-upload` / `Artifact Upload`).
+    fn stub_feature(identifier: &str) -> StubFeature {
+        let mut args: SmallMap<String, Arg> = SmallMap::new();
+        args.insert(
+            "enabled".to_owned(),
+            Arg::Boolean {
+                required: false,
+                default: true,
+                short: None,
+                long: None,
+                description: None,
+            },
+        );
+        StubFeature {
+            name: axl_runtime::engine::names::to_command_name(identifier),
+            export_name: identifier.to_owned(),
+            display_name: axl_runtime::engine::names::camel_to_display_name(identifier),
+            args,
+            path: PathBuf::from("/repo/feature/artifact_upload.axl"),
+        }
+    }
+
     // ── Cmd::build ─────────────────────────────────────────────────────────
 
     #[test]
@@ -1190,6 +1340,97 @@ mod tests {
         assert!(
             dev.find_subcommand(crate::credential_helper::GET_COMMAND)
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn build_rejects_top_level_task_named_feature() {
+        let t = stub_task(FEATURE_COMMAND, &[], SmallMap::new());
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        match cmd.build("0.0.0") {
+            Err(CmdError::ReservedName(name, ..)) => assert_eq!(name, FEATURE_COMMAND),
+            other => panic!("expected ReservedName, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn build_allows_feature_task_nested_in_group() {
+        let t = stub_task(FEATURE_COMMAND, &["dev"], SmallMap::new());
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let root = cmd.build("0.0.0").expect("build ok");
+        let dev = root.find_subcommand("dev").expect("dev group present");
+        assert!(dev.find_subcommand(FEATURE_COMMAND).is_some());
+    }
+
+    // ── Feature flags: hidden from task help, parseable, listed by `feature` ──
+
+    /// A feature's flags are registered on each task (so they still parse) but
+    /// hidden from the task's `--help`; only the task's own "<Task> Options"
+    /// section and a discovery footer remain.
+    #[test]
+    fn feature_flags_are_hidden_from_task_help() {
+        let mut task_args: SmallMap<String, Arg> = SmallMap::new();
+        task_args.insert("greeting".to_owned(), arg_string("hello"));
+        let t = stub_task("greet", &[], task_args);
+        let f = stub_feature("ArtifactUpload");
+        let cmd = Cmd {
+            tasks: vec![&t],
+            features: vec![&f as &dyn FeatureLike],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let mut root = cmd.build("0.0.0").expect("build ok");
+        let mut greet = root
+            .find_subcommand_mut("greet")
+            .expect("greet present")
+            .clone();
+        let help = greet.render_help().to_string();
+        assert!(help.contains("Greet Options"), "task section missing");
+        assert!(
+            !help.contains("Artifact Upload Options"),
+            "feature section should be hidden from task help"
+        );
+        assert!(
+            !help.contains("artifact-upload:enabled"),
+            "feature flag should be hidden from task help"
+        );
+        assert!(
+            help.contains("aspect feature"),
+            "discovery footer missing from task help"
+        );
+        // Hidden ≠ removed: the flag is still a registered arg on the command.
+        assert!(
+            greet
+                .get_arguments()
+                .any(|a| a.get_id() == "artifact-upload:enabled"),
+            "feature flag should still be parseable on the task"
+        );
+    }
+
+    #[test]
+    fn print_feature_help_renders_named_feature() {
+        let f = stub_feature("ArtifactUpload");
+        let cmd = Cmd {
+            tasks: vec![],
+            features: vec![&f as &dyn FeatureLike],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        // No panic; lists the feature when unnamed and renders flags when named.
+        assert_eq!(cmd.print_feature_help("0.0.0", None), ExitCode::SUCCESS);
+        assert_eq!(
+            cmd.print_feature_help("0.0.0", Some("artifact-upload")),
+            ExitCode::SUCCESS
         );
     }
 

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -157,6 +157,13 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                     cmd_for_help.print_help()?;
                     return Ok(ExitCode::SUCCESS);
                 }
+                Some("feature") => {
+                    let name = matches
+                        .subcommand_matches("feature")
+                        .and_then(|m| m.get_one::<String>("name"))
+                        .map(String::as_str);
+                    return Ok(cmd.print_feature_help(&cli_version, name));
+                }
                 _ => {}
             }
 


### PR DESCRIPTION
Task `--help` (e.g. `aspect test --help`) rendered the full flag set for **every** active feature as separate "<Feature> Options" sections — hundreds of lines that buried the task's own flags. This trims task `--help` to the task's own flags plus the global `--task:*` options, and moves feature-flag discovery to a new `aspect feature` command.

Feature flags remain **accepted** on the task command line — they're registered hidden, so `aspect test --artifact-upload:enabled=false` still parses and validates. Only their *display* moves.

### New `aspect feature` command

- `aspect feature` (and `aspect feature --help`) — lists active features alphabetically, keyed by the slug you pass back in, each with a one-line summary.
- `aspect feature <name>` — prints that feature's flags plus its "defined in" line. Unknown name → error listing valid features, exit 2.
- Every feature now has a concise one-line summary (several were blank or overly long).
- A footer on each task's `--help` points to `aspect feature`; `feature` is listed in the root `aspect --help` "Commands:" section.

A top-level task named `feature` is rejected (reachable when nested under a group), alongside the existing `get` reserved name.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no docs referenced the per-task feature-flag sections
- Breaking change (forces users to change their own code or config): no — feature flags still parse on tasks
- Suggested release notes appear below: yes

### Suggested release notes

- Task `--help` (e.g. `aspect test --help`) is now scoped to the task's own flags plus the global `--task:*` options. Feature flags are still accepted but are now listed via the new `aspect feature` command: run `aspect feature` to list features and `aspect feature <name>` to see one feature's flags.

### Test plan

- New test cases added (`cmd.rs`): feature flags hidden from task help but still registered/parseable; feature list sorted by slug with summaries; feature detail renders flags + defined-in line; `print_feature_help` exit codes; `feature` reserved-name guard.
- Covered by existing test cases — all `aspect-cli` tests pass; clippy clean.
- Manual testing: `aspect test --help`, `aspect feature`, `aspect feature <name>`, `aspect feature --help`, `aspect feature <name> --help`, `aspect feature bogus` (exit 2), `aspect --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
