### PR TITLE
feat(github-status-comments): coordinate via Aspect API instead of CI artifacts

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -24,6 +24,7 @@ load(
     "extract_changed_dirs",
 )
 load("@aspect//private/lib/github.axl", "detect_commit_sha", "github")
+load("@aspect//private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
 load("@aspect//private/lib/lifecycle.axl", "ReproFixCommand")
 load("@aspect//private/lib/log_snippet.axl", "SnippetOptions", "code_fence_for", "extract_junit_failure", "extract_snippet")
 load("@aspect//private/lib/path_glob.axl", "match_any", "match_path")
@@ -3486,9 +3487,85 @@ def impl(ctx: TaskContext) -> int:
     tc = test_gazelle_dir_helpers(tc)
     tc = test_log_snippet(ctx, tc, temp_dir)
     tc = test_bazel_render_snippets(ctx, tc, temp_dir)
+    tc = test_gitlab_token_cache(ctx, tc, temp_dir)
 
     print(tc, "tests passed")
     return 0
+
+def test_gitlab_token_cache(ctx: TaskContext, tc: int, temp_dir: str) -> int:
+    """Covers the installation-proof carriage added to the GitLab token
+    cache: `slot_key` normalization, `read_slot` (JSON + defensive
+    bare-token), and `get_or_mint`'s cache hit filling `_extra`."""
+    base = temp_dir + "/gitlab_token_cache_test"
+    if ctx.std.fs.exists(base):
+        ctx.std.fs.remove_dir_all(base)
+    ctx.std.fs.create_dir_all(base)
+
+    # slot_key: roles sort + dedup so any order shares a slot; no roles → _all.
+    tc = test_case(
+        tc,
+        gitlab_token_cache.slot_key("grp/proj", ["b", "a", "b"]) == gitlab_token_cache.slot_key("grp/proj", ["a", "b"]),
+        "slot_key normalizes role order + dedup",
+    )
+    tc = test_case(
+        tc,
+        gitlab_token_cache.slot_key("a/b/c", ["api"]) == "a__b__c@api.tok",
+        "slot_key encodes path slashes",
+    )
+    tc = test_case(
+        tc,
+        gitlab_token_cache.slot_key("grp/proj", None) == "grp__proj@_all.tok",
+        "slot_key uses _all when no roles",
+    )
+
+    # read_slot: JSON slot returns the token + fills _extra with the proof.
+    json_path = base + "/json.tok"
+    ctx.std.fs.write(json_path, json.encode({
+        "token": "glpat-xyz",
+        "installation_id": "inst-7",
+        "installation_proof": "proof-abc",
+    }))
+    extra = {}
+    tok = gitlab_token_cache.read_slot(ctx, json_path, extra)
+    tc = test_case(tc, tok == "glpat-xyz", "read_slot returns the JSON-slot token")
+    tc = test_case(tc, extra.get("installation_id") == "inst-7", "read_slot fills installation_id")
+    tc = test_case(tc, extra.get("installation_proof") == "proof-abc", "read_slot fills installation_proof")
+
+    # read_slot: a non-JSON slot reads defensively as a bare token, empty proof.
+    bare_path = base + "/bare.tok"
+    ctx.std.fs.write(bare_path, "glpat-plain")
+    bare_extra = {}
+    bare_tok = gitlab_token_cache.read_slot(ctx, bare_path, bare_extra)
+    tc = test_case(tc, bare_tok == "glpat-plain", "read_slot reads a bare-token slot")
+    tc = test_case(tc, bare_extra.get("installation_proof", "") == "", "bare-token slot has no proof")
+
+    # read_slot: empty file → None.
+    empty_path = base + "/empty.tok"
+    ctx.std.fs.write(empty_path, "")
+    tc = test_case(tc, gitlab_token_cache.read_slot(ctx, empty_path, {}) == None, "read_slot returns None for empty file")
+
+    # get_or_mint: a cache hit returns the token + fills _extra without minting.
+    # Point the cache dir at our temp dir and pre-write the slot.
+    prior = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR")
+    ctx.std.env.set_var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR", base)
+    slot = gitlab_token_cache.slot_path(ctx, "grp/proj", ["api"])
+    ctx.std.fs.create_dir_all(slot[:slot.rfind("/")])
+    ctx.std.fs.write(slot, json.encode({
+        "token": "glpat-cached",
+        "installation_id": "inst-9",
+        "installation_proof": "proof-9",
+    }))
+    hit_extra = {}
+    hit_tok = gitlab_token_cache.get_or_mint(ctx, project_path = "grp/proj", roles = ["api"], _extra = hit_extra)
+    tc = test_case(tc, hit_tok == "glpat-cached", "get_or_mint cache hit returns the token")
+    tc = test_case(tc, hit_extra.get("installation_proof") == "proof-9", "get_or_mint cache hit fills the proof")
+    if prior == None:
+        ctx.std.env.remove_var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR")
+    else:
+        ctx.std.env.set_var("ASPECT_WORKFLOWS_RUNNER_JOB_TMPDIR", prior)
+
+    ctx.std.fs.remove_dir_all(base)
+    return tc
 
 axl = task(
     group = ["tests"],

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -386,15 +386,16 @@ def _collapse_by(entries, key_of, rank_of):
             best[k] = e
     return list(best.values())
 
-def _union_entries_by_kind_name(primary, fallback):
-    """`primary` plus `fallback` entries whose `(kind, name)` isn't in
-    `primary` (primary wins; fallback fills gaps), preserving order."""
-    primary_keys = {(e.get("kind", ""), e.get("name", "")): True for e in primary}
-    return list(primary) + [
-        e
-        for e in fallback
-        if (e.get("kind", ""), e.get("name", "")) not in primary_keys
-    ]
+def _union_entries_by_task(primary, fallback):
+    """`primary` plus `fallback` entries whose `(job, kind, name)` isn't in
+    `primary` (primary wins; fallback fills gaps), preserving order. `job` is
+    in the identity so matrix rows — the same task kind/name run by distinct
+    jobs in one run — stay distinct (matching the display dedup key)."""
+    def _key(e):
+        return (e.get("job", ""), e.get("kind", ""), e.get("name", ""))
+
+    primary_keys = {_key(e): True for e in primary}
+    return list(primary) + [e for e in fallback if _key(e) not in primary_keys]
 
 def _dedup_for_display(entries):
     """Collapse exact-duplicate `(workflow_run_id, job, name, key)` rows
@@ -1039,6 +1040,17 @@ def _is_standard_base64(s):
             return False
     return True
 
+def _rehydrate_entries(entries):
+    """Rehydrate each entry's `repro_commands` / `fix_commands` in place after a
+    JSON round-trip (API response or comment state block), so the render path
+    can access `c.command`/`c.target` on `ReproFixCommand` records. Only touches
+    present keys, so older-release entries round-trip unchanged."""
+    for e in entries:
+        if "repro_commands" in e:
+            e["repro_commands"] = rehydrate_commands(e["repro_commands"])
+        if "fix_commands" in e:
+            e["fix_commands"] = rehydrate_commands(e["fix_commands"])
+
 def _parse_state(body):
     """Extract the cross-workflow state block from a comment body.
 
@@ -1071,14 +1083,7 @@ def _parse_state(body):
     def _string_list(v):
         return [k for k in v if type(k) == "string"] if type(v) == "list" else []
 
-    # JSON round-trip flattens ReproFixCommand records to dicts; rehydrate
-    # so `_collect_repro_fix_rows` can do `c.command`/`c.description`.
-    # Only touch present keys so older-release entries round-trip unchanged.
-    for e in parsed_entries:
-        if "repro_commands" in e:
-            e["repro_commands"] = rehydrate_commands(e["repro_commands"])
-        if "fix_commands" in e:
-            e["fix_commands"] = rehydrate_commands(e["fix_commands"])
+    _rehydrate_entries(parsed_entries)
     return {
         "head_sha": head_sha if type(head_sha) == "string" else "",
         "last_upsert_epoch_s": epoch if type(epoch) == "int" else 0,
@@ -1165,7 +1170,7 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
         if refreshed == None:
             entries.extend(snapshot)
         else:
-            entries.extend(_union_entries_by_kind_name(refreshed, snapshot))
+            entries.extend(_union_entries_by_task(refreshed, snapshot))
 
     # Deterministic order so the serialized block is byte-stable across
     # writers; else alternating ownership flips order each cycle and
@@ -1198,7 +1203,7 @@ def _merge_comment_only_state(existing_state, head_sha, run_id, workflow_name, o
             for e in (existing_state.get("entries", []) or [])
             if str(e.get("workflow_run_id", "")) == str(run_id)
         ]
-        my_entries = _union_entries_by_kind_name(own_entries, snapshot_mine)
+        my_entries = _union_entries_by_task(own_entries, snapshot_mine)
     return _merge_state(existing_state, head_sha, run_id, workflow_name, my_entries, {})
 
 def _github_status_comments(ctx: FeatureContext):
@@ -1482,7 +1487,9 @@ def _github_status_comments(ctx: FeatureContext):
             "final": final,
             "min_interval_s": max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds)),
         }
-        pending = _state.pop("_pending_post", None)
+        # Peek (don't pop) the pending confirmation — a failed contribute must
+        # not lose it, or the server never learns the post landed.
+        pending = _state.get("_pending_post")
         if pending:
             request["posted"] = pending
 
@@ -1495,8 +1502,14 @@ def _github_status_comments(ctx: FeatureContext):
             _publish_via_comment_state(ctx, token, own_entry, now_epoch, final)
             return
 
-        # Render the server's merged state, then post only if granted.
+        # Contribute succeeded — the confirmation (if any) was delivered.
+        _state.pop("_pending_post", None)
+
+        # Render the server's merged state, then post only if granted. Entries
+        # arrive as decoded JSON, so rehydrate the repro/fix command lists back
+        # to records (the render path accesses `c.command`/`c.target`).
         state = result["state"]
+        _rehydrate_entries(state.get("entries", []) or [])
         sel = _select_for_render(state)
         # Carry our chosen sticky keys into the next contribution so the server
         # accretes them (append-only) across the swarm.
@@ -1695,6 +1708,12 @@ def _github_status_comments(ctx: FeatureContext):
 def prepare_for_render(entries):
     """Public test hook; see `_prepare_for_render`."""
     return _prepare_for_render(entries)
+
+def rehydrate_entries(entries):
+    """Rehydrate API/state-block entries' command lists in place; see
+    `_rehydrate_entries`. Used by sibling features (e.g. GitLab) that render
+    entries decoded from the coordination API."""
+    _rehydrate_entries(entries)
 
 def collect_tip_rows(ctx, entries):
     """Public test hook; see `_collect_tip_rows`."""

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -118,6 +118,11 @@ _MARKER_FMT = "<!-- aspect-ci-status:pr-%d -->"
 _STATE_BLOCK_OPEN = "<!-- aspect-ci-status-state-v1:"
 _STATE_BLOCK_CLOSE = " -->"
 
+# How often a long-running task refreshes its budget-derived cadence from the
+# Aspect API (`/github/budget`). Coarser than the cadence itself — the shared
+# installation quota shifts on the minutes scale, not seconds.
+_BUDGET_REFRESH_S = 180
+
 # Badges keyed by the precomputed `_badge_key`, not raw status:
 #   "failed"  — terminal failed / live failing (error)
 #   "warning" — passed/running with non-fatal signal
@@ -1598,10 +1603,40 @@ def _github_status_comments(ctx: FeatureContext):
         if auth_extra.get("desired_cadence_s"):
             _state["_cadence_s"] = auth_extra["desired_cadence_s"]
 
+        # Installation identity + ownership proof for the periodic
+        # `/github/budget` refresh (see `_refresh_budget`).
+        _state["_installation_id"] = auth_extra.get("installation_id", "")
+        _state["_installation_proof"] = auth_extra.get("installation_proof", "")
+
         # Re-resolve with the App token; cache-hits if a sibling already did.
         upgraded = resolve_build_url(ctx, existing_app_token = token)
         if upgraded:
             _state["_ci_link_url"] = upgraded
+
+    def _refresh_budget(ctx, now):
+        """Periodically refresh `_cadence_s` from the Aspect API so a
+        long-running task adapts to shifting installation quota mid-run (other
+        consumers share the GitHub rate limit). Reads the installation's own
+        `/rate_limit` with our token and reports it to `/github/budget`, proving
+        installation ownership with the mint-time HMAC. Best-effort: any miss
+        leaves the prior cadence in place. Throttled to `_BUDGET_REFRESH_S`."""
+        if not _state.get("_installation_id") or not _state.get("_installation_proof"):
+            return
+        if now - _state.get("_last_budget_refresh_s", 0.0) < _BUDGET_REFRESH_S:
+            return
+        _state["_last_budget_refresh_s"] = now
+
+        headroom = github.read_rate_limit(ctx, _state["_github_token"])
+        if headroom == None:
+            return
+        result = github.status_comment_budget(ctx, {
+            "installation_id": _state["_installation_id"],
+            "installation_proof": _state["_installation_proof"],
+            "remaining": headroom["remaining"],
+            "reset": headroom["reset"],
+        })
+        if result.get("success") and result.get("desired_cadence_s"):
+            _state["_cadence_s"] = result["desired_cadence_s"]
 
     def _task_update(ctx, update):
         if not _state.get("_initialized"):
@@ -1689,13 +1724,17 @@ def _github_status_comments(ctx: FeatureContext):
             if phase_result == PHASE_SUPPRESS:
                 return
             if phase_result == PHASE_FALL_THROUGH:
-                # Budget-derived cadence from the Aspect API (mint-time), floored
-                # by the configured min; falls back to the floor before the first
-                # mint or when the API didn't return one.
+                # Budget-derived cadence from the Aspect API (refreshed
+                # periodically below), floored by the configured min; falls back
+                # to the floor before the first mint or when none was returned.
                 interval = max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds))
                 if now - _state.get("_last_publish_s", 0.0) < interval:
                     return
                 _state["_last_publish_s"] = now
+
+        # Refresh the budget-derived cadence on its own slow timer (self-gated
+        # to `_BUDGET_REFRESH_S`); only reached when we're about to publish.
+        _refresh_budget(ctx, monotonic())
         _publish(ctx, final = update.final)
 
     lifecycle.task_update.append(_task_update)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1,13 +1,24 @@
 """GitHub Status Comments feature \342\200\224 aggregates per-task status from sibling CI jobs into one PR comment.
 
-Every job is both a producer (uploads its task identity + data subset as an
-artifact) and a writer (polls own-run + sibling-workflow artifacts and
-PATCHes one PR comment). Polling is event-paced (ticks on BES events),
-throttled by min_poll_interval_seconds. GitHub Actions only.
+Every job contributes its own task status to the Aspect API
+(`github.status_comment_contribute` → `POST /scm/status-comment/contribute`),
+which merges it with every sibling job's contribution and returns the
+aggregated state plus a directive on whether THIS job should post the comment
+this cycle. The server owns cross-job coordination + the post throttle;
+rendering (the Jinja2 template, customizable via config) and posting (the
+GitHub issue-comment API) stay client-side. Contribution is event-paced (ticks
+on BES events), throttled by min_poll_interval_seconds. Works on any supported
+CI host (GitHub Actions, Buildkite, CircleCI) since coordination no longer
+depends on CI artifacts.
+
+When the Aspect API is unreachable, the feature falls back to coordinating
+through the comment's own embedded state block (read → merge own entry →
+render → post under a local time lease), so a single job still renders a
+correct comment.
 
 Requires the Aspect GitHub App with `prs.write` (issue-comment
-POST/PATCH/DELETE/GET) and `actions.read` (run-artifact list/download
-across any workflow on the same PR).
+POST/PATCH/DELETE/GET) and Aspect credentials (ASPECT_API_TOKEN) for the
+contribute call.
 
 Comment shape is precomputed in AXL; the Jinja2 template is a pure
 renderer. `_prepare_for_render` decorates each entry with:
@@ -18,9 +29,9 @@ renderer. `_prepare_for_render` decorates each entry with:
   - `_result_text`  Kind-specific Result cell text + elapsed.
 
 Inline failure snippets: each job extracts its own (it owns the local
-test.log / action-stderr paths; sibling writers can't read them) on its
-terminal update and ships them in its status artifact under `failure_snippets`.
-The writer picks which to show across all tasks via `_select_snippets`, which
+test.log / action-stderr paths; other jobs can't read them) on its terminal
+update and ships them in its contribution under `failure_snippets`. The
+renderer picks which to show across all tasks via `_select_snippets`, which
 first DEDUPES by `(label, snippet)` \342\200\224 the same target failing in several jobs
 collapses to one snippet attributed to all of them (`task_names`) rather than
 rendering N identical copies \342\200\224 then sticky-selects (an already-shown snippet is
@@ -51,7 +62,7 @@ Body-template variables:
 """
 
 load("@std//base64.axl", "base64")
-load("@std//time.axl", "monotonic", "time")
+load("@std//time.axl", "monotonic")
 load(
     "../private/lib/bazel_results.axl",
     "extract_failure_snippets",
@@ -64,7 +75,7 @@ load(
 )
 load("../private/lib/check_dispatch.axl", "SURFACE_PR_COMMENT", "snippet_budget_for")
 load("../private/lib/checkrun.axl", "checkrun")
-load("../private/lib/ci.axl", "resolve_build_url")
+load("../private/lib/ci.axl", "detect_ci_host", "resolve_build_url")
 load("../private/lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../private/lib/github.axl", "github")
 load("../private/lib/lifecycle.axl", "TaskLifecycleTrait")
@@ -74,16 +85,12 @@ load(
     "BUCKET_APP",
     "PHASE_FALL_THROUGH",
     "PHASE_SUPPRESS",
-    "effective_throttle_factor",
     "epoch_now_s",
-    "export_observations",
-    "ingest_sibling_observations",
     "should_emit_phase_change",
     "usage_footer",
 )
 load("../private/lib/repro_commands.axl", "ASPECT_CLI_INSTALL_HINT_MARKDOWN", "dedup_and_attribute", "rehydrate_commands")
 load("../private/lib/result_text.axl", "severity_for_status")
-load("../private/lib/tar.axl", "bsdtar")
 load(
     "../private/lib/tips.axl",
     "SURFACE_GITHUB_PR_SUMMARY",
@@ -97,29 +104,19 @@ load(
     "tip_to_payload",
 )
 
-_ARTIFACT_PREFIX = "aspect-ci-status-"
 _MARKER_FMT = "<!-- aspect-ci-status:pr-%d -->"
 
 # Cross-workflow state block embedded in the rendered comment.
 #
-# The PR comment is the canonical cross-workflow source of truth — each
-# workflow's artifact swarm sees only its own run_id's artifacts, so the
-# comment carries `workflow_runs` slots, per-task `entries` snapshot,
-# `head_sha`, `last_upsert_epoch_s`, and the sticky selection sets
-# `shown_snippets` / `shown_repros` / `shown_fixes` as base64 JSON in an HTML
-# comment. base64 keeps the literal `-->` terminator out of the payload.
+# The Aspect API is the source of truth for cross-job coordination, but the
+# rendered comment still embeds the merged state as base64 JSON in an HTML
+# comment (`workflow_runs` slots, per-task `entries` snapshot, `head_sha`,
+# `last_upsert_epoch_s`, and the sticky selection sets `shown_snippets` /
+# `shown_repros` / `shown_fixes`). That block is the fallback coordination
+# store when the API is unreachable. base64 keeps the literal `-->`
+# terminator out of the payload.
 _STATE_BLOCK_OPEN = "<!-- aspect-ci-status-state-v1:"
 _STATE_BLOCK_CLOSE = " -->"
-
-# Used by `_should_quiet_delete_log` — see that helper's docstring.
-_EVENTUAL_CONSISTENCY_WINDOW_S = 15
-
-# Delay before a terminal publish's one-shot re-sweep. Catches the race
-# where two tasks finish near-simultaneously and the artifact LIST
-# doesn't yet show the other's terminal artifact (would render it as
-# still `running`). The body-diff short-circuit skips the second PATCH
-# when no race actually occurred.
-_TERMINAL_SETTLE_DELAY_MS = 5000
 
 # Badges keyed by the precomputed `_badge_key`, not raw status:
 #   "failed"  — terminal failed / live failing (error)
@@ -399,47 +396,20 @@ def _union_entries_by_kind_name(primary, fallback):
         if (e.get("kind", ""), e.get("name", "")) not in primary_keys
     ]
 
-def _dedup_by_run_attempt(entries):
-    """Collapse `(kind, name, job)` to the highest `run_attempt`.
-
-    The artifacts API has no `attempt_number` filter, so a re-run's
-    listing returns every prior attempt; without this a task that
-    uploaded "Starting..." on attempt 1 and a terminal on attempt 2
-    appears in BOTH `running` and a terminal section. `job` is in the
-    key so matrix rows stay distinct. Ties keep first-seen (newest by
-    upstream order when callers feed newest-first)."""
-    return _collapse_by(
-        entries,
-        lambda e: (e.get("kind", ""), e.get("name", ""), e.get("job", "")),
-        _run_attempt_int,
-    )
-
 def _dedup_for_display(entries):
     """Collapse exact-duplicate `(workflow_run_id, job, name, key)` rows
     to the highest `run_attempt`, for the render path only.
 
-    Defense-in-depth: `_merge_state` already produces unique rows. Guards
-    a snapshot briefly carrying two rows for one task in one run_id
-    (eventual-consistency blip). `workflow_run_id` is in the key so
-    distinct concurrent workflows sharing a `(job, kind, name)` survive.
-    Display copy only; persisted state untouched."""
+    Defense-in-depth: the server merge already produces unique rows. Guards
+    a snapshot briefly carrying two rows for one task in one run_id.
+    `workflow_run_id` is in the key so distinct concurrent workflows sharing
+    a `(job, kind, name)` survive. Display copy only; persisted state
+    untouched."""
     return _collapse_by(
         entries,
         lambda e: (e.get("workflow_run_id", ""), e.get("job", ""), e.get("kind", ""), e.get("name", "")),
         _run_attempt_int,
     )
-
-def _should_quiet_delete_log(last_upload_at, now):
-    """Quiet (INFO vs WARN) a pre-upload `DeleteArtifact` failure in two
-    benign cases:
-      - `last_upload_at == None` → first cycle, nothing uploaded yet; the
-        Twirp delete 404s as expected.
-      - within `_EVENTUAL_CONSISTENCY_WINDOW_S` of an upload → the Azure
-        read replica may not see the fresh artifact yet.
-    Past the window, a failure stays at WARN."""
-    if last_upload_at == None:
-        return True
-    return (now - last_upload_at) <= _EVENTUAL_CONSISTENCY_WINDOW_S
 
 def _bucket_entries(entries):
     """Split entries into five status sections: running, failed, failing,
@@ -477,17 +447,6 @@ def _bucket_entries(entries):
         "successful": successful,
     }
 
-def _extract_zip(ctx, zip_path, dest_dir):
-    """Extract a zip into dest_dir using bsdtar. Returns False (warning)
-    when bsdtar is unavailable — sibling-artifact discovery is best-effort
-    and must not abort the task."""
-    bin_path = bsdtar(ctx)
-    if not bin_path:
-        _LOG.warn(ctx.std, "Sibling-artifact extraction skipped: bsdtar unavailable")
-        return False
-    child = ctx.std.process.command(bin_path).args(["xf", zip_path, "-C", dest_dir]).stdout("piped").stderr("piped").spawn()
-    return child.wait().code == 0
-
 def _earliest_start_ms(entries):
     """Smallest `start_time_ms` across entries (the body's headline
     timestamp), or 0 if none carry one."""
@@ -498,26 +457,6 @@ def _earliest_start_ms(entries):
             best = s
     return best
 
-def _max_recent_upsert_epoch(entries):
-    """Largest `last_pr_comment_upsert_epoch_s` across entries. Drives
-    the lease decision in `_publish`."""
-    best = 0
-    for e in entries:
-        v = e.get("last_pr_comment_upsert_epoch_s", 0) or 0
-        if v > best:
-            best = v
-    return best
-
-def _running_sibling_count(entries):
-    """Count entries still live (`running`/`failing`). `_publish` uses it
-    to pay the settle delay only for the last couple of finishers."""
-    n = 0
-    for e in entries:
-        s = e.get("status", "running")
-        if s == "running" or s == "failing":
-            n += 1
-    return n
-
 def _lease_held(now_epoch, last_upsert_epoch, lease_window_s):
     """True when a member published within `lease_window_s` of `now_epoch`.
     `last_upsert_epoch == 0` → nobody yet (first cycle). `max(0, …)` floors
@@ -526,21 +465,6 @@ def _lease_held(now_epoch, last_upsert_epoch, lease_window_s):
     if last_upsert_epoch <= 0:
         return False
     return max(0, now_epoch - last_upsert_epoch) < lease_window_s
-
-def _iso_in(ctx, minutes):
-    """RFC 3339 UTC timestamp `minutes` from now via GNU `date`. Returns
-    "" on failure so the caller drops the field rather than send junk."""
-    if minutes <= 0:
-        return ""
-    result = ctx.std.process.command("date").args([
-        "-u",
-        "-d",
-        "+%d minutes" % minutes,
-        "+%Y-%m-%dT%H:%M:%SZ",
-    ]).stdout("piped").spawn().wait_with_output()
-    if result.status.code == 0:
-        return result.stdout.strip()
-    return ""
 
 def _ci_run_url(env):
     """Return the GitHub Actions run URL, or "" if it can't be assembled."""
@@ -551,9 +475,46 @@ def _ci_run_url(env):
         return ""
     return server + "/" + repository + "/actions/runs/" + run_id
 
+# Per-host CI identity for the status-comment coordination key. `run_id` is the
+# broadest scope sibling jobs in one logical run share (GHA run, BK build, CCI
+# workflow); `workflow_name` keys the server's per-workflow re-trigger eviction.
+_CI_IDENTITY = {
+    "GITHUB_ACTIONS": {
+        "run_id": "GITHUB_RUN_ID",
+        "workflow_name": "GITHUB_WORKFLOW",
+        "job_name": "GITHUB_JOB",
+        "run_attempt": "GITHUB_RUN_ATTEMPT",
+    },
+    "BUILDKITE": {
+        "run_id": "BUILDKITE_BUILD_ID",
+        "workflow_name": "BUILDKITE_PIPELINE_SLUG",
+        "job_name": "BUILDKITE_STEP_KEY",
+        "run_attempt": "BUILDKITE_RETRY_COUNT",
+    },
+    "CIRCLECI": {
+        "run_id": "CIRCLE_WORKFLOW_ID",
+        "workflow_name": "CIRCLE_PROJECT_REPONAME",
+        "job_name": "CIRCLE_JOB",
+        "run_attempt": "",
+    },
+}
+
+def _ci_identity(env, marker):
+    """Resolve `(run_id, workflow_name, job_name, run_attempt)` for the host
+    identified by `marker`, or `None` for an unsupported host."""
+    spec = _CI_IDENTITY.get(marker)
+    if spec == None:
+        return None
+    return {
+        "run_id": env.var(spec["run_id"]) or "",
+        "workflow_name": env.var(spec["workflow_name"]) or "",
+        "job_name": env.var(spec["job_name"]) or "unknown-job",
+        "run_attempt": (env.var(spec["run_attempt"]) if spec["run_attempt"] else "") or "1",
+    }
+
 def _progress_dict(progress_styles):
-    """Serialize a ProgressStyles record to a dict surviving the
-    artifact-upload JSON round-trip (entry["progress"]["body"/"stream"])."""
+    """Serialize a ProgressStyles record to a dict surviving the contribution
+    JSON round-trip (entry["progress"]["body"/"stream"])."""
     if progress_styles == None:
         return {"body": "", "stream": ""}
     return {
@@ -578,11 +539,11 @@ def _results_subset(
     deduped at render). `data` is frozen on the final update so fields are
     copied out; live-state fields come from `_state`.
 
-    `failure_snippets` is the producer's own inline failure snippets (plain
-    dicts; only this job can read its log/stderr paths) — extracted on the
-    terminal update by the caller and shipped in the artifact, since sibling
-    writers can't re-derive them. The writer dedupes them across tasks and
-    sticky-selects against the global budget at render."""
+    `failure_snippets` is this job's own inline failure snippets (plain dicts;
+    only this job can read its log/stderr paths) — extracted on the terminal
+    update by the caller and shipped in the contribution, since other jobs
+    can't re-derive them. The renderer dedupes them across tasks and
+    sticky-selects against the global budget."""
     bz = data.get("bazel", {})
     return {
         "elapsed_ms": elapsed_ms,
@@ -1133,12 +1094,11 @@ def _live_runs(workflow_runs, my_run_id, my_workflow_name):
     """Reduce `workflow_runs` slots (plus this writer's own run) to the
     newest `run_id` per `workflow_name`.
 
-    A re-triggered workflow keeps its name but gets a fresh `GITHUB_RUN_ID`;
-    the stale slot would duplicate every task (artifacts expire → snapshot
-    fallback), so only the newest survives. Our own run competes like any
-    slot — a newer run of our name wins and drops ours (else we'd resurrect
-    stale rows). Empty-`workflow_name` slots pass through untouched (can't
-    match to a newer run); a nameless own-run is always kept."""
+    A re-triggered workflow keeps its name but gets a fresh run id; the stale
+    slot would duplicate every task, so only the newest survives. Our own run
+    competes like any slot — a newer run of our name wins and drops ours (else
+    we'd resurrect stale rows). Empty-`workflow_name` slots pass through
+    untouched (can't match to a newer run); a nameless own-run is always kept."""
     candidates = [r for r in workflow_runs if str(r.get("run_id", "")) != str(my_run_id)]
     candidates.append({"run_id": str(my_run_id), "workflow_name": my_workflow_name})
 
@@ -1155,23 +1115,23 @@ def _live_runs(workflow_runs, my_run_id, my_workflow_name):
     return list(newest_by_name.values()) + passthrough
 
 def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entries, refreshed_other_entries):
-    """Build the new state block to write to the comment.
+    """Merge a writer's entries into the comment state block.
 
-    Hybrid cross-workflow model:
+    The Aspect API owns coordination in the normal path; this drives the
+    comment-state-block fallback (and the snapshot tests):
       * `workflow_runs`: `{run_id, workflow_name}` slots, newest run_id per
-        name. Each writer overlays only its own slot (slot-independent →
-        no data race); `_live_runs` evicts re-triggered runs.
-      * `entries`: full per-task snapshot, kept for (a) fallback when a
-        sibling's artifacts are unreachable (TTL/API error), (b) terminal
-        persistence past artifact retention.
+        name. Each writer overlays only its own slot; `_live_runs` evicts
+        re-triggered runs.
+      * `entries`: full per-task snapshot, the cross-workflow source of truth.
 
     Args:
-      existing_state: parsed comment state, or `None` for first writer.
+      existing_state: parsed comment state, or `None` for the first writer.
       head_sha: THIS push's SHA; a mismatch discards everything (fresh start).
       my_run_id, my_workflow_name: this writer's identity.
-      my_entries: this swarm's authoritative entries.
-      refreshed_other_entries: `{run_id_str: [entry]}` for siblings refreshed
-        this cycle; missing run_ids fall back to the snapshot.
+      my_entries: this writer's authoritative entries.
+      refreshed_other_entries: `{run_id_str: [entry]}` overlaying another run's
+        slot; missing run_ids fall back to the snapshot. (The fallback passes
+        `{}` — only the snapshot tests exercise refreshes.)
 
     Returns a dict for `_serialize_state` (caller stamps `last_upsert_epoch_s`).
     """
@@ -1225,6 +1185,22 @@ def _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entri
         "entries": entries,
     }
 
+def _merge_comment_only_state(existing_state, head_sha, run_id, workflow_name, own_entries):
+    """`_merge_state` for the comment-state-block fallback (no cross-job
+    discovery): all jobs in a run share one run_id and `_merge_state` replaces
+    the whole own slot, so union our own entries over the snapshot for our
+    run_id first (ours wins per `(kind, name)`; siblings survive), then merge.
+    A fresh push (head_sha mismatch / no prior state) has nothing to preserve."""
+    my_entries = own_entries
+    if existing_state and existing_state.get("head_sha") == head_sha:
+        snapshot_mine = [
+            e
+            for e in (existing_state.get("entries", []) or [])
+            if str(e.get("workflow_run_id", "")) == str(run_id)
+        ]
+        my_entries = _union_entries_by_kind_name(own_entries, snapshot_mine)
+    return _merge_state(existing_state, head_sha, run_id, workflow_name, my_entries, {})
+
 def _github_status_comments(ctx: FeatureContext):
     lifecycle = ctx.traits[TaskLifecycleTrait]
 
@@ -1238,8 +1214,13 @@ def _github_status_comments(ctx: FeatureContext):
     if mode == "local-only" and is_ci:
         return
 
-    # Hard gate: artifact upload uses the GitHub Actions Twirp API.
-    if not ctx.std.env.var("GITHUB_ACTIONS"):
+    # Works on any supported CI host (GitHub Actions, Buildkite, CircleCI):
+    # cross-job coordination goes through the Aspect API, not CI artifacts.
+    host = detect_ci_host(ctx.std.env)
+    if host == None:
+        return
+    identity = _ci_identity(ctx.std.env, host["marker"])
+    if identity == None:
         return
 
     if github.bail_if_not_public_github(ctx.std, _LOG, "Skipping PR comment."):
@@ -1254,17 +1235,19 @@ def _github_status_comments(ctx: FeatureContext):
     pr_number = pr["pr_number"]
     head_sha = pr.get("sha") or ""
     marker = _MARKER_FMT % pr_number
-    job_name = ctx.std.env.var("GITHUB_JOB") or "unknown-job"
-    run_id = ctx.std.env.var("GITHUB_RUN_ID") or ""
-    run_attempt = ctx.std.env.var("GITHUB_RUN_ATTEMPT") or "1"
-    workflow_name = ctx.std.env.var("GITHUB_WORKFLOW") or ""
+    job_name = identity["job_name"]
+    run_id = identity["run_id"]
+    run_attempt = identity["run_attempt"]
+    workflow_name = identity["workflow_name"]
     if not run_id:
-        _LOG.info(ctx.std, "Missing GITHUB_RUN_ID; skipping.")
+        _LOG.info(ctx.std, "Missing CI run id (%s); skipping." % host["marker"])
         return
 
-    ci_run_url = _ci_run_url(ctx.std.env)
+    # Per-job CI run URL: GHA assembles the run/job URL; other hosts come from
+    # `resolve_build_url` (job-scoped from env). Resolved at init with the App
+    # token for the GHA per-job upgrade.
+    ci_run_url = _ci_run_url(ctx.std.env) if host["marker"] == "GITHUB_ACTIONS" else ""
     min_poll_interval_seconds = ctx.args.min_poll_interval_seconds
-    artifact_expires_minutes = ctx.args.artifact_expires_minutes
 
     # args.custom(dict, ...) hands None at runtime, not the declared default.
     templates = ctx.args.templates or {}
@@ -1289,21 +1272,13 @@ def _github_status_comments(ctx: FeatureContext):
         )
 
     def _own_payload(ctx):
-        """Build our own task entry dict — written to disk by _publish_self
-        and folded into the comment without a download round-trip.
+        """Build this task's entry dict — the contribution sent to the Aspect
+        API and rendered into the comment.
 
         `tips`: this task's tips (filtered/sorted), trimmed to render fields;
-        the aggregator dedups by id across siblings.
-
-        `rate_limit_observations`: piggybacks recent GitHub-API observations
-        so siblings ingest them and every member computes the same
-        `throttle_factor` → agreeing `lease_window` in `_publish`.
-
-        `last_pr_comment_upsert_epoch_s`: high-water mark of any upsert this
-        writer knows of (own or cross-workflow via the state block); 0 until
-        seen. `_publish` takes `max(...)` across siblings, so when anyone has
-        published recently everyone else honors the lease and skips the GET +
-        upsert."""
+        the aggregator dedups by id across siblings. The merge keys on
+        `(workflow_run_id, job, kind, name)`; `head_sha` scopes the merge to
+        this push."""
 
         # Prefer the per-job URL to drop the reviewer on the failing job's logs.
         link_url = _state.get("_ci_link_url") or ci_run_url
@@ -1315,10 +1290,6 @@ def _github_status_comments(ctx: FeatureContext):
             "status": _state.get("_status", "running"),
             "ci_run_url": link_url,
             "tips": [tip_to_payload(t) for t in collect_tips_sorted(ctx, surface = SURFACE_GITHUB_PR_SUMMARY)],
-            "rate_limit_observations": export_observations(ctx),
-            "last_pr_comment_upsert_epoch_s": _state.get("_last_pr_comment_upsert_epoch_s", 0),
-            # Cross-workflow merge tags: `head_sha` (drop prior-push rows),
-            # `workflow_run_id` (snapshot bucket + slot key), `workflow_name`.
             "workflow_run_id": run_id,
             "workflow_name": workflow_name,
             "head_sha": head_sha,
@@ -1331,144 +1302,6 @@ def _github_status_comments(ctx: FeatureContext):
         if check_run_url:
             payload["check_run_url"] = check_run_url
         return payload
-
-    def _publish_self(ctx, token):
-        """Upload this task's status payload, replacing the prior artifact.
-        Skips the round-trip when the payload is unchanged. Pre-upload
-        `delete_artifact` quiets benign 404s via `_should_quiet_delete_log`."""
-        if "_workdir" not in _state:
-            _state["_workdir"] = ctx.std.fs.mkdtemp(prefix = "aspect-ci-status-")
-        _state["_my_artifact_name"] = _ARTIFACT_PREFIX + job_name + "-" + _state["_task_name"] + "-" + run_attempt
-
-        payload = _own_payload(ctx)
-        payload_str = json.encode(payload)
-        if _state.get("_last_payload_str") == payload_str:
-            return True
-
-        payload_path = _state["_workdir"] + "/task.json"
-        ctx.std.fs.write(payload_path, payload_str)
-
-        quiet = _should_quiet_delete_log(_state.get("_last_upload_at"), monotonic())
-        github.delete_artifact(ctx, _state["_my_artifact_name"], quiet_failure_log = quiet)
-
-        # Server-side TTL, refreshed per-cycle so active tasks stay alive
-        # while inactive ones expire.
-        expires_at = _iso_in(ctx, artifact_expires_minutes)
-        up = github.upload_artifact(ctx, payload_path, _state["_my_artifact_name"], expires_at = expires_at)
-        if not up.get("success"):
-            _LOG.warn(ctx.std, "Upload failed: %s" % "; ".join(up.get("errors", []) or []))
-            return False
-        _state["_last_payload_str"] = payload_str
-        _state["_last_upload_at"] = monotonic()
-        return True
-
-    def _list_and_download_workflow_artifacts(ctx, token, target_run_id, is_own_swarm):
-        """Shared artifact list+download for own-swarm and cross-workflow.
-
-        Downloads cached by artifact id (per-run_id slot); ids change on
-        every replacement, so a stable id means no new payload since the
-        last poll.
-
-        Two dedup paths converge:
-          - Duplicate names: Azure eventual-consistency reads can list a
-            deleted artifact alongside the fresh one. Sort newest-id-first
-            and skip `seen` names → newest wins.
-          - `(name, key, job)` across attempts: no `attempt_number` filter,
-            so re-runs list every attempt; `_dedup_by_run_attempt` collapses.
-
-        `is_own_swarm=True` also: substitutes our own payload from `_state`,
-        GCs stale cache entries, and ingests sibling rate-limit observations
-        (swarm-scoped).
-
-        Returns `None` on a list transport failure.
-        """
-        listed = github.actions.list_run_artifacts(ctx, token, owner, repo, target_run_id, name_prefix = _ARTIFACT_PREFIX)
-        if not listed.get("success"):
-            _LOG.warn(ctx.std, "List artifacts failed (run_id=%s): %s" % (target_run_id, listed.get("error", "unknown")))
-            return None
-
-        # Per-run_id cache slot — disjoint id spaces; a shared cache would
-        # mis-GC cross-workflow entries against the own-swarm listing.
-        cache_key = "_entry_cache:" + str(target_run_id)
-        cache = _state.setdefault(cache_key, {})
-        own_name = _state.get("_my_artifact_name", "") if is_own_swarm else ""
-        workdir = _state["_workdir"]
-        seen = {}
-        current_ids = {}
-
-        sorted_artifacts = sorted(listed["artifacts"], key = lambda a: -(a.get("id") or 0))
-        for a in sorted_artifacts:
-            aname = a.get("name", "")
-            aid = str(a["id"])
-            current_ids[aid] = True
-
-            if aname in seen:
-                continue
-
-            if aname == own_name:
-                seen[aname] = _own_payload(ctx)
-                continue
-
-            cached = cache.get(aid)
-            if cached != None:
-                seen[aname] = cached
-                continue
-
-            zip_path = workdir + "/" + aid + ".zip"
-            dl = github.actions.download_artifact_zip(ctx, token, owner, repo, a["id"], zip_path)
-            if not dl.get("success"):
-                continue
-            extract_dir = workdir + "/x-" + aid
-            ctx.std.fs.create_dir_all(extract_dir)
-            if not _extract_zip(ctx, zip_path, extract_dir):
-                continue
-            json_path = extract_dir + "/task.json"
-            if not ctx.std.fs.exists(json_path):
-                continue
-            entry = json.try_decode(ctx.std.fs.read_to_string(json_path), None)
-            if not entry:
-                continue
-
-            # JSON round-trip flattens ReproFixCommand records to dicts;
-            # rehydrate for `c.command`/`c.description`. Only touch present
-            # keys so older-release entries pass through unchanged.
-            if "repro_commands" in entry:
-                entry["repro_commands"] = rehydrate_commands(entry["repro_commands"])
-            if "fix_commands" in entry:
-                entry["fix_commands"] = rehydrate_commands(entry["fix_commands"])
-            cache[aid] = entry
-            seen[aname] = entry
-
-            if is_own_swarm:
-                # Artifact name (stable per `(job, task_name, run_attempt)`)
-                # is the `sibling_id`, so a re-upload overwrites its prior
-                # slice. Absent field (older producers) → ingest no-ops.
-                ingest_sibling_observations(
-                    ctx,
-                    aname,
-                    entry.get("rate_limit_observations", {}) or {},
-                )
-
-        if is_own_swarm:
-            for aid in list(cache.keys()):
-                if aid not in current_ids:
-                    cache.pop(aid)
-
-        return _dedup_by_run_attempt(list(seen.values()))
-
-    def _collect_sibling_entries(ctx, token):
-        """Entries from our own run's artifacts (own-swarm wrapper)."""
-        return _list_and_download_workflow_artifacts(ctx, token, run_id, is_own_swarm = True)
-
-    def _collect_other_workflow_entries(ctx, token, other_run_id):
-        """Entries from a sibling workflow's artifacts (run_ids learned
-        from the state block), so our PATCH carries fresh values.
-
-        Returns the (possibly empty) list, or `None` on API failure.
-        `_merge_state` unions this with the snapshot, so partial/empty
-        refreshes never drop snapshot entries (terminal state survives
-        retention; no eventual-consistency thrashing)."""
-        return _list_and_download_workflow_artifacts(ctx, token, other_run_id, is_own_swarm = False)
 
     def _upsert_comment(ctx, token, body):
         """PATCH the existing comment when its id is known, else POST a
@@ -1534,118 +1367,30 @@ def _github_status_comments(ctx: FeatureContext):
                 return body
         return ""
 
-    def _publish(ctx, final = False):
-        token = _state.get("_github_token")
-        if not token:
-            return
-        if not _publish_self(ctx, token):
-            return
-        raw_entries = _collect_sibling_entries(ctx, token)
-        if raw_entries == None:
-            return
+    def _select_for_render(state):
+        """Run sticky + deterministic selection for snippets and repro/fix
+        commands over a merged `state` dict (`entries`, `shown_*`).
 
-        # Terminal-settle delay: when terminal and likely the last (or
-        # second-to-last) finisher, wait out the LIST eventual-consistency
-        # window and re-collect — else the comment can stick on a stale
-        # `running` entry. Gated on a multi-task swarm with ≤1 sibling still
-        # running (mid-stream terminals skip; the last task catches up).
-        if (
-            final and
-            len(raw_entries) > 1 and
-            _running_sibling_count(_prepare_for_render(raw_entries)) <= 1
-        ):
-            time.sleep(_TERMINAL_SETTLE_DELAY_MS)
-            raw_entries = _collect_sibling_entries(ctx, token)
-            if raw_entries == None:
-                return
-
-        # Lease coordination — the quota-burning PATCH is gated on a lease
-        # any member can hold. Combined epoch = `max(state.last_upsert_epoch_s,
-        # swarm-local)`: state block covers any-workflow; swarm-local covers
-        # bootstrap before any state block. `lease_window_s` uses
-        # `swarm_elapsed_s` + merged quota factor so members converge.
-        #
-        # Fast path: if the swarm-local lease holds, the combined one does
-        # too — skip the comment GET + per-sibling refresh (miss a new row
-        # for one cycle, but we wouldn't have PATCHed; next cycle catches
-        # up). `final=True` always runs the full path.
-        prepared_local = _prepare_for_render(raw_entries)
-        local_earliest_ms = _earliest_start_ms(prepared_local)
-        now_epoch = epoch_now_s(ctx.std)
-        swarm_started_epoch = local_earliest_ms // 1000 if local_earliest_ms > 0 else now_epoch
-        swarm_elapsed_s = max(0, now_epoch - swarm_started_epoch)
-        factor = effective_throttle_factor(ctx, BUCKET_APP, swarm_elapsed_s, min_poll_interval_seconds)
-        lease_window_s = min_poll_interval_seconds * factor
-        swarm_local_lease_epoch = _max_recent_upsert_epoch(prepared_local)
-        if not final and _lease_held(now_epoch, swarm_local_lease_epoch, lease_window_s):
-            return
-
-        # Cross-workflow merge (see `_merge_state`): fetch the comment,
-        # refresh each sibling's entries from its artifacts, overlay our
-        # own slot. Slot-independent writes → no cross-workflow clobber.
-        existing_body = _fetch_existing_comment_body(ctx, token)
-        if existing_body == None:
-            return
-        parsed = _parse_state(existing_body)
-        cross_workflow_lease_epoch = parsed["last_upsert_epoch_s"] if parsed else 0
-
-        # Propagate the cross-workflow epoch into our stamp so the next
-        # `_publish_self` carries it; siblings then see the higher value and
-        # skip their GET — only the leaseholder pays the cross-workflow GET.
-        if cross_workflow_lease_epoch > _state.get("_last_pr_comment_upsert_epoch_s", 0):
-            _state["_last_pr_comment_upsert_epoch_s"] = cross_workflow_lease_epoch
-
-        # Combined lease check — a sibling workflow may have published even
-        # when our swarm hasn't. Terminal bypasses the lease (else the
-        # verdict could freeze on stale state); the body-diff below still
-        # gates a redundant terminal PATCH.
-        last_publish_epoch = max(cross_workflow_lease_epoch, swarm_local_lease_epoch)
-        if not final and _lease_held(now_epoch, last_publish_epoch, lease_window_s):
-            return
-
-        refreshed_others = {}
-        if parsed and parsed.get("head_sha") == head_sha:
-            for r in parsed.get("workflow_runs", []) or []:
-                other_run_id = str(r.get("run_id") or "")
-                if not other_run_id or other_run_id == str(run_id):
-                    continue
-                other_entries = _collect_other_workflow_entries(ctx, token, other_run_id)
-                if other_entries != None:
-                    refreshed_others[other_run_id] = other_entries
-
-        new_state = _merge_state(parsed, head_sha, run_id, workflow_name, raw_entries, refreshed_others)
-
-        # Drop exact-duplicate rows before rendering (defense-in-depth;
-        # persisted `new_state["entries"]` untouched).
-        prepared = _prepare_for_render(_dedup_for_display(new_state["entries"]))
+        Returns the render inputs plus the updated sticky-key sets the caller
+        sends back to the server / persists in the fallback state block.
+        Selection reuses the prior `shown_*` keys so capped sections don't
+        flip-flop as jobs report in."""
+        prepared = _prepare_for_render(_dedup_for_display(state.get("entries", []) or []))
         sections = _bucket_entries(prepared)
 
-        # Sticky + deterministic selection for snippets and repro/fix commands,
-        # across siblings. Computed once so both renders agree; the chosen keys
-        # persist in the state block so a later sibling can't evict an
-        # already-shown item. Only reuse a prior sticky set on the SAME head_sha
-        # — a new commit starts fresh (matching the entry-refresh guard above),
-        # so a stale key from the previous commit can't consume a slot.
-        same_head = parsed and parsed.get("head_sha") == head_sha
-
         def _prior(key):
-            if not same_head:
-                return []
-            return [k for k in (parsed.get(key) or []) if type(k) == "string"]
+            return [k for k in (state.get(key) or []) if type(k) == "string"]
 
-        snippet_rows, shown_keys, snippet_overflow = _select_snippets(prepared, _prior("shown_snippets"))
-        new_state["shown_snippets"] = shown_keys
+        snippet_rows, shown_snippets, snippet_overflow = _select_snippets(prepared, _prior("shown_snippets"))
 
-        # Repro / fix commands: dedup + deterministic-sort, then sticky-select
-        # against the global cap; the rest collapse into an "N more" note.
         all_repro_rows, all_fix_rows = _collect_repro_fix_rows(sections)
-        repro_rows, repro_shown, repro_dropped = _select_sticky(
+        repro_rows, shown_repros, repro_dropped = _select_sticky(
             all_repro_rows,
             _prior("shown_repros"),
             _MAX_COMMENT_REPROS,
             lambda r: r["_key"],
         )
-        fix_rows, fix_shown, fix_dropped = _select_sticky(
+        fix_rows, shown_fixes, fix_dropped = _select_sticky(
             all_fix_rows,
             _prior("shown_fixes"),
             _MAX_COMMENT_FIXES,
@@ -1653,72 +1398,162 @@ def _github_status_comments(ctx: FeatureContext):
         )
         _finalize_command_rows(repro_rows)
         _finalize_command_rows(fix_rows)
-        repro_overflow = _by_task_overflow(repro_dropped)
-        fix_overflow = _by_task_overflow(fix_dropped)
-        new_state["shown_repros"] = repro_shown
-        new_state["shown_fixes"] = fix_shown
+        return {
+            "prepared": prepared,
+            "sections": sections,
+            "snippet_rows": snippet_rows,
+            "snippet_overflow": snippet_overflow,
+            "repro_rows": repro_rows,
+            "repro_overflow": _by_task_overflow(repro_dropped),
+            "fix_rows": fix_rows,
+            "fix_overflow": _by_task_overflow(fix_dropped),
+            "shown_snippets": shown_snippets,
+            "shown_repros": shown_repros,
+            "shown_fixes": shown_fixes,
+        }
 
-        # Earliest start across all siblings, pinned so it doesn't wobble.
-        earliest_ms = _earliest_start_ms(prepared)
-        started_at = format_run_date(ctx, earliest_ms)
+    def _render_comment(ctx, state, sel, now_epoch):
+        """Render `(stable_body, final_body)` from a merged `state` + selection.
 
-        # Two renders: `stable_body` zeros timestamp/usage/epoch so the
-        # unchanged-content short-circuit fires when no state changed;
-        # `final_body` carries live values. The state block's entries +
-        # workflow_runs are in the diff so a new sibling row invalidates it.
-        stable_state = dict(new_state)
-        stable_state["last_upsert_epoch_s"] = 0
-        stable_body = _render_body(
-            ctx,
-            marker,
-            prepared,
-            started_at,
-            body_template,
-            status_badges,
-            sections,
-            state = stable_state,
-            snippet_rows = snippet_rows,
-            snippet_overflow = snippet_overflow,
-            repro_rows = repro_rows,
-            fix_rows = fix_rows,
-            repro_overflow = repro_overflow,
-            fix_overflow = fix_overflow,
-        )
+        `stable_body` zeros the live timestamp/usage so the unchanged-content
+        short-circuit fires when nothing changed; `final_body` carries live
+        values. The embedded state block lets a job render a correct comment
+        from the server's merged state and is the fallback coordination store
+        when the API is unreachable."""
+        prepared = sel["prepared"]
+        started_at = format_run_date(ctx, _earliest_start_ms(prepared))
+        block = {
+            "head_sha": state.get("head_sha", head_sha),
+            "entries": state.get("entries", []) or [],
+            "workflow_runs": state.get("workflow_runs", []) or [],
+            "shown_snippets": sel["shown_snippets"],
+            "shown_repros": sel["shown_repros"],
+            "shown_fixes": sel["shown_fixes"],
+        }
+
+        def _body(stable):
+            s = dict(block)
+            s["last_upsert_epoch_s"] = 0 if stable else now_epoch
+            return _render_body(
+                ctx,
+                marker,
+                prepared,
+                started_at,
+                body_template,
+                status_badges,
+                sel["sections"],
+                last_updated_at = "" if stable else format_run_date(ctx, now_ms(ctx)),
+                api_usage = "" if stable else usage_footer(ctx),
+                state = s,
+                snippet_rows = sel["snippet_rows"],
+                snippet_overflow = sel["snippet_overflow"],
+                repro_rows = sel["repro_rows"],
+                fix_rows = sel["fix_rows"],
+                repro_overflow = sel["repro_overflow"],
+                fix_overflow = sel["fix_overflow"],
+            )
+
+        return (_body(True), _body(False))
+
+    def _publish(ctx, final = False):
+        token = _state.get("_github_token")
+        if not token:
+            return
+
+        own_entry = _own_payload(ctx)
+        now_epoch = epoch_now_s(ctx.std)
+
+        # Contribute our entry to the Aspect API, which merges it with every
+        # sibling job's contribution and tells us whether to post this cycle.
+        # `posted` confirms a prior grant so the server records the comment id
+        # + posted hash and measures the next interval from the real post.
+        request = {
+            "scm": "github",
+            "owner": owner,
+            "repo": repo,
+            "pr_number": pr_number,
+            "head_sha": head_sha,
+            "run_id": run_id,
+            "workflow_name": workflow_name,
+            "entries": [own_entry],
+            "shown_snippets": _state.get("_shown_snippets", []),
+            "shown_repros": _state.get("_shown_repros", []),
+            "shown_fixes": _state.get("_shown_fixes", []),
+            "final": final,
+            "min_interval_s": max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds)),
+        }
+        pending = _state.pop("_pending_post", None)
+        if pending:
+            request["posted"] = pending
+
+        result = github.status_comment_contribute(ctx, request)
+        if not result.get("success"):
+            # API unreachable / errored — fall back to coordinating through the
+            # comment's own state block (read → merge our entry → render →
+            # post), so a single job still renders a correct comment.
+            _LOG.trace("status-comment API unavailable (%s); using comment-state fallback" % result.get("error", ""))
+            _publish_via_comment_state(ctx, token, own_entry, now_epoch, final)
+            return
+
+        # Render the server's merged state, then post only if granted.
+        state = result["state"]
+        sel = _select_for_render(state)
+        # Carry our chosen sticky keys into the next contribution so the server
+        # accretes them (append-only) across the swarm.
+        _state["_shown_snippets"] = sel["shown_snippets"]
+        _state["_shown_repros"] = sel["shown_repros"]
+        _state["_shown_fixes"] = sel["shown_fixes"]
+
+        if not result.get("should_post"):
+            return
+
+        if "_comment_id" not in _state and result.get("comment_id"):
+            _state["_comment_id"] = result["comment_id"]
+
+        # We hold the post grant. Skip the PATCH when our render is unchanged
+        # (the client owns the content-changed decision); the grant lapses on
+        # its own lease. Otherwise upsert and confirm on the next contribution
+        # so the server clears the grant and advances its post interval.
+        stable_body, final_body = _render_comment(ctx, state, sel, now_epoch)
         if _state.get("_last_stable_body") == stable_body:
             return
-        final_state = dict(new_state)
-        final_state["last_upsert_epoch_s"] = now_epoch
-        final_body = _render_body(
-            ctx,
-            marker,
-            prepared,
-            started_at,
-            body_template,
-            status_badges,
-            sections,
-            last_updated_at = format_run_date(ctx, now_ms(ctx)),
-            api_usage = usage_footer(ctx),
-            state = final_state,
-            snippet_rows = snippet_rows,
-            snippet_overflow = snippet_overflow,
-            repro_rows = repro_rows,
-            fix_rows = fix_rows,
-            repro_overflow = repro_overflow,
-            fix_overflow = fix_overflow,
-        )
         if not _upsert_comment(ctx, token, final_body):
-            # Skip stamping — the swarm should retry, not honor a stale
-            # lease behind a broken publisher.
+            return
+        _state["_last_stable_body"] = stable_body
+        _state["_pending_post"] = {"comment_id": str(_state.get("_comment_id", ""))}
+
+    def _publish_via_comment_state(ctx, token, own_entry, now_epoch, final):
+        """Fallback coordination when the Aspect API is unreachable: the
+        comment's own state block is the shared store. Read the comment, merge
+        our entry (preserving sibling rows for our run), render, and post under
+        a simple time lease so concurrent jobs don't all PATCH at once."""
+        existing_body = _fetch_existing_comment_body(ctx, token)
+        if existing_body == None:
+            return
+        parsed = _parse_state(existing_body)
+
+        lease_epoch = parsed["last_upsert_epoch_s"] if parsed else 0
+        if not final and _lease_held(now_epoch, lease_epoch, min_poll_interval_seconds):
+            return
+
+        new_state = _merge_comment_only_state(parsed, head_sha, run_id, workflow_name, [own_entry])
+        sel = _select_for_render(new_state)
+        new_state["shown_snippets"] = sel["shown_snippets"]
+        new_state["shown_repros"] = sel["shown_repros"]
+        new_state["shown_fixes"] = sel["shown_fixes"]
+
+        stable_body, final_body = _render_comment(ctx, new_state, sel, now_epoch)
+        if _state.get("_last_stable_body") == stable_body:
+            return
+        if not _upsert_comment(ctx, token, final_body):
             return
         _state["_last_stable_body"] = stable_body
 
-        # Swarm siblings see this on our next `_publish_self` (~1 cycle
-        # later); cross-workflow siblings see it now via the state block.
-        _state["_last_pr_comment_upsert_epoch_s"] = now_epoch
-
     def _init(ctx):
         # One-time init on first task_update: cache task identity (FeatureContext
-        # has no ctx.task) for the artifact name, then authenticate for `_publish`.
+        # has no ctx.task), then mint the GitHub App token used to post the
+        # comment. (Cross-job coordination uses the Aspect JWT directly in
+        # `github.status_comment_contribute`, not this token.)
         _state["_task_kind"] = ctx.task.kind
         _state["_task_name"] = ctx.task.name
 
@@ -1726,12 +1561,14 @@ def _github_status_comments(ctx: FeatureContext):
         _state["_task_started_at"] = monotonic()
 
         auth_reason = {}
+        auth_extra = {}
         token = github.authenticate(
             ctx,
             owner = owner,
             repo = repo,
-            roles = ["prs.write", "actions.read"],
+            roles = ["prs.write"],
             _reason = auth_reason,
+            _extra = auth_extra,
         )
         if not token:
             # `_publish` no-ops without `_github_token`, disabling this surface.
@@ -1742,6 +1579,11 @@ def _github_status_comments(ctx: FeatureContext):
             ))
             return
         _state["_github_token"] = token
+
+        # Budget-derived comment-refresh cadence from the token mint; the
+        # `_task_update` throttle floors it by `min_poll_interval_seconds`.
+        if auth_extra.get("desired_cadence_s"):
+            _state["_cadence_s"] = auth_extra["desired_cadence_s"]
 
         # Re-resolve with the App token; cache-hits if a sibling already did.
         upgraded = resolve_build_url(ctx, existing_app_token = token)
@@ -1818,8 +1660,8 @@ def _github_status_comments(ctx: FeatureContext):
         if update.priority:
             _state["_saw_priority"] = True
         if not (update.final or is_initial):
-            # Outer per-task throttle on BES ticks; the swarm-wide lease in
-            # `_publish` is what actually gates the App-bucket PATCH.
+            # Per-task throttle on BES ticks — bounds how often we contribute
+            # to the Aspect API; the server gates the actual comment PATCH.
             now = monotonic()
             phase_result = should_emit_phase_change(
                 ctx,
@@ -1834,9 +1676,11 @@ def _github_status_comments(ctx: FeatureContext):
             if phase_result == PHASE_SUPPRESS:
                 return
             if phase_result == PHASE_FALL_THROUGH:
-                elapsed_s = now - _state.get("_task_started_at", now)
-                factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, min_poll_interval_seconds)
-                if now - _state.get("_last_publish_s", 0.0) < min_poll_interval_seconds * factor:
+                # Budget-derived cadence from the Aspect API (mint-time), floored
+                # by the configured min; falls back to the floor before the first
+                # mint or when the API didn't return one.
+                interval = max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds))
+                if now - _state.get("_last_publish_s", 0.0) < interval:
                     return
                 _state["_last_publish_s"] = now
         _publish(ctx, final = update.final)
@@ -1884,17 +1728,9 @@ def format_overflow_note(overflow, noun_singular, noun_plural):
     """Public test hook; see `_format_overflow_note`."""
     return _format_overflow_note(overflow, noun_singular, noun_plural)
 
-def dedup_by_run_attempt(entries):
-    """Public test hook; see `_dedup_by_run_attempt`."""
-    return _dedup_by_run_attempt(entries)
-
 def dedup_for_display(entries):
     """Public test hook; see `_dedup_for_display`."""
     return _dedup_for_display(entries)
-
-def should_quiet_delete_log(last_upload_at, now):
-    """Public test hook; see `_should_quiet_delete_log`."""
-    return _should_quiet_delete_log(last_upload_at, now)
 
 def render_body(ctx, marker, entries, started_at, body_template, status_badges, sections, state = None, snippet_rows = None, snippet_overflow = None):
     """Public test hook; see `_render_body`."""
@@ -1923,13 +1759,13 @@ def merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entrie
     """Public test hook; see `_merge_state`."""
     return _merge_state(existing_state, head_sha, my_run_id, my_workflow_name, my_entries, refreshed_other_entries)
 
+def merge_comment_only_state(existing_state, head_sha, run_id, workflow_name, own_entries):
+    """Public test hook; see `_merge_comment_only_state`."""
+    return _merge_comment_only_state(existing_state, head_sha, run_id, workflow_name, own_entries)
+
 def lease_held(now_epoch, last_upsert_epoch, lease_window_s):
     """Public test hook; see `_lease_held`."""
     return _lease_held(now_epoch, last_upsert_epoch, lease_window_s)
-
-def max_recent_upsert_epoch(entries):
-    """Public test hook; see `_max_recent_upsert_epoch`."""
-    return _max_recent_upsert_epoch(entries)
 
 def results_subset(
         data,
@@ -1974,21 +1810,10 @@ GithubStatusComments = feature(
         ),
         "min_poll_interval_seconds": args.int(
             default = 20,
-            description = "Minimum seconds between PR-comment refreshes. Default 20s. Each refresh counts " +
-                          "against the GitHub API rate limit; on busy repos this interval will automatically " +
-                          "stretch further as the remaining quota shrinks or the run goes on longer. When " +
-                          "multiple jobs in the same workflow run write to the same PR comment, they " +
-                          "coordinate so only one job refreshes the comment per interval — the cost stays " +
-                          "flat regardless of how many run in parallel. Terminal task verdicts always land " +
-                          "immediately.",
-        ),
-        "artifact_expires_minutes": args.int(
-            default = 30,
-            description = "Server-side TTL for the per-task status artifact. Each upload sets the " +
-                          "GitHub Actions artifact's expiresAt to now + this many minutes. " +
-                          "Active tasks keep refreshing the timestamp on every cycle; inactive ones " +
-                          "auto-expire so we don't accumulate junk in the run's artifact tab. " +
-                          "Set to 0 to disable (no expiry).",
+            description = "Minimum seconds between PR-comment refreshes. Default 20s. The Aspect API " +
+                          "decides which job posts each interval so the cost stays flat regardless of how " +
+                          "many jobs run in parallel; this value gates the local fallback lease used when " +
+                          "the API is unreachable. Terminal task verdicts always land immediately.",
         ),
         # Config-only (set via configure(..., feature_args = {...}) in config.axl).
         "templates": args.custom(

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -62,7 +62,7 @@ Body-template variables:
 """
 
 load("@std//base64.axl", "base64")
-load("@std//time.axl", "monotonic")
+load("@std//time.axl", "monotonic", "sleep")
 load(
     "../private/lib/bazel_results.axl",
     "extract_failure_snippets",
@@ -122,6 +122,14 @@ _STATE_BLOCK_CLOSE = " -->"
 # Aspect API (`/github/budget`). Coarser than the cadence itself — the shared
 # installation quota shifts on the minutes scale, not seconds.
 _BUDGET_REFRESH_S = 180
+
+# One settle delay (seconds) for the create-time duplicate backstop. After this
+# job creates a comment it lists once immediately; if no sibling is visible yet
+# it waits this long once more (GitHub read-after-write lag can hide a racing
+# sibling's just-created comment) and re-lists before giving up. Paid only on
+# create; a confirmed duplicate converges without waiting, and updates (PATCH)
+# never run the backstop at all.
+_DEDUP_SETTLE_S = 3
 
 # Badges keyed by the precomputed `_badge_key`, not raw status:
 #   "failed"  — terminal failed / live failing (error)
@@ -396,6 +404,7 @@ def _union_entries_by_task(primary, fallback):
     `primary` (primary wins; fallback fills gaps), preserving order. `job` is
     in the identity so matrix rows — the same task kind/name run by distinct
     jobs in one run — stay distinct (matching the display dedup key)."""
+
     def _key(e):
         return (e.get("job", ""), e.get("kind", ""), e.get("name", ""))
 
@@ -471,6 +480,20 @@ def _lease_held(now_epoch, last_upsert_epoch, lease_window_s):
     if last_upsert_epoch <= 0:
         return False
     return max(0, now_epoch - last_upsert_epoch) < lease_window_s
+
+def _dedup_survivor(items, marker):
+    """Pick the surviving status comment/note among `items` and the rest to
+    delete, so concurrent first-posters converge deterministically.
+
+    `items` are listed comments/notes, each a dict with an `id` and `body`.
+    Keeps the lowest `id` bearing `marker` (a stable choice every writer agrees
+    on regardless of arrival order). Returns `(survivor_id, [loser_id, ...])`,
+    or `(None, [])` when fewer than two marker items exist (nothing to do)."""
+    dupes = [it for it in items if marker in (it.get("body") or "")]
+    if len(dupes) <= 1:
+        return (None, [])
+    dupes_sorted = sorted(dupes, key = lambda it: it["id"])
+    return (dupes_sorted[0]["id"], [it["id"] for it in dupes_sorted[1:]])
 
 def _ci_run_url(env):
     """Return the GitHub Actions run URL, or "" if it can't be assembled."""
@@ -1332,20 +1355,32 @@ def _github_status_comments(ctx: FeatureContext):
             _LOG.warn(ctx.std, "Create failed: %s" % res.get("error", "unknown"))
             return False
         _state["_comment_id"] = res["comment_id"]
-
-        # Race mitigation: if two jobs both POSTed, keep the lowest comment
-        # id and delete the rest so all writers converge on one survivor.
-        listed2 = github.issues.list_comments(ctx, token, owner, repo, pr_number)
-        if not listed2.get("success"):
-            return True
-        dupes = [c for c in listed2["comments"] if marker in (c.get("body") or "")]
-        if len(dupes) <= 1:
-            return True
-        dupes_sorted = sorted(dupes, key = lambda c: c["id"])
-        _state["_comment_id"] = dupes_sorted[0]["id"]
-        for d in dupes_sorted[1:]:
-            github.issues.delete_comment(ctx, token, owner, repo, d["id"])
+        _dedup_marker_comments(ctx, token)
         return True
+
+    def _dedup_marker_comments(ctx, token):
+        """Converge concurrent first-posters on one comment: keep the lowest
+        marker-comment id and delete the rest.
+
+        Lists immediately; a confirmed duplicate converges at once. A racing
+        sibling's just-created comment can lag in `list_comments` (GitHub
+        read-after-write), so when only our own comment is visible it waits
+        `_DEDUP_SETTLE_S` once and re-lists before giving up. Runs only after a
+        create — once `_comment_id` is set, every later cycle PATCHes and never
+        reaches here."""
+        for attempt in range(2):
+            if attempt:
+                sleep(_DEDUP_SETTLE_S)
+            listed = github.issues.list_comments(ctx, token, owner, repo, pr_number)
+            if not listed.get("success"):
+                return
+            survivor, losers = _dedup_survivor(listed["comments"], marker)
+            if survivor == None:
+                continue
+            _state["_comment_id"] = survivor
+            for loser_id in losers:
+                github.issues.delete_comment(ctx, token, owner, repo, loser_id)
+            return
 
     def _fetch_existing_comment_body(ctx, token):
         """Read the PR's marker comment body so the render can merge other
@@ -1492,6 +1527,7 @@ def _github_status_comments(ctx: FeatureContext):
             "final": final,
             "min_interval_s": max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds)),
         }
+
         # Peek (don't pop) the pending confirmation — a failed contribute must
         # not lose it, or the server never learns the post landed.
         pending = _state.get("_pending_post")
@@ -1508,7 +1544,11 @@ def _github_status_comments(ctx: FeatureContext):
             return
 
         # Contribute succeeded — the confirmation (if any) was delivered.
+        # Record that server coordination works so the comment-state fallback
+        # only ever PATCHes (never creates out-of-band), letting the server's
+        # single-poster election own comment creation.
         _state.pop("_pending_post", None)
+        _state["_api_ok"] = True
 
         # Render the server's merged state, then post only if granted. Entries
         # arrive as decoded JSON, so rehydrate the repro/fix command lists back
@@ -1516,6 +1556,7 @@ def _github_status_comments(ctx: FeatureContext):
         state = result["state"]
         _rehydrate_entries(state.get("entries", []) or [])
         sel = _select_for_render(state)
+
         # Carry our chosen sticky keys into the next contribution so the server
         # accretes them (append-only) across the swarm.
         _state["_shown_snippets"] = sel["shown_snippets"]
@@ -1525,8 +1566,15 @@ def _github_status_comments(ctx: FeatureContext):
         if not result.get("should_post"):
             return
 
+        # Resolve the comment id before posting so we PATCH the existing comment
+        # rather than create a duplicate: prefer the server's hint, else
+        # discover the marker comment on the PR. The server only learns the id
+        # once a poster *confirms* (one cycle after it posts), so a job granted
+        # before that confirmation lands must look it up itself.
         if "_comment_id" not in _state and result.get("comment_id"):
             _state["_comment_id"] = result["comment_id"]
+        if "_comment_id" not in _state:
+            _fetch_existing_comment_body(ctx, token)
 
         # We hold the post grant. Skip the PATCH when our render is unchanged
         # (the client owns the content-changed decision); the grant lapses on
@@ -1544,9 +1592,16 @@ def _github_status_comments(ctx: FeatureContext):
         """Fallback coordination when the Aspect API is unreachable: the
         comment's own state block is the shared store. Read the comment, merge
         our entry (preserving sibling rows for our run), render, and post under
-        a simple time lease so concurrent jobs don't all PATCH at once."""
+        a simple time lease so concurrent jobs don't all PATCH at once.
+
+        Once server coordination has worked this run (`_api_ok`), this path may
+        only PATCH a comment it already knows/discovers — never create one
+        out-of-band — so the server's single-poster election stays the sole
+        creator and a transient API blip can't race a second comment."""
         existing_body = _fetch_existing_comment_body(ctx, token)
         if existing_body == None:
+            return
+        if "_comment_id" not in _state and _state.get("_api_ok"):
             return
         parsed = _parse_state(existing_body)
 
@@ -1824,6 +1879,10 @@ def merge_comment_only_state(existing_state, head_sha, run_id, workflow_name, ow
 def lease_held(now_epoch, last_upsert_epoch, lease_window_s):
     """Public test hook; see `_lease_held`."""
     return _lease_held(now_epoch, last_upsert_epoch, lease_window_s)
+
+def dedup_survivor(items, marker):
+    """Public test hook + shared helper for GitLab; see `_dedup_survivor`."""
+    return _dedup_survivor(items, marker)
 
 def results_subset(
         data,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1,7 +1,7 @@
 """GitHub Status Comments feature \342\200\224 aggregates per-task status from sibling CI jobs into one PR comment.
 
 Every job contributes its own task status to the Aspect API
-(`github.status_comment_contribute` → `POST /scm/status-comment/contribute`),
+(`github.status_comment_contribute` → `POST /status-comments/contribute`),
 which merges it with every sibling job's contribution and returns the
 aggregated state plus a directive on whether THIS job should post the comment
 this cycle. The server owns cross-job coordination + the post throttle;
@@ -1514,6 +1514,8 @@ def _github_status_comments(ctx: FeatureContext):
         # + posted hash and measures the next interval from the real post.
         request = {
             "scm": "github",
+            "installation_id": _state.get("_installation_id", ""),
+            "installation_proof": _state.get("_installation_proof", ""),
             "owner": owner,
             "repo": repo,
             "pr_number": pr_number,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1276,11 +1276,12 @@ def _github_status_comments(ctx: FeatureContext):
         _LOG.info(ctx.std, "Missing CI run id (%s); skipping." % host["marker"])
         return
 
-    # Per-job CI run URL: GHA assembles the run/job URL; other hosts come from
-    # `resolve_build_url` (job-scoped from env). Resolved at init with the App
-    # token for the GHA per-job upgrade.
+    # GHA assembles a run-level URL from env here as a fallback; other hosts
+    # leave this empty. The richer per-job URL is resolved in `_init` via
+    # `resolve_build_url` (App-token-authenticated on GHA) into
+    # `_state["_ci_link_url"]`, which the render path prefers over this value.
     ci_run_url = _ci_run_url(ctx.std.env) if host["marker"] == "GITHUB_ACTIONS" else ""
-    min_poll_interval_seconds = ctx.args.min_poll_interval_seconds
+    min_poll_interval_seconds = max(1, ctx.args.min_poll_interval_seconds)
 
     # args.custom(dict, ...) hands None at runtime, not the declared default.
     templates = ctx.args.templates or {}
@@ -1612,6 +1613,15 @@ def _github_status_comments(ctx: FeatureContext):
             return
 
         new_state = _merge_comment_only_state(parsed, head_sha, run_id, workflow_name, [own_entry])
+
+        # Seed the prior sticky-selection sets from the existing comment so
+        # capped sections don't flip-flop across fallback cycles (the merge
+        # carries only entries/runs). Drop them on a new push, matching the
+        # head_sha reset in `_merge_state`.
+        same_push = bool(parsed) and parsed.get("head_sha") == head_sha
+        for k in ("shown_snippets", "shown_repros", "shown_fixes"):
+            new_state[k] = parsed.get(k, []) if same_push else []
+
         sel = _select_for_render(new_state)
         new_state["shown_snippets"] = sel["shown_snippets"]
         new_state["shown_repros"] = sel["shown_repros"]

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -48,6 +48,7 @@ load(
     "DEFAULT_BODY_TEMPLATE",
     "DEFAULT_STATUS_BADGES",
     "bucket_entries",
+    "dedup_survivor",
     "lease_held",
     "merge_comment_only_state",
     "parse_state",
@@ -56,6 +57,7 @@ load(
     "render_body",
     "results_subset",
 )
+load("@std//time.axl", "sleep")
 load("../private/lib/bazel_results.axl", "format_run_date", "now_ms")
 load("../private/lib/environment.axl", "feature_logger")
 load("../private/lib/github.axl", "github")
@@ -66,6 +68,10 @@ load("../private/lib/lifecycle.axl", "TaskLifecycleTrait")
 load("../private/lib/rate_limit.axl", "epoch_now_s")
 
 _LOG = feature_logger("GitLab status comments")
+
+# One settle delay (seconds) for the create-time duplicate backstop — see the
+# GitHub feature's `_dedup_marker_comments` for the read-after-write rationale.
+_DEDUP_SETTLE_S = 3
 
 _MARKER_FMT = "<!-- aspect-ci-status:mr-%d -->"
 
@@ -213,8 +219,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
 
     def _upsert_note(ctx, token, body):
         """PUT the existing note when its id is known, else POST a fresh
-        one. After a POST, re-list and dedup by marker so concurrent
-        writers converge on the lowest-id survivor."""
+        one (the create-time duplicate backstop runs in `_dedup_notes`)."""
         if _state.get("_note_id") != None:
             res = gitlab.notes.update(
                 ctx,
@@ -242,31 +247,40 @@ def _gitlab_status_comments(ctx: FeatureContext):
             _LOG.warn(ctx.std, "Create note failed: %s" % res.get("error", "unknown"))
             return False
         _state["_note_id"] = res["note_id"]
-
-        # Race mitigation: if two tasks both POSTed within the same
-        # window, keep the lowest note id and delete the rest. Stable
-        # choice across writers so they converge on the same survivor.
-        listed2 = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base)
-        if not listed2["success"]:
-            return True
-        dupes = [n for n in listed2["notes"] if marker in (n.get("body") or "")]
-        if len(dupes) <= 1:
-            return True
-        dupes_sorted = sorted(dupes, key = lambda n: n["id"])
-        survivor = dupes_sorted[0]["id"]
-        _state["_note_id"] = survivor
-        for d in dupes_sorted[1:]:
-            del_res = gitlab.notes.delete(
-                ctx,
-                token = token,
-                project = project_path,
-                mr_iid = mr_iid,
-                note_id = d["id"],
-                api_base = api_base,
-            )
-            if not del_res["success"]:
-                _LOG.trace("Cleanup of duplicate note %s failed; will retry next cycle" % d["id"])
+        _dedup_notes(ctx, token)
         return True
+
+    def _dedup_notes(ctx, token):
+        """Converge concurrent first-posters on one note: keep the lowest
+        marker-note id and delete the rest.
+
+        Lists immediately; a confirmed duplicate converges at once. A racing
+        sibling's just-created note can lag in the notes list, so when only our
+        own note is visible it waits `_DEDUP_SETTLE_S` once and re-lists before
+        giving up. Runs only after a create — once `_note_id` is set, every
+        later cycle PUTs and never reaches here."""
+        for attempt in range(2):
+            if attempt:
+                sleep(_DEDUP_SETTLE_S)
+            listed = gitlab.notes.list(ctx, token = token, project = project_path, mr_iid = mr_iid, api_base = api_base)
+            if not listed["success"]:
+                return
+            survivor, losers = dedup_survivor(listed["notes"], marker)
+            if survivor == None:
+                continue
+            _state["_note_id"] = survivor
+            for loser_id in losers:
+                del_res = gitlab.notes.delete(
+                    ctx,
+                    token = token,
+                    project = project_path,
+                    mr_iid = mr_iid,
+                    note_id = loser_id,
+                    api_base = api_base,
+                )
+                if not del_res["success"]:
+                    _LOG.trace("Cleanup of duplicate note %s failed; will retry next cycle" % loser_id)
+            return
 
     def _render_note(ctx, state, now_epoch):
         """Render `(stable_body, final_body)` for the MR note from a merged
@@ -317,6 +331,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
             "final": final,
             "min_interval_s": min_poll_interval_seconds,
         }
+
         # Peek (don't pop) — a failed contribute must not lose the pending
         # confirmation, or the server never learns the post landed.
         pending = _state.get("_pending_post")
@@ -330,7 +345,11 @@ def _gitlab_status_comments(ctx: FeatureContext):
             return
 
         # Contribute succeeded — the confirmation (if any) was delivered.
+        # Record that server coordination works so the note-state fallback only
+        # ever PATCHes (never creates out-of-band), keeping the server's
+        # single-poster election the sole note creator.
         _state.pop("_pending_post", None)
+        _state["_api_ok"] = True
 
         if not result.get("should_post"):
             return
@@ -339,6 +358,13 @@ def _gitlab_status_comments(ctx: FeatureContext):
         # back to records before the render path reads `c.command`/`c.target`.
         state = result["state"]
         rehydrate_entries(state.get("entries", []) or [])
+
+        # Resolve the note id before posting so we PATCH the existing note
+        # rather than create a duplicate: the server only learns the id once a
+        # poster confirms (one cycle after it posts), so a job granted before
+        # that confirmation lands must discover the marker note itself.
+        if _state.get("_note_id") == None:
+            _fetch_existing_note_body(ctx, token)
 
         before = _state.get("_last_stable_body")
         _post(ctx, token, state, now_epoch)
@@ -351,9 +377,16 @@ def _gitlab_status_comments(ctx: FeatureContext):
         """Fallback when the Aspect API is unreachable: the MR note's own state
         block is the shared store. Read the note, merge our entry (preserving
         sibling rows for our pipeline), render, and post under a time lease so
-        concurrent tasks don't all PATCH at once."""
+        concurrent tasks don't all PATCH at once.
+
+        Once server coordination has worked this run (`_api_ok`), this path may
+        only PATCH a note it already knows/discovers — never create one
+        out-of-band — so a transient API blip can't race a second note past the
+        server's single-poster election."""
         existing_body = _fetch_existing_note_body(ctx, token)
         if existing_body == None:
+            return
+        if _state.get("_note_id") == None and _state.get("_api_ok"):
             return
         parsed = parse_state(existing_body)
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -59,7 +59,7 @@ load(
     "render_body",
     "results_subset",
 )
-load("@std//time.axl", "sleep")
+load("@std//time.axl", "monotonic", "sleep")
 load("../private/lib/bazel_results.axl", "format_run_date", "now_ms")
 load("../private/lib/environment.axl", "feature_logger")
 load("../private/lib/github.axl", "github")
@@ -67,7 +67,14 @@ load("../private/lib/gitlab.axl", "gitlab")
 load("../private/lib/gitlab_detect.axl", "detect_gitlab_mr")
 load("../private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
 load("../private/lib/lifecycle.axl", "TaskLifecycleTrait")
-load("../private/lib/rate_limit.axl", "epoch_now_s")
+load(
+    "../private/lib/rate_limit.axl",
+    "BUCKET_APP",
+    "PHASE_FALL_THROUGH",
+    "PHASE_SUPPRESS",
+    "epoch_now_s",
+    "should_emit_phase_change",
+)
 
 _LOG = feature_logger("GitLab status comments")
 
@@ -465,6 +472,33 @@ def _gitlab_status_comments(ctx: FeatureContext):
             _state["_failed_in_phase"] = _state.get("_current_phase", "")
 
         _refresh_own_base(ctx, status, update, elapsed_ms)
+
+        # Bypass the throttle on terminal verdicts and the first priority event
+        # (spawn-label flip); otherwise pace contributes to the Aspect API by
+        # `min_poll_interval_seconds`, mirroring `GithubStatusComments`. The
+        # server still gates the actual note PATCH. GitLab has no budget-derived
+        # cadence, so the configured floor is the interval.
+        is_initial = update.priority and not _state.get("_saw_priority", False)
+        if update.priority:
+            _state["_saw_priority"] = True
+        if not (final or is_initial):
+            now = monotonic()
+            phase_result = should_emit_phase_change(
+                ctx,
+                BUCKET_APP,
+                update,
+                _state,
+                now,
+                "_last_phase_change_s",
+                "_last_publish_s",
+                scale = 1,
+            )
+            if phase_result == PHASE_SUPPRESS:
+                return
+            if phase_result == PHASE_FALL_THROUGH:
+                if now - _state.get("_last_publish_s", 0.0) < min_poll_interval_seconds:
+                    return
+                _state["_last_publish_s"] = now
 
         _publish(ctx, final = final)
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -6,22 +6,18 @@ but uses GitLab Merge Request Notes instead of GitHub Issue Comments.
 
 ## Cross-task coordination
 
-The GH feature coordinates cross-task state via GitHub Actions artifacts
-(each task uploads its payload; sibling tasks download). GitLab CI's
-artifact API isn't conveniently reachable from runner code, so this
-feature uses a simpler design: **the MR note itself is the shared state
-store**. Each task on each `task_update`:
+Coordination goes through the Aspect API, same as `GithubStatusComments`:
+each task POSTs its own entry to `POST /scm/status-comment/contribute`
+(`scm: "gitlab"`) and gets back the merged set of all tasks' entries plus a
+directive on whether *it* should post the note this cycle. The server owns
+the merge + post throttle; this feature only renders the returned state and
+upserts the GitLab MR note (with the GitLab App token).
 
-  1. Fetches the marker note from the MR.
-  2. Parses the state block from the note's footer.
-  3. Merges this task's entry into the state's `entries` list (replacing
-     any prior entry with the same `(workflow_run_id, job, key, name)`).
-  4. Renders + upserts the note.
-
-This keeps the feature stateless across aspect-cli processes — every
-task writes the same view by reading + merging + writing. Lease
-coordination throttles concurrent writers so the App API quota stays
-flat regardless of how many tasks run in parallel.
+When the Aspect API is unreachable, it falls back to coordinating through the
+note's own embedded state block: read the note, merge our entry via
+`merge_comment_only_state` (all tasks in a pipeline share one
+`workflow_run_id` / CI_PIPELINE_ID, so it preserves sibling rows), render, and
+upsert under a time lease.
 
 ## Marker
 
@@ -39,10 +35,8 @@ template's variable contract.
 
 ## Out of scope vs GH counterpart
 
-* No GitLab CI artifact upload/download — uses the note's own state block
-  as the cross-task source of truth instead.
-* No terminal-settle delay — the artifact eventual-consistency window
-  doesn't apply since we don't depend on a listing API.
+* No inline failure-snippet / repro / fix sections — GitLab renders the
+  entries table only.
 * No per-task check-run deep link — the GitlabCommitStatuses feature
   doesn't publish a per-task page URL (commit_status `target_url` points
   at the CI job, not a per-status page). The `check_run_url` field on
@@ -55,27 +49,20 @@ load(
     "DEFAULT_STATUS_BADGES",
     "bucket_entries",
     "lease_held",
-    "max_recent_upsert_epoch",
-    "merge_state",
+    "merge_comment_only_state",
     "parse_state",
     "prepare_for_render",
     "render_body",
     "results_subset",
 )
 load("../private/lib/bazel_results.axl", "format_run_date", "now_ms")
-load("../private/lib/ci.axl", "detect_ci_host")
-load("../private/lib/environment.axl", "feature_logger", "workflows_results_url")
+load("../private/lib/environment.axl", "feature_logger")
+load("../private/lib/github.axl", "github")
 load("../private/lib/gitlab.axl", "gitlab")
 load("../private/lib/gitlab_detect.axl", "detect_gitlab_mr")
 load("../private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
-load("../private/lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
-load(
-    "../private/lib/rate_limit.axl",
-    "BUCKET_APP",
-    "effective_throttle_factor",
-    "epoch_now_s",
-    "usage_footer",
-)
+load("../private/lib/lifecycle.axl", "TaskLifecycleTrait")
+load("../private/lib/rate_limit.axl", "epoch_now_s")
 
 _LOG = feature_logger("GitLab status comments")
 
@@ -89,16 +76,16 @@ def _ci_run_url(env):
 
 def _own_entry(ctx, _state, run_id, run_attempt, job_name):
     """Snapshot this task's current state as an entry dict shaped for
-    `merge_state` / `render_body`. Caller refreshes on each publish so
-    `check_run_url` (published asynchronously by GitlabCommitStatuses)
-    and live phase info flow through.
+    `merge_comment_only_state` / `render_body`. Caller refreshes on each
+    publish so `check_run_url` (published asynchronously by
+    GitlabCommitStatuses) and live phase info flow through.
     """
     base = _state.get("_own_base", {})
     snapshot = dict(base)
     snapshot.update(_state.get("_own_live", {}))
 
     # `workflow_run_id` is the pipeline id; mirrors the GH state-block
-    # key so `merge_state` works unchanged. Stringified for byte-stable
+    # key so the shared merge works unchanged. Stringified for byte-stable
     # serialization (matches GH path).
     snapshot["workflow_run_id"] = str(run_id)
     snapshot["workflow_name"] = _state.get("_workflow_name", "")
@@ -145,8 +132,8 @@ def _gitlab_status_comments(ctx: FeatureContext):
     if not run_id:
         # Fall back to the MR IID so single-pipeline coordination still
         # works in the local-sim case where no real pipeline exists. A
-        # synthetic run_id is fine — `merge_state` only uses it as a
-        # slot key, not as something it dereferences against GL.
+        # synthetic run_id is fine — it's only used as a slot key, not
+        # dereferenced against GL.
         run_id = "local-mr-%d" % mr_iid
         _LOG.trace("No CI_PIPELINE_ID; using synthetic run_id=%s for local-sim coordination" % run_id)
 
@@ -280,81 +267,91 @@ def _gitlab_status_comments(ctx: FeatureContext):
                 _LOG.trace("Cleanup of duplicate note %s failed; will retry next cycle" % d["id"])
         return True
 
+    def _render_note(ctx, state, now_epoch):
+        """Render `(stable_body, final_body)` for the MR note from a merged
+        `state` dict. `stable_body` zeros the live-only fields so the
+        unchanged-content short-circuit fires when nothing changed. The
+        embedded state block is the fallback coordination store when the
+        Aspect API is unreachable."""
+        prepared = prepare_for_render(state["entries"])
+        sections = bucket_entries(prepared)
+        started_at = format_run_date(ctx, _earliest_start_ms(prepared) or now_ms(ctx))
+
+        def _body(stable):
+            s = dict(state)
+            s["last_upsert_epoch_s"] = 0 if stable else now_epoch
+            return render_body(ctx, marker, prepared, started_at, body_template, status_badges, sections, state = s)
+
+        return (_body(True), _body(False))
+
+    def _post(ctx, token, state, now_epoch):
+        """Render the merged `state` and upsert the MR note if it changed."""
+        stable_body, final_body = _render_note(ctx, state, now_epoch)
+        if _state.get("_last_stable_body") == stable_body:
+            return
+        if not _upsert_note(ctx, token, final_body):
+            return
+        _state["_last_stable_body"] = stable_body
+
     def _publish(ctx, final = False):
         token = _state.get("_gitlab_token")
         if not token:
             return
 
         own_entry = _own_entry(ctx, _state, run_id, run_attempt, job_name)
+        now_epoch = epoch_now_s(ctx.std)
 
+        # Contribute to the Aspect API, which merges our entry with every
+        # sibling job's and tells us whether to post this cycle (same
+        # coordination path as GitHub; `scm` keeps GitLab's state disjoint).
+        request = {
+            "scm": "gitlab",
+            "owner": project_path,
+            "repo": str(mr_iid),
+            "pr_number": mr_iid,
+            "head_sha": head_sha,
+            "run_id": run_id,
+            "workflow_name": workflow_name,
+            "entries": [own_entry],
+            "final": final,
+            "min_interval_s": min_poll_interval_seconds,
+        }
+        pending = _state.pop("_pending_post", None)
+        if pending:
+            request["posted"] = pending
+
+        result = github.status_comment_contribute(ctx, request)
+        if not result.get("success"):
+            _LOG.trace("status-comment API unavailable (%s); using note-state fallback" % result.get("error", ""))
+            _publish_via_note_state(ctx, token, own_entry, now_epoch, final)
+            return
+
+        if not result.get("should_post"):
+            return
+
+        before = _state.get("_last_stable_body")
+        _post(ctx, token, result["state"], now_epoch)
+        if _state.get("_last_stable_body") != before:
+            # Confirm the post on our next contribution so the server clears
+            # the grant and records the comment id.
+            _state["_pending_post"] = {"comment_id": str(_state.get("_note_id", ""))}
+
+    def _publish_via_note_state(ctx, token, own_entry, now_epoch, final):
+        """Fallback when the Aspect API is unreachable: the MR note's own state
+        block is the shared store. Read the note, merge our entry (preserving
+        sibling rows for our pipeline), render, and post under a time lease so
+        concurrent tasks don't all PATCH at once."""
         existing_body = _fetch_existing_note_body(ctx, token)
         if existing_body == None:
             return
         parsed = parse_state(existing_body)
-        cross_workflow_lease_epoch = parsed["last_upsert_epoch_s"] if parsed else 0
 
-        now_epoch = epoch_now_s(ctx.std)
-        elapsed_s = max(0, now_epoch - _state.get("_task_started_at_s", now_epoch))
-        factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, min_poll_interval_seconds)
-        lease_window_s = min_poll_interval_seconds * factor
-
-        # Terminal updates bypass the lease — the verdict has to land
-        # even if a sibling published seconds ago. The body-diff
-        # short-circuit below still gates the redundant PATCH.
-        if not final and lease_held(now_epoch, cross_workflow_lease_epoch, lease_window_s):
+        lease_epoch = parsed["last_upsert_epoch_s"] if parsed else 0
+        if not final and lease_held(now_epoch, lease_epoch, min_poll_interval_seconds):
             return
 
-        # Merge: my entry + every other entry the comment knows about.
-        # `merge_state` is the GH-feature helper; it slot-overlays
-        # by workflow_run_id (pipeline id) and dedups per-task by
-        # `(name, key)`. Single-pipeline case: only the local pipeline
-        # has a slot; multi-pipeline case: every pipeline contributes.
-        new_state = merge_state(parsed, head_sha, run_id, workflow_name, [own_entry], {})
-        prepared = prepare_for_render(new_state["entries"])
-        sections = bucket_entries(prepared)
-
-        # Earliest start across all entries — pinned to the run's
-        # wall-clock start so the body's headline timestamp doesn't
-        # wobble across PATCHes.
-        earliest_ms = _earliest_start_ms(prepared)
-        started_at = format_run_date(ctx, earliest_ms or now_ms(ctx))
-
-        # Two renders mirroring the GH path: `stable_body` zeros out
-        # the live-only fields so the unchanged-content short-circuit
-        # fires when no task state changed. `final_body` carries the
-        # live timestamp + quota footer + lease-stamped state block.
-        stable_state = dict(new_state)
-        stable_state["last_upsert_epoch_s"] = 0
-        stable_body = render_body(
-            ctx,
-            marker,
-            prepared,
-            started_at,
-            body_template,
-            status_badges,
-            sections,
-            state = stable_state,
-        )
-        if _state.get("_last_stable_body") == stable_body:
-            return
-
-        final_state = dict(new_state)
-        final_state["last_upsert_epoch_s"] = now_epoch
-        final_body = render_body(
-            ctx,
-            marker,
-            prepared,
-            started_at,
-            body_template,
-            status_badges,
-            sections,
-            state = final_state,
-        )
-
-        if not _upsert_note(ctx, token, final_body):
-            return
-        _state["_last_stable_body"] = stable_body
-        _state["_last_upsert_epoch_s"] = now_epoch
+        new_state = merge_comment_only_state(parsed, head_sha, run_id, workflow_name, [own_entry])
+        _post(ctx, token, new_state, now_epoch)
 
     def _earliest_start_ms(entries):
         ms_values = [e.get("start_time_ms", 0) for e in entries if e.get("start_time_ms", 0) > 0]
@@ -434,13 +431,10 @@ GitlabStatusComments = feature(
         ),
         "min_poll_interval_seconds": args.int(
             default = 20,
-            description = "Minimum seconds between MR-note refreshes. Default 20s. Each refresh counts " +
-                          "against the GitLab API rate limit; on busy projects this interval will " +
-                          "automatically stretch further as the remaining quota shrinks or the run goes " +
-                          "on longer. When multiple tasks in the same pipeline write to the same MR note, " +
-                          "they coordinate via a lease so only one task refreshes the note per interval — " +
-                          "the cost stays flat regardless of how many run in parallel. Terminal task " +
-                          "verdicts always land immediately.",
+            description = "Minimum seconds between MR-note refreshes. Default 20s. The Aspect API " +
+                          "decides which task posts each interval so the cost stays flat regardless of " +
+                          "how many tasks run in parallel; this value gates the local fallback lease used " +
+                          "when the API is unreachable. Terminal task verdicts always land immediately.",
         ),
         "templates": args.custom(
             dict,

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -7,9 +7,11 @@ but uses GitLab Merge Request Notes instead of GitHub Issue Comments.
 ## Cross-task coordination
 
 Coordination goes through the Aspect API, same as `GithubStatusComments`:
-each task POSTs its own entry to `POST /scm/status-comment/contribute`
-(`scm: "gitlab"`) and gets back the merged set of all tasks' entries plus a
-directive on whether *it* should post the note this cycle. The server owns
+each task POSTs its own entry to the provider-agnostic
+`POST /status-comments/contribute` (`scm: "gitlab"` in the body; the endpoint
+stores GitHub PRs and GitLab MRs in disjoint state keyed by `scm`) and gets
+back the merged set of all tasks' entries plus a directive on whether *it*
+should post the note this cycle. The server owns
 the merge + post throttle; this feature only renders the returned state and
 upserts the GitLab MR note (with the GitLab App token).
 
@@ -159,6 +161,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
         if _state.get("_gitlab_token"):
             return True
         auth_reason = {}
+        auth_extra = {}
         token = gitlab_token_cache.get_or_mint(
             ctx,
             project_path = project_path,
@@ -171,6 +174,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
             # `api`-scoped, request `api` here directly.
             roles = ["api"],
             _reason = auth_reason,
+            _extra = auth_extra,
         )
         if not token:
             _LOG.warn(ctx.std, "Authentication failed for %s — %s" % (
@@ -179,6 +183,11 @@ def _gitlab_status_comments(ctx: FeatureContext):
             ))
             return False
         _state["_gitlab_token"] = token
+
+        # Installation-ownership proof echoed to the contribute endpoint so the
+        # server can isolate this installation's coordination state.
+        _state["_installation_id"] = auth_extra.get("installation_id", "")
+        _state["_installation_proof"] = auth_extra.get("installation_proof", "")
         return True
 
     def _fetch_existing_note_body(ctx, token):
@@ -321,6 +330,8 @@ def _gitlab_status_comments(ctx: FeatureContext):
         # coordination path as GitHub; `scm` keeps GitLab's state disjoint).
         request = {
             "scm": "gitlab",
+            "installation_id": _state.get("_installation_id", ""),
+            "installation_proof": _state.get("_installation_proof", ""),
             "owner": project_path,
             "repo": str(mr_iid),
             "pr_number": mr_iid,

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -52,6 +52,7 @@ load(
     "merge_comment_only_state",
     "parse_state",
     "prepare_for_render",
+    "rehydrate_entries",
     "render_body",
     "results_subset",
 )
@@ -316,7 +317,9 @@ def _gitlab_status_comments(ctx: FeatureContext):
             "final": final,
             "min_interval_s": min_poll_interval_seconds,
         }
-        pending = _state.pop("_pending_post", None)
+        # Peek (don't pop) — a failed contribute must not lose the pending
+        # confirmation, or the server never learns the post landed.
+        pending = _state.get("_pending_post")
         if pending:
             request["posted"] = pending
 
@@ -326,11 +329,19 @@ def _gitlab_status_comments(ctx: FeatureContext):
             _publish_via_note_state(ctx, token, own_entry, now_epoch, final)
             return
 
+        # Contribute succeeded — the confirmation (if any) was delivered.
+        _state.pop("_pending_post", None)
+
         if not result.get("should_post"):
             return
 
+        # Entries arrive as decoded JSON — rehydrate repro/fix command lists
+        # back to records before the render path reads `c.command`/`c.target`.
+        state = result["state"]
+        rehydrate_entries(state.get("entries", []) or [])
+
         before = _state.get("_last_stable_body")
-        _post(ctx, token, result["state"], now_epoch)
+        _post(ctx, token, state, now_epoch)
         if _state.get("_last_stable_body") != before:
             # Confirm the post on our next contribution so the server clears
             # the grant and records the comment id.

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -4,17 +4,16 @@ Run with:
   aspect dev test-pr-comment-snapshots
 
 Dry-run style — we don't actually invoke the GitHub Issues API. We
-construct artifact-payload-shaped entry dicts (matching what
-`_publish_self` writes to the per-task task.json), pass them through
-`_prepare_for_render` + `_bucket_entries` + `_render_body`, and print
-the resulting Markdown body for each scenario.
+construct contribution-entry dicts (the per-task shape the coordination
+state holds), pass them through `_prepare_for_render` + `_bucket_entries`
++ `_render_body`, and print the resulting Markdown body for each scenario.
 
 Coverage:
   - All-running, mixed running + failed, all-passed clean,
     flake-only-warning, lint-warnings, format-diffs,
     delivery mixed-warn, aborted, all-failed, empty
   - Link availability variants (CI Run only, no Aspect, no Check, all)
-  - Live phase + ProgressStyles round-trip via the artifact-shape dict
+  - Live phase + ProgressStyles round-trip via the entry dict
   - Failed-in-phase prefix
   - Tips aggregation: single-task, multi-task dedup + attribution,
     severity-sort with the `_MAX_SUBORDINATE_TIPS` cap on
@@ -96,14 +95,14 @@ def _with_commands(data, repro = [], fix = []):
     `(command, description)` tuples (description usually `""`). Use
     in scenarios that need to assert the aggregator's repro / fix
     rendering — the producers normally append these at terminal-emit
-    time, but the snapshot tests fabricate the artifact-payload
-    shape directly so the inputs are spelled out here.
+    time, but the snapshot tests fabricate the entry shape directly so
+    the inputs are spelled out here.
 
     Runs the dicts through `rehydrate_commands` so the fixture matches
-    what `_list_and_download_workflow_artifacts` hands the renderer
-    after the JSON round-trip — `ReproFixCommand` records, not raw
-    dicts. Without this the renderer would trip on `c.command`
-    record-attribute access.
+    what the renderer receives after entries round-trip through JSON
+    (the coordination API or the comment state block) — `ReproFixCommand`
+    records, not raw dicts. Without this the renderer would trip on
+    `c.command` record-attribute access.
     """
     out = dict(data)
     out["repro_commands"] = rehydrate_commands(
@@ -313,9 +312,8 @@ def _entry(
         failed_in_phase = "",
         start_time_ms = _DEFAULT_START_MS,
         tips = None):
-    """Build an artifact-payload-shaped entry. Mirrors what
-    `_publish_self` writes to task.json so the test exercises the same
-    on-wire shape sibling jobs would read.
+    """Build a contribution-entry dict — the per-task shape the
+    coordination state holds and the renderer consumes.
 
     Emulates the producer-side composition: `body` is filled from
     `_body_for(kind, status, data)` matching what each real producer
@@ -963,8 +961,8 @@ def _check_format_overflow_note():
     )
 
 def _check_parse_state_absent():
-    """parse_state returns None when the body has no state block —
-    callers fall back to swarm-only behavior."""
+    """parse_state returns None when the body has no state block (e.g.
+    the comment doesn't exist yet, so there's no prior state to merge)."""
     _eq("parse_state — empty body", parse_state(""), None)
     _eq("parse_state — body without marker", parse_state("# heading\n\nsome content\n"), None)
 
@@ -1072,10 +1070,9 @@ def _check_merge_state_falls_back_to_snapshot_when_refresh_missing():
 
 def _check_merge_state_per_task_union_with_snapshot():
     """When the cross-workflow refresh returns a SUBSET of the snapshot's
-    tasks (e.g. an artifact-listing eventual-consistency window briefly
-    hides some artifacts), per-task union keeps the snapshot rows for
-    tasks the refresh didn't return. Without this, the comment would
-    flap between "many tasks" and "few tasks" as the listing converged.
+    tasks, per-task union keeps the snapshot rows for tasks the refresh
+    didn't return. Without this, the comment would flap between "many
+    tasks" and "few tasks" as state converges.
 
     Refresh wins for tasks it does return — status updates on those
     tasks land in this cycle."""
@@ -1089,8 +1086,8 @@ def _check_merge_state_per_task_union_with_snapshot():
         ],
     }
 
-    # Refresh returned only `lint` (with updated status). `test` and
-    # `build` were briefly invisible in the listing.
+    # Refresh returned only `lint` (with updated status); `test` and
+    # `build` were briefly absent from the refresh.
     partial_refresh = [
         {"kind": "lint", "name": "lint", "workflow_run_id": "200", "status": "passed"},
     ]
@@ -1102,8 +1099,7 @@ def _check_merge_state_per_task_union_with_snapshot():
     _eq("merge — per-task union: no rows dropped", len(new["entries"]), 3)
 
 def _check_merge_state_empty_refresh_keeps_snapshot():
-    """An empty refresh result (the listing was authoritative but
-    returned no artifacts) still keeps the snapshot — equivalent to
+    """An empty refresh result still keeps the snapshot — equivalent to
     refresh-missing."""
     existing = {
         "head_sha": "abc",
@@ -1178,8 +1174,8 @@ def _check_merge_state_workflow_runs_sorted():
 def _check_merge_state_entries_sorted():
     """merge_state's entries are sorted deterministically across
     (workflow_run_id, job, key, name, run_attempt) so the serialized
-    block is byte-stable across writers — even when each writer
-    discovers its swarm in a different artifact-id order."""
+    block is byte-stable across writers — even when each writer merges
+    sibling entries in a different order."""
     my_entries = [
         {"kind": "z", "name": "z", "job": "j", "workflow_run_id": "100", "run_attempt": "1"},
         {"kind": "a", "name": "a", "job": "j", "workflow_run_id": "100", "run_attempt": "1"},
@@ -1525,10 +1521,11 @@ def _check_repro_dedup_consecutive_headings(ctx):
     exactly once under the Fix section, not twice.
     """
 
-    # Entries are shaped like what comes back from `_list_and_download_workflow_artifacts`
-    # after `json.try_decode`: plain dicts (records lost their type on JSON
-    # encode). The real read path rehydrates the command lists at the
-    # boundary; do the same here so we exercise the production code path.
+    # Entries are shaped like what the renderer receives after they
+    # round-trip through JSON (the coordination API or the comment state
+    # block): plain dicts (records lost their type on JSON encode). The real
+    # read path rehydrates the command lists at the boundary; do the same
+    # here so we exercise the production code path.
     entries = [
         {
             "kind": "buildifier",

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -33,6 +33,7 @@ load(
     "collect_repro_fix_rows",
     "collect_tip_rows",
     "dedup_for_display",
+    "dedup_survivor",
     "format_overflow_note",
     "lease_held",
     "merge_comment_only_state",
@@ -617,6 +618,34 @@ def _check_lease_held():
     # Floor at 0 → diff < window → lease held (safer than under).
     if not lease_held(now_epoch = 100, last_upsert_epoch = 150, lease_window_s = 10):
         fail("lease_held under clock skew (sibling ahead) should be True")
+
+def _check_dedup_survivor():
+    """dedup_survivor: deterministic lowest-id survivor over marker-bearing
+    items; no-op below two matches. Drives the create-time duplicate backstop
+    in both the GitHub and GitLab features."""
+    marker = "<!-- aspect-ci-status:pr-7 -->"
+    other = "<!-- something-else -->"
+
+    # No items / single match → nothing to converge.
+    _eq("dedup_survivor — empty list", dedup_survivor([], marker), (None, []))
+    only_one = [{"id": 5, "body": "x " + marker}]
+    _eq("dedup_survivor — single match", dedup_survivor(only_one, marker), (None, []))
+
+    # Two markers → lowest id survives, the rest are losers (regardless of list
+    # order, so concurrent writers agree on the same survivor).
+    items = [
+        {"id": 30, "body": "later " + marker},
+        {"id": 10, "body": "first " + marker},
+        {"id": 20, "body": other},
+        {"id": 40, "body": "third " + marker},
+    ]
+    survivor, losers = dedup_survivor(items, marker)
+    _eq("dedup_survivor — lowest marker id survives", survivor, 10)
+    _eq("dedup_survivor — others deleted (non-marker excluded)", losers, [30, 40])
+
+    # Missing/None body is treated as non-matching, not an error.
+    no_body = [{"id": 1}, {"id": 2, "body": None}, {"id": 3, "body": marker}]
+    _eq("dedup_survivor — missing body ignored", dedup_survivor(no_body, marker), (None, []))
 
 def _check_state_serialize_round_trip():
     """serialize_state → parse_state round-trips head_sha, lease epoch,
@@ -1551,6 +1580,7 @@ def _test_impl(ctx):
     _check_repro_dedup_consecutive_headings(ctx)
     _check_format_http_failure_detail()
     _check_lease_held()
+    _check_dedup_survivor()
     _check_state_serialize_round_trip()
     _check_parse_state_absent()
     _check_parse_state_malformed()

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -981,6 +981,21 @@ def _check_merge_comment_only_accretes():
     fresh = merge_comment_only_state(parsed, "def", "wf-1", "ci", [own_b])
     _eq("comment-only — fresh push drops prior-SHA rows", sorted([e["name"] for e in fresh["entries"]]), ["B"])
 
+    # Matrix: two jobs run the same task kind/name with distinct `job`. The
+    # contributing job must not erase its sibling matrix row (identity is
+    # (job, kind, name), not (kind, name)).
+    matrix = {
+        "head_sha": "abc",
+        "workflow_runs": [{"run_id": "wf-1", "workflow_name": "ci"}],
+        "entries": [
+            {"kind": "test", "name": "test", "job": "cpu", "workflow_run_id": "wf-1", "status": "passed"},
+        ],
+    }
+    own_gpu = {"kind": "test", "name": "test", "job": "gpu", "workflow_run_id": "wf-1", "status": "running"}
+    merged = merge_comment_only_state(matrix, "abc", "wf-1", "ci", [own_gpu])
+    jobs = sorted([e["job"] for e in merged["entries"]])
+    _eq("comment-only — matrix sibling row survives", jobs, ["cpu", "gpu"])
+
 def _check_merge_state_two_workflows_with_fresh_refresh():
     """Cross-workflow: workflow A reads existing comment with B's slot
     and snapshot entries, fetches B's fresh data via

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -32,11 +32,10 @@ load(
     "by_task_overflow",
     "collect_repro_fix_rows",
     "collect_tip_rows",
-    "dedup_by_run_attempt",
     "dedup_for_display",
     "format_overflow_note",
     "lease_held",
-    "max_recent_upsert_epoch",
+    "merge_comment_only_state",
     "merge_state",
     "parse_state",
     "prepare_for_render",
@@ -45,7 +44,6 @@ load(
     "select_snippets",
     "select_sticky",
     "serialize_state",
-    "should_quiet_delete_log",
     "snippet_key",
 )
 load(
@@ -551,72 +549,6 @@ def _check_collect_tip_rows(ctx):
     if "a" not in rows[0]["body_quoted"] or "b" not in rows[0]["body_quoted"]:
         fail("combine-any: scopes not unioned across tasks: %r" % rows[0]["body_quoted"])
 
-def _check_dedup_by_run_attempt():
-    """Functional assertions for `_dedup_by_run_attempt` — collapse
-    `(name, key, job)` duplicates from a re-run workflow's artifact
-    listing to the entry from the latest attempt."""
-
-    # Re-run scenario: attempt 1 left a stale "running" entry; attempt
-    # 2 is the terminal "passed". One entry per (name, key, job)
-    # survives, with the higher run_attempt's payload.
-    out = dedup_by_run_attempt([
-        {"kind": "format", "name": "format-gha", "job": "format-task", "run_attempt": "1", "status": "running"},
-        {"kind": "format", "name": "format-gha", "job": "format-task", "run_attempt": "2", "status": "passed"},
-    ])
-    if len(out) != 1:
-        fail("dedup_by_run_attempt rerun: expected 1 entry, got %d: %r" % (len(out), out))
-    if out[0]["status"] != "passed" or out[0]["run_attempt"] != "2":
-        fail("dedup_by_run_attempt rerun: expected attempt-2 payload to win, got %r" % out[0])
-
-    # Different `job` → NOT collapsed (matrix-style: same task surfaced
-    # by two distinct yaml jobs is two legitimate rows).
-    out = dedup_by_run_attempt([
-        {"kind": "test", "name": "test-gha", "job": "cpu-test", "run_attempt": "1", "status": "passed"},
-        {"kind": "test", "name": "test-gha", "job": "gpu-test", "run_attempt": "1", "status": "passed"},
-    ])
-    if len(out) != 2:
-        fail("dedup_by_run_attempt matrix: expected 2 distinct rows, got %d: %r" % (len(out), out))
-
-    # Numeric ordering, not lexicographic: "10" > "9".
-    out = dedup_by_run_attempt([
-        {"kind": "x", "name": "x", "job": "j", "run_attempt": "9", "status": "running"},
-        {"kind": "x", "name": "x", "job": "j", "run_attempt": "10", "status": "passed"},
-    ])
-    if out[0]["run_attempt"] != "10":
-        fail("dedup_by_run_attempt numeric: expected '10' to win over '9', got %r" % out[0])
-
-    # Missing / non-numeric run_attempt defaults to 1.
-    out = dedup_by_run_attempt([
-        {"kind": "y", "name": "y", "job": "j", "status": "running"},
-        {"kind": "y", "name": "y", "job": "j", "run_attempt": "2", "status": "passed"},
-    ])
-    if out[0].get("run_attempt") != "2":
-        fail("dedup_by_run_attempt missing-attempt: expected attempt-2 to win, got %r" % out[0])
-
-def _check_should_quiet_delete_log():
-    """Functional assertions for `_should_quiet_delete_log` — gate for
-    the WARN→INFO downgrade on a pre-upload `DeleteArtifact` failure."""
-
-    # First cycle: no prior upload → benign (delete will 404 because
-    # nothing was ever uploaded). Quiet.
-    if not should_quiet_delete_log(None, 1000.0):
-        fail("should_quiet_delete_log: first cycle (None last_upload_at) must be quiet")
-
-    # Recent upload (within the 15s window): eventual-consistency miss
-    # is the most likely cause of a failure. Quiet.
-    if not should_quiet_delete_log(990.0, 1000.0):
-        fail("should_quiet_delete_log: 10s after upload must be quiet")
-    if not should_quiet_delete_log(985.0, 1000.0):
-        fail("should_quiet_delete_log: exactly 15s after upload must be quiet")
-    if not should_quiet_delete_log(1000.0, 1000.0):
-        fail("should_quiet_delete_log: 0s after upload must be quiet")
-
-    # Past the window: WARN-worthy.
-    if should_quiet_delete_log(984.0, 1000.0):
-        fail("should_quiet_delete_log: 16s after upload must NOT be quiet")
-    if should_quiet_delete_log(0.0, 1000.0):
-        fail("should_quiet_delete_log: 1000s after upload must NOT be quiet")
-
 def _check_format_http_failure_detail():
     """Functional assertions for `github.format_http_failure_detail` —
     one-line failure-detail formatting shared by the WARN and INFO
@@ -685,23 +617,6 @@ def _check_lease_held():
     # Floor at 0 → diff < window → lease held (safer than under).
     if not lease_held(now_epoch = 100, last_upsert_epoch = 150, lease_window_s = 10):
         fail("lease_held under clock skew (sibling ahead) should be True")
-
-def _check_max_recent_upsert_epoch():
-    _eq("max_recent_upsert_epoch — empty entries", max_recent_upsert_epoch([]), 0)
-    _eq(
-        "max_recent_upsert_epoch — missing field treated as 0",
-        max_recent_upsert_epoch([{"name": "a"}, {"name": "b"}]),
-        0,
-    )
-    _eq(
-        "max_recent_upsert_epoch — picks the largest",
-        max_recent_upsert_epoch([
-            {"last_pr_comment_upsert_epoch_s": 100},
-            {"last_pr_comment_upsert_epoch_s": 300},
-            {"last_pr_comment_upsert_epoch_s": 200},
-        ]),
-        300,
-    )
 
 def _check_state_serialize_round_trip():
     """serialize_state → parse_state round-trips head_sha, lease epoch,
@@ -1044,6 +959,27 @@ def _check_merge_state_first_writer():
     _eq("merge — first writer head_sha", new["head_sha"], "abc")
     _eq("merge — first writer workflow_runs", new["workflow_runs"], [{"run_id": "100", "workflow_name": "ci-gha"}])
     _eq("merge — first writer entries", new["entries"], my_entries)
+
+def _check_merge_comment_only_accretes():
+    """The API-unreachable fallback merges our own entry while preserving a
+    sibling job's row already in the comment (all jobs share one run_id).
+    A new head_sha resets — only our entry survives."""
+    parsed = {
+        "head_sha": "abc",
+        "workflow_runs": [{"run_id": "wf-1", "workflow_name": "ci"}],
+        "entries": [
+            {"kind": "build", "name": "A", "job": "A", "workflow_run_id": "wf-1", "status": "passed"},
+        ],
+    }
+    own_b = {"kind": "test", "name": "B", "job": "B", "workflow_run_id": "wf-1", "status": "running"}
+    new = merge_comment_only_state(parsed, "abc", "wf-1", "ci", [own_b])
+    by_name = {e["name"]: e for e in new["entries"]}
+    _eq("comment-only — A survives B's write", "A" in by_name, True)
+    _eq("comment-only — B added", "B" in by_name, True)
+    _eq("comment-only — A status preserved", by_name["A"]["status"], "passed")
+
+    fresh = merge_comment_only_state(parsed, "def", "wf-1", "ci", [own_b])
+    _eq("comment-only — fresh push drops prior-SHA rows", sorted([e["name"] for e in fresh["entries"]]), ["B"])
 
 def _check_merge_state_two_workflows_with_fresh_refresh():
     """Cross-workflow: workflow A reads existing comment with B's slot
@@ -1598,11 +1534,8 @@ def _test_impl(ctx):
 
     _check_collect_tip_rows(ctx)
     _check_repro_dedup_consecutive_headings(ctx)
-    _check_dedup_by_run_attempt()
-    _check_should_quiet_delete_log()
     _check_format_http_failure_detail()
     _check_lease_held()
-    _check_max_recent_upsert_epoch()
     _check_state_serialize_round_trip()
     _check_parse_state_absent()
     _check_parse_state_malformed()
@@ -1610,6 +1543,7 @@ def _test_impl(ctx):
     _check_parse_state_validates_field_types()
     _check_parse_state_filters_non_dict_rows()
     _check_merge_state_first_writer()
+    _check_merge_comment_only_accretes()
     _check_merge_state_two_workflows_with_fresh_refresh()
     _check_merge_state_falls_back_to_snapshot_when_refresh_missing()
     _check_merge_state_per_task_union_with_snapshot()

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -308,12 +308,17 @@ def _preferred_token_pair(ctx, owner, repo, profile = None, roles = None, existi
 
     return None, None, BUCKET_APP
 
-def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None):
+def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None, _extra = None):
     """Exchange Aspect credentials for a GitHub token via the App
     (requires owner + repo).
 
     Returns the token, or None with `_reason` populated on failure
     (stable `kind` from `_AUTH_KIND_*` + human-readable `reason`).
+
+    `_extra`, if a dict, is populated on success with any non-token fields
+    the mint response carries (currently `desired_cadence_s`, the
+    budget-derived comment-refresh cadence) for callers that want them;
+    other callers pass nothing and ignore it.
 
     Side-effect: on `_AUTH_KIND_NO_CREDENTIALS`, emits the host-specific
     `add-aspect-api-token-<host>` tip — at this layer so every App-using
@@ -364,6 +369,8 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
         # `_reason` error path instead of crashing the parent task.
         parsed = json.try_decode(resp.body, None)
         if parsed != None and "token" in parsed:
+            if type(_extra) == "dict" and "desired_cadence_s" in parsed:
+                _extra["desired_cadence_s"] = parsed["desired_cadence_s"]
             return parsed["token"]
         snippet = (resp.body or "")[:200].replace("\n", " ")
         _set_auth_reason(
@@ -386,6 +393,60 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
     else:
         _set_auth_reason(_reason, _AUTH_KIND_API_ERROR, "API request failed (HTTP %d): %s" % (resp.status, resp.body))
     return None
+
+# Status-comment coordination (Aspect API)
+
+def _status_comment_contribute(ctx, request, profile = None):
+    """Contribute this job's task status for a PR to the Aspect API and get
+    back the merged set of all jobs' contributions + a posting directive.
+
+    Every job POSTs its own contribution to
+    `POST /scm/status-comment/contribute`; the server stores + merges the
+    cross-job state and decides who posts when. Rendering + posting stay
+    client-side.
+
+    `request` is the JSON-encodable body — `{scm, owner, repo, pr_number,
+    head_sha, run_id, workflow_name, entries, shown_snippets, shown_repros,
+    shown_fixes, final, posted?}` (see the server's ContributeRequestSchema).
+
+    Returns a result dict:
+      `{"success": True, "state": {...}, "should_post": bool,
+        "comment_id": str, "next_eligible_epoch_s": int}`
+    on a 2xx, else `{"success": False, "error": str, "status": int}`. Never
+    raises — transport errors and non-2xx responses come back as
+    `success=False` so the caller can fall back to local coordination.
+    """
+    creds = ctx.aspect.auth.credentials(profile = profile)
+    if not creds:
+        _, msg = _classify_missing_credentials(ctx)
+        return {"success": False, "error": msg, "status": 0}
+
+    resp = ctx.http().post(
+        url = ctx.aspect.auth.api_url + "/scm/status-comment/contribute",
+        headers = {
+            "Authorization": "Bearer " + creds.access_token,
+            "Content-Type": "application/json",
+        },
+        data = json.encode(request),
+    ).map_err(lambda e: str(e)).block()
+
+    if type(resp) == "string":
+        return {"success": False, "error": "transport error: %s" % resp, "status": 0}
+
+    if resp.status >= 200 and resp.status < 300:
+        parsed = json.try_decode(resp.body, None)
+        if type(parsed) != "dict" or "state" not in parsed:
+            snippet = (resp.body or "")[:200].replace("\n", " ")
+            return {"success": False, "error": "unusable 2xx body: %s" % snippet, "status": resp.status}
+        return {
+            "success": True,
+            "state": parsed.get("state") or {},
+            "should_post": bool(parsed.get("should_post", False)),
+            "comment_id": parsed.get("comment_id", "") or "",
+            "next_eligible_epoch_s": parsed.get("next_eligible_epoch_s", 0) or 0,
+        }
+
+    return {"success": False, "error": resp.body or "", "status": resp.status}
 
 # Check Runs
 
@@ -2058,6 +2119,7 @@ def delete_review_comment(ctx, token, owner, repo, comment_id, api_base = DEFAUL
 github = struct(
     VALID_ROLES = VALID_ROLES,
     authenticate = _authenticate,
+    status_comment_contribute = _status_comment_contribute,
     preferred_token_pair = _preferred_token_pair,
     missing_credentials_reason = _missing_credentials_reason,
     validate_role = validate_role,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -413,7 +413,7 @@ def _status_comment_contribute(ctx, request, profile = None):
 
     Returns a result dict:
       `{"success": True, "state": {...}, "should_post": bool,
-        "comment_id": str, "next_eligible_epoch_s": int}`
+        "comment_id": str}`
     on a 2xx, else `{"success": False, "error": str, "status": int}`. Never
     raises — transport errors and non-2xx responses come back as
     `success=False` so the caller can fall back to local coordination.
@@ -445,7 +445,6 @@ def _status_comment_contribute(ctx, request, profile = None):
             "state": parsed.get("state") or {},
             "should_post": bool(parsed.get("should_post", False)),
             "comment_id": parsed.get("comment_id", "") or "",
-            "next_eligible_epoch_s": parsed.get("next_eligible_epoch_s", 0) or 0,
         }
 
     return {"success": False, "error": resp.body or "", "status": resp.status}

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -315,10 +315,10 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
     Returns the token, or None with `_reason` populated on failure
     (stable `kind` from `_AUTH_KIND_*` + human-readable `reason`).
 
-    `_extra`, if a dict, is populated on success with any non-token fields
-    the mint response carries (currently `desired_cadence_s`, the
-    budget-derived comment-refresh cadence) for callers that want them;
-    other callers pass nothing and ignore it.
+    `_extra`, if a dict, is populated on success with non-token fields the
+    mint response carries — `desired_cadence_s` (budget-derived comment-refresh
+    cadence) and `installation_id` + `installation_proof` (for the
+    `/github/budget` refresh path). Other callers pass nothing and ignore it.
 
     Side-effect: on `_AUTH_KIND_NO_CREDENTIALS`, emits the host-specific
     `add-aspect-api-token-<host>` tip — at this layer so every App-using
@@ -369,8 +369,10 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
         # `_reason` error path instead of crashing the parent task.
         parsed = json.try_decode(resp.body, None)
         if parsed != None and "token" in parsed:
-            if type(_extra) == "dict" and "desired_cadence_s" in parsed:
-                _extra["desired_cadence_s"] = parsed["desired_cadence_s"]
+            if type(_extra) == "dict":
+                for k in ("desired_cadence_s", "installation_id", "installation_proof"):
+                    if k in parsed:
+                        _extra[k] = parsed[k]
             return parsed["token"]
         snippet = (resp.body or "")[:200].replace("\n", " ")
         _set_auth_reason(
@@ -447,6 +449,51 @@ def _status_comment_contribute(ctx, request, profile = None):
         }
 
     return {"success": False, "error": resp.body or "", "status": resp.status}
+
+def _read_rate_limit(ctx, token, api_base = DEFAULT_GITHUB_API):
+    """Read the installation's GitHub core rate-limit headroom with its
+    installation `token`. Returns `{"remaining": int, "reset": int}` (the
+    `resources.core` bucket; `reset` is absolute Unix seconds), or `None` on
+    any failure. `GET /rate_limit` does not itself consume quota."""
+    success, _status, body = _do_request(ctx, "GET", api_base + "/rate_limit", token, quiet_4xx_auth = True)
+    if not success:
+        return None
+    parsed = json.try_decode(body, None)
+    core = (parsed or {}).get("resources", {}).get("core") if type(parsed) == "dict" else None
+    if type(core) != "dict" or type(core.get("remaining")) != "int" or type(core.get("reset")) != "int":
+        return None
+    return {"remaining": core["remaining"], "reset": core["reset"]}
+
+def _status_comment_budget(ctx, request, profile = None):
+    """Refresh the comment-refresh cadence for a long-running task via
+    `POST /scm/.../github/budget` — the client reports its installation's live
+    rate-limit headroom and gets back an updated `desired_cadence_s`, without
+    re-minting a token.
+
+    `request` is `{installation_id, installation_proof, remaining, reset}` (the
+    proof from the token mint; see the server's RequestSchema). Returns
+    `{"success": True, "desired_cadence_s": int}` on a 2xx, else
+    `{"success": False}`. Never raises — a failure just leaves the caller on
+    its prior cadence."""
+    creds = ctx.aspect.auth.credentials(profile = profile)
+    if not creds:
+        return {"success": False}
+
+    resp = ctx.http().post(
+        url = ctx.aspect.auth.api_url + "/github/budget",
+        headers = {
+            "Authorization": "Bearer " + creds.access_token,
+            "Content-Type": "application/json",
+        },
+        data = json.encode(request),
+    ).map_err(lambda e: str(e)).block()
+
+    if type(resp) == "string" or resp.status < 200 or resp.status >= 300:
+        return {"success": False}
+    parsed = json.try_decode(resp.body, None)
+    if type(parsed) != "dict" or type(parsed.get("desired_cadence_s")) != "int":
+        return {"success": False}
+    return {"success": True, "desired_cadence_s": parsed["desired_cadence_s"]}
 
 # Check Runs
 
@@ -2120,6 +2167,8 @@ github = struct(
     VALID_ROLES = VALID_ROLES,
     authenticate = _authenticate,
     status_comment_contribute = _status_comment_contribute,
+    status_comment_budget = _status_comment_budget,
+    read_rate_limit = _read_rate_limit,
     preferred_token_pair = _preferred_token_pair,
     missing_credentials_reason = _missing_credentials_reason,
     validate_role = validate_role,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -403,7 +403,7 @@ def _status_comment_contribute(ctx, request, profile = None):
     back the merged set of all jobs' contributions + a posting directive.
 
     Every job POSTs its own contribution to
-    `POST /scm/status-comment/contribute`; the server stores + merges the
+    `POST /status-comments/contribute`; the server stores + merges the
     cross-job state and decides who posts when. Rendering + posting stay
     client-side.
 
@@ -424,7 +424,7 @@ def _status_comment_contribute(ctx, request, profile = None):
         return {"success": False, "error": msg, "status": 0}
 
     resp = ctx.http().post(
-        url = ctx.aspect.auth.api_url + "/scm/status-comment/contribute",
+        url = ctx.aspect.auth.api_url + "/status-comments/contribute",
         headers = {
             "Authorization": "Bearer " + creds.access_token,
             "Content-Type": "application/json",
@@ -466,7 +466,7 @@ def _read_rate_limit(ctx, token, api_base = DEFAULT_GITHUB_API):
 
 def _status_comment_budget(ctx, request, profile = None):
     """Refresh the comment-refresh cadence for a long-running task via
-    `POST /scm/.../github/budget` — the client reports its installation's live
+    `POST /github/budget` — the client reports its installation's live
     rate-limit headroom and gets back an updated `desired_cadence_s`, without
     re-minting a token.
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
@@ -460,13 +460,18 @@ def _missing_credentials_reason(ctx):
     _, msg = _classify_missing_credentials(ctx)
     return msg
 
-def _authenticate(ctx, project_path, project_id = None, profile = None, roles = None, _reason = None):
+def _authenticate(ctx, project_path, project_id = None, profile = None, roles = None, _reason = None, _extra = None):
     """Exchange Aspect credentials for a GitLab token via the Aspect
     GitLab App. Requires `project_path`; optional `project_id` is a
     numeric hint (server treats `project_path` as authoritative).
 
     Returns the token, or None with `_reason` populated on failure
     (stable `kind` from `_AUTH_KIND_*` + human-readable `reason`).
+
+    On success, `_extra` (when provided) is populated with the
+    installation-ownership fields the mint returns — `installation_id` and
+    `installation_proof` — which the status-comment feature echoes to the
+    contribute endpoint as proof of installation ownership.
     """
     if not project_path:
         _set_auth_reason(_reason, _AUTH_KIND_NO_PROJECT_PATH, "project_path not provided")
@@ -515,6 +520,9 @@ def _authenticate(ctx, project_path, project_id = None, profile = None, roles = 
         # `_reason` error path instead of crashing the parent task.
         parsed = json.try_decode(resp.body, None)
         if parsed != None and "token" in parsed:
+            if _extra != None:
+                _extra["installation_id"] = parsed.get("installation_id", "")
+                _extra["installation_proof"] = parsed.get("installation_proof", "")
             return parsed["token"]
         snippet = (resp.body or "")[:200].replace("\n", " ")
         _set_auth_reason(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_token_cache.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_token_cache.axl
@@ -30,8 +30,7 @@ per-task identifier. The file is keyed by a hash of
 `(project_path, sorted roles list)` so callers requesting different
 roles get separate cache slots. Each slot stores JSON
 `{token, installation_id, installation_proof}` so the cached
-installation-ownership proof survives across sibling callers (a bare-token
-slot from the pre-proof format still reads, with an empty proof).
+installation-ownership proof survives across sibling callers.
 
 ## Cache invariants
 
@@ -76,10 +75,7 @@ def _read_slot(ctx, path, _extra):
     `_extra` with the stashed installation proof.
 
     The slot is JSON `{token, installation_id, installation_proof}`. A
-    bare-token slot (the pre-proof format) decodes as a plain string and
-    yields an empty proof — harmless for the token-only callers, and the
-    status-comment caller falls back to tenant-grain coordination until the
-    next mint rewrites the slot."""
+    non-JSON slot is read defensively as a bare token (empty proof)."""
     raw = ctx.std.fs.read_to_string(path).strip()
     if not raw:
         return None
@@ -142,4 +138,8 @@ def get_or_mint(ctx, project_path, project_id = None, profile = None, roles = No
 
 gitlab_token_cache = struct(
     get_or_mint = get_or_mint,
+    # Test-only hooks.
+    slot_key = _slot_key,
+    slot_path = _slot_path,
+    read_slot = _read_slot,
 )

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_token_cache.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_token_cache.axl
@@ -28,7 +28,10 @@ State lives in a per-task file under tmpdir, scoped by
 aspect-cli process is one task, so the process id is naturally a
 per-task identifier. The file is keyed by a hash of
 `(project_path, sorted roles list)` so callers requesting different
-roles get separate cache slots.
+roles get separate cache slots. Each slot stores JSON
+`{token, installation_id, installation_proof}` so the cached
+installation-ownership proof survives across sibling callers (a bare-token
+slot from the pre-proof format still reads, with an empty proof).
 
 ## Cache invariants
 
@@ -68,7 +71,27 @@ def _slot_key(project_path, roles):
 def _slot_path(ctx, project_path, roles):
     return _cache_dir(ctx) + "/" + _slot_key(project_path, roles)
 
-def get_or_mint(ctx, project_path, project_id = None, profile = None, roles = None, _reason = None):
+def _read_slot(ctx, path, _extra):
+    """Read a cache slot, returning the token (or None) and populating
+    `_extra` with the stashed installation proof.
+
+    The slot is JSON `{token, installation_id, installation_proof}`. A
+    bare-token slot (the pre-proof format) decodes as a plain string and
+    yields an empty proof — harmless for the token-only callers, and the
+    status-comment caller falls back to tenant-grain coordination until the
+    next mint rewrites the slot."""
+    raw = ctx.std.fs.read_to_string(path).strip()
+    if not raw:
+        return None
+    parsed = json.try_decode(raw, None)
+    if type(parsed) == "dict" and "token" in parsed:
+        if _extra != None:
+            _extra["installation_id"] = parsed.get("installation_id", "")
+            _extra["installation_proof"] = parsed.get("installation_proof", "")
+        return parsed["token"] or None
+    return raw or None
+
+def get_or_mint(ctx, project_path, project_id = None, profile = None, roles = None, _reason = None, _extra = None):
     """Return a GitLab OAuth access token for `(project_path, roles)`,
     reusing a cached value when present.
 
@@ -79,14 +102,20 @@ def get_or_mint(ctx, project_path, project_id = None, profile = None, roles = No
     result to the slot file. Mint failures populate `_reason` (when
     provided) and return None, exactly like `gitlab.authenticate`.
 
+    `_extra` (when provided) is populated with the mint's
+    `installation_id` + `installation_proof` on both a hit and a miss, so
+    the status-comment feature can prove installation ownership to the
+    contribute endpoint. Token-only callers omit it.
+
     Callers should treat the returned token as opaque — never log it
     or persist it beyond the current operation. The cache itself is
     the only authorized persistence boundary.
     """
     path = _slot_path(ctx, project_path, roles)
     if ctx.std.fs.exists(path):
-        return ctx.std.fs.read_to_string(path).strip() or None
+        return _read_slot(ctx, path, _extra)
 
+    mint_extra = {}
     tok = gitlab.authenticate(
         ctx,
         project_path = project_path,
@@ -94,12 +123,21 @@ def get_or_mint(ctx, project_path, project_id = None, profile = None, roles = No
         profile = profile,
         roles = roles,
         _reason = _reason,
+        _extra = mint_extra,
     )
     if tok == None:
         return None
 
+    if _extra != None:
+        _extra["installation_id"] = mint_extra.get("installation_id", "")
+        _extra["installation_proof"] = mint_extra.get("installation_proof", "")
+
     ctx.std.fs.create_dir_all(_cache_dir(ctx))
-    ctx.std.fs.write(path, tok)
+    ctx.std.fs.write(path, json.encode({
+        "token": tok,
+        "installation_id": mint_extra.get("installation_id", ""),
+        "installation_proof": mint_extra.get("installation_proof", ""),
+    }))
     return tok
 
 gitlab_token_cache = struct(


### PR DESCRIPTION
## Summary

The aggregated PR/MR status comment now coordinates across CI jobs through the **Aspect API** instead of CI artifacts. Each job POSTs its own task status to `POST /status-comments/contribute` (companion endpoint: aspect-build/silo#11072 / https://github.com/aspect-build/silo/pull/11076 / https://github.com/aspect-build/silo/pull/11077) and gets back the merged set of all jobs' contributions plus a directive on whether *it* should post the comment this cycle. Rendering (Jinja2 templates, customizable per-repo) and posting stay client-side.

This works on **GitHub Actions, Buildkite, and CircleCI** — `detect_ci_host` + GitHub PR detection replaces the old GitHub-Actions-only gate, since coordination no longer needs per-CI artifacts. `GitlabStatusComments` routes through the same provider-agnostic endpoint (`scm: "gitlab"` in the body) for coordination while posting to the MR note with the GitLab token.

### Adaptive cadence

The token mint returns a budget-derived `desired_cadence_s` (the API divides the installation's live GitHub rate-limit headroom across concurrent tasks and accounts for the observed burn rate). The feature uses it as its refresh interval, floored by `min_poll_interval_seconds`, and a long-running task refreshes it every few minutes via `POST /github/budget` (proving installation ownership with an HMAC from the mint — no extra token mint). The server elects one poster per interval; the client owns the content-changed decision (suppresses an unchanged PATCH).

When the API is unreachable, the feature falls back to coordinating through the comment's own embedded state block, so a single job still renders a correct comment.

### Converging concurrent first-posters on one comment

CI jobs start near-simultaneously, so racing to create the first comment is the common case. Two paths could slip a second comment past the server's single-poster election, both now closed:

- A job granted to post before any poster has *confirmed* doesn't yet know the comment id (the server learns it one cycle after a post), so it now discovers the existing marker comment and PATCHes it instead of creating a new one.
- The comment-state fallback no longer creates a comment out-of-band once server coordination has worked this run (`_api_ok`) — it may only PATCH a known/discovered comment, leaving creation to the server election.

The create-time duplicate backstop also tolerates GitHub's list-after-write lag: it lists once, and if a racing sibling's comment isn't visible yet, waits once and re-lists before converging on the lowest-id survivor (paid only on create; updates never run it). Survivor selection is a shared, unit-tested `dedup_survivor` helper used by both features.

### Per-installation isolation

A tenant can own multiple GitHub/GitLab App installations. The contribute state was keyed by tenant alone, so a tenant's installations shared one scratch namespace — one installation could read or clobber another's coordination state. The client now sends the installation-ownership proof (`installation_id` + `installation_proof`, minted at token time after an ownership check) on every contribute; the server re-verifies the HMAC locally (no round-trip) and partitions the state by `installation_id`, isolating a tenant's installations from each other. GitLab carries the proof too — its token-cache slot now stores `{token, installation_id, installation_proof}` (back-compatible with old bare-token slots) so the proof survives across sibling tasks sharing a cached token.

### What's here

- **`lib/github.axl`** — `status_comment_contribute`, `status_comment_budget`, and `read_rate_limit` helpers (existing `ctx.aspect.auth` + `ctx.http()` pattern; never raise); `authenticate` surfaces the mint's `desired_cadence_s` + `installation_id` + `installation_proof`.
- **`lib/gitlab.axl` / `lib/gitlab_token_cache.axl`** — `authenticate` / `get_or_mint` surface the mint's `installation_id` + `installation_proof` via `_extra`; the cache slot persists them as JSON so they survive across sibling callers.
- **`feature/github_status_comments.axl`** — `_publish` contributes (with the installation proof) → renders the server's merged state (rehydrating repro/fix commands) → resolves the comment id (server hint, else discovery) → posts only if granted → confirms on the next contribution; `_refresh_budget` polls the budget every `_BUDGET_REFRESH_S` (180s). Removes the artifact swarm, the unused lease/observation code, and the `artifact_expires_minutes` arg; the minted token drops `actions.read`.
- **`feature/gitlab_status_comments.axl`** — same contribute path (with the GitLab installation proof); posts to the GitLab MR note.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- The aggregated PR/MR status comment now coordinates across CI jobs through the Aspect API instead of CI artifacts. It works on GitHub Actions, Buildkite, and CircleCI, and its refresh cadence adapts to the GitHub installation's remaining API quota and how many jobs are running.

### Test plan

- `aspect tests axl` — 849 pass; `cargo test -p aspect-cli` — 52 pass; buildifier clean.
- Existing `test-pr-comment-snapshots` render scenarios unchanged; merge/fallback coverage in `_check_merge_comment_only_accretes` (incl. matrix-row preservation); convergence coverage in `_check_dedup_survivor`.
- Server-side merge/proof/PK coverage lands in the companion silo PR.
- Verified end-to-end live: a real PR's CI run hit the contribute endpoint (not the fallback) and rendered/posted correctly.

### Relationship to other PRs

- Companion server changes (the `/status-comments/contribute` route, per-installation key, installation-proof verification, GitLab proof-signing): aspect-build/silo. Land + deploy silo before rolling this out — old CLI ↔ new server and new CLI ↔ old server both degrade to the comment-state fallback rather than breaking.
- Supersedes #1288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
