### PR TITLE
fix(github): drop double-decode in _read_rate_limit

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -455,10 +455,9 @@ def _read_rate_limit(ctx, token, api_base = DEFAULT_GITHUB_API):
     `resources.core` bucket; `reset` is absolute Unix seconds), or `None` on
     any failure. `GET /rate_limit` does not itself consume quota."""
     success, _status, body = _do_request(ctx, "GET", api_base + "/rate_limit", token, quiet_4xx_auth = True)
-    if not success:
+    if not success or type(body) != "dict":
         return None
-    parsed = json.try_decode(body, None)
-    core = (parsed or {}).get("resources", {}).get("core") if type(parsed) == "dict" else None
+    core = body.get("resources", {}).get("core")
     if type(core) != "dict" or type(core.get("remaining")) != "int" or type(core.get("reset")) != "int":
         return None
     return {"remaining": core["remaining"], "reset": core["reset"]}


### PR DESCRIPTION
`_do_request` already returns the parsed JSON body for 2xx responses (line 142 of `lib/github.axl` returns `parsed`, not the raw string). `_read_rate_limit` was then handing that already-decoded dict back to `json.try_decode`, which is typed `(str, fallback) -> any` and raised:

```
error: Type of parameter `x` doesn't match, expected `str`, actual `dict (...)`
  --> aspect/private/lib/github.axl:460:14
```

The crash lands the first time the `github_status_comments` long-running heartbeat calls `_refresh_budget` after `_do_request` happens to succeed and return a dict — i.e., as soon as a real `/rate_limit` response comes back on a live CI run.

Fix is to consume `body` directly as the dict it already is. Type-guard on `type(body) != "dict"` covers the bodyless / non-JSON path (`_do_request` returns the raw string in those branches).

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases (`aspect dev test-github-detect` passes; that suite exercises the same `_do_request` path).
- Manual: on the affected release we saw the traceback every time the github-status-comments feature ticked. With the patch applied, `_read_rate_limit` returns a `{"remaining": …, "reset": …}` dict and the heartbeat continues.