### PR TITLE
refactor(status-comments): extract + test the convergence/fallback decisions

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -508,6 +508,25 @@ def _dedup_survivor(items, marker):
     dupes_sorted = sorted(dupes, key = lambda it: it["id"])
     return (dupes_sorted[0]["id"], [it["id"] for it in dupes_sorted[1:]])
 
+def _markers_stable(items, marker):
+    """True when exactly one marker comment/note is visible — the converged
+    steady state. Zero visible means read-after-write lag (keep rechecking),
+    two or more means a duplicate still to collapse."""
+    return len([it for it in items if marker in (it.get("body") or "")]) == 1
+
+def _should_create_fallback(api_ok, final, secs_since_start, grace_s):
+    """Whether the comment-state fallback may CREATE a comment/note out-of-band
+    when none is known or discoverable.
+
+    Only as a last resort: the Aspect API must never have worked this run
+    (`api_ok` False), and either this is the terminal `final` emit (its status
+    must surface — no later retry) or the task has run past `grace_s` (a
+    sustained outage, not a cold-start blip). The convergent recheck collapses
+    any rare duplicate this admits."""
+    if api_ok:
+        return False
+    return final or secs_since_start >= grace_s
+
 def _ci_run_url(env):
     """Return the GitHub Actions run URL, or "" if it can't be assembled."""
     server = env.var("GITHUB_SERVER_URL") or "https://github.com"
@@ -1375,9 +1394,7 @@ def _github_status_comments(ctx: FeatureContext):
             return False
         _state["_comment_id"] = res["comment_id"]
 
-        # Re-check on the next cycles too: a racing sibling may not be visible
-        # yet, and the spread between sibling workflows' first posts can exceed
-        # one settle.
+        # Arm the later-cycle recheck (see `_DEDUP_RECHECK_WINDOW_S`).
         _state["_dedup_recheck_until"] = monotonic() + _DEDUP_RECHECK_WINDOW_S
         _dedup_marker_comments(ctx, token)
         return True
@@ -1391,10 +1408,7 @@ def _github_status_comments(ctx: FeatureContext):
             return False
         survivor, losers = _dedup_survivor(listed["comments"], marker)
         if survivor == None:
-            # 0 or 1 marker comment visible. Stable only when one is actually
-            # present (a 0-count means read-after-write lag, not stable).
-            marker_count = len([c for c in listed["comments"] if marker in (c.get("body") or "")])
-            return marker_count == 1
+            return _markers_stable(listed["comments"], marker)
         _state["_comment_id"] = survivor
         for loser_id in losers:
             github.issues.delete_comment(ctx, token, owner, repo, loser_id)
@@ -1650,8 +1664,8 @@ def _github_status_comments(ctx: FeatureContext):
         if existing_body == None:
             return
         if "_comment_id" not in _state:
-            grace_elapsed = final or monotonic() - _state.get("_task_started_at", 0.0) >= _FALLBACK_CREATE_GRACE_S
-            if _state.get("_api_ok") or not grace_elapsed:
+            secs = monotonic() - _state.get("_task_started_at", 0.0)
+            if not _should_create_fallback(_state.get("_api_ok", False), final, secs, _FALLBACK_CREATE_GRACE_S):
                 return
         parsed = _parse_state(existing_body)
 
@@ -1689,7 +1703,8 @@ def _github_status_comments(ctx: FeatureContext):
         _state["_task_kind"] = ctx.task.kind
         _state["_task_name"] = ctx.task.name
 
-        # Anchor for the time-based throttle in `_task_update`.
+        # Anchor for the fallback-create grace (`_FALLBACK_CREATE_GRACE_S`) in
+        # `_publish_via_comment_state`.
         _state["_task_started_at"] = monotonic()
 
         auth_reason = {}
@@ -1942,6 +1957,14 @@ def lease_held(now_epoch, last_upsert_epoch, lease_window_s):
 def dedup_survivor(items, marker):
     """Public test hook + shared helper for GitLab; see `_dedup_survivor`."""
     return _dedup_survivor(items, marker)
+
+def markers_stable(items, marker):
+    """Public test hook + shared helper for GitLab; see `_markers_stable`."""
+    return _markers_stable(items, marker)
+
+def should_create_fallback(api_ok, final, secs_since_start, grace_s):
+    """Public test hook + shared helper for GitLab; see `_should_create_fallback`."""
+    return _should_create_fallback(api_ok, final, secs_since_start, grace_s)
 
 def results_subset(
         data,

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -52,12 +52,14 @@ load(
     "bucket_entries",
     "dedup_survivor",
     "lease_held",
+    "markers_stable",
     "merge_comment_only_state",
     "parse_state",
     "prepare_for_render",
     "rehydrate_entries",
     "render_body",
     "results_subset",
+    "should_create_fallback",
 )
 load("@std//time.axl", "monotonic", "sleep")
 load("../private/lib/bazel_results.axl", "format_run_date", "now_ms")
@@ -243,8 +245,9 @@ def _gitlab_status_comments(ctx: FeatureContext):
         return ""
 
     def _upsert_note(ctx, token, body):
-        """PUT the existing note when its id is known, else POST a fresh
-        one (the create-time duplicate backstop runs in `_dedup_notes`)."""
+        """PUT the existing note when its id is known, else POST a fresh one.
+        The create-time duplicate backstop runs in `_dedup_notes`; later update
+        cycles run a bounded no-sleep recheck via `_dedup_recheck`."""
         if _state.get("_note_id") != None:
             res = gitlab.notes.update(
                 ctx,
@@ -285,8 +288,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
             return False
         survivor, losers = dedup_survivor(listed["notes"], marker)
         if survivor == None:
-            marker_count = len([n for n in listed["notes"] if marker in (n.get("body") or "")])
-            return marker_count == 1
+            return markers_stable(listed["notes"], marker)
         _state["_note_id"] = survivor
         for loser_id in losers:
             del_res = gitlab.notes.delete(
@@ -432,8 +434,8 @@ def _gitlab_status_comments(ctx: FeatureContext):
         if existing_body == None:
             return
         if _state.get("_note_id") == None:
-            grace_elapsed = final or now_epoch - _state.get("_task_started_at_s", 0) >= _FALLBACK_CREATE_GRACE_S
-            if _state.get("_api_ok") or not grace_elapsed:
+            secs = now_epoch - _state.get("_task_started_at_s", 0)
+            if not should_create_fallback(_state.get("_api_ok", False), final, secs, _FALLBACK_CREATE_GRACE_S):
                 return
         parsed = parse_state(existing_body)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -35,6 +35,7 @@ load(
     "dedup_survivor",
     "format_overflow_note",
     "lease_held",
+    "markers_stable",
     "merge_comment_only_state",
     "merge_state",
     "parse_state",
@@ -44,6 +45,7 @@ load(
     "select_snippets",
     "select_sticky",
     "serialize_state",
+    "should_create_fallback",
     "snippet_key",
 )
 load(
@@ -644,6 +646,35 @@ def _check_dedup_survivor():
     # Missing/None body is treated as non-matching, not an error.
     no_body = [{"id": 1}, {"id": 2, "body": None}, {"id": 3, "body": marker}]
     _eq("dedup_survivor — missing body ignored", dedup_survivor(no_body, marker), (None, []))
+
+def _check_markers_stable():
+    """markers_stable: converged iff exactly one marker item is visible. Zero
+    (read-after-write lag) and two-or-more (duplicate to collapse) are not."""
+    marker = "<!-- aspect-ci-status:pr-7 -->"
+    other = "<!-- other -->"
+    _eq("markers_stable — none visible (lag)", markers_stable([], marker), False)
+    _eq("markers_stable — none matching", markers_stable([{"id": 1, "body": other}], marker), False)
+    _eq("markers_stable — exactly one", markers_stable([{"id": 1, "body": "x " + marker}, {"id": 2, "body": other}], marker), True)
+    _eq("markers_stable — duplicate", markers_stable([{"id": 1, "body": marker}, {"id": 2, "body": marker}], marker), False)
+    _eq("markers_stable — missing body ignored", markers_stable([{"id": 1}, {"id": 2, "body": marker}], marker), True)
+
+def _check_should_create_fallback():
+    """should_create_fallback: the out-of-band create gate. Never creates once
+    the API has worked; otherwise only on the terminal `final` emit or past the
+    grace window."""
+    grace = 45
+
+    # API has worked → never create out-of-band, even final / past grace.
+    _eq("fallback — api_ok blocks final", should_create_fallback(True, True, 999, grace), False)
+    _eq("fallback — api_ok blocks past-grace", should_create_fallback(True, False, 999, grace), False)
+
+    # API never worked: final always creates (last emit, no retry).
+    _eq("fallback — final creates immediately", should_create_fallback(False, True, 0, grace), True)
+
+    # API never worked, non-final: defer until grace elapses.
+    _eq("fallback — non-final before grace defers", should_create_fallback(False, False, 10, grace), False)
+    _eq("fallback — non-final at grace creates", should_create_fallback(False, False, 45, grace), True)
+    _eq("fallback — non-final past grace creates", should_create_fallback(False, False, 60, grace), True)
 
 def _check_state_serialize_round_trip():
     """serialize_state → parse_state round-trips head_sha, lease epoch,
@@ -1578,6 +1609,8 @@ def _test_impl(ctx):
     _check_format_http_failure_detail()
     _check_lease_held()
     _check_dedup_survivor()
+    _check_markers_stable()
+    _check_should_create_fallback()
     _check_state_serialize_round_trip()
     _check_parse_state_absent()
     _check_parse_state_malformed()


### PR DESCRIPTION
Critical-pass cleanup on the status-comment duplicate-convergence work (follow-up to #1291).

Pulls the two pure decisions out of the feature closures into shared, tested module helpers (re-exported for the GitLab feature, same pattern as `dedup_survivor`):

- `markers_stable(items, marker)` — converged iff exactly one marker comment/note is visible (0 = read-after-write lag, keep rechecking; 2+ = a duplicate still to collapse).
- `should_create_fallback(api_ok, final, secs_since_start, grace_s)` — the out-of-band create gate: never once the API has worked this run; otherwise only on the terminal `final` emit or past the grace window.

Both the GitHub and GitLab features now call these instead of inlining the logic, and both gain unit coverage in `github_status_comments_test.axl`.

Comment fixes: correct a stale `_task_started_at` anchor comment (it feeds the fallback grace now, not the throttle), drop an inline comment that restated `_DEDUP_RECHECK_WINDOW_S`, and note the PATCH-branch recheck in the GitLab `_upsert_note` docstring.

No behavior change.

---

### Changes are visible to end-users: no

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no

### Test plan

- Covered by existing test cases
- New test cases added

`aspect tests axl` — 860 pass (incl. new `markers_stable` / `should_create_fallback` cases); `cargo test -p aspect-cli` — 52 pass; buildifier clean.
