### PR TITLE
fix(status-comments): correct multi-CI-host link labels + slot eviction

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -530,7 +530,11 @@ def _ci_run_url(env):
 
 # Per-host CI identity for the status-comment coordination key. `run_id` is the
 # broadest scope sibling jobs in one logical run share (GHA run, BK build, CCI
-# workflow); `workflow_name` keys the server's per-workflow re-trigger eviction.
+# workflow); `workflow_name` keys the per-workflow re-trigger eviction. The
+# resolved `workflow_name` is prefixed with the host marker (see `_ci_identity`)
+# so two CI hosts that share a raw pipeline/repo name (e.g. CircleCI's
+# `CIRCLE_PROJECT_REPONAME` and Buildkite's `BUILDKITE_PIPELINE_SLUG` both
+# "myrepo") aren't mistaken for re-triggers of each other and evicted.
 _CI_IDENTITY = {
     "GITHUB_ACTIONS": {
         "run_id": "GITHUB_RUN_ID",
@@ -554,13 +558,18 @@ _CI_IDENTITY = {
 
 def _ci_identity(env, marker):
     """Resolve `(run_id, workflow_name, job_name, run_attempt)` for the host
-    identified by `marker`, or `None` for an unsupported host."""
+    identified by `marker`, or `None` for an unsupported host.
+
+    `workflow_name` is prefixed with `marker` so the re-trigger eviction key is
+    unique per CI host — two hosts sharing a raw pipeline/repo name don't
+    collapse each other's slots (see `_CI_IDENTITY`)."""
     spec = _CI_IDENTITY.get(marker)
     if spec == None:
         return None
+    raw_workflow_name = env.var(spec["workflow_name"]) or ""
     return {
         "run_id": env.var(spec["run_id"]) or "",
-        "workflow_name": env.var(spec["workflow_name"]) or "",
+        "workflow_name": "%s:%s" % (marker, raw_workflow_name),
         "job_name": env.var(spec["job_name"]) or "unknown-job",
         "run_attempt": (env.var(spec["run_attempt"]) if spec["run_attempt"] else "") or "1",
     }

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -106,6 +106,12 @@ load(
 
 _MARKER_FMT = "<!-- aspect-ci-status:pr-%d -->"
 
+# Fallback CI-host link label/icon for entries serialized without host metadata
+# (older entries, or hosts not in the registry). New entries carry the detected
+# host's `ci_host_label` / `ci_host_icon` from `detect_ci_host`.
+_DEFAULT_CI_HOST_LABEL = "GitHub Actions"
+_DEFAULT_CI_HOST_ICON = "🐙"
+
 # Cross-workflow state block embedded in the rendered comment.
 #
 # The Aspect API is the source of truth for cross-job coordination, but the
@@ -294,9 +300,12 @@ def _links_cell_text(entry):
       🔗 BES             — generic BES link from `--bes_results_url` +
                            invocation_id; independent of Aspect (both
                            render when pointed at distinct backends).
-      🐙 GitHub Actions  — run / per-job page (upgrades to per-job URL).
-      ☑️ Check           — GitHub Status Check; distinct icon from the
-                           GitHub Actions row, constant (not severity).
+      <icon> <host>      — the CI build/job page, labelled + iconed for the
+                           host that produced the entry (GitHub Actions /
+                           Buildkite / CircleCI / GitLab); falls back to
+                           GitHub Actions for entries without host metadata.
+      ☑️ Check           — GitHub Status Check; distinct icon from the CI
+                           host row, constant (not severity).
     """
     parts = []
 
@@ -309,7 +318,9 @@ def _links_cell_text(entry):
         parts.append("🔗 [BES](%s)" % bes_url)
 
     if entry.get("ci_run_url"):
-        parts.append("🐙 [GitHub Actions](%s)" % entry["ci_run_url"])
+        icon = entry.get("ci_host_icon") or _DEFAULT_CI_HOST_ICON
+        label = entry.get("ci_host_label") or _DEFAULT_CI_HOST_LABEL
+        parts.append("%s [%s](%s)" % (icon, label, entry["ci_run_url"]))
 
     if entry.get("check_run_url"):
         parts.append("☑️ [Check](%s)" % entry["check_run_url"])
@@ -1336,6 +1347,8 @@ def _github_status_comments(ctx: FeatureContext):
             "run_attempt": run_attempt,
             "status": _state.get("_status", "running"),
             "ci_run_url": link_url,
+            "ci_host_label": host["label"],
+            "ci_host_icon": host["icon"],
             "tips": [tip_to_payload(t) for t in collect_tips_sorted(ctx, surface = SURFACE_GITHUB_PR_SUMMARY)],
             "workflow_run_id": run_id,
             "workflow_name": workflow_name,

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -154,7 +154,11 @@ def _gitlab_status_comments(ctx: FeatureContext):
     run_id = env.var("ASPECT_GITLAB_PIPELINE_ID") or env.var("CI_PIPELINE_ID") or ""
     job_name = env.var("ASPECT_GITLAB_JOB_NAME") or env.var("CI_JOB_NAME") or "aspect-cli"
     run_attempt = env.var("CI_JOB_RETRY_INDEX") or "0"
-    workflow_name = env.var("CI_PIPELINE_NAME") or env.var("CI_PROJECT_NAME") or ""
+
+    # Host-prefixed so the re-trigger eviction key can't collide with another CI
+    # host that shares a raw pipeline/project name (matches the GitHub feature's
+    # `_ci_identity`).
+    workflow_name = "GITLAB_CI:%s" % (env.var("CI_PIPELINE_NAME") or env.var("CI_PROJECT_NAME") or "")
     if not run_id:
         # Fall back to the MR IID so single-pipeline coordination still
         # works in the local-sim case where no real pipeline exists. A

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -61,6 +61,7 @@ load(
 )
 load("@std//time.axl", "monotonic", "sleep")
 load("../private/lib/bazel_results.axl", "format_run_date", "now_ms")
+load("../private/lib/ci.axl", "detect_ci_host")
 load("../private/lib/environment.axl", "feature_logger")
 load("../private/lib/github.axl", "github")
 load("../private/lib/gitlab.axl", "gitlab")
@@ -163,6 +164,10 @@ def _gitlab_status_comments(ctx: FeatureContext):
         _LOG.trace("No CI_PIPELINE_ID; using synthetic run_id=%s for local-sim coordination" % run_id)
 
     ci_run_url = _ci_run_url(env)
+
+    # Label the CI link for the host that ran; default to GitLab CI (the natural
+    # host for an MR note) when off a recognized host (e.g. local-sim).
+    ci_host = detect_ci_host(env) or {"label": "GitLab CI", "icon": "🦊"}
     min_poll_interval_seconds = max(1, ctx.args.min_poll_interval_seconds)
 
     templates = ctx.args.templates or {}
@@ -477,6 +482,8 @@ def _gitlab_status_comments(ctx: FeatureContext):
         base["name"] = ctx.task.name
         base["status"] = status
         base["ci_run_url"] = ci_run_url
+        base["ci_host_label"] = ci_host["label"]
+        base["ci_host_icon"] = ci_host["icon"]
         _state["_own_base"] = base
 
     def _task_update(ctx, update):

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -1290,6 +1290,32 @@ def _check_merge_state_evicts_superseded_workflow_run():
     _eq("merge — our live row survives", keyed[("test", "cpu", "999")]["status"], "running")
     _eq("merge — distinct sibling workflow row survives", keyed[("lint", "lint", "500")]["status"], "passed")
 
+def _check_merge_state_distinct_hosts_same_raw_name_coexist():
+    """Two CI hosts on one PR can share a raw pipeline/repo name (e.g.
+    CircleCI's `CIRCLE_PROJECT_REPONAME` and Buildkite's
+    `BUILDKITE_PIPELINE_SLUG` both "myrepo"). `_ci_identity` host-prefixes
+    `workflow_name`, so the slots stay distinct and neither host's run evicts
+    the other's — the cause of a CI host's tasks vanishing from the comment."""
+    existing = {
+        "head_sha": "abc",
+        "workflow_runs": [
+            {"run_id": "circle-wf-1", "workflow_name": "CIRCLECI:myrepo"},
+        ],
+        "entries": [
+            {"kind": "test", "name": "test-cci", "job": "test", "workflow_run_id": "circle-wf-1", "status": "passed"},
+        ],
+    }
+
+    # A Buildkite run of the same repo — same raw name, different host prefix.
+    my_entries = [{"kind": "test", "name": "test-bk", "job": "test", "workflow_run_id": "bk-build-1", "status": "passed"}]
+    new = merge_state(existing, "abc", "bk-build-1", "BUILDKITE:myrepo", my_entries, {})
+
+    rids = sorted([r["run_id"] for r in new["workflow_runs"]])
+    _eq("merge — distinct-host slots both kept", rids, ["bk-build-1", "circle-wf-1"])
+    names = [e["name"] for e in new["entries"]]
+    _eq("merge — CircleCI task survives", "test-cci" in names, True)
+    _eq("merge — Buildkite task survives", "test-bk" in names, True)
+
 def _check_merge_state_evicts_superseded_sibling_run():
     """Two slots for the same SIBLING workflow (a re-run of a workflow
     that isn't ours) collapse to the newest run_id — the eviction isn't
@@ -1634,6 +1660,7 @@ def _test_impl(ctx):
     _check_merge_state_drops_stale_push()
     _check_merge_state_drops_orphan_snapshot_entries()
     _check_merge_state_evicts_superseded_workflow_run()
+    _check_merge_state_distinct_hosts_same_raw_name_coexist()
     _check_merge_state_evicts_superseded_sibling_run()
     _check_merge_state_losing_rerun_does_not_resurrect()
     _check_merge_state_keeps_empty_workflow_name_slots()

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -1510,6 +1510,46 @@ def _check_row_renders_name_and_kind(ctx):
     _eq("row — name == kind omits the bracket", "lint [lint]" in body, False)
     _eq("row — name == kind still renders the name", "✅ lint ·" in body, True)
 
+def _check_ci_host_link_label(ctx):
+    """The CI build/job link is labelled + iconed for the host that produced
+    the entry (carried as `ci_host_label` / `ci_host_icon`), and falls back to
+    GitHub Actions for entries serialized without host metadata."""
+    bk_url = "https://buildkite.com/acme/repo/builds/1#job"
+    gha_url = "https://github.com/acme/repo/actions/runs/1"
+    entries = [
+        {
+            "kind": "test",
+            "name": "test-bk",
+            "job": "a",
+            "status": "passed",
+            "elapsed_ms": 1000,
+            "ci_run_url": bk_url,
+            "ci_host_label": "Buildkite",
+            "ci_host_icon": "🏗",
+        },
+        {
+            "kind": "test",
+            "name": "test-old",
+            "job": "b",
+            "status": "passed",
+            "elapsed_ms": 1000,
+            "ci_run_url": gha_url,
+        },
+    ]
+    prepared = prepare_for_render(entries)
+    body = render_body(
+        ctx,
+        MARKER_FMT % 42,
+        prepared,
+        "2026-01-01 00:00:00 UTC",
+        DEFAULT_BODY_TEMPLATE,
+        DEFAULT_STATUS_BADGES,
+        bucket_entries(prepared),
+    )
+    _eq("ci-host — Buildkite label + icon", ("🏗 [Buildkite](%s)" % bk_url) in body, True)
+    _eq("ci-host — no GitHub Actions mislabel for the BK url", ("[GitHub Actions](%s)" % bk_url) in body, False)
+    _eq("ci-host — missing metadata falls back to GitHub Actions", ("🐙 [GitHub Actions](%s)" % gha_url) in body, True)
+
 def _check_repro_dedup_consecutive_headings(ctx):
     """Two fix commands from the same task collapse to one heading.
 
@@ -1606,6 +1646,7 @@ def _test_impl(ctx):
     _check_render_body_emits_state_block(ctx)
     _check_render_body_no_state_block_when_state_none(ctx)
     _check_row_renders_name_and_kind(ctx)
+    _check_ci_host_link_label(ctx)
     _check_select_snippets(ctx)
     _check_select_sticky()
     _check_by_task_overflow()


### PR DESCRIPTION
Two correctness fixes for repos that run more than one CI host against the same GitHub PR (e.g. GitHub Actions + Buildkite + CircleCI), surfaced while testing the aggregated status comment across hosts.

**1. CI link mislabeled.** The per-task build/job link was hardcoded to "🐙 GitHub Actions" regardless of the host that produced the entry, so a Buildkite or CircleCI task's link read "GitHub Actions" while pointing at buildkite.com / circleci.com. Each entry now carries the detected host's label + icon (`ci_host_label` / `ci_host_icon`, from `detect_ci_host`); entries without host metadata fall back to GitHub Actions.

**2. A host's tasks could vanish from the comment.** The per-workflow re-trigger eviction keeps only the newest `run_id` per `workflow_name`. When two hosts share a raw pipeline/repo name — CircleCI's `CIRCLE_PROJECT_REPONAME` and Buildkite's `BUILDKITE_PIPELINE_SLUG` both `"myrepo"` — they collided and one host's entire run was evicted as if it were a stale re-trigger of the other. `workflow_name` is now host-prefixed (`"BUILDKITE:myrepo"`, `"CIRCLECI:myrepo"`, `"GITLAB_CI:…"`) so distinct hosts never collide, while a genuine same-host re-trigger still evicts correctly. `workflow_name` is a coordination key only (not rendered), so the prefix is invisible.

Both apply to the GitHub and GitLab features.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fixed the Aspect Workflows PR/MR status comment for repos using multiple CI hosts: each task's CI link is now labelled for the host that ran it (GitHub Actions / Buildkite / CircleCI / GitLab), and tasks from one host no longer drop out of the comment when two hosts share a pipeline/repo name.

### Test plan

- Covered by existing test cases
- New test cases added

`aspect tests axl` — 860 pass; `aspect dev test-pr-comment-snapshots` — 20 scenarios + the new `ci-host` and `distinct-host` merge checks; `cargo test -p aspect-cli` — 52 pass; buildifier clean.
