### PR TITLE
feat(status-comments): per-task GitHub API budget with pace-based skip taper

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -360,9 +360,9 @@ BuildkiteAnnotations = feature(
             description = "When to create Buildkite annotations: ci-only (default), local-only, or always.",
         ),
         "min_update_interval_seconds": args.int(
-            default = 1,
+            default = 5,
             description = "Minimum seconds between live Buildkite annotation refreshes during a task. " +
-                          "Default 1s, minimum 1s (smaller values are silently raised to 1). Higher values " +
+                          "Default 5s, minimum 1s (smaller values are silently raised to 1). Higher values " +
                           "reduce `buildkite-agent annotate` invocations on chatty tasks at the cost of " +
                           "less-responsive live annotations. The task's terminal result and phase " +
                           "boundaries always land immediately regardless of this setting.",

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -53,7 +53,6 @@ load(
     "BUCKET_APP",
     "PHASE_FALL_THROUGH",
     "PHASE_SUPPRESS",
-    "effective_throttle_factor",
     "should_emit_phase_change",
     "usage_footer",
 )
@@ -269,8 +268,9 @@ def _github_status_checks(ctx: FeatureContext):
                 _LOG.warn(ctx.std, "Complete/fail API call failed: %s" % result.get("error", "unknown"))
             return
 
-        # PATCH on a completed run keeps the existing conclusion.
-        github.status_checks.update(ctx, token, owner, repo, check_run_id, output = output)
+        # Mid-run progress PATCH (keeps the existing conclusion) — skippable
+        # under budget pressure; the conclusion-setting calls above always land.
+        github.status_checks.update(ctx, token, owner, repo, check_run_id, output = output, skippable = True)
 
     # TaskLifecycleTrait hooks
 
@@ -405,9 +405,10 @@ def _github_status_checks(ctx: FeatureContext):
             if phase_result == PHASE_SUPPRESS:
                 return
             if phase_result == PHASE_FALL_THROUGH:
-                elapsed_s = float(now - _state.get("_started_ms", now)) / 1000.0
-                factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, min_update_interval_s)
-                if not should_emit_update(_state, now, int(min_update_interval_ms * factor), final):
+                # Space updates at the configured interval; the per-token budget
+                # gate in `github._do_request` caps total App spend (the PATCH
+                # below is skippable). No reactive factor — the budget is the cap.
+                if not should_emit_update(_state, now, min_update_interval_ms, final):
                     return
         elif final:
             _state["_ended_ms"] = now_ms(ctx)  # terminal render needs it for duration

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -8,11 +8,11 @@ this cycle. The server owns cross-job coordination + the post throttle;
 rendering (the Jinja2 template, customizable via config) and posting (the
 GitHub issue-comment API) stay client-side. Contribution is event-paced (ticks
 on BES events), throttled to the server's budget-derived `desired_cadence_s`
-(floored by min_poll_interval_seconds) widened by the live client-side
-`effective_throttle_factor` (burn-rate / swarm cold-start / elapsed-time) so a
-fresh swarm can't drain the shared App bucket between budget refreshes. Works on
-any supported CI host (GitHub Actions, Buildkite, CircleCI) since coordination no
-longer depends on CI artifacts.
+(floored by min_poll_interval_seconds). That cadence paces the Aspect-API
+contribute rate; the GitHub API spend (the elected poster's comment PATCH) is
+bounded separately by the per-token call budget enforced in
+`github._do_request`. Works on any supported CI host (GitHub Actions, Buildkite,
+CircleCI) since coordination no longer depends on CI artifacts.
 
 When the Aspect API is unreachable, the feature falls back to coordinating
 through the comment's own embedded state block (read → merge own entry →
@@ -88,7 +88,6 @@ load(
     "BUCKET_APP",
     "PHASE_FALL_THROUGH",
     "PHASE_SUPPRESS",
-    "effective_throttle_factor",
     "epoch_now_s",
     "should_emit_phase_change",
     "usage_footer",
@@ -1376,17 +1375,24 @@ def _github_status_comments(ctx: FeatureContext):
             payload["check_run_url"] = check_run_url
         return payload
 
-    def _upsert_comment(ctx, token, body):
+    def _upsert_comment(ctx, token, body, skippable = False):
         """PATCH the existing comment when its id is known, else POST a
         fresh one (the unchanged-content short-circuit is in `_publish`).
+
+        `skippable=True` (a mid-run heartbeat) lets the per-token budget gate
+        drop the PATCH when over budget — it returns `False` like any other
+        non-post, so the caller skips the lease stamp and retries next cycle.
+        The create is always must-succeed (it establishes the comment).
 
         Returns `True` on success so the caller stamps the lease; `False`
         on failure so the caller skips the stamp and a sibling can take
         over rather than honor a stale lease behind a broken upsert."""
         if "_comment_id" in _state:
-            res = github.issues.update_comment(ctx, token, owner, repo, _state["_comment_id"], body)
+            res = github.issues.update_comment(ctx, token, owner, repo, _state["_comment_id"], body, skippable = skippable)
             if not res.get("success"):
-                _LOG.warn(ctx.std, "Update failed: %s" % res.get("error", "unknown"))
+                # A budget skip is intentional, not a failure — stay quiet.
+                if not res.get("skipped"):
+                    _LOG.warn(ctx.std, "Update failed: %s" % res.get("error", "unknown"))
                 return False
 
             # A sibling whose comment was invisible at our create time can still
@@ -1650,7 +1656,9 @@ def _github_status_comments(ctx: FeatureContext):
         stable_body, final_body = _render_comment(ctx, state, sel, now_epoch)
         if _state.get("_last_stable_body") == stable_body:
             return
-        if not _upsert_comment(ctx, token, final_body):
+        # Mid-run PATCHes are skippable under budget pressure; the terminal
+        # verdict (final) always lands.
+        if not _upsert_comment(ctx, token, final_body, skippable = not final):
             return
         _state["_last_stable_body"] = stable_body
         _state["_pending_post"] = {"comment_id": str(_state.get("_comment_id", ""))}
@@ -1871,20 +1879,13 @@ def _github_status_comments(ctx: FeatureContext):
             if phase_result == PHASE_SUPPRESS:
                 return
             if phase_result == PHASE_FALL_THROUGH:
-                # Disabled surface (auth failed → no token): nothing will publish,
-                # so skip the throttle entirely. `effective_throttle_factor` has
-                # side effects (it records the factor other surfaces' usage_footer
-                # reads); a non-posting job must not stamp one.
-                if not _state.get("_github_token"):
-                    return
-
-                # Budget-derived cadence from the Aspect API, floored by the
-                # configured min, then widened by the live client-side throttle to
-                # cover quota drain the periodic budget can't see yet.
-                base_interval = max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds))
-                elapsed_s = now - _state.get("_task_started_at", now)
-                factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, base_interval)
-                interval = base_interval * factor
+                # Budget-derived cadence from the Aspect API (refreshed
+                # periodically below), floored by the configured min; falls back
+                # to the floor before the first mint or when none was returned.
+                # This paces the Aspect-API *contribute* rate; the App-bucket
+                # GitHub spend is bounded separately by the per-token budget gate
+                # in `github._do_request` (see `_publish`).
+                interval = max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds))
                 if now - _state.get("_last_publish_s", 0.0) < interval:
                     return
                 _state["_last_publish_s"] = now

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -7,9 +7,12 @@ aggregated state plus a directive on whether THIS job should post the comment
 this cycle. The server owns cross-job coordination + the post throttle;
 rendering (the Jinja2 template, customizable via config) and posting (the
 GitHub issue-comment API) stay client-side. Contribution is event-paced (ticks
-on BES events), throttled by min_poll_interval_seconds. Works on any supported
-CI host (GitHub Actions, Buildkite, CircleCI) since coordination no longer
-depends on CI artifacts.
+on BES events), throttled to the server's budget-derived `desired_cadence_s`
+(floored by min_poll_interval_seconds) widened by the live client-side
+`effective_throttle_factor` (burn-rate / swarm cold-start / elapsed-time) so a
+fresh swarm can't drain the shared App bucket between budget refreshes. Works on
+any supported CI host (GitHub Actions, Buildkite, CircleCI) since coordination no
+longer depends on CI artifacts.
 
 When the Aspect API is unreachable, the feature falls back to coordinating
 through the comment's own embedded state block (read → merge own entry →
@@ -85,6 +88,7 @@ load(
     "BUCKET_APP",
     "PHASE_FALL_THROUGH",
     "PHASE_SUPPRESS",
+    "effective_throttle_factor",
     "epoch_now_s",
     "should_emit_phase_change",
     "usage_footer",
@@ -1765,12 +1769,19 @@ def _github_status_comments(ctx: FeatureContext):
         headroom = github.read_rate_limit(ctx, _state["_github_token"])
         if headroom == None:
             return
-        result = github.status_comment_budget(ctx, {
+        budget_request = {
             "installation_id": _state["_installation_id"],
             "installation_proof": _state["_installation_proof"],
             "remaining": headroom["remaining"],
             "reset": headroom["reset"],
-        })
+        }
+
+        # Forward the window ceiling when the `/rate_limit` read carried it, so
+        # the budget service sizes its reserve floor against the real `limit`
+        # rather than the default fallback.
+        if "limit" in headroom:
+            budget_request["limit"] = headroom["limit"]
+        result = github.status_comment_budget(ctx, budget_request)
         if result.get("success") and result.get("desired_cadence_s"):
             _state["_cadence_s"] = result["desired_cadence_s"]
 
@@ -1860,10 +1871,20 @@ def _github_status_comments(ctx: FeatureContext):
             if phase_result == PHASE_SUPPRESS:
                 return
             if phase_result == PHASE_FALL_THROUGH:
-                # Budget-derived cadence from the Aspect API (refreshed
-                # periodically below), floored by the configured min; falls back
-                # to the floor before the first mint or when none was returned.
-                interval = max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds))
+                # Disabled surface (auth failed → no token): nothing will publish,
+                # so skip the throttle entirely. `effective_throttle_factor` has
+                # side effects (it records the factor other surfaces' usage_footer
+                # reads); a non-posting job must not stamp one.
+                if not _state.get("_github_token"):
+                    return
+
+                # Budget-derived cadence from the Aspect API, floored by the
+                # configured min, then widened by the live client-side throttle to
+                # cover quota drain the periodic budget can't see yet.
+                base_interval = max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds))
+                elapsed_s = now - _state.get("_task_started_at", now)
+                factor = effective_throttle_factor(ctx, BUCKET_APP, elapsed_s, base_interval)
+                interval = base_interval * factor
                 if now - _state.get("_last_publish_s", 0.0) < interval:
                     return
                 _state["_last_publish_s"] = now

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -88,6 +88,7 @@ load(
     "BUCKET_APP",
     "PHASE_FALL_THROUGH",
     "PHASE_SUPPRESS",
+    "cadence_seconds",
     "epoch_now_s",
     "should_emit_phase_change",
     "usage_footer",
@@ -126,11 +127,6 @@ _DEFAULT_CI_HOST_ICON = "🐙"
 # terminator out of the payload.
 _STATE_BLOCK_OPEN = "<!-- aspect-ci-status-state-v1:"
 _STATE_BLOCK_CLOSE = " -->"
-
-# How often a long-running task refreshes its budget-derived cadence from the
-# Aspect API (`/github/budget`). Coarser than the cadence itself — the shared
-# installation quota shifts on the minutes scale, not seconds.
-_BUDGET_REFRESH_S = 180
 
 # One settle delay (seconds) for the create-time duplicate backstop. After this
 # job creates a comment it lists once immediately; if no sibling is visible yet
@@ -1598,7 +1594,7 @@ def _github_status_comments(ctx: FeatureContext):
             "shown_repros": _state.get("_shown_repros", []),
             "shown_fixes": _state.get("_shown_fixes", []),
             "final": final,
-            "min_interval_s": max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds)),
+            "min_interval_s": max(min_poll_interval_seconds, cadence_seconds(ctx)),
         }
 
         # Peek (don't pop) the pending confirmation — a failed contribute must
@@ -1747,13 +1743,9 @@ def _github_status_comments(ctx: FeatureContext):
             return
         _state["_github_token"] = token
 
-        # Budget-derived comment-refresh cadence from the token mint; the
-        # `_task_update` throttle floors it by `min_poll_interval_seconds`.
-        if auth_extra.get("desired_cadence_s"):
-            _state["_cadence_s"] = auth_extra["desired_cadence_s"]
-
-        # Installation identity + ownership proof for the periodic
-        # `/github/budget` refresh (see `_refresh_budget`).
+        # Installation identity + ownership proof for the `contribute` call (see
+        # `_publish`). The budget refresh that also uses them is centralized in
+        # `github._do_request`, seeded from the same mint.
         _state["_installation_id"] = auth_extra.get("installation_id", "")
         _state["_installation_proof"] = auth_extra.get("installation_proof", "")
 
@@ -1761,38 +1753,6 @@ def _github_status_comments(ctx: FeatureContext):
         upgraded = resolve_build_url(ctx, existing_app_token = token)
         if upgraded:
             _state["_ci_link_url"] = upgraded
-
-    def _refresh_budget(ctx, now):
-        """Periodically refresh `_cadence_s` from the Aspect API so a
-        long-running task adapts to shifting installation quota mid-run (other
-        consumers share the GitHub rate limit). Reads the installation's own
-        `/rate_limit` with our token and reports it to `/github/budget`, proving
-        installation ownership with the mint-time HMAC. Best-effort: any miss
-        leaves the prior cadence in place. Throttled to `_BUDGET_REFRESH_S`."""
-        if not _state.get("_installation_id") or not _state.get("_installation_proof"):
-            return
-        if now - _state.get("_last_budget_refresh_s", 0.0) < _BUDGET_REFRESH_S:
-            return
-        _state["_last_budget_refresh_s"] = now
-
-        headroom = github.read_rate_limit(ctx, _state["_github_token"])
-        if headroom == None:
-            return
-        budget_request = {
-            "installation_id": _state["_installation_id"],
-            "installation_proof": _state["_installation_proof"],
-            "remaining": headroom["remaining"],
-            "reset": headroom["reset"],
-        }
-
-        # Forward the window ceiling when the `/rate_limit` read carried it, so
-        # the budget service sizes its reserve floor against the real `limit`
-        # rather than the default fallback.
-        if "limit" in headroom:
-            budget_request["limit"] = headroom["limit"]
-        result = github.status_comment_budget(ctx, budget_request)
-        if result.get("success") and result.get("desired_cadence_s"):
-            _state["_cadence_s"] = result["desired_cadence_s"]
 
     def _task_update(ctx, update):
         if not _state.get("_initialized"):
@@ -1880,20 +1840,16 @@ def _github_status_comments(ctx: FeatureContext):
             if phase_result == PHASE_SUPPRESS:
                 return
             if phase_result == PHASE_FALL_THROUGH:
-                # Budget-derived cadence from the Aspect API (refreshed
-                # periodically below), floored by the configured min; falls back
-                # to the floor before the first mint or when none was returned.
-                # This paces the Aspect-API *contribute* rate; the App-bucket
+                # Server budget-derived cadence (kept fresh by the centralized
+                # refresh in `github._do_request`), floored by the configured
+                # min. Paces the Aspect-API *contribute* rate; the App-bucket
                 # GitHub spend is bounded separately by the per-token budget gate
-                # in `github._do_request` (see `_publish`).
-                interval = max(min_poll_interval_seconds, _state.get("_cadence_s", min_poll_interval_seconds))
+                # (see `_publish`).
+                interval = max(min_poll_interval_seconds, cadence_seconds(ctx))
                 if now - _state.get("_last_publish_s", 0.0) < interval:
                     return
                 _state["_last_publish_s"] = now
 
-        # Refresh the budget-derived cadence on its own slow timer (self-gated
-        # to `_BUDGET_REFRESH_S`); only reached when we're about to publish.
-        _refresh_budget(ctx, monotonic())
         _publish(ctx, final = update.final)
 
     lifecycle.task_update.append(_task_update)

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -1656,6 +1656,7 @@ def _github_status_comments(ctx: FeatureContext):
         stable_body, final_body = _render_comment(ctx, state, sel, now_epoch)
         if _state.get("_last_stable_body") == stable_body:
             return
+
         # Mid-run PATCHes are skippable under budget pressure; the terminal
         # verdict (final) always lands.
         if not _upsert_comment(ctx, token, final_body, skippable = not final):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -18,7 +18,10 @@ load(
     "./rate_limit.axl",
     "BUCKET_APP",
     "BUCKET_ENV",
+    "apply_budget_refresh",
+    "budget_exhausted",
     "record_from_headers",
+    "record_token_budget",
 )
 load("./tar.axl", "zip_create")
 load("./text.axl", "pluralize")
@@ -145,7 +148,18 @@ def _do_request_once(ctx, method, url, token, payload = None, token_class = BUCK
 # after the server processed the first would duplicate the resource).
 _IDEMPOTENT_METHODS = ["GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
 
-def _do_request(ctx, method, url, token, payload = None, quiet_4xx_auth = False, token_class = BUCKET_APP):
+# Synthetic result for a call dropped by the budget gate — a distinct shape so
+# callers tell a budget skip from a real failure (status 0, never a GitHub
+# status) and quietly no-op the cycle rather than entering an error/fallback
+# path.
+_BUDGET_SKIPPED = (False, 0, "budget-exhausted: skipped")
+
+def _is_budget_skip(success, status, body):
+    """True iff `(success, status, body)` is the budget-gate skip sentinel —
+    lets callers tell an intentional skip from a real failure (and stay quiet)."""
+    return not success and status == 0 and body == _BUDGET_SKIPPED[2]
+
+def _do_request(ctx, method, url, token, payload = None, quiet_4xx_auth = False, token_class = BUCKET_APP, skippable = False):
     """HTTP call, retried for idempotent methods; POST runs once. Returns
     `(success, status, body)`.
 
@@ -153,7 +167,15 @@ def _do_request(ctx, method, url, token, payload = None, quiet_4xx_auth = False,
     log — use where a token fallback will transparently retry.
 
     `token_class` → `_do_request_once` (rate-limit bucket; see
-    [lib/rate_limit.axl](./rate_limit.axl))."""
+    [lib/rate_limit.axl](./rate_limit.axl)).
+
+    `skippable=True` marks a non-essential call (a mid-run heartbeat refresh):
+    when the App token's per-task budget is exhausted, the call is dropped and
+    `_BUDGET_SKIPPED` returned instead of spending quota. Defaults False — a
+    must-succeed call (terminal verdicts, comment/check-run creation) always
+    proceeds. Only the App bucket has a budget; Env calls ignore the gate."""
+    if skippable and token_class == BUCKET_APP and budget_exhausted(ctx, BUCKET_APP):
+        return _BUDGET_SKIPPED
     if method in _IDEMPOTENT_METHODS:
         success, status, body, attempts = _retry_http(lambda: _do_request_once(ctx, method, url, token, payload, token_class = token_class))
     else:
@@ -373,6 +395,10 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
                 for k in ("desired_cadence_s", "installation_id", "installation_proof"):
                     if k in parsed:
                         _extra[k] = parsed[k]
+            # Seed the App-bucket per-token budget: a mint resets the spend
+            # counter, so the freshly minted token starts its allowance over.
+            if type(parsed.get("api_call_budget")) == "int":
+                record_token_budget(ctx, BUCKET_APP, parsed["api_call_budget"])
             return parsed["token"]
         snippet = (resp.body or "")[:200].replace("\n", " ")
         _set_auth_reason(
@@ -468,10 +494,13 @@ def _read_rate_limit(ctx, token, api_base = DEFAULT_GITHUB_API):
     return result
 
 def _status_comment_budget(ctx, request, profile = None):
-    """Refresh the comment-refresh cadence for a long-running task via
-    `POST /github/budget` — the client reports its installation's live
-    rate-limit headroom and gets back an updated `desired_cadence_s`, without
-    re-minting a token.
+    """Refresh a long-running task's budget via `POST /github/budget` — the
+    client reports its installation's live rate-limit headroom and gets back an
+    updated `desired_cadence_s` + `api_call_budget`, without re-minting a token.
+
+    Side-effect: applies `api_call_budget` to the App bucket via
+    `apply_budget_refresh` (floor-DOWN only — a refresh re-measures the same
+    token's slice and can shrink but never renew it).
 
     `request` is `{installation_id, installation_proof, remaining, reset}` with
     an optional `limit` (the proof comes from the token mint; see the server's
@@ -496,6 +525,8 @@ def _status_comment_budget(ctx, request, profile = None):
     parsed = json.try_decode(resp.body, None)
     if type(parsed) != "dict" or type(parsed.get("desired_cadence_s")) != "int":
         return {"success": False}
+    if type(parsed.get("api_call_budget")) == "int":
+        apply_budget_refresh(ctx, BUCKET_APP, parsed["api_call_budget"])
     return {"success": True, "desired_cadence_s": parsed["desired_cadence_s"]}
 
 # Check Runs
@@ -518,8 +549,10 @@ def create_check_run(ctx, token, owner, repo, name, head_sha, status = None, out
         error_msg = error_msg + " - " + body["message"]
     return {"success": False, "error": error_msg, "status": status_code}
 
-def update_check_run(ctx, token, owner, repo, check_run_id, status = None, conclusion = None, output = None, details_url = None, api_base = DEFAULT_GITHUB_API):
-    """Update an existing check run."""
+def update_check_run(ctx, token, owner, repo, check_run_id, status = None, conclusion = None, output = None, details_url = None, api_base = DEFAULT_GITHUB_API, skippable = False):
+    """Update an existing check run. `skippable=True` (a mid-run progress
+    update) lets the budget gate drop the call when the App token is over
+    budget; pass `skippable=False` for the terminal conclusion so it lands."""
     url = api_base + "/repos/" + owner + "/" + repo + "/check-runs/" + str(check_run_id)
     payload = {}
     if status:
@@ -530,7 +563,7 @@ def update_check_run(ctx, token, owner, repo, check_run_id, status = None, concl
         payload["output"] = output
     if details_url:
         payload["details_url"] = details_url
-    success, status_code, body = _do_request(ctx, "PATCH", url, token, payload)
+    success, status_code, body = _do_request(ctx, "PATCH", url, token, payload, skippable = skippable)
     if success:
         return {"success": True, "check_run_id": body.get("id"), "html_url": body.get("html_url")}
     error_msg = "request failed: " + str(status_code)
@@ -1703,11 +1736,18 @@ def _issues_create_comment(ctx, token, owner, repo, issue_number, body, api_base
         return {"success": True, "comment_id": resp.get("id"), "html_url": resp.get("html_url")}
     return {"success": False, "error": "HTTP %d: %s" % (status_code, resp)}
 
-def _issues_update_comment(ctx, token, owner, repo, comment_id, body, api_base = DEFAULT_GITHUB_API):
+def _issues_update_comment(ctx, token, owner, repo, comment_id, body, api_base = DEFAULT_GITHUB_API, skippable = False):
+    """PATCH a comment body. `skippable=True` (a mid-run heartbeat refresh)
+    lets the budget gate drop the call when the App token is over budget; the
+    result then carries `"skipped": True` so the caller distinguishes it from a
+    real failure (no WARN). The terminal verdict passes `skippable=False` so the
+    final state always lands."""
     url = api_base + "/repos/" + owner + "/" + repo + "/issues/comments/" + str(comment_id)
-    success, status_code, resp = _do_request(ctx, "PATCH", url, token, {"body": body})
+    success, status_code, resp = _do_request(ctx, "PATCH", url, token, {"body": body}, skippable = skippable)
     if success:
         return {"success": True, "comment_id": resp.get("id")}
+    if _is_budget_skip(success, status_code, resp):
+        return {"success": False, "skipped": True}
     return {"success": False, "error": "HTTP %d: %s" % (status_code, resp)}
 
 def _issues_delete_comment(ctx, token, owner, repo, comment_id, api_base = DEFAULT_GITHUB_API):
@@ -1758,8 +1798,8 @@ def _actions_download_artifact_zip(ctx, token, owner, repo, artifact_id, output_
 def _status_checks_create(ctx, token, owner, repo, sha, name, api_base = DEFAULT_GITHUB_API):
     return create_check_run(ctx, token, owner, repo, name, sha, status = "in_progress", api_base = api_base)
 
-def _status_checks_update(ctx, token, owner, repo, check_run_id, output = None, details_url = None, api_base = DEFAULT_GITHUB_API):
-    return update_check_run(ctx, token, owner, repo, check_run_id, status = "in_progress", output = output, details_url = details_url, api_base = api_base)
+def _status_checks_update(ctx, token, owner, repo, check_run_id, output = None, details_url = None, api_base = DEFAULT_GITHUB_API, skippable = False):
+    return update_check_run(ctx, token, owner, repo, check_run_id, status = "in_progress", output = output, details_url = details_url, api_base = api_base, skippable = skippable)
 
 def _status_checks_complete(ctx, token, owner, repo, check_run_id, output = None, api_base = DEFAULT_GITHUB_API):
     return complete_check_run(ctx, token, owner, repo, check_run_id, conclusion = "success", output = output, api_base = api_base)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -157,7 +157,7 @@ _BUDGET_SKIPPED = (False, 0, "budget-exhausted: skipped")
 def _is_budget_skip(success, status, body):
     """True iff `(success, status, body)` is the budget-gate skip sentinel —
     lets callers tell an intentional skip from a real failure (and stay quiet)."""
-    return not success and status == 0 and body == _BUDGET_SKIPPED[2]
+    return (success, status, body) == _BUDGET_SKIPPED
 
 def _do_request(ctx, method, url, token, payload = None, quiet_4xx_auth = False, token_class = BUCKET_APP, skippable = False):
     """HTTP call, retried for idempotent methods; POST runs once. Returns
@@ -499,8 +499,8 @@ def _status_comment_budget(ctx, request, profile = None):
     updated `desired_cadence_s` + `api_call_budget`, without re-minting a token.
 
     Side-effect: applies `api_call_budget` to the App bucket via
-    `apply_budget_refresh` (floor-DOWN only — a refresh re-measures the same
-    token's slice and can shrink but never renew it).
+    `apply_budget_refresh` (floors the current window's budget DOWN; seeds the
+    fresh value after a window roll cleared it — see that function).
 
     `request` is `{installation_id, installation_proof, remaining, reset}` with
     an optional `limit` (the proof comes from the token mint; see the server's
@@ -552,7 +552,8 @@ def create_check_run(ctx, token, owner, repo, name, head_sha, status = None, out
 def update_check_run(ctx, token, owner, repo, check_run_id, status = None, conclusion = None, output = None, details_url = None, api_base = DEFAULT_GITHUB_API, skippable = False):
     """Update an existing check run. `skippable=True` (a mid-run progress
     update) lets the budget gate drop the call when the App token is over
-    budget; pass `skippable=False` for the terminal conclusion so it lands."""
+    budget — the result then carries `"skipped": True` (not an error); pass
+    `skippable=False` for the terminal conclusion so it lands."""
     url = api_base + "/repos/" + owner + "/" + repo + "/check-runs/" + str(check_run_id)
     payload = {}
     if status:
@@ -566,6 +567,8 @@ def update_check_run(ctx, token, owner, repo, check_run_id, status = None, concl
     success, status_code, body = _do_request(ctx, "PATCH", url, token, payload, skippable = skippable)
     if success:
         return {"success": True, "check_run_id": body.get("id"), "html_url": body.get("html_url")}
+    if _is_budget_skip(success, status_code, body):
+        return {"success": False, "skipped": True}
     error_msg = "request failed: " + str(status_code)
     if body and type(body) == "dict" and body.get("message"):
         error_msg = error_msg + " - " + body["message"]

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -155,7 +155,8 @@ _IDEMPOTENT_METHODS = ["GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
 # Synthetic result for a call dropped by the budget gate — a distinct shape so
 # callers tell a budget skip from a real failure (status 0, never a GitHub
 # status) and quietly no-op the cycle rather than entering an error/fallback
-# path. Matched by identity in `_is_budget_skip`, never parsed.
+# path. Recognized by value in `_is_budget_skip` (status 0 + this sentinel body,
+# which a real response never produces), never parsed.
 _BUDGET_SKIPPED = (False, 0, "budget-throttled: skipped")
 
 # Surface ids for the budget gate's per-surface quiet-gap damping — each
@@ -530,11 +531,16 @@ def _maybe_refresh_budget(ctx):
     the backoff schedule + reentrancy guard, using creds stashed at mint), reads
     the installation's live `/rate_limit`, reports it to `POST /github/budget`,
     and applies the returned budget + cadence. Best-effort and self-contained:
-    no feature drives it, and any miss just leaves the prior budget in place.
+    no feature drives it, and any miss just leaves the prior budget in place. A
+    failed attempt still consumes its backoff slot (the next retries one interval
+    later) since `claim_budget_refresh` stamps before the work.
 
-    The reentrancy guard is essential — this makes App calls (`/rate_limit`, and
-    the credentials read), which re-enter `_do_request`; the in-flight flag stops
-    those from claiming a nested refresh."""
+    The reentrancy guard matters because this makes its own App call (the
+    `GET /rate_limit`) which re-enters `_do_request`; the in-flight flag stops
+    that from claiming a nested refresh. Everything between the claim and
+    `end_budget_refresh` must stay non-raising (AXL has no `try/finally`); the
+    HTTP/JSON paths here all return sentinels rather than raise, and a leaked
+    flag self-heals via `_REFRESH_STALE_S`."""
     claimed = claim_budget_refresh(ctx)
     if not claimed:
         return
@@ -551,7 +557,7 @@ def _maybe_refresh_budget(ctx):
         _post_budget(ctx, request)
     end_budget_refresh(ctx)
 
-def _post_budget(ctx, request, profile = None):
+def _post_budget(ctx, request):
     """`POST /github/budget` — report the installation's live rate-limit headroom
     and apply the returned `api_call_budget` + `desired_cadence_s`.
 
@@ -561,7 +567,7 @@ def _post_budget(ctx, request, profile = None):
     installation_proof, remaining, reset}` + optional `limit` (the proof comes
     from the token mint; see the server's RequestSchema). Never raises — a
     failure just leaves the prior budget/cadence in place."""
-    creds = ctx.aspect.auth.credentials(profile = profile)
+    creds = ctx.aspect.auth.credentials()
     if not creds:
         return
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -19,7 +19,7 @@ load(
     "BUCKET_APP",
     "BUCKET_ENV",
     "apply_budget_refresh",
-    "budget_exhausted",
+    "budget_should_skip",
     "record_from_headers",
     "record_token_budget",
 )
@@ -151,15 +151,21 @@ _IDEMPOTENT_METHODS = ["GET", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
 # Synthetic result for a call dropped by the budget gate — a distinct shape so
 # callers tell a budget skip from a real failure (status 0, never a GitHub
 # status) and quietly no-op the cycle rather than entering an error/fallback
-# path.
-_BUDGET_SKIPPED = (False, 0, "budget-exhausted: skipped")
+# path. Matched by identity in `_is_budget_skip`, never parsed.
+_BUDGET_SKIPPED = (False, 0, "budget-throttled: skipped")
+
+# Surface ids for the budget gate's per-surface quiet-gap damping — each
+# repeating App-bucket writer is its own surface so a quiet one isn't skipped
+# because a chatty sibling kept the shared spend high.
+_SURFACE_COMMENTS = "comments"
+_SURFACE_CHECKS = "checks"
 
 def _is_budget_skip(success, status, body):
     """True iff `(success, status, body)` is the budget-gate skip sentinel —
     lets callers tell an intentional skip from a real failure (and stay quiet)."""
     return (success, status, body) == _BUDGET_SKIPPED
 
-def _do_request(ctx, method, url, token, payload = None, quiet_4xx_auth = False, token_class = BUCKET_APP, skippable = False):
+def _do_request(ctx, method, url, token, payload = None, quiet_4xx_auth = False, token_class = BUCKET_APP, skippable = False, surface = ""):
     """HTTP call, retried for idempotent methods; POST runs once. Returns
     `(success, status, body)`.
 
@@ -170,11 +176,13 @@ def _do_request(ctx, method, url, token, payload = None, quiet_4xx_auth = False,
     [lib/rate_limit.axl](./rate_limit.axl)).
 
     `skippable=True` marks a non-essential call (a mid-run heartbeat refresh):
-    when the App token's per-task budget is exhausted, the call is dropped and
-    `_BUDGET_SKIPPED` returned instead of spending quota. Defaults False — a
-    must-succeed call (terminal verdicts, comment/check-run creation) always
-    proceeds. Only the App bucket has a budget; Env calls ignore the gate."""
-    if skippable and token_class == BUCKET_APP and budget_exhausted(ctx, BUCKET_APP):
+    the per-token budget gate (`budget_should_skip`) may drop it under quota
+    pressure, returning `_BUDGET_SKIPPED` instead of spending. `surface`
+    identifies the caller (e.g. "comments", "checks") so the gate damps skipping
+    when that surface has been quiet. Defaults False — a must-succeed call
+    (terminal verdicts, comment/check-run creation) always proceeds. Only the
+    App bucket has a budget; Env calls ignore the gate."""
+    if skippable and token_class == BUCKET_APP and budget_should_skip(ctx, BUCKET_APP, surface):
         return _BUDGET_SKIPPED
     if method in _IDEMPOTENT_METHODS:
         success, status, body, attempts = _retry_http(lambda: _do_request_once(ctx, method, url, token, payload, token_class = token_class))
@@ -565,7 +573,7 @@ def update_check_run(ctx, token, owner, repo, check_run_id, status = None, concl
         payload["output"] = output
     if details_url:
         payload["details_url"] = details_url
-    success, status_code, body = _do_request(ctx, "PATCH", url, token, payload, skippable = skippable)
+    success, status_code, body = _do_request(ctx, "PATCH", url, token, payload, skippable = skippable, surface = _SURFACE_CHECKS)
     if success:
         return {"success": True, "check_run_id": body.get("id"), "html_url": body.get("html_url")}
     if _is_budget_skip(success, status_code, body):
@@ -1747,7 +1755,7 @@ def _issues_update_comment(ctx, token, owner, repo, comment_id, body, api_base =
     real failure (no WARN). The terminal verdict passes `skippable=False` so the
     final state always lands."""
     url = api_base + "/repos/" + owner + "/" + repo + "/issues/comments/" + str(comment_id)
-    success, status_code, resp = _do_request(ctx, "PATCH", url, token, {"body": body}, skippable = skippable)
+    success, status_code, resp = _do_request(ctx, "PATCH", url, token, {"body": body}, skippable = skippable, surface = _SURFACE_COMMENTS)
     if success:
         return {"success": True, "comment_id": resp.get("id")}
     if _is_budget_skip(success, status_code, resp):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -20,7 +20,11 @@ load(
     "BUCKET_ENV",
     "apply_budget_refresh",
     "budget_should_skip",
+    "claim_budget_refresh",
+    "end_budget_refresh",
+    "record_cadence",
     "record_from_headers",
+    "record_refresh_creds",
     "record_token_budget",
 )
 load("./tar.axl", "zip_create")
@@ -191,6 +195,13 @@ def _do_request(ctx, method, url, token, payload = None, quiet_4xx_auth = False,
         attempts = 1
     if not success and not (quiet_4xx_auth and _is_4xx_auth(status)):
         _warn_http_failure(ctx, "GitHub API %s %s" % (method, url), attempts, status, body)
+
+    # Centralized budget refresh: every App call is the trigger point, so any
+    # surface keeps the shared budget fresh without its own refresh code. Self-
+    # throttled to the backoff schedule and reentrancy-guarded (the refresh's own
+    # App calls won't recurse). Only off a successful App response.
+    if success and token_class == BUCKET_APP:
+        _maybe_refresh_budget(ctx)
     return (success, status, body)
 
 # Authentication
@@ -408,6 +419,17 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
             # counter, so the freshly minted token starts its allowance over.
             if type(parsed.get("api_call_budget")) == "int":
                 record_token_budget(ctx, BUCKET_APP, parsed["api_call_budget"])
+            if type(parsed.get("desired_cadence_s")) == "int":
+                record_cadence(ctx, parsed["desired_cadence_s"])
+
+            # Stash creds for the centralized mid-run budget refresh, so no
+            # feature has to drive it (see `_maybe_refresh_budget`).
+            record_refresh_creds(
+                ctx,
+                parsed["token"],
+                parsed.get("installation_proof", ""),
+                parsed.get("installation_id", ""),
+            )
             return parsed["token"]
         snippet = (resp.body or "")[:200].replace("\n", " ")
         _set_auth_reason(
@@ -502,23 +524,46 @@ def _read_rate_limit(ctx, token, api_base = DEFAULT_GITHUB_API):
         result["limit"] = core["limit"]
     return result
 
-def _status_comment_budget(ctx, request, profile = None):
-    """Refresh a long-running task's budget via `POST /github/budget` — the
-    client reports its installation's live rate-limit headroom and gets back an
-    updated `desired_cadence_s` + `api_call_budget`, without re-minting a token.
+def _maybe_refresh_budget(ctx):
+    """Centralized mid-run budget refresh, triggered from `_do_request` after a
+    successful App call. Claims a due refresh (`claim_budget_refresh` — honors
+    the backoff schedule + reentrancy guard, using creds stashed at mint), reads
+    the installation's live `/rate_limit`, reports it to `POST /github/budget`,
+    and applies the returned budget + cadence. Best-effort and self-contained:
+    no feature drives it, and any miss just leaves the prior budget in place.
 
-    Side-effect: applies `api_call_budget` to the App bucket via
-    `apply_budget_refresh` (floors the current window's budget DOWN; seeds the
-    fresh value after a window roll cleared it — see that function).
+    The reentrancy guard is essential — this makes App calls (`/rate_limit`, and
+    the credentials read), which re-enter `_do_request`; the in-flight flag stops
+    those from claiming a nested refresh."""
+    claimed = claim_budget_refresh(ctx)
+    if not claimed:
+        return
+    headroom = _read_rate_limit(ctx, claimed["token"])
+    if headroom != None:
+        request = {
+            "installation_id": claimed["installation_id"],
+            "installation_proof": claimed["proof"],
+            "remaining": headroom["remaining"],
+            "reset": headroom["reset"],
+        }
+        if "limit" in headroom:
+            request["limit"] = headroom["limit"]
+        _post_budget(ctx, request)
+    end_budget_refresh(ctx)
 
-    `request` is `{installation_id, installation_proof, remaining, reset}` with
-    an optional `limit` (the proof comes from the token mint; see the server's
-    RequestSchema). Returns `{"success": True, "desired_cadence_s": int}` on a
-    2xx, else `{"success": False}`. Never raises — a failure just leaves the
-    caller on its prior cadence."""
+def _post_budget(ctx, request, profile = None):
+    """`POST /github/budget` — report the installation's live rate-limit headroom
+    and apply the returned `api_call_budget` + `desired_cadence_s`.
+
+    `api_call_budget` flows to the App bucket via `apply_budget_refresh` (floors
+    the current window's budget DOWN; seeds the fresh value after a window roll);
+    `desired_cadence_s` to `record_cadence`. `request` is `{installation_id,
+    installation_proof, remaining, reset}` + optional `limit` (the proof comes
+    from the token mint; see the server's RequestSchema). Never raises — a
+    failure just leaves the prior budget/cadence in place."""
     creds = ctx.aspect.auth.credentials(profile = profile)
     if not creds:
-        return {"success": False}
+        return
 
     resp = ctx.http().post(
         url = ctx.aspect.auth.api_url + "/github/budget",
@@ -530,13 +575,14 @@ def _status_comment_budget(ctx, request, profile = None):
     ).map_err(lambda e: str(e)).block()
 
     if type(resp) == "string" or resp.status < 200 or resp.status >= 300:
-        return {"success": False}
+        return
     parsed = json.try_decode(resp.body, None)
-    if type(parsed) != "dict" or type(parsed.get("desired_cadence_s")) != "int":
-        return {"success": False}
+    if type(parsed) != "dict":
+        return
     if type(parsed.get("api_call_budget")) == "int":
         apply_budget_refresh(ctx, BUCKET_APP, parsed["api_call_budget"])
-    return {"success": True, "desired_cadence_s": parsed["desired_cadence_s"]}
+    if type(parsed.get("desired_cadence_s")) == "int":
+        record_cadence(ctx, parsed["desired_cadence_s"])
 
 # Check Runs
 
@@ -2222,8 +2268,6 @@ github = struct(
     VALID_ROLES = VALID_ROLES,
     authenticate = _authenticate,
     status_comment_contribute = _status_comment_contribute,
-    status_comment_budget = _status_comment_budget,
-    read_rate_limit = _read_rate_limit,
     preferred_token_pair = _preferred_token_pair,
     missing_credentials_reason = _missing_credentials_reason,
     validate_role = validate_role,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -395,6 +395,7 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
                 for k in ("desired_cadence_s", "installation_id", "installation_proof"):
                     if k in parsed:
                         _extra[k] = parsed[k]
+
             # Seed the App-bucket per-token budget: a mint resets the spend
             # counter, so the freshly minted token starts its allowance over.
             if type(parsed.get("api_call_budget")) == "int":

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -357,10 +357,11 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
     Returns the token, or None with `_reason` populated on failure
     (stable `kind` from `_AUTH_KIND_*` + human-readable `reason`).
 
-    `_extra`, if a dict, is populated on success with non-token fields the
-    mint response carries — `desired_cadence_s` (budget-derived comment-refresh
-    cadence) and `installation_id` + `installation_proof` (for the
-    `/github/budget` refresh path). Other callers pass nothing and ignore it.
+    `_extra`, if a dict, is populated on success with `installation_id` +
+    `installation_proof` (the comment surface forwards them on the `contribute`
+    call). The budget, cadence, and refresh creds the mint also carries are
+    recorded centrally here (see below), not via `_extra`. Other callers pass
+    nothing and ignore it.
 
     Side-effect: on `_AUTH_KIND_NO_CREDENTIALS`, emits the host-specific
     `add-aspect-api-token-<host>` tip — at this layer so every App-using
@@ -412,7 +413,7 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
         parsed = json.try_decode(resp.body, None)
         if parsed != None and "token" in parsed:
             if type(_extra) == "dict":
-                for k in ("desired_cadence_s", "installation_id", "installation_proof"):
+                for k in ("installation_id", "installation_proof"):
                     if k in parsed:
                         _extra[k] = parsed[k]
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -451,16 +451,21 @@ def _status_comment_contribute(ctx, request, profile = None):
 
 def _read_rate_limit(ctx, token, api_base = DEFAULT_GITHUB_API):
     """Read the installation's GitHub core rate-limit headroom with its
-    installation `token`. Returns `{"remaining": int, "reset": int}` (the
-    `resources.core` bucket; `reset` is absolute Unix seconds), or `None` on
-    any failure. `GET /rate_limit` does not itself consume quota."""
+    installation `token`. Returns `{"remaining": int, "reset": int}` from the
+    `resources.core` bucket (`reset` is absolute Unix seconds), plus `"limit":
+    int` when the response carries it — the budget service sizes its reserve
+    floor against that ceiling. `None` on any failure. `GET /rate_limit` does
+    not itself consume quota."""
     success, _status, body = _do_request(ctx, "GET", api_base + "/rate_limit", token, quiet_4xx_auth = True)
     if not success or type(body) != "dict":
         return None
     core = body.get("resources", {}).get("core")
     if type(core) != "dict" or type(core.get("remaining")) != "int" or type(core.get("reset")) != "int":
         return None
-    return {"remaining": core["remaining"], "reset": core["reset"]}
+    result = {"remaining": core["remaining"], "reset": core["reset"]}
+    if type(core.get("limit")) == "int":
+        result["limit"] = core["limit"]
+    return result
 
 def _status_comment_budget(ctx, request, profile = None):
     """Refresh the comment-refresh cadence for a long-running task via
@@ -468,11 +473,11 @@ def _status_comment_budget(ctx, request, profile = None):
     rate-limit headroom and gets back an updated `desired_cadence_s`, without
     re-minting a token.
 
-    `request` is `{installation_id, installation_proof, remaining, reset}` (the
-    proof from the token mint; see the server's RequestSchema). Returns
-    `{"success": True, "desired_cadence_s": int}` on a 2xx, else
-    `{"success": False}`. Never raises — a failure just leaves the caller on
-    its prior cadence."""
+    `request` is `{installation_id, installation_proof, remaining, reset}` with
+    an optional `limit` (the proof comes from the token mint; see the server's
+    RequestSchema). Returns `{"success": True, "desired_cadence_s": int}` on a
+    2xx, else `{"success": False}`. Never raises — a failure just leaves the
+    caller on its prior cadence."""
     creds = ctx.aspect.auth.credentials(profile = profile)
     if not creds:
         return {"success": False}

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
@@ -51,8 +51,11 @@ def _do_request(ctx, method, url, token, auth_kind = "bearer", payload = None):
     if type(response) == "string":
         return (False, 0, "transport error: " + response)
 
-    # Record GitLab's `RateLimit-*` headers so burn-rate throttling has data
-    # (GitLab calls run on the App bucket; see `gitlab_commit_statuses`).
+    # Record GitLab's `RateLimit-*` headers so `effective_throttle_factor` has
+    # burn-rate data (GitLab calls run on the App bucket; see
+    # `gitlab_commit_statuses`). This also increments the token-spend counter,
+    # but GitLab has no server-issued budget and tags no call `skippable`, so the
+    # budget gate never fires — the spend count is inert here, by design.
     record_from_headers(ctx, BUCKET_APP, response.headers)
 
     success = response.status >= 200 and response.status < 300

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
@@ -11,6 +11,8 @@ OAuth bearer); `auth_kind` picks the header convention:
     project access tokens; opt-in).
 """
 
+load("./rate_limit.axl", "BUCKET_APP", "record_from_headers")
+
 DEFAULT_GITLAB_API = "https://gitlab.com/api/v4"
 
 # Internal helpers
@@ -48,6 +50,11 @@ def _do_request(ctx, method, url, token, auth_kind = "bearer", payload = None):
     response = fut.map_err(lambda e: str(e)).block()
     if type(response) == "string":
         return (False, 0, "transport error: " + response)
+
+    # Record GitLab's `RateLimit-*` headers so burn-rate throttling has data
+    # (GitLab calls run on the App bucket; see `gitlab_commit_statuses`).
+    record_from_headers(ctx, BUCKET_APP, response.headers)
+
     success = response.status >= 200 and response.status < 300
     body = response.body
     if not body:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
@@ -8,8 +8,9 @@ auth. These are independent buckets, tracked separately under `BUCKET_APP`
 
 # Observation flow
 
-`github._do_request_once` calls `record_from_headers(ctx, bucket,
-response.headers)` after every response (parsing `X-RateLimit-*`). State
+`github._do_request_once` (and `gitlab._do_request`) call
+`record_from_headers(ctx, bucket, response.headers)` after every response
+(parsing GitHub's `X-RateLimit-*` or GitLab's `RateLimit-*`). State
 keeps, per bucket: an `observations` ring buffer of
 `(epoch_s, remaining, limit, reset_epoch)`, ingested `sibling_observations`,
 the `watermark` (lowest remaining, drives `% used`), last-seen `limits`,
@@ -61,6 +62,19 @@ early phases stay visible without burning quota at the heartbeat floor.
 When a fresh `reset_epoch` jumps forward by > `_RESET_JUMP_S`, the window
 rolled mid-task: flush the ring + reset the watermark so burn-rate
 re-baselines instead of computing across the boundary.
+
+# Token budget
+
+Separate from the reactive throttle factor: the Aspect API issues a per-token
+API-call budget (`record_token_budget`) — the calls this task may spend on the
+App token — and re-measures it on each `/github/budget` refresh
+(`apply_budget_refresh`, floor-DOWN only; a refresh never renews or raises the
+cap). The client meters its *own* calls (`record_from_headers` counts one per
+GitHub response) into `token_spent`. `budget_exhausted` reports `spent >=
+budget`; `github._do_request` reads it to drop skippable (non-terminal) App
+calls once the cap is hit. The budget is the hard cap; the contribute cadence
+(`desired_cadence_s`) does the spacing. No budget yet (cold start) → not
+exhausted, caller falls back to the cadence / cold-start floor.
 
 # Threshold warnings
 
@@ -185,6 +199,12 @@ def _new_state():
         "last_effective_factor": {"app": 1.0, "env": 1.0},
         "last_logged_factor_step": {"app": 1, "env": 1},
         "threshold_warned_tier": {"app": 0, "env": 0},
+        # Per-token API-call budget (see "Token budget" in the docstring).
+        # `token_budget` is None until the server issues one; `token_spent`
+        # counts this task's own calls against it. Once spent reaches budget,
+        # skippable calls are dropped (the cap; cadence does the spacing).
+        "token_budget": {"app": None, "env": None},
+        "token_spent": {"app": 0, "env": 0},
     }
 
 def _path(ctx):
@@ -343,19 +363,103 @@ def _reset_bucket_state(state, bucket):
     state["threshold_warned_tier"] = tiers
 
 def record_from_headers(ctx, bucket, headers, epoch_s = None):
-    """Parse `X-RateLimit-*` headers and forward to `record_observation`.
-    Called after every API response; no-ops on non-GitHub responses (no
-    `X-RateLimit-Remaining`) so callers needn't gate on endpoint type.
-    `headers` is the runtime's `HttpResponse.headers` 2-tuple list."""
+    """Parse the response's rate-limit headers (GitHub's `X-RateLimit-*` or
+    GitLab's un-prefixed `RateLimit-*`), forward to `record_observation`, and
+    meter this as one of *our own* calls against the token budget. Called after
+    every API response; no-ops on responses without rate-limit headers so
+    callers needn't gate on endpoint type. `headers` is the runtime's
+    `HttpResponse.headers` 2-tuple list.
+
+    Presence of the headers means a real call landed, so each response — one
+    per HTTP attempt, retries included (each burns real quota) — is one call
+    this task made: the per-task spend signal (siblings' drain shows only in
+    `remaining`, never our counter). The quota-free `GET /rate_limit` is
+    counted too; the slight over-count is conservative."""
     if not headers:
         return
-    remaining_s = _header_value(headers, "X-RateLimit-Remaining")
+    # GitHub sends `X-RateLimit-*`; GitLab sends the un-prefixed `RateLimit-*`.
+    # `_ratelimit_header` tries both so one code path covers both hosts.
+    remaining_s = _ratelimit_header(headers, "Remaining")
     if not remaining_s:
         return
-    limit = _parse_int(_header_value(headers, "X-RateLimit-Limit"))
-    reset = _parse_int(_header_value(headers, "X-RateLimit-Reset"))
+    limit = _parse_int(_ratelimit_header(headers, "Limit"))
+    reset = _parse_int(_ratelimit_header(headers, "Reset"))
     remaining = _parse_int(remaining_s)
     record_observation(ctx, bucket, remaining, limit, reset, epoch_s = epoch_s)
+    _increment_token_spent(ctx, bucket)
+
+def _ratelimit_header(headers, suffix):
+    """Value of the rate-limit header `suffix` (`Remaining`/`Limit`/`Reset`),
+    trying the GitHub `X-RateLimit-<suffix>` spelling first, then the GitLab
+    `RateLimit-<suffix>` one. `""` if neither is present."""
+    return (
+        _header_value(headers, "X-RateLimit-" + suffix) or
+        _header_value(headers, "RateLimit-" + suffix)
+    )
+
+# ── Token budget ─────────────────────────────────────────────────────
+#
+# The server (Aspect API) issues a per-token API-call budget at mint and
+# re-measures it on each `/github/budget` refresh. The client meters its own
+# spend (`record_from_headers`) against it and paces over the token lifetime.
+# See "Token budget" in the module docstring.
+
+def record_token_budget(ctx, bucket, budget):
+    """Seed the per-token budget on a fresh mint: set `budget` and zero the
+    spend counter. No-op on an unknown bucket or a negative budget."""
+    if bucket not in _VALID_BUCKETS or budget < 0:
+        return
+    state = _load(ctx)
+    _set_bucket_field(state, "token_budget", bucket, budget)
+    _set_bucket_field(state, "token_spent", bucket, 0)
+    _save(ctx, state)
+
+def apply_budget_refresh(ctx, bucket, budget):
+    """Apply a mid-token `/github/budget` re-measurement: floor the budget DOWN
+    only (`min(current, budget)`). A refresh re-measures the same token's slice
+    — more concurrent mints can shrink it, but it never renews, so it can only
+    lower the cap, never raise it or reset spend. No-op without a prior budget
+    (a refresh before any mint has nothing to lower) or on a bad bucket/value."""
+    if bucket not in _VALID_BUCKETS or budget < 0:
+        return
+    state = _load(ctx)
+    current = (state.get("token_budget") or {}).get(bucket)
+    if current == None:
+        return
+    _set_bucket_field(state, "token_budget", bucket, min(current, budget))
+    _save(ctx, state)
+
+def budget_exhausted(ctx, bucket):
+    """True iff `bucket`'s token budget is set and fully spent (`spent >=
+    budget`). False when no budget has been issued yet (cold start) — the
+    caller falls back to cadence / the cold-start floor there, not to a hard
+    skip. Drives the skippable-call gate in `github._do_request`."""
+    state = _load(ctx)
+    budget = (state.get("token_budget") or {}).get(bucket)
+    if budget == None:
+        return False
+    spent = (state.get("token_spent") or {}).get(bucket, 0)
+    return spent >= budget
+
+def _increment_token_spent(ctx, bucket):
+    """Count one of our own calls against `bucket`'s spend. Loads + saves its
+    own state (separate from the observation write in `record_observation`) to
+    keep the recording path's read-modify-write contained. No-op on an unknown
+    bucket."""
+    if bucket not in _VALID_BUCKETS:
+        return
+    state = _load(ctx)
+    spent = (state.get("token_spent") or {}).get(bucket, 0)
+    _set_bucket_field(state, "token_spent", bucket, spent + 1)
+    _save(ctx, state)
+
+def _set_bucket_field(state, field, bucket, value):
+    """Set `state[field][bucket] = value`, copying the inner dict (AXL dicts the
+    JSON round-trip hands back are mutable, but copy to match the rest of the
+    file's immutable-update style). Mutates `state`; caller saves."""
+    inner = dict(state.get(field) or {})
+    inner[bucket] = value
+    state[field] = inner
 
 # ── Threshold warnings ───────────────────────────────────────────────
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
@@ -706,6 +706,7 @@ def _refresh_interval(elapsed_s):
     cumulative span covers `elapsed_s`."""
     interval = _BUDGET_REFRESH_BASE_S
     consumed = 0
+
     # Walk the doubling steps until the cumulative span covers `elapsed_s` or the
     # interval saturates at the cap (further doublings are no-ops, so we stop).
     # The bound just needs to exceed the doublings-to-cap count; the cap check is

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
@@ -388,6 +388,7 @@ def record_from_headers(ctx, bucket, headers, epoch_s = None):
     counted too; the slight over-count is conservative."""
     if not headers:
         return
+
     # GitHub sends `X-RateLimit-*`; GitLab sends the un-prefixed `RateLimit-*`.
     # `_ratelimit_header` tries both so one code path covers both hosts.
     remaining_s = _ratelimit_header(headers, "Remaining")

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
@@ -181,6 +181,14 @@ _BUDGET_GAP_HORIZON_S = 300
 # budget is nearly gone, so even an after-a-pause update must yield to the cap.
 _BUDGET_CRITICAL_FRACTION = 0.90
 
+# Budget-refresh backoff: the interval between `/github/budget` refreshes is
+# `min(_BUDGET_REFRESH_MAX_S, _BUDGET_REFRESH_BASE_S × 2^step)`, doubling from
+# `BASE` (5s, 10s, 20s, 40s, 80s, 160s) and settling at `MAX` (≈3min). Front-
+# loaded so a fresh swarm re-measures its shrinking per-task slice fast, then
+# relaxes once concurrency stabilizes. `step` = refreshes done so far.
+_BUDGET_REFRESH_BASE_S = 5
+_BUDGET_REFRESH_MAX_S = 180
+
 # ── Cold-start window ────────────────────────────────────────────────
 #
 # Tunes the window's boundaries; rationale in the docstring.
@@ -220,6 +228,11 @@ _COLD_START_OVERRIDE_VAR = "ASPECT_WORKFLOWS_GITHUB_API_RATE_LIMIT_COLD_START"
 #   token_spent              {bucket: int}          — our own calls this window
 #   skippable_seen           {bucket: int}          — gated calls (every-Nth taper)
 #   last_call_epoch          {surface: int}         — per-surface last-spent time
+#   refresh_creds            {token, proof, installation_id} | None — for refresh
+#   refresh_epoch_start      int                    — first-mint time (backoff t=0)
+#   refresh_last             int                    — last budget-refresh time
+#   refresh_in_flight        bool                   — reentrancy guard
+#   desired_cadence_s        int                    — latest server cadence
 
 def _new_state():
     return {
@@ -239,6 +252,16 @@ def _new_state():
         "token_spent": {"app": 0, "env": 0},
         "skippable_seen": {"app": 0, "env": 0},
         "last_call_epoch": {},
+        # Centralized budget refresh (see "Token budget" in the docstring).
+        # Creds stashed at first App mint; the backoff schedule measures elapsed
+        # from `refresh_epoch_start`; `refresh_in_flight` guards reentrancy.
+        "refresh_creds": None,
+        "refresh_epoch_start": 0,
+        "refresh_last": 0,
+        "refresh_in_flight": False,
+        # Latest server `desired_cadence_s` (mint + refresh), 0 until first set —
+        # the comment surface reads it to pace its contribute rate.
+        "desired_cadence_s": 0,
     }
 
 def _path(ctx):
@@ -448,14 +471,18 @@ def _ratelimit_header(headers, suffix):
 # spend (`record_from_headers`) against it and tapers skipping over the
 # rate-limit window. See "Token budget" in the module docstring.
 
-def record_token_budget(ctx, bucket, budget):
+def record_token_budget(ctx, bucket, budget, now_epoch_s = None):
     """Seed the per-token budget on a fresh mint: set `budget` and zero the
-    spend counter. No-op on an unknown bucket or a negative budget."""
+    spend counter. The first App mint also anchors the refresh-backoff clock
+    (`refresh_epoch_start`). No-op on an unknown bucket or a negative budget."""
     if bucket not in _VALID_BUCKETS or budget < 0:
         return
     state = _load(ctx)
     _set_bucket_field(state, "token_budget", bucket, budget)
     _set_bucket_field(state, "token_spent", bucket, 0)
+    if bucket == BUCKET_APP and not state.get("refresh_epoch_start"):
+        now = now_epoch_s if now_epoch_s != None else epoch_now_s(std = ctx.std)
+        state["refresh_epoch_start"] = now
     _save(ctx, state)
 
 def apply_budget_refresh(ctx, bucket, budget):
@@ -580,6 +607,84 @@ def _increment_token_spent(ctx, bucket):
     spent = (state.get("token_spent") or {}).get(bucket, 0)
     _set_bucket_field(state, "token_spent", bucket, spent + 1)
     _save(ctx, state)
+
+def record_refresh_creds(ctx, token, proof, installation_id):
+    """Stash the App token, installation proof, and id so the centralized budget
+    refresh (`claim_budget_refresh`) can call `/github/budget` without a feature
+    handing it credentials. Called at App mint. Later mints overwrite (a fresher
+    token). No-op if any field is empty."""
+    if not token or not proof or not installation_id:
+        return
+    state = _load(ctx)
+    state["refresh_creds"] = {
+        "token": token,
+        "proof": proof,
+        "installation_id": installation_id,
+    }
+    _save(ctx, state)
+
+def claim_budget_refresh(ctx, now_epoch_s = None):
+    """Atomically claim a due budget refresh: if creds are stashed, a refresh is
+    due per the backoff schedule, and none is in flight, mark in-flight + stamp
+    `refresh_last` and return the creds for the caller to POST `/github/budget`.
+    Else return None. The caller MUST call `end_budget_refresh` when done — the
+    in-flight flag is the reentrancy guard that stops the refresh's own App calls
+    from re-claiming. Single load+save so the claim is race-free."""
+    state = _load(ctx)
+    creds = state.get("refresh_creds")
+    if not creds or state.get("refresh_in_flight"):
+        return None
+    now = now_epoch_s if now_epoch_s != None else epoch_now_s(std = ctx.std)
+    if not _budget_refresh_due(state, now):
+        return None
+    state["refresh_in_flight"] = True
+    state["refresh_last"] = now
+    _save(ctx, state)
+    return creds
+
+def end_budget_refresh(ctx):
+    """Clear the in-flight guard set by `claim_budget_refresh`."""
+    state = _load(ctx)
+    state["refresh_in_flight"] = False
+    _save(ctx, state)
+
+def record_cadence(ctx, cadence_s):
+    """Stash the server's latest `desired_cadence_s` (from a mint or refresh) so
+    the comment surface can read it via `cadence_seconds`. No-op on non-positive."""
+    if cadence_s <= 0:
+        return
+    state = _load(ctx)
+    state["desired_cadence_s"] = cadence_s
+    _save(ctx, state)
+
+def cadence_seconds(ctx):
+    """Latest server `desired_cadence_s`, or 0 if none recorded yet."""
+    return _load(ctx).get("desired_cadence_s") or 0
+
+def _budget_refresh_due(state, now):
+    """True iff at least `_refresh_interval(elapsed)` has passed since the last
+    refresh, where `elapsed` is time since the mint anchor. Before the first
+    refresh the reference is the anchor itself (so the first refresh waits one
+    base interval after mint, not since epoch 0). No anchor yet → not due."""
+    start = state.get("refresh_epoch_start") or 0
+    if not start:
+        return False
+    since = max(state.get("refresh_last") or 0, start)
+    return now - since >= _refresh_interval(max(0, now - start))
+
+def _refresh_interval(elapsed_s):
+    """Backoff interval at `elapsed_s` into the task's budget life: the doubling
+    schedule `_BUDGET_REFRESH_BASE_S × 2^step` (5,10,20,40,80,160) clamped at
+    `_BUDGET_REFRESH_MAX_S` (≈3min). Returns the interval of the step whose
+    cumulative span covers `elapsed_s`."""
+    interval = _BUDGET_REFRESH_BASE_S
+    consumed = 0
+    for _ in range(10):
+        if consumed + interval >= elapsed_s:
+            break
+        consumed += interval
+        interval = min(_BUDGET_REFRESH_MAX_S, interval * 2)
+    return interval
 
 def _set_bucket_field(state, field, bucket, value):
     """Set `state[field][bucket] = value`, copying the inner dict (AXL dicts the

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
@@ -189,6 +189,11 @@ _BUDGET_CRITICAL_FRACTION = 0.90
 _BUDGET_REFRESH_BASE_S = 5
 _BUDGET_REFRESH_MAX_S = 180
 
+# An in-flight refresh flag older than this is treated as stale and reclaimed
+# (the claimer must have died before clearing it — AXL has no `try/finally`).
+# Far longer than two HTTP round-trips, so it never preempts a live refresh.
+_REFRESH_STALE_S = 120
+
 # ── Cold-start window ────────────────────────────────────────────────
 #
 # Tunes the window's boundaries; rationale in the docstring.
@@ -629,13 +634,24 @@ def claim_budget_refresh(ctx, now_epoch_s = None):
     `refresh_last` and return the creds for the caller to POST `/github/budget`.
     Else return None. The caller MUST call `end_budget_refresh` when done — the
     in-flight flag is the reentrancy guard that stops the refresh's own App calls
-    from re-claiming. Single load+save so the claim is race-free."""
+    from re-claiming. Single load+save so the claim is race-free.
+
+    Self-healing: AXL has no `try/finally`, so if a claimer dies before
+    `end_budget_refresh` the flag would otherwise stick forever. An in-flight
+    flag older than `_REFRESH_STALE_S` (far longer than two HTTP calls) is
+    treated as stale and reclaimed, so a dropped refresh can't permanently block
+    future ones."""
     state = _load(ctx)
     creds = state.get("refresh_creds")
-    if not creds or state.get("refresh_in_flight"):
+    if not creds:
         return None
     now = now_epoch_s if now_epoch_s != None else epoch_now_s(std = ctx.std)
-    if not _budget_refresh_due(state, now):
+    if state.get("refresh_in_flight"):
+        # `refresh_last` is stamped when in-flight is set, so it is also the
+        # in-flight start; a stale flag means the prior claimer never finished.
+        if now - (state.get("refresh_last") or 0) < _REFRESH_STALE_S:
+            return None
+    elif not _budget_refresh_due(state, now):
         return None
     state["refresh_in_flight"] = True
     state["refresh_last"] = now

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
@@ -194,6 +194,10 @@ _BUDGET_REFRESH_MAX_S = 180
 # Far longer than two HTTP round-trips, so it never preempts a live refresh.
 _REFRESH_STALE_S = 120
 
+# Loop bound for `_refresh_interval`'s doubling walk — just needs to exceed the
+# BASE→MAX doublings (6 at 5s→180s); the cap check terminates the walk.
+_BUDGET_REFRESH_DOUBLINGS = 16
+
 # ── Cold-start window ────────────────────────────────────────────────
 #
 # Tunes the window's boundaries; rationale in the docstring.
@@ -421,7 +425,12 @@ def _reset_bucket_state(state, bucket):
     so a window roll starts a fresh allowance: zero the spend counter and clear
     the budget. Clearing (not flooring) is what lets the next `/github/budget`
     refresh re-seed the larger post-reset budget — `apply_budget_refresh` floors
-    down only *within* a window, but seeds when the budget is unset."""
+    down only *within* a window, but seeds when the budget is unset.
+
+    Left alone on purpose: the refresh-backoff state (`refresh_epoch_start` /
+    `refresh_last` — the schedule is task-wide, not per-window) and the taper
+    counters (`skippable_seen` / `last_call_epoch` — a rolling phase / wall-clock
+    quiet, both window-independent)."""
     wm = dict(state["watermark"])
     wm[bucket] = None
     state["watermark"] = wm
@@ -580,13 +589,11 @@ def _budget_skip_fraction(state, bucket, surface, spent, budget, now):
         return 0.0
     time_to_reset = max(0, reset_epoch - now)
     expected = float(budget) * (1.0 - float(time_to_reset) / float(_BUDGET_WINDOW_S))
-    pace = (float(spent) - expected) / float(budget)
-    pace = max(0.0, min(1.0, pace))
+    pace = _clamp01((float(spent) - expected) / float(budget))
 
     last = (state.get("last_call_epoch") or {}).get(surface, 0)
     gap = now - last if last else _BUDGET_GAP_HORIZON_S
-    damping = (float(_BUDGET_GAP_HORIZON_S) - float(gap)) / float(_BUDGET_GAP_HORIZON_S)
-    damping = max(0.0, min(1.0, damping))
+    damping = _clamp01((float(_BUDGET_GAP_HORIZON_S) - float(gap)) / float(_BUDGET_GAP_HORIZON_S))
     return pace * damping
 
 def _stamp_surface_call(state, surface, now):
@@ -600,6 +607,10 @@ def _round_half_up(x):
     """`x` rounded to the nearest int, ties up (Starlark has no `round`/`math`).
     Callers pass `x ≥ 1`, so the result is always ≥ 1."""
     return int(x + 0.5)
+
+def _clamp01(x):
+    """Clamp `x` into `[0.0, 1.0]`."""
+    return max(0.0, min(1.0, x))
 
 def _increment_token_spent(ctx, bucket):
     """Count one of our own calls against `bucket`'s spend. Loads + saves its
@@ -695,8 +706,12 @@ def _refresh_interval(elapsed_s):
     cumulative span covers `elapsed_s`."""
     interval = _BUDGET_REFRESH_BASE_S
     consumed = 0
-    for _ in range(10):
-        if consumed + interval >= elapsed_s:
+    # Walk the doubling steps until the cumulative span covers `elapsed_s` or the
+    # interval saturates at the cap (further doublings are no-ops, so we stop).
+    # The bound just needs to exceed the doublings-to-cap count; the cap check is
+    # what actually terminates the walk.
+    for _ in range(_BUDGET_REFRESH_DOUBLINGS):
+        if consumed + interval >= elapsed_s or interval >= _BUDGET_REFRESH_MAX_S:
             break
         consumed += interval
         interval = min(_BUDGET_REFRESH_MAX_S, interval * 2)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
@@ -189,6 +189,8 @@ _COLD_START_OVERRIDE_VAR = "ASPECT_WORKFLOWS_GITHUB_API_RATE_LIMIT_COLD_START"
 #   last_effective_factor    {bucket: float}
 #   last_logged_factor_step  {bucket: int}          — for log dedup
 #   threshold_warned_tier    {bucket: int}          — 0 / LOW / IMPORTANT
+#   token_budget             {bucket: int | None}   — server-issued call budget
+#   token_spent              {bucket: int}          — our own calls this window
 
 def _new_state():
     return {
@@ -350,10 +352,16 @@ def record_observation(ctx, bucket, remaining, limit, reset_epoch, epoch_s = Non
         _log_rate_limit_quota(ctx, bucket, remaining, limit, reset_epoch)
 
 def _reset_bucket_state(state, bucket):
-    """Reset the window-scoped per-bucket state (watermark, threshold tier)
-    on a reset crossing. Mutates `state`; caller saves. Leaves
+    """Reset the window-scoped per-bucket state on a reset crossing: watermark,
+    threshold tier, and the token budget. Mutates `state`; caller saves. Leaves
     `last_effective_factor` / `last_logged_factor_step` alone — they
-    self-correct on the next `effective_throttle_factor`."""
+    self-correct on the next `effective_throttle_factor`.
+
+    The budget is per-window (the server sizes it off the window's `remaining`),
+    so a window roll starts a fresh allowance: zero the spend counter and clear
+    the budget. Clearing (not flooring) is what lets the next `/github/budget`
+    refresh re-seed the larger post-reset budget — `apply_budget_refresh` floors
+    down only *within* a window, but seeds when the budget is unset."""
     wm = dict(state["watermark"])
     wm[bucket] = None
     state["watermark"] = wm
@@ -361,6 +369,9 @@ def _reset_bucket_state(state, bucket):
     tiers = dict(state["threshold_warned_tier"] or {})
     tiers[bucket] = _THRESHOLD_TIER_NONE
     state["threshold_warned_tier"] = tiers
+
+    _set_bucket_field(state, "token_budget", bucket, None)
+    _set_bucket_field(state, "token_spent", bucket, 0)
 
 def record_from_headers(ctx, bucket, headers, epoch_s = None):
     """Parse the response's rate-limit headers (GitHub's `X-RateLimit-*` or
@@ -415,18 +426,19 @@ def record_token_budget(ctx, bucket, budget):
     _save(ctx, state)
 
 def apply_budget_refresh(ctx, bucket, budget):
-    """Apply a mid-token `/github/budget` re-measurement: floor the budget DOWN
-    only (`min(current, budget)`). A refresh re-measures the same token's slice
-    — more concurrent mints can shrink it, but it never renews, so it can only
-    lower the cap, never raise it or reset spend. No-op without a prior budget
-    (a refresh before any mint has nothing to lower) or on a bad bucket/value."""
+    """Apply a `/github/budget` re-measurement. Within the current window
+    (budget already set) it floors DOWN only (`min(current, budget)`): a refresh
+    re-measures the same window's slice — more concurrent mints can shrink it,
+    but it never raises the cap or resets spend. When the budget is unset (a
+    window roll cleared it, see `_reset_bucket_state`) it SEEDS the fresh
+    post-reset value, so a long task crossing a window boundary picks up its new
+    allowance. No-op on a bad bucket/value."""
     if bucket not in _VALID_BUCKETS or budget < 0:
         return
     state = _load(ctx)
     current = (state.get("token_budget") or {}).get(bucket)
-    if current == None:
-        return
-    _set_bucket_field(state, "token_budget", bucket, min(current, budget))
+    new_budget = budget if current == None else min(current, budget)
+    _set_bucket_field(state, "token_budget", bucket, new_budget)
     _save(ctx, state)
 
 def budget_exhausted(ctx, bucket):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit.axl
@@ -68,13 +68,19 @@ re-baselines instead of computing across the boundary.
 Separate from the reactive throttle factor: the Aspect API issues a per-token
 API-call budget (`record_token_budget`) — the calls this task may spend on the
 App token — and re-measures it on each `/github/budget` refresh
-(`apply_budget_refresh`, floor-DOWN only; a refresh never renews or raises the
-cap). The client meters its *own* calls (`record_from_headers` counts one per
-GitHub response) into `token_spent`. `budget_exhausted` reports `spent >=
-budget`; `github._do_request` reads it to drop skippable (non-terminal) App
-calls once the cap is hit. The budget is the hard cap; the contribute cadence
-(`desired_cadence_s`) does the spacing. No budget yet (cold start) → not
-exhausted, caller falls back to the cadence / cold-start floor.
+(`apply_budget_refresh`, floor-DOWN within a window; seeds fresh across a roll).
+The client meters its *own* calls (`record_from_headers` counts one per GitHub
+response) into `token_spent`.
+
+`budget_should_skip` is the gate `github._do_request` calls for skippable
+(non-terminal) App calls. It tapers rather than cliff-edges: skip a fraction
+`pace × gap_damping`, where `pace` is how far spend is ahead of the straight-line
+budget line and `gap_damping` falls to 0 as the calling surface's quiet gap
+approaches `_BUDGET_GAP_HORIZON_S` — so bursts get skipped while genuine
+after-a-pause updates get through. Past `_BUDGET_CRITICAL_FRACTION` of budget it
+skips unconditionally; at the cap it skips all. No budget yet (cold start) → no
+skip, the cadence / cold-start floor governs. The fraction is realized with a
+deterministic every-Nth counter (no RNG).
 
 # Threshold warnings
 
@@ -154,6 +160,27 @@ _TIME_TO_RESET_FLOOR_S = 60
 # converges.
 _RESERVE_FRACTION = 0.30
 
+# ── Budget pace taper ────────────────────────────────────────────────
+#
+# The skippable-call gate (`budget_should_skip`) tapers skipping by how far
+# spend is ahead of the straight-line budget pace, damped by how long this
+# surface has been quiet — so bursts get skipped while genuine after-a-pause
+# updates get through. Rationale in `budget_should_skip`.
+
+# GitHub core rate-limit window length. Used to project the expected spend by
+# now (`budget × elapsed/window`); the absolute `reset` epoch is the only
+# window timing GitHub reports, so the fixed length is assumed.
+_BUDGET_WINDOW_S = 3600
+
+# Inter-call gap (since this surface's last spent call) at which gap damping
+# reaches 0 — past it a call is never skipped below the critical band, as an
+# update after this long a pause is genuine, not bursty. Full pace-skip at gap 0.
+_BUDGET_GAP_HORIZON_S = 300
+
+# Spend fraction past which skipping is unconditional (gap/pace ignored) — the
+# budget is nearly gone, so even an after-a-pause update must yield to the cap.
+_BUDGET_CRITICAL_FRACTION = 0.90
+
 # ── Cold-start window ────────────────────────────────────────────────
 #
 # Tunes the window's boundaries; rationale in the docstring.
@@ -171,13 +198,13 @@ _COLD_START_OVERRIDE_VAR = "ASPECT_WORKFLOWS_GITHUB_API_RATE_LIMIT_COLD_START"
 # Rate-limit state has no single feature owner (every HTTP caller is a
 # peer) and swarm aggregation is intrinsic — the file-pattern (Pattern 3
 # in DEVELOPMENT.md): tmpdir + record + json. Each public function loads at
-# entry, mutates, and saves at exit; internal helpers take the loaded state
-# so one API call is one read + one write.
+# entry, mutates, and saves at exit; internal helpers take the loaded state.
 #
-# Performance: every response funnels through `record_from_headers`, so a
-# long task loads+saves hundreds of times. File is ~KB, page cache warm,
-# eval single-threaded — negligible. If it ever profiles hot, cache
-# in-memory keyed by task identity.
+# Performance: every response funnels through `record_from_headers` (and a
+# skippable App call also hits the budget gate first), so a long task does a
+# few load+save pairs per call and hundreds over its life. File is ~KB, page
+# cache warm, eval single-threaded — negligible. If it ever profiles hot,
+# cache in-memory keyed by task identity.
 
 # State is a plain dict, not a `record`, because the code reassigns many
 # fields per call and AXL records are immutable. Schema:
@@ -191,6 +218,8 @@ _COLD_START_OVERRIDE_VAR = "ASPECT_WORKFLOWS_GITHUB_API_RATE_LIMIT_COLD_START"
 #   threshold_warned_tier    {bucket: int}          — 0 / LOW / IMPORTANT
 #   token_budget             {bucket: int | None}   — server-issued call budget
 #   token_spent              {bucket: int}          — our own calls this window
+#   skippable_seen           {bucket: int}          — gated calls (every-Nth taper)
+#   last_call_epoch          {surface: int}         — per-surface last-spent time
 
 def _new_state():
     return {
@@ -203,10 +232,13 @@ def _new_state():
         "threshold_warned_tier": {"app": 0, "env": 0},
         # Per-token API-call budget (see "Token budget" in the docstring).
         # `token_budget` is None until the server issues one; `token_spent`
-        # counts this task's own calls against it. Once spent reaches budget,
-        # skippable calls are dropped (the cap; cadence does the spacing).
+        # counts this task's own calls against it. `skippable_seen` counts gated
+        # calls for the deterministic every-Nth taper; `last_call_epoch` is the
+        # per-surface last-spent timestamp the gap damping reads.
         "token_budget": {"app": None, "env": None},
         "token_spent": {"app": 0, "env": 0},
+        "skippable_seen": {"app": 0, "env": 0},
+        "last_call_epoch": {},
     }
 
 def _path(ctx):
@@ -413,8 +445,8 @@ def _ratelimit_header(headers, suffix):
 #
 # The server (Aspect API) issues a per-token API-call budget at mint and
 # re-measures it on each `/github/budget` refresh. The client meters its own
-# spend (`record_from_headers`) against it and paces over the token lifetime.
-# See "Token budget" in the module docstring.
+# spend (`record_from_headers`) against it and tapers skipping over the
+# rate-limit window. See "Token budget" in the module docstring.
 
 def record_token_budget(ctx, bucket, budget):
     """Seed the per-token budget on a fresh mint: set `budget` and zero the
@@ -444,15 +476,98 @@ def apply_budget_refresh(ctx, bucket, budget):
 
 def budget_exhausted(ctx, bucket):
     """True iff `bucket`'s token budget is set and fully spent (`spent >=
-    budget`). False when no budget has been issued yet (cold start) — the
-    caller falls back to cadence / the cold-start floor there, not to a hard
-    skip. Drives the skippable-call gate in `github._do_request`."""
+    budget`). False when no budget has been issued yet (cold start). A pure
+    read; `budget_should_skip` is the gate `github._do_request` actually calls."""
     state = _load(ctx)
     budget = (state.get("token_budget") or {}).get(bucket)
     if budget == None:
         return False
     spent = (state.get("token_spent") or {}).get(bucket, 0)
     return spent >= budget
+
+def budget_should_skip(ctx, bucket, surface, now_epoch_s = None):
+    """Decide whether to drop one skippable App call, tapering by budget pace and
+    how long `surface` has been quiet. The gate `github._do_request` calls for
+    `skippable=True` calls.
+
+    Regimes, given `spent`/`budget` and the gap since this surface's last spent
+    call:
+      - no budget yet (cold start)           → don't skip (cadence governs)
+      - spent ≥ budget                        → skip (hard cap)
+      - spent/budget ≥ `_BUDGET_CRITICAL_FRACTION` → skip (near-empty, unconditional)
+      - else skip a fraction `pace × gap_damping`:
+          pace        = clamp((spent − expected) / budget, 0, 1),
+                        expected = budget × (1 − time_to_reset/`_BUDGET_WINDOW_S`)
+          gap_damping = clamp((`_BUDGET_GAP_HORIZON_S` − gap) / horizon, 0, 1)
+        realized deterministically (no RNG): skip every `round(1/frac)`-th gated
+        call (frac 0.5 → every 2nd, 0.25 → every 4th, 0.1 → every 10th).
+
+    A long quiet gap drives damping → 0 so an after-a-pause update gets through;
+    a burst (gap ≈ 0) keeps damping ≈ 1 so the pace taper bites. Only a call that
+    goes through stamps `last_call_epoch[surface]`, so skips let the gap grow —
+    self-correcting, no surface is starved. Side-effects (counter + stamp) are
+    saved; mirrors `_increment_token_spent`'s contained read-modify-write."""
+    if bucket not in _VALID_BUCKETS:
+        return False
+    state = _load(ctx)
+    budget = (state.get("token_budget") or {}).get(bucket)
+    if budget == None:
+        return False  # cold start — cadence governs, no budget to pace against
+    if budget <= 0:
+        return True  # drained bucket (budget 0) — hard cap from the first call
+    spent = (state.get("token_spent") or {}).get(bucket, 0)
+    if spent >= budget:
+        return True
+    if float(spent) / float(budget) >= _BUDGET_CRITICAL_FRACTION:
+        return True
+
+    now = now_epoch_s if now_epoch_s != None else epoch_now_s(std = ctx.std)
+    skip_frac = _budget_skip_fraction(state, bucket, surface, spent, budget, now)
+    if skip_frac <= 0.0:
+        _stamp_surface_call(state, surface, now)
+        _save(ctx, state)
+        return False
+
+    # Skip every Nth gated call; rounding `1/skip_frac` (not floor/ceil) keeps the
+    # realized rate near the target at small fractions instead of flooring to zero.
+    skip_every = _round_half_up(1.0 / skip_frac)
+    seen = (state.get("skippable_seen") or {}).get(bucket, 0) + 1
+    _set_bucket_field(state, "skippable_seen", bucket, seen)
+    skip = seen % skip_every == 0
+    if not skip:
+        _stamp_surface_call(state, surface, now)
+    _save(ctx, state)
+    return skip
+
+def _budget_skip_fraction(state, bucket, surface, spent, budget, now):
+    """Pace skip-fraction (`(spent − expected)/budget`) damped by this surface's
+    quiet gap, both clamped to [0, 1]. Pure over loaded `state`."""
+    obs = state["observations"].get(bucket, []) or []
+    reset_epoch = obs[-1][3] if obs else 0
+    if not reset_epoch:
+        return 0.0
+    time_to_reset = max(0, reset_epoch - now)
+    expected = float(budget) * (1.0 - float(time_to_reset) / float(_BUDGET_WINDOW_S))
+    pace = (float(spent) - expected) / float(budget)
+    pace = max(0.0, min(1.0, pace))
+
+    last = (state.get("last_call_epoch") or {}).get(surface, 0)
+    gap = now - last if last else _BUDGET_GAP_HORIZON_S
+    damping = (float(_BUDGET_GAP_HORIZON_S) - float(gap)) / float(_BUDGET_GAP_HORIZON_S)
+    damping = max(0.0, min(1.0, damping))
+    return pace * damping
+
+def _stamp_surface_call(state, surface, now):
+    """Record `now` as `surface`'s last spent-call time (resets its quiet gap).
+    Mutates `state`; caller saves."""
+    stamps = dict(state.get("last_call_epoch") or {})
+    stamps[surface] = now
+    state["last_call_epoch"] = stamps
+
+def _round_half_up(x):
+    """`x` rounded to the nearest int, ties up (Starlark has no `round`/`math`).
+    Callers pass `x ≥ 1`, so the result is always ≥ 1."""
+    return int(x + 0.5)
 
 def _increment_token_spent(ctx, bucket):
     """Count one of our own calls against `bucket`'s spend. Loads + saves its
@@ -996,7 +1111,11 @@ def set_state_for_test(
         sibling_observations = None,
         last_effective_factor = None,
         last_logged_factor_step = None,
-        threshold_warned_tier = None):
+        threshold_warned_tier = None,
+        token_budget = None,
+        token_spent = None,
+        skippable_seen = None,
+        last_call_epoch = None):
     """Overwrite individual fields on the state for test setup. Each
     arg is optional — unset fields keep their current value."""
     state = _load(ctx)
@@ -1014,4 +1133,12 @@ def set_state_for_test(
         state["last_logged_factor_step"] = last_logged_factor_step
     if threshold_warned_tier != None:
         state["threshold_warned_tier"] = threshold_warned_tier
+    if token_budget != None:
+        state["token_budget"] = token_budget
+    if token_spent != None:
+        state["token_spent"] = token_spent
+    if skippable_seen != None:
+        state["skippable_seen"] = skippable_seen
+    if last_call_epoch != None:
+        state["last_call_epoch"] = last_call_epoch
     _save(ctx, state)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
@@ -1130,6 +1130,7 @@ def _budget(ctx, bucket = BUCKET_APP):
 
 def _test_budget_record_seeds_and_zeroes(ctx):
     _reset(ctx)
+
     # No budget issued yet → not exhausted (caller falls back to cadence).
     _assert("budget — unset is not exhausted", not budget_exhausted(ctx, BUCKET_APP))
     record_token_budget(ctx, BUCKET_APP, 100)
@@ -1138,6 +1139,7 @@ def _test_budget_record_seeds_and_zeroes(ctx):
 
 def _test_budget_zero_is_exhausted(ctx):
     _reset(ctx)
+
     # A drained bucket yields budget 0 → exhausted from the first call, with
     # zero spend (the design's "back off entirely" boundary).
     record_token_budget(ctx, BUCKET_APP, 0)
@@ -1158,6 +1160,7 @@ def _test_budget_spend_counts_per_call(ctx):
 def _test_budget_counts_gitlab_headers(ctx):
     _reset(ctx)
     record_token_budget(ctx, BUCKET_APP, 5)
+
     # GitLab spells the headers without the `X-` prefix.
     headers = [("RateLimit-Remaining", "900"), ("RateLimit-Limit", "1000"), ("RateLimit-Reset", str(_FAR_FUTURE))]
     record_from_headers(ctx, BUCKET_APP, headers, epoch_s = 1.0)
@@ -1167,6 +1170,7 @@ def _test_budget_counts_gitlab_headers(ctx):
 def _test_budget_no_headers_no_spend(ctx):
     _reset(ctx)
     record_token_budget(ctx, BUCKET_APP, 5)
+
     # Non-GitHub/GitLab response (no rate-limit headers) → no spend counted.
     record_from_headers(ctx, BUCKET_APP, [("Content-Type", "application/json")], epoch_s = 1.0)
     _eq("budget — non-rate-limit response not counted", _budget(ctx)[1], 0)
@@ -1174,16 +1178,19 @@ def _test_budget_no_headers_no_spend(ctx):
 def _test_budget_refresh_floors_down_only(ctx):
     _reset(ctx)
     record_token_budget(ctx, BUCKET_APP, 100)
+
     # Spend some, then a refresh that would RAISE the budget — must be ignored.
     record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = 1.0)
     apply_budget_refresh(ctx, BUCKET_APP, 500)
     _eq("budget — refresh never raises", _budget(ctx), (100, 1))
+
     # A lower refresh shrinks the cap but keeps the spend counter.
     apply_budget_refresh(ctx, BUCKET_APP, 40)
     _eq("budget — refresh floors down, spend kept", _budget(ctx), (40, 1))
 
 def _test_budget_refresh_seeds_when_unset(ctx):
     _reset(ctx)
+
     # With no budget set (none issued, or a window roll cleared it), a refresh
     # seeds the value rather than no-opping — so a fresh window's budget lands.
     apply_budget_refresh(ctx, BUCKET_APP, 50)
@@ -1204,6 +1211,7 @@ def _test_budget_window_roll_reseeds(ctx):
     record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "5000"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(near + 4000))], epoch_s = 11.0)
     _eq("budget — roll clears the budget", _budget(ctx), (None, 1))
     _assert("budget — not exhausted after roll", not budget_exhausted(ctx, BUCKET_APP))
+
     # The next refresh seeds the fresh window's (larger) allowance.
     apply_budget_refresh(ctx, BUCKET_APP, 200)
     _eq("budget — fresh window allowance seeded", _budget(ctx), (200, 1))
@@ -1214,6 +1222,7 @@ def _test_budget_exhausted_shrink_below_spent(ctx):
     for i in range(5):
         record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = float(i))
     _assert("budget — 5/10 not exhausted", not budget_exhausted(ctx, BUCKET_APP))
+
     # A refresh shrinks the cap below what's already spent → exhausted.
     apply_budget_refresh(ctx, BUCKET_APP, 4)
     _assert("budget — shrunk below spend → exhausted", budget_exhausted(ctx, BUCKET_APP))
@@ -1224,6 +1233,7 @@ def _test_budget_mint_resets_spend(ctx):
     record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = 1.0)
     record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = 2.0)
     _assert("budget — exhausted before re-mint", budget_exhausted(ctx, BUCKET_APP))
+
     # A fresh mint resets the spend counter against the new allowance.
     record_token_budget(ctx, BUCKET_APP, 50)
     _eq("budget — re-mint zeroes spend", _budget(ctx), (50, 0))
@@ -1232,6 +1242,7 @@ def _test_budget_mint_resets_spend(ctx):
 def _test_budget_env_bucket_independent(ctx):
     _reset(ctx)
     record_token_budget(ctx, BUCKET_APP, 1)
+
     # Env-bucket spend must not exhaust the App budget (separate counters).
     record_from_headers(ctx, BUCKET_ENV, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "1000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = 1.0)
     _eq("budget — env spend isolated from app", _budget(ctx, BUCKET_APP)[1], 0)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
@@ -24,6 +24,7 @@ load(
     "PHASE_SUPPRESS",
     "apply_budget_refresh",
     "budget_exhausted",
+    "budget_should_skip",
     "cold_start_phase_change_gate_seconds",
     "effective_throttle_factor",
     "export_observations",
@@ -1128,6 +1129,132 @@ def _budget(ctx, bucket = BUCKET_APP):
         (s.get("token_spent") or {}).get(bucket, 0),
     )
 
+# Fixed clock for `budget_should_skip` tests; `reset_epoch` is set relative to
+# it so `time_to_reset` (hence the budget pace line) is deterministic. Window
+# length is 3600s, gap horizon 300s, critical band 0.90 — see rate_limit.axl.
+_NOW = 100000
+
+def _setup_skip(ctx, budget, spent, ttr, gap, surface = "comments"):
+    """Seed budget state for a `budget_should_skip` call: `budget`/`spent`, an
+    observation whose `reset_epoch` is `ttr` seconds ahead of `_NOW`, and a
+    `last_call_epoch[surface]` `gap` seconds before `_NOW` (gap None → never
+    called)."""
+    last = {} if gap == None else {surface: _NOW - gap}
+    set_state_for_test(
+        ctx,
+        observations = {BUCKET_APP: [[float(_NOW), 1, 5000, _NOW + ttr]], "env": []},
+        token_budget = {BUCKET_APP: budget, "env": None},
+        token_spent = {BUCKET_APP: spent, "env": 0},
+        skippable_seen = {BUCKET_APP: 0, "env": 0},
+        last_call_epoch = last,
+    )
+
+def _skip(ctx, surface = "comments"):
+    return budget_should_skip(ctx, BUCKET_APP, surface, now_epoch_s = _NOW)
+
+def _test_budget_skip_cold_start_never_skips(ctx):
+    _reset(ctx)
+
+    # No budget issued → cadence governs, gate never skips.
+    _assert("skip — cold start allows", not _skip(ctx))
+
+def _test_budget_skip_zero_budget_always(ctx):
+    _reset(ctx)
+    _setup_skip(ctx, budget = 0, spent = 0, ttr = 1800, gap = 0)
+    _assert("skip — zero budget skips", _skip(ctx))
+
+def _test_budget_skip_hard_cap(ctx):
+    _reset(ctx)
+    _setup_skip(ctx, budget = 100, spent = 100, ttr = 1800, gap = 0)
+    _assert("skip — at cap skips", _skip(ctx))
+
+def _test_budget_skip_critical_band_ignores_gap(ctx):
+    _reset(ctx)
+
+    # 92% spent: past the 0.90 critical band → skip even after a long quiet gap.
+    _setup_skip(ctx, budget = 100, spent = 92, ttr = 1800, gap = 600)
+    _assert("skip — critical band skips despite earned silence", _skip(ctx))
+
+def _test_budget_skip_under_pace_never_skips(ctx):
+    _reset(ctx)
+
+    # Halfway through the window (ttr 1800) → expected 50; spent 40 is under
+    # pace → no skip even at gap 0.
+    _setup_skip(ctx, budget = 100, spent = 40, ttr = 1800, gap = 0)
+    _assert("skip — under pace allows", not _skip(ctx))
+
+def _test_budget_skip_long_gap_earns_silence(ctx):
+    _reset(ctx)
+
+    # Ahead of pace (expected 50, spent 80) but quiet ≥ horizon → damping 0 → allow.
+    _setup_skip(ctx, budget = 100, spent = 80, ttr = 1800, gap = 300)
+    _assert("skip — long quiet gap allows despite over-pace", not _skip(ctx))
+
+def _test_budget_skip_first_call_never_skips(ctx):
+    _reset(ctx)
+
+    # Surface never called (no last_call_epoch) → treated as maximally quiet →
+    # the first update lands even when ahead of pace.
+    _setup_skip(ctx, budget = 100, spent = 80, ttr = 1800, gap = None)
+    _assert("skip — first-ever surface call allowed", not _skip(ctx))
+
+def _test_budget_skip_burst_over_pace_tapers(ctx):
+    _reset(ctx)
+
+    # Ahead of pace (expected 50, spent 80 → pace 0.30), gap 0 → damping 1 →
+    # skip_frac 0.30 → skip_every round(1/0.30)=3 → skip every 3rd gated call.
+    # Seed a recent last-call so the surface is bursty (gap 0), then probe; the
+    # counter persists and allowed calls re-stamp to _NOW (gap stays 0).
+    _setup_skip(ctx, budget = 100, spent = 80, ttr = 1800, gap = 0)
+    results = [_skip(ctx) for _ in range(6)]
+    skipped = len([r for r in results if r])
+
+    # skip_every 3 → skip at seen 3 and 6 → 2 of 6 skipped (~30%).
+    _eq("skip — burst tapers toward the pace fraction", skipped, 2)
+
+def _test_budget_skip_partial_gap_damping(ctx):
+    # Pace 0.30 (spent 80, expected 50), gap 150 → damping 0.5 → skip_frac 0.15
+    # → skip_every round(1/0.15)=7: only the 7th gated call (seen % 7 == 0)
+    # skips. Probe the boundary by seeding the counter just below it.
+    _reset(ctx)
+    _setup_skip(ctx, budget = 100, spent = 80, ttr = 1800, gap = 150)
+    set_state_for_test(ctx, skippable_seen = {BUCKET_APP: 5, "env": 0})
+    _assert("skip — partial damping allows 6th call", not _skip(ctx))
+
+    _setup_skip(ctx, budget = 100, spent = 80, ttr = 1800, gap = 150)
+    set_state_for_test(ctx, skippable_seen = {BUCKET_APP: 6, "env": 0})
+    _assert("skip — partial damping skips 7th call", _skip(ctx))
+
+def _test_budget_skip_only_allowed_stamps_surface(ctx):
+    _reset(ctx)
+    _setup_skip(ctx, budget = 100, spent = 40, ttr = 1800, gap = 0)
+
+    # Under pace → allowed → stamps last_call_epoch[comments] to _NOW.
+    _assert("skip — allowed call passes", not _skip(ctx))
+    _eq(
+        "skip — allowed call stamps surface",
+        (inspect_for_test(ctx).get("last_call_epoch") or {}).get("comments"),
+        _NOW,
+    )
+
+def _test_budget_skip_per_surface_gap(ctx):
+    _reset(ctx)
+
+    # checks has a fresh burst gap (0), comments has earned silence (gap 300).
+    # Both over pace (skip_frac 0.30 → skip_every 3 for checks). The quiet
+    # surface's skip_frac is 0 (early return, doesn't advance the shared
+    # per-bucket counter), so seeding seen=2 lands the checks call on seen 3 → skip.
+    set_state_for_test(
+        ctx,
+        observations = {BUCKET_APP: [[float(_NOW), 1, 5000, _NOW + 1800]], "env": []},
+        token_budget = {BUCKET_APP: 100, "env": None},
+        token_spent = {BUCKET_APP: 80, "env": 0},
+        skippable_seen = {BUCKET_APP: 2, "env": 0},
+        last_call_epoch = {"comments": _NOW - 300, "checks": _NOW},
+    )
+    _assert("skip — quiet surface allowed (earned silence)", not _skip(ctx, surface = "comments"))
+    _assert("skip — bursty surface skips on its Nth", _skip(ctx, surface = "checks"))
+
 def _test_budget_record_seeds_and_zeroes(ctx):
     _reset(ctx)
 
@@ -1306,7 +1433,18 @@ def _test_impl(ctx):
     _test_budget_exhausted_shrink_below_spent(ctx)
     _test_budget_mint_resets_spend(ctx)
     _test_budget_env_bucket_independent(ctx)
-    print("rate_limit.axl: OK (60 sections)")
+    _test_budget_skip_cold_start_never_skips(ctx)
+    _test_budget_skip_zero_budget_always(ctx)
+    _test_budget_skip_hard_cap(ctx)
+    _test_budget_skip_critical_band_ignores_gap(ctx)
+    _test_budget_skip_under_pace_never_skips(ctx)
+    _test_budget_skip_long_gap_earns_silence(ctx)
+    _test_budget_skip_first_call_never_skips(ctx)
+    _test_budget_skip_burst_over_pace_tapers(ctx)
+    _test_budget_skip_partial_gap_damping(ctx)
+    _test_budget_skip_only_allowed_stamps_surface(ctx)
+    _test_budget_skip_per_surface_gap(ctx)
+    print("rate_limit.axl: OK (71 sections)")
     return 0
 
 rate_limit_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
@@ -1433,6 +1433,31 @@ def _test_refresh_not_due_without_anchor(ctx):
     record_refresh_creds(ctx, "tok", "proof", "inst-1")
     _eq("refresh — no anchor, never due", claim_budget_refresh(ctx, now_epoch_s = 9999), None)
 
+def _test_refresh_creds_partial_rejected_and_overwritten(ctx):
+    _reset(ctx)
+    # A mint missing the proof/id (passed as "") must NOT stash partial creds —
+    # else a refresh would POST without a valid proof.
+    record_refresh_creds(ctx, "tok", "", "inst-1")
+    _eq("refresh — partial creds rejected", inspect_for_test(ctx)["refresh_creds"], None)
+    # A complete mint stashes; a later mint overwrites with the fresher token.
+    record_refresh_creds(ctx, "tok1", "proof1", "inst-1")
+    record_refresh_creds(ctx, "tok2", "proof2", "inst-1")
+    _eq("refresh — later mint overwrites creds",
+        inspect_for_test(ctx)["refresh_creds"]["token"], "tok2")
+
+def _test_refresh_stale_in_flight_self_heals(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 100, now_epoch_s = 5000)
+    record_refresh_creds(ctx, "tok", "proof", "inst-1")
+    # Claim, then never call end_budget_refresh (simulate a dropped claimer).
+    _assert("refresh — initial claim", claim_budget_refresh(ctx, now_epoch_s = 5005) != None)
+    _assert("refresh — in-flight held", inspect_for_test(ctx)["refresh_in_flight"])
+    # A re-claim within the stale window is still blocked.
+    _eq("refresh — fresh in-flight blocks", claim_budget_refresh(ctx, now_epoch_s = 5060), None)
+    # Past _REFRESH_STALE_S (120s) the flag is treated as stale and reclaimed.
+    _assert("refresh — stale in-flight reclaimed",
+        claim_budget_refresh(ctx, now_epoch_s = 5005 + 121) != None)
+
 def _test_impl(ctx):
     _test_record_basic(ctx)
     _test_record_buffer_truncation(ctx)
@@ -1507,7 +1532,9 @@ def _test_impl(ctx):
     _test_refresh_claim_requires_creds(ctx)
     _test_refresh_claim_backoff_and_reentrancy(ctx)
     _test_refresh_not_due_without_anchor(ctx)
-    print("rate_limit.axl: OK (76 sections)")
+    _test_refresh_creds_partial_rejected_and_overwritten(ctx)
+    _test_refresh_stale_in_flight_self_heals(ctx)
+    print("rate_limit.axl: OK (78 sections)")
     return 0
 
 rate_limit_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
@@ -1182,12 +1182,31 @@ def _test_budget_refresh_floors_down_only(ctx):
     apply_budget_refresh(ctx, BUCKET_APP, 40)
     _eq("budget — refresh floors down, spend kept", _budget(ctx), (40, 1))
 
-def _test_budget_refresh_without_prior_is_noop(ctx):
+def _test_budget_refresh_seeds_when_unset(ctx):
     _reset(ctx)
-    # A refresh before any mint has no budget to lower → stays unset.
+    # With no budget set (none issued, or a window roll cleared it), a refresh
+    # seeds the value rather than no-opping — so a fresh window's budget lands.
     apply_budget_refresh(ctx, BUCKET_APP, 50)
-    _eq("budget — refresh before mint is a no-op", _budget(ctx)[0], None)
-    _assert("budget — still not exhausted", not budget_exhausted(ctx, BUCKET_APP))
+    _eq("budget — refresh seeds when unset", _budget(ctx), (50, 0))
+
+def _test_budget_window_roll_reseeds(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 10)
+    near = 1000
+    for i in range(10):
+        record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(near))], epoch_s = float(i))
+    _assert("budget — exhausted before roll", budget_exhausted(ctx, BUCKET_APP))
+
+    # A window roll (`reset_epoch` jumps forward) clears the budget and zeroes
+    # spend, so the task isn't stuck exhausted on the old window's allowance.
+    # The roll observation is itself a call, so spend lands at 1 (it increments
+    # after the roll reset within the same `record_from_headers`).
+    record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "5000"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(near + 4000))], epoch_s = 11.0)
+    _eq("budget — roll clears the budget", _budget(ctx), (None, 1))
+    _assert("budget — not exhausted after roll", not budget_exhausted(ctx, BUCKET_APP))
+    # The next refresh seeds the fresh window's (larger) allowance.
+    apply_budget_refresh(ctx, BUCKET_APP, 200)
+    _eq("budget — fresh window allowance seeded", _budget(ctx), (200, 1))
 
 def _test_budget_exhausted_shrink_below_spent(ctx):
     _reset(ctx)
@@ -1271,11 +1290,12 @@ def _test_impl(ctx):
     _test_budget_counts_gitlab_headers(ctx)
     _test_budget_no_headers_no_spend(ctx)
     _test_budget_refresh_floors_down_only(ctx)
-    _test_budget_refresh_without_prior_is_noop(ctx)
+    _test_budget_refresh_seeds_when_unset(ctx)
+    _test_budget_window_roll_reseeds(ctx)
     _test_budget_exhausted_shrink_below_spent(ctx)
     _test_budget_mint_resets_spend(ctx)
     _test_budget_env_bucket_independent(ctx)
-    print("rate_limit.axl: OK (58 sections)")
+    print("rate_limit.axl: OK (60 sections)")
     return 0
 
 rate_limit_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
@@ -1392,6 +1392,7 @@ def _test_refresh_mint_anchors_start_once(ctx):
     _reset(ctx)
     record_token_budget(ctx, BUCKET_APP, 100, now_epoch_s = 5000)
     _eq("refresh — first mint anchors start", inspect_for_test(ctx)["refresh_epoch_start"], 5000)
+
     # A later mint must not move the anchor (the backoff clock is task-wide).
     record_token_budget(ctx, BUCKET_APP, 80, now_epoch_s = 5100)
     _eq("refresh — later mint keeps anchor", inspect_for_test(ctx)["refresh_epoch_start"], 5000)
@@ -1399,6 +1400,7 @@ def _test_refresh_mint_anchors_start_once(ctx):
 def _test_refresh_claim_requires_creds(ctx):
     _reset(ctx)
     record_token_budget(ctx, BUCKET_APP, 100, now_epoch_s = 5000)
+
     # Anchored + past the first interval, but no creds stashed → nothing to claim.
     _eq("refresh — no creds, no claim", claim_budget_refresh(ctx, now_epoch_s = 5010), None)
 
@@ -1429,34 +1431,45 @@ def _test_refresh_claim_backoff_and_reentrancy(ctx):
 
 def _test_refresh_not_due_without_anchor(ctx):
     _reset(ctx)
+
     # Creds but no mint anchor (no App budget recorded) → never due.
     record_refresh_creds(ctx, "tok", "proof", "inst-1")
     _eq("refresh — no anchor, never due", claim_budget_refresh(ctx, now_epoch_s = 9999), None)
 
 def _test_refresh_creds_partial_rejected_and_overwritten(ctx):
     _reset(ctx)
+
     # A mint missing the proof/id (passed as "") must NOT stash partial creds —
     # else a refresh would POST without a valid proof.
     record_refresh_creds(ctx, "tok", "", "inst-1")
     _eq("refresh — partial creds rejected", inspect_for_test(ctx)["refresh_creds"], None)
+
     # A complete mint stashes; a later mint overwrites with the fresher token.
     record_refresh_creds(ctx, "tok1", "proof1", "inst-1")
     record_refresh_creds(ctx, "tok2", "proof2", "inst-1")
-    _eq("refresh — later mint overwrites creds",
-        inspect_for_test(ctx)["refresh_creds"]["token"], "tok2")
+    _eq(
+        "refresh — later mint overwrites creds",
+        inspect_for_test(ctx)["refresh_creds"]["token"],
+        "tok2",
+    )
 
 def _test_refresh_stale_in_flight_self_heals(ctx):
     _reset(ctx)
     record_token_budget(ctx, BUCKET_APP, 100, now_epoch_s = 5000)
     record_refresh_creds(ctx, "tok", "proof", "inst-1")
+
     # Claim, then never call end_budget_refresh (simulate a dropped claimer).
     _assert("refresh — initial claim", claim_budget_refresh(ctx, now_epoch_s = 5005) != None)
     _assert("refresh — in-flight held", inspect_for_test(ctx)["refresh_in_flight"])
+
     # A re-claim within the stale window is still blocked.
     _eq("refresh — fresh in-flight blocks", claim_budget_refresh(ctx, now_epoch_s = 5060), None)
+
     # Past _REFRESH_STALE_S (120s) the flag is treated as stale and reclaimed.
-    _assert("refresh — stale in-flight reclaimed",
-        claim_budget_refresh(ctx, now_epoch_s = 5005 + 121) != None)
+    _assert(
+        "refresh — stale in-flight reclaimed",
+        claim_budget_refresh(ctx, now_epoch_s = 5005 + 121) != None,
+    )
 
 def _test_impl(ctx):
     _test_record_basic(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
@@ -22,6 +22,8 @@ load(
     "PHASE_EMIT",
     "PHASE_FALL_THROUGH",
     "PHASE_SUPPRESS",
+    "apply_budget_refresh",
+    "budget_exhausted",
     "cold_start_phase_change_gate_seconds",
     "effective_throttle_factor",
     "export_observations",
@@ -29,6 +31,7 @@ load(
     "inspect_for_test",
     "record_from_headers",
     "record_observation",
+    "record_token_budget",
     "reset_for_test",
     "set_state_for_test",
     "should_emit_phase_change",
@@ -1117,6 +1120,104 @@ def _test_cold_start_floor_re_engages_after_reset_crossing(ctx):
         10.0,
     )
 
+def _budget(ctx, bucket = BUCKET_APP):
+    """Project the `(token_budget, token_spent)` pair for `bucket`."""
+    s = inspect_for_test(ctx)
+    return (
+        (s.get("token_budget") or {}).get(bucket),
+        (s.get("token_spent") or {}).get(bucket, 0),
+    )
+
+def _test_budget_record_seeds_and_zeroes(ctx):
+    _reset(ctx)
+    # No budget issued yet → not exhausted (caller falls back to cadence).
+    _assert("budget — unset is not exhausted", not budget_exhausted(ctx, BUCKET_APP))
+    record_token_budget(ctx, BUCKET_APP, 100)
+    _eq("budget — recorded, spend zeroed", _budget(ctx), (100, 0))
+    _assert("budget — fresh budget not exhausted", not budget_exhausted(ctx, BUCKET_APP))
+
+def _test_budget_zero_is_exhausted(ctx):
+    _reset(ctx)
+    # A drained bucket yields budget 0 → exhausted from the first call, with
+    # zero spend (the design's "back off entirely" boundary).
+    record_token_budget(ctx, BUCKET_APP, 0)
+    _eq("budget — zero recorded", _budget(ctx), (0, 0))
+    _assert("budget — zero budget is exhausted", budget_exhausted(ctx, BUCKET_APP))
+
+def _test_budget_spend_counts_per_call(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 2)
+    headers = [("X-RateLimit-Remaining", "4999"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))]
+    record_from_headers(ctx, BUCKET_APP, headers, epoch_s = 1.0)
+    _eq("budget — one call counted", _budget(ctx)[1], 1)
+    _assert("budget — 1/2 not exhausted", not budget_exhausted(ctx, BUCKET_APP))
+    record_from_headers(ctx, BUCKET_APP, headers, epoch_s = 2.0)
+    _eq("budget — two calls counted", _budget(ctx)[1], 2)
+    _assert("budget — 2/2 exhausted", budget_exhausted(ctx, BUCKET_APP))
+
+def _test_budget_counts_gitlab_headers(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 5)
+    # GitLab spells the headers without the `X-` prefix.
+    headers = [("RateLimit-Remaining", "900"), ("RateLimit-Limit", "1000"), ("RateLimit-Reset", str(_FAR_FUTURE))]
+    record_from_headers(ctx, BUCKET_APP, headers, epoch_s = 1.0)
+    _eq("budget — gitlab header counted as spend", _budget(ctx)[1], 1)
+    _eq("budget — gitlab observation recorded", len(inspect_for_test(ctx)["observations"][BUCKET_APP]), 1)
+
+def _test_budget_no_headers_no_spend(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 5)
+    # Non-GitHub/GitLab response (no rate-limit headers) → no spend counted.
+    record_from_headers(ctx, BUCKET_APP, [("Content-Type", "application/json")], epoch_s = 1.0)
+    _eq("budget — non-rate-limit response not counted", _budget(ctx)[1], 0)
+
+def _test_budget_refresh_floors_down_only(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 100)
+    # Spend some, then a refresh that would RAISE the budget — must be ignored.
+    record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = 1.0)
+    apply_budget_refresh(ctx, BUCKET_APP, 500)
+    _eq("budget — refresh never raises", _budget(ctx), (100, 1))
+    # A lower refresh shrinks the cap but keeps the spend counter.
+    apply_budget_refresh(ctx, BUCKET_APP, 40)
+    _eq("budget — refresh floors down, spend kept", _budget(ctx), (40, 1))
+
+def _test_budget_refresh_without_prior_is_noop(ctx):
+    _reset(ctx)
+    # A refresh before any mint has no budget to lower → stays unset.
+    apply_budget_refresh(ctx, BUCKET_APP, 50)
+    _eq("budget — refresh before mint is a no-op", _budget(ctx)[0], None)
+    _assert("budget — still not exhausted", not budget_exhausted(ctx, BUCKET_APP))
+
+def _test_budget_exhausted_shrink_below_spent(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 10)
+    for i in range(5):
+        record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = float(i))
+    _assert("budget — 5/10 not exhausted", not budget_exhausted(ctx, BUCKET_APP))
+    # A refresh shrinks the cap below what's already spent → exhausted.
+    apply_budget_refresh(ctx, BUCKET_APP, 4)
+    _assert("budget — shrunk below spend → exhausted", budget_exhausted(ctx, BUCKET_APP))
+
+def _test_budget_mint_resets_spend(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 2)
+    record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = 1.0)
+    record_from_headers(ctx, BUCKET_APP, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "5000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = 2.0)
+    _assert("budget — exhausted before re-mint", budget_exhausted(ctx, BUCKET_APP))
+    # A fresh mint resets the spend counter against the new allowance.
+    record_token_budget(ctx, BUCKET_APP, 50)
+    _eq("budget — re-mint zeroes spend", _budget(ctx), (50, 0))
+    _assert("budget — re-mint clears exhaustion", not budget_exhausted(ctx, BUCKET_APP))
+
+def _test_budget_env_bucket_independent(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 1)
+    # Env-bucket spend must not exhaust the App budget (separate counters).
+    record_from_headers(ctx, BUCKET_ENV, [("X-RateLimit-Remaining", "1"), ("X-RateLimit-Limit", "1000"), ("X-RateLimit-Reset", str(_FAR_FUTURE))], epoch_s = 1.0)
+    _eq("budget — env spend isolated from app", _budget(ctx, BUCKET_APP)[1], 0)
+    _assert("budget — app not exhausted by env spend", not budget_exhausted(ctx, BUCKET_APP))
+
 def _test_impl(ctx):
     _test_record_basic(ctx)
     _test_record_buffer_truncation(ctx)
@@ -1164,7 +1265,17 @@ def _test_impl(ctx):
     _test_should_emit_phase_change_within_debounce_suppresses(ctx)
     _test_should_emit_phase_change_after_debounce_emits(ctx)
     _test_should_emit_phase_change_scale_seconds(ctx)
-    print("rate_limit.axl: OK (48 sections)")
+    _test_budget_record_seeds_and_zeroes(ctx)
+    _test_budget_zero_is_exhausted(ctx)
+    _test_budget_spend_counts_per_call(ctx)
+    _test_budget_counts_gitlab_headers(ctx)
+    _test_budget_no_headers_no_spend(ctx)
+    _test_budget_refresh_floors_down_only(ctx)
+    _test_budget_refresh_without_prior_is_noop(ctx)
+    _test_budget_exhausted_shrink_below_spent(ctx)
+    _test_budget_mint_resets_spend(ctx)
+    _test_budget_env_bucket_independent(ctx)
+    print("rate_limit.axl: OK (58 sections)")
     return 0
 
 rate_limit_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
@@ -25,13 +25,18 @@ load(
     "apply_budget_refresh",
     "budget_exhausted",
     "budget_should_skip",
+    "cadence_seconds",
+    "claim_budget_refresh",
     "cold_start_phase_change_gate_seconds",
     "effective_throttle_factor",
+    "end_budget_refresh",
     "export_observations",
     "ingest_sibling_observations",
     "inspect_for_test",
+    "record_cadence",
     "record_from_headers",
     "record_observation",
+    "record_refresh_creds",
     "record_token_budget",
     "reset_for_test",
     "set_state_for_test",
@@ -1375,6 +1380,59 @@ def _test_budget_env_bucket_independent(ctx):
     _eq("budget — env spend isolated from app", _budget(ctx, BUCKET_APP)[1], 0)
     _assert("budget — app not exhausted by env spend", not budget_exhausted(ctx, BUCKET_APP))
 
+def _test_cadence_round_trip(ctx):
+    _reset(ctx)
+    _eq("cadence — 0 before any record", cadence_seconds(ctx), 0)
+    record_cadence(ctx, 45)
+    _eq("cadence — recorded value read back", cadence_seconds(ctx), 45)
+    record_cadence(ctx, 0)  # non-positive is a no-op
+    _eq("cadence — non-positive ignored", cadence_seconds(ctx), 45)
+
+def _test_refresh_mint_anchors_start_once(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 100, now_epoch_s = 5000)
+    _eq("refresh — first mint anchors start", inspect_for_test(ctx)["refresh_epoch_start"], 5000)
+    # A later mint must not move the anchor (the backoff clock is task-wide).
+    record_token_budget(ctx, BUCKET_APP, 80, now_epoch_s = 5100)
+    _eq("refresh — later mint keeps anchor", inspect_for_test(ctx)["refresh_epoch_start"], 5000)
+
+def _test_refresh_claim_requires_creds(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 100, now_epoch_s = 5000)
+    # Anchored + past the first interval, but no creds stashed → nothing to claim.
+    _eq("refresh — no creds, no claim", claim_budget_refresh(ctx, now_epoch_s = 5010), None)
+
+def _test_refresh_claim_backoff_and_reentrancy(ctx):
+    _reset(ctx)
+    record_token_budget(ctx, BUCKET_APP, 100, now_epoch_s = 5000)
+    record_refresh_creds(ctx, "tok", "proof", "inst-1")
+
+    # Too soon (< 5s base interval after the anchor) → not due.
+    _eq("refresh — not due before base interval", claim_budget_refresh(ctx, now_epoch_s = 5003), None)
+
+    # 5s in → first refresh due; claim returns creds and marks in-flight.
+    claimed = claim_budget_refresh(ctx, now_epoch_s = 5005)
+    _assert("refresh — due at base interval", claimed != None)
+    _eq("refresh — claim returns creds", claimed["installation_id"], "inst-1")
+    _assert("refresh — in-flight set", inspect_for_test(ctx)["refresh_in_flight"])
+
+    # While in-flight, a re-claim (e.g. the refresh's own App call) is blocked.
+    _eq("refresh — reentrancy blocked", claim_budget_refresh(ctx, now_epoch_s = 5006), None)
+
+    end_budget_refresh(ctx)
+    _assert("refresh — in-flight cleared", not inspect_for_test(ctx)["refresh_in_flight"])
+
+    # Next step's interval has doubled to 10s: not due 6s after the last refresh,
+    # due at 10s.
+    _eq("refresh — second interval not yet due", claim_budget_refresh(ctx, now_epoch_s = 5011), None)
+    _assert("refresh — second interval due at 10s", claim_budget_refresh(ctx, now_epoch_s = 5015) != None)
+
+def _test_refresh_not_due_without_anchor(ctx):
+    _reset(ctx)
+    # Creds but no mint anchor (no App budget recorded) → never due.
+    record_refresh_creds(ctx, "tok", "proof", "inst-1")
+    _eq("refresh — no anchor, never due", claim_budget_refresh(ctx, now_epoch_s = 9999), None)
+
 def _test_impl(ctx):
     _test_record_basic(ctx)
     _test_record_buffer_truncation(ctx)
@@ -1444,7 +1502,12 @@ def _test_impl(ctx):
     _test_budget_skip_partial_gap_damping(ctx)
     _test_budget_skip_only_allowed_stamps_surface(ctx)
     _test_budget_skip_per_surface_gap(ctx)
-    print("rate_limit.axl: OK (71 sections)")
+    _test_cadence_round_trip(ctx)
+    _test_refresh_mint_anchors_start_once(ctx)
+    _test_refresh_claim_requires_creds(ctx)
+    _test_refresh_claim_backoff_and_reentrancy(ctx)
+    _test_refresh_not_due_without_anchor(ctx)
+    print("rate_limit.axl: OK (76 sections)")
     return 0
 
 rate_limit_tests = task(


### PR DESCRIPTION
Bounds each task's GitHub App API spend to a server-issued per-task budget, with a pace-based taper that smooths skipping, a centralized backoff refresh, and per-surface fairness.

## Model

- The Aspect API issues a per-task `api_call_budget` (the calls a task may spend before its rate-limit window resets) at mint, re-measured on each `/github/budget` refresh — floored **down** within a window, re-seeded across a window roll so a long task isn't stranded.
- The client meters its **own** App-bucket calls (`record_from_headers`, one per GitHub response) and gates **skippable** (non-terminal) calls in `github._do_request`. Creates and terminal verdicts always land.
- The gate **tapers** rather than cliff-edges: it drops a fraction `pace × gap_damping` of skippable calls.
  - `pace` = how far spend is ahead of the straight-line budget line.
  - `gap_damping` falls from 1 to 0 as the calling **surface's** quiet gap approaches 5 min — an update after a real pause gets through; a burst is skipped. Per-surface, so a quiet surface isn't penalized for a chatty sibling.
  - Past 90% of budget → skip regardless of gap; at the cap → skip all. No budget yet (cold start) → never skip. Realized deterministically (skip every round(1/frac)-th call, no RNG).
- **Centralized refresh**: `github._do_request`, after a successful App call, triggers a self-throttled `/github/budget` refresh — no per-feature code. Backoff is front-loaded for the swarm case (5s, 10s, 20s, 40s, 80s, 160s, then ~3 min) measured from the first mint; reentrancy-guarded, and self-heals a stale in-flight flag.
- `desired_cadence_s` (unchanged, decoupled from budget) paces the Aspect-API *contribute* rate and the server's poster election; stored centrally and read by the comment surface.

## Changes

- **`rate_limit.axl`**: per-token budget + per-surface taper state + centralized refresh (backoff schedule, credential stash, reentrancy/stale guard); spend metered per response, reset on the window roll `record_observation` detects. `record_from_headers` also parses GitLab's `RateLimit-*`.
- **`github.axl`**: record budget + cadence + refresh creds at mint; `skippable`/`surface` params on `_do_request` drop tapered calls with a `_BUDGET_SKIPPED` sentinel callers distinguish from real failures; `_do_request` triggers the centralized refresh after a successful App call. Mid-run comment PATCH (`comments`) and check-run PATCH (`checks`) are skippable.
- **`github_status_comments` / `github_status_checks`**: the budget bounds spend; the configured cadence / min-interval space the calls. The comments feature's bespoke refresh is removed (now central).
- **`gitlab.axl`**: records `RateLimit-*` so GitLab burn-rate throttling has data (GitLab keeps `effective_throttle_factor`; no server budget, so its spend metering is inert by design).
- **`buildkite_annotations.axl`**: default min update interval 1s → 5s.

## Release notes

- The GitHub PR status comment and status checks bound their GitHub API usage to a server-issued per-task budget, tapering update frequency under quota pressure while still surfacing updates after a pause. Buildkite annotations now refresh at most every 5s by default.

## Test plan

- `rate_limit.axl` test sections (78 total) cover budget recording, per-response metering, GitLab header parsing, floor-down/seed-on-roll refresh, the zero/drained boundary, the full taper (cold start, hard cap, critical band, under-pace, earned-silence gap, first-call, burst, partial damping, per-surface), cadence round-trip, and the centralized refresh (anchor, creds, backoff doubling, reentrancy, stale self-heal).
- `aspect dev test-rate-limit`, `test-pr-comment-snapshots`, `test-gitlab-client`, `test-gitlab-features`, `test-gitlab-detect` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
