### PR TITLE
fix(ci): make `aspect ci warming` + bazelrc work on real runners

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/bazelrc.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazelrc.axl
@@ -70,17 +70,21 @@ def _flag_str(flag) -> str:
     return flag[0] if type(flag) == "tuple" else flag
 
 def startup_flags_for_rc(startup_flags: list) -> list:
-    """Drop startup flags that don't belong in the generated home rc.
+    """Drop the rc-suppression startup flags, which are illegal inside an rc file.
 
-    `get_bazelrc_flags` includes `--nohome_rc` because the workflows feature
-    passes these as *command-line* startup flags to `aspect <task>`. Here we
-    write them into the home rc itself (~/.bazelrc), so `--nohome_rc` would be
-    self-defeating — Bazel reads ~/.bazelrc, then that flag tells it to ignore
-    the very file it's reading. (`--nosystem_rc` stays: it suppresses the
-    separate /etc/bazel.bazelrc, e.g. a stale rc from a prior rosetta run.)
+    `get_bazelrc_flags` includes `--nohome_rc` and `--nosystem_rc` because the
+    workflows feature passes these as *command-line* startup flags to
+    `aspect <task>`. Here we write the flags into the home rc itself
+    (~/.bazelrc), and Bazel rejects any `--no*_rc` option that appears inside a
+    bazelrc with a fatal `Can't specify --nosystem_rc in the .bazelrc file`
+    (likewise `--nohome_rc`, which would also be self-defeating — Bazel would be
+    told to ignore the very file it's reading). These flags only suppress *other*
+    rc files (`/etc/bazel.bazelrc`, `~/.bazelrc`); that's a command-line concern
+    and there's nothing the generated rc can do about it, so we drop them here.
 
     Public (not `_`-prefixed) so `bazelrc_test.axl` can load it."""
-    return [f for f in startup_flags if f != "--nohome_rc"]
+    _RC_SUPPRESSION_FLAGS = ["--nohome_rc", "--nosystem_rc", "--noworkspace_rc"]
+    return [f for f in startup_flags if f not in _RC_SUPPRESSION_FLAGS]
 
 def command_sections(bazel_version: str | None) -> list:
     """The rc command sections the build flags go under. `common` (one section,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazelrc_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazelrc_test.axl
@@ -57,9 +57,9 @@ def _test_generic_flags_include_remote_cache_env(_ctx):
     _eq("bytestream prefix", "--remote_bytestream_uri_prefix=aw-remote.example" in flags, True)
 
 def _test_startup_flags_for_rc(_ctx):
-    # --nohome_rc must be dropped: the generated file IS the home rc, so keeping
-    # it would tell Bazel to ignore the rc it's reading. --nosystem_rc stays
-    # (suppresses the separate /etc/bazel.bazelrc), as do the output paths.
+    # The `--no*_rc` suppression flags must all be dropped: Bazel fatals on any of
+    # them appearing inside a bazelrc ("Can't specify --nosystem_rc in the
+    # .bazelrc file"), and the generated file IS the home rc. Output paths stay.
     got = startup_flags_for_rc([
         "--nohome_rc",
         "--nosystem_rc",
@@ -67,7 +67,7 @@ def _test_startup_flags_for_rc(_ctx):
         "--output_base=/mnt/ephemeral/output/x",
     ])
     _eq("nohome_rc dropped", "--nohome_rc" in got, False)
-    _eq("nosystem_rc kept", "--nosystem_rc" in got, True)
+    _eq("nosystem_rc dropped", "--nosystem_rc" in got, False)
     _eq("output_user_root kept", "--output_user_root=/mnt/ephemeral/bazel/x" in got, True)
     _eq("output_base kept", "--output_base=/mnt/ephemeral/output/x" in got, True)
 

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -54,20 +54,24 @@ def _impl(ctx: TaskContext) -> int:
     if bazel_trait.startup_flags:
         startup_flags = bazel_trait.startup_flags(startup_flags)
 
-    # Carry the startup flags (e.g. --output_base) on a RunCommand passed via
-    # `rc=`, since the runtime resolves startup flags from the build's
-    # RunCommand rather than a mutable ctx.bazel attribute. Use `parse_rc` (not
-    # `new_rc`): it reads the workspace `.bazelrc` from the Bazel root, so a
-    # user `--config=<group>` forwarded via `--bazel-flag` resolves against the
-    # config groups defined there. A blank rc (`new_rc`) carries
-    # `--ignore_all_rc_files`, which would make `bazel build --config=ci` fail
-    # with "Config value 'ci' is not defined in any .rc file". Command flags
-    # stay in `flags=`, which `build` appends to the rc's resolved options.
-    rc = ctx.bazel.parse_rc(startup_flags = startup_flags)
+    # Build a RunCommand that carries BOTH the command flags and the startup
+    # flags (e.g. --output_base), since the runtime resolves a build's flags and
+    # startup flags from its RunCommand rather than a mutable ctx.bazel
+    # attribute. Use `parse_rc` (not `new_rc`): it reads the workspace `.bazelrc`
+    # from the Bazel root, and the `flags` we pass become synthetic options that
+    # are expanded *against* that rc — so a user `--config=<group>` forwarded via
+    # `--bazel-flag` resolves against the config groups defined there.
+    #
+    # The flags MUST go through `parse_rc`, not the per-call `flags=` on `build`:
+    # `build`'s `flags=` are appended raw *after* the rc is resolved, and the
+    # resolved invocation also carries `--ignore_all_rc_files`, so a raw
+    # `--config=ci` would reach a Bazel told to ignore the very `.bazelrc` that
+    # defines `ci` — failing with "Config value 'ci' is not defined in any .rc
+    # file". Passing them to `parse_rc` makes them part of the resolved command.
+    rc = ctx.bazel.parse_rc(flags = flags, startup_flags = startup_flags)
 
     invocation = ctx.bazel.build(
         rc = rc,
-        flags = flags,
         *ctx.args.targets
     )
     code = invocation.wait().code

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -23,13 +23,19 @@ def _impl(ctx: TaskContext) -> int:
     on_workflows_runner = bool(ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER"))
     mount = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_STORAGE_PATH")
     if mount:
-        # Match rosetta's pre-warming cleanup. Best-effort: bazel may have
-        # left output dirs read-only, so chmod first; spawn errors are
-        # tolerated since the dirs may not exist yet on a fresh runner.
+        # Match rosetta's pre-warming cleanup. Best-effort throughout: bazel may
+        # have left output dirs read-only, so chmod first; spawn errors are
+        # tolerated since the dirs/server may not exist yet on a fresh runner.
         for sub in ["bazel", "output", "caches/repository"]:
             d = mount + "/" + sub
             ctx.std.process.command("find").args([d, "-type", "d", "-exec", "chmod", "u+w", "{}", "+"]).spawn().wait()
-            ctx.std.process.command("rm").args(["-rf", d]).spawn().wait()
+
+            # Remove the directories' *contents*, not the directories
+            # themselves: the storage-mount subdirs are created (and owned) by
+            # the runner bootstrap, so `rm -rf <dir>` fails with "Permission
+            # denied" on the mount entry while `rm -rf <dir>/*` clears what we
+            # actually need to. Use a shell so the glob expands.
+            ctx.std.process.command("sh").args(["-c", "rm -rf -- '%s'/* '%s'/.[!.]* 2>/dev/null || true" % (d, d)]).spawn().wait()
 
     bazel_trait = ctx.traits[BazelTrait]
 
@@ -48,11 +54,16 @@ def _impl(ctx: TaskContext) -> int:
     if bazel_trait.startup_flags:
         startup_flags = bazel_trait.startup_flags(startup_flags)
 
-    # The runtime resolves startup flags from the build's RunCommand, not a
-    # mutable ctx.bazel attribute, so carry them on a blank rc (reads no on-disk
-    # .bazelrc — only these flags) passed via `rc=`. Command flags stay in
-    # `flags=`, which `build` appends to the rc's resolved options.
-    rc = ctx.bazel.new_rc(startup_flags = startup_flags)
+    # Carry the startup flags (e.g. --output_base) on a RunCommand passed via
+    # `rc=`, since the runtime resolves startup flags from the build's
+    # RunCommand rather than a mutable ctx.bazel attribute. Use `parse_rc` (not
+    # `new_rc`): it reads the workspace `.bazelrc` from the Bazel root, so a
+    # user `--config=<group>` forwarded via `--bazel-flag` resolves against the
+    # config groups defined there. A blank rc (`new_rc`) carries
+    # `--ignore_all_rc_files`, which would make `bazel build --config=ci` fail
+    # with "Config value 'ci' is not defined in any .rc file". Command flags
+    # stay in `flags=`, which `build` appends to the rc's resolved options.
+    rc = ctx.bazel.parse_rc(startup_flags = startup_flags)
 
     invocation = ctx.bazel.build(
         rc = rc,


### PR DESCRIPTION
The first live runs of `aspect ci bazelrc` / `aspect ci warming` on real Aspect Workflows runners surfaced three bugs:

1. **`aspect ci bazelrc` wrote an illegal startup flag into `~/.bazelrc`.** It emitted `startup --nosystem_rc`, and Bazel fatals on any `--no*_rc` option inside a bazelrc: `Can't specify --nosystem_rc in the .bazelrc file`. `startup_flags_for_rc` already dropped `--nohome_rc` for this exact reason but kept `--nosystem_rc` on a mistaken assumption. Now drops all rc-suppression startup flags.

2. **`aspect ci warming` cleanup hit `Permission denied`.** It ran `rm -rf <mount>/<subdir>`, but those storage-mount subdirs are created and owned by the runner bootstrap, so removing the dir entry itself is denied. Match rosetta: remove the directories' *contents* (`rm -rf <dir>/*`) instead.

3. **`aspect ci warming --bazel-flag=--config=ci` failed with `Config value 'ci' is not defined`.** Warming built against a blank `new_rc` (which carries `--ignore_all_rc_files`), so the workspace `.bazelrc` defining `build:ci` was never read. Switched to `parse_rc`, which reads the workspace `.bazelrc` while still carrying `--output_base` / user startup flags.

## Changes are visible to end-users

Yes — `aspect ci bazelrc` and `aspect ci warming` now function on Workflows runners (previously failed).

### Suggested release notes

- Fixed `aspect ci bazelrc` writing an illegal `--nosystem_rc` startup flag into `~/.bazelrc`.
- Fixed `aspect ci warming` failing to clean the runner storage mount (`Permission denied`).
- Fixed `aspect ci warming` not reading the workspace `.bazelrc`, so `--bazel-flag=--config=<group>` now resolves.

## Test plan

- `aspect dev test-bazelrc` passes (8 tests, incl. updated `--nosystem_rc` assertion).
- buildifier clean on all three changed `.axl` files.
- Needs a live re-run on a Workflows runner to confirm the warming cleanup + `--config` path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
