### PR TITLE
ci: bump setup-aspect to v2026.26.7 and add the plugin to all four CI providers

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,7 +4,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     command: |
       aspect --version
       aspect version
@@ -66,7 +66,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -182,7 +182,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -227,7 +227,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 20
     retry:
       automatic:
@@ -243,7 +243,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -261,7 +261,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -277,7 +277,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -302,7 +302,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -318,7 +318,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -344,7 +344,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -373,7 +373,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 20
     retry:
       automatic:
@@ -418,7 +418,7 @@ steps:
     agents:
       queue: aspect-default
     plugins:
-      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+      - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
     timeout_in_minutes: 10
     retry:
       automatic:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,6 +3,8 @@ steps:
     label: ":aspect: Workflows Runner Smoke Test"
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     command: |
       aspect --version
       aspect version
@@ -63,6 +65,8 @@ steps:
     label: ":aspect: AXL Tests"
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -177,6 +181,8 @@ steps:
     label: ":bazel: bazelrc e2e (no server restart)"
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -220,6 +226,8 @@ steps:
       - pre-build
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 20
     retry:
       automatic:
@@ -234,6 +242,8 @@ steps:
       - pre-build
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -250,6 +260,8 @@ steps:
       - pre-build
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -264,6 +276,8 @@ steps:
       - pre-build
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -287,6 +301,8 @@ steps:
     label: ":aspect: Build Task"
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -301,6 +317,8 @@ steps:
     label: ":aspect: Test Task"
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -325,6 +343,8 @@ steps:
     label: ":aspect: Test Task – new flags"
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 10
     retry:
       automatic:
@@ -352,6 +372,8 @@ steps:
     label: ":aspect: Lint Task"
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 20
     retry:
       automatic:
@@ -395,6 +417,8 @@ steps:
         allow_failure: true
     agents:
       queue: aspect-default
+    plugins:
+      - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
     timeout_in_minutes: 10
     retry:
       automatic:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  setup-aspect: aspect-build/setup-aspect@2026.26.7
 # Manual break-glass override for `aspect delivery`. Settable via the
 # CircleCI "Trigger Pipeline" UI or API; default empty means normal
 # selective delivery on every other build.
@@ -48,6 +50,7 @@ jobs:
       - run:
           name: Bootstrap
           command: .aspect/bootstrap.sh
+      - setup-aspect/setup
       - run:
           name: Build Task (ASPECT_DEBUG=1)
           command: ASPECT_DEBUG=1 aspect build --task:name build-cci-debug
@@ -63,6 +66,7 @@ jobs:
       - run:
           name: Bootstrap
           command: .aspect/bootstrap.sh
+      - setup-aspect/setup
       - run:
           name: Test Task (ASPECT_DEBUG=1)
           command: ASPECT_DEBUG=1 aspect test --task:name test-cci-debug
@@ -78,6 +82,7 @@ jobs:
       - run:
           name: Bootstrap
           command: .aspect/bootstrap.sh
+      - setup-aspect/setup
       - run:
           name: Lint Task (ASPECT_DEBUG=1)
           command: |
@@ -103,6 +108,7 @@ jobs:
       - run:
           name: Bootstrap
           command: .aspect/bootstrap.sh
+      - setup-aspect/setup
       - run:
           name: Buildifier Task (ASPECT_DEBUG=1)
           command: ASPECT_DEBUG=1 aspect buildifier --task:name buildifier-cci-debug
@@ -118,6 +124,7 @@ jobs:
       - run:
           name: Bootstrap
           command: .aspect/bootstrap.sh
+      - setup-aspect/setup
       # Starlark patterns are handled by buildifier-task; ignore them here so
       # the two steps don't do duplicate work.
       - run:
@@ -135,6 +142,7 @@ jobs:
       - run:
           name: Bootstrap
           command: .aspect/bootstrap.sh
+      - setup-aspect/setup
       - run:
           name: Gazelle Task (ASPECT_DEBUG=1)
           command: ASPECT_DEBUG=1 aspect gazelle --task:name gazelle-cci-debug
@@ -153,6 +161,7 @@ jobs:
       - run:
           name: Bootstrap
           command: .aspect/bootstrap.sh
+      - setup-aspect/setup
       # `--config=pure_go` is required on Linux: toolchains_llvm_bootstrapped's
       # lld can't accept Go's non-PIC relocations on x86_64. See .bazelrc.
       - run:
@@ -172,6 +181,7 @@ jobs:
       - run:
           name: Bootstrap
           command: .aspect/bootstrap.sh
+      - setup-aspect/setup
       - run:
           name: Delivery Task (ASPECT_DEBUG=1)
           command: ASPECT_DEBUG=1 aspect delivery --task:name delivery-cci-debug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  setup-aspect: aspect-build/setup-aspect@2026.26.7
+  setup-aspect: aspect-build/setup-aspect@2026.26.8
 # Manual break-glass override for `aspect delivery`. Settable via the
 # CircleCI "Trigger Pipeline" UI or API; default empty means normal
 # selective delivery on every other build.

--- a/.github/workflows/build_release_artifacts.yaml
+++ b/.github/workflows/build_release_artifacts.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || '' }}
           fetch-depth: 0 # need to see tags (https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches)
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
           disk-cache: ${{ github.workflow }}

--- a/.github/workflows/build_release_artifacts.yaml
+++ b/.github/workflows/build_release_artifacts.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || '' }}
           fetch-depth: 0 # need to see tags (https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches)
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
           disk-cache: ${{ github.workflow }}

--- a/.github/workflows/ci-workflows-delivery.yaml
+++ b/.github/workflows/ci-workflows-delivery.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Bootstrap
         if: inputs.prebuild_run_id == ''
         run: .aspect/bootstrap.sh
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Delivery Task
@@ -89,7 +89,7 @@ jobs:
       - name: Bootstrap
         if: inputs.prebuild_run_id == ''
         run: .aspect/bootstrap.sh
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Delivery Task (ASPECT_DEBUG=1)

--- a/.github/workflows/ci-workflows-delivery.yaml
+++ b/.github/workflows/ci-workflows-delivery.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Bootstrap
         if: inputs.prebuild_run_id == ''
         run: .aspect/bootstrap.sh
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Delivery Task
@@ -89,7 +89,7 @@ jobs:
       - name: Bootstrap
         if: inputs.prebuild_run_id == ''
         run: .aspect/bootstrap.sh
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Delivery Task (ASPECT_DEBUG=1)

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -37,7 +37,7 @@ jobs:
       # via bootstrap.sh; no point installing a launcher we'd immediately
       # shadow. aspect-api-token is also omitted: auth login would run
       # before any `aspect` binary exists.
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
       - name: Pre-build CLI
@@ -112,7 +112,7 @@ jobs:
       # run before setup-aspect. That order also lets setup-aspect's
       # built-in `aspect auth login` find the prebuilt `aspect` on PATH.
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -164,7 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -184,7 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -197,7 +197,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -228,7 +228,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -241,7 +241,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -254,7 +254,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -267,7 +267,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task
@@ -279,7 +279,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task (ASPECT_DEBUG=1)
@@ -291,7 +291,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test Task
@@ -303,7 +303,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test Task (ASPECT_DEBUG=1)
@@ -327,7 +327,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -344,7 +344,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -390,7 +390,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -419,7 +419,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Cache Diff Task
@@ -431,7 +431,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Cache Diff Task (ASPECT_DEBUG=1)
@@ -448,7 +448,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Runner smoke test
@@ -519,7 +519,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - uses: ./.github/actions/build-dev-launcher
@@ -539,7 +539,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - uses: ./.github/actions/build-dev-launcher
@@ -626,7 +626,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test Task — new flags

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -37,7 +37,7 @@ jobs:
       # via bootstrap.sh; no point installing a launcher we'd immediately
       # shadow. aspect-api-token is also omitted: auth login would run
       # before any `aspect` binary exists.
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
       - name: Pre-build CLI
@@ -112,7 +112,7 @@ jobs:
       # run before setup-aspect. That order also lets setup-aspect's
       # built-in `aspect auth login` find the prebuilt `aspect` on PATH.
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -164,7 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -184,7 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -197,7 +197,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -228,7 +228,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -241,7 +241,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -254,7 +254,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -267,7 +267,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task
@@ -279,7 +279,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task (ASPECT_DEBUG=1)
@@ -291,7 +291,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test Task
@@ -303,7 +303,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test Task (ASPECT_DEBUG=1)
@@ -327,7 +327,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -344,7 +344,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -390,7 +390,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           launcher-install: false
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
@@ -419,7 +419,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Cache Diff Task
@@ -431,7 +431,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Cache Diff Task (ASPECT_DEBUG=1)
@@ -448,7 +448,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Runner smoke test
@@ -519,7 +519,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - uses: ./.github/actions/build-dev-launcher
@@ -539,7 +539,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - uses: ./.github/actions/build-dev-launcher
@@ -626,7 +626,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test Task — new flags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.5
+
 workflow:
   rules:
     # Run for everything except tag pushes
@@ -27,6 +30,7 @@ pre-build:
 build-task:
   stage: CI
   needs: [pre-build]
+  extends: .setup-aspect
   tags:
     - aspect-workflows
     - aspect-default
@@ -37,6 +41,7 @@ build-task:
 test-task:
   stage: CI
   needs: [pre-build]
+  extends: .setup-aspect
   tags:
     - aspect-workflows
     - aspect-default
@@ -47,6 +52,7 @@ test-task:
 lint-task:
   stage: CI
   needs: [pre-build]
+  extends: .setup-aspect
   tags:
     - aspect-workflows
     - aspect-default
@@ -64,6 +70,7 @@ lint-task:
 buildifier-task:
   stage: CI
   needs: [pre-build]
+  extends: .setup-aspect
   tags:
     - aspect-workflows
     - aspect-default
@@ -74,6 +81,7 @@ buildifier-task:
 format-task:
   stage: CI
   needs: [pre-build]
+  extends: .setup-aspect
   tags:
     - aspect-workflows
     - aspect-default
@@ -86,6 +94,7 @@ format-task:
 gazelle-task:
   stage: CI
   needs: [pre-build]
+  extends: .setup-aspect
   tags:
     - aspect-workflows
     - aspect-default
@@ -101,6 +110,7 @@ gazelle-task:
 gazelle-from-source-task:
   stage: CI
   needs: [pre-build]
+  extends: .setup-aspect
   tags:
     - aspect-workflows
     - aspect-default
@@ -111,6 +121,7 @@ gazelle-from-source-task:
 delivery-task:
   stage: CI
   needs: [pre-build]
+  extends: .setup-aspect
   tags:
     - aspect-workflows
     - aspect-default

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,5 @@
 include:
-  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.5
-
+  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.6
 workflow:
   rules:
     # Run for everything except tag pushes


### PR DESCRIPTION
## Summary

Updates the `setup-aspect` integration across all four CI providers in this repo's own pipelines:

- **GitHub Actions** — bump the 28 `setup-aspect` pins from v2026.23.2 → **v2026.26.7**.
- **Buildkite** — add the `setup-aspect` plugin (**v2026.26.6**) to each task step (it was GHA-only before).
- **CircleCI** — add the orb (**2026.26.8**) + `setup-aspect/setup` after each `.aspect/bootstrap.sh` step.
- **GitLab** — add the component (**2026.26.6**) via `extends: .setup-aspect` on each task job.

The plugin runs after the bootstrap that builds the CLI from source, so its `aspect ci bazelrc` uses the freshly-built CLI. The pure cache-upload `pre-build` job is intentionally left without the plugin.

## Changes are visible to end-users

No — this is the aspect-cli repo's own CI configuration.

## Test plan

- YAML parses for all four configs.
- The CI runs on this PR exercise the updated pipelines across all four providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
