### PR TITLE
feat(warming): runner metadata, health checks + status surfaces on `aspect ci warming`

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -35,6 +35,7 @@ load("@aspect//private/lib/runner_job_history_test.axl", "runner_job_history_tes
 load("@aspect//private/lib/sandbox_recovery_test.axl", "sandbox_recovery_tests")
 load("@aspect//private/lib/tar_test.axl", "tar_tests")
 load("@aspect//private/lib/tips_test.axl", "tips_tests")
+load("@aspect//private/lib/warming_results_test.axl", "warming_template_snapshot_tests")
 load("@aspect//private/lib/wrapper_test.axl", "wrapper_tests")
 load("@aspect//tips.axl", "TASK_SCREENS", "TIP_SUGGESTION", "TIP_TEMPLATE_RAW", "add_tip")
 load("@aspect//traits.axl", "BazelTrait", "DeliveryTrait", "LintTrait", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixInfo", "ReproFixSuggestion", "TaskLifecycleTrait", "TaskUpdate", "repro_fix_replace")
@@ -373,6 +374,10 @@ def config(ctx: ConfigContext):
     # gazelle_results template snapshots.
     # Run with: aspect dev test-gazelle-template-snapshots
     ctx.tasks.add(gazelle_template_snapshot_tests)
+
+    # warming_results template snapshots.
+    # Run with: aspect dev test-warming-template-snapshots
+    ctx.tasks.add(warming_template_snapshot_tests)
 
     # Buildkite annotations: snapshots the annotate body per kind × status.
     # Run with: aspect dev test-bk-annotation-snapshots

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -4,7 +4,7 @@ A default 'build' task that wraps a 'bazel build' command.
 
 load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("./private/lib/artifacts.axl", "artifacts")
-load("./private/lib/bazel_flags.axl", "announce_bazel_args")
+load("./private/lib/bazel_flags.axl", "announce_bazel_args", "bazel_flag_args")
 load("./private/lib/bazel_runner.axl", "run_bazel_task")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "TaskLifecycleTrait")
@@ -27,14 +27,6 @@ build = task(
             default = "",
             description = "Read newline-separated target patterns from this file instead of the command line (mirrors Bazel's --target_pattern_file). Blank lines and `#` comments are ignored. Cannot be combined with command-line target patterns.",
         ),
-        "bazel_flags": args.string_list(
-            description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
-            long = "bazel-flag",
-        ),
-        "bazel_startup_flags": args.string_list(
-            description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
-            long = "bazel-startup-flag",
-        ),
         "bazel_retry_attempts": args.int(
             default = DEFAULT_BAZEL_RETRY_ATTEMPTS,
             description = BAZEL_RETRY_ATTEMPTS_DESCRIPTION,
@@ -51,7 +43,7 @@ build = task(
             default = False,
             description = "Cancel any running Bazel invocation before starting the build.",
         ),
-    } | announce_bazel_args("the build") | repro_flavor_args(),
+    } | bazel_flag_args("the build") | announce_bazel_args("the build") | repro_flavor_args(),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
+++ b/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
@@ -61,6 +61,7 @@ load("@std//time.axl", "time")
 load(
     "./private/lib/bazel_flags.axl",
     "announce_bazel_args",
+    "bazel_flag_args",
     "resolve_bazel_announce",
     "resolve_flags",
     "resolve_startup_flags",
@@ -445,14 +446,6 @@ diff = task(
                 "it and pipe stdout."
             ),
         ),
-        "bazel_flags": args.string_list(
-            description = "Additional Bazel flags forwarded to the probe/build (e.g. --bazel-flag=--config=ci). Repeat to pass multiple.",
-            long = "bazel-flag",
-        ),
-        "bazel_startup_flags": args.string_list(
-            description = "Additional Bazel startup flags. Repeat to pass multiple. Note: changing startup flags restarts the Bazel server.",
-            long = "bazel-startup-flag",
-        ),
         "targets": args.positional(
             minimum = 1,
             maximum = 512,
@@ -463,5 +456,5 @@ diff = task(
                 "workspace. Intersected with `tests(<patterns>)`."
             ),
         ),
-    } | announce_bazel_args("the cache-diff probe"),
+    } | bazel_flag_args("the cache-diff probe") | announce_bazel_args("the cache-diff probe"),
 )

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -18,7 +18,7 @@ Usage:
 load("@aspect//bazel.axl", "BazelTrait")
 load("@std//time.axl", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
-load("./private/lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
+load("./private/lib/bazel_flags.axl", "announce_bazel_args", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
@@ -696,14 +696,6 @@ format = task(
             long = "formatter-arg-for-tree-walk",
             description = "Extra positional arguments appended to the formatter binary's argv only when no positional files would otherwise reach it — i.e. when `aspect format` is invoked without explicit file args AND change-detection produced no file list (typically `--scope=all`, but also `--scope=changed` runs where the change-detection source returned no matches or degraded to scope-all). Appended after the (empty) file list and after `formatter_args`. Designed for bare formatter binaries that need an explicit tree-walk flag to do anything useful when the task delegates discovery to them. Example: `formatter_args_for_tree_walk = [\"-r\", \".\"]` for `@buildifier_prebuilt//buildifier`. Has no effect when the formatter receives at least one file (positionally or via `--scope=changed`), so it cannot accidentally turn a per-file invocation into a whole-tree rewrite. Wrapper targets like `format_multirun` from rules_lint walk on their own and don't need this.",
         ),
-        "bazel_flags": args.string_list(
-            long = "bazel-flag",
-            description = "Additional Bazel flags forwarded to the formatter build. Repeat the flag to pass multiple — e.g. `--bazel-flag=--config=ci --bazel-flag=--keep_going`.",
-        ),
-        "bazel_startup_flags": args.string_list(
-            long = "bazel-startup-flag",
-            description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
-        ),
         # Positional file list: when non-empty the formatter gets these directly
         # (change-detection + --scope/--base-ref/--merge-base/--include-/
         # --exclude-pattern skipped). Empty → change-detection via --scope.
@@ -714,7 +706,7 @@ format = task(
             maximum = 4096,
             minimum = 0,
         ),
-    } | announce_bazel_args("the formatter build") | repro_flavor_args(include_fix = True),
+    } | bazel_flag_args("the formatter build") | announce_bazel_args("the formatter build") | repro_flavor_args(include_fix = True),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -84,7 +84,7 @@ https://github.com/bazel-contrib/bazel-gazelle#lazy-indexing-in-fix-and-update
 load("@aspect//bazel.axl", "BazelTrait")
 load("@std//time.axl", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
-load("./private/lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
+load("./private/lib/bazel_flags.axl", "announce_bazel_args", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
@@ -735,15 +735,7 @@ gazelle = task(
             maximum = 4096,
             description = "Directories gazelle should update BUILD files in. When empty (default), gazelle considers every directory in the workspace. Combine with --scope=changed to take the intersection with directories that contain changed files. Useful for scoping to a sub-workspace within a monorepo. CAUTION: under --scope=changed, supplying narrow dirs intersection-filters the derived set. Changed dirs that fall outside the listed roots are dropped, so the BUILD updates those changes would have triggered are silently missed. NOTE: positional dirs only narrow the BUILD-regeneration step. Under gazelle's default `-index=all`, gazelle still traverses every workspace directory, parses every BUILD, and re-determines target exports (often re-parsing source) repo-wide. Pair with `--gazelle-flag=-index=lazy` (plus `# gazelle:go_search` / `# gazelle:proto_search` directives) to also narrow that traversal + parse + indexing work. Optionally also pass `--gazelle-flag=-r=false` to skip recursion on top of that, but some gazelle language extensions are incompatible with non-recursive mode — test against your plugin set first. See https://github.com/bazel-contrib/bazel-gazelle#lazy-indexing-in-fix-and-update.",
         ),
-        "bazel_flags": args.string_list(
-            description = "Additional Bazel flags forwarded to the gazelle build. Repeat the flag to pass multiple — e.g. `--bazel-flag=--config=ci --bazel-flag=--keep_going`.",
-            long = "bazel-flag",
-        ),
-        "bazel_startup_flags": args.string_list(
-            description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
-            long = "bazel-startup-flag",
-        ),
-    } | announce_bazel_args("the gazelle build") | repro_flavor_args(include_fix = True),
+    } | bazel_flag_args("the gazelle build") | announce_bazel_args("the gazelle build") | repro_flavor_args(include_fix = True),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -19,7 +19,7 @@ Usage:
 load("@aspect//bazel.axl", "BazelTrait")
 load("@std//time.axl", "sleep", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
-load("./private/lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
+load("./private/lib/bazel_flags.axl", "announce_bazel_args", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
@@ -1056,14 +1056,6 @@ lint = task(
             long = "aspect",
             description = "Bazel aspect label(s) to apply for linting (e.g. //tools/lint:linters.bzl%eslint). Repeat the flag to run multiple aspects in a single invocation. Aspects may also be supplied via `--bazel-flag=--aspects=…` or a bazelrc `--config`; at least one rules_lint aspect must reach Bazel one way or another.",
         ),
-        "bazel_flags": args.string_list(
-            description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
-            long = "bazel-flag",
-        ),
-        "bazel_startup_flags": args.string_list(
-            description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
-            long = "bazel-startup-flag",
-        ),
         "fix": args.boolean(
             description = (
                 "Apply auto-fixes from rules_lint to the working tree. " +
@@ -1105,7 +1097,7 @@ lint = task(
             default = ["..."],
             description = "Bazel target patterns to lint. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory. Pass multiple patterns to combine includes and excludes; when any pattern is hyphen-led, separate them from flags with `--` (e.g. `aspect lint -- //... -//experimental/...`).",
         ),
-    } | announce_bazel_args("the lint build") | repro_flavor_args(include_fix = True),
+    } | bazel_flag_args("the lint build") | announce_bazel_args("the lint build") | repro_flavor_args(include_fix = True),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -9,7 +9,7 @@ helpers directly and print what *would* be sent to BK for each scenario.
 
 Coverage:
   - Each task kind (bazel_results, lint_results, delivery_results,
-    format_results, gazelle_results)
+    format_results, gazelle_results, warming_results)
   - Each terminal status (passed, failed)
   - Style selection edge cases: soft-lint passing with warnings, delivery
     all-skipped, delivery all-failed, soft-format passing with files.
@@ -63,6 +63,11 @@ load(
     lint_render_check_output = "render_check_output",
 )
 load("../lib/result_text.axl", "severity_for_status")
+load(
+    "../lib/warming_results.axl",
+    warming_init_data = "init_data",
+    warming_render_check_output = "render_check_output",
+)
 
 # ─── Test harness ─────────────────────────────────────────────────────────────
 
@@ -116,7 +121,26 @@ _RENDERERS = {
     "delivery_results": delivery_render_check_output,
     "format_results": format_render_check_output,
     "gazelle_results": gazelle_render_check_output,
+    "warming_results": warming_render_check_output,
 }
+
+def _make_warming_complete():
+    r = warming_init_data()
+    r["start_time_ms"] = 1744630000000
+    r["finish_time_ms"] = 1744630004500
+    r["bazel"]["wall_time_ms"] = 4500
+    r["bazel"]["targets_total"] = 1284
+    r["warming"]["on_runner"] = True
+    r["warming"]["cleaned"] = True
+    r["warming"]["archive_attempted"] = True
+    r["warming"]["archive_succeeded"] = True
+    return r
+
+def _make_warming_archive_failed():
+    r = _make_warming_complete()
+    r["warming"]["archive_succeeded"] = False
+    r["warming"]["archive_error"] = "the warming archiver exited with code 3"
+    return r
 
 def _test_impl(ctx):
     scenarios = [
@@ -150,6 +174,8 @@ def _test_impl(ctx):
         # Empty subject (query-driven task with no explicit target list): the
         # title omits the subject entirely — there is no synthetic placeholder.
         ("22. build-passed (empty subject)", "bazel_results", _make_build_passed(), "passed", True, "", "build"),
+        ("23. warming-complete", "warming_results", _make_warming_complete(), "passed", True, "//...", "warming"),
+        ("24. warming-archive-failed", "warming_results", _make_warming_archive_failed(), "failed", True, "//...", "warming"),
     ]
 
     sep = "=" * 70

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags.axl
@@ -10,6 +10,10 @@ enforce this with a clear error if a task forgets):
   - `announce_bazel_version`  (read by `resolve_bazel_announce`)
   - `announce_bazel_command`  (read by `resolve_bazel_announce`)
 
+Declare the first two via `bazel_flag_args(<noun>)` and the three
+`announce_bazel_*` via `announce_bazel_args(<noun>)` so every task carries
+the same canonical descriptions.
+
 The three `announce_bazel_*` args are `"auto" | "true" | "false"`
 enums; `resolve_announce` maps `"auto"` to on-under-CI. `_rc` gates the
 parsed-rc disclosure here; `_version` / `_command` gate the per-spawn
@@ -115,6 +119,28 @@ def announce_bazel_args(rc_phrase):
             values = enum,
             long = "announce-bazel-command",
             description = "Print the exact bazel command line before each bazel spawn. %s" % _ANNOUNCE_AUTO,
+        ),
+    }
+
+def bazel_flag_args(build_phrase: str) -> dict:
+    """The `bazel_flags` / `bazel_startup_flags` CLI args every Bazel-spawning
+    task declares, with one canonical description each.
+
+    Returns a dict to splat into a task's `args = {...}`, mirroring
+    `announce_bazel_args`. Identical across tasks except for the noun naming
+    the bazel invocation — pass `build_phrase` as the thing being run, e.g.
+    `"the build"`, `"the test invocation"`, `"the gazelle build"`. The resolved
+    values are read back by `resolve_flags` / `resolve_startup_flags` /
+    `setup_bazel_command`.
+    """
+    return {
+        "bazel_flags": args.string_list(
+            long = "bazel-flag",
+            description = "Additional Bazel flags forwarded to %s (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple." % build_phrase,
+        ),
+        "bazel_startup_flags": args.string_list(
+            long = "bazel-startup-flag",
+            description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
         ),
     }
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
@@ -56,6 +56,11 @@ load(
     lint_render_check_output = "render_check_output",
 )
 load("./log_snippet.axl", "SnippetOptions")
+load(
+    "./warming_results.axl",
+    warming_init_data = "init_data",
+    warming_render_check_output = "render_check_output",
+)
 
 # Dispatch table: `task_update.kind` → struct(init, render). Adding a
 # new kind: implement `init_data()` + `render_check_output()` in a
@@ -86,6 +91,10 @@ RENDERERS = {
         init = gazelle_init_data,
         render = gazelle_render_check_output,
     ),
+    "warming_results": struct(
+        init = warming_init_data,
+        render = warming_render_check_output,
+    ),
 }
 
 # Used before the first `task_update` has fired (initial / "running"
@@ -97,6 +106,7 @@ _TASK_KIND_DEFAULTS = {
     "delivery": "delivery_results",
     "format": "format_results",
     "gazelle": "gazelle_results",
+    "warming": "warming_results",
 }
 
 def renderer_for_kind(kind):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results.axl
@@ -1,0 +1,206 @@
+"""Warming task status-check rendering.
+
+Parallel to `format_results.axl` / `gazelle_results.axl` for the `warming`
+task (`aspect ci warming`). Warming runs a real `bazel build --nobuild`, so it
+streams BES events into `data["bazel"]` like build/test and reuses the shared
+summary + details renderers (Targets / Build Metrics / Invocation / Runner
+metadata / Task timing). On top of that it surfaces the two warming-specific
+steps the shared renderer doesn't model:
+
+  - the prior-state cleanup under the runner's storage mount, and
+  - the warming-archive upload (the actual point of the task) — attempted only
+    on an Aspect Workflows runner; off-runner it's reported as skipped.
+
+Public API (matches the bazel_results / format_results interface so
+GithubStatusChecks and BuildkiteAnnotations dispatch by `task_update.kind`):
+
+  init_data()                                  → dict
+  render_check_output(ctx, data, status, …)    → {title, summary, text}
+  conclusion(status, data)                     → str
+"""
+
+load(
+    "./bazel_results.axl",
+    "REPRO_COMMANDS_BLOCK",
+    "SHARED_DETAILS_BODY_TEMPLATE",
+    "TIPS_BLOCK",
+    "active_phase_data",
+    "build_details_data",
+    "build_summary_data",
+    "format_run_date",
+    bazel_init_data = "init_data",
+)
+load("./result_text.axl", "emoji_for_status")
+
+_DETAILS_LIMIT = 65000  # GitHub check-run `output.text` hard limit
+
+def init_data():
+    """Return a fresh warming-data dict.
+
+    Starts from bazel_results.init_data() so process_event can populate the
+    full bazel state the shared summary + details renderers consume, plus the
+    warming-specific fields layered on top.
+    """
+    r = bazel_init_data()
+    r["warming"] = {
+        "cleaned": False,  # prior storage-mount state was cleaned
+        "on_runner": False,  # running on an Aspect Workflows runner
+        "build_failed": False,  # the `bazel build --nobuild` populate step failed
+        "archive_attempted": False,  # the warming archiver was invoked
+        "archive_succeeded": False,  # the archiver exited 0
+        "archiver_path": "",  # resolved path of the archiver binary
+        "archive_error": "",  # non-empty when the archive step failed
+        "archive_skipped_reason": "",  # why the archive step was skipped (off-runner)
+    }
+    return r
+
+def _title(data, status, target_pattern = "", task_kind = ""):
+    """Compute the check-run title.
+
+    "✅ warming //... · Warming complete"
+    "✅ warming //... · Caches populated (archive skipped)"
+    "❌ warming //... · Archive upload failed"
+    "❌ warming //... · Populate failed"
+    "🔄 warming //... · Running..."
+    """
+    display = emoji_for_status(status) + " " + (task_kind or "warming")
+    base = display + ((" " + target_pattern) if target_pattern else "")
+    w = data.get("warming", {}) or {}
+
+    if status == "running":
+        return base + " · Running..."
+    if status == "failing":
+        return base + " · Failing..."
+    if status == "aborted":
+        return base + " · Aborted"
+    if w.get("build_failed"):
+        return base + " · Populate failed"
+    if w.get("archive_error"):
+        return base + " · Archive upload failed"
+    if status == "failed":
+        return base + " · Failed"
+    if w.get("archive_succeeded"):
+        return base + " · Warming complete"
+    if w.get("archive_skipped_reason"):
+        return base + " · Caches populated (archive skipped)"
+    return base + " · Passed"
+
+def conclusion(status, data):
+    """Terminal bookend conclusion. See `lifecycle.task_update` for the
+    contract; returns the trailing `· <conclusion>` text, or "".
+    """
+    w = data.get("warming", {}) or {}
+    if w.get("build_failed"):
+        return "Cache populate failed"
+    if w.get("archive_error"):
+        return "Archive upload failed"
+    if status == "failed" or status == "failing":
+        return ""
+    if w.get("archive_succeeded"):
+        return "Caches populated and archived"
+    if w.get("archive_skipped_reason"):
+        return "Caches populated (archive skipped)"
+    if status == "passed":
+        return "Caches populated"
+    return ""
+
+_SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
+{% for item in row %}{{ item.icon }} {{ item.value }}{% if not loop.last %} · {% endif %}{% endfor %}{% if not loop.last %}  {% endif %}
+{%- endfor %}{% endif %}
+{% if config_items %}
+:gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
+:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
+
+_DETAILS_TEMPLATE = """{% if is_running %}
+> 🔄 Warming task in progress...
+
+{% elif is_aborted %}
+> ⚠️ Warming task was aborted before completing. Check the task log for details.
+
+{% elif build_failed %}
+> ❌ The `bazel build --nobuild` cache-populate step failed. Check the task log for details.
+
+{% elif archive_error %}
+> ❌ The warming archive upload failed: {{ archive_error }}
+
+{% else %}
+### ✅ {% if archive_succeeded %}Warming complete{% else %}Caches populated{% endif %}
+
+{% if cleaned %}- 🧹 Cleaned prior Bazel state under the runner storage mount.
+{% endif %}- 🔨 Populated the repository, output, and Bazel caches (`bazel build --nobuild`).
+{% if archive_succeeded %}- 📦 Uploaded the warming archive to the warming bucket.
+{% elif archive_skipped_reason %}- ℹ️ Archive upload skipped — {{ archive_skipped_reason }}.
+{% endif %}
+{% endif %}
+""" + REPRO_COMMANDS_BLOCK + SHARED_DETAILS_BODY_TEMPLATE
+
+def _build_details_data(data, status):
+    w = data.get("warming", {}) or {}
+    return {
+        "is_running": status == "running",
+        "is_aborted": status == "aborted",
+        "build_failed": bool(w.get("build_failed")),
+        "archive_error": w.get("archive_error", "") or "",
+        "archive_succeeded": bool(w.get("archive_succeeded")),
+        "archive_skipped_reason": w.get("archive_skipped_reason", "") or "",
+        "cleaned": bool(w.get("cleaned")),
+    }
+
+def render_check_output(ctx, data, status, render_ctx, links, templates = None, metadata_keys = None, snippet_options = None, max_snippets = 0):
+    """Render title, summary, and text for a warming check run.
+
+    Matches the bazel_results / format_results interface so GithubStatusChecks
+    and BuildkiteAnnotations can dispatch by task_update.kind interchangeably.
+    snippet_options/max_snippets are accepted for parity and ignored.
+    """
+    t = templates or {}
+    run_date = format_run_date(ctx, data.get("start_time_ms", 0))
+    summary_data = build_summary_data(
+        ctx,
+        data,
+        status,
+        render_ctx,
+        links,
+        metadata_keys,
+        run_date = run_date,
+    )
+    finish_date = format_run_date(ctx, data.get("finish_time_ms", 0))
+    shared_data = build_details_data(
+        data,
+        links,
+        render_ctx = render_ctx,
+        status = status,
+        start_date = run_date,
+        finish_date = finish_date,
+        std = ctx.std,
+        task_phases = ctx.task.phases(),
+        task_active = active_phase_data(ctx),
+        task_elapsed_ms = ctx.task.elapsed_ms,
+        include_bazel_targets = True,
+    )
+    details_data = dict(shared_data)
+    details_data.update(_build_details_data(data, status))
+
+    summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
+    details_tmpl = t.get("details") or _DETAILS_TEMPLATE
+
+    summary_text = ctx.template.jinja2(summary_tmpl, data = summary_data)
+    details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+
+    # Hard cap on the details body (GitHub limit). The warming body is bounded
+    # by construction (no per-file list), so truncate rather than cascade.
+    if len(details_text) > _DETAILS_LIMIT:
+        details_text = details_text[:_DETAILS_LIMIT]
+
+    task_kind = render_ctx.get("task_kind", "") if render_ctx else ""
+    target_pattern = render_ctx.get("subject", "") if render_ctx else ""
+    return {
+        "title": _title(
+            data,
+            status,
+            target_pattern = target_pattern,
+            task_kind = task_kind,
+        ),
+        "summary": summary_text,
+        "text": details_text,
+    }

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results_test.axl
@@ -1,0 +1,182 @@
+"""Snapshot tests for `lib/warming_results.axl` template rendering.
+
+Run with:
+  aspect dev test-warming-template-snapshots
+
+Scenarios:
+  1. complete           — cleaned + populated + archived (on a Workflows runner)
+  2. archive-skipped    — populated, archive skipped (off a Workflows runner)
+  3. populate-failed    — `bazel build --nobuild` failed
+  4. archive-failed     — archiver invoked but exited non-zero
+  5. archiver-missing   — archiver binary not found at the resolved path
+  6. in-progress        — status=running (populate phase, placeholder body)
+  7. aborted            — bazel aborted mid-populate
+  8. metadata-all       — GitHubStatusChecksTrait.metadata_keys = ["*"]
+
+Body-content invariant (asserted in the loop): the "Warming task in progress…"
+placeholder renders IFF status == "running".
+"""
+
+load("./warming_results.axl", "init_data", "render_check_output")
+
+def _make_base():
+    """Common metadata / runner info shared by all scenarios."""
+    r = init_data()
+    r["bazel"]["invocation_id"] = ""
+    r["sink_invocation_id"] = ""
+    r["start_time_ms"] = 1744630000000
+    r["finish_time_ms"] = 1744630003200
+    r["bazel"]["wall_time_ms"] = 3200
+    r["target_pattern"] = "//..."
+    r["bazel"]["workspace_status"] = {
+        "BUILD_USER": "aspect-runner",
+        "BUILD_HOST": "ip-10-0-86-10",
+        "BUILD_TIMESTAMP": "1776727956",
+    }
+    r["bazel"]["metadata"] = {
+        "BRANCH": "main",
+        "BRANCH_NAME": "main",
+        "COMMIT_SHA": "abc123def456789abcdef",
+        "COMMIT_MESSAGE": "chore: warm the caches",
+        "COMMIT_AUTHOR": "Greg Magolan <greg@aspect.build>",
+        "COMMIT_AUTHOR_NAME": "Greg Magolan",
+        "COMMIT_AUTHOR_EMAIL": "greg@aspect.build",
+        "COMMIT_TIMESTAMP": "2026-04-28 10:12:34 -0700",
+        "USER": "Greg Magolan",
+        "CI_HOST": "GITHUB",
+        "VCS": "GITHUB",
+        "REPO_OWNER": "aspect-build",
+        "REPO_NAME": "silo",
+        "BUILD_NUMBER": "12345",
+        "RUN_TYPE": "PULL_REQUEST",
+        "ASPECT_TASK_NAME": "Warming",
+        "ASPECT_TASK_ID": "warming",
+        "BUILD_URL": "https://github.com/aspect-build/silo/actions/runs/12345",
+    }
+
+    # A populated build records some targets so the shared "Bazel targets"
+    # section renders like a real warming run.
+    r["bazel"]["targets_total"] = 1284
+    return r
+
+def _make_complete():
+    r = _make_base()
+    r["warming"]["on_runner"] = True
+    r["warming"]["cleaned"] = True
+    r["warming"]["archive_attempted"] = True
+    r["warming"]["archive_succeeded"] = True
+    r["warming"]["archiver_path"] = "/etc/aspect/workflows/bin/warming_archive"
+    return r
+
+def _make_archive_skipped():
+    r = _make_base()
+    r["warming"]["on_runner"] = False
+    r["warming"]["cleaned"] = False
+    r["warming"]["archive_skipped_reason"] = "not on an Aspect Workflows runner"
+    return r
+
+def _make_populate_failed():
+    r = _make_base()
+    r["warming"]["on_runner"] = True
+    r["warming"]["cleaned"] = True
+    r["warming"]["build_failed"] = True
+    return r
+
+def _make_archive_failed():
+    r = _make_base()
+    r["warming"]["on_runner"] = True
+    r["warming"]["cleaned"] = True
+    r["warming"]["archive_attempted"] = True
+    r["warming"]["archiver_path"] = "/etc/aspect/workflows/bin/warming_archive"
+    r["warming"]["archive_error"] = "the warming archiver exited with code 3"
+    return r
+
+def _make_archiver_missing():
+    r = _make_base()
+    r["warming"]["on_runner"] = True
+    r["warming"]["cleaned"] = True
+    r["warming"]["archive_attempted"] = True
+    r["warming"]["archiver_path"] = "/etc/aspect/workflows/bin/warming_archive"
+    r["warming"]["archive_error"] = "the warming archiver was not found at /etc/aspect/workflows/bin/warming_archive. Upgrade to the latest aspect-cli to enable warming: https://github.com/aspect-build/aspect-cli/releases"
+    return r
+
+def _render_ctx(task_kind = "warming"):
+    return {
+        "triggered_by": "Greg Magolan (pull_request)",
+        "subject": "//...",
+        "started_ms": 1744630000000,
+        "ended_ms": 1744630003200,
+        "progress": "",
+        "task_kind": task_kind,
+    }
+
+def _links(ci = "github"):
+    if ci == "buildkite":
+        ci_label = "Buildkite"
+        ci_url = "https://buildkite.com/aspect-build/silo/builds/12345/steps/canvas?sid=s1"
+    else:
+        ci_label = "GitHub Actions"
+        ci_url = "https://github.com/aspect-build/silo/actions/runs/12345/job/99"
+    return {
+        "ci_label": ci_label,
+        "ci_url": ci_url,
+        "aspect_url": "",
+        "results_base_url": "",
+        "artifacts_browse_url": "",
+        "artifact_urls": {},
+        "testlogs_label_urls": {},
+    }
+
+def _test_impl(ctx):
+    scenarios = [
+        # (label,                       data,                     status,    ci,          metadata_keys)
+        ("1. complete · GH", _make_complete(), "passed", "github", None),
+        ("2. archive-skipped · GH", _make_archive_skipped(), "passed", "github", None),
+        ("3. populate-failed · GH", _make_populate_failed(), "failed", "github", None),
+        ("4. archive-failed · BK", _make_archive_failed(), "failed", "buildkite", None),
+        ("5. archiver-missing · GH", _make_archiver_missing(), "failed", "github", None),
+        ("6. in-progress · GH", _make_base(), "running", "github", None),
+        ("7. aborted · GH", _make_base(), "aborted", "github", None),
+        ("8. complete · meta=*", _make_complete(), "passed", "github", ["*"]),
+    ]
+
+    sep = "=" * 70
+    errors = []
+
+    for (label, data, status, ci, metadata_keys) in scenarios:
+        rc = _render_ctx()
+        lk = _links(ci = ci)
+        out = render_check_output(ctx, data, status, rc, lk, metadata_keys = metadata_keys)
+        print(sep)
+        print("SCENARIO: " + label)
+        print(sep)
+        print("TITLE:    " + out["title"])
+        print("")
+        print("SUMMARY:")
+        print(out["summary"])
+        print("")
+        print("DETAILS (first 4000 chars):")
+        print(out["text"][:4000])
+        print("")
+
+        has_placeholder = "Warming task in progress" in out["text"]
+        if status == "running" and not has_placeholder:
+            errors.append("%s: status=running but body has no in-progress placeholder" % label)
+        if status != "running" and has_placeholder:
+            errors.append("%s: status=%s rendered the in-progress placeholder" % (label, status))
+
+    if errors:
+        for e in errors:
+            print("FAIL: " + e)
+        fail("Body-content invariant violations: %d" % len(errors))
+
+    print(sep)
+    print("All " + str(len(scenarios)) + " warming scenarios rendered without error.")
+    return 0
+
+warming_template_snapshot_tests = task(
+    kind = "test-warming-template-snapshots",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -3,7 +3,7 @@
 load("@aspect//bazel.axl", "BazelTrait")
 load("@std//time.axl", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
-load("./private/lib/bazel_flags.axl", "announce_bazel_args", "resolve_bazel_announce")
+load("./private/lib/bazel_flags.axl", "announce_bazel_args", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/environment.axl", "error")
@@ -165,14 +165,6 @@ run = task(
         "run_args": args.trailing_var_args(
             description = "Arguments forwarded to the target binary. Separate from `aspect run`'s own flags with `--`, e.g. `aspect run //foo:bar -- --binary-arg value`.",
         ),
-        "bazel_flags": args.string_list(
-            description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci --bazel-flag=--keep_going). Repeat the flag to pass multiple.",
-            long = "bazel-flag",
-        ),
-        "bazel_startup_flags": args.string_list(
-            description = "Additional Bazel startup flags (e.g. --bazel-startup-flag=--host_jvm_args=-Xmx2g). Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
-            long = "bazel-startup-flag",
-        ),
         "run_in": args.string(
             default = "",
             description = RUN_IN_DESCRIPTION + (
@@ -185,7 +177,7 @@ run = task(
                 "this flag as a no-op."
             ),
         ),
-    } | announce_bazel_args("the build"),
+    } | bazel_flag_args("the build") | announce_bazel_args("the build"),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -4,7 +4,7 @@ A default 'test' task that wraps a 'bazel test' command.
 
 load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("./private/lib/artifacts.axl", "artifacts")
-load("./private/lib/bazel_flags.axl", "announce_bazel_args")
+load("./private/lib/bazel_flags.axl", "announce_bazel_args", "bazel_flag_args")
 load("./private/lib/bazel_runner.axl", "run_bazel_task")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "TaskLifecycleTrait")
@@ -126,14 +126,6 @@ test = task(
             long = "coverage-tool-arg",
             description = "Argument forwarded to --coverage-tool. Repeat the flag to pass multiple. The `{report}` (or `{lcov}`) placeholder is replaced with the absolute path of the merged LCOV report. Example: `--coverage-tool=codecov --coverage-tool-arg=-f --coverage-tool-arg={report}`.",
         ),
-        "bazel_flags": args.string_list(
-            long = "bazel-flag",
-            description = "Additional Bazel flags forwarded to the test invocation (e.g. --bazel-flag=--config=ci --bazel-flag=--test_filter=foo). Repeat the flag to pass multiple.",
-        ),
-        "bazel_startup_flags": args.string_list(
-            long = "bazel-startup-flag",
-            description = "Additional Bazel startup flags. Repeat the flag to pass multiple. Note: changing startup flags restarts the Bazel server.",
-        ),
         "bazel_retry_attempts": args.int(
             default = DEFAULT_BAZEL_RETRY_ATTEMPTS,
             description = BAZEL_RETRY_ATTEMPTS_DESCRIPTION,
@@ -150,7 +142,7 @@ test = task(
             default = False,
             description = "Cancel any running Bazel invocation before starting the test.",
         ),
-    } | announce_bazel_args("the test") | repro_flavor_args(),
+    } | bazel_flag_args("the test invocation") | announce_bazel_args("the test") | repro_flavor_args(),
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -8,10 +8,32 @@ runner it then runs the warming archiver
 (`ASPECT_WORKFLOWS_RUNNER_WARMING_ARCHIVER`, defaulting to
 `/etc/aspect/workflows/bin/warming_archive`) to upload the populated caches to
 the warming bucket — so a CI workflow only needs to call `aspect ci warming`.
+
+Like every other task that calls Bazel, it resolves its flags through
+`setup_phase` (which folds in the Workflows runner metadata — the per-runner
+`--output_base`, repository cache, and identity header — and runs the
+`HealthCheckTrait` health checks before building). It is therefore not given an
+`--output-base` flag of its own; on a Workflows runner the output base comes
+from the runner metadata.
+
+The whole run surfaces as a single status check / Buildkite annotation
+(`kind = "warming_results"`, rendered by `private/lib/warming_results.axl`)
+spanning three phases — 🧹 clean, 🔨 populate, 📦 archive — so the check
+reflects the archive-upload outcome, not just the build. Off a Workflows runner
+the archive step is reported as skipped and the task still passes.
 """
 
-load("@aspect//traits.axl", "BazelTrait")
+load("@aspect//bazel.axl", "BazelTrait")
+load("@std//time.axl", "sleep_iter")
+load("./private/lib/artifacts.axl", "artifacts")
+load("./private/lib/bazel_flags.axl", "announce_bazel_args", "bazel_flag_args", "resolve_bazel_announce")
+load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
+load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/environment.axl", "error", "warn")
+load("./private/lib/health_check.axl", "HealthCheckTrait")
+load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
+load("./private/lib/tips.axl", "tips")
+load("./private/lib/warming_results.axl", warming_conclusion = "conclusion", warming_init_data = "init_data")
 
 ASPECT_CLI_RELEASES_URL = "https://github.com/aspect-build/aspect-cli/releases"
 
@@ -19,94 +41,231 @@ ASPECT_CLI_RELEASES_URL = "https://github.com/aspect-build/aspect-cli/releases"
 # ASPECT_WORKFLOWS_RUNNER_WARMING_ARCHIVER; falls back to its default location.
 _DEFAULT_WARMING_ARCHIVER = "/etc/aspect/workflows/bin/warming_archive"
 
-def _impl(ctx: TaskContext) -> int:
+_KIND = "warming_results"
+
+def _pick_status(data, had_failure, terminal):
+    """Lifecycle status for the warming surface. A recorded failure (build or
+    archive) → failed/failing; otherwise running while in-flight, passed at
+    the terminal."""
+    w = data.get("warming", {}) or {}
+    if data.get("bazel", {}).get("aborted"):
+        return "aborted"
+    if had_failure or w.get("build_failed") or w.get("archive_error"):
+        return "failed" if terminal else "failing"
+    return "passed" if terminal else "running"
+
+def _emit_final(ctx, lifecycle, data, exit_code):
+    """Emit the terminal task_update for status-check consumers and return the
+    TaskConclusion `_impl` returns."""
+    status = _pick_status(data, had_failure = exit_code != 0, terminal = True)
+    if not data.get("finish_time_ms"):
+        data["finish_time_ms"] = now_ms(ctx)
+    if data.get("start_time_ms") and not data["bazel"].get("wall_time_ms"):
+        data["bazel"]["wall_time_ms"] = data["finish_time_ms"] - data["start_time_ms"]
+
+    bookend = warming_conclusion(status, data)
+    return task_update(
+        ctx,
+        lifecycle,
+        status,
+        ProgressStyles(body = bookend),
+        kind = _KIND,
+        data = data,
+        final = True,
+        conclusion = bookend,
+        exit_code = exit_code,
+    )
+
+def _clean_storage_mount(ctx, mount: str):
+    """Remove prior Bazel state under the runner storage `mount`. Match
+    rosetta's pre-warming cleanup. Best-effort throughout: bazel may have left
+    output dirs read-only, so chmod first; spawn errors are tolerated since the
+    dirs/server may not exist yet on a fresh runner."""
+    for sub in ["bazel", "output", "caches/repository"]:
+        d = mount + "/" + sub
+        ctx.std.process.command("find").args([d, "-type", "d", "-exec", "chmod", "u+w", "{}", "+"]).spawn().wait()
+
+        # Remove the directories' *contents*, not the directories themselves:
+        # the storage-mount subdirs are created (and owned) by the runner
+        # bootstrap, so `rm -rf <dir>` fails with "Permission denied" on the
+        # mount entry while `rm -rf <dir>/*` clears what we actually need to.
+        # Use a shell so the glob expands.
+        ctx.std.process.command("sh").args(["-c", "rm -rf -- '%s'/* '%s'/.[!.]* 2>/dev/null || true" % (d, d)]).spawn().wait()
+
+def _impl(ctx: TaskContext) -> int | TaskConclusion:
+    bazel_trait = ctx.traits[BazelTrait]
+    hc_trait = ctx.traits[HealthCheckTrait]
+    lifecycle = ctx.traits[TaskLifecycleTrait]
+
     on_workflows_runner = bool(ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER"))
+    targets = list(ctx.args.targets)
+
+    data = warming_init_data()
+    data["start_time_ms"] = now_ms(ctx)
+    data["target_pattern"] = " ".join(targets)
+    data["warming"]["on_runner"] = on_workflows_runner
+
+    # Single pre-task setup phase: opens the status surface + renders the first
+    # body, resolves Bazel flags + parses the workspace .bazelrc (folding in the
+    # runner metadata, incl. --output_base), and runs the health_check hooks (a
+    # failed check concludes the surface and fails the task inside).
+    setup_phase(ctx, lifecycle, data["target_pattern"], _KIND, data, hc_trait, bazel_trait, "build")
+    announce_version, announce_command = resolve_bazel_announce(ctx)
+
     mount = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_STORAGE_PATH")
     if mount:
-        # Match rosetta's pre-warming cleanup. Best-effort throughout: bazel may
-        # have left output dirs read-only, so chmod first; spawn errors are
-        # tolerated since the dirs/server may not exist yet on a fresh runner.
-        for sub in ["bazel", "output", "caches/repository"]:
-            d = mount + "/" + sub
-            ctx.std.process.command("find").args([d, "-type", "d", "-exec", "chmod", "u+w", "{}", "+"]).spawn().wait()
+        task_update(
+            ctx,
+            lifecycle,
+            "running",
+            ProgressStyles(
+                body = "Cleaning prior Bazel state...",
+                stream = "Cleaning prior Bazel state",
+            ),
+            kind = _KIND,
+            data = data,
+            phase = Phase(name = "clean", description = "Clean prior Bazel state", emoji = "🧹"),
+        )
+        _clean_storage_mount(ctx, mount)
+        data["warming"]["cleaned"] = True
 
-            # Remove the directories' *contents*, not the directories
-            # themselves: the storage-mount subdirs are created (and owned) by
-            # the runner bootstrap, so `rm -rf <dir>` fails with "Permission
-            # denied" on the mount entry while `rm -rf <dir>/*` clears what we
-            # actually need to. Use a shell so the glob expands.
-            ctx.std.process.command("sh").args(["-c", "rm -rf -- '%s'/* '%s'/.[!.]* 2>/dev/null || true" % (d, d)]).spawn().wait()
+    # Populate phase: `bazel build --nobuild`. Pass build_event_sinks (the Aspect
+    # backend gRPC sink in CI) so the "✨ Aspect Workflows" link resolves to a
+    # real record. The local iterator drains BES into `data["bazel"]`.
+    events = bazel.build_events.iterator()
+    build_events = [events] + list(bazel_trait.build_event_sinks)
 
-    bazel_trait = ctx.traits[BazelTrait]
+    for hook in bazel_trait.build_start:
+        hook(ctx)
 
-    flags = ["--nobuild"]
-    flags.extend(ctx.args.bazel_flags)
-    flags.extend(bazel_trait.extra_flags)
-    for hook in bazel_trait.task_flags:
-        flags.extend(hook(ctx))
-    if bazel_trait.flags:
-        flags = bazel_trait.flags(flags)
-
-    startup_flags = list(ctx.args.bazel_startup_flags)
-    startup_flags.extend(bazel_trait.extra_startup_flags)
-    if ctx.args.output_base:
-        startup_flags.insert(0, "--output_base=" + ctx.args.output_base)
-    if bazel_trait.startup_flags:
-        startup_flags = bazel_trait.startup_flags(startup_flags)
-
-    # Build a RunCommand that carries BOTH the command flags and the startup
-    # flags (e.g. --output_base), since the runtime resolves a build's flags and
-    # startup flags from its RunCommand rather than a mutable ctx.bazel
-    # attribute. Use `parse_rc` (not `new_rc`): it reads the workspace `.bazelrc`
-    # from the Bazel root, and the `flags` we pass become synthetic options that
-    # are expanded *against* that rc — so a user `--config=<group>` forwarded via
-    # `--bazel-flag` resolves against the config groups defined there.
-    #
-    # The flags MUST go through `parse_rc`, not the per-call `flags=` on `build`:
-    # `build`'s `flags=` are appended raw *after* the rc is resolved, and the
-    # resolved invocation also carries `--ignore_all_rc_files`, so a raw
-    # `--config=ci` would reach a Bazel told to ignore the very `.bazelrc` that
-    # defines `ci` — failing with "Config value 'ci' is not defined in any .rc
-    # file". Passing them to `parse_rc` makes them part of the resolved command.
-    rc = ctx.bazel.parse_rc(flags = flags, startup_flags = startup_flags)
-
-    invocation = ctx.bazel.build(
-        rc = rc,
-        *ctx.args.targets
+    task_update(
+        ctx,
+        lifecycle,
+        "running",
+        ProgressStyles(
+            body = "Populating caches... (bazel build --nobuild)",
+            stream = "Populating caches (bazel build --nobuild)",
+        ),
+        kind = _KIND,
+        data = data,
+        phase = Phase(name = "populate", description = "Populate Bazel caches", emoji = "🔨"),
     )
-    code = invocation.wait().code
-    if code != 0:
-        return code
 
-    if on_workflows_runner:
-        archiver = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_WARMING_ARCHIVER") or _DEFAULT_WARMING_ARCHIVER
-        if not ctx.std.fs.exists(archiver):
-            error(
-                ctx.std,
-                "Cannot upload the warming archive: the warming archiver was not found at %s. Upgrade to the latest aspect-cli to enable warming: %s" % (archiver, ASPECT_CLI_RELEASES_URL),
-            )
-            return 1
-
-        # Upload the populated caches to the warming bucket. Inherits the
-        # script's stdout/stderr so the user sees its progress in real time.
-        archive = ctx.std.process.command(archiver).spawn().wait()
-        return archive.code
-
-    warn(
-        ctx.std,
-        "not on an Aspect Workflows runner; skipping the warming archive upload " +
-        "step. The bazel cache populate step ran successfully. On an Aspect " +
-        "Workflows runner this task also uploads the populated caches to the " +
-        "warming bucket.",
+    build = ctx.bazel.build(
+        flags = ["--nobuild"],
+        build_events = build_events,
+        announce_version = announce_version,
+        announce_command = announce_command,
+        *targets
     )
-    return 0
+
+    # sink_invocation_id is minted in Build::spawn before it returns. Populate +
+    # re-emit (status-surface only, empty stream) so the Workflows link surfaces
+    # at spawn rather than at build.wait().
+    data["sink_invocation_id"] = build.sink_invocation_id
+    task_update(
+        ctx,
+        lifecycle,
+        "running",
+        ProgressStyles(body = "Populating caches... (bazel build --nobuild)"),
+        kind = _KIND,
+        data = data,
+    )
+
+    # Tick-driven drain: heartbeat refresh every MIN_HEARTBEAT_INTERVAL_MS even
+    # when bazel is silent. Per event: build_event hooks (artifact recording) +
+    # process_event (populate the bazel state for the rendered sections).
+    last_emit_ms = now_ms(ctx)
+    for _tick in sleep_iter(BES_DRAIN_TICK_MS):
+        interesting = False
+        for _ in range(10000):
+            event = events.try_pop()
+            if event == None:
+                break
+            for handler in bazel_trait.build_event:
+                handler(ctx, event)
+            if process_event(data, event):
+                interesting = True
+        if interesting or now_ms(ctx) - last_emit_ms >= MIN_HEARTBEAT_INTERVAL_MS:
+            dispatch_task_update(ctx, lifecycle, TaskUpdate(
+                kind = _KIND,
+                status = _pick_status(data, had_failure = False, terminal = False),
+                data = data,
+                progress = ProgressStyles(),
+            ))
+            last_emit_ms = now_ms(ctx)
+        if events.done:
+            break
+
+    build_status = build.wait()
+    for sink in bazel_trait.build_event_sinks:
+        sink.wait()
+
+    # Fire the attempt-end + build-end hooks the `workflows` feature registers
+    # (sandbox-state repair, runner-unhealthy signaling on server-internal-error
+    # exits). Warming runs a single attempt, so both fire exactly once.
+    dispatch_bazel_attempt_end(ctx, bazel_trait, build_status.code)
+    dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
+
+    if not build_status.success:
+        data["warming"]["build_failed"] = True
+        return _emit_final(ctx, lifecycle, data, build_status.code or 1)
+
+    # Archive phase: upload the populated caches to the warming bucket. Only on
+    # an Aspect Workflows runner; off-runner it's reported as skipped.
+    if not on_workflows_runner:
+        reason = "not on an Aspect Workflows runner"
+        data["warming"]["archive_skipped_reason"] = reason
+        warn(
+            ctx.std,
+            "not on an Aspect Workflows runner; skipping the warming archive upload " +
+            "step. The bazel cache populate step ran successfully. On an Aspect " +
+            "Workflows runner this task also uploads the populated caches to the " +
+            "warming bucket.",
+        )
+        return _emit_final(ctx, lifecycle, data, 0)
+
+    task_update(
+        ctx,
+        lifecycle,
+        "running",
+        ProgressStyles(
+            body = "Uploading warming archive...",
+            stream = "Uploading warming archive",
+        ),
+        kind = _KIND,
+        data = data,
+        phase = Phase(name = "archive", description = "Upload warming archive", emoji = "📦"),
+    )
+
+    archiver = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_WARMING_ARCHIVER") or _DEFAULT_WARMING_ARCHIVER
+    data["warming"]["archiver_path"] = archiver
+    data["warming"]["archive_attempted"] = True
+    if not ctx.std.fs.exists(archiver):
+        msg = "the warming archiver was not found at %s. Upgrade to the latest aspect-cli to enable warming: %s" % (archiver, ASPECT_CLI_RELEASES_URL)
+        error(ctx.std, "Cannot upload the warming archive: " + msg)
+        data["warming"]["archive_error"] = msg
+        return _emit_final(ctx, lifecycle, data, 1)
+
+    # Inherits the script's stdout/stderr so the user sees its progress in real time.
+    archive = ctx.std.process.command(archiver).spawn().wait()
+    if archive.code != 0:
+        data["warming"]["archive_error"] = "the warming archiver exited with code %d" % archive.code
+        return _emit_final(ctx, lifecycle, data, archive.code)
+
+    data["warming"]["archive_succeeded"] = True
+    return _emit_final(ctx, lifecycle, data, 0)
 
 warming = task(
     group = ["ci"],
     summary = "Pre-populate Bazel caches on a CI runner (and archive them on Aspect Workflows runners).",
     description = "Cleans prior Bazel state under the runner's storage mount, then runs `bazel build --nobuild` against the given targets so subsequent jobs on the same runner pool start with hot caches. On an Aspect Workflows runner it then creates and uploads the warming archives to the warming bucket, so a warming pipeline only needs to call `aspect ci warming`. Off a Workflows runner the cache-populate step still runs and the archive step is skipped.",
     implementation = _impl,
-    traits = [BazelTrait],
+    traits = [
+        BazelTrait,
+        HealthCheckTrait,
+        TaskLifecycleTrait,
+    ] + artifacts.TRAITS + tips.TRAITS,
     args = {
         "targets": args.positional(
             minimum = 1,
@@ -114,17 +273,5 @@ warming = task(
             default = ["..."],
             description = "Bazel target patterns to warm. Defaults to '...' which expands to all rule targets in the package at and beneath the current directory.",
         ),
-        "bazel_flags": args.string_list(
-            long = "bazel-flag",
-            description = "Additional Bazel flags forwarded to the build (e.g. --bazel-flag=--config=ci). Repeat the flag to pass multiple.",
-        ),
-        "bazel_startup_flags": args.string_list(
-            long = "bazel-startup-flag",
-            description = "Additional Bazel startup flags. Repeat the flag to pass multiple.",
-        ),
-        "output_base": args.string(
-            default = "",
-            description = "Bazel output base path. Use to target a specific Bazel server instance.",
-        ),
-    },
+    } | bazel_flag_args("the warming build") | announce_bazel_args("the warming build"),
 )

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -18,9 +18,11 @@ from the runner metadata.
 
 The whole run surfaces as a single status check / Buildkite annotation
 (`kind = "warming_results"`, rendered by `private/lib/warming_results.axl`)
-spanning three phases — 🧹 clean, 🔨 populate, 📦 archive — so the check
-reflects the archive-upload outcome, not just the build. Off a Workflows runner
-the archive step is reported as skipped and the task still passes.
+spanning the 🔨 populate and 📦 archive phases, so the check reflects the
+archive-upload outcome, not just the build. Off a Workflows runner the archive
+step is reported as skipped and the task still passes. (The prior-state cleanup
+runs before `setup_phase` — see `_impl` — so it precedes the surface and isn't
+a surface phase of its own.)
 """
 
 load("@aspect//bazel.axl", "BazelTrait")
@@ -105,29 +107,25 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     data["target_pattern"] = " ".join(targets)
     data["warming"]["on_runner"] = on_workflows_runner
 
+    # Clean the prior Bazel state under the runner storage mount BEFORE
+    # `setup_phase`. The Workflows `agent_health_check` (run inside `setup_phase`)
+    # calls `ctx.bazel.health_check()`, which starts/uses the Bazel server in the
+    # runner `--output_base` under this same mount. Cleaning afterwards would
+    # delete `<mount>/output/*` out from under that live server and poison it, so
+    # the cleanup must run first. Best-effort, no surface emit (the surface isn't
+    # open yet); it's logged for the CLI and recorded in `data["warming"]`.
+    mount = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_STORAGE_PATH")
+    if mount:
+        print("Cleaning prior Bazel state under " + mount + "...")
+        _clean_storage_mount(ctx, mount)
+        data["warming"]["cleaned"] = True
+
     # Single pre-task setup phase: opens the status surface + renders the first
     # body, resolves Bazel flags + parses the workspace .bazelrc (folding in the
     # runner metadata, incl. --output_base), and runs the health_check hooks (a
     # failed check concludes the surface and fails the task inside).
     setup_phase(ctx, lifecycle, data["target_pattern"], _KIND, data, hc_trait, bazel_trait, "build")
     announce_version, announce_command = resolve_bazel_announce(ctx)
-
-    mount = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_STORAGE_PATH")
-    if mount:
-        task_update(
-            ctx,
-            lifecycle,
-            "running",
-            ProgressStyles(
-                body = "Cleaning prior Bazel state...",
-                stream = "Cleaning prior Bazel state",
-            ),
-            kind = _KIND,
-            data = data,
-            phase = Phase(name = "clean", description = "Clean prior Bazel state", emoji = "🧹"),
-        )
-        _clean_storage_mount(ctx, mount)
-        data["warming"]["cleaned"] = True
 
     # Populate phase: `bazel build --nobuild`. Pass build_event_sinks (the Aspect
     # backend gRPC sink in CI) so the "✨ Aspect Workflows" link resolves to a


### PR DESCRIPTION
Brings `aspect ci warming` in line with every other Bazel-calling task and gives it a proper CI status surface.

Previously warming hand-rolled its flag resolution, declared only `BazelTrait`, took a bespoke `--output-base` flag, and emitted no status check or annotation. This PR:

- Routes flag resolution through `setup_phase` / `setup_bazel_command`, which folds in the Workflows **runner metadata** (per-runner `--output_base`, `--output_user_root`, repository cache, identity header) and runs the **`HealthCheckTrait`** health checks before building. The bespoke `--output-base` flag is removed — the output base now comes from the runner metadata, and the health check's output-base assertion is satisfied via the active run command.
- Fires the `build_start` / `bazel_attempt_end` / `build_end` BazelTrait hooks (sandbox-state repair, runner-unhealthy signaling) that warming never invoked.
- Surfaces the whole run (🧹 clean → 🔨 populate → 📦 archive) as a single **GitHub status check / Buildkite annotation** via a new `warming_results` kind that extends `bazel_results`, so it inherits the shared Targets / Build Metrics / Invocation / Runner-metadata / Task-timing sections. A failed populate or archive fails the check; off a Workflows runner the archive step is reported as skipped and the task still passes.

It also unifies the `--bazel-flag` / `--bazel-startup-flag` descriptions across build / test / format / lint / run / gazelle / cache-diff / warming behind a shared `bazel_flag_args(<noun>)` helper (mirroring `announce_bazel_args`). `delivery` keeps its task-specific wording.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (companion PR updates `docs/cli/migration/warming.mdx` in the site repo — removes the `--output-base` mention and the `setup-aspect` plugin registration from the warming CI examples)
- Breaking change (forces users to change their own code or config): no (the removed `--output-base` warming flag was for targeting a specific Bazel server; the runner metadata now supplies it)
- Suggested release notes appear below: yes

### Suggested release notes

- `aspect ci warming` now renders a GitHub status check / Buildkite annotation for the whole run (clean → populate → archive), runs the standard runner health checks, and picks up the Workflows runner metadata automatically. The `--output-base` flag is removed — the output base comes from the runner metadata.

### Test plan

- New test cases added — `test-warming-template-snapshots` snapshot suite (8 scenarios) plus two `warming_results` scenarios in the BK-annotation snapshot suite.
- Covered by existing test cases — `aspect tests axl` (860 unit tests) and all template-snapshot suites pass; flag-helper consistency verified via each task's `--help`.
