### PR TITLE
fix(workflows): define failure_snippets macro for all detail templates

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -2921,7 +2921,15 @@ BAZEL_TARGETS_TEMPLATE = """### 🎯 Bazel targets ({{ total_targets }})
 # Mirrors the Aspect UI tabs (Bazel targets ↔ Targets, Bazel details ↔ Details).
 # `include_bazel_targets` is True for non-bazel tasks; False for build/test
 # (which hoist Bazel targets to slot 1).
-SHARED_DETAILS_BODY_TEMPLATE = """{% if artifacts_browse_url or artifact_links %}
+#
+# Leads with SNIPPET_MACRO so `failure_snippets(...)` — used by the embedded
+# BAZEL_TARGETS_TEMPLATE — is in scope wherever SHARED is composed into a
+# details template. Non-bazel surfaces (lint, format, gazelle, delivery,
+# warming) embed SHARED with include_bazel_targets=True but don't hoist their
+# own copy of BAZEL_TARGETS_TEMPLATE, so this is their only macro definition.
+# Redefining it (build/test also prepend SNIPPET_MACRO for their hoisted slot)
+# is harmless in minijinja: last definition wins and macro blocks emit nothing.
+SHARED_DETAILS_BODY_TEMPLATE = SNIPPET_MACRO + """{% if artifacts_browse_url or artifact_links %}
 ### 📎 Artifacts
 
 {% if artifacts_browse_url %}[Artifacts]({{ artifacts_browse_url }}){% endif %}{% if artifact_links %}{% if artifacts_browse_url %} · {% endif %}{% for a in artifact_links %}[{{ a.label }}]({{ a.url }}){% if not loop.last %} · {% endif %}{% endfor %}{% endif %}
@@ -3130,8 +3138,9 @@ SHARED_DETAILS_BODY_TEMPLATE = """{% if artifacts_browse_url or artifact_links %
 # Build/test detail template: aborted prelude, hoisted Bazel targets as the
 # primary slot, then SHARED (which skips its own Bazel targets via
 # include_bazel_targets=False).
-# SNIPPET_MACRO is defined once at the top so `failure_snippets(...)` is in scope
-# for every embedded copy of BAZEL_TARGETS_TEMPLATE (hoisted slot + SHARED slot).
+# SNIPPET_MACRO is prepended so `failure_snippets(...)` is in scope for the
+# hoisted BAZEL_TARGETS_TEMPLATE, which precedes SHARED. (SHARED prepends its
+# own copy too; the redefinition is harmless — see the note there.)
 DETAILS_TEMPLATE = SNIPPET_MACRO + """
 {% if aborted %}
 > :warning: **Build aborted**{% if abort_reason %} (`{{ abort_reason }}`){% endif %}{% if abort_description %}: {{ abort_description }}{% endif %}

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results_test.axl
@@ -360,9 +360,30 @@ def _test_impl(ctx):
 
     _check_long_subject_title_is_capped(ctx)
 
+    _check_failed_actions_invoke_snippet_macro(ctx)
+
     print(sep)
     print("All " + str(len(scenarios)) + " delivery scenarios rendered without error.")
     return 0
+
+def _check_failed_actions_invoke_snippet_macro(ctx):
+    """A failed Bazel action drives the embedded Bazel-targets block to call the
+    `failure_snippets` macro (bazel_results.SNIPPET_MACRO).
+
+    This details template embeds SHARED_DETAILS_BODY_TEMPLATE with
+    include_bazel_targets=True, so a non-empty `failed_actions` list takes the
+    branch that invokes the macro. The macro must be in scope — regression guard
+    for the crash when it wasn't (findings-only scenarios never hit the branch)."""
+    data = _make_base()
+    data["bazel"]["failed_actions"] = [{
+        "label": "//pkg:target",
+        "mnemonics": ["Push"],
+        "stderr_path": "",
+    }]
+    data["bazel"]["failed_actions_total"] = 1
+    out = render_check_output(ctx, data, "failed", _render_ctx(), _links())
+    if "//pkg:target" not in out["text"]:
+        fail("failed action label missing — Bazel-targets block did not render: %r" % out["text"][:600])
 
 def _check_long_subject_title_is_capped(ctx):
     """A resolved subject longer than the title budget is truncated with a

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/format_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/format_results_test.axl
@@ -291,9 +291,30 @@ def _test_impl(ctx):
             print("FAIL: " + e)
         fail("Body-content invariant violations: %d" % len(errors))
 
+    _check_failed_actions_invoke_snippet_macro(ctx)
+
     print(sep)
     print("All " + str(len(scenarios)) + " format scenarios rendered without error.")
     return 0
+
+def _check_failed_actions_invoke_snippet_macro(ctx):
+    """A failed Bazel action drives the embedded Bazel-targets block to call the
+    `failure_snippets` macro (bazel_results.SNIPPET_MACRO).
+
+    This details template embeds SHARED_DETAILS_BODY_TEMPLATE with
+    include_bazel_targets=True, so a non-empty `failed_actions` list takes the
+    branch that invokes the macro. The macro must be in scope — regression guard
+    for the crash when it wasn't (findings-only scenarios never hit the branch)."""
+    data = _make_base()
+    data["bazel"]["failed_actions"] = [{
+        "label": "//pkg:target",
+        "mnemonics": ["Format"],
+        "stderr_path": "",
+    }]
+    data["bazel"]["failed_actions_total"] = 1
+    out = render_check_output(ctx, data, "failed", _render_ctx(), _links())
+    if "//pkg:target" not in out["text"]:
+        fail("failed action label missing — Bazel-targets block did not render: %r" % out["text"][:600])
 
 format_template_snapshot_tests = task(
     kind = "test-format-template-snapshots",

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results_test.axl
@@ -306,9 +306,30 @@ def _test_impl(ctx):
             print("FAIL: " + e)
         fail("Body-content invariant violations: %d" % len(errors))
 
+    _check_failed_actions_invoke_snippet_macro(ctx)
+
     print(sep)
     print("All " + str(len(scenarios)) + " gazelle scenarios rendered without error.")
     return 0
+
+def _check_failed_actions_invoke_snippet_macro(ctx):
+    """A failed Bazel action drives the embedded Bazel-targets block to call the
+    `failure_snippets` macro (bazel_results.SNIPPET_MACRO).
+
+    This details template embeds SHARED_DETAILS_BODY_TEMPLATE with
+    include_bazel_targets=True, so a non-empty `failed_actions` list takes the
+    branch that invokes the macro. The macro must be in scope — regression guard
+    for the crash when it wasn't (findings-only scenarios never hit the branch)."""
+    data = _make_base()
+    data["bazel"]["failed_actions"] = [{
+        "label": "//pkg:target",
+        "mnemonics": ["GazelleUpdate"],
+        "stderr_path": "",
+    }]
+    data["bazel"]["failed_actions_total"] = 1
+    out = render_check_output(ctx, data, "failed", _render_ctx(), _links())
+    if "//pkg:target" not in out["text"]:
+        fail("failed action label missing — Bazel-targets block did not render: %r" % out["text"][:600])
 
 gazelle_template_snapshot_tests = task(
     kind = "test-gazelle-template-snapshots",

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
@@ -140,6 +140,28 @@ def _make_results_build_failed():
     accumulate(r, diags)
     return r
 
+def _make_results_failed_actions():
+    """A failed Bazel action (e.g. Clippy) in the underlying lint build.
+
+    lint's details template embeds SHARED_DETAILS_BODY_TEMPLATE with
+    include_bazel_targets=True, so a non-empty `failed_actions` list makes the
+    Bazel-targets block invoke the `failure_snippets` Jinja2 macro. Regression
+    guard for the macro being out of scope in non-bazel details templates.
+    """
+    r = _make_base()
+    r["lint"]["build_failed"] = True
+    r["bazel"]["failed_actions"] = [{
+        "label": "//workflows/telemetry/telemetry-rs:telemetry-rs",
+        "mnemonics": ["Clippy"],
+        "stderr_path": "",
+    }]
+    r["bazel"]["failed_actions_total"] = 1
+    diags = [
+        {"tool": "clippy", "file": "workflows/telemetry/telemetry-rs/src/lib.rs", "line": 309, "rule_id": "E0433", "severity": "error", "message": "failed to resolve: use of unresolved module or unlinked crate `opentelemetry_appender_tracing`"},
+    ]
+    accumulate(r, diags)
+    return r
+
 def _make_results_large():
     """200+ findings to exercise the group-table trim cascade."""
     r = _make_base()
@@ -633,6 +655,7 @@ def _test_impl(ctx):
         ("3. errors-only · Buildkite", _make_results_errors_only(), "failed", "//...", True, "buildkite", None),
         ("4. warnings-only · GitHub", _make_results_warnings_only(), "passed", "//...", True, "github", None),
         ("5. build-failed · GitHub", _make_results_build_failed(), "failed", "//...", False, "github", None),
+        ("5b. failed-actions · GitHub", _make_results_failed_actions(), "failed", "//...", False, "github", None),
         ("6. large-trim · GitHub", _make_results_large(), "failed", "//...", True, "github", None),
         ("7. hold-the-line · GitHub", _make_results_hold_the_line(), "failed", "//...", True, "github", None),
         # Exercise GitHubStatusChecksTrait.metadata_keys through the shared summary renderer.
@@ -663,9 +686,32 @@ def _test_impl(ctx):
 
     _check_fix_renders_before_reproduce(ctx)
 
+    _check_failed_actions_invoke_snippet_macro(ctx)
+
     print(sep)
     print("All " + str(len(scenarios)) + " lint scenarios + annotation pipeline rendered without error.")
     return 0
+
+def _check_failed_actions_invoke_snippet_macro(ctx):
+    """A failed Bazel action drives the embedded Bazel-targets block to call the
+    `failure_snippets` macro.
+
+    The macro lives in bazel_results.SNIPPET_MACRO; SHARED_DETAILS_BODY_TEMPLATE
+    prepends it so it's in scope wherever SHARED is composed. Before that fix the
+    lint details template rendered fine for every findings-only scenario (the
+    macro call is guarded by `build_failures`), then crashed in production the
+    moment a Clippy action failed. This asserts the branch is actually taken so
+    the macro is exercised, not merely present."""
+    data = _make_results_failed_actions()
+    out = render_check_output(ctx, data, "failed", _render_ctx(), _links())
+    body = out["text"]
+
+    # The failed action populates the Bazel-targets "Failed to build" block,
+    # which is the sole caller of failure_snippets in this template.
+    if "🎯 Bazel targets" not in body:
+        fail("Bazel-targets block missing — failed_actions did not render: %r" % body[:600])
+    if "//workflows/telemetry/telemetry-rs:telemetry-rs" not in body:
+        fail("failed action label missing from rendered body: %r" % body[:600])
 
 def _check_fix_renders_before_reproduce(ctx):
     """The Fix block renders before the Reproduce block in the details body.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results_test.axl
@@ -170,9 +170,30 @@ def _test_impl(ctx):
             print("FAIL: " + e)
         fail("Body-content invariant violations: %d" % len(errors))
 
+    _check_failed_actions_invoke_snippet_macro(ctx)
+
     print(sep)
     print("All " + str(len(scenarios)) + " warming scenarios rendered without error.")
     return 0
+
+def _check_failed_actions_invoke_snippet_macro(ctx):
+    """A failed Bazel action drives the embedded Bazel-targets block to call the
+    `failure_snippets` macro (bazel_results.SNIPPET_MACRO).
+
+    This details template embeds SHARED_DETAILS_BODY_TEMPLATE with
+    include_bazel_targets=True, so a non-empty `failed_actions` list takes the
+    branch that invokes the macro. The macro must be in scope — regression guard
+    for the crash when it wasn't (findings-only scenarios never hit the branch)."""
+    data = _make_base()
+    data["bazel"]["failed_actions"] = [{
+        "label": "//pkg:target",
+        "mnemonics": ["Warming"],
+        "stderr_path": "",
+    }]
+    data["bazel"]["failed_actions_total"] = 1
+    out = render_check_output(ctx, data, "failed", _render_ctx(), _links())
+    if "//pkg:target" not in out["text"]:
+        fail("failed action label missing — Bazel-targets block did not render: %r" % out["text"][:600])
 
 warming_template_snapshot_tests = task(
     kind = "test-warming-template-snapshots",


### PR DESCRIPTION
A failed Bazel action inside a lint (or format/gazelle/delivery/warming) run crashed the GitHub status-check renderer with:

```
error: unknown function: failure_snippets is unknown (in template:92)
```

**Root cause.** These five non-bazel status surfaces build their details template ending in `SHARED_DETAILS_BODY_TEMPLATE`, which embeds `BAZEL_TARGETS_TEMPLATE` (they pass `include_bazel_targets=True` because they run an internal `bazel build`). That block invokes the `failure_snippets` Jinja2 macro whenever a build action fails. The macro lives in `bazel_results.SNIPPET_MACRO`, but only bazel's own `DETAILS_TEMPLATE` prepended it — the five non-bazel templates never did. Because the macro call is guarded by `{% if build_failures or ... %}`, findings-only renders never took that branch, so the gap stayed latent until a real action failed (the reported case was a Clippy compile error under a lint run).

**Fix.** Prepend `SNIPPET_MACRO` to `SHARED_DETAILS_BODY_TEMPLATE` itself, so the macro is in scope wherever SHARED is composed. build/test keep their own leading `SNIPPET_MACRO` for the hoisted Bazel-targets slot that precedes SHARED; the resulting redefinition is a no-op in minijinja (last definition wins, macro blocks emit nothing).

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fixed a crash in the GitHub/Buildkite status-check renderer for lint, format, gazelle, delivery, and warming tasks when the underlying Bazel build had a failed action (e.g. a Clippy error under lint).

### Test plan

- New test cases added: each affected snapshot suite (`test-{lint,format,gazelle,delivery,warming}-template-snapshots`) gains a regression check that renders with a non-empty `failed_actions` list, forcing the `failure_snippets` macro to be invoked.
- Verified reverting the one-line fix reproduces the exact `unknown function: failure_snippets` error in all five suites, and that all suites (plus the build/test `test-template-snapshots` and PR-comment/Buildkite-annotation suites) pass with the fix in place.
