### PR TITLE
feat(workflows): degrade gracefully when a status body fails to render

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -3173,7 +3173,10 @@ _SUMMARY_FALLBACK_TEMPLATE = """⚠️ Status summary unavailable — the {{ sur
 def _render_or_fallback(ctx, template, data, fallback_template, surface):
     """Shared try/warn/fallback for a status body. On render error, logs a
     WARNING to CLI output with the message and renders `fallback_template`
-    (macro-free, so it can't itself fail). Returns (text, ok)."""
+    (macro-free, so it can't itself fail).
+
+    Returns (text, ok): `ok` is False when the fallback was used.
+    """
     ok, text = ctx.template.try_jinja2(template, data = data)
     if ok:
         return (text, True)
@@ -3187,10 +3190,11 @@ def render_details_or_fallback(ctx, template, data, surface = "check"):
     A template bug in one status surface must not abort the whole invocation
     (see anchor: SNIPPET_MACRO / failure_snippets). On render error this logs a
     WARNING to CLI output with the error and returns a minimal fallback body
-    embedding the same message; the caller keeps the correct status/title.
+    embedding the same message; the caller keeps the correct status/title. The
+    fallback body is far under _DETAILS_LIMIT, so the caller's size-trim cascade
+    is a no-op on it.
 
-    Returns (text, ok): `ok` is False when the fallback was used, so callers can
-    skip the size-trim cascade (the fallback is already tiny).
+    Returns (text, ok); ok is False when the fallback was used.
     """
     return _render_or_fallback(ctx, template, data, _DETAILS_FALLBACK_TEMPLATE, surface + " details")
 
@@ -4294,8 +4298,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "build/test")
 
     # Fit details within the GitHub limit; each step re-renders only if still
-    # over. On a render fallback the body is tiny, so every size guard below is
-    # already false and the cascade is a natural no-op. Inline snippets are extra (not the data users primarily came for), so
+    # over. Inline snippets are extra (not the data users primarily came for), so
     # they shed FIRST — secondary buckets, then all of them — before any of the
     # established trims below. Reference sections (redundant with Aspect Web UI)
     # go next, before the failure/target lists themselves:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -49,6 +49,7 @@ load(
     "./environment.axl",
     "build_aspect_runner_rows",
     "display_cloud_provider",
+    "feature_logger",
     "is_aspect_workflows_runner",
 )
 load("./log_snippet.axl", "SnippetOptions", "code_fence_for", "extract_junit_failure", "extract_snippet", "has_snippet")
@@ -3148,6 +3149,60 @@ DETAILS_TEMPLATE = SNIPPET_MACRO + """
 {% endif %}
 """ + BAZEL_TARGETS_TEMPLATE + SHARED_DETAILS_BODY_TEMPLATE
 
+_RENDER_LOG = feature_logger("Status render")
+
+# Fallback body when a details template fails to render. Rendered with
+# `try_jinja2` (macro-free, no data refs beyond `error`/`surface`) so it cannot
+# itself fail. Keeps the check updating with the correct status/title (both
+# computed outside the template) while surfacing the bug to reviewers.
+_DETAILS_FALLBACK_TEMPLATE = """> ⚠️ **Details unavailable** — the {{ surface }} status body failed to render.
+> This is a bug in aspect-cli; the task status above is still accurate.
+>
+> ```
+> {{ error }}
+> ```
+"""
+
+# Fallback for a summary render failure. The status/title/conclusion are all
+# computed in AXL outside the template, so the check state stays correct; only
+# this one-line body is degraded. Deliberately terse — the summary is the first
+# thing reviewers read, so we don't dump a stack trace into it (the WARNING and
+# the details fallback carry the message).
+_SUMMARY_FALLBACK_TEMPLATE = """⚠️ Status summary unavailable — the {{ surface }} summary body failed to render (see task log)."""
+
+def _render_or_fallback(ctx, template, data, fallback_template, surface):
+    """Shared try/warn/fallback for a status body. On render error, logs a
+    WARNING to CLI output with the message and renders `fallback_template`
+    (macro-free, so it can't itself fail). Returns (text, ok)."""
+    ok, text = ctx.template.try_jinja2(template, data = data)
+    if ok:
+        return (text, True)
+    _RENDER_LOG.warn(ctx.std, "%s body failed to render: %s" % (surface, text))
+    fallback = ctx.template.jinja2(fallback_template, data = {"surface": surface, "error": text})
+    return (fallback, False)
+
+def render_details_or_fallback(ctx, template, data, surface = "check"):
+    """Render a details body, degrading to a fallback instead of crashing.
+
+    A template bug in one status surface must not abort the whole invocation
+    (see anchor: SNIPPET_MACRO / failure_snippets). On render error this logs a
+    WARNING to CLI output with the error and returns a minimal fallback body
+    embedding the same message; the caller keeps the correct status/title.
+
+    Returns (text, ok): `ok` is False when the fallback was used, so callers can
+    skip the size-trim cascade (the fallback is already tiny).
+    """
+    return _render_or_fallback(ctx, template, data, _DETAILS_FALLBACK_TEMPLATE, surface + " details")
+
+def render_summary_or_fallback(ctx, template, data, surface = "check"):
+    """Render a summary body, degrading to a one-line fallback instead of
+    crashing. Summary templates carry no macros today, so this is
+    defense-in-depth against future edits — see render_details_or_fallback.
+
+    Returns (text, ok); ok is False when the fallback was used.
+    """
+    return _render_or_fallback(ctx, template, data, _SUMMARY_FALLBACK_TEMPLATE, surface + " summary")
+
 def build_summary_data(ctx, data, status, render_ctx, links, metadata_keys, run_date = "", config_items = None, complete_suffix = ""):
     """Build Jinja2 template data for SUMMARY_TEMPLATE.
 
@@ -4235,11 +4290,12 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
         trace.log("debug [render_check_output]   packages_loaded=" + str(data["bazel"].get("packages_loaded", 0)))
 
     details_tmpl = t.get("details") or DETAILS_TEMPLATE
-    summary_text = ctx.template.jinja2(t.get("summary") or SUMMARY_TEMPLATE, data = summary_data)
-    details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+    (summary_text, _summary_ok) = render_summary_or_fallback(ctx, t.get("summary") or SUMMARY_TEMPLATE, summary_data, surface = "build/test")
+    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "build/test")
 
     # Fit details within the GitHub limit; each step re-renders only if still
-    # over. Inline snippets are extra (not the data users primarily came for), so
+    # over. On a render fallback the body is tiny, so every size guard below is
+    # already false and the cascade is a natural no-op. Inline snippets are extra (not the data users primarily came for), so
     # they shed FIRST — secondary buckets, then all of them — before any of the
     # established trims below. Reference sections (redundant with Aspect Web UI)
     # go next, before the failure/target lists themselves:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -4295,7 +4295,17 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
 
     details_tmpl = t.get("details") or DETAILS_TEMPLATE
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, t.get("summary") or SUMMARY_TEMPLATE, summary_data, surface = "build/test")
-    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "build/test")
+
+    # Re-render the details body after a trim step, degrading to the fallback on
+    # any render error. Trimming mutates details_data, so a template that only
+    # errors on a trimmed shape must still fall back rather than abort — and the
+    # fallback is far under _DETAILS_LIMIT, so the remaining trim guards go false
+    # and the cascade stops on its own.
+    def _render_details():
+        (text, _ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "build/test")
+        return text
+
+    details_text = _render_details()
 
     # Fit details within the GitHub limit; each step re-renders only if still
     # over. Inline snippets are extra (not the data users primarily came for), so
@@ -4320,49 +4330,49 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
                       "), dropping inline snippet bodies from secondary failure buckets")
         _drop_snippets(details_data.get("failed_tests_snippets", []))
         _drop_snippets(details_data.get("timeout_tests_snippets", []))
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT and max_snippets > 0:
         if debug_render:
             trace.log("debug [render_check_output]   still OVER (" + str(len(details_text)) +
                       "), dropping all inline snippet bodies")
         _drop_snippets(details_data.get("build_failures_snippets", []))
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT:
         if debug_render:
             trace.log("debug [render_check_output]   OVER LIMIT (" + str(len(details_text)) +
                       "), dropping build_metadata sub-block from Bazel details")
         details_data["build_metadata_rows"] = []
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT:
         if debug_render:
             trace.log("debug [render_check_output]   still OVER (" + str(len(details_text)) +
                       "), dropping workspace_status sub-block from Bazel details")
         details_data["workspace_status_rows"] = []
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT:
         if debug_render:
             trace.log("debug [render_check_output]   still OVER (" + str(len(details_text)) +
                       "), dropping invocation sub-block from Bazel details")
         details_data["invocation_rows"] = []
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT:
         if debug_render:
             trace.log("debug [render_check_output]   still OVER (" + str(len(details_text)) +
                       "), dropping Runner metadata section")
         details_data["aspect_runner_rows"] = []
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT:
         if debug_render:
             trace.log("debug [render_check_output]   still OVER (" + str(len(details_text)) +
                       "), dropping Performance")
         details_data["invocation_stats"] = None
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT:
         if debug_render:
@@ -4370,7 +4380,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
                       "), dropping parsed-options lists")
         details_data["startup_options"] = []
         details_data["cmd_line_options"] = []
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT:
         built = details_data.get("built_targets", [])
@@ -4384,7 +4394,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             overflow = built_total - len(built)
             details_data["built_targets"] = built
             details_data["built_targets_overflow"] = str(overflow) if overflow > 0 else ""
-            details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+            details_text = _render_details()
         if debug_render:
             trace.log("debug [render_check_output]   after target trim: details len=" + str(len(details_text)) +
                       " built_targets=" + str(len(built)))
@@ -4399,7 +4409,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             overflow = passed_total - len(passed)
             details_data["passed_tests"] = passed
             details_data["passed_tests_overflow"] = str(overflow) if overflow > 0 else ""
-            details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+            details_text = _render_details()
         if debug_render:
             trace.log("debug [render_check_output]   after test trim: details len=" + str(len(details_text)) +
                       " passed_tests=" + str(len(passed)))
@@ -4414,7 +4424,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             overflow = skipped_total - len(skipped)
             details_data["skipped_targets"] = skipped
             details_data["skipped_targets_overflow"] = str(overflow) if overflow > 0 else ""
-            details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+            details_text = _render_details()
         if debug_render:
             trace.log("debug [render_check_output]   after skipped trim: details len=" + str(len(details_text)) +
                       " skipped_targets=" + str(len(skipped)))
@@ -4422,7 +4432,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     if len(details_text) > _DETAILS_LIMIT:
         # Last resort.
         details_data["cached_tests"] = []
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     if debug_render:
         trace.log("debug [render_check_output]   summary len=" + str(len(summary_text)))

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -3151,12 +3151,12 @@ DETAILS_TEMPLATE = SNIPPET_MACRO + """
 
 _RENDER_LOG = feature_logger("Status render")
 
-# Fallback body when a details template fails to render. Rendered with
-# `try_jinja2` (macro-free, no data refs beyond `error`/`surface`) so it cannot
-# itself fail. Keeps the check updating with the correct status/title (both
-# computed outside the template) while surfacing the bug to reviewers.
-_DETAILS_FALLBACK_TEMPLATE = """> ⚠️ **Details unavailable** — the {{ surface }} status body failed to render.
-> This is a bug in aspect-cli; the task status above is still accurate.
+# Fallback body when a details template fails to render (either a built-in
+# template or a user-supplied override). Rendered with `try_jinja2` (macro-free,
+# no data refs beyond `error`/`surface`) so it cannot itself fail. Keeps the
+# check updating with the correct status/title (both computed outside the
+# template) while surfacing the render error to reviewers.
+_DETAILS_FALLBACK_TEMPLATE = """> ⚠️ **Details unavailable** — the {{ surface }} status body failed to render. The task status above is still accurate.
 >
 > ```
 > {{ error }}

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
@@ -8,7 +8,7 @@ Two task implementations live here:
     `compute_invocation_state`, `conclusion`, and skipped-bucket plumbing.
 """
 
-load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "aspect_web_ui_url", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "failed_labels_by_subcommand", "init_data", "process_event", "render_bes_url", "render_check_output", "repro_by_target", "repro_targets")
+load("./bazel_results.axl", "MAX_TEST_TARGETS", "STATUS_ICONS", "STATUS_LABELS", "aspect_web_ui_url", "bes_get", "build_details_data", "common_label_root", "compute_invocation_state", "conclusion", "failed_labels_by_subcommand", "init_data", "process_event", "render_bes_url", "render_check_output", "render_details_or_fallback", "render_summary_or_fallback", "repro_by_target", "repro_targets")
 load("./lifecycle.axl", "ReproFixCommand")
 
 # Fake data builders
@@ -1167,7 +1167,42 @@ def _test_render_bes_url(ctx):
         "",
     )
 
+def _test_render_or_fallback_passthrough(ctx):
+    """A template that renders cleanly returns (text, True) unchanged."""
+    (text, ok) = render_details_or_fallback(ctx, "hello {{ name }}", {"name": "world"}, surface = "lint")
+    _eq("details passthrough ok", ok, True)
+    _eq("details passthrough text", text, "hello world")
+
+    (text, ok) = render_summary_or_fallback(ctx, "hi {{ name }}", {"name": "there"}, surface = "lint")
+    _eq("summary passthrough ok", ok, True)
+    _eq("summary passthrough text", text, "hi there")
+
+def _test_render_details_or_fallback_degrades(ctx):
+    """A broken details template returns (fallback, False) instead of raising.
+
+    The fallback embeds the surface and the error, and stays well under
+    _DETAILS_LIMIT so the caller's trim cascade is a no-op on it. Guard against
+    the crash class where an undefined macro aborts the whole invocation."""
+    (text, ok) = render_details_or_fallback(ctx, "{{ undefined_macro(x) }}", {}, surface = "lint")
+    _eq("details fallback not ok", ok, False)
+    if "Details unavailable" not in text:
+        fail("details fallback body missing marker: %r" % text)
+    if "lint details" not in text:
+        fail("details fallback should name the surface: %r" % text)
+    if "undefined_macro" not in text:
+        fail("details fallback should embed the render error: %r" % text)
+
+def _test_render_summary_or_fallback_degrades(ctx):
+    """A broken summary template returns (fallback, False) instead of raising."""
+    (text, ok) = render_summary_or_fallback(ctx, "{{ undefined_macro(x) }}", {}, surface = "lint")
+    _eq("summary fallback not ok", ok, False)
+    if "Status summary unavailable" not in text:
+        fail("summary fallback body missing marker: %r" % text)
+
 _UNIT_TESTS = [
+    _test_render_or_fallback_passthrough,
+    _test_render_details_or_fallback_degrades,
+    _test_render_summary_or_fallback_degrades,
     _test_status_maps_cover_every_terminal_status,
     _test_aspect_web_ui_url,
     _test_render_bes_url,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
@@ -1199,7 +1199,29 @@ def _test_render_summary_or_fallback_degrades(ctx):
     if "Status summary unavailable" not in text:
         fail("summary fallback body missing marker: %r" % text)
 
+def _test_try_template_engines_return_ok_text_tuple(ctx):
+    """Each try_* engine returns (True, rendered) on success and (False, error)
+    on a malformed template, never raising. The fallback helpers key off this
+    (ok, text) contract."""
+    for (engine, render) in [
+        ("handlebars", ctx.template.try_handlebars),
+        ("jinja2", ctx.template.try_jinja2),
+        ("liquid", ctx.template.try_liquid),
+    ]:
+        (ok, text) = render("Hi {{ name }}", data = {"name": "there"})
+        _eq("%s try render ok" % engine, ok, True)
+        if "there" not in text:
+            fail("%s try render dropped data: %r" % (engine, text))
+
+    (hb_ok, _) = ctx.template.try_handlebars("Hi {{name", data = {})
+    _eq("handlebars malformed not ok", hb_ok, False)
+    (lq_ok, _) = ctx.template.try_liquid("Hi {% if %}", data = {})
+    _eq("liquid malformed not ok", lq_ok, False)
+    (jj_ok, _) = ctx.template.try_jinja2("{{ undefined_macro(x) }}", data = {})
+    _eq("jinja2 undefined call not ok", jj_ok, False)
+
 _UNIT_TESTS = [
+    _test_try_template_engines_return_ok_text_tuple,
     _test_render_or_fallback_passthrough,
     _test_render_details_or_fallback_degrades,
     _test_render_summary_or_fallback_degrades,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results.axl
@@ -20,6 +20,8 @@ load(
     "build_summary_data",
     "format_run_date",
     "html_escape",
+    "render_details_or_fallback",
+    "render_summary_or_fallback",
     bazel_init_data = "init_data",
 )
 load("./result_text.axl", "emoji_for_status")
@@ -513,8 +515,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
     details_tmpl = t.get("details") or _DETAILS_TEMPLATE
 
-    summary_text = ctx.template.jinja2(summary_tmpl, data = summary_data)
-    details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+    (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "delivery")
+    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "delivery")
 
     # Trim cascade: halve per-group row counts until we fit.
     if len(details_text) > _DETAILS_LIMIT:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results.axl
@@ -516,7 +516,16 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_tmpl = t.get("details") or _DETAILS_TEMPLATE
 
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "delivery")
-    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "delivery")
+
+    # Re-render via the fallback helper: the trim cascade mutates details_data,
+    # so a template that only errors on a trimmed shape must still degrade
+    # rather than abort. A fallback body is far under _DETAILS_LIMIT, so the
+    # trim guards go false and the cascade stops on its own.
+    def _render_details():
+        (text, _ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "delivery")
+        return text
+
+    details_text = _render_details()
 
     # Trim cascade: halve per-group row counts until we fit.
     if len(details_text) > _DETAILS_LIMIT:
@@ -539,11 +548,11 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             if not trimmed:
                 break
             details_data["groups"] = new_groups
-            details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+            details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT:
         details_data["groups"] = []
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     target_pattern = render_ctx.get("subject", "") if render_ctx else ""
     task_kind = render_ctx.get("task_kind", "") if render_ctx else ""

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/format_results.axl
@@ -362,7 +362,16 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_tmpl = t.get("details") or _DETAILS_TEMPLATE
 
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "format")
-    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "format")
+
+    # Re-render via the fallback helper: the trim cascade mutates details_data,
+    # so a template that only errors on a trimmed shape must still degrade
+    # rather than abort. A fallback body is far under _DETAILS_LIMIT, so the
+    # trim guards go false and the cascade stops on its own.
+    def _render_details():
+        (text, _ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "format")
+        return text
+
+    details_text = _render_details()
 
     # Trim cascade: if file list overflows the limit, drop files progressively.
     if len(details_text) > _DETAILS_LIMIT:
@@ -377,7 +386,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             details_data["file_list"] = "\n".join(files)
             details_data["overflow"] = str(missing) if missing > 0 else ""
             details_data["has_overflow"] = missing > 0
-            details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+            details_text = _render_details()
 
     task_kind = render_ctx.get("task_kind", "") if render_ctx else ""
     target_pattern = render_ctx.get("subject", "") if render_ctx else ""

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/format_results.axl
@@ -24,6 +24,8 @@ load(
     "build_details_data",
     "build_summary_data",
     "format_run_date",
+    "render_details_or_fallback",
+    "render_summary_or_fallback",
     bazel_init_data = "init_data",
 )
 load("./repro_commands.axl", "patch_download_cmd")
@@ -359,8 +361,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
     details_tmpl = t.get("details") or _DETAILS_TEMPLATE
 
-    summary_text = ctx.template.jinja2(summary_tmpl, data = summary_data)
-    details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+    (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "format")
+    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "format")
 
     # Trim cascade: if file list overflows the limit, drop files progressively.
     if len(details_text) > _DETAILS_LIMIT:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results.axl
@@ -23,6 +23,8 @@ load(
     "build_details_data",
     "build_summary_data",
     "format_run_date",
+    "render_details_or_fallback",
+    "render_summary_or_fallback",
     bazel_init_data = "init_data",
 )
 load("./repro_commands.axl", "patch_download_cmd")
@@ -415,8 +417,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
     details_tmpl = t.get("details") or _DETAILS_TEMPLATE
 
-    summary_text = ctx.template.jinja2(summary_tmpl, data = summary_data)
-    details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+    (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "gazelle")
+    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "gazelle")
 
     # Trim cascade: if file list overflows the limit, trim progressively.
     if len(details_text) > _DETAILS_LIMIT:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results.axl
@@ -418,7 +418,16 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_tmpl = t.get("details") or _DETAILS_TEMPLATE
 
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "gazelle")
-    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "gazelle")
+
+    # Re-render via the fallback helper: the trim cascade mutates details_data,
+    # so a template that only errors on a trimmed shape must still degrade
+    # rather than abort. A fallback body is far under _DETAILS_LIMIT, so the
+    # trim guards go false and the cascade stops on its own.
+    def _render_details():
+        (text, _ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "gazelle")
+        return text
+
+    details_text = _render_details()
 
     # Trim cascade: if file list overflows the limit, trim progressively.
     if len(details_text) > _DETAILS_LIMIT:
@@ -433,7 +442,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
             details_data["file_list"] = "\n".join(files)
             details_data["overflow"] = str(missing) if missing > 0 else ""
             details_data["has_overflow"] = missing > 0
-            details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+            details_text = _render_details()
 
     task_kind = render_ctx.get("task_kind", "") if render_ctx else ""
     target_pattern = render_ctx.get("subject", "") if render_ctx else ""

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
@@ -839,8 +839,6 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "lint")
 
     # Trim cascade on overflow: keep the summaries, halve per-group rows first.
-    # A render fallback yields a tiny body, so the size guard below is already
-    # false and the cascade is a natural no-op.
     if len(details_text) > _DETAILS_LIMIT:
         for _ in range(10):
             if len(details_text) <= _DETAILS_LIMIT:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
@@ -25,6 +25,8 @@ load(
     "format_run_date",
     "html_escape",
     "merged_meta",
+    "render_details_or_fallback",
+    "render_summary_or_fallback",
     bazel_init_data = "init_data",
 )
 load("./result_text.axl", "emoji_for_status")
@@ -833,10 +835,12 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
     details_tmpl = t.get("details") or _DETAILS_TEMPLATE
 
-    summary_text = ctx.template.jinja2(summary_tmpl, data = summary_data)
-    details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+    (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "lint")
+    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "lint")
 
     # Trim cascade on overflow: keep the summaries, halve per-group rows first.
+    # A render fallback yields a tiny body, so the size guard below is already
+    # false and the cascade is a natural no-op.
     if len(details_text) > _DETAILS_LIMIT:
         for _ in range(10):
             if len(details_text) <= _DETAILS_LIMIT:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
@@ -836,7 +836,16 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_tmpl = t.get("details") or _DETAILS_TEMPLATE
 
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "lint")
-    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "lint")
+
+    # Re-render via the fallback helper: the trim cascade mutates details_data,
+    # so a template that only errors on a trimmed shape must still degrade
+    # rather than abort. A fallback body is far under _DETAILS_LIMIT, so the
+    # trim guards go false and the cascade stops on its own.
+    def _render_details():
+        (text, _ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "lint")
+        return text
+
+    details_text = _render_details()
 
     # Trim cascade on overflow: keep the summaries, halve per-group rows first.
     if len(details_text) > _DETAILS_LIMIT:
@@ -850,21 +859,24 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
                 if len(rows) > 2:
                     half = max(1, len(rows) // 2)
                     kept = rows[:half]
-                    missing = g["count"] - len(kept)
+                    # `count` is stringified for the template (_groups_for_template);
+                    # parse it back for the arithmetic, and re-stringify overflow
+                    # to match the field's rendered shape ("" when none).
+                    missing = int(g["count"]) - len(kept)
                     g = dict(g)
                     g["rows"] = kept
-                    g["overflow"] = missing if missing > 0 else 0
+                    g["overflow"] = str(missing) if missing > 0 else ""
                     trimmed = True
                 new_groups.append(g)
             if not trimmed:
                 break
             details_data["groups"] = new_groups
-            details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+            details_text = _render_details()
 
     if len(details_text) > _DETAILS_LIMIT:
         # Last resort: drop the group tables entirely; keep summary counts.
         details_data["groups"] = []
-        details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+        details_text = _render_details()
 
     target_pattern = render_ctx.get("subject", "") if render_ctx else ""
     task_kind = render_ctx.get("task_kind", "") if render_ctx else ""

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
@@ -859,6 +859,7 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
                 if len(rows) > 2:
                     half = max(1, len(rows) // 2)
                     kept = rows[:half]
+
                     # `count` is stringified for the template (_groups_for_template);
                     # parse it back for the arithmetic, and re-stringify overflow
                     # to match the field's rendered shape ("" when none).

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
@@ -695,15 +695,12 @@ def _test_impl(ctx):
     return 0
 
 def _check_broken_template_degrades_gracefully(ctx):
-    """A details template that fails to render must NOT crash the invocation.
+    """End-to-end: a broken details template routed through render_check_output
+    degrades to a fallback instead of crashing the invocation.
 
-    Regression guard for the graceful-degradation path: render_check_output
-    routes the body through render_details_or_fallback (try_jinja2 + fallback +
-    WARNING). A template calling an undefined macro would otherwise abort the
-    whole process (the original failure_snippets crash). Instead we expect a
-    fallback body, and the status/title to stay correct (computed outside the
-    template). The WARNING to CLI output is not asserted here — it prints during
-    this test run and is covered by the runtime try_jinja2 unit test."""
+    The shared fallback helpers are unit-tested in bazel_results_test; this
+    covers the surface wiring — that the status/title (computed outside the
+    template) survive and the trim cascade tolerates the fallback body."""
     data = _make_results_mixed()
     broken = {"details": "### findings\n{{ not_a_real_macro(rows) }}"}
     out = render_check_output(ctx, data, "failed", _render_ctx(), _links(), templates = broken)
@@ -712,10 +709,6 @@ def _check_broken_template_degrades_gracefully(ctx):
         fail("broken template did not fall back — body: %r" % out["text"][:400])
     if "lint //..." not in out["title"]:
         fail("status/title lost on fallback: %r" % out["title"])
-
-    # The custom summary template still renders normally (only details broke).
-    if not out["summary"]:
-        fail("summary should still render when only details template is broken")
 
 def _check_failed_actions_invoke_snippet_macro(ctx):
     """A failed Bazel action drives the embedded Bazel-targets block to call the

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
@@ -688,9 +688,34 @@ def _test_impl(ctx):
 
     _check_failed_actions_invoke_snippet_macro(ctx)
 
+    _check_broken_template_degrades_gracefully(ctx)
+
     print(sep)
     print("All " + str(len(scenarios)) + " lint scenarios + annotation pipeline rendered without error.")
     return 0
+
+def _check_broken_template_degrades_gracefully(ctx):
+    """A details template that fails to render must NOT crash the invocation.
+
+    Regression guard for the graceful-degradation path: render_check_output
+    routes the body through render_details_or_fallback (try_jinja2 + fallback +
+    WARNING). A template calling an undefined macro would otherwise abort the
+    whole process (the original failure_snippets crash). Instead we expect a
+    fallback body, and the status/title to stay correct (computed outside the
+    template). The WARNING to CLI output is not asserted here — it prints during
+    this test run and is covered by the runtime try_jinja2 unit test."""
+    data = _make_results_mixed()
+    broken = {"details": "### findings\n{{ not_a_real_macro(rows) }}"}
+    out = render_check_output(ctx, data, "failed", _render_ctx(), _links(), templates = broken)
+
+    if "Details unavailable" not in out["text"]:
+        fail("broken template did not fall back — body: %r" % out["text"][:400])
+    if "lint //..." not in out["title"]:
+        fail("status/title lost on fallback: %r" % out["title"])
+
+    # The custom summary template still renders normally (only details broke).
+    if not out["summary"]:
+        fail("summary should still render when only details template is broken")
 
 def _check_failed_actions_invoke_snippet_macro(ctx):
     """A failed Bazel action drives the embedded Bazel-targets block to call the

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
@@ -690,6 +690,8 @@ def _test_impl(ctx):
 
     _check_broken_template_degrades_gracefully(ctx)
 
+    _check_trim_induced_render_error_degrades_gracefully(ctx)
+
     print(sep)
     print("All " + str(len(scenarios)) + " lint scenarios + annotation pipeline rendered without error.")
     return 0
@@ -709,6 +711,34 @@ def _check_broken_template_degrades_gracefully(ctx):
         fail("broken template did not fall back — body: %r" % out["text"][:400])
     if "lint //..." not in out["title"]:
         fail("status/title lost on fallback: %r" % out["title"])
+
+def _check_trim_induced_render_error_degrades_gracefully(ctx):
+    """A template that renders fine at first but errors only after the trim
+    cascade mutates the data must still degrade, not crash.
+
+    The cascade re-renders with the same template on progressively trimmed
+    `details_data`; a template whose error is gated on a trimmed shape (here:
+    an undefined call reached once a group carries `overflow` from row-halving)
+    would abort the invocation if the re-renders used the throwing render path.
+    Uses the large fixture so the initial body exceeds _DETAILS_LIMIT and the
+    cascade runs."""
+    data = _make_results_large()
+
+    # A huge line per row pushes the initial body past _DETAILS_LIMIT so the
+    # cascade runs and trims rows (setting `overflow` on a group). The undefined
+    # call is gated on that trimmed shape, so it fires on a re-render, not the
+    # first render — the case that would crash if re-renders used the throwing
+    # path.
+    broken = {"details": (
+        "{% for g in groups %}{% if g.overflow %}{{ boom_after_trim() }}{% endif %}" +
+        "{% for r in g.rows %}{{ r.file }} " + ("x" * 9000) + "\n{% endfor %}{% endfor %}"
+    )}
+    out = render_check_output(ctx, data, "failed", _render_ctx(), _links(), templates = broken)
+
+    if "Details unavailable" not in out["text"]:
+        fail("trim-induced render error did not fall back — body: %r" % out["text"][:400])
+    if "lint //..." not in out["title"]:
+        fail("status/title lost on trim-induced fallback: %r" % out["title"])
 
 def _check_failed_actions_invoke_snippet_macro(ctx):
     """A failed Bazel action drives the embedded Bazel-targets block to call the

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results.axl
@@ -28,6 +28,8 @@ load(
     "build_details_data",
     "build_summary_data",
     "format_run_date",
+    "render_details_or_fallback",
+    "render_summary_or_fallback",
     bazel_init_data = "init_data",
 )
 load("./result_text.axl", "emoji_for_status")
@@ -184,8 +186,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
     details_tmpl = t.get("details") or _DETAILS_TEMPLATE
 
-    summary_text = ctx.template.jinja2(summary_tmpl, data = summary_data)
-    details_text = ctx.template.jinja2(details_tmpl, data = details_data)
+    (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "warming")
+    (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "warming")
 
     # Hard cap on the details body (GitHub limit). The warming body is bounded
     # by construction (no per-file list), so truncate rather than cascade.

--- a/crates/axl-runtime/src/engine/template/mod.rs
+++ b/crates/axl-runtime/src/engine/template/mod.rs
@@ -68,6 +68,19 @@ fn json_to_minijinja(value: &JsonValue) -> MinijinjaValue {
     }
 }
 
+/// Build a JSON object from AXL template `data` kwargs. Each value is
+/// converted via its `to_json_value`, which can fail on an unserializable
+/// value (that error is a caller bug, so it propagates).
+fn template_data_to_json<'v>(
+    data: UnpackDictEntries<String, Value<'v>>,
+) -> anyhow::Result<JsonValue> {
+    let mut json_map: Map<String, JsonValue> = Map::new();
+    for (k, v) in data.entries {
+        json_map.insert(k, v.to_json_value()?);
+    }
+    Ok(JsonValue::Object(json_map))
+}
+
 pub(super) fn jinja2_render(template: &str, data: &JsonValue) -> anyhow::Result<String> {
     let mut env = MinijinjaEnvironment::new();
     env.add_template("template", template)
@@ -158,12 +171,7 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named, default = UnpackDictEntries::default())]
         data: UnpackDictEntries<String, Value<'v>>,
     ) -> anyhow::Result<String> {
-        let mut json_map: Map<String, JsonValue> = Map::new();
-        for (k, v) in data.entries {
-            json_map.insert(k, v.to_json_value()?);
-        }
-        let json_data = JsonValue::Object(json_map);
-        handlebars_render(template.as_str(), &json_data)
+        handlebars_render(template.as_str(), &template_data_to_json(data)?)
     }
 
     /// Renders a Jinja2 template with the provided data.
@@ -185,12 +193,7 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named, default = UnpackDictEntries::default())]
         data: UnpackDictEntries<String, Value<'v>>,
     ) -> anyhow::Result<String> {
-        let mut json_map: Map<String, JsonValue> = Map::new();
-        for (k, v) in data.entries {
-            json_map.insert(k, v.to_json_value()?);
-        }
-        let json_data = JsonValue::Object(json_map);
-        jinja2_render(template.as_str(), &json_data)
+        jinja2_render(template.as_str(), &template_data_to_json(data)?)
     }
 
     /// Renders a Jinja2 template like `jinja2`, but never fails the evaluation:
@@ -210,8 +213,8 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
     /// ```starlark
     /// ok, text = ctx.template.try_jinja2(tmpl, data = d)
     /// if not ok:
-    ///     _LOG.warn(ctx.std, "render failed: %s" % text)
-    ///     text = fallback_body(text)
+    ///     # `text` holds the render error; fall back instead of raising.
+    ///     text = "unavailable"
     /// ```
     fn try_jinja2<'v>(
         #[allow(unused)] this: Value<'v>,
@@ -220,12 +223,7 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
         data: UnpackDictEntries<String, Value<'v>>,
         heap: Heap<'v>,
     ) -> anyhow::Result<Value<'v>> {
-        let mut json_map: Map<String, JsonValue> = Map::new();
-        for (k, v) in data.entries {
-            json_map.insert(k, v.to_json_value()?);
-        }
-        let json_data = JsonValue::Object(json_map);
-        let (ok, text) = match jinja2_render(template.as_str(), &json_data) {
+        let (ok, text) = match jinja2_render(template.as_str(), &template_data_to_json(data)?) {
             Ok(rendered) => (true, rendered),
             Err(e) => (false, e.to_string()),
         };
@@ -252,12 +250,7 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named, default = UnpackDictEntries::default())]
         data: UnpackDictEntries<String, Value<'v>>,
     ) -> anyhow::Result<String> {
-        let mut json_map: Map<String, JsonValue> = Map::new();
-        for (k, v) in data.entries {
-            json_map.insert(k, v.to_json_value()?);
-        }
-        let json_data = JsonValue::Object(json_map);
-        liquid_render(template.as_str(), &json_data)
+        liquid_render(template.as_str(), &template_data_to_json(data)?)
     }
 }
 

--- a/crates/axl-runtime/src/engine/template/mod.rs
+++ b/crates/axl-runtime/src/engine/template/mod.rs
@@ -10,7 +10,10 @@ use starlark::starlark_module;
 use starlark::starlark_simple_value;
 use starlark::values::StringValue;
 use starlark::values::dict::UnpackDictEntries;
-use starlark::values::{NoSerialize, ProvidesStaticType, StarlarkValue, Value, starlark_value};
+use starlark::values::tuple::AllocTuple;
+use starlark::values::{
+    Heap, NoSerialize, ProvidesStaticType, StarlarkValue, Value, starlark_value,
+};
 
 use crate::engine::template::handlebars::handlebars_render;
 // use crate::engine::template::jinja2::jinja2_render;
@@ -190,6 +193,46 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
         jinja2_render(template.as_str(), &json_data)
     }
 
+    /// Renders a Jinja2 template like `jinja2`, but never fails the evaluation:
+    /// a render error is returned to the caller as a value instead of
+    /// propagating and aborting the whole invocation.
+    ///
+    /// **Returns** a 2-tuple `(ok, text)`:
+    /// - `(True, rendered)` on success.
+    /// - `(False, error_message)` on any parse/render error.
+    ///
+    /// Callers use this where a template bug in one surface must degrade to a
+    /// fallback body rather than crash the process (e.g. status-check
+    /// renderers). Prefer `jinja2` for internal templates whose failure is a
+    /// programming error that should surface loudly.
+    ///
+    /// **Example**
+    /// ```starlark
+    /// ok, text = ctx.template.try_jinja2(tmpl, data = d)
+    /// if not ok:
+    ///     _LOG.warn(ctx.std, "render failed: %s" % text)
+    ///     text = fallback_body(text)
+    /// ```
+    fn try_jinja2<'v>(
+        #[allow(unused)] this: Value<'v>,
+        #[starlark(require = pos)] template: StringValue<'v>,
+        #[starlark(require = named, default = UnpackDictEntries::default())]
+        data: UnpackDictEntries<String, Value<'v>>,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<Value<'v>> {
+        let mut json_map: Map<String, JsonValue> = Map::new();
+        for (k, v) in data.entries {
+            json_map.insert(k, v.to_json_value()?);
+        }
+        let json_data = JsonValue::Object(json_map);
+        let (ok, text) = match jinja2_render(template.as_str(), &json_data) {
+            Ok(rendered) => (true, rendered),
+            Err(e) => (false, e.to_string()),
+        };
+        let items = [heap.alloc(ok), heap.alloc_str(&text).to_value()];
+        Ok(heap.alloc(AllocTuple(items)))
+    }
+
     /// Renders a Liquid template with the provided data.
     ///
     /// **Parameters**
@@ -215,5 +258,36 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
         }
         let json_data = JsonValue::Object(json_map);
         liquid_render(template.as_str(), &json_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jinja2_render_ok() {
+        let data = JsonValue::Object(Map::from_iter([(
+            "name".to_string(),
+            JsonValue::String("World".to_string()),
+        )]));
+        assert_eq!(
+            jinja2_render("Hello, {{ name }}!", &data).unwrap(),
+            "Hello, World!"
+        );
+    }
+
+    #[test]
+    fn jinja2_render_undefined_call_errors() {
+        // The failure `try_jinja2` is built to catch: calling a macro/function
+        // that was never defined. Confirm it surfaces as Err (not a panic, not
+        // a silent empty string) so the tuple mapping returns (False, msg).
+        let err = jinja2_render("{{ not_a_real_macro(x) }}", &JsonValue::Object(Map::new()))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("not_a_real_macro") || err.contains("unknown"),
+            "error should name the undefined call: {err}"
+        );
     }
 }

--- a/crates/axl-runtime/src/engine/template/mod.rs
+++ b/crates/axl-runtime/src/engine/template/mod.rs
@@ -81,6 +81,18 @@ fn template_data_to_json<'v>(
     Ok(JsonValue::Object(json_map))
 }
 
+/// Map a render `Result` to the `(ok, text)` tuple the `try_*` methods return:
+/// `(True, rendered)` on success, `(False, error_message)` on failure. The
+/// failure never propagates — that's the whole point of the `try_*` variants.
+fn render_result_to_tuple(heap: Heap<'_>, result: anyhow::Result<String>) -> Value<'_> {
+    let (ok, text) = match result {
+        Ok(rendered) => (true, rendered),
+        Err(e) => (false, e.to_string()),
+    };
+    let items = [heap.alloc(ok), heap.alloc_str(&text).to_value()];
+    heap.alloc(AllocTuple(items))
+}
+
 pub(super) fn jinja2_render(template: &str, data: &JsonValue) -> anyhow::Result<String> {
     let mut env = MinijinjaEnvironment::new();
     env.add_template("template", template)
@@ -174,6 +186,23 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
         handlebars_render(template.as_str(), &template_data_to_json(data)?)
     }
 
+    /// Renders a Handlebars template like `handlebars`, but never fails the
+    /// evaluation — see `try_jinja2` for the `(ok, text)` contract and when to
+    /// prefer this over the raising variant.
+    fn try_handlebars<'v>(
+        #[allow(unused)] this: Value<'v>,
+        #[starlark(require = pos)] template: StringValue<'v>,
+        #[starlark(require = named, default = UnpackDictEntries::default())]
+        data: UnpackDictEntries<String, Value<'v>>,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<Value<'v>> {
+        let json = template_data_to_json(data)?;
+        Ok(render_result_to_tuple(
+            heap,
+            handlebars_render(template.as_str(), &json),
+        ))
+    }
+
     /// Renders a Jinja2 template with the provided data.
     ///
     /// **Parameters**
@@ -223,12 +252,11 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
         data: UnpackDictEntries<String, Value<'v>>,
         heap: Heap<'v>,
     ) -> anyhow::Result<Value<'v>> {
-        let (ok, text) = match jinja2_render(template.as_str(), &template_data_to_json(data)?) {
-            Ok(rendered) => (true, rendered),
-            Err(e) => (false, e.to_string()),
-        };
-        let items = [heap.alloc(ok), heap.alloc_str(&text).to_value()];
-        Ok(heap.alloc(AllocTuple(items)))
+        let json = template_data_to_json(data)?;
+        Ok(render_result_to_tuple(
+            heap,
+            jinja2_render(template.as_str(), &json),
+        ))
     }
 
     /// Renders a Liquid template with the provided data.
@@ -252,6 +280,23 @@ pub(crate) fn template_methods(registry: &mut MethodsBuilder) {
     ) -> anyhow::Result<String> {
         liquid_render(template.as_str(), &template_data_to_json(data)?)
     }
+
+    /// Renders a Liquid template like `liquid`, but never fails the evaluation
+    /// — see `try_jinja2` for the `(ok, text)` contract and when to prefer this
+    /// over the raising variant.
+    fn try_liquid<'v>(
+        #[allow(unused)] this: Value<'v>,
+        #[starlark(require = pos)] template: StringValue<'v>,
+        #[starlark(require = named, default = UnpackDictEntries::default())]
+        data: UnpackDictEntries<String, Value<'v>>,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<Value<'v>> {
+        let json = template_data_to_json(data)?;
+        Ok(render_result_to_tuple(
+            heap,
+            liquid_render(template.as_str(), &json),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -270,11 +315,12 @@ mod tests {
         );
     }
 
+    // The `try_*` methods rely on the underlying `*_render` returning Err (not
+    // panicking, not silently emitting "") so the tuple mapping can report
+    // (False, msg). One error-path test per engine pins that contract.
+
     #[test]
     fn jinja2_render_undefined_call_errors() {
-        // The failure `try_jinja2` is built to catch: calling a macro/function
-        // that was never defined. Confirm it surfaces as Err (not a panic, not
-        // a silent empty string) so the tuple mapping returns (False, msg).
         let err = jinja2_render("{{ not_a_real_macro(x) }}", &JsonValue::Object(Map::new()))
             .unwrap_err()
             .to_string();
@@ -282,5 +328,39 @@ mod tests {
             err.contains("not_a_real_macro") || err.contains("unknown"),
             "error should name the undefined call: {err}"
         );
+    }
+
+    #[test]
+    fn handlebars_render_ok() {
+        let data = JsonValue::Object(Map::from_iter([(
+            "name".to_string(),
+            JsonValue::String("World".to_string()),
+        )]));
+        assert_eq!(
+            handlebars_render("Hello, {{name}}!", &data).unwrap(),
+            "Hello, World!"
+        );
+    }
+
+    #[test]
+    fn handlebars_render_malformed_template_errors() {
+        assert!(handlebars_render("Hello, {{name", &JsonValue::Object(Map::new())).is_err());
+    }
+
+    #[test]
+    fn liquid_render_ok() {
+        let data = JsonValue::Object(Map::from_iter([(
+            "name".to_string(),
+            JsonValue::String("World".to_string()),
+        )]));
+        assert_eq!(
+            liquid_render("Hello, {{ name }}!", &data).unwrap(),
+            "Hello, World!"
+        );
+    }
+
+    #[test]
+    fn liquid_render_malformed_template_errors() {
+        assert!(liquid_render("Hello, {% if %}", &JsonValue::Object(Map::new())).is_err());
     }
 }


### PR DESCRIPTION
Makes a template render error in any CI status surface degrade gracefully instead of aborting the whole `aspect` process.

Lifecycle handler dispatch calls each status surface's renderer in a bare loop, so an error raised while rendering one surface's body unwinds the entire invocation. AXL has no `try`/`except`, so the fix starts at the template-expansion layer.

**Changes:**
- New non-throwing runtime builtins `ctx.template.try_jinja2` / `try_handlebars` / `try_liquid` — like their raising counterparts but return a `(ok, text_or_error)` tuple, so a render failure becomes a value the caller can branch on.
- Shared AXL helpers `render_summary_or_fallback` / `render_details_or_fallback` (in `bazel_results.axl`): on render failure they log a `WARNING:` to CLI output with the error and return a minimal, macro-free fallback body embedding the same message.
- All six status renderers (build/test, lint, format, gazelle, delivery, warming), both summary and details bodies, routed through the helpers.

The status, title, and conclusion are computed in AXL outside the template, so the check still posts with the correct verdict — only the body text degrades. The fallback body is far under the size limit, so each surface's existing trim cascade is a no-op on it. Templates can be user-supplied overrides, so the fallback attributes nothing to aspect-cli.

Example CLI output when a template fails to render:

```
WARNING: Status render: lint details body failed to render: unknown function: not_a_real_macro is unknown (in template:2)
```

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- A template render error in one CI status surface (lint/format/gazelle/delivery/warming/build/test) no longer aborts the whole `aspect` run — the affected check posts a fallback body with the correct status and a `WARNING:` is logged.

### Test plan

- Rust unit tests: per-engine success + error-path coverage for `jinja2`/`handlebars`/`liquid` render, pinning the contract the `try_*` variants rely on.
- AXL unit tests in `bazel_results_test`: drive all three `try_*` engines (success + malformed), and exercise `render_details_or_fallback` / `render_summary_or_fallback` directly (passthrough + fallback for both bodies).
- AXL end-to-end test in the lint suite renders a broken details template through `render_check_output` and asserts the fallback body appears and the status/title survive.
- All status-surface snapshot suites pass against a from-source CLI build.
