### PR TITLE
feat(workflows): register + heartbeat GitHub check runs for orphan cleanup

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -445,6 +445,14 @@ def config(ctx: ConfigContext):
             "--config=ci",
         ])
 
+    # On GitHub Actions, disable Bazel's curses UI — the log viewer doesn't
+    # render cursor-movement escapes, so the animated progress leaves garbled,
+    # duplicated lines. Plain streaming output reads correctly.
+    if bool(ctx.std.env.var("GITHUB_ACTIONS")):
+        ctx.traits[BazelTrait].extra_flags.extend([
+            "--curses=no",
+        ])
+
     # Configure user_task's attrs by path (group/name).
     t = ctx.tasks["user/nested/user-task"]
     t.args.message = "hello axl"

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -256,6 +256,7 @@ def _github_status_checks(ctx: FeatureContext):
             return
 
         result = github.status_check_register(ctx, {
+            "scm": "github",
             "installation_id": installation_id,
             "installation_proof": installation_proof,
             "owner": owner,

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -332,10 +332,15 @@ def _github_status_checks(ctx: FeatureContext):
                 result = github.status_checks.fail(ctx, token, owner, repo, check_run_id, output = output)
             if result["success"]:
                 _state["_gh_conclusion"] = desired
+
+                # Deregister only once the terminal conclusion actually lands on
+                # GitHub. If the PATCH failed, leave the check registered so the
+                # sweep still finalizes it (as "Disconnected") rather than
+                # dropping cleanup for a check GitHub still shows in progress.
+                if final:
+                    _deregister_check(ctx)
             else:
                 _LOG.warn(ctx.std, "Complete/fail API call failed: %s" % result.get("error", "unknown"))
-            if final:
-                _deregister_check(ctx)
             return
 
         # A terminal update whose conclusion was already set early (e.g. `failing`

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -60,6 +60,12 @@ load("../private/lib/tips.axl", "SURFACE_GITHUB_STATUS_CHECKS", "collect_tips_so
 
 _LOG = feature_logger("GitHub status checks")
 
+# Cadence for re-registering (heartbeating) a check run with the orphan-cleanup
+# backend. A tight fraction of the backend's staleness window so a live task
+# beats several times before it could be judged stale; the register upsert is
+# cheap (one Aspect API call, not a GitHub call).
+_HEARTBEAT_INTERVAL_MS = 30 * 1000
+
 def _detect_triggered_by(env):
     """Return a short string describing who/what triggered this build."""
     if env.var("GITHUB_ACTIONS"):
@@ -161,13 +167,17 @@ def _github_status_checks(ctx: FeatureContext):
         _state["_triggered_by"] = _detect_triggered_by(ctx.std.env)
 
         # actions.read is for the job deep-link only — fails gracefully.
+        # `_extra` captures the installation id + proof from the mint, forwarded
+        # on the register heartbeat so the backend can attribute this check.
         auth_reason = {}
+        auth_extra = {}
         token = github.authenticate(
             ctx,
             owner = owner,
             repo = repo,
             roles = ["checks.write", "actions.read"],
             _reason = auth_reason,
+            _extra = auth_extra,
         )
         if not token:
             _LOG.warn(ctx.std, "Authentication failed for %s/%s — %s" % (
@@ -177,6 +187,8 @@ def _github_status_checks(ctx: FeatureContext):
             ))
             return
         _state["_github_token"] = token
+        _state["_installation_id"] = auth_extra.get("installation_id", "")
+        _state["_installation_proof"] = auth_extra.get("installation_proof", "")
 
         # Re-resolve with the just-minted App token to upgrade the GHA run
         # URL to the per-job URL; cache-hits on the typical path.
@@ -205,6 +217,12 @@ def _github_status_checks(ctx: FeatureContext):
             _LOG.warn(ctx.std, "Failed to create check run: %s" % result.get("error", "unknown error"))
             return
         _state["_check_run_id"] = result["check_run_id"]
+        _state["_check_name"] = check_name
+
+        # Register the check for orphan cleanup and send the first heartbeat, so
+        # the backend finalizes it as "Disconnected" if this process dies before
+        # its own terminal update. Best-effort; retried on later heartbeats.
+        _register_check(ctx, final = False)
 
         # Publish the URL so siblings (GithubStatusComments) can deep-link;
         # `checkrun.url` returns "" until this fires.
@@ -222,6 +240,56 @@ def _github_status_checks(ctx: FeatureContext):
             output = initial_output,
             details_url = html_url or None,
         )
+
+    def _register_check(ctx, final):
+        """Register/heartbeat (`final=False`) or deregister (`final=True`) this
+        task's check run with the Aspect API for orphan cleanup. Best-effort and
+        non-blocking; a miss just leaves the backend to finalize on staleness.
+
+        Needs the installation id + proof from the token mint; skips silently if
+        they're absent (e.g. an env-token path that didn't mint an App token).
+        """
+        check_run_id = _state.get("_check_run_id")
+        installation_id = _state.get("_installation_id")
+        installation_proof = _state.get("_installation_proof")
+        if not check_run_id or not installation_id or not installation_proof:
+            return
+
+        result = github.status_check_register(ctx, {
+            "installation_id": installation_id,
+            "installation_proof": installation_proof,
+            "owner": owner,
+            "repo": repo,
+            "run_id": ctx.std.env.var("GITHUB_RUN_ID") or "",
+            "run_attempt": ctx.std.env.var("GITHUB_RUN_ATTEMPT") or "1",
+            "head_sha": sha,
+            "check_run_id": check_run_id,
+            "name": _state.get("_check_name", ""),
+            "final": final,
+        })
+        if result["success"] and not final:
+            _state["_last_register_ms"] = now_ms(ctx)
+
+    def _deregister_check(ctx):
+        """Deregister once, after the task lands its own terminal conclusion, so
+        the sweep never finalizes this concluded check as "Disconnected". Guarded
+        so it fires at most once and disables any later heartbeat."""
+        if _state.get("_deregistered"):
+            return
+        _state["_deregistered"] = True
+        _register_check(ctx, final = True)
+
+    def _maybe_heartbeat(ctx):
+        """Re-register on the heartbeat cadence so this check's liveness clock
+        keeps advancing while the task runs. Driven off `_task_update` rather
+        than a timer — updates fire regularly, and a wall-clock gate keeps the
+        rate bounded even when they don't. Stops once deregistered so a late
+        update can't resurrect a concluded check."""
+        if not _state.get("_check_run_id") or _state.get("_deregistered"):
+            return
+        last = _state.get("_last_register_ms", 0)
+        if now_ms(ctx) - last >= _HEARTBEAT_INTERVAL_MS:
+            _register_check(ctx, final = False)
 
     def _push_status(ctx, status, final, output = None):
         """Send a check-run update for `(status, final)`. Idempotent re:
@@ -266,7 +334,15 @@ def _github_status_checks(ctx: FeatureContext):
                 _state["_gh_conclusion"] = desired
             else:
                 _LOG.warn(ctx.std, "Complete/fail API call failed: %s" % result.get("error", "unknown"))
+            if final:
+                _deregister_check(ctx)
             return
+
+        # A terminal update whose conclusion was already set early (e.g. `failing`
+        # then `failed` — same `failure`) skips the block above; still deregister
+        # so the sweep never mislabels this concluded check as "Disconnected".
+        if final and _state.get("_gh_conclusion"):
+            _deregister_check(ctx)
 
         # Mid-run progress PATCH (keeps the existing conclusion) — skippable
         # under budget pressure; the conclusion-setting calls above always land.
@@ -361,6 +437,9 @@ def _github_status_checks(ctx: FeatureContext):
         check_run_id = _state.get("_check_run_id")
         if not token or not check_run_id:
             return
+
+        # Keep this check's liveness clock fresh while the task runs.
+        _maybe_heartbeat(ctx)
 
         renderer = renderer_for_kind(update.kind)
         if renderer == None:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -508,6 +508,60 @@ def _status_comment_contribute(ctx, request, profile = None):
 
     return {"success": False, "error": resp.body or "", "status": resp.status}
 
+# Number of attempts per `_status_check_register` call, and the fixed delay
+# between them. Registration is idempotent (keyed by check_run_id server-side),
+# so re-POSTing on a transient flake is safe; a short in-call retry rides out a
+# one-off blip without waiting for the next heartbeat.
+_REGISTER_ATTEMPTS = 3
+_REGISTER_RETRY_MS = 500
+
+def _status_check_register(ctx, request, profile = None):
+    """Register/heartbeat/deregister one GitHub check run with the Aspect API.
+
+    The task's aspect-cli process posts this while it runs so the backend can
+    finalize the check as "Disconnected" if the process dies before sending its
+    own terminal update (see the Marvin `/status-checks/register` handler).
+    `final=False` registers or heartbeats; `final=True` deregisters after the
+    task's terminal conclusion lands.
+
+    `request` is the JSON-encodable body — `{installation_id,
+    installation_proof, owner, repo, run_id, run_attempt, head_sha,
+    check_run_id, name, final}`.
+
+    Best-effort and never raising: retries up to `_REGISTER_ATTEMPTS` times on a
+    transport error or non-2xx (idempotent upsert, safe to repeat), then returns
+    `{"success": bool, "status": int}`. A miss just widens the sweep's job; the
+    caller never blocks on it.
+    """
+    creds = ctx.aspect.auth.credentials(profile = profile)
+    if not creds:
+        return {"success": False, "status": 0}
+
+    url = ctx.aspect.auth.api_url + "/status-checks/register"
+    headers = {
+        "Authorization": "Bearer " + creds.access_token,
+        "Content-Type": "application/json",
+    }
+    body = json.encode(request)
+
+    status = 0
+    for attempt in range(_REGISTER_ATTEMPTS):
+        if attempt > 0:
+            time.sleep(_REGISTER_RETRY_MS)
+        resp = ctx.http().post(url = url, headers = headers, data = body).map_err(lambda e: str(e)).block()
+        if type(resp) == "string":
+            continue  # transport error — retry
+        status = resp.status
+        if status >= 200 and status < 300:
+            return {"success": True, "status": status}
+
+        # 4xx is a deterministic reject (bad proof, missing permission, bad
+        # body); retrying just burns time. Only transport errors and 5xx retry.
+        if status >= 400 and status < 500:
+            break
+
+    return {"success": False, "status": status}
+
 def _read_rate_limit(ctx, token, api_base = DEFAULT_GITHUB_API):
     """Read the installation's GitHub core rate-limit headroom with its
     installation `token`. Returns `{"remaining": int, "reset": int}` from the
@@ -2275,6 +2329,7 @@ github = struct(
     VALID_ROLES = VALID_ROLES,
     authenticate = _authenticate,
     status_comment_contribute = _status_comment_contribute,
+    status_check_register = _status_check_register,
     preferred_token_pair = _preferred_token_pair,
     missing_credentials_reason = _missing_credentials_reason,
     validate_role = validate_role,


### PR DESCRIPTION
A task's aspect-cli process creates a GitHub check run and flips it to a terminal conclusion when the task finishes. If the process is killed first — GHA cancel, spot reclaim, OOM, crash — no terminal update lands and the check hangs "in progress" forever.

Each task now **registers the check it created** with the Aspect API and **heartbeats** (~30s) while it runs, then **deregisters** once it lands its own terminal conclusion. The backend finalizes any check that stops heartbeating (or whose run a cancellation webhook reports) as "Disconnected".

Backend counterpart (the `/status-checks/register` endpoint + sweep): aspect-build/silo#11194

## Details

- `github.status_check_register` POSTs `/status-checks/register` with the installation id + proof captured from the token mint. It retries transient failures up to 3× (the upsert is idempotent) and short-circuits deterministic 4xx.
- The heartbeat rides `_task_update` on a wall-clock gate, so it stays bounded even for quiet long-running tasks, and stops once deregistered.
- Deregistration fires only after the terminal conclusion PATCH actually lands on GitHub — a hard-failing build (`failing` then terminal `failed`, both `failure`) still deregisters, and a failed PATCH leaves the check registered so the sweep still finalizes it.
- Best-effort throughout: a missed register/heartbeat only widens the backend's cleanup window and never blocks the task. Skips silently when no App token was minted (e.g. an env-token path with no installation proof).

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- GitHub status checks left "in progress" by a cancelled or killed CI job are now automatically finalized as "Disconnected" instead of hanging indefinitely.

### Test plan

- CLI builds and the AXL builtins load clean; the backend PR carries the unit coverage for the register/sweep behavior.

### Requires

- Deploy of aspect-build/silo#11194 first — the `/status-checks/register` endpoint must exist. Until then the register calls no-op (best-effort) and nothing regresses.
