### PR TITLE
feat(bes): warn on BES delivery failures; add shared diag logger

### DIFF
--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use axl_runtime::banner;
+use axl_runtime::diag;
 use axl_runtime::engine::arg::Arg;
 use axl_runtime::engine::arguments::Arguments;
 use axl_runtime::engine::feature::FeatureLike;
@@ -210,9 +211,9 @@ impl<'a, 'v> Cmd<'a, 'v> {
             .filter(|s| !s.is_empty())
             .cloned();
         if deprecated_key.is_some() {
-            eprintln!(
-                "\x1b[1;33mWARNING:\x1b[0m --task-key is deprecated; use --task:name instead. \
-                 --task-key will be removed in a future release."
+            diag::warn(
+                "--task-key is deprecated; use --task:name instead. \
+                 --task-key will be removed in a future release.",
             );
         }
         // An explicit name (`--task:name` / `--task-key`) is meaningful as-is.

--- a/crates/axl-runtime/src/diag.rs
+++ b/crates/axl-runtime/src/diag.rs
@@ -24,7 +24,7 @@ use crate::ci::on_recognized_ci;
 
 /// Severity of a diagnostic line, carrying its label and color.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Severity {
+enum Severity {
     /// Cyan `INFO:` — a notable but expected runtime branch fired.
     Info,
     /// Yellow `WARNING:` — a subsystem problem; the task continues.
@@ -63,7 +63,7 @@ const RESET: &str = "\x1b[0m";
 ///
 /// Pure (no I/O) so both the wording and the color gating are unit-testable;
 /// [`emit`] wraps it for the stderr side effect.
-pub fn format_line(sev: Severity, colorize: bool, msg: &str) -> String {
+fn format_line(sev: Severity, colorize: bool, msg: &str) -> String {
     if colorize {
         format!("{}{}{}: {msg}", sev.color(), sev.label(), RESET)
     } else {
@@ -79,7 +79,7 @@ fn colorize() -> bool {
 }
 
 /// Print one severity-prefixed line to stderr, colorized per [`colorize`].
-pub fn emit(sev: Severity, msg: &str) {
+fn emit(sev: Severity, msg: &str) {
     eprintln!("{}", format_line(sev, colorize(), msg));
 }
 

--- a/crates/axl-runtime/src/diag.rs
+++ b/crates/axl-runtime/src/diag.rs
@@ -1,0 +1,131 @@
+//! Severity-prefixed user-facing diagnostics for the Rust side of the CLI.
+//!
+//! The Rust counterpart of the `info` / `warn` / `error` std helpers in
+//! `lib/environment.axl`: the same `INFO:` / `WARNING:` / `ERROR:` prefix
+//! style (mirroring Bazel's uppercase severity labels), the same ANSI colors,
+//! and the same "degrade to plain text when color is off" behavior — so a line
+//! printed from Rust is indistinguishable from one printed by an AXL task.
+//!
+//! Use this for user-facing subsystem messages (a backend became unreachable,
+//! a fallback fired). It is **not** the structured/debug channel — that is
+//! `tracing` (and the `ASPECT_DEBUG`-gated ad-hoc logging some subsystems keep).
+//!
+//! Two deliberate differences from the AXL helpers:
+//!   - **Writes to stderr, not stdout.** These are diagnostics about a task's
+//!     machinery; keeping them off stdout avoids interleaving with piped build
+//!     output. Color therefore keys off *stderr's* TTY, matching `banner`.
+//!   - **No `std` handle.** Rust callers have no Starlark `ctx`, so the color
+//!     predicate reads the ambient environment directly (via [`crate::ci`] and
+//!     `IsTerminal`) instead of `std.io.stdout.is_tty`.
+
+use std::io::IsTerminal;
+
+use crate::ci::on_recognized_ci;
+
+/// Severity of a diagnostic line, carrying its label and color.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Severity {
+    /// Cyan `INFO:` — a notable but expected runtime branch fired.
+    Info,
+    /// Yellow `WARNING:` — a subsystem problem; the task continues.
+    Warning,
+    /// Red `ERROR:` — a recoverable error, usually preceding a non-zero exit.
+    Error,
+}
+
+impl Severity {
+    /// The uppercase label (without the trailing colon).
+    fn label(self) -> &'static str {
+        match self {
+            Severity::Info => "INFO",
+            Severity::Warning => "WARNING",
+            Severity::Error => "ERROR",
+        }
+    }
+
+    /// The SGR color-open sequence for the label, matching the AXL helpers
+    /// (`INFO` bold cyan, `WARNING`/`ERROR` plain yellow/red).
+    fn color(self) -> &'static str {
+        match self {
+            Severity::Info => "\x1b[1;36m",
+            Severity::Warning => "\x1b[0;33m",
+            Severity::Error => "\x1b[0;31m",
+        }
+    }
+}
+
+/// SGR reset.
+const RESET: &str = "\x1b[0m";
+
+/// Format a severity line: `<LABEL>: <msg>`. The colon and message sit outside
+/// the color span, so the label degrades to a plain `LABEL:` when `colorize`
+/// is false (a non-rendering log gets no stray escapes).
+///
+/// Pure (no I/O) so both the wording and the color gating are unit-testable;
+/// [`emit`] wraps it for the stderr side effect.
+pub fn format_line(sev: Severity, colorize: bool, msg: &str) -> String {
+    if colorize {
+        format!("{}{}{}: {msg}", sev.color(), sev.label(), RESET)
+    } else {
+        format!("{}: {msg}", sev.label())
+    }
+}
+
+/// Whether to emit ANSI color, using the same predicate as the rest of the CLI:
+/// an interactive stderr, or a recognized CI host (whose log viewers render
+/// ANSI despite a non-TTY pipe).
+fn colorize() -> bool {
+    std::io::stderr().is_terminal() || on_recognized_ci()
+}
+
+/// Print one severity-prefixed line to stderr, colorized per [`colorize`].
+pub fn emit(sev: Severity, msg: &str) {
+    eprintln!("{}", format_line(sev, colorize(), msg));
+}
+
+/// Print a cyan `INFO:` line for a notable runtime branch.
+pub fn info(msg: &str) {
+    emit(Severity::Info, msg);
+}
+
+/// Print a yellow `WARNING:` line for a non-fatal subsystem failure.
+pub fn warn(msg: &str) {
+    emit(Severity::Warning, msg);
+}
+
+/// Print a red `ERROR:` line for a recoverable error (usually preceding a
+/// non-zero exit).
+pub fn error(msg: &str) {
+    emit(Severity::Error, msg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn colorized_matches_axl_severity_style() {
+        // Colon and message outside the color span; colors match lib/environment.axl.
+        assert_eq!(
+            format_line(Severity::Info, true, "hello"),
+            "\x1b[1;36mINFO\x1b[0m: hello"
+        );
+        assert_eq!(
+            format_line(Severity::Warning, true, "hello"),
+            "\x1b[0;33mWARNING\x1b[0m: hello"
+        );
+        assert_eq!(
+            format_line(Severity::Error, true, "hello"),
+            "\x1b[0;31mERROR\x1b[0m: hello"
+        );
+    }
+
+    #[test]
+    fn plain_omits_ansi() {
+        for sev in [Severity::Info, Severity::Warning, Severity::Error] {
+            let line = format_line(sev, false, "hello");
+            assert_eq!(line, format!("{}: hello", sev.label()));
+            assert!(!line.contains('\x1b'), "{sev:?} leaked an escape: {line:?}");
+        }
+    }
+}

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    io::IsTerminal,
     sync::OnceLock,
     thread::{self, JoinHandle},
 };
@@ -17,14 +16,14 @@ use build_event_stream::{
     lifecycle,
 };
 
-use tokio_stream::{wrappers::ReceiverStream, StreamExt};
+use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 
-use crate::ci::on_recognized_ci;
+use crate::diag;
 use crate::engine::r#async::rt::AsyncRuntime;
 
 use super::super::stream::Subscriber;
 use super::retry::{
-    backoff, is_retryable, BufferOverflow, RetryBuffer, RetryConfig, SinkError, SinkOutcome,
+    BufferOverflow, RetryBuffer, RetryConfig, SinkError, SinkOutcome, backoff, is_retryable,
 };
 
 #[derive(Debug)]
@@ -102,36 +101,14 @@ fn dbg(endpoint: &str, invocation_id: &str, msg: &str) {
     eprintln!("BES sink {endpoint} [{short}]: {msg}");
 }
 
-/// The `WARNING` label, matching the CLI's severity-prefix style (yellow when
-/// colorized, plain otherwise) from the `warn()` std helper in
-/// `lib/environment.axl`. The `:` sits outside the color span so the label
-/// degrades to a plain `WARNING:` in a non-rendering log.
-fn warn_label(colorize: bool) -> &'static str {
-    if colorize {
-        "\x1b[0;33mWARNING\x1b[0m:"
-    } else {
-        "WARNING:"
-    }
-}
-
-/// Format a user-facing sink WARNING line. Pure (no I/O) so both the wording
-/// and the color gating are unit-testable; [`warn`] wraps it for the stderr
-/// side effect.
-fn warn_line(colorize: bool, endpoint: &str, msg: &str) -> String {
-    format!("{} BES sink {endpoint}: {msg}", warn_label(colorize))
-}
-
-/// Emit an always-on, user-facing WARNING on stderr. Unlike [`dbg`], this is
-/// not gated on `ASPECT_DEBUG` — it fires on the failures that mean build
-/// events are delayed or lost, so a build that "passes" while its BES upload
-/// is broken still tells the user something is wrong (the upload is
-/// best-effort and never fails the build).
-///
-/// Color follows the same predicate as the rest of the CLI: emitted on an
-/// interactive stderr or a recognized CI host, plain text otherwise.
+/// Emit an always-on, user-facing `WARNING:` for this sink. Unlike [`dbg`],
+/// this is not gated on `ASPECT_DEBUG` — it fires on the failures that mean
+/// build events are delayed or lost, so a build that "passes" while its BES
+/// upload is broken still tells the user something is wrong (the upload is
+/// best-effort and never fails the build). Prefixed `BES sink <endpoint>:` to
+/// distinguish it in multi-sink configurations.
 fn warn(endpoint: &str, msg: &str) {
-    let colorize = std::io::stderr().is_terminal() || on_recognized_ci();
-    eprintln!("{}", warn_line(colorize, endpoint, msg));
+    diag::warn(&format!("BES sink {endpoint}: {msg}"));
 }
 
 /// Send one of the unary lifecycle events (`build_enqueued`,
@@ -863,27 +840,6 @@ fn finalize(endpoint: &str, last_error: String) -> SinkError {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn warn_line_colorized_matches_cli_warning_style() {
-        // Yellow WARNING with the colon outside the color span, per the `warn()`
-        // std helper in lib/environment.axl.
-        let line = warn_line(true, "grpcs://bes.example.com", "could not connect");
-        assert_eq!(
-            line,
-            "\x1b[0;33mWARNING\x1b[0m: BES sink grpcs://bes.example.com: could not connect"
-        );
-    }
-
-    #[test]
-    fn warn_line_plain_omits_ansi() {
-        let line = warn_line(false, "grpcs://bes.example.com", "could not connect");
-        assert_eq!(
-            line,
-            "WARNING: BES sink grpcs://bes.example.com: could not connect"
-        );
-        assert!(!line.contains('\x1b'));
-    }
 
     #[test]
     fn fail_preserves_machine_cause_independent_of_user_message() {

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    io::IsTerminal,
     sync::OnceLock,
     thread::{self, JoinHandle},
 };
@@ -18,6 +19,7 @@ use build_event_stream::{
 
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 
+use crate::ci::on_recognized_ci;
 use crate::engine::r#async::rt::AsyncRuntime;
 
 use super::super::stream::Subscriber;
@@ -100,14 +102,23 @@ fn dbg(endpoint: &str, invocation_id: &str, msg: &str) {
     eprintln!("BES sink {endpoint} [{short}]: {msg}");
 }
 
-/// SGR sequence for a bold-yellow `WARNING:` label, matching the CLI's
-/// user-facing warning style (see `cmd.rs`).
-const WARN_LABEL: &str = "\x1b[1;33mWARNING:\x1b[0m";
+/// The `WARNING` label, matching the CLI's severity-prefix style (yellow when
+/// colorized, plain otherwise) from the `warn()` std helper in
+/// `lib/environment.axl`. The `:` sits outside the color span so the label
+/// degrades to a plain `WARNING:` in a non-rendering log.
+fn warn_label(colorize: bool) -> &'static str {
+    if colorize {
+        "\x1b[0;33mWARNING\x1b[0m:"
+    } else {
+        "WARNING:"
+    }
+}
 
-/// Format a user-facing sink WARNING line. Pure (no I/O) so the wording is
-/// unit-testable; [`warn`] wraps it for the stderr side effect.
-fn warn_line(endpoint: &str, msg: &str) -> String {
-    format!("{WARN_LABEL} BES sink {endpoint}: {msg}")
+/// Format a user-facing sink WARNING line. Pure (no I/O) so both the wording
+/// and the color gating are unit-testable; [`warn`] wraps it for the stderr
+/// side effect.
+fn warn_line(colorize: bool, endpoint: &str, msg: &str) -> String {
+    format!("{} BES sink {endpoint}: {msg}", warn_label(colorize))
 }
 
 /// Emit an always-on, user-facing WARNING on stderr. Unlike [`dbg`], this is
@@ -115,8 +126,12 @@ fn warn_line(endpoint: &str, msg: &str) -> String {
 /// events are delayed or lost, so a build that "passes" while its BES upload
 /// is broken still tells the user something is wrong (the upload is
 /// best-effort and never fails the build).
+///
+/// Color follows the same predicate as the rest of the CLI: emitted on an
+/// interactive stderr or a recognized CI host, plain text otherwise.
 fn warn(endpoint: &str, msg: &str) {
-    eprintln!("{}", warn_line(endpoint, msg));
+    let colorize = std::io::stderr().is_terminal() || on_recognized_ci();
+    eprintln!("{}", warn_line(colorize, endpoint, msg));
 }
 
 /// Send one of the unary lifecycle events (`build_enqueued`,
@@ -850,13 +865,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn warn_line_has_bold_yellow_label_and_endpoint() {
-        let line = warn_line("grpcs://bes.example.com", "could not connect");
+    fn warn_line_colorized_matches_cli_warning_style() {
+        // Yellow WARNING with the colon outside the color span, per the `warn()`
+        // std helper in lib/environment.axl.
+        let line = warn_line(true, "grpcs://bes.example.com", "could not connect");
         assert_eq!(
             line,
-            "\x1b[1;33mWARNING:\x1b[0m BES sink grpcs://bes.example.com: could not connect"
+            "\x1b[0;33mWARNING\x1b[0m: BES sink grpcs://bes.example.com: could not connect"
         );
-        assert!(line.starts_with(WARN_LABEL));
+    }
+
+    #[test]
+    fn warn_line_plain_omits_ansi() {
+        let line = warn_line(false, "grpcs://bes.example.com", "could not connect");
+        assert_eq!(
+            line,
+            "WARNING: BES sink grpcs://bes.example.com: could not connect"
+        );
+        assert!(!line.contains('\x1b'));
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -101,12 +101,10 @@ fn dbg(endpoint: &str, invocation_id: &str, msg: &str) {
     eprintln!("BES sink {endpoint} [{short}]: {msg}");
 }
 
-/// Emit an always-on, user-facing `WARNING:` for this sink. Unlike [`dbg`],
-/// this is not gated on `ASPECT_DEBUG` — it fires on the failures that mean
-/// build events are delayed or lost, so a build that "passes" while its BES
-/// upload is broken still tells the user something is wrong (the upload is
-/// best-effort and never fails the build). Prefixed `BES sink <endpoint>:` to
-/// distinguish it in multi-sink configurations.
+/// Emit a user-facing `WARNING:` for this sink, prefixed `BES sink <endpoint>:`
+/// to distinguish it in multi-sink configurations. Unlike [`dbg`], it is not
+/// `ASPECT_DEBUG`-gated: BES upload is best-effort and never fails the build,
+/// so this is the only signal that events were delayed or lost.
 fn warn(endpoint: &str, msg: &str) {
     diag::warn(&format!("BES sink {endpoint}: {msg}"));
 }
@@ -178,9 +176,11 @@ async fn work(
         }
     });
 
-    // Bound the initial connect: a TLS handshake against an unresponsive
-    // endpoint can stall indefinitely without any of the retry machinery
-    // ever running.
+    // `Client::new` only builds a lazy channel (endpoint URI + TLS config); it
+    // does not dial, so a failure here is a client misconfiguration, not an
+    // unreachable backend — the real connect/auth errors surface on the first
+    // lifecycle RPC below. The timeout guards against a pathological stall in
+    // channel construction.
     const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
     let connect_started = std::time::Instant::now();
     let mut client =
@@ -189,8 +189,8 @@ async fn work(
             Ok(Err(e)) => {
                 return Err(fail(
                     &endpoint,
-                    "could not connect, build events will not be delivered",
-                    format!("connect failed: {e}"),
+                    "invalid backend configuration, build events will not be delivered",
+                    format!("client setup failed: {e}"),
                 ));
             }
             Err(_) => {
@@ -198,9 +198,9 @@ async fn work(
                 return Err(fail(
                     &endpoint,
                     &format!(
-                        "could not connect within {secs}s, build events will not be delivered"
+                        "client setup stalled for {secs}s, build events will not be delivered"
                     ),
-                    format!("connect timed out after {secs}s"),
+                    format!("client setup timed out after {secs}s"),
                 ));
             }
         };
@@ -821,7 +821,7 @@ async fn retry_lifecycle(
 /// Terminate the sink: warn the user (with `user_msg`) that events won't be
 /// delivered, and return the `SinkError` carrying the machine-readable
 /// `last_error` cause. The two strings differ when the user-facing phrasing
-/// should read better than the raw cause (e.g. connect failures).
+/// should read better than the raw cause (e.g. client-setup failures).
 fn fail(endpoint: &str, user_msg: &str, last_error: String) -> SinkError {
     warn(endpoint, user_msg);
     SinkError { last_error }

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -16,13 +16,13 @@ use build_event_stream::{
     lifecycle,
 };
 
-use tokio_stream::{StreamExt, wrappers::ReceiverStream};
+use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 
 use crate::engine::r#async::rt::AsyncRuntime;
 
 use super::super::stream::Subscriber;
 use super::retry::{
-    BufferOverflow, RetryBuffer, RetryConfig, SinkError, SinkOutcome, backoff, is_retryable,
+    backoff, is_retryable, BufferOverflow, RetryBuffer, RetryConfig, SinkError, SinkOutcome,
 };
 
 #[derive(Debug)]
@@ -100,6 +100,25 @@ fn dbg(endpoint: &str, invocation_id: &str, msg: &str) {
     eprintln!("BES sink {endpoint} [{short}]: {msg}");
 }
 
+/// SGR sequence for a bold-yellow `WARNING:` label, matching the CLI's
+/// user-facing warning style (see `cmd.rs`).
+const WARN_LABEL: &str = "\x1b[1;33mWARNING:\x1b[0m";
+
+/// Format a user-facing sink WARNING line. Pure (no I/O) so the wording is
+/// unit-testable; [`warn`] wraps it for the stderr side effect.
+fn warn_line(endpoint: &str, msg: &str) -> String {
+    format!("{WARN_LABEL} BES sink {endpoint}: {msg}")
+}
+
+/// Emit an always-on, user-facing WARNING on stderr. Unlike [`dbg`], this is
+/// not gated on `ASPECT_DEBUG` — it fires on the failures that mean build
+/// events are delayed or lost, so a build that "passes" while its BES upload
+/// is broken still tells the user something is wrong (the upload is
+/// best-effort and never fails the build).
+fn warn(endpoint: &str, msg: &str) {
+    eprintln!("{}", warn_line(endpoint, msg));
+}
+
 /// Send one of the unary lifecycle events (`build_enqueued`,
 /// `invocation_started`, `invocation_finished`, `build_finished`),
 /// timing the round trip and logging the result. Errors are wrapped
@@ -174,11 +193,22 @@ async fn work(
     let connect_started = std::time::Instant::now();
     let mut client =
         match tokio::time::timeout(CONNECT_TIMEOUT, Client::new(endpoint.clone(), headers)).await {
-            Ok(r) => r.map_err(|e| finalize(&endpoint, format!("connect failed: {e}")))?,
-            Err(_) => {
-                return Err(finalize(
+            Ok(Ok(client)) => client,
+            Ok(Err(e)) => {
+                return Err(fail(
                     &endpoint,
-                    "connect timed out after 10s".to_string(),
+                    "could not connect, build events will not be delivered",
+                    format!("connect failed: {e}"),
+                ));
+            }
+            Err(_) => {
+                let secs = CONNECT_TIMEOUT.as_secs();
+                return Err(fail(
+                    &endpoint,
+                    &format!(
+                        "could not connect within {secs}s, build events will not be delivered"
+                    ),
+                    format!("connect timed out after {secs}s"),
                 ));
             }
         };
@@ -216,6 +246,10 @@ async fn work(
     let mut next_seq: i64 = 1;
     let mut attempt: u32 = 0;
     let mut last_message_sent = false;
+    // Warn at most once per sink when the stream first drops into retry, so a
+    // flapping or slow backend produces an early user-facing signal without a
+    // line per retry attempt.
+    let mut warned_transient = false;
 
     'reconnect: loop {
         dbg(
@@ -258,6 +292,16 @@ async fn work(
                         &endpoint,
                         format!("giving up after {attempt} attempts: {err}"),
                     ));
+                }
+                if !warned_transient {
+                    warn(
+                        &endpoint,
+                        &format!(
+                            "backend unreachable, retrying (up to {} times): {err}",
+                            retry.max_retries
+                        ),
+                    );
+                    warned_transient = true;
                 }
                 let delay = backoff(retry.retry_min_delay, attempt);
                 dbg(
@@ -782,7 +826,55 @@ async fn retry_lifecycle(
     }
 }
 
-fn finalize(endpoint: &str, last_error: String) -> SinkError {
-    eprintln!("WARNING: BES sink {endpoint} giving up: {last_error}");
+/// Terminate the sink: warn the user (with `user_msg`) that events won't be
+/// delivered, and return the `SinkError` carrying the machine-readable
+/// `last_error` cause. The two strings differ when the user-facing phrasing
+/// should read better than the raw cause (e.g. connect failures).
+fn fail(endpoint: &str, user_msg: &str, last_error: String) -> SinkError {
+    warn(endpoint, user_msg);
     SinkError { last_error }
+}
+
+/// [`fail`] for the give-up cases, where the raw cause is also fit to show the
+/// user directly.
+fn finalize(endpoint: &str, last_error: String) -> SinkError {
+    fail(
+        endpoint,
+        &format!("giving up, build events were not delivered: {last_error}"),
+        last_error,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warn_line_has_bold_yellow_label_and_endpoint() {
+        let line = warn_line("grpcs://bes.example.com", "could not connect");
+        assert_eq!(
+            line,
+            "\x1b[1;33mWARNING:\x1b[0m BES sink grpcs://bes.example.com: could not connect"
+        );
+        assert!(line.starts_with(WARN_LABEL));
+    }
+
+    #[test]
+    fn fail_preserves_machine_cause_independent_of_user_message() {
+        // The user-facing phrasing and the machine-readable cause are allowed to
+        // differ; `SinkError` must carry the latter verbatim for callers that
+        // inspect `sink.error`.
+        let err = fail(
+            "grpcs://bes.example.com",
+            "could not connect, build events will not be delivered",
+            "connect failed: transport error".to_string(),
+        );
+        assert_eq!(err.last_error, "connect failed: transport error");
+    }
+
+    #[test]
+    fn finalize_carries_cause_in_sink_error() {
+        let err = finalize("grpcs://bes.example.com", "deadline exceeded".to_string());
+        assert_eq!(err.last_error, "deadline exceeded");
+    }
 }

--- a/crates/axl-runtime/src/lib.rs
+++ b/crates/axl-runtime/src/lib.rs
@@ -7,6 +7,7 @@ extern crate self as axl_runtime;
 pub mod banner;
 pub mod builtins;
 pub mod ci;
+pub mod diag;
 pub mod docs;
 pub mod engine;
 pub mod eval;


### PR DESCRIPTION
The CLI-streamed BES sink (`--bes-backend`, distinct from Bazel's `--bes_backend`) forwards build events best-effort and never fails the build. When delivery failed it dropped events with no user-facing signal — a passing build gave no indication its data never landed in the BES backend.

This surfaces a user-facing `WARNING:` on the failures that mean events are delayed or lost:

- **Invalid backend configuration** — the client channel could not be constructed (bad endpoint URI / TLS config).
- **First drop into retry** — the stream broke or a lifecycle RPC failed mid-flight; warned once per sink (not per attempt), so a flapping or unreachable backend gives an early signal without log spam.
- **Terminal give-up** — retries exhausted or a non-retryable error (e.g. failed auth); the sink stops and reports that events were not delivered.

The warning is informational only; BES upload remains best-effort and does not affect the build's exit code.

**Shared diagnostics helper.** The Rust side had no shared user-facing diagnostic facility, so warnings were hand-rolled ANSI (bold, ungated — leaking raw escapes into piped logs). This adds `axl_runtime::diag` with `info` / `warn` / `error`, mirroring the `info`/`warn`/`error` std helpers in `lib/environment.axl`: same severity labels and colors, color gated on an interactive stderr or a recognized CI host (plain text otherwise). Both existing hand-rolled `WARNING:` sites — the BES sink and the `--task-key` deprecation notice in `cmd.rs` — now route through it.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Suggested release notes:

- The CLI now prints a `WARNING` when it cannot deliver build events to a `--bes-backend` (bad configuration, retries, or give-up), instead of dropping them silently.

### Test plan

- New test cases added: `diag` severity formatting (colorized and plain), and `fail`/`finalize` preserving the machine-readable cause on `SinkError`.
- Manual testing: a build with `--bes-backend=grpcs://localhost:59999` (nothing listening) passes and prints `WARNING: BES sink https://localhost:59999: giving up, build events were not delivered: ...` — plain when piped, yellow under a TTY/CI. Verified the migrated `--task-key` deprecation warning renders identically.
