### PR TITLE
feat(bes): announce and summarize build-event streaming to each BES backend

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -13,6 +13,7 @@ load("@aspect//private/lib/bazel_flags_test.axl", "bazel_flags_tests")
 load("@aspect//private/lib/bazel_results_test.axl", "bazel_results_unit_tests", "template_snapshot_tests")
 load("@aspect//private/lib/bazel_runner_test.axl", "bazel_runner_tests")
 load("@aspect//private/lib/bazelrc_test.axl", "bazelrc_tests")
+load("@aspect//private/lib/bes_sinks_test.axl", "bes_sinks_tests")
 load("@aspect//private/lib/ci_test.axl", "ci_tests")
 load("@aspect//private/lib/circleci_test.axl", "circleci_tests")
 load("@aspect//private/lib/delivery_results_test.axl", "delivery_results_unit_tests", "delivery_template_snapshot_tests")
@@ -371,6 +372,10 @@ def config(ctx: ConfigContext):
     # deployment_flags.axl: --deployment / --aspect-* capability resolution.
     # Run with: aspect dev test-deployment-flags
     ctx.tasks.add(deployment_flags_tests)
+
+    # bes_sinks.axl: the end-of-build BES upload summary line.
+    # Run with: aspect dev test-bes-sinks
+    ctx.tasks.add(bes_sinks_tests)
 
     # auth.axl: status/configure detail string builders.
     # Run with: aspect dev test-auth

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -154,7 +154,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "expand_config_flags", "resolve_bazel_announce", "sibling_rc")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "now_ms", "process_event", bazel_init_data = "init_data")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "bes_args", "collect_bes_from_args")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
 load("./private/lib/ci.axl", "resolve_build_url")
 load("./private/lib/delivery_results.axl", delivery_add_result = "add_result", delivery_build_manifest = "build_manifest", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
 load(
@@ -514,10 +514,11 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
                 break
         status = build.wait()
 
-        # Flush trait sinks (e.g. bessie) before any retry — re-binding a
+        # Flush the CLI-streamed BES sinks before any retry — re-binding a
         # Live sink errors.
         for sink in build_events:
             sink.wait()
+        summarize_bes_upload(ctx, build_events)
 
         dispatch_bazel_attempt_end(ctx, bazel_trait, status.code)
 
@@ -1044,6 +1045,7 @@ def _delivery_impl(ctx):
     # CLI-streamed `--bes-backend` sinks stream phase-1 events and are waited
     # alongside the trait sinks (see `_get_output_shas`).
     build_events = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    announce_bes_sinks(ctx, build_events)
 
     for handler in bazel_trait.build_start:
         handler(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -21,7 +21,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "bes_args", "collect_bes_from_args")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("./private/lib/format_results.axl", fmt_init_data = "init_data", format_conclusion = "conclusion")
@@ -320,9 +320,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # Pass build_event_sinks (carries the Aspect backend gRPC sink in CI) so the
     # "✨ Aspect Workflows" link resolves to a real record, not a 404.
-    bes_sinks = collect_bes_from_args(ctx)
+    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
-    build_events = [events] + bes_sinks + list(bazel_trait.build_event_sinks)
+    build_events = [events] + bes_sinks
 
     # Fire build_start hooks before spawning — Workflows registers the BK
     # `--- :bazel: Running bazel …` marker; other features hook pre-spawn work.
@@ -399,8 +400,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             break
 
     build_status = build.wait()
-    for sink in bes_sinks + list(bazel_trait.build_event_sinks):
+    for sink in bes_sinks:
         sink.wait()
+    summarize_bes_upload(ctx, bes_sinks)
     dispatch_bazel_attempt_end(ctx, bazel_trait, build_status.code)
     dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -87,7 +87,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "bes_args", "collect_bes_from_args")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
 load("./private/lib/gazelle_results.axl", "dedupe_subtrees", "dir_at_or_below", "extract_changed_dirs", gaz_init_data = "init_data", gazelle_conclusion = "conclusion")
@@ -462,9 +462,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     r = runnable(ctx, [ctx.args.gazelle_target], rc = rc)
 
     # See format.axl for why the trait sinks need to be plumbed in.
-    bes_sinks = collect_bes_from_args(ctx)
+    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
-    build_events = [events] + bes_sinks + list(bazel_trait.build_event_sinks)
+    build_events = [events] + bes_sinks
 
     # Fire build_start hooks before spawning — Workflows registers the BK
     # `--- :bazel: Running bazel …` section marker here.
@@ -541,8 +542,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             break
 
     build_status = build.wait()
-    for sink in bes_sinks + list(bazel_trait.build_event_sinks):
+    for sink in bes_sinks:
         sink.wait()
+    summarize_bes_upload(ctx, bes_sinks)
     dispatch_bazel_attempt_end(ctx, bazel_trait, build_status.code)
     dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -22,7 +22,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "bes_args", "collect_bes_from_args")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "warn")
 load("./private/lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
@@ -707,9 +707,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for hook in lint_trait.lint_start:
         hook(ctx)
 
-    bes_sinks = collect_bes_from_args(ctx)
+    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
-    build_events = [events] + bes_sinks + list(bazel_trait.build_event_sinks)
+    build_events = [events] + bes_sinks
 
     for hook in bazel_trait.build_start:
         hook(ctx)
@@ -834,8 +835,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # 7. Wait for build
     build_status = build.wait()
-    for sink in bes_sinks + list(bazel_trait.build_event_sinks):
+    for sink in bes_sinks:
         sink.wait()
+    summarize_bes_upload(ctx, bes_sinks)
 
     dispatch_bazel_attempt_end(ctx, bazel_trait, build_status.code)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -16,8 +16,8 @@ load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
-load("./bes_sinks.axl", "collect_bes_from_args")
-load("./deployment_flags.axl", "announce_deployment_bes_streamed", "announce_deployment_flags", "deployment_endpoint_flags")
+load("./bes_sinks.axl", "collect_bes_from_args", "summarize_bes_upload")
+load("./deployment_flags.axl", "announce_deployment_flags", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "flavor_allows", "print_repro_and_fix", "repro_prefix")
@@ -299,7 +299,12 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     # injected --remote_cache / BES backend / --remote_executor aren't silent.
     announce_deployment_flags(ctx, deployment)
 
-    bes_sinks = collect_bes_from_args(ctx, extra_backends = deployment.bes_backends)
+    # The CLI-streamed BES sinks (explicit `--bes-backend` + the deployment's BES)
+    # are the user-facing backends we summarize at build end; the trait's own sinks
+    # (the internal Aspect Workflows backend) are appended for streaming but left
+    # out of that summary.
+    cli_bes_sinks = collect_bes_from_args(ctx, extra_backends = deployment.bes_backends)
+    bes_sinks = list(cli_bes_sinks)
     if bazel_trait.build_event_sinks:
         bes_sinks.extend(bazel_trait.build_event_sinks)
     need_bes = bool(bazel_trait.build_event) or bool(lifecycle.task_update)
@@ -471,15 +476,11 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
 
         # Flush sinks before deciding whether to retry — re-binding a Live
         # sink errors (see BuildEventSink::bind_grpc).
-        any_sink_failed = False
         for sink in bes_sinks:
             sink.wait()
-            any_sink_failed = any_sink_failed or sink.failed
 
-        # Confirm the deployment's BES stream landed (a failure already prints its
-        # own `WARNING: BES sink … giving up`, so only announce the clean case).
-        if deployment.bes_backends and not any_sink_failed:
-            announce_deployment_bes_streamed(ctx, deployment)
+        # Summarize how many build events each CLI-streamed backend received.
+        summarize_bes_upload(ctx, cli_bes_sinks)
 
         dispatch_bazel_attempt_end(ctx, bazel_trait, invocation_status.code)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -16,7 +16,7 @@ load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
-load("./bes_sinks.axl", "collect_bes_from_args", "summarize_bes_upload")
+load("./bes_sinks.axl", "announce_bes_sinks", "collect_bes_from_args", "summarize_bes_upload")
 load("./deployment_flags.axl", "announce_deployment_flags", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
@@ -295,18 +295,18 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     rc = setup_phase(ctx, lifecycle, " ".join(targets), "bazel_results", data, hc_trait, bazel_trait, command, bazel_base_flags = base_flags)
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
-    # Surface which deployment's remote capabilities `--aspect-*` wired in, so the
-    # injected --remote_cache / BES backend / --remote_executor aren't silent.
+    # Surface which deployment's `--remote_cache` / `--remote_executor` the
+    # `--aspect-*` flags wired in, so the injected base flags aren't silent. (BES
+    # is announced separately, below, by `announce_bes_sinks`.)
     announce_deployment_flags(ctx, deployment)
 
-    # The CLI-streamed BES sinks (explicit `--bes-backend` + the deployment's BES)
-    # are the user-facing backends we summarize at build end; the trait's own sinks
-    # (the internal Aspect Workflows backend) are appended for streaming but left
-    # out of that summary.
-    cli_bes_sinks = collect_bes_from_args(ctx, extra_backends = deployment.bes_backends)
-    bes_sinks = list(cli_bes_sinks)
+    # Every CLI-streamed BES sink: explicit `--bes-backend`, the deployment's BES,
+    # and the trait's own sinks (the Workflows runner's env-injected backend). All
+    # are announced now and summarized at build end.
+    bes_sinks = collect_bes_from_args(ctx, extra_backends = deployment.bes_backends)
     if bazel_trait.build_event_sinks:
         bes_sinks.extend(bazel_trait.build_event_sinks)
+    announce_bes_sinks(ctx, bes_sinks)
     need_bes = bool(bazel_trait.build_event) or bool(lifecycle.task_update)
 
     # Per-invocation extras: inject `--remote_header` / `--bes_header` auth for an
@@ -480,7 +480,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
             sink.wait()
 
         # Summarize how many build events each CLI-streamed backend received.
-        summarize_bes_upload(ctx, cli_bes_sinks)
+        summarize_bes_upload(ctx, bes_sinks)
 
         dispatch_bazel_attempt_end(ctx, bazel_trait, invocation_status.code)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
@@ -99,6 +99,7 @@ def bes_upload_line(uri: str, sent: int, acked: int, failed: bool) -> str:
 
     if not failed:
         return "Streamed %d build event%s to %s." % (sent, plural, backend)
+
     # Failed. A stream that never sent an event failed to connect; one that acked
     # everything it sent delivered its events (the failure was the post-stream
     # lifecycle close), so report the plain count; otherwise it's a partial upload.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
@@ -15,6 +15,7 @@ resolution. (The companion case — BES routed through Bazel via
 """
 
 load("./aspect_endpoint_auth.axl", "endpoint_host", "headers_have_auth", "is_aspect_host", "resolve_aspect_bearer")
+load("./environment.axl", "info")
 
 def bes_args() -> dict:
     """The `bes_backends` / `bes_headers` CLI args every BES-capable task
@@ -82,3 +83,29 @@ def collect_bes_from_args(ctx, extra_backends = []) -> list:
             ),
         )
     return sinks
+
+def bes_upload_line(uri: str, sent: int, acked: int, failed: bool) -> str:
+    """The one-line summary of a CLI-streamed BES backend's upload.
+
+    Reports `<acked> of <sent>` only for a genuine partial upload — a failed
+    stream that left events unconfirmed (`acked < sent`). A clean stream, or a
+    failure after every event was acked (e.g. a post-stream lifecycle error),
+    reports the full `<n> build events` since delivery of the events succeeded.
+    Public so `bes_sinks_test.axl` can assert the message shapes."""
+    backend = uri or "the BES backend"
+    plural = "" if sent == 1 else "s"
+    if failed and acked < sent:
+        return "Uploaded %d of %d build event%s to %s before the stream failed." % (acked, sent, plural, backend)
+    return "Streamed %d build event%s to %s." % (sent, plural, backend)
+
+def summarize_bes_upload(ctx, sinks: list):
+    """Log one line per CLI-streamed BES backend summarizing how many build events
+    it received (see `bes_upload_line`). Call after `sink.wait()`.
+
+    A failed sink already prints its own `WARNING: … giving up` with the cause, so
+    this adds the event count rather than repeating the failure. Covers only the
+    user-facing backends (`--bes-backend` and the deployment's BES), not the CLI's
+    internal build-event sinks.
+    """
+    for sink in sinks:
+        info(ctx.std, bes_upload_line(sink.uri, sink.events_sent, sink.events_acked, sink.failed))

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
@@ -85,27 +85,52 @@ def collect_bes_from_args(ctx, extra_backends = []) -> list:
     return sinks
 
 def bes_upload_line(uri: str, sent: int, acked: int, failed: bool) -> str:
-    """The one-line summary of a CLI-streamed BES backend's upload.
+    """The one-line summary of a CLI-streamed BES backend's upload:
 
-    Reports `<acked> of <sent>` only for a genuine partial upload — a failed
-    stream that left events unconfirmed (`acked < sent`). A clean stream, or a
-    failure after every event was acked (e.g. a post-stream lifecycle error),
-    reports the full `<n> build events` since delivery of the events succeeded.
+      - clean stream (or one that failed only after acking every event it sent,
+        e.g. a post-stream lifecycle error) → `Streamed <n> build events`
+      - failed before sending anything (a connect failure) → `Failed to stream`
+      - failed with events left unconfirmed → `Uploaded <acked> of <sent> … before
+        the stream failed`
+
     Public so `bes_sinks_test.axl` can assert the message shapes."""
     backend = uri or "the BES backend"
     plural = "" if sent == 1 else "s"
-    if failed and acked < sent:
-        return "Uploaded %d of %d build event%s to %s before the stream failed." % (acked, sent, plural, backend)
-    return "Streamed %d build event%s to %s." % (sent, plural, backend)
+
+    if not failed:
+        return "Streamed %d build event%s to %s." % (sent, plural, backend)
+    # Failed. A stream that never sent an event failed to connect; one that acked
+    # everything it sent delivered its events (the failure was the post-stream
+    # lifecycle close), so report the plain count; otherwise it's a partial upload.
+    if sent == 0:
+        return "Failed to stream build events to %s." % backend
+    if acked >= sent:
+        return "Streamed %d build event%s to %s." % (sent, plural, backend)
+    return "Uploaded %d of %d build event%s to %s before the stream failed." % (acked, sent, plural, backend)
+
+def grpc_backends(sinks: list) -> list:
+    """The gRPC-backend sinks among `sinks`, i.e. those with a backend `uri`. File
+    sinks (a local BEP dump, `uri == None`) have no backend to stream to and are
+    dropped, so both announcement helpers cover only real BES backends."""
+    return [s for s in sinks if s.uri]
+
+def announce_bes_sinks(ctx, sinks: list):
+    """Announce, one line per CLI-streamed BES backend, that build events are being
+    streamed to it — so a `--bes-backend`, a deployment's BES, and the Workflows
+    runner's env-injected backend are all visible at build start (the sinks are
+    CLI-side gRPC streams, otherwise invisible in the Bazel command). The
+    end-of-build counterpart is `summarize_bes_upload`."""
+    for sink in grpc_backends(sinks):
+        info(ctx.std, "Streaming build events to %s." % sink.uri)
 
 def summarize_bes_upload(ctx, sinks: list):
     """Log one line per CLI-streamed BES backend summarizing how many build events
     it received (see `bes_upload_line`). Call after `sink.wait()`.
 
     A failed sink already prints its own `WARNING: … giving up` with the cause, so
-    this adds the event count rather than repeating the failure. Covers only the
-    user-facing backends (`--bes-backend` and the deployment's BES), not the CLI's
-    internal build-event sinks.
+    this adds the event count rather than repeating the failure. Covers every
+    CLI-streamed backend — `--bes-backend`, the deployment's BES, and the Workflows
+    runner's env-injected backend.
     """
-    for sink in sinks:
+    for sink in grpc_backends(sinks):
         info(ctx.std, bes_upload_line(sink.uri, sink.events_sent, sink.events_acked, sink.failed))

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
@@ -1,10 +1,11 @@
-"""Tests for `lib/bes_sinks.axl` — the end-of-build BES upload summary line.
+"""Tests for `lib/bes_sinks.axl` — the BES upload summary line and the gRPC-sink
+filter shared by the announce/summary helpers.
 
 Run with:
   aspect dev test-bes-sinks
 """
 
-load("./bes_sinks.axl", "bes_upload_line")
+load("./bes_sinks.axl", "bes_upload_line", "grpc_backends")
 
 def _eq(label, got, want):
     if got != want:
@@ -60,6 +61,15 @@ def _test_failed_after_full_ack(_):
         "Streamed 1284 build events to grpcs://bes.acme.aspect.build.",
     )
 
+def _test_connect_failure(_):
+    """A stream that failed before sending anything (a connect failure) reports a
+    plain failure, not a misleading 'Streamed 0 build events'."""
+    _eq(
+        "nothing sent, failed",
+        bes_upload_line("grpcs://localhost:1", 0, 0, True),
+        "Failed to stream build events to grpcs://localhost:1.",
+    )
+
 def _test_missing_uri(_):
     """A sink with no URI falls back to a generic backend name."""
     _eq(
@@ -73,11 +83,24 @@ def _test_missing_uri(_):
         "Uploaded 1 of 3 build events to the BES backend before the stream failed.",
     )
 
+def _test_grpc_backends_filters_file_sinks(_):
+    """`grpc_backends` keeps only sinks with a backend URI, so a file sink (a
+    local BEP dump, `uri == None`) is dropped from both announce and summary
+    rather than surfacing a spurious "the BES backend" line."""
+    grpc_a = struct(uri = "grpcs://bes.a")
+    grpc_b = struct(uri = "grpcs://bes.b")
+    file_sink = struct(uri = None)
+    got = grpc_backends([grpc_a, file_sink, grpc_b])
+    _eq("only gRPC-backend sinks survive", [s.uri for s in got], ["grpcs://bes.a", "grpcs://bes.b"])
+    _eq("no gRPC sinks → empty", grpc_backends([file_sink]), [])
+
 _UNIT_TESTS = [
     _test_clean_stream,
     _test_failed_stream,
     _test_failed_after_full_ack,
+    _test_connect_failure,
     _test_missing_uri,
+    _test_grpc_backends_filters_file_sinks,
 ]
 
 def _test_impl(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
@@ -1,0 +1,93 @@
+"""Tests for `lib/bes_sinks.axl` — the end-of-build BES upload summary line.
+
+Run with:
+  aspect dev test-bes-sinks
+"""
+
+load("./bes_sinks.axl", "bes_upload_line")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _test_clean_stream(_):
+    """A clean stream reports the sent count and names the backend."""
+    _eq(
+        "many events",
+        bes_upload_line("grpcs://bes.acme.aspect.build", 1284, 1284, False),
+        "Streamed 1284 build events to grpcs://bes.acme.aspect.build.",
+    )
+    _eq(
+        "singular event",
+        bes_upload_line("grpcs://bes.acme.aspect.build", 1, 1, False),
+        "Streamed 1 build event to grpcs://bes.acme.aspect.build.",
+    )
+    _eq(
+        "zero events",
+        bes_upload_line("grpcs://bes.acme.aspect.build", 0, 0, False),
+        "Streamed 0 build events to grpcs://bes.acme.aspect.build.",
+    )
+
+def _test_failed_stream(_):
+    """A failed stream that left events unconfirmed reports acked-of-sent so the
+    partial upload is visible."""
+    _eq(
+        "partial upload",
+        bes_upload_line("grpcs://bes.acme.aspect.build", 1284, 812, True),
+        "Uploaded 812 of 1284 build events to grpcs://bes.acme.aspect.build before the stream failed.",
+    )
+    _eq(
+        "nothing acked",
+        bes_upload_line("grpcs://bes.acme.aspect.build", 500, 0, True),
+        "Uploaded 0 of 500 build events to grpcs://bes.acme.aspect.build before the stream failed.",
+    )
+    # Pluralization keys off the sent count, so a single sent-but-unacked event
+    # still reads naturally.
+    _eq(
+        "singular sent",
+        bes_upload_line("grpcs://bes.acme.aspect.build", 1, 0, True),
+        "Uploaded 0 of 1 build event to grpcs://bes.acme.aspect.build before the stream failed.",
+    )
+
+def _test_failed_after_full_ack(_):
+    """A failure after every event was acked (e.g. a post-stream lifecycle error)
+    reports the full count — the events themselves were delivered, so the
+    partial-upload framing would misleadingly imply loss."""
+    _eq(
+        "all acked despite failure",
+        bes_upload_line("grpcs://bes.acme.aspect.build", 1284, 1284, True),
+        "Streamed 1284 build events to grpcs://bes.acme.aspect.build.",
+    )
+
+def _test_missing_uri(_):
+    """A sink with no URI falls back to a generic backend name."""
+    _eq(
+        "empty uri, clean",
+        bes_upload_line("", 3, 3, False),
+        "Streamed 3 build events to the BES backend.",
+    )
+    _eq(
+        "empty uri, failed",
+        bes_upload_line("", 3, 1, True),
+        "Uploaded 1 of 3 build events to the BES backend before the stream failed.",
+    )
+
+_UNIT_TESTS = [
+    _test_clean_stream,
+    _test_failed_stream,
+    _test_failed_after_full_ack,
+    _test_missing_uri,
+]
+
+def _test_impl(ctx):
+    for t in _UNIT_TESTS:
+        t(ctx)
+    print("bes_sinks_test.axl: OK (%d tests)" % len(_UNIT_TESTS))
+    return 0
+
+bes_sinks_tests = task(
+    kind = "test-bes-sinks",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
@@ -41,6 +41,7 @@ def _test_failed_stream(_):
         bes_upload_line("grpcs://bes.acme.aspect.build", 500, 0, True),
         "Uploaded 0 of 500 build events to grpcs://bes.acme.aspect.build before the stream failed.",
     )
+
     # Pluralization keys off the sent count, so a single sent-but-unacked event
     # still reads naturally.
     _eq(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -41,9 +41,10 @@ _SCHEME = "grpcs://"
 
 # What `deployment_endpoint_flags` hands back to `run_bazel_task`: Bazel base
 # flags to prepend (--remote_cache / --remote_executor) and extra CLI-streamed
-# BES backend URIs, plus the deployment name and the injected capabilities as
-# `(label, uri)` pairs (empty when nothing was) so the runner can announce which
-# endpoint each capability is wired to.
+# BES backend URIs, plus the deployment name and the base-flag capabilities as
+# `(label, uri)` pairs for the "Using deployment …" line. BES is wired via
+# `bes_backends` and announced by its own streaming line, so it is not in
+# `capabilities`.
 DeploymentFlags = record(
     base_flags = field(list),
     bes_backends = field(list),
@@ -130,8 +131,8 @@ def deployment_endpoint_flags(ctx) -> DeploymentFlags:
         if explicit:
             fail(flag + ": " + named + " does not advertise " + capability + ". Run `aspect auth configure <host>` for a deployment that serves one.")
 
-    # Capabilities are reported in a consistent order: remote cache, remote
-    # execution, then BES backend.
+    # The "Using deployment …" capabilities are reported cache then exec (BES is
+    # wired below but announced via its own streaming line, not here).
     base_flags = []
     bes_backends = []
     capabilities = []
@@ -153,9 +154,10 @@ def deployment_endpoint_flags(ctx) -> DeploymentFlags:
 
     if want_bes:
         if endpoints.bes:
-            uri = _SCHEME + endpoints.bes
-            bes_backends.append(uri)
-            capabilities.append(("bes backend", uri))
+            # Wired as a CLI-streamed BES sink; its own "Streaming build events to
+            # …" line announces it (and the end-of-build summary reports it), so it
+            # is deliberately left out of the `capabilities` display below.
+            bes_backends.append(_SCHEME + endpoints.bes)
         else:
             _require(bes_explicit, "--aspect-bes-backend", "a BES backend")
 
@@ -177,10 +179,10 @@ def join_and(items: list[str], oxford: bool = False) -> str:
     return ", ".join(items[:-1]) + ", and " + items[-1]
 
 def announce_deployment_flags(ctx, flags: DeploymentFlags):
-    """Tell the user, in one line, which deployment's capabilities this bazel call
-    is wired to (`--aspect-*`) and the endpoint each uses, so the injected
-    --remote_cache / bes backend / --remote_executor aren't silent. No-op when
-    nothing was injected."""
+    """Tell the user, in one line, which deployment's base-flag capabilities this
+    bazel call is wired to (`--aspect-*`) and the endpoint each uses, so the
+    injected --remote_cache / --remote_executor aren't silent. (BES is announced
+    separately by `announce_bes_sinks`.) No-op when nothing was injected."""
     if not flags.capabilities:
         return
     parts = [label + " (" + uri + ")" for (label, uri) in flags.capabilities]

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -185,10 +185,3 @@ def announce_deployment_flags(ctx, flags: DeploymentFlags):
         return
     parts = [label + " (" + uri + ")" for (label, uri) in flags.capabilities]
     info(ctx.std, "Using deployment '" + flags.deployment + "' for " + join_and(parts, oxford = True))
-
-def announce_deployment_bes_streamed(ctx, flags: DeploymentFlags):
-    """Confirm the deployment's CLI-streamed BES backend(s) received the build's
-    events (the sink is a CLI-side gRPC stream, not a bazel flag, so it's
-    otherwise invisible). Caller gates this on a clean, non-failed stream."""
-    for backend in flags.bes_backends:
-        info(ctx.std, "Streamed build events to " + backend + ".")

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -90,18 +90,19 @@ def _test_explicit_false_overrides_umbrella(ctx):
     _eq("still gets bes from umbrella", got.bes_backends, ["grpcs://bes.gcp"])
 
 def _test_umbrella_reports_injected_capabilities(ctx):
-    # The announced capabilities are (label, uri) pairs in cache/exec/bes order,
-    # for the "Using deployment …" line + per-endpoint detail.
+    # The "Using deployment …" capabilities are (label, uri) pairs in cache/exec
+    # order. BES is wired (bes_backends) but announced via its own streaming line,
+    # so it is not among the reported capabilities.
     got = deployment_endpoint_flags(_ctx(
         _endpoints("gcp", cache = "remote.gcp", bes = "bes.gcp", exec = "remote.gcp"),
         aspect_remote = True,
     ))
     _eq("deployment name carried", got.deployment, "gcp")
-    _eq("capabilities carry label + uri in cache/exec/bes order", got.capabilities, [
+    _eq("capabilities carry label + uri in cache/exec order (no bes)", got.capabilities, [
         ("remote cache", "grpcs://remote.gcp"),
         ("remote execution", "grpcs://remote.gcp"),
-        ("bes backend", "grpcs://bes.gcp"),
     ])
+    _eq("bes still wired as a backend", got.bes_backends, ["grpcs://bes.gcp"])
 
 def _test_join_and(ctx):
     _eq("empty", join_and([]), "")

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -6,7 +6,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "bes_args", "collect_bes_from_args")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
 load("./private/lib/environment.axl", "error")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
@@ -88,9 +88,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # flags + aspect injection that capture the executable, the `args` attribute,
     # and the target env so `r.spawn` replays them the way `bazel run` does.
     r = runnable(ctx, [target], rc = rc)
-    bes_sinks = collect_bes_from_args(ctx)
+    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
-    build_events = [events] + bes_sinks + list(bazel_trait.build_event_sinks)
+    build_events = [events] + bes_sinks
 
     for hook in bazel_trait.build_start:
         hook(ctx)
@@ -129,8 +130,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             break
 
     build_status = build.wait()
-    for sink in bes_sinks + list(bazel_trait.build_event_sinks):
+    for sink in bes_sinks:
         sink.wait()
+    summarize_bes_upload(ctx, bes_sinks)
     dispatch_bazel_attempt_end(ctx, bazel_trait, build_status.code)
     dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -32,7 +32,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "bes_args", "collect_bes_from_args")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
 load("./private/lib/environment.axl", "error", "warn")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
@@ -138,9 +138,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Populate phase: `bazel build --nobuild`. Pass build_event_sinks (the Aspect
     # backend gRPC sink in CI) so the "✨ Aspect Workflows" link resolves to a
     # real record. The local iterator drains BES into `data["bazel"]`.
-    bes_sinks = collect_bes_from_args(ctx)
+    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
-    build_events = [events] + bes_sinks + list(bazel_trait.build_event_sinks)
+    build_events = [events] + bes_sinks
 
     for hook in bazel_trait.build_start:
         hook(ctx)
@@ -205,8 +206,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             break
 
     build_status = build.wait()
-    for sink in bes_sinks + list(bazel_trait.build_event_sinks):
+    for sink in bes_sinks:
         sink.wait()
+    summarize_bes_upload(ctx, bes_sinks)
 
     # Fire the attempt-end + build-end hooks the `workflows` feature registers
     # (sandbox-state repair, runner-unhealthy signaling on server-internal-error

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -37,7 +37,7 @@ use super::iter::ExecutionLogIterator;
 use super::iter::WorkspaceEventIterator;
 use super::sink::execlog::ExecLogSink;
 use super::sink::grpc;
-use super::sink::retry::{RetryConfig, SinkOutcome};
+use super::sink::retry::{RetryConfig, SinkOutcome, SinkStats};
 use super::sink::tracing as tracing_sink;
 use super::stream::BuildEventStream;
 use super::stream::ExecLogStream;
@@ -145,8 +145,12 @@ enum SinkPhase {
 }
 
 enum SinkLive {
-    Grpc { join: JoinHandle<SinkOutcome> },
-    File { signal: Arc<FileSignal> },
+    Grpc {
+        join: JoinHandle<(SinkStats, SinkOutcome)>,
+    },
+    File {
+        signal: Arc<FileSignal>,
+    },
 }
 
 #[derive(Debug, Default)]
@@ -156,6 +160,12 @@ struct SinkOutcomeState {
     /// `times_bound > 0` distinguishes "never bound" from "freshly bound
     /// but already waited" — needed by the `done` attribute.
     times_bound: usize,
+    /// Distinct build events streamed to the backend on the most recent bind
+    /// (gRPC sinks only; 0 for file sinks). See `SinkStats`.
+    events_sent: u64,
+    /// Build events the backend confirmed on the most recent bind (gRPC sinks
+    /// only; 0 for file sinks). See `SinkStats`.
+    events_acked: u64,
 }
 
 pub struct FileSignal {
@@ -241,6 +251,13 @@ impl BuildEventSink {
     fn file_path(&self) -> Option<String> {
         match &*self.config {
             SinkConfig::File { path } => Some(path.clone()),
+            _ => None,
+        }
+    }
+
+    fn grpc_uri(&self) -> Option<String> {
+        match &*self.config {
+            SinkConfig::Grpc { uri, .. } => Some(uri.clone()),
             _ => None,
         }
     }
@@ -342,12 +359,27 @@ impl<'v> values::StarlarkValue<'v> for BuildEventSink {
                 Some(e) => heap.alloc_str(e).to_value(),
                 None => Value::new_none(),
             }),
+            // Build events streamed to a gRPC backend and those the server acked
+            // (its sequence-number acks are the only delivery confirmation), so a
+            // caller can report how many events reached the backend. Both are 0
+            // for a file sink or a stream that never bound. See `wait`.
+            "events_sent" => Some(heap.alloc(outcome.events_sent)),
+            "events_acked" => Some(heap.alloc(outcome.events_acked)),
+            // The gRPC backend URI (None for a file sink), so a summary can name
+            // the backend without the caller tracking it separately.
+            "uri" => Some(match self.grpc_uri() {
+                Some(uri) => heap.alloc_str(&uri).to_value(),
+                None => Value::new_none(),
+            }),
             _ => None,
         }
     }
 
     fn has_attr(&self, attribute: &str, _heap: Heap<'v>) -> bool {
-        matches!(attribute, "done" | "failed" | "error")
+        matches!(
+            attribute,
+            "done" | "failed" | "error" | "events_sent" | "events_acked" | "uri"
+        )
     }
 }
 
@@ -367,13 +399,16 @@ pub(crate) fn build_event_sink_methods(registry: &mut MethodsBuilder) {
                 SinkPhase::Idle => return Ok(NoneOr::None),
             }
         };
-        let outcome: Result<(), String> = match live {
+        let (outcome, stats): (Result<(), String>, SinkStats) = match live {
             SinkLive::Grpc { join } => match join.join() {
-                Ok(Ok(())) => Ok(()),
-                Ok(Err(e)) => Err(e.last_error),
-                Err(_) => Err("sink worker thread panicked".to_string()),
+                Ok((stats, Ok(()))) => (Ok(()), stats),
+                Ok((stats, Err(e))) => (Err(e.last_error), stats),
+                Err(_) => (
+                    Err("sink worker thread panicked".to_string()),
+                    SinkStats::default(),
+                ),
             },
-            SinkLive::File { signal } => signal.wait(),
+            SinkLive::File { signal } => (signal.wait(), SinkStats::default()),
         };
         let (failed, error) = match outcome {
             Ok(()) => (false, None),
@@ -382,6 +417,8 @@ pub(crate) fn build_event_sink_methods(registry: &mut MethodsBuilder) {
         let mut out = sink.outcome.lock().unwrap();
         out.failed = failed;
         out.error = error;
+        out.events_sent = stats.sent;
+        out.events_acked = stats.acked;
         Ok(NoneOr::None)
     }
 }

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -23,7 +23,8 @@ use crate::engine::r#async::rt::AsyncRuntime;
 
 use super::super::stream::Subscriber;
 use super::retry::{
-    BufferOverflow, RetryBuffer, RetryConfig, SinkError, SinkOutcome, backoff, is_retryable,
+    BufferOverflow, RetryBuffer, RetryConfig, SinkError, SinkOutcome, SinkStats, backoff,
+    is_retryable,
 };
 
 #[derive(Debug)]
@@ -72,7 +73,7 @@ impl Grpc {
         headers: HashMap<String, String>,
         invocation_id: String,
         retry: RetryConfig,
-    ) -> JoinHandle<SinkOutcome> {
+    ) -> JoinHandle<(SinkStats, SinkOutcome)> {
         thread::spawn(move || rt.block_on(work(recv, endpoint, headers, invocation_id, retry)))
     }
 }
@@ -150,7 +151,7 @@ async fn work(
     headers: HashMap<String, String>,
     invocation_id: String,
     retry: RetryConfig,
-) -> SinkOutcome {
+) -> (SinkStats, SinkOutcome) {
     dbg(
         &endpoint,
         &invocation_id,
@@ -187,21 +188,27 @@ async fn work(
         match tokio::time::timeout(CONNECT_TIMEOUT, Client::new(endpoint.clone(), headers)).await {
             Ok(Ok(client)) => client,
             Ok(Err(e)) => {
-                return Err(fail(
-                    &endpoint,
-                    "invalid backend configuration, build events will not be delivered",
-                    format!("client setup failed: {e}"),
-                ));
+                return (
+                    SinkStats::default(),
+                    Err(fail(
+                        &endpoint,
+                        "invalid backend configuration, build events will not be delivered",
+                        format!("client setup failed: {e}"),
+                    )),
+                );
             }
             Err(_) => {
                 let secs = CONNECT_TIMEOUT.as_secs();
-                return Err(fail(
-                    &endpoint,
-                    &format!(
-                        "client setup stalled for {secs}s, build events will not be delivered"
-                    ),
-                    format!("client setup timed out after {secs}s"),
-                ));
+                return (
+                    SinkStats::default(),
+                    Err(fail(
+                        &endpoint,
+                        &format!(
+                            "client setup stalled for {secs}s, build events will not be delivered"
+                        ),
+                        format!("client setup timed out after {secs}s"),
+                    )),
+                );
             }
         };
     dbg(
@@ -215,7 +222,7 @@ async fn work(
 
     let build_id = invocation_id.clone();
 
-    send_lifecycle_logged(
+    if let Err(e) = send_lifecycle_logged(
         "build_enqueued",
         &retry,
         &mut client,
@@ -223,8 +230,11 @@ async fn work(
         &endpoint,
         &invocation_id,
     )
-    .await?;
-    send_lifecycle_logged(
+    .await
+    {
+        return (SinkStats::default(), Err(e));
+    }
+    if let Err(e) = send_lifecycle_logged(
         "invocation_started",
         &retry,
         &mut client,
@@ -232,10 +242,14 @@ async fn work(
         &endpoint,
         &invocation_id,
     )
-    .await?;
+    .await
+    {
+        return (SinkStats::default(), Err(e));
+    }
 
     let mut buffer = RetryBuffer::new(retry.retry_max_buffer_size);
     let mut next_seq: i64 = 1;
+    let mut max_acked: i64 = 0;
     let mut attempt: u32 = 0;
     let mut last_message_sent = false;
     // Warn at most once per sink when the stream first drops into retry, so a
@@ -262,6 +276,7 @@ async fn work(
             &mut event_rx,
             &mut buffer,
             &mut next_seq,
+            &mut max_acked,
             &mut last_message_sent,
             &endpoint,
         )
@@ -280,10 +295,14 @@ async fn work(
             DriveOutcome::Done | DriveOutcome::UpstreamClosed => break 'reconnect,
             DriveOutcome::Transient(err) => {
                 if attempt >= retry.max_retries {
-                    return Err(finalize(
-                        &endpoint,
-                        format!("giving up after {attempt} attempts: {err}"),
-                    ));
+                    let stats = SinkStats::from_counters(next_seq, max_acked);
+                    return (
+                        stats,
+                        Err(finalize(
+                            &endpoint,
+                            format!("giving up after {attempt} attempts: {err}"),
+                        )),
+                    );
                 }
                 if !warned_transient {
                     warn(
@@ -306,10 +325,15 @@ async fn work(
                 continue 'reconnect;
             }
             DriveOutcome::Fatal(err) => {
-                return Err(finalize(&endpoint, format!("non-retryable: {err}")));
+                let stats = SinkStats::from_counters(next_seq, max_acked);
+                return (
+                    stats,
+                    Err(finalize(&endpoint, format!("non-retryable: {err}"))),
+                );
             }
             DriveOutcome::BufferFull(err) => {
-                return Err(finalize(&endpoint, err.to_string()));
+                let stats = SinkStats::from_counters(next_seq, max_acked);
+                return (stats, Err(finalize(&endpoint, err.to_string())));
             }
         }
     }
@@ -356,7 +380,7 @@ async fn work(
         .await?;
         Ok::<(), SinkError>(())
     };
-    match retry.timeout {
+    let outcome = match retry.timeout {
         Some(d) => match tokio::time::timeout(d, post_stream).await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => Err(e),
@@ -366,7 +390,9 @@ async fn work(
             )),
         },
         None => post_stream.await,
-    }
+    };
+    let stats = SinkStats::from_counters(next_seq, max_acked);
+    (stats, outcome)
 }
 
 /// Bound for the `event_rx.recv()` wait inside `preload_first_event`.
@@ -498,6 +524,7 @@ async fn drive_stream(
     event_rx: &mut tokio::sync::mpsc::UnboundedReceiver<BuildEvent>,
     buffer: &mut RetryBuffer,
     next_seq: &mut i64,
+    max_acked: &mut i64,
     last_message_sent: &mut bool,
     endpoint: &str,
 ) -> DriveOutcome {
@@ -689,6 +716,7 @@ async fn drive_stream(
                 match resp {
                     Some(Ok(r)) => {
                         buffer.prune_until(r.sequence_number);
+                        *max_acked = (*max_acked).max(r.sequence_number);
                         // Once we've sent last_message AND every event we
                         // sent has been ack'd, we're done — exit without
                         // waiting for the server to close the response

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -226,14 +226,23 @@ mod tests {
     #[test]
     fn sink_stats_from_counters() {
         // Fresh forwarder that never streamed an event (next_seq still 1).
-        assert_eq!(SinkStats::from_counters(1, 0), SinkStats { sent: 0, acked: 0 });
+        assert_eq!(
+            SinkStats::from_counters(1, 0),
+            SinkStats { sent: 0, acked: 0 }
+        );
         // Streamed 1284, server acked 812.
         assert_eq!(
             SinkStats::from_counters(1285, 812),
-            SinkStats { sent: 1284, acked: 812 }
+            SinkStats {
+                sent: 1284,
+                acked: 812
+            }
         );
         // Defensive clamp: negative counters (unreachable in practice) report 0.
-        assert_eq!(SinkStats::from_counters(0, -1), SinkStats { sent: 0, acked: 0 });
+        assert_eq!(
+            SinkStats::from_counters(0, -1),
+            SinkStats { sent: 0, acked: 0 }
+        );
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -189,6 +189,31 @@ pub struct SinkError {
 /// the sink gave up.
 pub type SinkOutcome = Result<(), SinkError>;
 
+/// How much a gRPC sink transferred, reported on both clean and failed exits so
+/// the end-of-build summary can say how many build events reached the backend.
+/// `sent` counts distinct events streamed (deduped across reconnect replays);
+/// `acked` counts those the server confirmed (its sequence-number acks are the
+/// only delivery signal), so `acked < sent` means events were streamed but not
+/// confirmed landed.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SinkStats {
+    pub sent: u64,
+    pub acked: u64,
+}
+
+impl SinkStats {
+    /// Derive the stats from a forwarder's live counters at an exit point.
+    /// `next_seq` is the next unused sequence number (starts at 1, so distinct
+    /// events sent is `next_seq - 1`); `max_acked` is the highest sequence the
+    /// server confirmed. Both clamp at 0 so a pre-stream exit reports nothing.
+    pub fn from_counters(next_seq: i64, max_acked: i64) -> Self {
+        SinkStats {
+            sent: (next_seq - 1).max(0) as u64,
+            acked: max_acked.max(0) as u64,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -196,6 +221,19 @@ mod tests {
 
     fn req() -> PublishBuildToolEventStreamRequest {
         PublishBuildToolEventStreamRequest::default()
+    }
+
+    #[test]
+    fn sink_stats_from_counters() {
+        // Fresh forwarder that never streamed an event (next_seq still 1).
+        assert_eq!(SinkStats::from_counters(1, 0), SinkStats { sent: 0, acked: 0 });
+        // Streamed 1284, server acked 812.
+        assert_eq!(
+            SinkStats::from_counters(1285, 812),
+            SinkStats { sent: 1284, acked: 812 }
+        );
+        // Defensive clamp: negative counters (unreachable in practice) report 0.
+        assert_eq!(SinkStats::from_counters(0, -1), SinkStats { sent: 0, acked: 0 });
     }
 
     #[test]


### PR DESCRIPTION
Makes the CLI's Build Event Service (BES) streaming visible: it announces each backend it streams to at build start, and summarizes how many build events each received at build completion — so a `--bes-backend`, a deployment's BES, and the Workflows runner's env-injected backend all report their result instead of streaming silently.

```
INFO: Streaming build events to grpcs://bes.myco.aspect.build.
…
INFO: Streamed 1284 build events to grpcs://bes.myco.aspect.build.
```

When a stream gives up before every event is confirmed, the summary reports what actually landed; a stream that never connected says so plainly:

```
INFO: Uploaded 812 of 1284 build events to grpcs://bes.myco.aspect.build before the stream failed.
INFO: Failed to stream build events to grpcs://bes.myco.aspect.build.
```

The count distinguishes events *sent* from events the server *acked* (its sequence-number acks are the only delivery confirmation), so a partial upload is visible rather than reported complete. A failure *after* every event was acked (e.g. a post-stream lifecycle error) still reports the full count, since the events were delivered.

Covers every CLI-streamed backend across all bazel-spawning tasks (build, test, run, gazelle, warming, format, lint, delivery). File sinks (local BEP dumps) are excluded — they have no backend to stream to.

### Implementation

The gRPC sink already tracked per-event sequence numbers and processed server acks; this threads those out through a new `SinkStats { sent, acked }` carried on both the clean and failed exits, records them in the sink's outcome state, and exposes `events_sent` / `events_acked` / `uri` on the `BuildEventSink` Starlark value. `bes_sinks.axl` gains `announce_bes_sinks` (start) and `summarize_bes_upload` (end), which each task calls around its sink `wait()`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Bazel-spawning commands now announce which BES backend(s) they stream build events to, and report how many events each received at build completion (including a partial count, or a plain failure, when a stream doesn't fully deliver).

### Test plan

- New test cases:
  - `bes_sinks_test.axl` (`test-bes-sinks`) — the summary line across clean / partial-failure / connect-failure / full-count-despite-failure / pluralization / missing-URI, and `grpc_backends` file-sink filtering.
  - `SinkStats::from_counters` unit test (`retry.rs`) — sent/acked derivation and the negative-counter clamp.
- Covered by existing test cases: the `BuildEventSink` sink lifecycle / `wait` tests.
- Manual testing: `aspect build`/`run` with `--bes-backend` (reachable and unreachable) — confirmed the start announcement, the streamed-count summary, and the connect-failure message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
