### PR TITLE
feat: show "N of M tests run" in live test progress

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -119,7 +119,7 @@ def _body_for(kind, status, data):
     """Mirror the producer's `progress.body` narrative form.
 
     Running emits ship the live phase narrative (`Bazel test running
-    (12 tests run)` / `Linting`); terminal emits ship a verb-prefixed
+    (12 of 58 tests run)` / `Linting`); terminal emits ship a verb-prefixed
     summary (`Bazel test complete (58/58 passed)` /
     `Lint failed (3 errors)`)."""
     compact = _compact_for(kind, status, data)
@@ -2071,7 +2071,7 @@ def _test_impl(ctx):
                     current_phase = "test",
                     current_phase_elapsed_ms = 65000,
                     progress = {
-                        "body": "Bazel test running... (12 tests run)",
+                        "body": "Bazel test running... (12 of 58 tests run)",
                         "stream": "",
                     },
                 ),

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -11,6 +11,7 @@ Event kinds consumed:
   "workspace_status"         — captures workspace_status key=value pairs (BUILD_USER, etc.)
   "configuration"            — captures cpu arch and compilation_mode (target config only)
   "action_completed"         — accumulates failed build actions (up to MAX_FAILED_ACTIONS)
+  "target_configured"        — caches rule kind per label; counts configured targets (incl. test targets, the live progress denominator)
   "target_completed"         — accumulates failed build targets
   "test_result"              — captures per-attempt test.log + test.xml paths and duration (keyed by label)
   "test_summary"             — buckets tests into failed / flaky / passed; tracks duration
@@ -314,6 +315,10 @@ def init_data():
             # label -> rule kind (e.g. "cc_library", "py_test") from
             # target_configured. Detects tests and displays the kind.
             "target_kinds": {},
+            # Count of configured targets whose kind is a test (`*_test`),
+            # from target_configured. The expected-test denominator for the
+            # live "N of M tests run" progress narrative.
+            "test_targets_configured": 0,
             # All built labels (test + non-test), capped at MAX_BUILT_TARGETS.
             "built_targets": [],
             # Targets that completed (success + failure), counting target_completed
@@ -573,6 +578,8 @@ def process_event(data, event):
             target_kind = target_kind[:-len(" rule")]
         if label and target_kind:
             data["bazel"]["target_kinds"][label] = target_kind
+            if _is_test_kind(target_kind):
+                data["bazel"]["test_targets_configured"] += 1
         data["bazel"]["targets_configured_counted"] += 1
         return False
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -577,8 +577,14 @@ def process_event(data, event):
         if target_kind.endswith(" rule"):
             target_kind = target_kind[:-len(" rule")]
         if label and target_kind:
+            # Aspects that apply to a test target emit extra target_configured
+            # events for the same label (distinct `aspect` field) while
+            # test_summary still reports the test once. Count each test label
+            # a single time — first-seen — so the "N of M tests run"
+            # denominator matches the run count and doesn't overshoot.
+            first_seen = label not in data["bazel"]["target_kinds"]
             data["bazel"]["target_kinds"][label] = target_kind
-            if _is_test_kind(target_kind):
+            if first_seen and _is_test_kind(target_kind):
                 data["bazel"]["test_targets_configured"] += 1
         data["bazel"]["targets_configured_counted"] += 1
         return False

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
@@ -846,6 +846,30 @@ def _make_test_summary(label, status, cached = False, duration_ms = 0):
         ),
     )
 
+def _make_target_configured(label, target_kind):
+    """Synthesize a minimal `target_configured` BES event for `process_event`.
+
+    Bazel suffixes the rule kind with ` rule` (e.g. `cc_test rule`); mirror
+    that so the handler's strip logic is exercised."""
+    return struct(
+        kind = "target_configured",
+        id = struct(label = label),
+        payload = struct(target_kind = target_kind + " rule"),
+    )
+
+def _test_target_configured_counts_test_targets(ctx):
+    """`target_configured` bumps `test_targets_configured` only for `*_test`
+    rule kinds — the expected-test denominator for the live progress
+    narrative. Non-test targets bump `targets_configured_counted` but not
+    the test count."""
+    data = init_data()
+    process_event(data, _make_target_configured("//pkg:lib", "cc_library"))
+    process_event(data, _make_target_configured("//pkg:a_test", "cc_test"))
+    process_event(data, _make_target_configured("//pkg:b_test", "py_test"))
+
+    _eq("only *_test targets counted", data["bazel"]["test_targets_configured"], 2)
+    _eq("every configured target counted", data["bazel"]["targets_configured_counted"], 3)
+
 def _test_failed_test_survives_passed_bucket_cap(ctx):
     """Regression: a failed test arriving after `passed_tests` hits
     `MAX_TEST_TARGETS` must still land in `failed_tests`. A previous
@@ -1240,6 +1264,7 @@ _UNIT_TESTS = [
     _test_bes_get_returns_default_for_missing_field,
     _test_bes_get_returns_value_for_present_field,
     _test_bes_get_handles_none,
+    _test_target_configured_counts_test_targets,
     _test_failed_test_survives_passed_bucket_cap,
     _test_flaky_test_survives_passed_bucket_cap,
     _test_common_label_root_same_package_returns_all_pattern,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
@@ -870,6 +870,18 @@ def _test_target_configured_counts_test_targets(ctx):
     _eq("only *_test targets counted", data["bazel"]["test_targets_configured"], 2)
     _eq("every configured target counted", data["bazel"]["targets_configured_counted"], 3)
 
+def _test_target_configured_dedups_aspect_events(ctx):
+    """Aspects on a test target re-emit target_configured for the same label.
+    The test denominator must count each test label once so it matches the
+    run count and doesn't overshoot (e.g. "10 of 20 tests run" that never
+    catches up)."""
+    data = init_data()
+    process_event(data, _make_target_configured("//pkg:a_test", "cc_test"))
+    process_event(data, _make_target_configured("//pkg:a_test", "cc_test"))
+    process_event(data, _make_target_configured("//pkg:a_test", "cc_test"))
+
+    _eq("test label counted once despite aspect re-emits", data["bazel"]["test_targets_configured"], 1)
+
 def _test_failed_test_survives_passed_bucket_cap(ctx):
     """Regression: a failed test arriving after `passed_tests` hits
     `MAX_TEST_TARGETS` must still land in `failed_tests`. A previous
@@ -1265,6 +1277,7 @@ _UNIT_TESTS = [
     _test_bes_get_returns_value_for_present_field,
     _test_bes_get_handles_none,
     _test_target_configured_counts_test_targets,
+    _test_target_configured_dedups_aspect_events,
     _test_failed_test_survives_passed_bucket_cap,
     _test_flaky_test_survives_passed_bucket_cap,
     _test_common_label_root_same_package_returns_all_pattern,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -21,7 +21,7 @@ load("./deployment_flags.axl", "announce_deployment_flags", "deployment_endpoint
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "flavor_allows", "print_repro_and_fix", "repro_prefix")
-load("./text.axl", "pluralize")
+load("./text.axl", "format_int_comma", "pluralize")
 
 # ─── Lifecycle status + Result-cell text ──────────────────────────────────────
 #
@@ -115,7 +115,9 @@ def _live_progress(data, command, status):
     Returns a `ProgressStyles` record where `body` is the narrative
     form — verb-prefixed phrase with an optional parenthetical count:
 
-      running:  `Bazel test running (12 tests run)`
+      running:  `Bazel test running (12 of 58 tests run)`
+                (falls back to `(12 tests run)` before the expected
+                test count is known)
       passed:   `Bazel test complete (58/58 passed)`
       failed:   `Bazel test failed (3 tests failed)`
       warning:  `Bazel test complete (2 flaky)`
@@ -135,7 +137,16 @@ def _live_progress(data, command, status):
             flaky = data["bazel"].get("flaky_test_total", 0) or 0
             total = passed + failed + flaky
             if total > 0:
-                running_detail = pluralize(total, "test") + " run"
+                # Prefer "N of M tests run" once the expected test count is
+                # known and at least covers the run count. The denominator
+                # streams in via target_configured events, so guard against a
+                # stale-low expected total (would render M < N) by falling
+                # back to the bare "N tests run" form until it catches up.
+                expected = data["bazel"].get("test_targets_configured", 0) or 0
+                if expected >= total:
+                    running_detail = format_int_comma(total) + " of " + pluralize(expected, "test") + " run"
+                else:
+                    running_detail = pluralize(total, "test") + " run"
                 if failed > 0:
                     running_detail = running_detail + " · " + pluralize(failed, "failed", plural = "failed")
         if not running_detail:


### PR DESCRIPTION
The live "Bazel test running..." status narrative reported only the number of tests completed so far — e.g. `Bazel test running... (539 tests run)`. It now shows the expected-test denominator so users get a sense of progress toward completion: `Bazel test running... (539 of 1,024 tests run)`.

The denominator is a new `test_targets_configured` counter, incremented in the `target_configured` BES event handler whenever the resolved rule kind is a test (`*_test`). Because `target_configured` events stream in alongside the run, the fraction updates live throughout the invocation. When the expected total hasn't yet caught up to the run count (which would render `M < N`), the narrative falls back to the bare `N tests run` form until it does.

The build task is intentionally left as `N targets built`: the only "targets expected" totals arrive from Bazel's terminal `build_metrics` event, so a running build has no meaningful denominator to display.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Live test progress in status surfaces now reads `Bazel test running... (539 of 1,024 tests run)`, showing progress toward the expected test count instead of just the count run so far.

### Test plan

- New test cases added — `test_targets_configured` counter coverage in `bazel_results_test.axl`
- Covered by existing test cases — `bazel-runner`, `bazel-results`, and `pr-comment-snapshots` suites pass
