### PR TITLE
feat(auth): choose the issuer when OAuth discovery advertises multiple

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -28,6 +28,7 @@ load("@aspect//private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
 load("@aspect//private/lib/lifecycle.axl", "ReproFixCommand")
 load("@aspect//private/lib/log_snippet.axl", "SnippetOptions", "code_fence_for", "extract_junit_failure", "extract_snippet")
 load("@aspect//private/lib/path_glob.axl", "match_any", "match_path")
+load("@aspect//private/lib/prompt.axl", "prompt_choice")
 load("@aspect//private/lib/repro_commands.axl", "build_aspect_command", "dedup_and_attribute", "patch_download_cmd", "task_cli_path")
 load("@aspect//private/lib/result_text.axl", "severity_for_status")
 load("@aspect//private/lib/runnable.axl", "apparent_label", "runnable")
@@ -3649,9 +3650,19 @@ def impl(ctx: TaskContext) -> int:
     tc = test_log_snippet(ctx, tc, temp_dir)
     tc = test_bazel_render_snippets(ctx, tc, temp_dir)
     tc = test_gitlab_token_cache(ctx, tc, temp_dir)
+    tc = test_prompt_choice(tc)
 
     print(tc, "tests passed")
     return 0
+
+def test_prompt_choice(tc: int) -> int:
+    """prompt_choice returns None off a TTY rather than blocking on stdin — the
+    branch that keeps `configure`/`init` safe in CI. The interactive selection
+    loop needs a real terminal and is exercised via live CI, not here."""
+    fake_ctx = struct(std = struct(io = struct(stdout = struct(is_tty = False))))
+    got = prompt_choice(fake_ctx, ["a", "b"], lambda x: x, ["Choose:"])
+    tc = test_case(tc, got == None, "prompt_choice: off-TTY returns None")
+    return tc
 
 def test_gitlab_token_cache(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     """Covers the installation-proof carriage added to the GitLab token

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -1,6 +1,7 @@
 load("./private/lib/aspect_endpoint_auth.axl", "login_hint")
 load("./private/lib/deployment_flags.axl", "join_and")
 load("./private/lib/environment.axl", "error", "info")
+load("./private/lib/prompt.axl", "prompt_choice")
 
 def _run_browser_login(ctx: TaskContext, deployment: str):
     """Open the deployment's authorize URL in a browser and wait for the callback,
@@ -149,29 +150,8 @@ login = task(
     },
 )
 
-def _prompt_issuer(ctx, servers):
-    """Prompt the user to choose an authorization server issuer by number.
-
-    TTY only: returns None off a TTY (the caller prints how to pass --issuer and
-    exits) rather than reading a number nobody typed. On a TTY, an empty,
-    non-numeric, or out-of-range entry re-prompts instead of aborting.
-    """
-    if not ctx.std.io.stdout.is_tty:
-        return None
-    ctx.std.io.stdout.write("This deployment advertises multiple authorization servers.\n")
-    ctx.std.io.stdout.write("Choose one to log in against:\n")
-    for i, server in enumerate(servers):
-        ctx.std.io.stdout.write("  {}. {}\n".format(i + 1, server.issuer))
-    for _attempt in range(len(servers) + 100):
-        ctx.std.io.stdout.write("Enter a number [1-{}]: ".format(len(servers)))
-        ctx.std.io.stdout.flush()
-        raw = str(ctx.std.io.stdin.read(16)).strip()
-        if raw.isdigit():
-            idx = int(raw) - 1
-            if idx >= 0 and idx < len(servers):
-                return servers[idx].issuer
-        print("Please enter a number between 1 and {}.".format(len(servers)))
-    return None
+def _advertised_issuers(servers):
+    return ", ".join([s.issuer for s in servers])
 
 def _discover_deployment(ctx, host):
     """Discover and record `host`'s deployment, resolving a multi-issuer choice.
@@ -198,14 +178,20 @@ def _discover_deployment(ctx, host):
             return None
         if info.status == "issuer_not_advertised":
             error(ctx.std, "'" + issuer + "' is not one of the authorization servers this deployment advertises.")
-            error(ctx.std, "Choose one of: " + ", ".join([s.issuer for s in info.auth_servers]))
+            error(ctx.std, "Choose one of: " + _advertised_issuers(info.auth_servers))
             return None
-        # needs_issuer: prompt (TTY) then loop to re-run with the chosen issuer.
-        issuer = _prompt_issuer(ctx, info.auth_servers)
-        if not issuer:
+        chosen = prompt_choice(
+            ctx,
+            info.auth_servers,
+            lambda s: s.issuer,
+            ["This deployment advertises multiple authorization servers.", "Choose one to log in against:"],
+        )
+        if chosen == None:
             error(ctx.std, "This deployment advertises multiple authorization servers; pass --issuer=<url>.")
-            error(ctx.std, "Choose one of: " + ", ".join([s.issuer for s in info.auth_servers]))
+            error(ctx.std, "Choose one of: " + _advertised_issuers(info.auth_servers))
             return None
+        issuer = chosen.issuer
+    # A prompted issuer always resolves on the second pass; guard the loop bound.
     return None
 
 def _configure_impl(ctx: TaskContext) -> int:

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -149,28 +149,75 @@ login = task(
     },
 )
 
+def _prompt_issuer(ctx, servers):
+    """Prompt the user to choose an authorization server issuer by number.
+
+    TTY only: returns None off a TTY (the caller prints how to pass --issuer and
+    exits) rather than reading a number nobody typed. On a TTY, an empty,
+    non-numeric, or out-of-range entry re-prompts instead of aborting.
+    """
+    if not ctx.std.io.stdout.is_tty:
+        return None
+    ctx.std.io.stdout.write("This deployment advertises multiple authorization servers.\n")
+    ctx.std.io.stdout.write("Choose one to log in against:\n")
+    for i, server in enumerate(servers):
+        ctx.std.io.stdout.write("  {}. {}\n".format(i + 1, server.issuer))
+    for _attempt in range(len(servers) + 100):
+        ctx.std.io.stdout.write("Enter a number [1-{}]: ".format(len(servers)))
+        ctx.std.io.stdout.flush()
+        raw = str(ctx.std.io.stdin.read(16)).strip()
+        if raw.isdigit():
+            idx = int(raw) - 1
+            if idx >= 0 and idx < len(servers):
+                return servers[idx].issuer
+        print("Please enter a number between 1 and {}.".format(len(servers)))
+    return None
+
+def _discover_deployment(ctx, host):
+    """Discover and record `host`'s deployment, resolving a multi-issuer choice.
+
+    Returns the recorded (`status == "ok"`) DeploymentInfo, or None after printing
+    a message and when the caller should exit non-zero. `--issuer` selects among
+    advertised authorization servers; when the deployment offers more than one and
+    none was given, prompts on a TTY, else instructs the user to pass --issuer.
+    The prompt re-invokes discovery once with the chosen issuer, so every outcome
+    (including a transport error on that second probe) is reported uniformly.
+    """
+    issuer = ctx.args.issuer
+    for _attempt in range(2):
+        info = ctx.aspect.auth.configure(host, name = ctx.args.name, make_default = ctx.args.default, issuer = issuer)
+        if info.status == "ok":
+            return info
+        if info.status == "unreachable":
+            error(ctx.std, "Could not reach '" + host + "' (" + info.reason + ").")
+            error(ctx.std, "Check your network and that the host is correct, then try again.")
+            return None
+        if info.status == "not_a_deployment":
+            error(ctx.std, "'" + host + "' is not an Aspect Workflows deployment authentication endpoint.")
+            error(ctx.std, "Double-check the URL — it should be the deployment's remote-cache or BES host (e.g. remote.<deployment>.example.com).")
+            return None
+        if info.status == "issuer_not_advertised":
+            error(ctx.std, "'" + issuer + "' is not one of the authorization servers this deployment advertises.")
+            error(ctx.std, "Choose one of: " + ", ".join([s.issuer for s in info.auth_servers]))
+            return None
+        # needs_issuer: prompt (TTY) then loop to re-run with the chosen issuer.
+        issuer = _prompt_issuer(ctx, info.auth_servers)
+        if not issuer:
+            error(ctx.std, "This deployment advertises multiple authorization servers; pass --issuer=<url>.")
+            error(ctx.std, "Choose one of: " + ", ".join([s.issuer for s in info.auth_servers]))
+            return None
+    return None
+
 def _configure_impl(ctx: TaskContext) -> int:
     if len(ctx.args.host) != 1:
         error(ctx.std, "Provide exactly one deployment host, e.g. `aspect auth configure remote.acme.aspect.build`.")
         return 1
     host = ctx.args.host[0]
-    info = ctx.aspect.auth.configure(host, name = ctx.args.name, make_default = ctx.args.default)
-
-    if info.status == "unreachable":
-        error(ctx.std, "Could not reach '" + host + "' (" + info.reason + ").")
-        error(ctx.std, "Check your network and that the host is correct, then try again.")
-        return 1
-    if info.status == "not_a_deployment":
-        error(ctx.std, "'" + host + "' is not an Aspect Workflows deployment authentication endpoint.")
-        error(ctx.std, "Double-check the URL — it should be the deployment's remote-cache or BES host (e.g. remote.<deployment>.example.com).")
+    info = _discover_deployment(ctx, host)
+    if info == None:
         return 1
 
     print("Configured deployment '" + info.name + "'.")
-    if info.multiple_auth_servers:
-        print("")
-        print("This deployment advertised multiple authorization servers; the CLI")
-        print("configured the first. To use a different one, add its issuer and")
-        print("client_id to ~/.aspect/config.json by hand.")
     if not info.can_login:
         print("")
         print("This deployment does not advertise its login config, so the CLI")
@@ -206,6 +253,9 @@ configure = task(
         "default": args.boolean(
             default = False,
             description = "Make this the default deployment (what build/test target without an explicit --deployment), taking over from any current default. Without it, a deployment becomes the default only when none is set yet.",
+        ),
+        "issuer": args.string(
+            description = "Authorization server issuer to log in against, for deployments that advertise more than one (e.g. https://auth.acme.example.com). Required when running non-interactively; on a TTY you are prompted to choose. Fails if the deployment does not advertise it.",
         ),
         "login": args.boolean(
             default = True,

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -166,6 +166,11 @@ def _configure_impl(ctx: TaskContext) -> int:
         return 1
 
     print("Configured deployment '" + info.name + "'.")
+    if info.multiple_auth_servers:
+        print("")
+        print("This deployment advertised multiple authorization servers; the CLI")
+        print("configured the first. To use a different one, add its issuer and")
+        print("client_id to ~/.aspect/config.json by hand.")
     if not info.can_login:
         print("")
         print("This deployment does not advertise its login config, so the CLI")

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -191,6 +191,7 @@ def _discover_deployment(ctx, host):
             error(ctx.std, "Choose one of: " + _advertised_issuers(info.auth_servers))
             return None
         issuer = chosen.issuer
+
     # A prompted issuer always resolves on the second pass; guard the loop bound.
     return None
 

--- a/crates/aspect-cli/src/builtins/aspect/init.axl
+++ b/crates/aspect-cli/src/builtins/aspect/init.axl
@@ -27,6 +27,7 @@ ships as placeholders (unless `--skip-repin`).
 """
 
 load("./private/lib/init_render.axl", "load_config", "preset_flags", "preset_names", "render")
+load("./private/lib/prompt.axl", "prompt_choice")
 
 # Default template source: the latest published release of this GitHub repo.
 # `--template-ref` overrides the ref (branch, tag, or commit), e.g.
@@ -83,29 +84,15 @@ def parse_template(spec):
     fail("unknown --template scheme {!r} in {!r}; supported: github:, file:".format(scheme, spec))
 
 def _prompt_preset(ctx, names):
-    """Prompt the user to choose a preset by number, re-prompting on bad input.
+    """Prompt the user to choose a preset by name, printing an off-TTY hint.
 
-    TTY only: returns None off a TTY (the caller prints a hint and exits) rather
-    than reading a number nobody typed. On a TTY, an empty, non-numeric, or
-    out-of-range entry re-prompts instead of aborting — a typo shouldn't discard
-    the template that was just fetched.
+    A typo shouldn't discard the template that was just fetched, so
+    [`prompt_choice`] re-prompts on bad input; None means off a TTY or exhausted.
     """
     if not ctx.std.io.stdout.is_tty:
         print("No --preset given and stdin is not a TTY; pass --preset=<name>.")
         return None
-    ctx.std.io.stdout.write("Choose a preset:\n")
-    for i, name in enumerate(names):
-        ctx.std.io.stdout.write("  {}. {}\n".format(i + 1, name))
-    for _attempt in range(len(names) + 100):
-        ctx.std.io.stdout.write("Enter a number [1-{}]: ".format(len(names)))
-        ctx.std.io.stdout.flush()
-        raw = str(ctx.std.io.stdin.read(16)).strip()
-        if raw.isdigit():
-            idx = int(raw) - 1
-            if idx >= 0 and idx < len(names):
-                return names[idx]
-        print("Please enter a number between 1 and {}.".format(len(names)))
-    return None
+    return prompt_choice(ctx, names, lambda name: name, ["Choose a preset:"])
 
 def project_name(arg_name, out_dir):
     """Resolve the project name (snake_case).

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/prompt.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/prompt.axl
@@ -1,0 +1,26 @@
+"""Interactive terminal prompts shared across tasks."""
+
+def prompt_choice(ctx, items, label, header):
+    """Prompt the user to pick one of `items` by number, re-prompting on bad input.
+
+    `label` maps an item to its display string; `header` is a list of lines printed
+    before the numbered list. Returns the chosen item, or None off a TTY (the
+    caller prints how to supply the choice non-interactively and exits) — an empty,
+    non-numeric, or out-of-range entry re-prompts rather than aborting.
+    """
+    if not ctx.std.io.stdout.is_tty:
+        return None
+    for line in header:
+        ctx.std.io.stdout.write(line + "\n")
+    for i, item in enumerate(items):
+        ctx.std.io.stdout.write("  {}. {}\n".format(i + 1, label(item)))
+    for _attempt in range(len(items) + 100):
+        ctx.std.io.stdout.write("Enter a number [1-{}]: ".format(len(items)))
+        ctx.std.io.stdout.flush()
+        raw = str(ctx.std.io.stdin.read(16)).strip()
+        if raw.isdigit():
+            idx = int(raw) - 1
+            if idx >= 0 and idx < len(items):
+                return items[idx]
+        print("Please enter a number between 1 and {}.".format(len(items)))
+    return None

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -361,16 +361,30 @@ struct AspectAuthServer {
     scopes: Vec<String>,
 }
 
-/// The chosen OAuth config for a deployment: one issuer with its PKCE client and
-/// scopes, resolved from the discovery document's authorization servers.
-struct SelectedAuthServer<'a> {
-    issuer: &'a str,
-    client_id: &'a str,
-    scopes: &'a [String],
-    /// The document advertised more than one authorization server and we picked
-    /// the first. `configure` surfaces this so the user knows a different issuer
-    /// would require editing `~/.aspect/config.json` by hand.
-    multiple: bool,
+/// A usable OAuth config the CLI can log in with: an issuer paired with its PKCE
+/// client and scopes. Owned (not borrowed from the [`ProtectedResource`]) so it
+/// can cross the discover → prompt → persist boundary, where a deployment that
+/// advertises more than one is resolved to the user's choice.
+#[derive(Debug, Clone, PartialEq)]
+struct AuthServer {
+    issuer: String,
+    client_id: String,
+    scopes: Vec<String>,
+}
+
+/// Whether two issuers name the same authorization server, tolerant of how a
+/// user types the `--issuer` flag: scheme and trailing slash are ignored and the
+/// host compares case-insensitively (`Auth.Dev.Aspect.Build`, `auth.dev.aspect.build`,
+/// and `https://auth.dev.aspect.build/` all match).
+fn issuers_match(a: &str, b: &str) -> bool {
+    fn normalize(s: &str) -> String {
+        s.trim()
+            .trim_end_matches('/')
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .to_ascii_lowercase()
+    }
+    normalize(a) == normalize(b)
 }
 
 /// A deployment endpoint's discovery document, served at
@@ -380,7 +394,7 @@ struct SelectedAuthServer<'a> {
 /// {issuer, client_id, scopes} — the OAuth config the CLI mints a bearer against
 /// (interactive PKCE or API token). The flat top-level `authorization_servers`
 /// (issuer URLs) + `client_id` + `scopes_supported` are the legacy shape, used
-/// as a fallback by [`ProtectedResource::selected_auth_server`] when no usable
+/// as a fallback by [`ProtectedResource::auth_servers`] when no usable
 /// `aspect_authorization_servers` entry is present (older deployments). `scopes`
 /// are overridable per deployment for a bring-your-own IdP that doesn't accept
 /// the standard OIDC set, and empty falls back to [`DEFAULT_LOGIN_SCOPES`].
@@ -405,34 +419,81 @@ struct ProtectedResource {
 }
 
 impl ProtectedResource {
-    /// The OAuth config to log in with: the first usable `aspect_authorization_servers`
-    /// entry (one that carries an issuer) when the document uses the current shape,
-    /// else the legacy flat fields (`authorization_servers[0]` + top-level
-    /// `client_id`/`scopes_supported`). `multiple` reflects the list actually
-    /// selected from, counting only issuer-bearing entries. Returns `None` when
-    /// neither shape advertises an issuer, so the caller records a deployment that
-    /// can't log in.
-    fn selected_auth_server(&self) -> Option<SelectedAuthServer<'_>> {
-        let mut usable = self
+    /// The authorization servers the CLI can log in against, in advertised order:
+    /// every issuer-bearing `aspect_authorization_servers` entry when the document
+    /// uses the current shape, else the legacy flat fields
+    /// (`authorization_servers` + top-level `client_id`/`scopes_supported`).
+    /// Empty when neither shape advertises an issuer, so the caller records a
+    /// deployment that can't log in.
+    fn auth_servers(&self) -> Vec<AuthServer> {
+        let nested: Vec<AuthServer> = self
             .aspect_authorization_servers
             .iter()
-            .filter(|s| !s.issuer.is_empty());
-        if let Some(first) = usable.next() {
-            return Some(SelectedAuthServer {
-                issuer: &first.issuer,
-                client_id: &first.client_id,
-                scopes: &first.scopes,
-                multiple: usable.next().is_some(),
-            });
+            .filter(|s| !s.issuer.is_empty())
+            .map(|s| AuthServer {
+                issuer: s.issuer.clone(),
+                client_id: s.client_id.clone(),
+                scopes: s.scopes.clone(),
+            })
+            .collect();
+        if !nested.is_empty() {
+            return nested;
         }
-        let mut usable = self.authorization_servers.iter().filter(|s| !s.is_empty());
-        let issuer = usable.next()?;
-        Some(SelectedAuthServer {
-            issuer,
-            client_id: &self.client_id,
-            scopes: &self.scopes_supported,
-            multiple: usable.next().is_some(),
-        })
+        self.authorization_servers
+            .iter()
+            .filter(|s| !s.is_empty())
+            .map(|issuer| AuthServer {
+                issuer: issuer.clone(),
+                client_id: self.client_id.clone(),
+                scopes: self.scopes_supported.clone(),
+            })
+            .collect()
+    }
+}
+
+/// The outcome of picking which advertised authorization server to configure,
+/// given the `candidates` a deployment advertised and an optional `requested`
+/// issuer (`--issuer`). See [`resolve_auth_server`].
+enum AuthServerChoice {
+    /// No authorization server advertised: record a deployment that can't log in.
+    None,
+    /// One server resolved — either the sole candidate or the `requested` match.
+    Selected(AuthServer),
+    /// More than one advertised and no `requested` issuer to disambiguate: the
+    /// caller must prompt (interactive) or fail (non-interactive).
+    Ambiguous,
+    /// A `requested` issuer was given but no candidate matches it.
+    NotAdvertised,
+}
+
+/// Pick the authorization server to configure from the `candidates` a deployment
+/// advertised (in advertised order), honoring an optional `requested` issuer:
+///   - `requested` set → the matching candidate ([`issuers_match`], host-tolerant),
+///     or [`AuthServerChoice::NotAdvertised`] when none matches — even with a
+///     single candidate, so a typo'd `--issuer` is caught rather than ignored.
+///   - `requested` unset → the sole candidate, [`AuthServerChoice::None`] when
+///     there are none, or [`AuthServerChoice::Ambiguous`] when more than one.
+fn resolve_auth_server(candidates: &[AuthServer], requested: Option<&str>) -> AuthServerChoice {
+    if let Some(requested) = requested {
+        return match candidates.iter().find(|c| issuers_match(&c.issuer, requested)) {
+            Some(c) => AuthServerChoice::Selected(c.clone()),
+            None => AuthServerChoice::NotAdvertised,
+        };
+    }
+    match candidates {
+        [] => AuthServerChoice::None,
+        [only] => AuthServerChoice::Selected(only.clone()),
+        _ => AuthServerChoice::Ambiguous,
+    }
+}
+
+/// The Starlark-facing view of an advertised [`AuthServer`], for the `configure`
+/// task's issuer prompt.
+fn auth_server_info(server: AuthServer) -> AuthServerInfo {
+    AuthServerInfo {
+        issuer: server.issuer,
+        client_id: server.client_id,
+        scopes: server.scopes,
     }
 }
 
@@ -531,23 +592,23 @@ fn deployment_name_from_host(host: &str) -> String {
     }
 }
 
-/// Build a [`Deployment`] record from a discovered [`ProtectedResource`],
-/// returning whether the document advertised more than one usable authorization
-/// server (so the caller can warn that only the first was recorded).
+/// Build a [`Deployment`] record from a discovered [`ProtectedResource`] and the
+/// `selected` authorization server the deployment logs in against (chosen by the
+/// caller from [`ProtectedResource::auth_servers`]; `None` when the endpoint
+/// advertises no issuer, recording a deployment that can't log in).
 ///
-/// `issuer` + `client_id` + `scopes` come from the selected authorization server
-/// ([`ProtectedResource::selected_auth_server`]); all are absent when the endpoint
-/// advertises no issuer. `hosts` are the endpoints this deployment's token covers:
-/// the configured host, the advertised `resource` host, and every
-/// `aspect_endpoints` host, deduped. The typed `endpoints` map is recorded (hosts
-/// normalized) so `--deployment` can wire each to its Bazel flag. `configured_host`
-/// is the host the user ran `configure` against (the `resource` may be a canonical
-/// alias).
+/// `issuer` + `client_id` + `scopes` come from `selected`. `hosts` are the
+/// endpoints this deployment's token covers: the configured host, the advertised
+/// `resource` host, and every `aspect_endpoints` host, deduped. The typed
+/// `endpoints` map is recorded (hosts normalized) so `--deployment` can wire each
+/// to its Bazel flag. `configured_host` is the host the user ran `configure`
+/// against (the `resource` may be a canonical alias).
 fn deployment_from_discovery(
     name: String,
     configured_host: &str,
     info: &ProtectedResource,
-) -> (Deployment, bool) {
+    selected: Option<&AuthServer>,
+) -> Deployment {
     let mut hosts: Vec<String> = Vec::new();
     let mut push = |h: &str| {
         let h = endpoint_host_str(h);
@@ -567,20 +628,16 @@ fn deployment_from_discovery(
     push(&endpoints.cache);
     push(&endpoints.bes);
     push(&endpoints.exec);
-    let selected = info.selected_auth_server();
-    let multiple = selected.as_ref().is_some_and(|s| s.multiple);
-    let advertised = |s: &str| (!s.is_empty()).then(|| s.to_string());
-    let deployment = Deployment {
+    Deployment {
         name,
         default: false,
-        issuer: selected.as_ref().and_then(|s| advertised(s.issuer)),
-        client_id: selected.as_ref().and_then(|s| advertised(s.client_id)),
+        issuer: selected.map(|s| s.issuer.clone()),
+        client_id: selected.map(|s| s.client_id.clone()),
         api_url: None,
         hosts,
-        scopes: selected.as_ref().map(|s| s.scopes.to_vec()).unwrap_or_default(),
+        scopes: selected.map(|s| s.scopes.clone()).unwrap_or_default(),
         endpoints,
-    };
-    (deployment, multiple)
+    }
 }
 
 /// Insert or replace `deployment` in `existing` (by name), keeping exactly one
@@ -1776,15 +1833,71 @@ fn auth_session_methods(registry: &mut MethodsBuilder) {
     }
 }
 
-/// The outcome of `ctx.aspect.auth.configure(host)`, exposed to the `configure`
-/// task so it can report what happened and decide whether to run login.
+/// One authorization server advertised by a deployment's discovery document,
+/// exposed to the `configure` task so it can present the choice when more than one
+/// is offered. `scopes` are informational for the task; the recorded deployment
+/// carries them once an issuer is chosen.
+#[derive(Debug, Display, ProvidesStaticType, NoSerialize, Allocative, Clone)]
+#[display("<aspect.AuthServerInfo>")]
+pub struct AuthServerInfo {
+    pub issuer: String,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+}
+
+starlark_simple_value!(AuthServerInfo);
+
+#[starlark_value(type = "aspect.AuthServerInfo")]
+impl<'v> values::StarlarkValue<'v> for AuthServerInfo {
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(auth_server_info_methods)
+    }
+}
+
+#[starlark_module]
+fn auth_server_info_methods(registry: &mut MethodsBuilder) {
+    #[starlark(attribute)]
+    fn issuer<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
+        attr_str!(this, AuthServerInfo, issuer)
+    }
+
+    #[starlark(attribute)]
+    fn client_id<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
+        attr_str!(this, AuthServerInfo, client_id)
+    }
+
+    #[starlark(attribute)]
+    fn scopes<'v>(
+        this: values::Value<'v>,
+        heap: values::Heap<'v>,
+    ) -> anyhow::Result<values::Value<'v>> {
+        let scopes = this
+            .downcast_ref_err::<AuthServerInfo>()
+            .into_anyhow_result()?
+            .scopes
+            .clone();
+        Ok(heap.alloc(scopes))
+    }
+}
+
+/// The outcome of `ctx.aspect.auth.configure(host, issuer = ...)`, exposed to the
+/// `configure` task so it can report what happened and decide whether to run login.
 ///
-/// `status` distinguishes the outcomes: `"ok"` (recorded — the other fields are
-/// populated), `"unreachable"` (a transport error; `reason` carries a terse
-/// description and the host may still be a real deployment), or
-/// `"not_a_deployment"` (reached the host, but it isn't an Aspect Workflows
-/// endpoint). `can_login` is true when the deployment advertised an authorization
-/// server + client_id.
+/// `status` distinguishes the outcomes; the two `auth_servers`-bearing statuses
+/// record nothing (the task resolves the choice and re-invokes):
+///   - `"ok"` — recorded; the other fields are populated.
+///   - `"unreachable"` — a transport error; `reason` carries a terse description
+///     and the host may still be a real deployment.
+///   - `"not_a_deployment"` — reached the host, but it isn't an Aspect Workflows
+///     endpoint.
+///   - `"needs_issuer"` — the deployment advertised more than one authorization
+///     server and no `issuer` was given; `auth_servers` lists the choices to
+///     prompt from.
+///   - `"issuer_not_advertised"` — the given `issuer` matches none of the
+///     advertised servers; `auth_servers` lists the valid choices.
+///
+/// `can_login` is true when the recorded deployment has an issuer + client_id.
 #[derive(Debug, Display, ProvidesStaticType, NoSerialize, Allocative, Clone)]
 #[display("<aspect.DeploymentInfo>")]
 pub struct DeploymentInfo {
@@ -1794,10 +1907,10 @@ pub struct DeploymentInfo {
     pub can_login: bool,
     pub is_default: bool,
     pub hosts: Vec<String>,
-    /// Discovery advertised more than one usable authorization server; the CLI
-    /// recorded the first. The `configure` task surfaces this so the user knows a
-    /// different issuer would require editing `~/.aspect/config.json` by hand.
-    pub multiple_auth_servers: bool,
+    /// The advertised authorization servers, populated for `"needs_issuer"` and
+    /// `"issuer_not_advertised"` so the task can prompt from — or list — the valid
+    /// choices.
+    pub auth_servers: Vec<AuthServerInfo>,
 }
 
 starlark_simple_value!(DeploymentInfo);
@@ -1851,8 +1964,16 @@ fn deployment_info_methods(registry: &mut MethodsBuilder) {
     }
 
     #[starlark(attribute)]
-    fn multiple_auth_servers<'v>(this: values::Value<'v>) -> anyhow::Result<bool> {
-        attr_bool!(this, DeploymentInfo, multiple_auth_servers)
+    fn auth_servers<'v>(
+        this: values::Value<'v>,
+        heap: values::Heap<'v>,
+    ) -> anyhow::Result<values::Value<'v>> {
+        let servers = this
+            .downcast_ref_err::<DeploymentInfo>()
+            .into_anyhow_result()?
+            .auth_servers
+            .clone();
+        Ok(heap.alloc(servers))
     }
 }
 
@@ -2291,22 +2412,29 @@ fn auth_methods(registry: &mut MethodsBuilder) {
     /// `/.well-known/oauth-protected-resource` document and record it in
     /// `~/.aspect/config.json` (replacing any entry of the same derived/`name`
     /// deployment). Returns a [`DeploymentInfo`] the caller uses to report the
-    /// result and decide whether to run the interactive login. `name` overrides
-    /// the host-derived deployment name. `make_default` forces this deployment to
-    /// become the default (taking the crown from any other); otherwise it becomes
-    /// the default only when none is set yet — a second configure never hijacks it.
+    /// result and decide whether to run the interactive login.
+    ///
+    /// `name` overrides the host-derived deployment name. `make_default` forces
+    /// this deployment to become the default (taking the crown from any other);
+    /// otherwise it becomes the default only when none is set yet — a second
+    /// configure never hijacks it. `issuer` selects among advertised authorization
+    /// servers ([`resolve_auth_server`]): when set it must match an advertised one
+    /// (else `"issuer_not_advertised"`, records nothing), and it is required only
+    /// when the deployment advertises more than one — an unset `issuer` there
+    /// records nothing and returns `"needs_issuer"` for the task to resolve.
     fn configure<'v>(
         #[allow(unused)] this: values::Value<'v>,
         host: &str,
         #[starlark(require = named, default = NoneOr::None)] name: NoneOr<String>,
         #[starlark(require = named, default = false)] make_default: bool,
+        #[starlark(require = named, default = NoneOr::None)] issuer: NoneOr<String>,
         heap: values::Heap<'v>,
     ) -> anyhow::Result<values::Value<'v>> {
         let host = endpoint_host_str(host);
-        // Distinguish the two user-facing failure modes (unreachable vs. not an
-        // Aspect Workflows deployment) so the task prints the right guidance
-        // rather than a Starlark traceback. An `aspect_endpoints` map is the
-        // definitive marker of a deployment — probe_protected_resource requires it.
+        // Distinguish the user-facing failure modes (unreachable vs. not an Aspect
+        // Workflows deployment) so the task prints the right guidance rather than a
+        // Starlark traceback. An `aspect_endpoints` map is the definitive marker of
+        // a deployment — probe_protected_resource requires it.
         let mk = |status: &str, reason: String| DeploymentInfo {
             status: status.to_string(),
             reason,
@@ -2314,7 +2442,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
             can_login: false,
             is_default: false,
             hosts: Vec::new(),
-            multiple_auth_servers: false,
+            auth_servers: Vec::new(),
         };
         let info = match block_on(probe_protected_resource(&host)) {
             Discovery::Reachable(info) => info,
@@ -2327,8 +2455,28 @@ fn auth_methods(registry: &mut MethodsBuilder) {
             .into_option()
             .filter(|n| !n.is_empty())
             .unwrap_or_else(|| deployment_name_from_host(&host));
-        let (mut deployment, multiple_auth_servers) =
-            deployment_from_discovery(name.clone(), &host, &info);
+        let requested = issuer.into_option().filter(|s| !s.is_empty());
+        let candidates = info.auth_servers();
+        // Hand the advertised choices back so the task can prompt from them or list
+        // the valid values when `--issuer` names one that isn't advertised.
+        let with_candidates = |status: &str| DeploymentInfo {
+            status: status.to_string(),
+            reason: String::new(),
+            name: name.clone(),
+            can_login: false,
+            is_default: false,
+            hosts: Vec::new(),
+            auth_servers: candidates.iter().cloned().map(auth_server_info).collect(),
+        };
+        let selected = match resolve_auth_server(&candidates, requested.as_deref()) {
+            AuthServerChoice::Ambiguous => return Ok(heap.alloc(with_candidates("needs_issuer"))),
+            AuthServerChoice::NotAdvertised => {
+                return Ok(heap.alloc(with_candidates("issuer_not_advertised")));
+            }
+            AuthServerChoice::Selected(s) => Some(s),
+            AuthServerChoice::None => None,
+        };
+        let mut deployment = deployment_from_discovery(name.clone(), &host, &info, selected.as_ref());
         // `--default` forces this deployment to take the default crown (upsert
         // then clears it on every other entry); without it, upsert only sets the
         // default when none exists yet, so a second configure doesn't hijack it.
@@ -2343,7 +2491,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
             can_login,
             is_default,
             hosts,
-            multiple_auth_servers,
+            auth_servers: Vec::new(),
         }))
     }
 
@@ -2706,6 +2854,72 @@ mod tests {
         assert_eq!(deployment_name_from_host("localhost"), "localhost");
     }
 
+    fn nested(issuer: &str, client_id: &str) -> AspectAuthServer {
+        AspectAuthServer {
+            issuer: issuer.to_string(),
+            client_id: client_id.to_string(),
+            scopes: vec!["openid".to_string()],
+        }
+    }
+
+    /// A discovery document serving `cache` at `remote.acme.aspect.build` with the
+    /// given authorization servers (nested current shape or legacy flat fields).
+    fn protected_resource(
+        aspect_authorization_servers: Vec<AspectAuthServer>,
+        authorization_servers: Vec<&str>,
+        client_id: &str,
+        scopes_supported: Vec<&str>,
+    ) -> ProtectedResource {
+        ProtectedResource {
+            resource: "https://remote.acme.aspect.build".to_string(),
+            aspect_authorization_servers,
+            authorization_servers: authorization_servers.iter().map(|s| s.to_string()).collect(),
+            client_id: client_id.to_string(),
+            scopes_supported: scopes_supported.iter().map(|s| s.to_string()).collect(),
+            aspect_endpoints: Endpoints {
+                cache: "remote.acme.aspect.build".to_string(),
+                ..Default::default()
+            },
+        }
+    }
+
+    fn configure_from(info: &ProtectedResource, issuer: Option<&str>) -> Deployment {
+        let candidates = info.auth_servers();
+        let selected = match resolve_auth_server(&candidates, issuer) {
+            AuthServerChoice::Selected(s) => Some(s),
+            AuthServerChoice::None => None,
+            other => panic!(
+                "expected a selectable auth server, got {}",
+                match other {
+                    AuthServerChoice::Ambiguous => "ambiguous",
+                    AuthServerChoice::NotAdvertised => "not-advertised",
+                    _ => unreachable!(),
+                }
+            ),
+        };
+        deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", info, selected.as_ref())
+    }
+
+    #[test]
+    fn issuers_match_ignores_scheme_slash_and_case() {
+        assert!(issuers_match(
+            "https://auth.dev.aspect.build",
+            "auth.dev.aspect.build"
+        ));
+        assert!(issuers_match(
+            "https://auth.dev.aspect.build",
+            "https://auth.dev.aspect.build/"
+        ));
+        assert!(issuers_match(
+            "https://Auth.Dev.Aspect.Build",
+            "http://auth.dev.aspect.build"
+        ));
+        assert!(!issuers_match(
+            "https://auth.dev.aspect.build",
+            "https://auth.prod.aspect.build"
+        ));
+    }
+
     #[test]
     fn deployment_from_discovery_records_issuer_client_and_all_hosts() {
         // A deployment advertising an authorization server + client_id + endpoints
@@ -2724,9 +2938,7 @@ mod tests {
                 exec: "https://remote.acme.aspect.build".to_string(),
             },
         };
-        let (d, multiple) =
-            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &advertised);
-        assert!(!multiple);
+        let d = configure_from(&advertised, None);
         assert_eq!(d.issuer.as_deref(), Some("https://acme.auth.aspect.build"));
         assert_eq!(d.client_id.as_deref(), Some("abc"));
         // A BYO-IdP scope override is recorded verbatim...
@@ -2767,7 +2979,7 @@ mod tests {
                 exec: String::new(),
             },
         };
-        let (d, _) = deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &bare);
+        let d = configure_from(&bare, None);
         assert!(d.issuer.is_none() && d.client_id.is_none());
         assert_eq!(
             d.hosts,
@@ -2781,162 +2993,121 @@ mod tests {
     }
 
     #[test]
-    fn deployment_from_discovery_prefers_aspect_authorization_servers() {
-        // The current shape nests issuer/client_id/scopes per authorization server.
-        // When present it wins over the flat legacy fields (which older servers set,
-        // and which a transitional server may still populate alongside).
-        let info = ProtectedResource {
-            resource: "https://remote.acme.aspect.build".to_string(),
-            aspect_authorization_servers: vec![AspectAuthServer {
+    fn auth_servers_prefers_nested_over_legacy_flat_fields() {
+        // The current nested shape wins over the flat legacy fields (which a
+        // transitional server may still populate alongside).
+        let info = protected_resource(
+            vec![AspectAuthServer {
                 issuer: "https://auth.dev.aspect.build".to_string(),
                 client_id: "nested-client".to_string(),
                 scopes: vec!["openid".to_string(), "email".to_string()],
             }],
-            authorization_servers: vec!["https://legacy.auth.aspect.build".to_string()],
-            client_id: "legacy-client".to_string(),
-            scopes_supported: vec!["openid".to_string()],
-            aspect_endpoints: Endpoints {
-                cache: "remote.acme.aspect.build".to_string(),
-                ..Default::default()
-            },
-        };
-        let (d, multiple) =
-            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
-        assert!(!multiple);
-        assert_eq!(d.issuer.as_deref(), Some("https://auth.dev.aspect.build"));
-        assert_eq!(d.client_id.as_deref(), Some("nested-client"));
-        assert_eq!(d.scopes, vec!["openid".to_string(), "email".to_string()]);
+            vec!["https://legacy.auth.aspect.build"],
+            "legacy-client",
+            vec!["openid"],
+        );
+        let servers = info.auth_servers();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].issuer, "https://auth.dev.aspect.build");
+        assert_eq!(servers[0].client_id, "nested-client");
+        assert_eq!(servers[0].scopes, vec!["openid".to_string(), "email".to_string()]);
     }
 
     #[test]
-    fn deployment_from_discovery_flags_multiple_auth_servers_and_takes_first() {
-        // More than one advertised: record the first and flag it so the caller can
-        // prompt/warn that a different issuer needs a re-run of `configure`.
-        let info = ProtectedResource {
-            resource: "https://remote.acme.aspect.build".to_string(),
-            aspect_authorization_servers: vec![
-                AspectAuthServer {
-                    issuer: "https://auth.dev.aspect.build".to_string(),
-                    client_id: "first-client".to_string(),
-                    scopes: vec!["openid".to_string()],
-                },
-                AspectAuthServer {
-                    issuer: "https://auth.corp.example.com".to_string(),
-                    client_id: "second-client".to_string(),
-                    scopes: vec!["openid".to_string()],
-                },
+    fn auth_servers_skips_issuerless_nested_entries() {
+        // Issuer-less nested entries are dropped; a valid later entry still surfaces.
+        let info = protected_resource(
+            vec![
+                nested("", "skip-me"),
+                nested("https://auth.dev.aspect.build", "good-client"),
             ],
-            authorization_servers: vec![],
-            client_id: String::new(),
-            scopes_supported: vec![],
-            aspect_endpoints: Endpoints {
-                cache: "remote.acme.aspect.build".to_string(),
-                ..Default::default()
-            },
-        };
-        let (d, multiple) =
-            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
-        assert!(multiple);
+            vec![],
+            "",
+            vec![],
+        );
+        let servers = info.auth_servers();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].client_id, "good-client");
+    }
+
+    #[test]
+    fn auth_servers_falls_back_to_legacy_when_no_usable_nested_entry() {
+        // A nested list with no issuer-bearing entry falls back to the flat fields.
+        let info = protected_resource(
+            vec![nested("", "nested-client")],
+            vec!["https://legacy.auth.aspect.build"],
+            "legacy-client",
+            vec!["openid"],
+        );
+        let servers = info.auth_servers();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].issuer, "https://legacy.auth.aspect.build");
+        assert_eq!(servers[0].client_id, "legacy-client");
+        assert_eq!(servers[0].scopes, vec!["openid".to_string()]);
+    }
+
+    #[test]
+    fn resolve_auth_server_selects_sole_candidate_without_a_request() {
+        let info = protected_resource(
+            vec![nested("https://auth.dev.aspect.build", "the-client")],
+            vec![],
+            "",
+            vec![],
+        );
+        let d = configure_from(&info, None);
         assert_eq!(d.issuer.as_deref(), Some("https://auth.dev.aspect.build"));
-        assert_eq!(d.client_id.as_deref(), Some("first-client"));
+        assert_eq!(d.client_id.as_deref(), Some("the-client"));
     }
 
     #[test]
-    fn deployment_from_discovery_falls_back_to_legacy_when_no_usable_nested_entry() {
-        // A nested list with no issuer-bearing entry is not usable; fall back to the
-        // flat legacy fields rather than recording an issuer-less deployment.
-        let info = ProtectedResource {
-            resource: "https://remote.acme.aspect.build".to_string(),
-            aspect_authorization_servers: vec![AspectAuthServer {
-                issuer: String::new(),
-                client_id: "nested-client".to_string(),
-                scopes: vec![],
-            }],
-            authorization_servers: vec!["https://legacy.auth.aspect.build".to_string()],
-            client_id: "legacy-client".to_string(),
-            scopes_supported: vec!["openid".to_string()],
-            aspect_endpoints: Endpoints {
-                cache: "remote.acme.aspect.build".to_string(),
-                ..Default::default()
-            },
-        };
-        let (d, _) =
-            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
-        assert_eq!(d.issuer.as_deref(), Some("https://legacy.auth.aspect.build"));
-        assert_eq!(d.client_id.as_deref(), Some("legacy-client"));
-        assert_eq!(d.scopes, vec!["openid".to_string()]);
-    }
-
-    #[test]
-    fn deployment_from_discovery_skips_issuerless_entry_for_a_later_usable_one() {
-        // An issuer-less entry ahead of a valid one is skipped rather than aborting
-        // the nested shape: the first usable entry wins. Only one entry is usable,
-        // so `multiple` is false even though the raw list has two elements.
-        let info = ProtectedResource {
-            resource: "https://remote.acme.aspect.build".to_string(),
-            aspect_authorization_servers: vec![
-                AspectAuthServer {
-                    issuer: String::new(),
-                    client_id: "skip-me".to_string(),
-                    scopes: vec![],
-                },
-                AspectAuthServer {
-                    issuer: "https://auth.dev.aspect.build".to_string(),
-                    client_id: "good-client".to_string(),
-                    scopes: vec!["openid".to_string()],
-                },
+    fn resolve_auth_server_is_ambiguous_when_multiple_and_no_request() {
+        let info = protected_resource(
+            vec![
+                nested("https://auth.dev.aspect.build", "first"),
+                nested("https://auth.corp.example.com", "second"),
             ],
-            authorization_servers: vec![],
-            client_id: String::new(),
-            scopes_supported: vec![],
-            aspect_endpoints: Endpoints {
-                cache: "remote.acme.aspect.build".to_string(),
-                ..Default::default()
-            },
-        };
-        let (d, multiple) =
-            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
-        assert!(!multiple);
-        assert_eq!(d.issuer.as_deref(), Some("https://auth.dev.aspect.build"));
-        assert_eq!(d.client_id.as_deref(), Some("good-client"));
+            vec![],
+            "",
+            vec![],
+        );
+        assert!(matches!(
+            resolve_auth_server(&info.auth_servers(), None),
+            AuthServerChoice::Ambiguous
+        ));
     }
 
     #[test]
-    fn deployment_from_discovery_multiple_counts_only_usable_entries() {
-        // The `multiple` warning keys on usable (issuer-bearing) entries, not raw
-        // list length: two usable entries alongside a skipped issuer-less one still
-        // count as multiple.
-        let info = ProtectedResource {
-            resource: "https://remote.acme.aspect.build".to_string(),
-            aspect_authorization_servers: vec![
-                AspectAuthServer {
-                    issuer: "https://auth.dev.aspect.build".to_string(),
-                    client_id: "first".to_string(),
-                    scopes: vec![],
-                },
-                AspectAuthServer {
-                    issuer: String::new(),
-                    client_id: "skip-me".to_string(),
-                    scopes: vec![],
-                },
-                AspectAuthServer {
-                    issuer: "https://auth.corp.example.com".to_string(),
-                    client_id: "second".to_string(),
-                    scopes: vec![],
-                },
+    fn resolve_auth_server_picks_requested_issuer_among_many() {
+        // The requested issuer selects its paired client_id, host-tolerantly (no
+        // scheme), even when it isn't the first advertised.
+        let info = protected_resource(
+            vec![
+                nested("https://auth.dev.aspect.build", "first"),
+                nested("https://auth.corp.example.com", "second"),
             ],
-            authorization_servers: vec![],
-            client_id: String::new(),
-            scopes_supported: vec![],
-            aspect_endpoints: Endpoints {
-                cache: "remote.acme.aspect.build".to_string(),
-                ..Default::default()
-            },
-        };
-        let (d, multiple) =
-            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
-        assert!(multiple);
-        assert_eq!(d.client_id.as_deref(), Some("first"));
+            vec![],
+            "",
+            vec![],
+        );
+        let d = configure_from(&info, Some("auth.corp.example.com"));
+        assert_eq!(d.issuer.as_deref(), Some("https://auth.corp.example.com"));
+        assert_eq!(d.client_id.as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn resolve_auth_server_rejects_unadvertised_issuer_even_when_sole() {
+        // A requested issuer that isn't advertised is rejected rather than ignored,
+        // even when the deployment offers exactly one server.
+        let info = protected_resource(
+            vec![nested("https://auth.dev.aspect.build", "the-client")],
+            vec![],
+            "",
+            vec![],
+        );
+        assert!(matches!(
+            resolve_auth_server(&info.auth_servers(), Some("https://auth.prod.aspect.build")),
+            AuthServerChoice::NotAdvertised
+        ));
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -476,7 +476,10 @@ enum AuthServerChoice {
 ///     there are none, or [`AuthServerChoice::Ambiguous`] when more than one.
 fn resolve_auth_server(candidates: &[AuthServer], requested: Option<&str>) -> AuthServerChoice {
     if let Some(requested) = requested {
-        return match candidates.iter().find(|c| issuers_match(&c.issuer, requested)) {
+        return match candidates
+            .iter()
+            .find(|c| issuers_match(&c.issuer, requested))
+        {
             Some(c) => AuthServerChoice::Selected(c.clone()),
             None => AuthServerChoice::NotAdvertised,
         };
@@ -2477,7 +2480,8 @@ fn auth_methods(registry: &mut MethodsBuilder) {
             AuthServerChoice::Selected(s) => Some(s),
             AuthServerChoice::None => None,
         };
-        let mut deployment = deployment_from_discovery(name.clone(), &host, &info, selected.as_ref());
+        let mut deployment =
+            deployment_from_discovery(name.clone(), &host, &info, selected.as_ref());
         // `--default` forces this deployment to take the default crown (upsert
         // then clears it on every other entry); without it, upsert only sets the
         // default when none exists yet, so a second configure doesn't hijack it.
@@ -2874,7 +2878,10 @@ mod tests {
         ProtectedResource {
             resource: "https://remote.acme.aspect.build".to_string(),
             aspect_authorization_servers,
-            authorization_servers: authorization_servers.iter().map(|s| s.to_string()).collect(),
+            authorization_servers: authorization_servers
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
             client_id: client_id.to_string(),
             scopes_supported: scopes_supported.iter().map(|s| s.to_string()).collect(),
             aspect_endpoints: Endpoints {
@@ -2898,7 +2905,12 @@ mod tests {
                 }
             ),
         };
-        deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", info, selected.as_ref())
+        deployment_from_discovery(
+            "acme".to_string(),
+            "remote.acme.aspect.build",
+            info,
+            selected.as_ref(),
+        )
     }
 
     #[test]
@@ -3016,7 +3028,10 @@ mod tests {
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0].issuer, "https://auth.dev.aspect.build");
         assert_eq!(servers[0].client_id, "nested-client");
-        assert_eq!(servers[0].scopes, vec!["openid".to_string(), "email".to_string()]);
+        assert_eq!(
+            servers[0].scopes,
+            vec!["openid".to_string(), "email".to_string()]
+        );
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -374,15 +374,16 @@ struct AuthServer {
 
 /// Whether two issuers name the same authorization server, tolerant of how a
 /// user types the `--issuer` flag: scheme and trailing slash are ignored and the
-/// host compares case-insensitively (`Auth.Dev.Aspect.Build`, `auth.dev.aspect.build`,
-/// and `https://auth.dev.aspect.build/` all match).
+/// comparison is case-insensitive (`HTTPS://Auth.Dev.Aspect.Build`,
+/// `auth.dev.aspect.build`, and `https://auth.dev.aspect.build/` all match).
 fn issuers_match(a: &str, b: &str) -> bool {
     fn normalize(s: &str) -> String {
-        s.trim()
-            .trim_end_matches('/')
+        // Lowercase first so the scheme strip is case-insensitive too.
+        let s = s.trim().to_ascii_lowercase();
+        s.trim_end_matches('/')
             .trim_start_matches("https://")
             .trim_start_matches("http://")
-            .to_ascii_lowercase()
+            .to_string()
     }
     normalize(a) == normalize(b)
 }
@@ -2913,6 +2914,11 @@ mod tests {
         assert!(issuers_match(
             "https://Auth.Dev.Aspect.Build",
             "http://auth.dev.aspect.build"
+        ));
+        // The scheme strip is case-insensitive too.
+        assert!(issuers_match(
+            "HTTPS://auth.dev.aspect.build",
+            "auth.dev.aspect.build"
         ));
         assert!(!issuers_match(
             "https://auth.dev.aspect.build",

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -346,12 +346,45 @@ fn resolve_aspect_env() -> anyhow::Result<AuthEnv> {
 /// Protected Resource Metadata). Both the remote-cache and BES edges serve it.
 const PROTECTED_RESOURCE_PATH: &str = "/.well-known/oauth-protected-resource";
 
+/// One entry of the discovery document's `aspect_authorization_servers` list —
+/// an OAuth issuer bundled with the PKCE `client_id` and `scopes` to use against
+/// it. Pairing the client and scopes with each issuer lets a deployment advertise
+/// more than one authorization server, which the flat top-level
+/// `client_id`/`scopes_supported` cannot express.
+#[derive(Debug, Deserialize)]
+struct AspectAuthServer {
+    #[serde(default)]
+    issuer: String,
+    #[serde(default)]
+    client_id: String,
+    #[serde(default)]
+    scopes: Vec<String>,
+}
+
+/// The chosen OAuth config for a deployment: one issuer with its PKCE client and
+/// scopes, resolved from the discovery document's authorization servers.
+struct SelectedAuthServer<'a> {
+    issuer: &'a str,
+    client_id: &'a str,
+    scopes: &'a [String],
+    /// The document advertised more than one authorization server and we picked
+    /// the first. `configure` surfaces this so the user knows a different issuer
+    /// would require editing `~/.aspect/config.json` by hand.
+    multiple: bool,
+}
+
 /// A deployment endpoint's discovery document, served at
-/// [`PROTECTED_RESOURCE_PATH`]. `authorization_servers[0]` is the OAuth issuer
-/// the CLI mints a bearer against (interactive PKCE or API token); `client_id` is
-/// the public PKCE client. `scopes_supported` are the OAuth scopes the CLI
-/// requests at login (overridable per deployment for a bring-your-own IdP that
-/// doesn't accept the standard OIDC set); empty falls back to that default set.
+/// [`PROTECTED_RESOURCE_PATH`].
+///
+/// `aspect_authorization_servers` is the current, preferred shape: a list of
+/// {issuer, client_id, scopes} — the OAuth config the CLI mints a bearer against
+/// (interactive PKCE or API token). The flat top-level `authorization_servers`
+/// (issuer URLs) + `client_id` + `scopes_supported` are the legacy shape, used
+/// as a fallback by [`ProtectedResource::selected_auth_server`] when no usable
+/// `aspect_authorization_servers` entry is present (older deployments). `scopes`
+/// are overridable per deployment for a bring-your-own IdP that doesn't accept
+/// the standard OIDC set, and empty falls back to [`DEFAULT_LOGIN_SCOPES`].
+///
 /// `aspect_endpoints` is the capability → host map the deployment serves (remote
 /// cache + BES share one client, so one login covers every host); the CLI records
 /// it so `--deployment` can wire each host to the right Bazel flag.
@@ -359,6 +392,8 @@ const PROTECTED_RESOURCE_PATH: &str = "/.well-known/oauth-protected-resource";
 struct ProtectedResource {
     #[serde(default)]
     resource: String,
+    #[serde(default)]
+    aspect_authorization_servers: Vec<AspectAuthServer>,
     #[serde(default)]
     authorization_servers: Vec<String>,
     #[serde(default)]
@@ -370,13 +405,34 @@ struct ProtectedResource {
 }
 
 impl ProtectedResource {
-    /// The OAuth issuer — the first advertised authorization server. Empty when
-    /// none is advertised.
-    fn issuer(&self) -> &str {
-        self.authorization_servers
-            .first()
-            .map(String::as_str)
-            .unwrap_or("")
+    /// The OAuth config to log in with: the first usable `aspect_authorization_servers`
+    /// entry (one that carries an issuer) when the document uses the current shape,
+    /// else the legacy flat fields (`authorization_servers[0]` + top-level
+    /// `client_id`/`scopes_supported`). `multiple` reflects the list actually
+    /// selected from, counting only issuer-bearing entries. Returns `None` when
+    /// neither shape advertises an issuer, so the caller records a deployment that
+    /// can't log in.
+    fn selected_auth_server(&self) -> Option<SelectedAuthServer<'_>> {
+        let mut usable = self
+            .aspect_authorization_servers
+            .iter()
+            .filter(|s| !s.issuer.is_empty());
+        if let Some(first) = usable.next() {
+            return Some(SelectedAuthServer {
+                issuer: &first.issuer,
+                client_id: &first.client_id,
+                scopes: &first.scopes,
+                multiple: usable.next().is_some(),
+            });
+        }
+        let mut usable = self.authorization_servers.iter().filter(|s| !s.is_empty());
+        let issuer = usable.next()?;
+        Some(SelectedAuthServer {
+            issuer,
+            client_id: &self.client_id,
+            scopes: &self.scopes_supported,
+            multiple: usable.next().is_some(),
+        })
     }
 }
 
@@ -475,19 +531,23 @@ fn deployment_name_from_host(host: &str) -> String {
     }
 }
 
-/// Build a [`Deployment`] record from a discovered [`ProtectedResource`].
-/// `issuer` + `client_id` are the OAuth config for login (interactive or API
-/// token); absent when the endpoint does not advertise them. `hosts` are the
-/// endpoints this deployment's token covers: the configured host, the advertised
-/// `resource` host, and every `aspect_endpoints` host, deduped. The typed
-/// `endpoints` map is recorded (hosts normalized) so `--deployment` can wire each
-/// to its Bazel flag. `configured_host` is the host the user ran `configure`
-/// against (the `resource` may be a canonical alias).
+/// Build a [`Deployment`] record from a discovered [`ProtectedResource`],
+/// returning whether the document advertised more than one usable authorization
+/// server (so the caller can warn that only the first was recorded).
+///
+/// `issuer` + `client_id` + `scopes` come from the selected authorization server
+/// ([`ProtectedResource::selected_auth_server`]); all are absent when the endpoint
+/// advertises no issuer. `hosts` are the endpoints this deployment's token covers:
+/// the configured host, the advertised `resource` host, and every
+/// `aspect_endpoints` host, deduped. The typed `endpoints` map is recorded (hosts
+/// normalized) so `--deployment` can wire each to its Bazel flag. `configured_host`
+/// is the host the user ran `configure` against (the `resource` may be a canonical
+/// alias).
 fn deployment_from_discovery(
     name: String,
     configured_host: &str,
     info: &ProtectedResource,
-) -> Deployment {
+) -> (Deployment, bool) {
     let mut hosts: Vec<String> = Vec::new();
     let mut push = |h: &str| {
         let h = endpoint_host_str(h);
@@ -507,17 +567,20 @@ fn deployment_from_discovery(
     push(&endpoints.cache);
     push(&endpoints.bes);
     push(&endpoints.exec);
+    let selected = info.selected_auth_server();
+    let multiple = selected.as_ref().is_some_and(|s| s.multiple);
     let advertised = |s: &str| (!s.is_empty()).then(|| s.to_string());
-    Deployment {
+    let deployment = Deployment {
         name,
         default: false,
-        issuer: advertised(info.issuer()),
-        client_id: advertised(&info.client_id),
+        issuer: selected.as_ref().and_then(|s| advertised(s.issuer)),
+        client_id: selected.as_ref().and_then(|s| advertised(s.client_id)),
         api_url: None,
         hosts,
-        scopes: info.scopes_supported.clone(),
+        scopes: selected.as_ref().map(|s| s.scopes.to_vec()).unwrap_or_default(),
         endpoints,
-    }
+    };
+    (deployment, multiple)
 }
 
 /// Insert or replace `deployment` in `existing` (by name), keeping exactly one
@@ -1731,6 +1794,10 @@ pub struct DeploymentInfo {
     pub can_login: bool,
     pub is_default: bool,
     pub hosts: Vec<String>,
+    /// Discovery advertised more than one usable authorization server; the CLI
+    /// recorded the first. The `configure` task surfaces this so the user knows a
+    /// different issuer would require editing `~/.aspect/config.json` by hand.
+    pub multiple_auth_servers: bool,
 }
 
 starlark_simple_value!(DeploymentInfo);
@@ -1781,6 +1848,11 @@ fn deployment_info_methods(registry: &mut MethodsBuilder) {
             .hosts
             .clone();
         Ok(heap.alloc(hosts))
+    }
+
+    #[starlark(attribute)]
+    fn multiple_auth_servers<'v>(this: values::Value<'v>) -> anyhow::Result<bool> {
+        attr_bool!(this, DeploymentInfo, multiple_auth_servers)
     }
 }
 
@@ -2242,6 +2314,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
             can_login: false,
             is_default: false,
             hosts: Vec::new(),
+            multiple_auth_servers: false,
         };
         let info = match block_on(probe_protected_resource(&host)) {
             Discovery::Reachable(info) => info,
@@ -2254,7 +2327,8 @@ fn auth_methods(registry: &mut MethodsBuilder) {
             .into_option()
             .filter(|n| !n.is_empty())
             .unwrap_or_else(|| deployment_name_from_host(&host));
-        let mut deployment = deployment_from_discovery(name.clone(), &host, &info);
+        let (mut deployment, multiple_auth_servers) =
+            deployment_from_discovery(name.clone(), &host, &info);
         // `--default` forces this deployment to take the default crown (upsert
         // then clears it on every other entry); without it, upsert only sets the
         // default when none exists yet, so a second configure doesn't hijack it.
@@ -2269,6 +2343,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
             can_login,
             is_default,
             hosts,
+            multiple_auth_servers,
         }))
     }
 
@@ -2633,12 +2708,13 @@ mod tests {
 
     #[test]
     fn deployment_from_discovery_records_issuer_client_and_all_hosts() {
-        // A deployment advertising an authorization server + client_id + endpoints:
-        // recorded and loggable. hosts = configured host ∪ resource ∪ every
-        // endpoint host, deduped; the typed endpoints map is preserved (and its
-        // hosts are normalized to bare hosts).
+        // A deployment advertising an authorization server + client_id + endpoints
+        // via the legacy flat shape: recorded and loggable. hosts = configured host
+        // ∪ resource ∪ every endpoint host, deduped; the typed endpoints map is
+        // preserved (and its hosts are normalized to bare hosts).
         let advertised = ProtectedResource {
             resource: "https://remote.acme.aspect.build".to_string(),
+            aspect_authorization_servers: vec![],
             authorization_servers: vec!["https://acme.auth.aspect.build".to_string()],
             client_id: "abc".to_string(),
             scopes_supported: vec!["openid".to_string(), "groups".to_string()],
@@ -2648,8 +2724,9 @@ mod tests {
                 exec: "https://remote.acme.aspect.build".to_string(),
             },
         };
-        let d =
+        let (d, multiple) =
             deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &advertised);
+        assert!(!multiple);
         assert_eq!(d.issuer.as_deref(), Some("https://acme.auth.aspect.build"));
         assert_eq!(d.client_id.as_deref(), Some("abc"));
         // A BYO-IdP scope override is recorded verbatim...
@@ -2680,6 +2757,7 @@ mod tests {
         // not loggable. No exec advertised → exec stays empty.
         let bare = ProtectedResource {
             resource: "https://remote.acme.aspect.build".to_string(),
+            aspect_authorization_servers: vec![],
             authorization_servers: vec![],
             client_id: String::new(),
             scopes_supported: vec![],
@@ -2689,7 +2767,7 @@ mod tests {
                 exec: String::new(),
             },
         };
-        let d = deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &bare);
+        let (d, _) = deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &bare);
         assert!(d.issuer.is_none() && d.client_id.is_none());
         assert_eq!(
             d.hosts,
@@ -2700,6 +2778,165 @@ mod tests {
         );
         assert!(d.endpoints.exec.is_empty());
         assert!(auth_env_from(&d).is_err());
+    }
+
+    #[test]
+    fn deployment_from_discovery_prefers_aspect_authorization_servers() {
+        // The current shape nests issuer/client_id/scopes per authorization server.
+        // When present it wins over the flat legacy fields (which older servers set,
+        // and which a transitional server may still populate alongside).
+        let info = ProtectedResource {
+            resource: "https://remote.acme.aspect.build".to_string(),
+            aspect_authorization_servers: vec![AspectAuthServer {
+                issuer: "https://auth.dev.aspect.build".to_string(),
+                client_id: "nested-client".to_string(),
+                scopes: vec!["openid".to_string(), "email".to_string()],
+            }],
+            authorization_servers: vec!["https://legacy.auth.aspect.build".to_string()],
+            client_id: "legacy-client".to_string(),
+            scopes_supported: vec!["openid".to_string()],
+            aspect_endpoints: Endpoints {
+                cache: "remote.acme.aspect.build".to_string(),
+                ..Default::default()
+            },
+        };
+        let (d, multiple) =
+            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
+        assert!(!multiple);
+        assert_eq!(d.issuer.as_deref(), Some("https://auth.dev.aspect.build"));
+        assert_eq!(d.client_id.as_deref(), Some("nested-client"));
+        assert_eq!(d.scopes, vec!["openid".to_string(), "email".to_string()]);
+    }
+
+    #[test]
+    fn deployment_from_discovery_flags_multiple_auth_servers_and_takes_first() {
+        // More than one advertised: record the first and flag it so the caller can
+        // prompt/warn that a different issuer needs a re-run of `configure`.
+        let info = ProtectedResource {
+            resource: "https://remote.acme.aspect.build".to_string(),
+            aspect_authorization_servers: vec![
+                AspectAuthServer {
+                    issuer: "https://auth.dev.aspect.build".to_string(),
+                    client_id: "first-client".to_string(),
+                    scopes: vec!["openid".to_string()],
+                },
+                AspectAuthServer {
+                    issuer: "https://auth.corp.example.com".to_string(),
+                    client_id: "second-client".to_string(),
+                    scopes: vec!["openid".to_string()],
+                },
+            ],
+            authorization_servers: vec![],
+            client_id: String::new(),
+            scopes_supported: vec![],
+            aspect_endpoints: Endpoints {
+                cache: "remote.acme.aspect.build".to_string(),
+                ..Default::default()
+            },
+        };
+        let (d, multiple) =
+            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
+        assert!(multiple);
+        assert_eq!(d.issuer.as_deref(), Some("https://auth.dev.aspect.build"));
+        assert_eq!(d.client_id.as_deref(), Some("first-client"));
+    }
+
+    #[test]
+    fn deployment_from_discovery_falls_back_to_legacy_when_no_usable_nested_entry() {
+        // A nested list with no issuer-bearing entry is not usable; fall back to the
+        // flat legacy fields rather than recording an issuer-less deployment.
+        let info = ProtectedResource {
+            resource: "https://remote.acme.aspect.build".to_string(),
+            aspect_authorization_servers: vec![AspectAuthServer {
+                issuer: String::new(),
+                client_id: "nested-client".to_string(),
+                scopes: vec![],
+            }],
+            authorization_servers: vec!["https://legacy.auth.aspect.build".to_string()],
+            client_id: "legacy-client".to_string(),
+            scopes_supported: vec!["openid".to_string()],
+            aspect_endpoints: Endpoints {
+                cache: "remote.acme.aspect.build".to_string(),
+                ..Default::default()
+            },
+        };
+        let (d, _) =
+            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
+        assert_eq!(d.issuer.as_deref(), Some("https://legacy.auth.aspect.build"));
+        assert_eq!(d.client_id.as_deref(), Some("legacy-client"));
+        assert_eq!(d.scopes, vec!["openid".to_string()]);
+    }
+
+    #[test]
+    fn deployment_from_discovery_skips_issuerless_entry_for_a_later_usable_one() {
+        // An issuer-less entry ahead of a valid one is skipped rather than aborting
+        // the nested shape: the first usable entry wins. Only one entry is usable,
+        // so `multiple` is false even though the raw list has two elements.
+        let info = ProtectedResource {
+            resource: "https://remote.acme.aspect.build".to_string(),
+            aspect_authorization_servers: vec![
+                AspectAuthServer {
+                    issuer: String::new(),
+                    client_id: "skip-me".to_string(),
+                    scopes: vec![],
+                },
+                AspectAuthServer {
+                    issuer: "https://auth.dev.aspect.build".to_string(),
+                    client_id: "good-client".to_string(),
+                    scopes: vec!["openid".to_string()],
+                },
+            ],
+            authorization_servers: vec![],
+            client_id: String::new(),
+            scopes_supported: vec![],
+            aspect_endpoints: Endpoints {
+                cache: "remote.acme.aspect.build".to_string(),
+                ..Default::default()
+            },
+        };
+        let (d, multiple) =
+            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
+        assert!(!multiple);
+        assert_eq!(d.issuer.as_deref(), Some("https://auth.dev.aspect.build"));
+        assert_eq!(d.client_id.as_deref(), Some("good-client"));
+    }
+
+    #[test]
+    fn deployment_from_discovery_multiple_counts_only_usable_entries() {
+        // The `multiple` warning keys on usable (issuer-bearing) entries, not raw
+        // list length: two usable entries alongside a skipped issuer-less one still
+        // count as multiple.
+        let info = ProtectedResource {
+            resource: "https://remote.acme.aspect.build".to_string(),
+            aspect_authorization_servers: vec![
+                AspectAuthServer {
+                    issuer: "https://auth.dev.aspect.build".to_string(),
+                    client_id: "first".to_string(),
+                    scopes: vec![],
+                },
+                AspectAuthServer {
+                    issuer: String::new(),
+                    client_id: "skip-me".to_string(),
+                    scopes: vec![],
+                },
+                AspectAuthServer {
+                    issuer: "https://auth.corp.example.com".to_string(),
+                    client_id: "second".to_string(),
+                    scopes: vec![],
+                },
+            ],
+            authorization_servers: vec![],
+            client_id: String::new(),
+            scopes_supported: vec![],
+            aspect_endpoints: Endpoints {
+                cache: "remote.acme.aspect.build".to_string(),
+                ..Default::default()
+            },
+        };
+        let (d, multiple) =
+            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info);
+        assert!(multiple);
+        assert_eq!(d.client_id.as_deref(), Some("first"));
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -420,17 +420,18 @@ struct ProtectedResource {
 }
 
 impl ProtectedResource {
-    /// The authorization servers the CLI can log in against, in advertised order:
-    /// every issuer-bearing `aspect_authorization_servers` entry when the document
-    /// uses the current shape, else the legacy flat fields
-    /// (`authorization_servers` + top-level `client_id`/`scopes_supported`).
-    /// Empty when neither shape advertises an issuer, so the caller records a
-    /// deployment that can't log in.
+    /// The authorization servers the CLI can log in against, in advertised order.
+    /// A login target needs both an issuer and a `client_id` (PKCE), so this keeps
+    /// only `aspect_authorization_servers` entries carrying both when the document
+    /// uses the current shape; if none qualify it falls back to the legacy flat
+    /// fields (`authorization_servers` + top-level `client_id`/`scopes_supported`).
+    /// Empty when neither shape advertises a usable server, so the caller records
+    /// a deployment that can't log in.
     fn auth_servers(&self) -> Vec<AuthServer> {
         let nested: Vec<AuthServer> = self
             .aspect_authorization_servers
             .iter()
-            .filter(|s| !s.issuer.is_empty())
+            .filter(|s| !s.issuer.is_empty() && !s.client_id.is_empty())
             .map(|s| AuthServer {
                 issuer: s.issuer.clone(),
                 client_id: s.client_id.clone(),
@@ -3035,11 +3036,13 @@ mod tests {
     }
 
     #[test]
-    fn auth_servers_skips_issuerless_nested_entries() {
-        // Issuer-less nested entries are dropped; a valid later entry still surfaces.
+    fn auth_servers_skips_nested_entries_missing_issuer_or_client_id() {
+        // A login target needs both issuer and client_id; entries missing either
+        // are dropped so a later fully-usable entry surfaces instead.
         let info = protected_resource(
             vec![
-                nested("", "skip-me"),
+                nested("", "no-issuer"),
+                nested("https://auth.partial.aspect.build", ""),
                 nested("https://auth.dev.aspect.build", "good-client"),
             ],
             vec![],
@@ -3048,14 +3051,16 @@ mod tests {
         );
         let servers = info.auth_servers();
         assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].issuer, "https://auth.dev.aspect.build");
         assert_eq!(servers[0].client_id, "good-client");
     }
 
     #[test]
     fn auth_servers_falls_back_to_legacy_when_no_usable_nested_entry() {
-        // A nested list with no issuer-bearing entry falls back to the flat fields.
+        // A nested list whose only entry lacks a client_id is not usable; fall back
+        // to the flat fields rather than recording an issuer-only deployment.
         let info = protected_resource(
-            vec![nested("", "nested-client")],
+            vec![nested("https://auth.partial.aspect.build", "")],
             vec!["https://legacy.auth.aspect.build"],
             "legacy-client",
             vec!["openid"],


### PR DESCRIPTION
A deployment's `/.well-known/oauth-protected-resource` document carries its OAuth login config in an `aspect_authorization_servers` list — objects of `{issuer, client_id, scopes}` — so a deployment can advertise more than one authorization server. The CLI didn't parse this field: it read only the flat top-level `authorization_servers`/`client_id`/`scopes_supported`. Since the server moved `client_id` into the per-issuer objects, discovery recorded an empty `client_id` and the configured deployment could not log in.

Discovery now reads `aspect_authorization_servers` (falling back to the legacy flat fields for older deployments). When a deployment advertises more than one authorization server, `aspect auth configure` resolves which one to use:

- `--issuer <url>` selects it, matching host-tolerantly (scheme and trailing slash ignored, case-insensitive). A value the deployment doesn't advertise is an error, even when only one is advertised.
- On a TTY with no `--issuer`, the user is prompted to choose from the advertised list.
- Non-interactively with no `--issuer`, configure fails asking for `--issuer` rather than guessing.

A deployment that advertises a single authorization server needs no flag and no prompt. The numbered-choice prompt is a shared `prompt_choice` helper, also now used by `aspect init`'s preset picker.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- `aspect auth configure` now works against deployments that advertise their OAuth client in the `aspect_authorization_servers` discovery field, and lets you choose the authorization server (via `--issuer` or an interactive prompt) when a deployment advertises more than one.

### Test plan

- New test cases added (issuer matching + selection in `auth.rs`; `prompt_choice` off-TTY in `.aspect/axl.axl`)
- Covered by existing test cases
- Manual testing: ran `aspect auth configure` against a live deployment — verified the correct `client_id` is now recorded, `--issuer` with an unadvertised value fails with the list of valid issuers, and a scheme-less `--issuer` matches.
