### PR TITLE
fix(bes): bound every wait in the BES stream so a hung backend can't wedge the build

### DIFF
--- a/.aspect/version.axl
+++ b/.aspect/version.axl
@@ -1,5 +1,5 @@
 version(
-    "2026.28.4",
+    "2026.30.1",
     sources = [
         # Cargo build
         local("target/debug/aspect-cli"),

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -1103,6 +1103,7 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
                 retry_min_delay,
                 retry_max_buffer_size: retry_max_buffer_size as usize,
                 timeout,
+                ..Default::default()
             },
         ))
     }

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -145,6 +145,19 @@ async fn send_lifecycle_logged(
     Ok(())
 }
 
+/// Per-sink stream state that survives across `drive_stream` reconnect
+/// attempts: the unacked-event replay buffer plus the sequence/ack counters
+/// every attempt shares.
+struct StreamState {
+    buffer: RetryBuffer,
+    /// Next unused sequence number (BES streams are 1-based).
+    next_seq: i64,
+    /// Highest sequence number the server has acked.
+    max_acked: i64,
+    /// Whether the event flagged `last_message` has been written to a stream.
+    last_message_sent: bool,
+}
+
 async fn work(
     recv: Subscriber<BuildEvent>,
     endpoint: String,
@@ -247,11 +260,13 @@ async fn work(
         return (SinkStats::default(), Err(e));
     }
 
-    let mut buffer = RetryBuffer::new(retry.retry_max_buffer_size);
-    let mut next_seq: i64 = 1;
-    let mut max_acked: i64 = 0;
+    let mut state = StreamState {
+        buffer: RetryBuffer::new(retry.retry_max_buffer_size),
+        next_seq: 1,
+        max_acked: 0,
+        last_message_sent: false,
+    };
     let mut attempt: u32 = 0;
-    let mut last_message_sent = false;
     // Warn at most once per sink when the stream first drops into retry, so a
     // flapping or slow backend produces an early user-facing signal without a
     // line per retry attempt.
@@ -264,8 +279,8 @@ async fn work(
             &format!(
                 "entering drive_stream (attempt={}, next_seq={}, buffered={})",
                 attempt,
-                next_seq,
-                buffer.len()
+                state.next_seq,
+                state.buffer.len()
             ),
         );
         let drive_started = std::time::Instant::now();
@@ -274,10 +289,7 @@ async fn work(
             &build_id,
             &invocation_id,
             &mut event_rx,
-            &mut buffer,
-            &mut next_seq,
-            &mut max_acked,
-            &mut last_message_sent,
+            &mut state,
             &endpoint,
             &retry,
         )
@@ -296,7 +308,7 @@ async fn work(
             DriveOutcome::Done | DriveOutcome::UpstreamClosed => break 'reconnect,
             DriveOutcome::Transient(err) => {
                 if attempt >= retry.max_retries {
-                    let stats = SinkStats::from_counters(next_seq, max_acked);
+                    let stats = SinkStats::from_counters(state.next_seq, state.max_acked);
                     return (
                         stats,
                         Err(finalize(
@@ -326,14 +338,14 @@ async fn work(
                 continue 'reconnect;
             }
             DriveOutcome::Fatal(err) => {
-                let stats = SinkStats::from_counters(next_seq, max_acked);
+                let stats = SinkStats::from_counters(state.next_seq, state.max_acked);
                 return (
                     stats,
                     Err(finalize(&endpoint, format!("non-retryable: {err}"))),
                 );
             }
             DriveOutcome::BufferFull(err) => {
-                let stats = SinkStats::from_counters(next_seq, max_acked);
+                let stats = SinkStats::from_counters(state.next_seq, state.max_acked);
                 return (stats, Err(finalize(&endpoint, err.to_string())));
             }
         }
@@ -392,7 +404,7 @@ async fn work(
         },
         None => post_stream.await,
     };
-    let stats = SinkStats::from_counters(next_seq, max_acked);
+    let stats = SinkStats::from_counters(state.next_seq, state.max_acked);
     (stats, outcome)
 }
 
@@ -416,8 +428,8 @@ const FIRST_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(
 /// event flows out and the server responds.
 ///
 /// Source of the first message:
-///   - **Reconnect** (`buffer` non-empty): replay the buffer's first entry.
-///   - **Fresh attempt** (`buffer` empty): wait up to `FIRST_EVENT_TIMEOUT`
+///   - **Reconnect** (`state.buffer` non-empty): replay its first entry.
+///   - **Fresh attempt** (buffer empty): wait up to `FIRST_EVENT_TIMEOUT`
 ///     for the first event on `event_rx`. If none arrives, return `None`
 ///     and let the caller open the bidi without pre-load (the stream-open
 ///     timeout in `drive_stream` still bounds the worst case).
@@ -431,11 +443,9 @@ async fn preload_first_event(
     invocation_id: &str,
     endpoint: &str,
     event_rx: &mut tokio::sync::mpsc::UnboundedReceiver<BuildEvent>,
-    buffer: &mut RetryBuffer,
-    next_seq: &mut i64,
-    last_message_sent: &mut bool,
+    state: &mut StreamState,
 ) -> Result<Option<i64>, DriveOutcome> {
-    if let Some((seq, req)) = buffer.iter().next() {
+    if let Some((seq, req)) = state.buffer.iter().next() {
         let seq = *seq;
         let req = req.clone();
         if sender.send(req).await.is_err() {
@@ -451,15 +461,15 @@ async fn preload_first_event(
         return Ok(Some(seq));
     }
 
-    if *last_message_sent {
+    if state.last_message_sent {
         return Ok(None);
     }
 
     let started = std::time::Instant::now();
     match tokio::time::timeout(FIRST_EVENT_TIMEOUT, event_rx.recv()).await {
         Ok(Some(event)) => {
-            let seq = *next_seq;
-            *next_seq += 1;
+            let seq = state.next_seq;
+            state.next_seq += 1;
             let last = event.last_message;
             let req = build_tool::bazel_event(
                 build_id.to_string(),
@@ -467,7 +477,7 @@ async fn preload_first_event(
                 seq,
                 &event,
             );
-            if let Err(overflow) = buffer.push(seq, req.clone()) {
+            if let Err(overflow) = state.buffer.push(seq, req.clone()) {
                 return Err(DriveOutcome::BufferFull(overflow));
             }
             if sender.send(req).await.is_err() {
@@ -476,7 +486,7 @@ async fn preload_first_event(
                 )));
             }
             if last {
-                *last_message_sent = true;
+                state.last_message_sent = true;
             }
             dbg(
                 endpoint,
@@ -506,6 +516,15 @@ async fn preload_first_event(
             );
             Ok(None)
         }
+    }
+}
+
+/// Sleep until an optional deadline; pends forever when `None`. For
+/// `tokio::select!` arms guarded on the deadline being armed.
+async fn sleep_opt(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(d) => tokio::time::sleep_until(d).await,
+        None => std::future::pending::<()>().await,
     }
 }
 
@@ -539,8 +558,8 @@ async fn send_bounded(
 /// Drive a single bidi stream until it ends (cleanly or with error).
 ///
 /// Owns the request channel for this connection. Pulls events from
-/// `event_rx`, assigns sequence numbers, buffers them in `buffer`, and
-/// writes them down the wire. In parallel reads responses and prunes
+/// `event_rx`, assigns sequence numbers, buffers them in `state.buffer`,
+/// and writes them down the wire. In parallel reads responses and prunes
 /// the buffer up to each ack'd `sequence_number`. Replays any leftover
 /// buffered events under their original seqs at the start of the
 /// connection (skipping the one already pre-loaded by
@@ -550,16 +569,13 @@ async fn send_bounded(
 /// never wedge the sink: stream open (`OPEN_TIMEOUT`), each write into
 /// the request channel (`retry.send_stall_timeout`), ack progress while
 /// unacked events are outstanding (`retry.ack_progress_timeout`), and
-/// the post-half-close drain (`HALF_CLOSE_DEADLINE`).
+/// the post-half-close drain (`retry.half_close_timeout`).
 async fn drive_stream(
     client: &mut Client,
     build_id: &str,
     invocation_id: &str,
     event_rx: &mut tokio::sync::mpsc::UnboundedReceiver<BuildEvent>,
-    buffer: &mut RetryBuffer,
-    next_seq: &mut i64,
-    max_acked: &mut i64,
-    last_message_sent: &mut bool,
+    state: &mut StreamState,
     endpoint: &str,
     retry: &RetryConfig,
 ) -> DriveOutcome {
@@ -572,9 +588,7 @@ async fn drive_stream(
         invocation_id,
         endpoint,
         event_rx,
-        buffer,
-        next_seq,
-        last_message_sent,
+        state,
     )
     .await
     {
@@ -584,8 +598,8 @@ async fn drive_stream(
 
     // Bound the bidi stream open: tonic does not add a deadline and the
     // server may accept the TCP/TLS handshake without ever responding. With
-    // the pre-load above this should now succeed promptly; the timeout is
-    // belt-and-suspenders.
+    // the pre-load above the open succeeds promptly in practice; the timeout
+    // bounds the worst case.
     const OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
     dbg(
         endpoint,
@@ -593,7 +607,7 @@ async fn drive_stream(
         "opening publish_build_tool_event_stream bidi (10s timeout)",
     );
     let open_started = std::time::Instant::now();
-    let response_stream = match tokio::time::timeout(
+    let mut response_stream = match tokio::time::timeout(
         OPEN_TIMEOUT,
         client.publish_build_tool_event_stream(request_stream),
     )
@@ -639,13 +653,12 @@ async fn drive_stream(
             )));
         }
     };
-    let mut response_stream = response_stream;
     dbg(
         endpoint,
         invocation_id,
         &format!(
             "replaying {} buffered events (skipping pre-loaded seq={:?})",
-            buffer.len(),
+            state.buffer.len(),
             preloaded_seq
         ),
     );
@@ -654,12 +667,17 @@ async fn drive_stream(
     // numbers. The server dedups via OrderedBuildEvent.sequence_number.
     // Skip the entry `preload_first_event` already sent — server would
     // dedup anyway, but resending wastes bytes.
-    for (seq, req) in buffer.iter() {
+    for (seq, req) in state.buffer.iter() {
         if Some(*seq) == preloaded_seq {
             continue;
         }
-        if let Err(outcome) =
-            send_bounded(&sender, req.clone(), retry.send_stall_timeout, "during replay").await
+        if let Err(outcome) = send_bounded(
+            &sender,
+            req.clone(),
+            retry.send_stall_timeout,
+            "during replay",
+        )
+        .await
         {
             return outcome;
         }
@@ -670,20 +688,15 @@ async fn drive_stream(
     // Ack-progress watchdog: armed while unacked events are outstanding and
     // the request side is still open, reset on every ack. Catches a backend
     // that keeps the connection alive but silently stops acking mid-stream —
-    // otherwise that case is only detected at buffer overflow (10k events)
-    // or not at all. Once half-closed, `half_close_deadline` governs instead.
-    let mut ack_deadline: Option<tokio::time::Instant> = (!buffer.is_empty())
+    // otherwise that case is only detected at buffer overflow, or never.
+    // Once half-closed, `half_close_deadline` governs instead.
+    let mut ack_deadline: Option<tokio::time::Instant> = (!state.buffer.is_empty())
         .then(|| tokio::time::Instant::now() + retry.ack_progress_timeout);
 
-    // Hard deadline for waiting after the request side is half-closed.
-    // Once we drop `sender_opt` (last_message sent or upstream broadcaster
-    // closed), the server is supposed to ack any pending events and then
-    // close the response stream. In practice some BES backends sit on the
-    // half-closed connection without acking or closing — without this
-    // deadline `wait()` blocks indefinitely on the sink JoinHandle and the
-    // entire build task hangs at end-of-build. 30s is generous enough for
-    // a slow ack while still bounding the total stall.
-    const HALF_CLOSE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+    // Hard deadline for waiting after the request side is half-closed
+    // (`sender_opt` dropped: last_message sent or upstream broadcaster
+    // closed), when the server is supposed to ack any pending events and
+    // close the response stream. See `RetryConfig::half_close_timeout`.
     let mut half_close_deadline: Option<tokio::time::Instant> = None;
 
     // If a previous attempt already sent last_message, the pre-load
@@ -695,32 +708,32 @@ async fn drive_stream(
     // drive_stream parks in response_stream.next() forever waiting
     // for an ack or close that a flaky backend may never send, and
     // Build.wait() hangs.
-    if *last_message_sent {
+    if state.last_message_sent {
         sender_opt = None;
-        half_close_deadline = Some(tokio::time::Instant::now() + HALF_CLOSE_DEADLINE);
+        half_close_deadline = Some(tokio::time::Instant::now() + retry.half_close_timeout);
     }
 
     loop {
         tokio::select! {
             // Pulling new events from the upstream broadcaster.
             // Disabled once last_message has been sent.
-            ev = event_rx.recv(), if !*last_message_sent && sender_opt.is_some() => {
+            ev = event_rx.recv(), if !state.last_message_sent && sender_opt.is_some() => {
                 let Some(event) = ev else {
                     // Upstream closed without a final last_message. Drop the
                     // request side so the server flushes any pending acks,
                     // and wait for the response stream to wind down.
                     sender_opt = None;
-                    if buffer.is_empty() {
+                    if state.buffer.is_empty() {
                         return DriveOutcome::UpstreamClosed;
                     }
                     half_close_deadline.get_or_insert_with(|| {
-                        tokio::time::Instant::now() + HALF_CLOSE_DEADLINE
+                        tokio::time::Instant::now() + retry.half_close_timeout
                     });
                     continue;
                 };
 
-                let seq = *next_seq;
-                *next_seq += 1;
+                let seq = state.next_seq;
+                state.next_seq += 1;
                 let last = event.last_message;
                 let req = build_tool::bazel_event(
                     build_id.to_string(),
@@ -729,13 +742,12 @@ async fn drive_stream(
                     &event,
                 );
 
-                if let Err(overflow) = buffer.push(seq, req.clone()) {
+                if let Err(overflow) = state.buffer.push(seq, req.clone()) {
                     return DriveOutcome::BufferFull(overflow);
                 }
-                if ack_deadline.is_none() {
-                    ack_deadline =
-                        Some(tokio::time::Instant::now() + retry.ack_progress_timeout);
-                }
+                ack_deadline.get_or_insert_with(|| {
+                    tokio::time::Instant::now() + retry.ack_progress_timeout
+                });
 
                 let s = sender_opt.as_ref().unwrap();
                 if let Err(outcome) =
@@ -745,14 +757,14 @@ async fn drive_stream(
                 }
 
                 if last {
-                    *last_message_sent = true;
+                    state.last_message_sent = true;
                     dbg(endpoint, invocation_id, "last_message sent — half-closing");
                     // Drop the request side to signal half-close, but stay
                     // in the loop so we keep draining acks until the server
                     // closes the response side.
                     sender_opt = None;
                     half_close_deadline.get_or_insert_with(|| {
-                        tokio::time::Instant::now() + HALF_CLOSE_DEADLINE
+                        tokio::time::Instant::now() + retry.half_close_timeout
                     });
                 }
             }
@@ -760,9 +772,9 @@ async fn drive_stream(
             resp = response_stream.next() => {
                 match resp {
                     Some(Ok(r)) => {
-                        buffer.prune_until(r.sequence_number);
-                        *max_acked = (*max_acked).max(r.sequence_number);
-                        ack_deadline = (!buffer.is_empty())
+                        state.buffer.prune_until(r.sequence_number);
+                        state.max_acked = state.max_acked.max(r.sequence_number);
+                        ack_deadline = (!state.buffer.is_empty())
                             .then(|| tokio::time::Instant::now() + retry.ack_progress_timeout);
                         // Once we've sent last_message AND every event we
                         // sent has been ack'd, we're done — exit without
@@ -771,10 +783,10 @@ async fn drive_stream(
                         // stream open after the final ack, which previously
                         // caused this loop to hang indefinitely on every
                         // successful upload.
-                        if *last_message_sent && buffer.is_empty() {
+                        if state.last_message_sent && state.buffer.is_empty() {
                             return DriveOutcome::Done;
                         }
-                        if sender_opt.is_none() && buffer.is_empty() {
+                        if sender_opt.is_none() && state.buffer.is_empty() {
                             return DriveOutcome::UpstreamClosed;
                         }
                     }
@@ -797,15 +809,15 @@ async fn drive_stream(
                             invocation_id,
                             &format!(
                                 "response stream closed (last_message_sent={}, buffered={})",
-                                *last_message_sent,
-                                buffer.len()
+                                state.last_message_sent,
+                                state.buffer.len()
                             ),
                         );
                         // Server closed the response stream.
-                        if *last_message_sent && buffer.is_empty() {
+                        if state.last_message_sent && state.buffer.is_empty() {
                             return DriveOutcome::Done;
                         }
-                        if sender_opt.is_none() && buffer.is_empty() {
+                        if sender_opt.is_none() && state.buffer.is_empty() {
                             return DriveOutcome::UpstreamClosed;
                         }
                         // Server closed prematurely with unacked events —
@@ -829,20 +841,17 @@ async fn drive_stream(
             //     outer loop converts to a terminal SinkError that the
             //     caller's `sink.wait()` surfaces. Returning Done here
             //     would silently drop unacked events.
-            _ = async {
-                match half_close_deadline {
-                    Some(d) => tokio::time::sleep_until(d).await,
-                    None => std::future::pending::<()>().await,
-                }
-            }, if half_close_deadline.is_some() => {
-                if !buffer.is_empty() {
+            _ = sleep_opt(half_close_deadline), if half_close_deadline.is_some() => {
+                if !state.buffer.is_empty() {
                     return DriveOutcome::Transient(ClientError::Status(
-                        tonic::Status::deadline_exceeded(
-                            "BES half-close deadline elapsed with unacked events",
-                        ),
+                        tonic::Status::deadline_exceeded(format!(
+                            "half-close deadline ({:?}) elapsed with {} events unacked",
+                            retry.half_close_timeout,
+                            state.buffer.len()
+                        )),
                     ));
                 }
-                return if *last_message_sent {
+                return if state.last_message_sent {
                     DriveOutcome::Done
                 } else {
                     DriveOutcome::UpstreamClosed
@@ -851,26 +860,21 @@ async fn drive_stream(
             // Ack-progress watchdog arm (see `ack_deadline`). Disabled once
             // the request side is half-closed — `half_close_deadline` bounds
             // that phase with a tighter deadline.
-            _ = async {
-                match ack_deadline {
-                    Some(d) => tokio::time::sleep_until(d).await,
-                    None => std::future::pending::<()>().await,
-                }
-            }, if ack_deadline.is_some() && half_close_deadline.is_none() => {
+            _ = sleep_opt(ack_deadline), if ack_deadline.is_some() && half_close_deadline.is_none() => {
                 dbg(
                     endpoint,
                     invocation_id,
                     &format!(
                         "no ack progress within {:?} ({} events unacked) — reconnecting",
                         retry.ack_progress_timeout,
-                        buffer.len()
+                        state.buffer.len()
                     ),
                 );
                 return DriveOutcome::Transient(ClientError::Status(
                     tonic::Status::deadline_exceeded(format!(
                         "no BES ack progress within {:?} ({} events unacked)",
                         retry.ack_progress_timeout,
-                        buffer.len()
+                        state.buffer.len()
                     )),
                 ));
             }
@@ -953,19 +957,27 @@ mod tests {
     use futures::Stream;
     use tonic::{Request, Response, Status, Streaming};
 
-    /// In-process BES server whose bidi handler misbehaves in a controlled
-    /// way: with `drain_inbound = false` it holds the request stream alive
-    /// without ever polling it, so HTTP/2 flow-control credit is never
-    /// returned and the client's writes stall (a hung backend, or a peer
-    /// that died without closing the connection). With `true` it reads and
-    /// discards every request but never sends an ack. Neither mode ever
-    /// closes the response stream.
-    struct MisbehavingServer {
-        drain_inbound: bool,
+    /// How the in-process BES server treats the bidi stream.
+    #[derive(Clone, Copy)]
+    enum ServerMode {
+        /// Hold the request stream open without ever polling it: HTTP/2
+        /// flow-control credit is never returned and the client's writes
+        /// stall (a hung backend, or a peer that died without closing the
+        /// connection). Never acks, never closes the response stream.
+        Stall,
+        /// Read and discard every request; never ack, never close the
+        /// response stream.
+        DrainNoAck,
+        /// Well-behaved: ack every request's sequence number.
+        Ack,
+    }
+
+    struct TestServer {
+        mode: ServerMode,
     }
 
     #[tonic::async_trait]
-    impl PublishBuildEvent for MisbehavingServer {
+    impl PublishBuildEvent for TestServer {
         async fn publish_lifecycle_event(
             &self,
             _request: Request<PublishLifecycleEventRequest>,
@@ -981,27 +993,47 @@ mod tests {
             request: Request<Streaming<PublishBuildToolEventStreamRequest>>,
         ) -> Result<Response<Self::PublishBuildToolEventStreamStream>, Status> {
             let mut inbound = request.into_inner();
-            let drain = self.drain_inbound;
-            tokio::spawn(async move {
-                if drain {
-                    while inbound.next().await.is_some() {}
+            match self.mode {
+                ServerMode::Stall | ServerMode::DrainNoAck => {
+                    let drain = matches!(self.mode, ServerMode::DrainNoAck);
+                    tokio::spawn(async move {
+                        if drain {
+                            while inbound.next().await.is_some() {}
+                        }
+                        // Park forever still owning `inbound`: the request
+                        // stream must stay open (and unread in Stall mode),
+                        // never reset from the server side.
+                        let _hold = inbound;
+                        std::future::pending::<()>().await;
+                    });
+                    Ok(Response::new(Box::pin(futures::stream::pending())))
                 }
-                // Keep `inbound` alive without polling (or after it ends) so
-                // the stream is never reset from the server side.
-                std::future::pending::<()>().await;
-            });
-            Ok(Response::new(Box::pin(futures::stream::pending())))
+                ServerMode::Ack => {
+                    let (ack_tx, ack_rx) = tokio::sync::mpsc::channel(16);
+                    tokio::spawn(async move {
+                        while let Some(Ok(req)) = inbound.next().await {
+                            let seq = req.ordered_build_event.map_or(0, |e| e.sequence_number);
+                            let ack = PublishBuildToolEventStreamResponse {
+                                stream_id: None,
+                                sequence_number: seq,
+                            };
+                            if ack_tx.send(Ok(ack)).await.is_err() {
+                                break;
+                            }
+                        }
+                    });
+                    Ok(Response::new(Box::pin(ReceiverStream::new(ack_rx))))
+                }
+            }
         }
     }
 
-    async fn start_server(drain_inbound: bool) -> String {
+    async fn start_server(mode: ServerMode) -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(
             tonic::transport::Server::builder()
-                .add_service(PublishBuildEventServer::new(MisbehavingServer {
-                    drain_inbound,
-                }))
+                .add_service(PublishBuildEventServer::new(TestServer { mode }))
                 .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
         );
         format!("http://{addr}")
@@ -1017,9 +1049,14 @@ mod tests {
         }
     }
 
-    /// Run `drive_stream` against a misbehaving server and return its
-    /// outcome, panicking if it fails to detect the stall and hangs.
-    async fn drive_against(endpoint: String, events: Vec<BuildEvent>, retry: RetryConfig) -> DriveOutcome {
+    /// Run `drive_stream` against a [`TestServer`] and return its outcome,
+    /// panicking if it fails to complete within the test bound (i.e. a stall
+    /// went undetected).
+    async fn drive_against(
+        endpoint: String,
+        events: Vec<BuildEvent>,
+        retry: RetryConfig,
+    ) -> DriveOutcome {
         let mut client = Client::new(endpoint, HashMap::new()).await.unwrap();
         let (tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<BuildEvent>();
         for ev in events {
@@ -1027,10 +1064,12 @@ mod tests {
         }
         // `tx` stays alive across the call: upstream must look open, since a
         // closed upstream arms the (already bounded) half-close path instead.
-        let mut buffer = RetryBuffer::new(retry.retry_max_buffer_size);
-        let mut next_seq = 1i64;
-        let mut max_acked = 0i64;
-        let mut last_message_sent = false;
+        let mut state = StreamState {
+            buffer: RetryBuffer::new(retry.retry_max_buffer_size),
+            next_seq: 1,
+            max_acked: 0,
+            last_message_sent: false,
+        };
         let outcome = tokio::time::timeout(
             Duration::from_secs(30),
             drive_stream(
@@ -1038,16 +1077,13 @@ mod tests {
                 "test-build",
                 "test-invocation",
                 &mut event_rx,
-                &mut buffer,
-                &mut next_seq,
-                &mut max_acked,
-                &mut last_message_sent,
+                &mut state,
                 "test-endpoint",
                 &retry,
             ),
         )
         .await
-        .expect("drive_stream hung: stall was not detected");
+        .expect("drive_stream did not complete within the test bound");
         drop(tx);
         outcome
     }
@@ -1057,7 +1093,7 @@ mod tests {
     /// Transient outcome instead of suspending the loop forever.
     #[tokio::test(flavor = "multi_thread")]
     async fn send_stall_surfaces_transient() {
-        let endpoint = start_server(false).await;
+        let endpoint = start_server(ServerMode::Stall).await;
         let retry = RetryConfig {
             send_stall_timeout: Duration::from_millis(300),
             // Keep the ack watchdog out of the way so the send path is what
@@ -1081,7 +1117,7 @@ mod tests {
     /// overflow (or forever).
     #[tokio::test(flavor = "multi_thread")]
     async fn ack_silence_surfaces_transient() {
-        let endpoint = start_server(true).await;
+        let endpoint = start_server(ServerMode::DrainNoAck).await;
         let retry = RetryConfig {
             send_stall_timeout: Duration::from_secs(60),
             ack_progress_timeout: Duration::from_millis(300),
@@ -1096,6 +1132,45 @@ mod tests {
                 );
             }
             other => panic!("expected Transient ack timeout, got {}", other.label()),
+        }
+    }
+
+    /// Server ends up holding unacked events when the build finishes
+    /// (`last_message` sent, request side half-closed): the half-close
+    /// deadline must bound the wait for outstanding acks.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn half_close_with_unacked_events_surfaces_transient() {
+        let endpoint = start_server(ServerMode::DrainNoAck).await;
+        let retry = RetryConfig {
+            half_close_timeout: Duration::from_millis(300),
+            ..Default::default()
+        };
+        let mut events: Vec<BuildEvent> = (0..5).map(|_| progress_event(64)).collect();
+        events.last_mut().unwrap().last_message = true;
+        match drive_against(endpoint, events, retry).await {
+            DriveOutcome::Transient(ClientError::Status(s)) => {
+                assert!(
+                    s.message().contains("half-close deadline"),
+                    "unexpected status: {s}"
+                );
+            }
+            other => panic!(
+                "expected Transient half-close timeout, got {}",
+                other.label()
+            ),
+        }
+    }
+
+    /// Well-behaved server acking every event: the stream completes `Done`
+    /// after `last_message` with no deadline firing spuriously.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn acked_stream_completes_done() {
+        let endpoint = start_server(ServerMode::Ack).await;
+        let mut events: Vec<BuildEvent> = (0..5).map(|_| progress_event(64)).collect();
+        events.last_mut().unwrap().last_message = true;
+        match drive_against(endpoint, events, RetryConfig::default()).await {
+            DriveOutcome::Done => {}
+            other => panic!("expected Done, got {}", other.label()),
         }
     }
 

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -279,6 +279,7 @@ async fn work(
             &mut max_acked,
             &mut last_message_sent,
             &endpoint,
+            &retry,
         )
         .await;
         dbg(
@@ -508,6 +509,33 @@ async fn preload_first_event(
     }
 }
 
+/// Send one request into the bidi request channel, bounding the wait.
+///
+/// The channel only backs up when tonic's request pump stops pulling —
+/// i.e. the server stopped reading and the HTTP/2 flow-control windows
+/// are full (hung backend, or a dead connection the keepalive hasn't
+/// killed yet). An unbounded `send().await` there would suspend
+/// `drive_stream`'s select loop forever; instead surface a Transient
+/// outcome so the outer retry loop tears the stream down and replays.
+async fn send_bounded(
+    sender: &tokio::sync::mpsc::Sender<PublishBuildToolEventStreamRequest>,
+    req: PublishBuildToolEventStreamRequest,
+    stall_timeout: std::time::Duration,
+    context: &str,
+) -> Result<(), DriveOutcome> {
+    match tokio::time::timeout(stall_timeout, sender.send(req)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(_)) => Err(DriveOutcome::Transient(ClientError::Status(
+            tonic::Status::unavailable(format!("request stream closed {context}")),
+        ))),
+        Err(_) => Err(DriveOutcome::Transient(ClientError::Status(
+            tonic::Status::deadline_exceeded(format!(
+                "request stream stalled for {stall_timeout:?} {context} (server stopped reading)"
+            )),
+        ))),
+    }
+}
+
 /// Drive a single bidi stream until it ends (cleanly or with error).
 ///
 /// Owns the request channel for this connection. Pulls events from
@@ -517,6 +545,12 @@ async fn preload_first_event(
 /// buffered events under their original seqs at the start of the
 /// connection (skipping the one already pre-loaded by
 /// `preload_first_event`).
+///
+/// Every wait is bounded so a hung or silently-dropped connection can
+/// never wedge the sink: stream open (`OPEN_TIMEOUT`), each write into
+/// the request channel (`retry.send_stall_timeout`), ack progress while
+/// unacked events are outstanding (`retry.ack_progress_timeout`), and
+/// the post-half-close drain (`HALF_CLOSE_DEADLINE`).
 async fn drive_stream(
     client: &mut Client,
     build_id: &str,
@@ -527,6 +561,7 @@ async fn drive_stream(
     max_acked: &mut i64,
     last_message_sent: &mut bool,
     endpoint: &str,
+    retry: &RetryConfig,
 ) -> DriveOutcome {
     let (sender, receiver) = tokio::sync::mpsc::channel::<PublishBuildToolEventStreamRequest>(64);
     let request_stream = ReceiverStream::new(receiver);
@@ -623,14 +658,22 @@ async fn drive_stream(
         if Some(*seq) == preloaded_seq {
             continue;
         }
-        if sender.send(req.clone()).await.is_err() {
-            return DriveOutcome::Transient(ClientError::Status(tonic::Status::unavailable(
-                "request stream closed during replay",
-            )));
+        if let Err(outcome) =
+            send_bounded(&sender, req.clone(), retry.send_stall_timeout, "during replay").await
+        {
+            return outcome;
         }
     }
 
     let mut sender_opt = Some(sender);
+
+    // Ack-progress watchdog: armed while unacked events are outstanding and
+    // the request side is still open, reset on every ack. Catches a backend
+    // that keeps the connection alive but silently stops acking mid-stream —
+    // otherwise that case is only detected at buffer overflow (10k events)
+    // or not at all. Once half-closed, `half_close_deadline` governs instead.
+    let mut ack_deadline: Option<tokio::time::Instant> = (!buffer.is_empty())
+        .then(|| tokio::time::Instant::now() + retry.ack_progress_timeout);
 
     // Hard deadline for waiting after the request side is half-closed.
     // Once we drop `sender_opt` (last_message sent or upstream broadcaster
@@ -689,14 +732,16 @@ async fn drive_stream(
                 if let Err(overflow) = buffer.push(seq, req.clone()) {
                     return DriveOutcome::BufferFull(overflow);
                 }
+                if ack_deadline.is_none() {
+                    ack_deadline =
+                        Some(tokio::time::Instant::now() + retry.ack_progress_timeout);
+                }
 
                 let s = sender_opt.as_ref().unwrap();
-                if s.send(req).await.is_err() {
-                    // Request channel rejected: the bidi stream broke.
-                    // Hold onto the buffered event for replay on reconnect.
-                    return DriveOutcome::Transient(ClientError::Status(
-                        tonic::Status::unavailable("request stream closed mid-send"),
-                    ));
+                if let Err(outcome) =
+                    send_bounded(s, req, retry.send_stall_timeout, "mid-send").await
+                {
+                    return outcome;
                 }
 
                 if last {
@@ -717,6 +762,8 @@ async fn drive_stream(
                     Some(Ok(r)) => {
                         buffer.prune_until(r.sequence_number);
                         *max_acked = (*max_acked).max(r.sequence_number);
+                        ack_deadline = (!buffer.is_empty())
+                            .then(|| tokio::time::Instant::now() + retry.ack_progress_timeout);
                         // Once we've sent last_message AND every event we
                         // sent has been ack'd, we're done — exit without
                         // waiting for the server to close the response
@@ -801,6 +848,32 @@ async fn drive_stream(
                     DriveOutcome::UpstreamClosed
                 };
             }
+            // Ack-progress watchdog arm (see `ack_deadline`). Disabled once
+            // the request side is half-closed — `half_close_deadline` bounds
+            // that phase with a tighter deadline.
+            _ = async {
+                match ack_deadline {
+                    Some(d) => tokio::time::sleep_until(d).await,
+                    None => std::future::pending::<()>().await,
+                }
+            }, if ack_deadline.is_some() && half_close_deadline.is_none() => {
+                dbg(
+                    endpoint,
+                    invocation_id,
+                    &format!(
+                        "no ack progress within {:?} ({} events unacked) — reconnecting",
+                        retry.ack_progress_timeout,
+                        buffer.len()
+                    ),
+                );
+                return DriveOutcome::Transient(ClientError::Status(
+                    tonic::Status::deadline_exceeded(format!(
+                        "no BES ack progress within {:?} ({} events unacked)",
+                        retry.ack_progress_timeout,
+                        buffer.len()
+                    )),
+                ));
+            }
         }
     }
 }
@@ -868,6 +941,163 @@ fn finalize(endpoint: &str, last_error: String) -> SinkError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::pin::Pin;
+    use std::time::Duration;
+
+    use axl_proto::build_event_stream::{Progress, build_event::Payload};
+    use axl_proto::google::devtools::build::v1::{
+        PublishBuildToolEventStreamResponse,
+        publish_build_event_server::{PublishBuildEvent, PublishBuildEventServer},
+    };
+    use futures::Stream;
+    use tonic::{Request, Response, Status, Streaming};
+
+    /// In-process BES server whose bidi handler misbehaves in a controlled
+    /// way: with `drain_inbound = false` it holds the request stream alive
+    /// without ever polling it, so HTTP/2 flow-control credit is never
+    /// returned and the client's writes stall (a hung backend, or a peer
+    /// that died without closing the connection). With `true` it reads and
+    /// discards every request but never sends an ack. Neither mode ever
+    /// closes the response stream.
+    struct MisbehavingServer {
+        drain_inbound: bool,
+    }
+
+    #[tonic::async_trait]
+    impl PublishBuildEvent for MisbehavingServer {
+        async fn publish_lifecycle_event(
+            &self,
+            _request: Request<PublishLifecycleEventRequest>,
+        ) -> Result<Response<()>, Status> {
+            Ok(Response::new(()))
+        }
+
+        type PublishBuildToolEventStreamStream =
+            Pin<Box<dyn Stream<Item = Result<PublishBuildToolEventStreamResponse, Status>> + Send>>;
+
+        async fn publish_build_tool_event_stream(
+            &self,
+            request: Request<Streaming<PublishBuildToolEventStreamRequest>>,
+        ) -> Result<Response<Self::PublishBuildToolEventStreamStream>, Status> {
+            let mut inbound = request.into_inner();
+            let drain = self.drain_inbound;
+            tokio::spawn(async move {
+                if drain {
+                    while inbound.next().await.is_some() {}
+                }
+                // Keep `inbound` alive without polling (or after it ends) so
+                // the stream is never reset from the server side.
+                std::future::pending::<()>().await;
+            });
+            Ok(Response::new(Box::pin(futures::stream::pending())))
+        }
+    }
+
+    async fn start_server(drain_inbound: bool) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(PublishBuildEventServer::new(MisbehavingServer {
+                    drain_inbound,
+                }))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+        );
+        format!("http://{addr}")
+    }
+
+    fn progress_event(stderr_bytes: usize) -> BuildEvent {
+        BuildEvent {
+            payload: Some(Payload::Progress(Progress {
+                stderr: "x".repeat(stderr_bytes),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+    }
+
+    /// Run `drive_stream` against a misbehaving server and return its
+    /// outcome, panicking if it fails to detect the stall and hangs.
+    async fn drive_against(endpoint: String, events: Vec<BuildEvent>, retry: RetryConfig) -> DriveOutcome {
+        let mut client = Client::new(endpoint, HashMap::new()).await.unwrap();
+        let (tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<BuildEvent>();
+        for ev in events {
+            tx.send(ev).unwrap();
+        }
+        // `tx` stays alive across the call: upstream must look open, since a
+        // closed upstream arms the (already bounded) half-close path instead.
+        let mut buffer = RetryBuffer::new(retry.retry_max_buffer_size);
+        let mut next_seq = 1i64;
+        let mut max_acked = 0i64;
+        let mut last_message_sent = false;
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(30),
+            drive_stream(
+                &mut client,
+                "test-build",
+                "test-invocation",
+                &mut event_rx,
+                &mut buffer,
+                &mut next_seq,
+                &mut max_acked,
+                &mut last_message_sent,
+                "test-endpoint",
+                &retry,
+            ),
+        )
+        .await
+        .expect("drive_stream hung: stall was not detected");
+        drop(tx);
+        outcome
+    }
+
+    /// Server accepts the stream then never reads: flow-control windows and
+    /// the request channel fill, and the bounded send must surface a
+    /// Transient outcome instead of suspending the loop forever.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn send_stall_surfaces_transient() {
+        let endpoint = start_server(false).await;
+        let retry = RetryConfig {
+            send_stall_timeout: Duration::from_millis(300),
+            // Keep the ack watchdog out of the way so the send path is what
+            // trips first.
+            ack_progress_timeout: Duration::from_secs(60),
+            ..Default::default()
+        };
+        // 128 KiB events overrun the HTTP/2 window quickly; 100 of them is
+        // far more than window + request-channel capacity (64).
+        let events = (0..100).map(|_| progress_event(128 * 1024)).collect();
+        match drive_against(endpoint, events, retry).await {
+            DriveOutcome::Transient(ClientError::Status(s)) => {
+                assert!(s.message().contains("stalled"), "unexpected status: {s}");
+            }
+            other => panic!("expected Transient stall, got {}", other.label()),
+        }
+    }
+
+    /// Server reads every event but never acks: the ack-progress watchdog
+    /// must surface a Transient outcome rather than waiting for buffer
+    /// overflow (or forever).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ack_silence_surfaces_transient() {
+        let endpoint = start_server(true).await;
+        let retry = RetryConfig {
+            send_stall_timeout: Duration::from_secs(60),
+            ack_progress_timeout: Duration::from_millis(300),
+            ..Default::default()
+        };
+        let events = (0..5).map(|_| progress_event(64)).collect();
+        match drive_against(endpoint, events, retry).await {
+            DriveOutcome::Transient(ClientError::Status(s)) => {
+                assert!(
+                    s.message().contains("no BES ack progress"),
+                    "unexpected status: {s}"
+                );
+            }
+            other => panic!("expected Transient ack timeout, got {}", other.label()),
+        }
+    }
 
     #[test]
     fn fail_preserves_machine_cause_independent_of_user_message() {

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -19,6 +19,16 @@ pub struct RetryConfig {
     pub retry_min_delay: Duration,
     pub retry_max_buffer_size: usize,
     pub timeout: Option<Duration>,
+    /// How long a single write into the bidi request stream may block before
+    /// the connection is declared stalled (server stopped reading; HTTP/2
+    /// flow-control windows and the request channel are full) and the stream
+    /// is torn down for a retry. Not exposed to Starlark; overridable in
+    /// tests.
+    pub send_stall_timeout: Duration,
+    /// How long the server may go without acking while unacked events are
+    /// outstanding (pre-half-close) before the stream is torn down for a
+    /// retry. Not exposed to Starlark; overridable in tests.
+    pub ack_progress_timeout: Duration,
 }
 
 impl Default for RetryConfig {
@@ -28,6 +38,8 @@ impl Default for RetryConfig {
             retry_min_delay: Duration::from_secs(1),
             retry_max_buffer_size: 10_000,
             timeout: None,
+            send_stall_timeout: Duration::from_secs(60),
+            ack_progress_timeout: Duration::from_secs(120),
         }
     }
 }

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -29,6 +29,12 @@ pub struct RetryConfig {
     /// outstanding (pre-half-close) before the stream is torn down for a
     /// retry. Not exposed to Starlark; overridable in tests.
     pub ack_progress_timeout: Duration,
+    /// How long to wait, after the request side half-closes, for the server
+    /// to ack outstanding events and close the response stream. Some
+    /// backends sit on a half-closed stream without acking or closing;
+    /// without this bound the sink thread — and the build's `sink.wait()` —
+    /// would hang. Not exposed to Starlark; overridable in tests.
+    pub half_close_timeout: Duration,
 }
 
 impl Default for RetryConfig {
@@ -40,6 +46,7 @@ impl Default for RetryConfig {
             timeout: None,
             send_stall_timeout: Duration::from_secs(60),
             ack_progress_timeout: Duration::from_secs(120),
+            half_close_timeout: Duration::from_secs(30),
         }
     }
 }

--- a/crates/build-event-stream/src/client.rs
+++ b/crates/build-event-stream/src/client.rs
@@ -19,14 +19,13 @@ pub struct Client {
     inner: PublishBuildEventClient<InterceptedService<Channel, AuthInterceptor>>,
 }
 
-/// HTTP/2 PING cadence (mirrors Bazel's `--grpc_keepalive_time` default of
-/// 30s for its own gRPC connections). Without keepalives a peer that
-/// vanishes without a FIN/RST — e.g. a backend scaled in mid-stream — leaves
-/// reads pending forever and writes pending until the OS TCP retransmit
-/// limit (~15+ minutes).
+/// HTTP/2 PING cadence (also used as the TCP keepalive interval). Without
+/// keepalives, a peer that vanishes without a FIN/RST leaves reads pending
+/// forever and writes pending until the OS TCP retransmit limit (~15+
+/// minutes). 30s matches the `--grpc_keepalive_time=30s` commonly configured
+/// for Bazel's own gRPC connections.
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
-/// How long to wait for a PING ack before declaring the connection dead
-/// (mirrors Bazel's `--grpc_keepalive_timeout`).
+/// How long to wait for a PING ack before declaring the connection dead.
 const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(15);
 /// Bound for TCP connection establishment when the lazy channel first dials.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);

--- a/crates/build-event-stream/src/client.rs
+++ b/crates/build-event-stream/src/client.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use axl_proto::google::devtools::build::v1::{
     PublishBuildToolEventStreamRequest, PublishBuildToolEventStreamResponse,
@@ -18,6 +19,18 @@ pub struct Client {
     inner: PublishBuildEventClient<InterceptedService<Channel, AuthInterceptor>>,
 }
 
+/// HTTP/2 PING cadence (mirrors Bazel's `--grpc_keepalive_time` default of
+/// 30s for its own gRPC connections). Without keepalives a peer that
+/// vanishes without a FIN/RST — e.g. a backend scaled in mid-stream — leaves
+/// reads pending forever and writes pending until the OS TCP retransmit
+/// limit (~15+ minutes).
+const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
+/// How long to wait for a PING ack before declaring the connection dead
+/// (mirrors Bazel's `--grpc_keepalive_timeout`).
+const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(15);
+/// Bound for TCP connection establishment when the lazy channel first dials.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 #[derive(thiserror::Error, Debug)]
 pub enum ClientError {
     #[error(transparent)]
@@ -35,6 +48,11 @@ impl Client {
     ) -> Result<Self, ClientError> {
         let channel = Channel::from_shared(endpoint)?
             .user_agent("AXL")?
+            .connect_timeout(CONNECT_TIMEOUT)
+            .tcp_keepalive(Some(KEEP_ALIVE_INTERVAL))
+            .http2_keep_alive_interval(KEEP_ALIVE_INTERVAL)
+            .keep_alive_timeout(KEEP_ALIVE_TIMEOUT)
+            .keep_alive_while_idle(true)
             .tls_config(
                 ClientTlsConfig::new()
                     .with_native_roots()


### PR DESCRIPTION
The custom BES client had several unbounded waits. gRPC gives no liveness guarantees on a long-lived bidi stream: the peer — or an intermediary (load balancer, NAT) — can stall mid-stream or drop the connection without a FIN/RST, and unless the client bounds its own waits it blocks forever. Bazel hardens its BES uploader against this with gRPC keepalives and deadlines; our client was missing the equivalent bounds, so `sink.wait()` could hang a task indefinitely at end-of-build.

Every failure path resolves into the existing retry/replay machinery, so the worst case is a bounded retry budget ending in a `SinkError` warning instead of an infinite hang:

1. **Keepalive on the gRPC channel** (`client.rs`): `http2_keep_alive_interval(30s)` + `keep_alive_timeout(15s)` + `keep_alive_while_idle(true)` + `tcp_keepalive(30s)` + `connect_timeout(10s)`, matching the `--grpc_keepalive_time=30s` commonly configured for Bazel's own gRPC connections. Previously a silently dropped connection left reads pending forever and writes pending until the OS TCP retransmit limit (~15+ minutes).
2. **Bounded sends into the bidi request stream** (`RetryConfig::send_stall_timeout`, 60s): an unbounded `sender.send().await` inside the drive loop could suspend the entire select loop when the peer stopped reading (flow-control windows + the 64-slot request channel full). Since this happens *before* `last_message`, the half-close deadline never arms — this was the forever-hang. A stalled send now tears the stream down for a retry.
3. **Mid-stream ack-progress watchdog** (`RetryConfig::ack_progress_timeout`, 120s): a stream where events flow out but acks stop coming back was previously only detected at buffer overflow (10k events), or never. The watchdog arms while unacked events are outstanding, resets on every ack, and reconnects on expiry.
4. **Half-close deadline is now configurable** (`RetryConfig::half_close_timeout`, previously a hard-coded 30s const), so the post-`last_message` drain path is testable.

None of the new timeouts are exposed to Starlark. Also groups the cross-attempt stream state (`buffer`/`next_seq`/`max_acked`/`last_message_sent`) into a `StreamState` struct.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (internal timeouts, no user-facing config)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- fix: BES upload can no longer hang the build indefinitely on a stalled or silently dropped backend connection; the stream now uses gRPC keepalives and bounded send/ack deadlines, retrying and eventually surfacing a warning instead

### Test plan

- New test cases added: an in-process BES server with scripted behaviors (`Stall` — holds the request stream unread so flow control fills; `DrainNoAck` — reads but never acks; `Ack` — well-behaved) drives `drive_stream` through all four paths: send stall → Transient, ack silence → Transient, half-close with unacked events → Transient, and fully-acked stream → Done with no spurious watchdog firings
- Covered by existing test cases (retry classification, buffer, backoff)
