### PR TITLE
fix(lint): bound lint-output reads so an unfetchable remote blob can't hang the task

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3,9 +3,9 @@ Exercise axl
 """
 
 load("@aspect//delivery.axl", delivery_UncacheableAction = "UncacheableAction", delivery_collect_blocking_culprits = "collect_blocking_culprits", delivery_count_unexplained_unresolved = "count_unexplained_unresolved", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
-load("@aspect//lint.axl", "file_uri_to_path", "filter_all", "filter_changeset", "linter_error_message")
+load("@aspect//lint.axl", "filter_all", "filter_changeset", "linter_error_message")
 load("@aspect//private/lib/artifacts.axl", "artifact_name", "build_log_header", "build_log_relpath", "collect_build_action_logs", "dedup_path", "testlog_dest_dir")
-load("@aspect//private/lib/bazel_results.axl", "compute_reproducer_command", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
+load("@aspect//private/lib/bazel_results.axl", "bb_clientd_root", "compute_reproducer_command", "file_uri_to_path", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
 load(
     "@aspect//private/lib/build_metadata.axl",
     "detect_vcs_from_host",
@@ -2536,7 +2536,7 @@ def test_detect_build_url(ctx: TaskContext, tc: int) -> int:
     return tc
 
 def test_file_uri_to_path(tc: int) -> int:
-    """Coverage for lint.file_uri_to_path BES URI → bb_clientd path."""
+    """Coverage for bazel_results.file_uri_to_path BES URI → local path."""
     BB = "/mnt/ephemeral/buildbarn/bb_clientd"
 
     # file:// passthrough (scheme stripped).
@@ -2560,6 +2560,41 @@ def test_file_uri_to_path(tc: int) -> int:
     expected_sha512 = BB + "/cas/cache.example.com/blobs/sha512/file/HASHHASH-9999"
     tc = test_case(tc, file_uri_to_path(uri_sha512) == expected_sha512, "file_uri_to_path: bytestream sha512")
 
+    # Explicit bb_root overrides the default mount root.
+    custom = file_uri_to_path(uri4, "/custom/mount")
+    tc = test_case(tc, custom == "/custom/mount/cas/localhost/blobs/sha256/file/abc123def-4567", "file_uri_to_path: explicit bb_root")
+
+    # bb_root None (runner without bb_clientd): bytestream URIs have no local
+    # path; file:// still resolves.
+    tc = test_case(tc, file_uri_to_path(uri4, None) == "", "file_uri_to_path: bytestream with bb_root None → \"\"")
+    tc = test_case(tc, file_uri_to_path("file:///a/b", None) == "/a/b", "file_uri_to_path: file:// unaffected by bb_root None")
+
+    # Empty / non-URI values.
+    tc = test_case(tc, file_uri_to_path("") == "", "file_uri_to_path: empty → \"\"")
+
+    return tc
+
+def test_bb_clientd_root(ctx: TaskContext, tc: int) -> int:
+    """Coverage for bazel_results.bb_clientd_root env precedence."""
+    prior_mount = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_BB_CLIENTD_MOUNT")
+    prior_no_bb = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD")
+
+    ctx.std.env.remove_var("ASPECT_WORKFLOWS_RUNNER_BB_CLIENTD_MOUNT")
+    ctx.std.env.remove_var("ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD")
+    tc = test_case(tc, bb_clientd_root(ctx) == "/mnt/ephemeral/buildbarn/bb_clientd", "bb_clientd_root: legacy default when no env")
+
+    ctx.std.env.set_var("ASPECT_WORKFLOWS_RUNNER_BB_CLIENTD_MOUNT", "/data/bb_clientd")
+    tc = test_case(tc, bb_clientd_root(ctx) == "/data/bb_clientd", "bb_clientd_root: runner-exported mount wins")
+
+    # The no-bb_clientd marker wins over everything, including a stale mount env.
+    ctx.std.env.set_var("ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD", "1")
+    tc = test_case(tc, bb_clientd_root(ctx) == None, "bb_clientd_root: NO_BB_CLIENTD → None")
+
+    for name, prior in [("ASPECT_WORKFLOWS_RUNNER_BB_CLIENTD_MOUNT", prior_mount), ("ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD", prior_no_bb)]:
+        if prior == None:
+            ctx.std.env.remove_var(name)
+        else:
+            ctx.std.env.set_var(name, prior)
     return tc
 
 def test_validate_role(tc: int) -> int:
@@ -3626,6 +3661,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_collect_build_action_logs(ctx, tc, temp_dir)
     tc = test_sarif_lib(tc)
     tc = test_file_uri_to_path(tc)
+    tc = test_bb_clientd_root(ctx, tc)
     tc = test_json_try_decode(tc)
     tc = test_apparent_label(tc)
     tc = test_process_bes_target_completed(ctx, tc)

--- a/crates/aspect-cli/src/builtins/aspect/feature/circleci_test_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/circleci_test_results.axl
@@ -13,7 +13,6 @@ load("../private/lib/circleci.axl", "circleci")
 load("../private/lib/environment.axl", "detect_ci", "info", "warn")
 load("../private/lib/tar.axl", "tar_create")
 
-# bb_clientd FUSE mount root for bytestream:// URIs (see lib/artifacts.axl).
 # Non-passing statuses for upload_test_results="failed" (mirrors lib/artifacts.axl).
 _NOT_PASSED_STATUSES = [
     "failed",

--- a/crates/aspect-cli/src/builtins/aspect/feature/circleci_test_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/circleci_test_results.axl
@@ -8,14 +8,12 @@ on CircleCI.
 """
 
 load("@aspect//bazel.axl", "BazelTrait")
-load("../private/lib/bazel_results.axl", "bes_get")
+load("../private/lib/bazel_results.axl", "bb_clientd_root", "bes_get", "file_uri_to_path")
 load("../private/lib/circleci.axl", "circleci")
 load("../private/lib/environment.axl", "detect_ci", "info", "warn")
 load("../private/lib/tar.axl", "tar_create")
 
 # bb_clientd FUSE mount root for bytestream:// URIs (see lib/artifacts.axl).
-_BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
-
 # Non-passing statuses for upload_test_results="failed" (mirrors lib/artifacts.axl).
 _NOT_PASSED_STATUSES = [
     "failed",
@@ -27,21 +25,6 @@ _NOT_PASSED_STATUSES = [
     "incomplete",
     "no_status",
 ]
-
-def _file_uri_to_path(uri: str) -> str:
-    """file:// or bytestream:// URI -> local path (bytestream via bb_clientd)."""
-    if not uri:
-        return uri
-    if uri.startswith("file://"):
-        return uri[len("file://"):]
-    if uri.startswith("bytestream://"):
-        rest = uri[len("bytestream://"):]
-        parts = rest.split("/")
-        host = parts[0].split(":")[0]
-        blob_hash = parts[2]
-        blob_size = parts[3]
-        return _BB_CLIENTD_ROOT + "/cas/" + host + "/blobs/sha256/file/" + blob_hash + "-" + blob_size
-    return uri
 
 def _should_collect(strategy: str, status: str, cached: bool) -> bool:
     """all=every test, executed=ran this build, failed=non-passing only."""
@@ -78,7 +61,7 @@ def _collect_test_xml(ctx, event, strategy: str, entries: dict) -> None:
         name = bes_get(file, "name", "") or ""
         if not name.endswith(".xml"):
             continue
-        src = _file_uri_to_path(bes_get(file, "file", "") or "")
+        src = file_uri_to_path(bes_get(file, "file", "") or "", bb_clientd_root(ctx))
         if not src or not ctx.std.fs.exists(src):
             continue
         entries[label_path + "/" + name] = {"src": src, "cached": cached}

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -567,18 +567,32 @@ def _body_text(status, data):
 def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS):
     """Read a lint output file, or None when its contents can't be read yet.
 
-    bytestream:// URIs resolve through the bb_clientd FUSE mount, where the
+    Paths under the bb_clientd mount (bytestream:// URIs resolved by
+    `file_uri_to_path`) go through the bounded `poll_read_to_string`: the
     inode exists as soon as the BES event arrives but reading blocks until
     the blob materializes — and blocks *forever* when the blob can't be
-    fetched at all (e.g. evicted from the remote cache with no action re-run
-    to re-upload it). A plain read would wedge the whole task inside one
-    uninterruptible syscall, so this uses the bounded `poll_read_to_string`:
-    the read runs in the background, each call returns within `timeout_ms`
-    (0 = poll without blocking), and None (file not readable yet) keeps the
-    file in the pending queue — retried each tick until the post-build drain
-    budget warns and skips it. None always means unreadable, never empty: a
-    clean linter's empty `.out` reads as "".
+    fetched at all. A plain read would wedge the whole task inside one
+    uninterruptible syscall, so the read runs in the background, each call
+    returns within `timeout_ms` (0 = poll without blocking), and None keeps
+    the file in the pending queue — retried each tick until the post-build
+    drain budget warns and skips it.
+
+    Anything else is a plain local path (file:// URIs — no remote CAS in
+    play), read directly: local disk can't stall the way bb_clientd reads
+    can, and the direct path avoids a background probe thread per read. An
+    empty read of a file whose size is non-zero is a failed read, matching
+    the probe's contract.
+
+    Either way, None always means unreadable, never empty: a clean linter's
+    empty `.out` reads as "".
     """
+    if not filepath.startswith(_BB_CLIENTD_ROOT):
+        if not ctx.std.fs.exists(filepath):
+            return None
+        content = ctx.std.fs.try_read_to_string(filepath)
+        if content == "" and ctx.std.fs.metadata(filepath).size > 0:
+            return None
+        return content
     return ctx.std.fs.poll_read_to_string(filepath, timeout_ms)
 
 def _probe_timeout_ms(ctx, pass_deadline_ms):

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -20,7 +20,7 @@ load("@aspect//bazel.axl", "BazelTrait")
 load("@std//time.axl", "sleep", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
-load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
+load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "bb_clientd_root", "file_uri_to_path", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
@@ -34,9 +34,6 @@ load("./private/lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif
 load("./private/lib/tar.axl", "tar_create")
 load("./private/lib/text.axl", "pluralize")
 load("./private/lib/tips.axl", "tips")
-
-# bb_clientd FUSE mount root for resolving bytestream:// URIs on Aspect Workflows runners.
-_BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
 
 # Poll budget for pending lint files after build.wait(): remote downloads are
 # async and the BES event can arrive before the file lands. 30s is generous.
@@ -59,36 +56,8 @@ _PASS_READ_BUDGET_MS = 1000
 # without it, a wedged storage layer is silent until the post-build skip.
 _PENDING_READ_WARN_MS = 30000
 
-def file_uri_to_path(uri):
-    """Resolve a BES file URI to a local path via the bb_clientd FUSE mount.
-
-    Handles both bytestream forms:
-      - bytestream://HOST:PORT/blobs/HASH/SIZE              (4 parts)
-      - bytestream://HOST:PORT/blobs/<digest>/HASH/SIZE     (5 parts, modern sha256)
-    In the 5-part form parts[2] is the digest-function name, HASH/SIZE shift to
-    parts[3]/parts[4]; treating parts[2] as the hash yields non-resolving paths.
-    """
-    if uri.startswith("file://"):
-        return uri[len("file://"):]
-    if uri.startswith("bytestream://"):
-        rest = uri[len("bytestream://"):]
-        parts = rest.split("/")
-        host = parts[0].split(":")[0]
-
-        # parts[2] is a digest-function name in the 5-part form; hash/size shift right.
-        if len(parts) >= 5 and parts[2] in ("sha256", "sha512", "blake3"):
-            digest_fn = parts[2]
-            blob_hash = parts[3]
-            blob_size = parts[4]
-        else:
-            digest_fn = "sha256"
-            blob_hash = parts[2] if len(parts) > 2 else ""
-            blob_size = parts[3] if len(parts) > 3 else ""
-        return _BB_CLIENTD_ROOT + "/cas/" + host + "/blobs/" + digest_fn + "/file/" + blob_hash + "-" + blob_size
-    return uri
-
-def _bb_clientd_mounted(ctx):
-    """True when a bb_clientd virtual filesystem is mounted at _BB_CLIENTD_ROOT.
+def _bb_clientd_mounted(ctx, root):
+    """True when a bb_clientd virtual filesystem is mounted at `root`.
 
     Read from /proc/self/mounts: procfs never blocks, while stat()ing the
     mount root would be served by the (possibly wedged) bb_clientd daemon
@@ -101,8 +70,8 @@ def _bb_clientd_mounted(ctx):
     """
     mounts = ctx.std.fs.try_read_to_string("/proc/self/mounts")
     if mounts:
-        return " " + _BB_CLIENTD_ROOT + " " in mounts
-    return ctx.std.fs.exists(_BB_CLIENTD_ROOT)
+        return " " + root + " " in mounts
+    return ctx.std.fs.exists(root)
 
 # Filter functions — (all_diagnostics, changed_files) -> relevant_diagnostics
 def filter_all(diagnostics, changed_files):
@@ -603,7 +572,8 @@ def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS):
     Either way, None always means unreadable, never empty: a clean linter's
     empty `.out` reads as "".
     """
-    if not filepath.startswith(_BB_CLIENTD_ROOT):
+    root = bb_clientd_root(ctx)
+    if root == None or not filepath.startswith(root):
         if not ctx.std.fs.exists(filepath):
             return None
         content = ctx.std.fs.try_read_to_string(filepath)
@@ -691,7 +661,7 @@ def _record_lint_result(result, failed_linters):
         failed_linters[result["failed_tool"]] = True
     return (result["interesting"], result["linter_exit_code"] != 0)
 
-def _drain_pending_files(ctx, pending, pending_meta, data, strategy, changed_files, lint_trait, github_output, patches, failed_linters, pass_deadline_ms):
+def _drain_pending_files(ctx, bb_root, pending, pending_meta, data, strategy, changed_files, lint_trait, github_output, patches, failed_linters, pass_deadline_ms):
     """One pass over pending files → (still_pending, was_interesting, exit_nonzero).
     still_pending holds files whose remote download hasn't landed or whose
     contents couldn't be read yet. `pass_deadline_ms` caps this pass's total
@@ -707,7 +677,7 @@ def _drain_pending_files(ctx, pending, pending_meta, data, strategy, changed_fil
     exit_nonzero = False
     now = now_ms(ctx)
     for pfile in pending:
-        pfilepath = file_uri_to_path(pfile.file)
+        pfilepath = file_uri_to_path(pfile.file, bb_root)
         result = _try_process_lint_file(ctx, pfile, pfilepath, data, strategy, changed_files, lint_trait, github_output, patches, _probe_timeout_ms(ctx, pass_deadline_ms))
         if result == None:
             meta = pending_meta.setdefault(pfilepath, {"first_ms": now, "warned": False})
@@ -879,7 +849,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # Whether bytestream:// paths can resolve at all on this runner; remote
     # lint outputs are skipped (and counted) when they can't.
-    bb_clientd_ok = _bb_clientd_mounted(ctx)
+    bb_root = bb_clientd_root(ctx)
+    bb_clientd_ok = bb_root != None and _bb_clientd_mounted(ctx, bb_root)
     skipped_remote_files = 0
 
     # Emit on each interesting tick, and at least every MIN_HEARTBEAT_INTERVAL_MS
@@ -891,6 +862,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
         pending_files, pending_interesting, pending_exit_nonzero = _drain_pending_files(
             ctx,
+            bb_root,
             pending_files,
             pending_meta,
             data,
@@ -917,12 +889,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 interesting = True
             if event.kind == "named_set_of_files":
                 for file in event.payload.files:
-                    filepath = file_uri_to_path(file.file)
+                    filepath = file_uri_to_path(file.file, bb_root)
                     tool = detect_lint_tool(file.name)
                     if tool:
                         lint_tools_run[tool] = True
                     if file.name.endswith(".patch") or file.name.endswith(".out") or file.name.endswith(".report") or file.name.endswith(".exit_code"):
-                        if not bb_clientd_ok and filepath.startswith(_BB_CLIENTD_ROOT):
+                        uri = file.file
+                        if not bb_clientd_ok and type(uri) == "string" and uri.startswith("bytestream://"):
                             skipped_remote_files += 1
                             continue
                         result = _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, lint_trait, github_output, patches, _probe_timeout_ms(ctx, pass_deadline_ms))
@@ -965,6 +938,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         for _i in range(_POST_BUILD_DOWNLOAD_TIMEOUT_MS // BES_DRAIN_TICK_MS + 1):
             pending_files, _, pending_exit_nonzero = _drain_pending_files(
                 ctx,
+                bb_root,
                 pending_files,
                 pending_meta,
                 data,
@@ -986,13 +960,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 slow_warned = True
             if now_ms(ctx) >= post_build_deadline_ms:
                 for pfile in pending_files:
-                    pfilepath = file_uri_to_path(pfile.file)
+                    pfilepath = file_uri_to_path(pfile.file, bb_root)
                     warn(ctx.std, "Lint file not readable %ds after build completed (skipping): %s" % (_POST_BUILD_DOWNLOAD_TIMEOUT_MS // 1000, pfilepath))
                 break
             sleep(BES_DRAIN_TICK_MS)
 
     if skipped_remote_files:
-        warn(ctx.std, "Skipped %s (bytestream:// URIs): no bb_clientd mount at %s on this runner" % (pluralize(skipped_remote_files, "remote lint output"), _BB_CLIENTD_ROOT))
+        warn(ctx.std, "Skipped %s (bytestream:// URIs): this runner has no bb_clientd mount" % pluralize(skipped_remote_files, "remote lint output"))
 
     build_failed = not build_status.success
     data["lint"]["build_failed"] = build_failed

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -64,14 +64,33 @@ def _bb_clientd_mounted(ctx, root):
     itself. Without procfs (macOS) fall back to a direct existence check.
 
     Runners without bb_clientd — non-Aspect runners, or future Aspect runner
-    versions — can still receive bytestream:// URIs in BES events; their
-    resolved paths can never become readable, so intake skips those files
-    outright instead of letting them churn in the pending queue.
+    versions — still receive bytestream:// URIs in BES events; those fall
+    back to the file's local output-tree path instead (see _lint_file_path).
     """
     mounts = ctx.std.fs.try_read_to_string("/proc/self/mounts")
     if mounts:
         return " " + root + " " in mounts
     return ctx.std.fs.exists(root)
+
+def _lint_file_path(file, bb_root):
+    """Best local path for a BES-announced lint output file, or "".
+
+    With a bb_clientd mount (`bb_root` set), bytestream:// URIs resolve
+    through it. Without one (non-Aspect runners, runners without bb_clientd),
+    fall back to the file's output-tree path (path_prefix/name, relative to
+    the workspace): the lint build passes --remote_download_regex for lint
+    outputs, so Bazel downloads them into bazel-out even under minimal
+    downloads and the local copy serves the read. file:// URIs are local
+    paths either way. "" when nothing can serve the file (e.g. inlined
+    contents with no path_prefix).
+    """
+    uri = file.file
+    if bb_root == None and type(uri) == "string" and uri.startswith("bytestream://"):
+        prefix = list(file.path_prefix or [])
+        if prefix and file.name:
+            return "/".join(prefix) + "/" + file.name
+        return ""
+    return file_uri_to_path(uri, bb_root)
 
 # Filter functions — (all_diagnostics, changed_files) -> relevant_diagnostics
 def filter_all(diagnostics, changed_files):
@@ -563,9 +582,10 @@ def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS):
     the file in the pending queue — retried each tick until the post-build
     drain budget warns and skips it.
 
-    Anything else is a plain local path (file:// URIs — no remote CAS in
-    play), read directly: local disk can't stall the way bb_clientd reads
-    can, and the direct path avoids a background probe thread per read. An
+    Anything else is a plain local path — file:// URIs, or the output-tree
+    fallback for bytestream URIs on runners without bb_clientd — read
+    directly: local disk can't stall the way bb_clientd reads can, and the
+    direct path avoids a background probe thread per read. An
     empty read of a file whose size is non-zero is a failed read, matching
     the probe's contract.
 
@@ -677,7 +697,7 @@ def _drain_pending_files(ctx, bb_root, pending, pending_meta, data, strategy, ch
     exit_nonzero = False
     now = now_ms(ctx)
     for pfile in pending:
-        pfilepath = file_uri_to_path(pfile.file, bb_root)
+        pfilepath = _lint_file_path(pfile, bb_root)
         result = _try_process_lint_file(ctx, pfile, pfilepath, data, strategy, changed_files, lint_trait, github_output, patches, _probe_timeout_ms(ctx, pass_deadline_ms))
         if result == None:
             meta = pending_meta.setdefault(pfilepath, {"first_ms": now, "warned": False})
@@ -850,7 +870,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Whether bytestream:// paths can resolve at all on this runner; remote
     # lint outputs are skipped (and counted) when they can't.
     bb_root = bb_clientd_root(ctx)
-    bb_clientd_ok = bb_root != None and _bb_clientd_mounted(ctx, bb_root)
+    if bb_root != None and not _bb_clientd_mounted(ctx, bb_root):
+        bb_root = None
     skipped_remote_files = 0
 
     # Emit on each interesting tick, and at least every MIN_HEARTBEAT_INTERVAL_MS
@@ -889,13 +910,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 interesting = True
             if event.kind == "named_set_of_files":
                 for file in event.payload.files:
-                    filepath = file_uri_to_path(file.file, bb_root)
+                    filepath = _lint_file_path(file, bb_root)
                     tool = detect_lint_tool(file.name)
                     if tool:
                         lint_tools_run[tool] = True
                     if file.name.endswith(".patch") or file.name.endswith(".out") or file.name.endswith(".report") or file.name.endswith(".exit_code"):
-                        uri = file.file
-                        if not bb_clientd_ok and type(uri) == "string" and uri.startswith("bytestream://"):
+                        if not filepath:
                             skipped_remote_files += 1
                             continue
                         result = _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, lint_trait, github_output, patches, _probe_timeout_ms(ctx, pass_deadline_ms))
@@ -960,13 +980,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 slow_warned = True
             if now_ms(ctx) >= post_build_deadline_ms:
                 for pfile in pending_files:
-                    pfilepath = file_uri_to_path(pfile.file, bb_root)
+                    pfilepath = _lint_file_path(pfile, bb_root)
                     warn(ctx.std, "Lint file not readable %ds after build completed (skipping): %s" % (_POST_BUILD_DOWNLOAD_TIMEOUT_MS // 1000, pfilepath))
                 break
             sleep(BES_DRAIN_TICK_MS)
 
     if skipped_remote_files:
-        warn(ctx.std, "Skipped %s (bytestream:// URIs): this runner has no bb_clientd mount" % pluralize(skipped_remote_files, "remote lint output"))
+        warn(ctx.std, "Skipped %s: no bb_clientd mount on this runner and no local output-tree path to read instead" % pluralize(skipped_remote_files, "remote lint output"))
 
     build_failed = not build_status.success
     data["lint"]["build_failed"] = build_failed

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -42,9 +42,17 @@ _BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
 # async and the BES event can arrive before the file lands. 30s is generous.
 _POST_BUILD_DOWNLOAD_TIMEOUT_MS = 30000
 
-# Bound for a single lint-file read probe (see _read_lint_file). Matches the
-# drain tick so one stuck file delays a tick by at most one interval.
+# Bound for a single lint-file read probe (see _read_lint_file).
 _LINT_FILE_PROBE_TIMEOUT_MS = 250
+
+# Blocking budget for one drain/event pass. Each pass may spend at most this
+# long waiting on freshly spawned read probes in total; past the budget,
+# probes are polled nonblocking (timeout 0) and their results harvested on a
+# later pass. Bounds a batch of many distinct stuck files — hundreds of
+# unfetchable blobs would otherwise stall one pass for minutes at one probe
+# timeout each — so the loop keeps ticking, heartbeating, and checking its
+# own deadlines.
+_PASS_READ_BUDGET_MS = 1000
 
 # Age at which a still-unreadable lint file gets a one-time warning naming it.
 # Surfaces a stuck remote-cache/FUSE read while the task is still running —
@@ -556,7 +564,7 @@ def _body_text(status, data):
         return "Lint aborted"
     return ""
 
-def _read_lint_file(ctx, filepath):
+def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS):
     """Read a lint output file, or None when its contents can't be read yet.
 
     bytestream:// URIs resolve through the bb_clientd FUSE mount, where the
@@ -565,19 +573,29 @@ def _read_lint_file(ctx, filepath):
     fetched at all (e.g. evicted from the remote cache with no action re-run
     to re-upload it). A plain read would wedge the whole task inside one
     uninterruptible syscall, so this uses the bounded `poll_read_to_string`:
-    the read runs in the background, each call returns within the timeout,
-    and None (file not readable yet) keeps the file in the pending queue —
-    retried each tick until the post-build drain budget warns and skips it.
-    None always means unreadable, never empty: a clean linter's empty `.out`
-    reads as "".
+    the read runs in the background, each call returns within `timeout_ms`
+    (0 = poll without blocking), and None (file not readable yet) keeps the
+    file in the pending queue — retried each tick until the post-build drain
+    budget warns and skips it. None always means unreadable, never empty: a
+    clean linter's empty `.out` reads as "".
     """
-    return ctx.std.fs.poll_read_to_string(filepath, _LINT_FILE_PROBE_TIMEOUT_MS)
+    return ctx.std.fs.poll_read_to_string(filepath, timeout_ms)
 
-def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, lint_trait, github_output, patches):
+def _probe_timeout_ms(ctx, pass_deadline_ms):
+    """Per-read probe bound for one drain/event pass: the standard probe
+    timeout, clamped to what remains of the pass's `_PASS_READ_BUDGET_MS`
+    blocking budget. 0 (nonblocking poll) once the budget is spent."""
+    remaining = pass_deadline_ms - now_ms(ctx)
+    if remaining <= 0:
+        return 0
+    return min(remaining, _LINT_FILE_PROBE_TIMEOUT_MS)
+
+def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, lint_trait, github_output, patches, probe_timeout_ms):
     """Read and process one BES lint output file.
 
     Returns None when the file's contents can't be read yet (see
-    `_read_lint_file`), else {"interesting": bool, "linter_exit_code": int,
+    `_read_lint_file`; `probe_timeout_ms` bounds the read wait, 0 = poll
+    without blocking), else {"interesting": bool, "linter_exit_code": int,
     "failed_tool": str}. A None keeps the file in the pending queue, retried
     each tick until the post-build drain timeout warns and skips it.
     `failed_tool` names the linter when its `.exit_code` was non-zero (else ""),
@@ -586,14 +604,14 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
     results equal a terminal pass and findings don't flicker as batches arrive.
     """
     if file.name.endswith(".out"):
-        out = _read_lint_file(ctx, filepath)
+        out = _read_lint_file(ctx, filepath, probe_timeout_ms)
         if out == None:
             return None
         ctx.std.io.stderr.write(out)
         return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
     if file.name.endswith(".report"):
-        report = _read_lint_file(ctx, filepath)
+        report = _read_lint_file(ctx, filepath, probe_timeout_ms)
         if report == None:
             return None
         if "sarif-" in report:
@@ -610,7 +628,7 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
         # Readability gate (content discarded): requeues the patch until the
         # blob is materialized, since lint_patch hooks buffer the path and
         # later re-read it with a plain read_to_string.
-        if _read_lint_file(ctx, filepath) == None:
+        if _read_lint_file(ctx, filepath, probe_timeout_ms) == None:
             return None
         patches.append(filepath)
         for hook in lint_trait.lint_patch:
@@ -618,7 +636,7 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
         return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
     if file.name.endswith(".exit_code"):
-        content = _read_lint_file(ctx, filepath)
+        content = _read_lint_file(ctx, filepath, probe_timeout_ms)
         if content == None:
             return None
         stripped = content.rstrip()
@@ -642,10 +660,11 @@ def _record_lint_result(result, failed_linters):
         failed_linters[result["failed_tool"]] = True
     return (result["interesting"], result["linter_exit_code"] != 0)
 
-def _drain_pending_files(ctx, pending, pending_meta, data, strategy, changed_files, lint_trait, github_output, patches, failed_linters):
+def _drain_pending_files(ctx, pending, pending_meta, data, strategy, changed_files, lint_trait, github_output, patches, failed_linters, pass_deadline_ms):
     """One pass over pending files → (still_pending, was_interesting, exit_nonzero).
     still_pending holds files whose remote download hasn't landed or whose
-    contents couldn't be read yet.
+    contents couldn't be read yet. `pass_deadline_ms` caps this pass's total
+    blocking time on read probes (see `_probe_timeout_ms`).
     `pending_meta` (path → {"first_ms", "warned"}) tracks how long each file
     has been unreadable across passes; a file pending longer than
     `_PENDING_READ_WARN_MS` gets a one-time warning naming it, so a stuck
@@ -658,7 +677,7 @@ def _drain_pending_files(ctx, pending, pending_meta, data, strategy, changed_fil
     now = now_ms(ctx)
     for pfile in pending:
         pfilepath = file_uri_to_path(pfile.file)
-        result = _try_process_lint_file(ctx, pfile, pfilepath, data, strategy, changed_files, lint_trait, github_output, patches)
+        result = _try_process_lint_file(ctx, pfile, pfilepath, data, strategy, changed_files, lint_trait, github_output, patches, _probe_timeout_ms(ctx, pass_deadline_ms))
         if result == None:
             meta = pending_meta.setdefault(pfilepath, {"first_ms": now, "warned": False})
             if not meta["warned"] and now - meta["first_ms"] >= _PENDING_READ_WARN_MS:
@@ -832,6 +851,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     last_emit_ms = now_ms(ctx)
     for _tick in sleep_iter(BES_DRAIN_TICK_MS):
         interesting = False
+        pass_deadline_ms = now_ms(ctx) + _PASS_READ_BUDGET_MS
 
         pending_files, pending_interesting, pending_exit_nonzero = _drain_pending_files(
             ctx,
@@ -844,6 +864,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             github_output,
             patches,
             failed_linters,
+            pass_deadline_ms,
         )
         if pending_interesting:
             interesting = True
@@ -865,7 +886,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                     if tool:
                         lint_tools_run[tool] = True
                     if file.name.endswith(".patch") or file.name.endswith(".out") or file.name.endswith(".report") or file.name.endswith(".exit_code"):
-                        result = _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, lint_trait, github_output, patches)
+                        result = _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, lint_trait, github_output, patches, _probe_timeout_ms(ctx, pass_deadline_ms))
                         if result == None:
                             pending_files.append(file)
                         else:
@@ -914,6 +935,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 github_output,
                 patches,
                 failed_linters,
+                now_ms(ctx) + _PASS_READ_BUDGET_MS,
             )
             if pending_exit_nonzero:
                 linter_exit_code = 1

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -87,6 +87,23 @@ def file_uri_to_path(uri):
         return _BB_CLIENTD_ROOT + "/cas/" + host + "/blobs/" + digest_fn + "/file/" + blob_hash + "-" + blob_size
     return uri
 
+def _bb_clientd_mounted(ctx):
+    """True when a bb_clientd virtual filesystem is mounted at _BB_CLIENTD_ROOT.
+
+    Read from /proc/self/mounts: procfs never blocks, while stat()ing the
+    mount root would be served by the (possibly wedged) bb_clientd daemon
+    itself. Without procfs (macOS) fall back to a direct existence check.
+
+    Runners without bb_clientd — non-Aspect runners, or future Aspect runner
+    versions — can still receive bytestream:// URIs in BES events; their
+    resolved paths can never become readable, so intake skips those files
+    outright instead of letting them churn in the pending queue.
+    """
+    mounts = ctx.std.fs.try_read_to_string("/proc/self/mounts")
+    if mounts:
+        return " " + _BB_CLIENTD_ROOT + " " in mounts
+    return ctx.std.fs.exists(_BB_CLIENTD_ROOT)
+
 # Filter functions — (all_diagnostics, changed_files) -> relevant_diagnostics
 def filter_all(diagnostics, changed_files):
     return diagnostics
@@ -860,6 +877,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # rules_lint tool names observed in BES file-name markers.
     lint_tools_run = {}
 
+    # Whether bytestream:// paths can resolve at all on this runner; remote
+    # lint outputs are skipped (and counted) when they can't.
+    bb_clientd_ok = _bb_clientd_mounted(ctx)
+    skipped_remote_files = 0
+
     # Emit on each interesting tick, and at least every MIN_HEARTBEAT_INTERVAL_MS
     # to keep the elapsed timer live.
     last_emit_ms = now_ms(ctx)
@@ -900,6 +922,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                     if tool:
                         lint_tools_run[tool] = True
                     if file.name.endswith(".patch") or file.name.endswith(".out") or file.name.endswith(".report") or file.name.endswith(".exit_code"):
+                        if not bb_clientd_ok and filepath.startswith(_BB_CLIENTD_ROOT):
+                            skipped_remote_files += 1
+                            continue
                         result = _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, lint_trait, github_output, patches, _probe_timeout_ms(ctx, pass_deadline_ms))
                         if result == None:
                             pending_files.append(file)
@@ -965,6 +990,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                     warn(ctx.std, "Lint file not readable %ds after build completed (skipping): %s" % (_POST_BUILD_DOWNLOAD_TIMEOUT_MS // 1000, pfilepath))
                 break
             sleep(BES_DRAIN_TICK_MS)
+
+    if skipped_remote_files:
+        warn(ctx.std, "Skipped %s (bytestream:// URIs): no bb_clientd mount at %s on this runner" % (pluralize(skipped_remote_files, "remote lint output"), _BB_CLIENTD_ROOT))
 
     build_failed = not build_status.success
     data["lint"]["build_failed"] = build_failed

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -62,10 +62,6 @@ def _bb_clientd_mounted(ctx, root):
     Read from /proc/self/mounts: procfs never blocks, while stat()ing the
     mount root would be served by the (possibly wedged) bb_clientd daemon
     itself. Without procfs (macOS) fall back to a direct existence check.
-
-    Runners without bb_clientd — non-Aspect runners, or future Aspect runner
-    versions — still receive bytestream:// URIs in BES events; those fall
-    back to the file's local output-tree path instead (see _lint_file_path).
     """
     mounts = ctx.std.fs.try_read_to_string("/proc/self/mounts")
     if mounts:
@@ -867,8 +863,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # rules_lint tool names observed in BES file-name markers.
     lint_tools_run = {}
 
-    # Whether bytestream:// paths can resolve at all on this runner; remote
-    # lint outputs are skipped (and counted) when they can't.
+    # bytestream:// URIs resolve through bb_clientd only when this runner has
+    # a usable mount (declared by env and actually mounted); bb_root None
+    # routes them to the output-tree fallback instead (see _lint_file_path).
     bb_root = bb_clientd_root(ctx)
     if bb_root != None and not _bb_clientd_mounted(ctx, bb_root):
         bb_root = None
@@ -986,7 +983,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             sleep(BES_DRAIN_TICK_MS)
 
     if skipped_remote_files:
-        warn(ctx.std, "Skipped %s: no bb_clientd mount on this runner and no local output-tree path to read instead" % pluralize(skipped_remote_files, "remote lint output"))
+        warn(ctx.std, "Skipped %s: no local path can serve them (no bb_clientd mount and no output-tree path)" % pluralize(skipped_remote_files, "lint output file"))
 
     build_failed = not build_status.success
     data["lint"]["build_failed"] = build_failed

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -46,6 +46,11 @@ _POST_BUILD_DOWNLOAD_TIMEOUT_MS = 30000
 # drain tick so one stuck file delays a tick by at most one interval.
 _LINT_FILE_PROBE_TIMEOUT_MS = 250
 
+# Age at which a still-unreadable lint file gets a one-time warning naming it.
+# Surfaces a stuck remote-cache/FUSE read while the task is still running —
+# without it, a wedged storage layer is silent until the post-build skip.
+_PENDING_READ_WARN_MS = 30000
+
 def file_uri_to_path(uri):
     """Resolve a BES file URI to a local path via the bb_clientd FUSE mount.
 
@@ -637,21 +642,31 @@ def _record_lint_result(result, failed_linters):
         failed_linters[result["failed_tool"]] = True
     return (result["interesting"], result["linter_exit_code"] != 0)
 
-def _drain_pending_files(ctx, pending, data, strategy, changed_files, lint_trait, github_output, patches, failed_linters):
+def _drain_pending_files(ctx, pending, pending_meta, data, strategy, changed_files, lint_trait, github_output, patches, failed_linters):
     """One pass over pending files → (still_pending, was_interesting, exit_nonzero).
     still_pending holds files whose remote download hasn't landed or whose
     contents couldn't be read yet.
+    `pending_meta` (path → {"first_ms", "warned"}) tracks how long each file
+    has been unreadable across passes; a file pending longer than
+    `_PENDING_READ_WARN_MS` gets a one-time warning naming it, so a stuck
+    remote-cache read is visible in the log while the task is still running.
     `failed_linters` accumulates tool names whose `.exit_code` was non-zero.
     """
     still_pending = []
     interesting = False
     exit_nonzero = False
+    now = now_ms(ctx)
     for pfile in pending:
         pfilepath = file_uri_to_path(pfile.file)
         result = _try_process_lint_file(ctx, pfile, pfilepath, data, strategy, changed_files, lint_trait, github_output, patches)
         if result == None:
+            meta = pending_meta.setdefault(pfilepath, {"first_ms": now, "warned": False})
+            if not meta["warned"] and now - meta["first_ms"] >= _PENDING_READ_WARN_MS:
+                warn(ctx.std, "Lint file still not readable %ds after its build event arrived (retrying): %s" % ((now - meta["first_ms"]) // 1000, pfilepath))
+                meta["warned"] = True
             still_pending.append(pfile)
         else:
+            pending_meta.pop(pfilepath, None)
             file_interesting, file_exit_nonzero = _record_lint_result(result, failed_linters)
             interesting = interesting or file_interesting
             exit_nonzero = exit_nonzero or file_exit_nonzero
@@ -804,8 +819,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     github_output = ctx.std.env.var("GITHUB_OUTPUT")
 
     # Files whose download hadn't completed when their named_set_of_files BES
-    # event arrived; retried each tick.
+    # event arrived; retried each tick. `pending_meta` tracks per-path age so
+    # a stuck read warns while the task runs (see _drain_pending_files).
     pending_files = []
+    pending_meta = {}
 
     # rules_lint tool names observed in BES file-name markers.
     lint_tools_run = {}
@@ -819,6 +836,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         pending_files, pending_interesting, pending_exit_nonzero = _drain_pending_files(
             ctx,
             pending_files,
+            pending_meta,
             data,
             strategy,
             changed_files,
@@ -888,6 +906,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             pending_files, _, pending_exit_nonzero = _drain_pending_files(
                 ctx,
                 pending_files,
+                pending_meta,
                 data,
                 strategy,
                 changed_files,

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -42,6 +42,10 @@ _BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
 # async and the BES event can arrive before the file lands. 30s is generous.
 _POST_BUILD_DOWNLOAD_TIMEOUT_MS = 30000
 
+# Bound for a single lint-file read probe (see _read_lint_file). Matches the
+# drain tick so one stuck file delays a tick by at most one interval.
+_LINT_FILE_PROBE_TIMEOUT_MS = 250
+
 def file_uri_to_path(uri):
     """Resolve a BES file URI to a local path via the bb_clientd FUSE mount.
 
@@ -551,19 +555,18 @@ def _read_lint_file(ctx, filepath):
     """Read a lint output file, or None when its contents can't be read yet.
 
     bytestream:// URIs resolve through the bb_clientd FUSE mount, where the
-    inode exists as soon as the BES event arrives but reading can still fail
-    transiently (EIO) while the blob fetch is in flight — so exists()+read
-    can crash. `try_read_to_string` collapses read errors to "", which is
-    ambiguous with a legitimately empty file (a clean linter's `.out` is
-    empty); an empty read of a file whose stat size is non-zero disambiguates
-    the failure. None keeps the file in the pending queue for retry.
+    inode exists as soon as the BES event arrives but reading blocks until
+    the blob materializes — and blocks *forever* when the blob can't be
+    fetched at all (e.g. evicted from the remote cache with no action re-run
+    to re-upload it). A plain read would wedge the whole task inside one
+    uninterruptible syscall, so this uses the bounded `poll_read_to_string`:
+    the read runs in the background, each call returns within the timeout,
+    and None (file not readable yet) keeps the file in the pending queue —
+    retried each tick until the post-build drain budget warns and skips it.
+    None always means unreadable, never empty: a clean linter's empty `.out`
+    reads as "".
     """
-    if not ctx.std.fs.exists(filepath):
-        return None
-    content = ctx.std.fs.try_read_to_string(filepath)
-    if content == "" and ctx.std.fs.metadata(filepath).size > 0:
-        return None
-    return content
+    return ctx.std.fs.poll_read_to_string(filepath, _LINT_FILE_PROBE_TIMEOUT_MS)
 
 def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, lint_trait, github_output, patches):
     """Read and process one BES lint output file.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/artifacts.axl
@@ -552,9 +552,10 @@ def _collect_test_files(ctx, event, strategy, test_entries, skipped_files):
         bes_get(event.id, "attempt", 0) or 0,
     )
 
+    bb_root = bb_clientd_root(ctx)
     for file in (bes_get(payload, "test_action_output", None) or []):
         raw_uri = file.file
-        src = file_uri_to_path(raw_uri, bb_clientd_root(ctx))
+        src = file_uri_to_path(raw_uri, bb_root)
         if not src:
             src = "/".join(file.path_prefix) + "/" + file.name
         if not src:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/artifacts.axl
@@ -38,7 +38,7 @@ Consumer:
 """
 
 load("@aspect//bazel.axl", "BazelTrait")
-load("./bazel_results.axl", "bes_get", "file_uri_to_path")
+load("./bazel_results.axl", "bb_clientd_root", "bes_get", "file_uri_to_path")
 load("./buildkite.axl", "buildkite")
 load("./ci.axl", "detect_artifacts_browse_url", "detect_ci_host")
 load("./circleci.axl", "circleci")
@@ -554,7 +554,7 @@ def _collect_test_files(ctx, event, strategy, test_entries, skipped_files):
 
     for file in (bes_get(payload, "test_action_output", None) or []):
         raw_uri = file.file
-        src = file_uri_to_path(raw_uri)
+        src = file_uri_to_path(raw_uri, bb_clientd_root(ctx))
         if not src:
             src = "/".join(file.path_prefix) + "/" + file.name
         if not src:
@@ -647,7 +647,7 @@ def _build_log_body(ctx, raw):
             return ""
 
         # Read one past the cap so an exactly-cap-sized log isn't misflagged.
-        text = ctx.std.fs.try_read_to_string_capped(file_uri_to_path(raw), _MAX_BUILD_LOG_BYTES + 1)
+        text = ctx.std.fs.try_read_to_string_capped(file_uri_to_path(raw, bb_clientd_root(ctx)), _MAX_BUILD_LOG_BYTES + 1)
     elif raw != None:
         text = str(raw[:_MAX_BUILD_LOG_BYTES + 1])  # slice bytes before decoding
     else:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -83,7 +83,7 @@ MIN_HEARTBEAT_INTERVAL_MS = 5000
 BES_DRAIN_TICK_MS = 250
 
 # Default bb_clientd FUSE mount root on Aspect Workflows runners, used for
-# runners that predate the ASPECT_WORKFLOWS_BB_CLIENTD_MOUNT platform env
+# runners that predate the ASPECT_WORKFLOWS_RUNNER_BB_CLIENTD_MOUNT platform env
 # (see bb_clientd_root). Also the fallback for `process_event`'s internal
 # path derivations, which have no ctx to read the env from.
 _DEFAULT_BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
@@ -206,12 +206,12 @@ def bb_clientd_root(ctx) -> str | None:
     None when the runner declares it has no bb_clientd
     (ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD=1) — bytestream URIs cannot be
     resolved locally at all, so callers should skip remote-blob reads.
-    Otherwise the runner-exported ASPECT_WORKFLOWS_BB_CLIENTD_MOUNT, falling
+    Otherwise the runner-exported ASPECT_WORKFLOWS_RUNNER_BB_CLIENTD_MOUNT, falling
     back to the legacy hard-coded root for runners predating the env vars.
     """
     if ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD"):
         return None
-    return ctx.std.env.var("ASPECT_WORKFLOWS_BB_CLIENTD_MOUNT") or _DEFAULT_BB_CLIENTD_ROOT
+    return ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_BB_CLIENTD_MOUNT") or _DEFAULT_BB_CLIENTD_ROOT
 
 def file_uri_to_path(uri, bb_root = _DEFAULT_BB_CLIENTD_ROOT):
     """Convert a file:// or bytestream:// URI to a local filesystem path.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -82,10 +82,11 @@ MIN_HEARTBEAT_INTERVAL_MS = 5000
 # don't stall the loop.
 BES_DRAIN_TICK_MS = 250
 
-# bb_clientd FUSE mount root for resolving bytestream:// URIs on Aspect
-# Workflows runners. lib/artifacts.axl loads `file_uri_to_path` from here, so
-# both files resolve the same CAS blobs off this one root.
-_BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
+# Default bb_clientd FUSE mount root on Aspect Workflows runners, used for
+# runners that predate the ASPECT_WORKFLOWS_BB_CLIENTD_MOUNT platform env
+# (see bb_clientd_root). Also the fallback for `process_event`'s internal
+# path derivations, which have no ctx to read the env from.
+_DEFAULT_BB_CLIENTD_ROOT = "/mnt/ephemeral/buildbarn/bb_clientd"
 
 # TestSummary overall_status values from BlazeTestStatus proto enum. starbuf_derive
 # lowercases CamelCase to snake_case: Failed → "failed", FailedToBuild → "failed_to_build".
@@ -199,29 +200,55 @@ def bes_get(obj, field, default = None):
         return default
     return getattr(obj, field, default)
 
-def file_uri_to_path(uri):
+def bb_clientd_root(ctx) -> str | None:
+    """Resolve the bb_clientd mount root for bytestream:// URI resolution.
+
+    None when the runner declares it has no bb_clientd
+    (ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD=1) — bytestream URIs cannot be
+    resolved locally at all, so callers should skip remote-blob reads.
+    Otherwise the runner-exported ASPECT_WORKFLOWS_BB_CLIENTD_MOUNT, falling
+    back to the legacy hard-coded root for runners predating the env vars.
+    """
+    if ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD"):
+        return None
+    return ctx.std.env.var("ASPECT_WORKFLOWS_BB_CLIENTD_MOUNT") or _DEFAULT_BB_CLIENTD_ROOT
+
+def file_uri_to_path(uri, bb_root = _DEFAULT_BB_CLIENTD_ROOT):
     """Convert a file:// or bytestream:// URI to a local filesystem path.
 
     `file://` (disk-cache / local outputs) is returned verbatim; `bytestream://`
-    (remote cache) is resolved via the bb_clientd FUSE mount:
+    (remote cache) is resolved via the bb_clientd mount:
       bytestream://host:port/blobs/<hash>/<size>
-      -> {_BB_CLIENTD_ROOT}/cas/{host}/blobs/sha256/file/{hash}-{size}
+      -> {bb_root}/cas/{host}/blobs/sha256/file/{hash}-{size}
+    (a 5-part form with an explicit digest-function segment shifts hash/size
+    right). Callers with a ctx should pass `bb_root = bb_clientd_root(ctx)` so
+    the runner-exported mount wins over the legacy default.
 
-    Returns "" for a non-string `uri` — the BES `File.file` oneof yields bytes
-    when contents are inlined (not a URI), which we can't turn into a path.
+    Returns "" for a non-string `uri` (the BES `File.file` oneof yields bytes
+    when contents are inlined) and for bytestream URIs when `bb_root` is None
+    (runner without bb_clientd) — there is no local path they can resolve to.
     """
     if type(uri) != "string" or not uri:
         return ""
     if uri.startswith("file://"):
         return uri[len("file://"):]
     if uri.startswith("bytestream://"):
+        if bb_root == None:
+            return ""
         rest = uri[len("bytestream://"):]
         parts = rest.split("/")
-        host_port = parts[0]
-        host = host_port.split(":")[0]
-        blob_hash = parts[2]
-        blob_size = parts[3]
-        return _BB_CLIENTD_ROOT + "/cas/" + host + "/blobs/sha256/file/" + blob_hash + "-" + blob_size
+        host = parts[0].split(":")[0]
+
+        # parts[2] is a digest-function name in the 5-part form; hash/size shift right.
+        if len(parts) >= 5 and parts[2] in ("sha256", "sha512", "blake3"):
+            digest_fn = parts[2]
+            blob_hash = parts[3]
+            blob_size = parts[4]
+        else:
+            digest_fn = "sha256"
+            blob_hash = parts[2] if len(parts) > 2 else ""
+            blob_size = parts[3] if len(parts) > 3 else ""
+        return bb_root + "/cas/" + host + "/blobs/" + digest_fn + "/file/" + blob_hash + "-" + blob_size
     return uri
 
 def _repro_with_prefix(prefix, labels, max_chars):

--- a/crates/axl-runtime/src/engine/std/fs.rs
+++ b/crates/axl-runtime/src/engine/std/fs.rs
@@ -5,11 +5,12 @@ use starlark::environment::MethodsBuilder;
 use starlark::environment::MethodsStatic;
 use starlark::values::ValueOfUnchecked;
 use starlark::values::list::UnpackList;
-use starlark::values::none::NoneType;
+use starlark::values::none::{NoneOr, NoneType};
+use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
-use std::sync::{Arc, Mutex};
-use std::time::UNIX_EPOCH;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::time::{Duration, UNIX_EPOCH};
 
 use super::stream;
 
@@ -188,6 +189,72 @@ impl<'v> values::StarlarkValue<'v> for Filesystem {
 }
 
 starlark_simple_value!(Filesystem);
+
+/// A background read whose completion callers poll for. `state` is `None`
+/// while the reader thread is still running; `Some(result)` once it finished
+/// (`result` is `None` on any I/O/UTF-8 error, `Some(content)` on success).
+struct ReadProbe {
+    state: Mutex<Option<Option<String>>>,
+    done: Condvar,
+}
+
+/// In-flight [`ReadProbe`]s keyed by path. Entries are removed when a poll
+/// consumes a completed probe; a probe whose read never returns (e.g. a FUSE
+/// request the filesystem daemon never answers) leaves its entry — and its
+/// stuck reader thread — in place for the life of the process, which is what
+/// bounds the leak to one thread per distinct stuck path.
+static READ_PROBES: OnceLock<Mutex<HashMap<String, Arc<ReadProbe>>>> = OnceLock::new();
+
+/// Poll a coalesced background read of `path` (see `poll_read_to_string` for
+/// the contract). Only the call that spawns the probe blocks (up to
+/// `timeout`); later polls for the same path return its state immediately.
+fn poll_read(path: &str, timeout: Duration) -> Option<String> {
+    let registry = READ_PROBES.get_or_init(Default::default);
+    let (probe, spawned_here) = {
+        let mut reg = registry.lock().unwrap();
+        match reg.get(path) {
+            Some(probe) => (probe.clone(), false),
+            None => {
+                let probe = Arc::new(ReadProbe {
+                    state: Mutex::new(None),
+                    done: Condvar::new(),
+                });
+                reg.insert(path.to_string(), probe.clone());
+                let thread_probe = probe.clone();
+                let thread_path = path.to_string();
+                let spawned = std::thread::Builder::new()
+                    .name("fs-read-probe".to_string())
+                    .spawn(move || {
+                        let result = fs::read_to_string(&thread_path).ok();
+                        *thread_probe.state.lock().unwrap() = Some(result);
+                        thread_probe.done.notify_all();
+                    });
+                if spawned.is_err() {
+                    *probe.state.lock().unwrap() = Some(None);
+                }
+                (probe, true)
+            }
+        }
+    };
+
+    let mut state = probe.state.lock().unwrap();
+    if spawned_here && state.is_none() {
+        state = probe
+            .done
+            .wait_timeout_while(state, timeout, |s| s.is_none())
+            .unwrap()
+            .0;
+    }
+    let result = state.clone();
+    drop(state);
+    match result {
+        Some(result) => {
+            registry.lock().unwrap().remove(path);
+            result
+        }
+        None => None,
+    }
+}
 
 #[starlark_module]
 pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
@@ -571,6 +638,36 @@ pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
         Ok(heap.alloc_str(s.as_str()))
     }
 
+    /// Reads the entire contents of a file into a string without ever
+    /// blocking the caller for more than `timeout_ms`, or returns `None`
+    /// when the contents aren't available yet.
+    ///
+    /// Built for polling files on network-backed filesystems (e.g. a
+    /// bb_clientd FUSE mount materializing remote-cache blobs), where a read
+    /// can block indefinitely — a plain `read_to_string` would wedge the
+    /// task. The read runs on a background thread; the first call for a path
+    /// waits up to `timeout_ms` for it, and while that read is still in
+    /// flight, subsequent calls for the same path return `None` immediately
+    /// rather than starting another read. Whenever the read eventually
+    /// completes, the next call returns its result: the file contents, or
+    /// `None` on any I/O/UTF-8 error (including a missing file).
+    ///
+    /// Callers are expected to poll until content or a caller-side deadline:
+    /// `None` always means "not readable yet", never "empty file" (an empty
+    /// readable file returns `""`).
+    fn poll_read_to_string<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        #[starlark(require = pos)] path: values::StringValue,
+        #[starlark(require = pos)] timeout_ms: i32,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<NoneOr<values::StringValue<'v>>> {
+        let timeout = Duration::from_millis(timeout_ms.max(0) as u64);
+        Ok(match poll_read(path.as_str(), timeout) {
+            Some(content) => NoneOr::Other(heap.alloc_str(content.as_str())),
+            None => NoneOr::None,
+        })
+    }
+
     /// Reads at most `max_bytes` bytes from the start of a file into a string,
     /// or returns `""` on any I/O error (missing file, permission denied,
     /// transient failure). Like `try_read_to_string`, the silent fall-through
@@ -681,5 +778,92 @@ fn marshal_metadata<'v>(m: &fs::Metadata, heap: Heap<'v>) -> Metadata<'v> {
         accessed,
         created,
         readonly: heap.alloc(permissions.readonly()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poll_read_returns_content_for_readable_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ok.txt");
+        fs::write(&path, "hello").unwrap();
+        let got = poll_read(path.to_str().unwrap(), Duration::from_secs(5));
+        assert_eq!(got.as_deref(), Some("hello"));
+        // Consumed probes are removed so a later poll re-reads fresh content.
+        fs::write(&path, "world").unwrap();
+        let got = poll_read(path.to_str().unwrap(), Duration::from_secs(5));
+        assert_eq!(got.as_deref(), Some("world"));
+    }
+
+    #[test]
+    fn poll_read_distinguishes_empty_from_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let empty = dir.path().join("empty.txt");
+        fs::write(&empty, "").unwrap();
+        assert_eq!(
+            poll_read(empty.to_str().unwrap(), Duration::from_secs(5)).as_deref(),
+            Some("")
+        );
+        let missing = dir.path().join("missing.txt");
+        assert_eq!(
+            poll_read(missing.to_str().unwrap(), Duration::from_secs(5)),
+            None
+        );
+    }
+
+    /// A FIFO with no writer blocks `open()` indefinitely — the same shape as
+    /// a FUSE read the daemon never answers. The first poll must give up at
+    /// its timeout, later polls must return immediately while the probe is
+    /// still stuck, and once the "blob" arrives (a writer opens the FIFO) a
+    /// later poll must deliver the content.
+    #[cfg(unix)]
+    #[test]
+    fn poll_read_never_blocks_on_a_stuck_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stuck.fifo");
+        nix::unistd::mkfifo(&path, nix::sys::stat::Mode::from_bits(0o644).unwrap()).unwrap();
+        let p = path.to_str().unwrap();
+
+        let started = std::time::Instant::now();
+        assert_eq!(poll_read(p, Duration::from_millis(200)), None);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "first poll must return at its timeout"
+        );
+
+        // Probe is in flight: this must not block for another timeout.
+        let started = std::time::Instant::now();
+        assert_eq!(poll_read(p, Duration::from_secs(60)), None);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "in-flight poll must return immediately"
+        );
+
+        // The "download" lands: the stuck open() completes, EOF ends the read.
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .and_then(|mut f| f.write_all(b"landed"))
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            match poll_read(p, Duration::from_millis(100)) {
+                Some(content) => {
+                    assert_eq!(content, "landed");
+                    break;
+                }
+                None => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "probe never completed after the FIFO writer arrived"
+                    );
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
When the lint task reads BES-announced lint outputs (`.out`/`.report`/`.patch`/`.exit_code`) through the bb_clientd FUSE mount, the read blocks in uninterruptible D-state until the blob materializes — indefinitely for a blob that never will.

**Bounded reads**

- New `fs.poll_read_to_string(path, timeout_ms)` builtin: the read runs on a background thread; the first call for a path waits up to `timeout_ms`, and while that read is in flight, later calls return `None` immediately instead of spawning another (coalescing bounds the leak to one abandoned thread per distinct stuck path). `None` always means "not readable yet", never "empty" — a readable empty file returns `""`.
- `_read_lint_file` probes bb_clientd paths with it; plain local paths keep a direct read.
- Each drain/event pass caps its total blocking time at 1s (`_PASS_READ_BUDGET_MS`); past the budget, probes poll nonblocking and results are harvested on later passes — hundreds of stuck files can't stall a single pass.
- Stalls are never silent: a file still unreadable 30s after its build event gets a one-time warning naming its path, and the existing 30s post-build budget warns and skips whatever never lands.

**Runner-aware resolution** (consolidates three duplicated `file_uri_to_path` copies — lint, bazel_results, circleci — into one implementation in `bazel_results.axl`)

- New `bb_clientd_root(ctx)`: `ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD=1` → `None`; else the runner-exported `ASPECT_WORKFLOWS_RUNNER_BB_CLIENTD_MOUNT`; else the legacy hard-coded root for older runners. Mount liveness is verified via `/proc/self/mounts` — procfs cannot block, whereas stat()ing the mount root would be served by the possibly-wedged daemon itself.
- Without a usable mount (non-Aspect runners, future runners without bb_clientd), bytestream URIs fall back to the file's output-tree path (`path_prefix/name`): the lint build passes `--remote_download_regex` for lint outputs, so Bazel downloads them locally even under minimal downloads — lint now works on any runner with a remote cache, where those results were previously dropped after a 30s stall. Files with no resolvable path at all are skipped with one notice.

Residuals, noted for follow-up: the GitHub/GitLab comment hooks re-read `.patch` files with a plain read (only reachable after the bounded gate proved the blob local moments earlier); `process_event`'s internal test-log path derivations keep the default root (no `ctx` in scope); fetching foreign-host bytestream URIs via a ByteStream RPC when no local copy exists.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (new builtin is documented in its docstring; docgen picks it up)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- fix: lint tasks no longer hang indefinitely when a lint output blob can't be fetched from the remote cache; unreadable files are warned about while the task runs and skipped after the post-build download budget
- fix: lint results now surface on runners without bb_clientd (e.g. non-Aspect CI with a remote cache) by reading the Bazel-downloaded output-tree copies
- feat: the bb_clientd mount root is resolved from the runner-exported `ASPECT_WORKFLOWS_RUNNER_BB_CLIENTD_MOUNT` / `ASPECT_WORKFLOWS_RUNNER_NO_BB_CLIENTD` platform env instead of being hard-coded
- feat: new `fs.poll_read_to_string(path, timeout_ms)` AXL builtin for bounded, poll-based reads of files on network-backed filesystems

### Test plan

- New test cases added: `poll_read` unit tests cover readable files (fresh content on re-poll), empty-vs-unreadable disambiguation, and a stuck read simulated with a writer-less FIFO (first poll returns at its timeout, in-flight polls return immediately, content is delivered once the "blob" lands); axl suite cases cover `file_uri_to_path` (4/5-part forms, explicit `bb_root`, `bb_root = None`) and `bb_clientd_root` env precedence (default / mount env / `NO_BB_CLIENTD` marker)
- Covered by existing test cases (lint results processing, post-build drain budget; full suites: 896 axl + 55 crate tests)
