### PR TITLE
feat(config): load user-global ~/.aspect/config.axl last

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "axl-runtime",
  "chrono",
  "clap",
+ "dirs",
  "include_dir",
  "names",
  "opentelemetry",

--- a/crates/aspect-cli/Cargo.toml
+++ b/crates/aspect-cli/Cargo.toml
@@ -40,6 +40,7 @@ tracing-opentelemetry = { git = "https://github.com/thesayyn/tracing-opentelemet
 tracing-subscriber = "0.3.20"
 serde_json = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+dirs = "6.0.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aspect-cli/src/helpers.rs
+++ b/crates/aspect-cli/src/helpers.rs
@@ -94,6 +94,20 @@ async fn find_ancestor_with_any(start: &Path, markers: &[&str]) -> Option<PathBu
     None
 }
 
+/// User-global config file: `<home_dir>/.aspect/config.axl`, if it exists.
+///
+/// Callers append this after all project config.axl files so per-user
+/// overrides are applied last among configs (explicit CLI flags still win
+/// over any config value).
+#[instrument]
+pub async fn find_user_config(home_dir: Option<&Path>) -> Option<PathBuf> {
+    let path = home_dir?.join(DOT_ASPECT_FOLDER).join(AXL_CONFIG_EXTENSION);
+    match fs::metadata(&path).await {
+        Ok(meta) if meta.is_file() => Some(path),
+        _ => None,
+    }
+}
+
 /// Returns a list of axl search paths by constructing paths from the
 /// `aspect_root_dir` up to `current_work_dir`, appending `.aspect` to each.
 /// If the relative path from `aspect_root_dir` to `current_work_dir` includes
@@ -279,6 +293,31 @@ mod tests {
         tokio_fs::create_dir_all(&cwd).await.unwrap();
 
         assert_eq!(find_git_root(&cwd).await, None);
+    }
+
+    /// `~/.aspect/config.axl` is found when present.
+    #[tokio::test]
+    async fn user_config_found_when_present() {
+        let (_tmp, home) = setup(&[".aspect/config.axl"]).await;
+
+        assert_eq!(
+            find_user_config(Some(&home)).await,
+            Some(home.join(".aspect/config.axl"))
+        );
+    }
+
+    /// Missing file, missing home dir, and a `config.axl` directory all
+    /// resolve to no user config.
+    #[tokio::test]
+    async fn user_config_absent_cases() {
+        let (_tmp, home) = setup(&[]).await;
+        assert_eq!(find_user_config(Some(&home)).await, None);
+        assert_eq!(find_user_config(None).await, None);
+
+        tokio_fs::create_dir_all(home.join(".aspect/config.axl"))
+            .await
+            .unwrap();
+        assert_eq!(find_user_config(Some(&home)).await, None);
     }
 
     /// When aspect and git roots diverge (e.g. git repo contains a

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -5,6 +5,7 @@ mod helpers;
 mod trace;
 mod trace_buffer;
 
+use std::path::Path;
 use std::process::ExitCode;
 use std::time::Duration;
 
@@ -103,15 +104,21 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
     }
 
     let search_paths = get_default_axl_search_paths(&current_work_dir, &aspect_root);
-    let (scripts, mut configs) = search_sources(&search_paths).await?;
+    let (scripts, configs) = search_sources(&search_paths).await?;
 
-    // User-global overrides run last among configs (the aspect root may be
-    // the home dir itself, in which case it's already in the list).
-    if let Some(user_config) = find_user_config(dirs::home_dir().as_deref()).await {
-        if !configs.contains(&user_config) {
-            configs.push(user_config);
-        }
-    }
+    // User-global overrides run last among configs, scoped to their own
+    // module so loads resolve within ~/.aspect. Skipped when the aspect
+    // root is the home dir itself — the file is already in `configs`.
+    let user_config = find_user_config(dirs::home_dir().as_deref())
+        .await
+        .filter(|path| !configs.contains(path))
+        .map(|path| {
+            let dir = path
+                .parent()
+                .expect("config path has a parent")
+                .to_path_buf();
+            (path, Mod::user_config_scope(dir))
+        });
 
     // `_root` is entered on this thread; spawn_blocking moves work to a
     // different thread where the span stack is empty. Capture the span and
@@ -136,7 +143,16 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                 .map_err(anyhow::Error::from)?;
 
             // Phase 2: run config files.
-            mpe.execute_configs(&configs, &root_mod)
+            let config_entries: Vec<(&Path, &Mod)> = configs
+                .iter()
+                .map(|path| (path.as_path(), &root_mod))
+                .chain(
+                    user_config
+                        .iter()
+                        .map(|(path, r#mod)| (path.as_path(), r#mod)),
+                )
+                .collect();
+            mpe.execute_configs(&config_entries)
                 .map_err(anyhow::Error::from)?;
 
             // Build the CLI surface from current eval state.

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -20,7 +20,8 @@ use tracing::info_span;
 
 use crate::cmd::Cmd;
 use crate::helpers::{
-    find_aspect_root, find_bazel_root, find_git_root, get_default_axl_search_paths, search_sources,
+    find_aspect_root, find_bazel_root, find_git_root, find_user_config,
+    get_default_axl_search_paths, search_sources,
 };
 
 // Must use a multi thread runtime with at least 3 threads for following reasons;
@@ -102,7 +103,15 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
     }
 
     let search_paths = get_default_axl_search_paths(&current_work_dir, &aspect_root);
-    let (scripts, configs) = search_sources(&search_paths).await?;
+    let (scripts, mut configs) = search_sources(&search_paths).await?;
+
+    // User-global overrides run last among configs (the aspect root may be
+    // the home dir itself, in which case it's already in the list).
+    if let Some(user_config) = find_user_config(dirs::home_dir().as_deref()).await {
+        if !configs.contains(&user_config) {
+            configs.push(user_config);
+        }
+    }
 
     // `_root` is entered on this thread; spawn_blocking moves work to a
     // different thread where the span stack is empty. Capture the span and

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -335,11 +335,13 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
     /// discovered in Phase 1 are reused, so subsequent phases see the updated state.
     /// `ctx.tasks.add(...)` may insert additional tasks into `self.tasks`.
     ///
-    /// `configs` are absolute paths evaluated in order, so a later file's writes
-    /// win over an earlier one's. Paths need not live under `mode.root` — the
-    /// user-global `~/.aspect/config.axl` is passed here as the final entry.
+    /// Each config is an absolute path paired with the module scope its `load()`
+    /// statements resolve against. Files are evaluated in order, so a later
+    /// file's writes win over an earlier one's — the user-global
+    /// `~/.aspect/config.axl` is passed last, scoped to its own module so its
+    /// relative loads resolve within `~/.aspect` rather than the project.
     #[tracing::instrument(name = "execute.configs", skip_all)]
-    pub fn execute_configs(&mut self, configs: &[PathBuf], mode: &'l Mod) -> Result<(), EvalError> {
+    pub fn execute_configs(&mut self, configs: &[(&Path, &'l Mod)]) -> Result<(), EvalError> {
         let heap = self.heap();
 
         // Register trait types from all tasks into a TraitMap; instances are created lazily
@@ -369,8 +371,8 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
             self.telemetry_value,
         ));
 
-        for config_path in configs {
-            let frozen = self.eval_file(mode, config_path)?;
+        for (config_path, scope) in configs {
+            let frozen = self.eval_file(scope, config_path)?;
 
             let function_name = "config";
             let def = frozen
@@ -1008,10 +1010,14 @@ fn display_width(s: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{
-        TimingMode, display_width, format_duration, render_phase_breakdown, render_timing_segment,
-        task_label_for,
+        ModuleEnv, MultiPhaseEval, TimingMode, display_width, format_duration,
+        render_phase_breakdown, render_timing_segment, task_label_for,
     };
+    use crate::engine::arguments::Arguments;
     use crate::engine::task_info::PhaseRecord;
+    use crate::eval::Loader;
+    use crate::module::Mod;
+    use starlark::values::ValueLike;
     use std::time::Duration;
 
     #[test]
@@ -1178,6 +1184,100 @@ mod tests {
             desc_cols[0], desc_cols[1],
             "description columns misaligned: {out:?}"
         );
+    }
+
+    /// A user-global config outside the project evaluates under its own
+    /// module scope: its relative `load()` resolves within the user config
+    /// dir, and because it runs last, its writes win over the project config.
+    #[test]
+    fn user_scoped_config_loads_locally_and_wins_over_project_config() {
+        let proj = tempfile::tempdir().unwrap();
+        let user_dir = tempfile::tempdir().unwrap();
+
+        let script = proj.path().join("hello.axl");
+        std::fs::write(
+            &script,
+            r#"
+def _impl(ctx):
+    pass
+
+hello = task(
+    implementation = _impl,
+    args = {"greeting": args.string(default = "default")},
+)
+"#,
+        )
+        .unwrap();
+        let proj_config = proj.path().join("config.axl");
+        std::fs::write(
+            &proj_config,
+            r#"
+def config(ctx):
+    ctx.tasks["hello"].args.greeting = "project"
+"#,
+        )
+        .unwrap();
+
+        let user_config = user_dir.path().join("config.axl");
+        std::fs::write(
+            user_dir.path().join("greeting.axl"),
+            r#"USER_GREETING = "user""#,
+        )
+        .unwrap();
+        std::fs::write(
+            &user_config,
+            r#"
+load("./greeting.axl", "USER_GREETING")
+
+def config(ctx):
+    ctx.tasks["hello"].args.greeting = USER_GREETING
+"#,
+        )
+        .unwrap();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _g = rt.enter();
+
+        let modules: Vec<Mod> = vec![];
+        let root_mod = Mod::new(
+            proj.path().to_path_buf(),
+            "_root".to_string(),
+            proj.path().to_path_buf(),
+        );
+        let user_mod = Mod::user_config_scope(user_dir.path().to_path_buf());
+
+        ModuleEnv::with(|env| -> anyhow::Result<()> {
+            let loader = Loader::new(
+                "test".to_string(),
+                proj.path().to_path_buf(),
+                proj.path().to_path_buf(),
+                None,
+                &modules,
+            );
+            let mut mpe = MultiPhaseEval::new(env, &loader);
+            mpe.eval(&[script], &root_mod, &modules).unwrap();
+            mpe.execute_configs(&[
+                (proj_config.as_path(), &root_mod),
+                (user_config.as_path(), &user_mod),
+            ])
+            .unwrap();
+
+            let tasks = mpe.tasks();
+            assert_eq!(tasks.len(), 1);
+            let overrides = tasks[0]
+                .overrides()
+                .downcast_ref::<Arguments>()
+                .expect("overrides is an Arguments");
+            assert_eq!(
+                overrides
+                    .get("greeting")
+                    .expect("greeting override set")
+                    .to_repr(),
+                r#""user""#
+            );
+            Ok(())
+        })
+        .unwrap();
     }
 }
 

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -334,6 +334,10 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
     /// and `Feature` values in-place via `set_attr` — the same `Value<'v>` objects
     /// discovered in Phase 1 are reused, so subsequent phases see the updated state.
     /// `ctx.tasks.add(...)` may insert additional tasks into `self.tasks`.
+    ///
+    /// `configs` are absolute paths evaluated in order, so a later file's writes
+    /// win over an earlier one's. Paths need not live under `mode.root` — the
+    /// user-global `~/.aspect/config.axl` is passed here as the final entry.
     #[tracing::instrument(name = "execute.configs", skip_all)]
     pub fn execute_configs(&mut self, configs: &[PathBuf], mode: &'l Mod) -> Result<(), EvalError> {
         let heap = self.heap();
@@ -366,13 +370,7 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         ));
 
         for config_path in configs {
-            let rel_path = config_path
-                .strip_prefix(&mode.root)
-                .map_err(|e| EvalError::UnknownError(anyhow!("Failed to strip prefix: {e}")))?
-                .to_path_buf();
-
-            let abs = mode.root.join(&rel_path);
-            let frozen = self.eval_file(mode, &abs)?;
+            let frozen = self.eval_file(mode, config_path)?;
 
             let function_name = "config";
             let def = frozen

--- a/crates/axl-runtime/src/module/eval.rs
+++ b/crates/axl-runtime/src/module/eval.rs
@@ -192,6 +192,8 @@ pub const AXL_MODULE_FILE: &str = "MODULE.aspect";
 
 pub const AXL_ROOT_MODULE_NAME: &str = "root";
 
+pub const AXL_USER_MODULE_NAME: &str = "user";
+
 pub const AXL_SCRIPT_EXTENSION: &str = "axl";
 
 pub const AXL_CONFIG_EXTENSION: &str = "config.axl";

--- a/crates/axl-runtime/src/module/mod.rs
+++ b/crates/axl-runtime/src/module/mod.rs
@@ -5,6 +5,6 @@ mod module;
 pub use disk_store::{DiskStore, StoreError};
 pub use eval::{
     AXL_CONFIG_EXTENSION, AXL_MODULE_FILE, AXL_ROOT_MODULE_NAME, AXL_SCRIPT_EXTENSION,
-    AXL_VERSION_EXTENSION, ModEvaluator, register_globals,
+    AXL_USER_MODULE_NAME, AXL_VERSION_EXTENSION, ModEvaluator, register_globals,
 };
 pub use module::{AxlArchiveDep, AxlLocalDep, Dep, Mod};

--- a/crates/axl-runtime/src/module/module.rs
+++ b/crates/axl-runtime/src/module/module.rs
@@ -14,7 +14,7 @@ use starlark::values::ProvidesStaticType;
 use starlark::values::StarlarkValue;
 use starlark::values::starlark_value;
 
-use crate::module::AXL_ROOT_MODULE_NAME;
+use crate::module::{AXL_ROOT_MODULE_NAME, AXL_USER_MODULE_NAME};
 
 #[derive(Debug, ProvidesStaticType, Default)]
 pub struct Mod {
@@ -40,6 +40,14 @@ impl Mod {
 
     pub fn is_root(&self) -> bool {
         self.name == AXL_ROOT_MODULE_NAME
+    }
+
+    /// Module scope for the user-global config area (`~/.aspect`). Loads in
+    /// the user `config.axl` — relative (`./x.axl`) or module-rooted
+    /// (`x.axl`) — resolve within `dir` and are confined to it, independent
+    /// of any project module.
+    pub fn user_config_scope(dir: PathBuf) -> Self {
+        Self::new(dir.clone(), AXL_USER_MODULE_NAME.to_string(), dir)
     }
 
     pub fn from_eval<'v, 'a, 'e>(eval: &'e mut Evaluator<'v, 'a, '_>) -> Result<&'e mut Mod> {

--- a/docs/design.md
+++ b/docs/design.md
@@ -127,7 +127,7 @@ def config(ctx: ConfigContext):
     cfg.some_field = "value"
 ```
 
-Config files are evaluated in order: the project root's `.aspect/config.axl` first, then any nested `.aspect/config.axl` files down toward the invocation directory, and finally the user-global `~/.aspect/config.axl` if it exists — so per-user overrides win over repo defaults. An explicit CLI flag always beats any config value.
+Config files are evaluated in order: the project root's `.aspect/config.axl` first, then any nested `.aspect/config.axl` files down toward the invocation directory, and finally the user-global `~/.aspect/config.axl` if it exists — so per-user overrides win over repo defaults. An explicit CLI flag always beats any config value. The user-global config evaluates in its own module scope: its `load()` statements resolve within `~/.aspect` (and are confined to it), independent of the project.
 
 ### Feature Files
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -127,6 +127,8 @@ def config(ctx: ConfigContext):
     cfg.some_field = "value"
 ```
 
+Config files are evaluated in order: the project root's `.aspect/config.axl` first, then any nested `.aspect/config.axl` files down toward the invocation directory, and finally the user-global `~/.aspect/config.axl` if it exists — so per-user overrides win over repo defaults. An explicit CLI flag always beats any config value.
+
 ### Feature Files
 
 Features are composable behavior injectors. They run after all config files have been evaluated and inject closures into fragment hook lists. They also contribute CLI flags to every task subcommand.


### PR DESCRIPTION
Config discovery previously only walked `.aspect/` directories from the Aspect project root down to the invocation directory, so there was no per-user config layer. This appends `~/.aspect/config.axl` (when it exists) as the final config file: user overrides win over repo configs, and explicit CLI flags still take precedence over any config value. When the project root *is* the home directory, the file is deduped rather than evaluated twice.

The user config evaluates in its own module scope rooted at `~/.aspect`, so its `load()` statements — relative (`./x.axl`) or module-rooted (`x.axl`) — resolve within `~/.aspect` and are confined to it, independent of the project. To support per-file scopes, `execute_configs` now takes `(path, module scope)` pairs instead of one shared module root.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- A user-global `~/.aspect/config.axl` is now loaded after all project `config.axl` files, letting per-user overrides win over repo defaults (CLI flags still take precedence). Its `load()` statements resolve within `~/.aspect`.

### Test plan

- New test cases added:
  - `find_user_config` found/absent/not-a-file cases
  - `execute_configs` integration test: a user-scoped config outside the project resolves its relative `load()` locally and its writes win over the project config
- Manual testing; please provide instructions so we can reproduce:
  1. Create a project with `.aspect/hello.axl` defining a task with `args.string(default = "project-default")` and a project `.aspect/config.axl` setting it to `"project-config"`.
  2. With `$HOME/.aspect/config.axl` setting it to `"user-config"` (directly, or via `load("./helpers.axl", ...)`), running the task prints `user-config`.
  3. Passing the flag explicitly prints the flag value; with no user config (or `HOME` equal to the project root) it prints `project-config`; a user config that `load()`s outside `~/.aspect` fails with a confinement error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
