### PR TITLE
feat(delivery): local-hash fallback for targets not in the remote cache

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -16,6 +16,7 @@ load("@aspect//private/lib/bazelrc_test.axl", "bazelrc_tests")
 load("@aspect//private/lib/bes_sinks_test.axl", "bes_sinks_tests")
 load("@aspect//private/lib/ci_test.axl", "ci_tests")
 load("@aspect//private/lib/circleci_test.axl", "circleci_tests")
+load("@aspect//private/lib/delivery_digests_test.axl", "delivery_digests_unit_tests")
 load("@aspect//private/lib/delivery_results_test.axl", "delivery_results_unit_tests", "delivery_template_snapshot_tests")
 load("@aspect//private/lib/deployment_flags_test.axl", "deployment_flags_tests")
 load("@aspect//private/lib/format_results_test.axl", "format_template_snapshot_tests")
@@ -388,6 +389,10 @@ def config(ctx: ConfigContext):
     # Delivery results unit: init_data/add_result/build_manifest schema shape.
     # Run with: aspect dev test-delivery-results
     ctx.tasks.add(delivery_results_unit_tests)
+
+    # Delivery digests unit: --local-hash-fallback eligibility + digest merge.
+    # Run with: aspect dev test-delivery-digests
+    ctx.tasks.add(delivery_digests_unit_tests)
 
     # format_results template snapshots.
     # Run with: aspect dev test-format-template-snapshots

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,9 +128,10 @@ delivery-task:
     ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS: $FORCE_TARGETS
   script:
     - .aspect/bootstrap.sh
-    # --warn-unresolved-digest: the deliverable set includes py_deliverable, a
-    # stamped py_binary whose PyWriteBuildData action is uncacheable and never
-    # resolves a digest — a known, tolerated missing digest, so keep it a warning
-    # rather than the (new) default hard failure.
-    - ASPECT_DEBUG=1 aspect delivery --task:name delivery-gl-debug --warn-unresolved-digest
-    - aspect delivery --task:name delivery-gl --warn-unresolved-digest
+    # --local-hash-fallback: the deliverable set includes no_remote_exec_deliverable,
+    # a deterministic target tagged no-remote-exec that is not in the remote cache;
+    # the flag hashes it locally so it delivers (first run) and SKIPs on the second
+    # invocation, exercising change-detection continuity end-to-end.
+    # --warn-unresolved-digest: still covers py_deliverable's volatile stamped action.
+    - ASPECT_DEBUG=1 aspect delivery --task:name delivery-gl-debug --local-hash-fallback --warn-unresolved-digest
+    - aspect delivery --task:name delivery-gl --local-hash-fallback --warn-unresolved-digest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -130,8 +130,12 @@ delivery-task:
     - .aspect/bootstrap.sh
     # --local-hash-fallback: the deliverable set includes no_remote_exec_deliverable,
     # a deterministic target tagged no-remote-exec that is not in the remote cache;
-    # the flag hashes it locally so it delivers (first run) and SKIPs on the second
-    # invocation, exercising change-detection continuity end-to-end.
+    # the flag hashes it locally so it delivers. The first delivery-gl run delivers
+    # it via the local hash; the repeated delivery-gl run (same commit, same
+    # --task:name, so it hits the recorded state) must SKIP it, proving digest
+    # stability + change-detection continuity end-to-end. delivery-gl-debug is the
+    # ASPECT_DEBUG variant under its own state prefix.
     # --warn-unresolved-digest: still covers py_deliverable's volatile stamped action.
     - ASPECT_DEBUG=1 aspect delivery --task:name delivery-gl-debug --local-hash-fallback --warn-unresolved-digest
+    - aspect delivery --task:name delivery-gl --local-hash-fallback --warn-unresolved-digest
     - aspect delivery --task:name delivery-gl --local-hash-fallback --warn-unresolved-digest

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -158,6 +158,7 @@ load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTE
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
 load("./private/lib/ci.axl", "resolve_build_url")
+load("./private/lib/delivery_digests.axl", "eligible_for_local_hash", "extract_delivery_hash_digests", "merge_local_digests", "volatile_deliverable_labels")
 load("./private/lib/delivery_results.axl", delivery_add_result = "add_result", delivery_build_manifest = "build_manifest", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
 load(
     "./private/lib/deliveryd.axl",
@@ -458,11 +459,13 @@ def _surface_phase_stderr(ctx, phase, log_path):
 
 def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, user_remote_executor_uri, ansi, data):
     """Run phase 1 (build) + phase 2 (digest extraction); return
-    `(output_shas, non_hermetic_misses, uncacheable_actions, exit_code)`.
+    `(output_shas, non_hermetic_misses, uncacheable_actions, volatile_deliverables, exit_code)`.
     Phase-1 BES events drive `data`; phase-2's gRPC log yields the per-target
     digests for change detection, and phase-2 BES yields `uncacheable_actions` —
     the non-DeliveryHash actions Bazel could not read from cache (the "nasty"
-    targets that block hashing).
+    targets that block hashing). `volatile_deliverables` is the set of apparent
+    labels with a non-cacheable (stamped/non-hermetic) phase-1 action, derived
+    from the phase-1 execution log — ineligible for the local-hash fallback.
 
     Phase 2 is expected to exit non-zero on first delivery, so its stderr is
     captured and echoed/uploaded only when rows can't explain it (see
@@ -609,7 +612,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
         archive_bazel_attempt(data, attempt + 1, status.code)
 
     if status.code != 0:
-        return {}, {}, [], status.code
+        return {}, {}, [], {}, status.code
     info(ctx.std, "Build took {}.".format(fmt_elapsed(time.monotonic() - _t_phase1)))
 
     # Phase 2. Parse the gRPC log regardless of exit code — non-zero usually
@@ -735,7 +738,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
     if not ctx.std.fs.exists(log_path):
         error(ctx.std, "Phase-2 produced no gRPC log; could not checksum delivery digests. Phase-2 raw log: {}".format(phase2_log_path))
         _surface_phase_stderr(ctx, 2, phase2_log_path)
-        return {}, {}, uncacheable_actions, (phase2_status.code if phase2_status.code != 0 else 1)
+        return {}, {}, uncacheable_actions, {}, (phase2_status.code if phase2_status.code != 0 else 1)
 
     log_file = ctx.std.fs.open(log_path)
     getactionresult_count = 0
@@ -772,6 +775,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
     # — real key-drift symptoms (transient/non-hermetic). Caller surfaces them
     # inline on the failed row.
     non_hermetic_misses = {}
+    volatile_deliverables = {}
     if misses_by_producer:
         action_meta = {}
         execlog_file = ctx.std.fs.open(phase1_execlog_path)
@@ -795,6 +799,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
                 if meta and not meta["remote_cacheable"]:
                     continue
                 non_hermetic_misses.setdefault(producer, []).append(m)
+        volatile_deliverables = volatile_deliverable_labels(action_meta)
     ctx.std.fs.remove_file(phase1_execlog_path)
 
     # Gate on `non_hermetic_misses` (post opt-out filter), not raw
@@ -827,7 +832,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
                           " \"Action must be cached ... but it is not\" lines are expected, and are shown" +
                           " only because a digest could not be resolved for an unexpected reason.")
 
-    return output_shas, non_hermetic_misses, uncacheable_actions, 0
+    return output_shas, non_hermetic_misses, uncacheable_actions, volatile_deliverables, 0
 
 def _pick_status(data, had_failure, terminal):
     """Delivery lifecycle status from accumulated data: aborted → "aborted";
@@ -1276,7 +1281,7 @@ def _delivery_impl(ctx):
     # Phase 1/2 — skipped only in --mode=always + --track-state=false.
     if phase_1_2_runs:
         _t_build = time.monotonic()
-        output_shas, non_hermetic_misses, uncacheable_actions, build_code = _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, user_remote_executor_uri or "", ansi, data)
+        output_shas, non_hermetic_misses, uncacheable_actions, volatile_deliverables, build_code = _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, user_remote_executor_uri or "", ansi, data)
         info(ctx.std, "Build+checksum total: {}.".format(fmt_elapsed(time.monotonic() - _t_build)))
 
         for handler in bazel_trait.build_end:
@@ -1299,6 +1304,7 @@ def _delivery_impl(ctx):
         output_shas = {}
         non_hermetic_misses = {}
         uncacheable_actions = []
+        volatile_deliverables = {}
 
     # The nasty targets: uncacheable actions that blocked hashing. If every
     # target still got a digest, they didn't actually matter — say nothing.

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -349,6 +349,8 @@ _GRPC_LOG_PATH = "/tmp/aspect-delivery-grpc-{}.bin"
 _PHASE2_LOG_PATH = "/tmp/aspect-delivery-phase2-{}.log"
 _PHASE3_LOG_PATH = "/tmp/aspect-delivery-phase3-{}.log"
 _EXECLOG_PATH = "/tmp/aspect-delivery-execlog-{}.bin"
+_LOCAL_HASH_EXECLOG_PATH = "/tmp/aspect-delivery-localhash-execlog-{}.bin"
+_LOCAL_HASH_LOG_PATH = "/tmp/aspect-delivery-localhash-{}.log"
 
 # Mnemonic of the per-target action our hashsum aspect registers; the gRPC
 # log uses it to find the change-detection digest entries. Any other non-OK
@@ -840,6 +842,74 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
 
     return output_shas, non_hermetic_misses, uncacheable_actions, volatile_deliverables, 0
 
+def _resolve_local_digests(ctx, rc, eligible: list, output_shas: dict, announce_version: bool, announce_command: bool) -> int:
+    """Phase 2b — the `--local-hash-fallback` pass.
+
+    Build `eligible` (unresolved-but-deterministic deliverables) with the
+    `hashsum_local` aspect, whose DeliveryHash action runs LOCALLY (no
+    `no-local`). `--nouse_action_cache` forces every DeliveryHash spawn to be
+    scheduled and logged with its stable action digest, defeating the
+    local-action-cache blind spot without changing the digest. The upstream is a
+    disk/remote cache hit when a cache is present; with no cache the eligible
+    targets are rebuilt locally.
+
+    Read each DeliveryHash spawn's action digest from the execution log and merge
+    into `output_shas`. Best-effort: a build failure (or a missing log) is
+    non-fatal — logs and returns 0, leaving targets unresolved to fall through to
+    the existing warn/fail path. Returns the count newly resolved."""
+    hashsum_local = ctx.bazel.aspect(
+        implementation = _HASHSUM_BZL,
+        symbol = "hashsum_local",
+        parameters = {"nonce": _delivery_nonce(ctx)},
+        output_groups = ["delivery_hash"],
+    )
+    execlog_path = _LOCAL_HASH_EXECLOG_PATH.format(ctx.task.name)
+    log_path = _LOCAL_HASH_LOG_PATH.format(ctx.task.name)
+
+    status = ctx.bazel.build(
+        rc = rc,
+        aspects = [hashsum_local],
+        flags = [
+            "--output_groups=+delivery_hash",
+            "--nouse_action_cache",
+            "--remote_download_outputs=minimal",
+        ],
+        execution_log = [bazel.execution_log.file(path = execlog_path)],
+        stdout = None,
+        stderr = ctx.std.fs.create(log_path),
+        announce_version = announce_version,
+        announce_command = announce_command,
+        *eligible
+    ).wait()
+
+    if status.code != 0:
+        warn(ctx.std, "--local-hash-fallback build failed (exit {}); leaving {} target(s) unresolved. Log: {}".format(status.code, len(eligible), log_path))
+        if ctx.std.fs.exists(log_path):
+            ctx.std.io.stderr.write(ctx.std.fs.read_to_string(log_path))
+        return 0
+
+    if not ctx.std.fs.exists(execlog_path):
+        warn(ctx.std, "--local-hash-fallback produced no execution log; leaving {} target(s) unresolved.".format(len(eligible)))
+        return 0
+
+    spawns = []
+    execlog_file = ctx.std.fs.open(execlog_path)
+    for entry in bazel.build.execution_log.ExecLogEntry().parse_from_delimited(execlog_file):
+        spawn = entry.type
+        if spawn == None or type(spawn) != "spawn":
+            continue
+        if not spawn.target_label or not spawn.mnemonic:
+            continue
+        spawns.append({
+            "target_label": spawn.target_label,
+            "mnemonic": spawn.mnemonic,
+            "digest_hash": spawn.digest.hash if spawn.digest else "",
+        })
+    ctx.std.fs.remove_file(execlog_path)
+
+    extracted = extract_delivery_hash_digests(spawns, _DELIVERY_HASH_MNEMONIC)
+    return merge_local_digests(output_shas, extracted, eligible)
+
 def _pick_status(data, had_failure, terminal):
     """Delivery lifecycle status from accumulated data: aborted → "aborted";
     had_failure → "failing"/"failed"; `warn` count > 0 → "warning";
@@ -1311,6 +1381,19 @@ def _delivery_impl(ctx):
         non_hermetic_misses = {}
         uncacheable_actions = []
         volatile_deliverables = {}
+
+    # Phase 2b — --local-hash-fallback. For deliverables phase 2 could not resolve
+    # from the remote cache but whose actions are deterministic (not volatile),
+    # compute the DeliveryHash action digest LOCALLY and merge it into
+    # output_shas, so they deliver and are change-tracked. Opt-in; skipped when
+    # the flag is off. Non-fatal — unresolved targets fall through below.
+    if phase_1_2_runs and ctx.args.local_hash_fallback:
+        prelim_unresolved = [t for t in targets if not output_shas.get(t)]
+        eligible = eligible_for_local_hash(prelim_unresolved, volatile_deliverables)
+        if eligible:
+            resolved = _resolve_local_digests(ctx, rc, eligible, output_shas, announce_version, announce_command)
+            if resolved > 0:
+                info(ctx.std, "Resolved {} delivery digest(s) via --local-hash-fallback (local build).".format(resolved))
 
     # The nasty targets: uncacheable actions that blocked hashing. If every
     # target still got a digest, they didn't actually matter — say nothing.

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -28,6 +28,7 @@ Three orthogonal flags shape every invocation:
   --mode={selective,always}    default `selective` — the delivery model
   --dry-run                       default off — preview, do not run targets
   --track-state={true,false}      default true — record/query delivery state
+  --local-hash-fallback           default off — locally hash uncached targets
 
 `selective` uses change detection (only candidates not yet delivered for the
 `--task:name[:--salt]` prefix); `always` skips it and treats every resolved
@@ -1823,6 +1824,10 @@ Currently \x1b[3monly\x1b[23m supported on Aspect Workflows CI runners. Support 
         "warn_unresolved_digest": args.boolean(
             default = False,
             description = "Downgrade a delivery target whose change-detection digest could not be resolved from a hard failure (exit 1) to a warning. By default such a target fails the task: an unresolvable digest means an uncacheable action (typically a non-hermetic genrule — e.g. one that shells out to `git` — or a stamped action, on the target itself or a shared upstream dependency) could not be read from the remote cache while computing digests, so change detection could not run and the target would be silently NOT delivered. The failure names the offending target(s) and how to fix them (make them deterministic/cacheable, or tag them `no-remote` / `local`). Set this flag if your repo knowingly ships such actions and prefers a warning over a red build.",
+        ),
+        "local_hash_fallback": args.boolean(
+            default = False,
+            description = "Deliver deterministic targets that are not in the remote cache (e.g. large targets tagged `no-remote-exec`) by computing their change-detection digest with a local build. By default such a target cannot be hashed (change detection reads digests from the remote cache) and is not delivered. When set, delivery runs an extra local hash pass over the unresolved-but-deterministic deliverables and reads each DeliveryHash action digest from the execution log, so they deliver and are change-tracked. Volatile targets (a stamped or otherwise non-cacheable action) are excluded — their digest is not stable — and still require --warn-unresolved-digest. Best-effort: if the local pass fails to build, those targets fall through to the usual warn/fail. Note: the local pass runs with --nouse_action_cache; with a disk or remote cache present the upstream is a cache hit, otherwise the eligible targets are rebuilt locally.",
         ),
         "upload_grpc_log": args.string(
             default = "auto",

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -319,22 +319,28 @@ def _delivery_nonce(ctx) -> str:
 # analysis with no churn. The `nonce` attr is unused by the action; a fresh
 # value per run (via `parameters`) mints a new AspectKey so the DeliveryHash
 # actions re-run their remote lookups without discarding the graph.
-_HASHSUM_BZL = """def _hashsum_impl(target, ctx):
-    files = target[DefaultInfo].files
-    runfiles = target[DefaultInfo].default_runfiles
-    hash_file = ctx.actions.declare_file(target.label.name + ".delivery_hash")
-    ctx.actions.run_shell(
-        inputs = depset([], transitive = [files, runfiles.files]),
-        outputs = [hash_file],
-        command = "echo 'Delivery by AXL' > " + hash_file.path,
-        mnemonic = "DeliveryHash",
-        progress_message = "Computing delivery hash for %{label}",
-        execution_requirements = {"no-local": "1"},
-    )
-    return [OutputGroupInfo(delivery_hash = depset([hash_file]))]
+_HASHSUM_BZL = """def _make_hashsum_impl(no_local):
+    def _hashsum_impl(target, ctx):
+        files = target[DefaultInfo].files
+        runfiles = target[DefaultInfo].default_runfiles
+        hash_file = ctx.actions.declare_file(target.label.name + ".delivery_hash")
+        ctx.actions.run_shell(
+            inputs = depset([], transitive = [files, runfiles.files]),
+            outputs = [hash_file],
+            command = "echo 'Delivery by AXL' > " + hash_file.path,
+            mnemonic = "DeliveryHash",
+            progress_message = "Computing delivery hash for %{label}",
+            execution_requirements = {"no-local": "1"} if no_local else {},
+        )
+        return [OutputGroupInfo(delivery_hash = depset([hash_file]))]
+    return _hashsum_impl
 
 hashsum = aspect(
-    implementation = _hashsum_impl,
+    implementation = _make_hashsum_impl(True),
+    attrs = {"nonce": attr.string(default = "")},
+)
+hashsum_local = aspect(
+    implementation = _make_hashsum_impl(False),
     attrs = {"nonce": attr.string(default = "")},
 )
 """

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -856,7 +856,9 @@ def _resolve_local_digests(ctx, rc, eligible: list, output_shas: dict, announce_
     Read each DeliveryHash spawn's action digest from the execution log and merge
     into `output_shas`. Best-effort: a build failure (or a missing log) is
     non-fatal — logs and returns 0, leaving targets unresolved to fall through to
-    the existing warn/fail path. Returns the count newly resolved."""
+    the existing warn/fail path. Returns the count newly resolved. Layers
+    `aspect_endpoint_auth_flags` the same as phases 1-3 so its remote-cache reads
+    authenticate on Aspect Workflows runners."""
     hashsum_local = ctx.bazel.aspect(
         implementation = _HASHSUM_BZL,
         symbol = "hashsum_local",
@@ -869,7 +871,7 @@ def _resolve_local_digests(ctx, rc, eligible: list, output_shas: dict, announce_
     status = ctx.bazel.build(
         rc = rc,
         aspects = [hashsum_local],
-        flags = [
+        flags = aspect_endpoint_auth_flags(ctx, rc, "build") + [
             "--output_groups=+delivery_hash",
             "--nouse_action_cache",
             "--remote_download_outputs=minimal",

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_digests.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_digests.axl
@@ -1,0 +1,60 @@
+"""Pure helpers for the delivery `--local-hash-fallback` path.
+
+Isolated from `delivery.axl` so the eligibility gate and execution-log digest
+extraction are unit-testable without loading the delivery task. See
+`--local-hash-fallback` in `delivery.axl` for how these are wired into phase 2b.
+"""
+
+load("./runnable.axl", "apparent_label")
+
+def volatile_deliverable_labels(action_meta: dict) -> dict:
+    """Apparent labels of targets with a non-cacheable action.
+
+    `action_meta` maps `(target_label, mnemonic)` -> `{"cacheable": bool,
+    "remote_cacheable": bool}` (read from the phase-1 execution log). A target
+    with any `cacheable == False` action is volatile (stamped / non-hermetic):
+    its digest is not stable across builds, so it must NOT be local-hashed.
+    Returns a set-like dict `{apparent_label: True}`."""
+    volatile = {}
+    for key, meta in action_meta.items():
+        target_label = key[0]
+        if not meta.get("cacheable", True):
+            volatile[apparent_label(target_label)] = True
+    return volatile
+
+def eligible_for_local_hash(unresolved_deliverables: list, volatile_labels: dict) -> list:
+    """Deliverables eligible for the local-hash fallback: unresolved AND not
+    volatile. Input order preserved. Aliases / transitioned targets self-filter
+    downstream — the local pass simply won't produce a digest for them."""
+    return [d for d in unresolved_deliverables if apparent_label(d) not in volatile_labels]
+
+def extract_delivery_hash_digests(spawns: list, mnemonic: str) -> dict:
+    """Map apparent target label -> action digest hash for each DeliveryHash
+    spawn in a decoded execution log. `spawns` is a list of dicts
+    `{"target_label": str, "mnemonic": str, "digest_hash": str}` (the fields the
+    caller pulls off `ExecLogEntry.Spawn`). Keeps only entries whose mnemonic
+    matches `mnemonic` and carry a non-empty digest hash."""
+    out = {}
+    for s in spawns:
+        if s.get("mnemonic") != mnemonic:
+            continue
+        h = s.get("digest_hash") or ""
+        if not h:
+            continue
+        out[apparent_label(s["target_label"])] = h
+    return out
+
+def merge_local_digests(output_shas: dict, extracted: dict, eligible: list) -> int:
+    """Fill `output_shas` for each eligible target the local pass hashed.
+    `output_shas` is keyed by the ORIGINAL target label; `extracted` is keyed by
+    apparent label. Mutates `output_shas` in place; never overwrites an existing
+    (phase-2) entry. Returns the count newly resolved."""
+    count = 0
+    for label in eligible:
+        if label in output_shas:
+            continue
+        h = extracted.get(apparent_label(label))
+        if h:
+            output_shas[label] = h
+            count += 1
+    return count

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_digests_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_digests_test.axl
@@ -1,0 +1,57 @@
+"""Tests for `lib/delivery_digests.axl` — the --local-hash-fallback pure logic.
+
+Run with: aspect dev test-delivery-digests
+"""
+
+load("./delivery_digests.axl", "eligible_for_local_hash", "extract_delivery_hash_digests", "merge_local_digests", "volatile_deliverable_labels")
+
+def _check_volatile_detects_cacheable_false():
+    action_meta = {
+        ("//ml:torch", "Genrule"): {"cacheable": True, "remote_cacheable": True},
+        ("//app:py", "PyWriteBuildData"): {"cacheable": False, "remote_cacheable": True},
+    }
+    v = volatile_deliverable_labels(action_meta)
+    if "//app:py" not in v or "//ml:torch" in v:
+        fail("expected only //app:py volatile, got {}".format(v))
+
+def _check_eligible_excludes_volatile():
+    got = eligible_for_local_hash(["//ml:torch", "//app:py"], {"//app:py": True})
+    if got != ["//ml:torch"]:
+        fail("expected [//ml:torch], got {}".format(got))
+
+def _check_extract_filters_by_mnemonic_and_empty():
+    spawns = [
+        {"target_label": "//ml:torch", "mnemonic": "DeliveryHash", "digest_hash": "aaa"},
+        {"target_label": "//ml:torch", "mnemonic": "Genrule", "digest_hash": "zzz"},
+        {"target_label": "//ml:other", "mnemonic": "DeliveryHash", "digest_hash": ""},
+    ]
+    got = extract_delivery_hash_digests(spawns, "DeliveryHash")
+    if got != {"//ml:torch": "aaa"}:
+        fail("expected {//ml:torch: aaa}, got {}".format(got))
+
+def _check_merge_fills_only_eligible_and_missing():
+    output_shas = {"//already:done": "kept"}
+    extracted = {"//ml:torch": "aaa", "//not:eligible": "bbb"}
+    n = merge_local_digests(output_shas, extracted, ["//ml:torch", "//already:done"])
+    if n != 1 or output_shas.get("//ml:torch") != "aaa" or output_shas.get("//already:done") != "kept":
+        fail("bad merge: n={} shas={}".format(n, output_shas))
+
+_UNIT_TESTS = [
+    _check_volatile_detects_cacheable_false,
+    _check_eligible_excludes_volatile,
+    _check_extract_filters_by_mnemonic_and_empty,
+    _check_merge_fills_only_eligible_and_missing,
+]
+
+def _unit_test_impl(ctx: TaskContext) -> int:
+    for t in _UNIT_TESTS:
+        t()
+    print("delivery_digests.axl: OK (%d tests)" % len(_UNIT_TESTS))
+    return 0
+
+delivery_digests_unit_tests = task(
+    kind = "test-delivery-digests",
+    group = ["dev"],
+    implementation = _unit_test_impl,
+    args = {},
+)

--- a/examples/deliverable/BUILD.bazel
+++ b/examples/deliverable/BUILD.bazel
@@ -62,6 +62,17 @@ py_binary(
     tags = ["deliverable"],
 )
 
+# Deterministic target tagged no-remote-exec — the ENG-1799 fixture. Its output
+# is stable (cacheable) but it is not pushed to the remote cache, so the
+# require-cached checksum phase cannot hash it. With --local-hash-fallback it
+# delivers via a locally-computed digest; without the flag it warns/fails (the
+# in-tree contrast to py_deliverable's volatile, always-unhashable case).
+custom_deliverable(
+    name = "no_remote_exec_deliverable",
+    data = [":delivery_payload"],
+    tags = ["deliverable", "no-remote-exec"],
+)
+
 # A genrule whose build action fails, emitting realistic stdout + stderr, for
 # exercising build-log upload (upload_build_logs) during the delivery task's
 # phase-1 build. `manual` keeps it out of `//...`; to test the case live, add


### PR DESCRIPTION
Delivery's change-detection digest is read from the remote cache (`--experimental_remote_require_cached` denies any action not in the cache), so a deliverable whose actions never upload — e.g. large ML targets tagged `no-remote-exec` — can never resolve a digest and is dropped from delivery with a FAIL/WARN. `--warn-unresolved-digest` only downgrades the error; the target still doesn't deliver. [ENG-1799](https://linear.app/aspect-build/issue/ENG-1799/axl-delivery-manifest-support-targets-that-are-not-in-the-remote-cache)

This adds an opt-in `--local-hash-fallback` flag (default **off** — with the flag unset, behavior is byte-identical to today). When set, a new phase 2b runs after the remote checksum phase for deliverables that are still unresolved **and** deterministic: it rebuilds just those targets with a local-executing variant of the hashsum aspect under `--nouse_action_cache`, reads each `DeliveryHash` action digest from the execution log, and merges it into the digest set — so the targets deliver and are change-tracked like any other.

**Design notes**

- The local digest is the same REv2 action digest the remote path reads (`ExecLogEntry.Spawn.digest.hash`), and `no-local` is a strategy selector that doesn't enter the Action proto — verified empirically that the digest is identical across the aspect refactor and stable across fresh output bases. A target hashed locally in one run and read from the remote cache in another yields the same key: no spurious re-delivery.
- `--nouse_action_cache` defeats the local action-cache blind spot (an unchanged `DeliveryHash` spawn is otherwise a cache hit and absent from the execlog) without changing the digest; with a disk/remote cache present the upstream actions are cache hits, not rebuilds.
- Volatile targets (any `cacheable=false` action, e.g. a stamped `py_binary`'s `PyWriteBuildData`) are excluded from the fallback — their digest is unstable by construction — and keep today's FAIL/WARN + `--warn-unresolved-digest` behavior.
- Phase 2b is best-effort: a fallback build failure warns and falls through to the existing unresolved-digest path; it can't change exit codes on its own.
- The pure logic (eligibility gate, execlog digest extraction, merge) lives in `private/lib/delivery_digests.axl` with unit tests (`aspect dev test-delivery-digests`).

**Dogfood / e2e**

`examples/deliverable` gains `no_remote_exec_deliverable` — a deterministic target tagged `no-remote-exec` (the in-tree ENG-1799 repro, contrast to the volatile `py_deliverable` fixture). The CI `delivery-task` job now passes `--local-hash-fallback` and repeats the `delivery-gl` invocation: the first run must deliver the fixture via the local hash, the repeated run must SKIP it under the same state prefix — proving digest stability and change-detection continuity end-to-end.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no — customer docs for the delivery-manifest guide follow in a separate docs-site PR
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- New `aspect delivery --local-hash-fallback` flag (default off): deliver deterministic targets that are not in the remote cache (e.g. large targets tagged `no-remote-exec`) by computing their change-detection digest with a local build. Volatile (stamped/non-cacheable) targets are unaffected and still require `--warn-unresolved-digest`.

### Test plan

- New unit tests: `aspect dev test-delivery-digests` (eligibility gate, execlog digest extraction, merge semantics)
- Existing suites: `aspect dev test-delivery-results` (11 tests) green; `aspect delivery --help` shows the new flag
- Live e2e: the `delivery-task` CI job on this PR runs delivery three times — verify `no_remote_exec_deliverable` shows OK (delivered via local hash) on the first `delivery-gl` invocation and SKIP on the repeated one, while `py_deliverable` stays WARN
- Verified in an isolated Bazel workspace that the `DeliveryHash` action digest is stable across fresh output bases, content-sensitive, and identical between the `hashsum` and `hashsum_local` aspect variants
