### PR TITLE
fix(auth): don't inject BES/cache auth when a credential helper covers the host

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
@@ -75,6 +75,43 @@ def headers_have_auth(headers: list[str]) -> bool:
     prefix."""
     return any([h.lower().startswith("authorization=") for h in headers])
 
+def _credential_helper_scope(value: str) -> str | None:
+    """The scope of a `--credential_helper` value, or `None` for an unscoped
+    (default) helper that applies to every URI.
+
+    Bazel accepts `<path>` (default helper) or `<scope>=<path>`, split on the
+    first `=`. A `<scope>` is an exact host (`bes.example.com`) or a wildcard
+    (`*.example.com`, matching that domain and its subdomains). A bare path with
+    no `=` is the default helper, invoked for any host lacking a more specific one.
+    """
+    idx = value.find("=")
+    if idx == -1:
+        return None
+    return value[:idx]
+
+def credential_helper_covers_host(values: list[str], host: str) -> bool:
+    """Whether any `--credential_helper` in `values` would be invoked for `host`,
+    and so may itself supply an `authorization` header for it.
+
+    Mirrors Bazel's per-URI resolution: an unscoped default helper covers every
+    host, an exact-host scope covers that host, and a `*.<domain>` wildcard covers
+    `<domain>` and its subdomains. When a helper covers the endpoint's host, the
+    CLI must not also inject its own `authorization` — the stream would carry two.
+    """
+    host = host.lower()
+    for value in values:
+        scope = _credential_helper_scope(value)
+        if scope == None:
+            return True
+        scope = scope.lower()
+        if scope.startswith("*."):
+            domain = scope[2:]
+            if host == domain or host.endswith("." + domain):
+                return True
+        elif scope == host:
+            return True
+    return False
+
 def resolve_aspect_bearer(ctx, what: str, uri: str = "") -> str:
     """Best-effort resolution of the `Bearer <jwt>` Authorization value for the
     endpoint `uri`, described by `what` (e.g. "build events", "the remote cache").

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
@@ -5,7 +5,7 @@ Run with:
   aspect dev test-aspect-endpoint-auth
 """
 
-load("./aspect_endpoint_auth.axl", "endpoint_host", "headers_have_auth", "is_aspect_host", "login_hint", "needs_aspect_token")
+load("./aspect_endpoint_auth.axl", "credential_helper_covers_host", "endpoint_host", "headers_have_auth", "is_aspect_host", "login_hint", "needs_aspect_token")
 
 def _eq(label, got, want):
     if got != want:
@@ -65,6 +65,28 @@ def _test_headers_have_auth(_):
     _eq("amongst others", headers_have_auth(["x-foo=bar", "AUTHORIZATION=Bearer x"]), True)
     _eq("value mentioning auth not matched", headers_have_auth(["x-note=authorization=no"]), False)
 
+def _test_credential_helper_covers_host(_):
+    """A `--credential_helper` registered for the endpoint host means Bazel will
+    add its own `authorization`, so the CLI must treat the stream as already
+    authenticated. Mirrors Bazel's scope resolution: default helper, exact host,
+    and `*.<domain>` wildcard (domain itself + subdomains)."""
+    host = "bes.acme.aspect.build"
+
+    _eq("no helpers", credential_helper_covers_host([], host), False)
+    _eq("unscoped default helper covers all", credential_helper_covers_host(["/usr/bin/cred-helper"], host), True)
+    _eq("exact host match", credential_helper_covers_host(["bes.acme.aspect.build=/usr/bin/h"], host), True)
+    _eq("exact host case-insensitive", credential_helper_covers_host(["BES.ACME.ASPECT.BUILD=/usr/bin/h"], host), True)
+    _eq("other host no match", credential_helper_covers_host(["remote.acme.aspect.build=/usr/bin/h"], host), False)
+    _eq("wildcard subdomain match", credential_helper_covers_host(["*.acme.aspect.build=/usr/bin/h"], host), True)
+    _eq("wildcard domain itself match", credential_helper_covers_host(["*.acme.aspect.build=/h"], "acme.aspect.build"), True)
+    _eq("wildcard non-subdomain no match", credential_helper_covers_host(["*.other.aspect.build=/h"], host), False)
+    _eq("wildcard is not a substring match", credential_helper_covers_host(["*.aspect.build=/h"], "notacme.aspect.build"), True)
+    _eq(
+        "amongst others",
+        credential_helper_covers_host(["remote.acme.aspect.build=/h", "bes.acme.aspect.build=/h"], host),
+        True,
+    )
+
 def _test_login_hint(_):
     """The hint names a configured deployment with `--deployment`, but stays a
     bare login when no deployment owns the endpoint."""
@@ -77,8 +99,9 @@ def _test_impl(ctx):
     _test_is_aspect_host(ctx)
     _test_needs_aspect_token(ctx)
     _test_headers_have_auth(ctx)
+    _test_credential_helper_covers_host(ctx)
     _test_login_hint(ctx)
-    print("aspect_endpoint_auth_test.axl: OK (5 sections)")
+    print("aspect_endpoint_auth_test.axl: OK (6 sections)")
     return 0
 
 aspect_endpoint_auth_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags.axl
@@ -56,7 +56,7 @@ also checked at runtime by `assert_ctx_bazel_ready_for_health_check` (see
     bazel-spawning task.
 """
 
-load("./aspect_endpoint_auth.axl", "headers_have_auth", "needs_aspect_token", "resolve_aspect_bearer")
+load("./aspect_endpoint_auth.axl", "credential_helper_covers_host", "endpoint_host", "headers_have_auth", "needs_aspect_token", "resolve_aspect_bearer")
 load("./environment.axl", "color_enabled", "detect_ci")
 
 def _require_arg(ctx, name):
@@ -340,16 +340,26 @@ def _endpoint_auth_flags(ctx, rc, command, endpoint_flag, header_flag, what):
 
     Reads the effective `endpoint_flag` (from `--bazel-flag`, a first-class flag,
     or `.bazelrc` — all resolved through `rc`). When a configured deployment owns
-    its host (see `aspect_endpoint_auth.axl`) and the user has not already set
-    `<header_flag>=authorization=…`, returns the one auth header flag. Best-effort:
-    an owned endpoint with no usable credential warns and returns `[]`. `what`
-    describes the endpoint in that warning.
+    its host (see `aspect_endpoint_auth.axl`) and the stream will not already carry
+    an `authorization` — neither an explicit `<header_flag>=authorization=…` nor a
+    `--credential_helper` registered for the host — returns the one auth header
+    flag. Suppressing on a matching credential helper keeps Bazel from adding a
+    second `authorization` alongside the injected one, which gRPC would comma-join
+    into a token a JWT-validating proxy rejects. Best-effort: an owned endpoint
+    with no usable credential warns and returns `[]`. `what` describes the endpoint
+    in that warning.
     """
     endpoint = rc.flag_value(endpoint_flag, command = command)
     if not endpoint:
         return []
-    user_set_auth = headers_have_auth(rc.flag_values(header_flag, command = command))
-    if not needs_aspect_token(ctx, [endpoint], user_set_auth):
+    already_authenticated = (
+        headers_have_auth(rc.flag_values(header_flag, command = command)) or
+        credential_helper_covers_host(
+            rc.flag_values("--credential_helper", command = command),
+            endpoint_host(endpoint),
+        )
+    )
+    if not needs_aspect_token(ctx, [endpoint], already_authenticated):
         return []
     bearer = resolve_aspect_bearer(ctx, what, endpoint)
     if not bearer:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags.axl
@@ -352,12 +352,17 @@ def _endpoint_auth_flags(ctx, rc, command, endpoint_flag, header_flag, what):
     endpoint = rc.flag_value(endpoint_flag, command = command)
     if not endpoint:
         return []
+
+    # `--credential_helper` carries Bazel's `oldName` alias
+    # `--experimental_credential_helper`; both populate the same option, so a
+    # helper configured under either spelling makes Bazel add its own auth.
+    credential_helpers = (
+        rc.flag_values("--credential_helper", command = command) +
+        rc.flag_values("--experimental_credential_helper", command = command)
+    )
     already_authenticated = (
         headers_have_auth(rc.flag_values(header_flag, command = command)) or
-        credential_helper_covers_host(
-            rc.flag_values("--credential_helper", command = command),
-            endpoint_host(endpoint),
-        )
+        credential_helper_covers_host(credential_helpers, endpoint_host(endpoint))
     )
     if not needs_aspect_token(ctx, [endpoint], already_authenticated):
         return []

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
@@ -348,6 +348,19 @@ def _test_bes_backend_auth_flags(_):
         ),
         [],
     )
+
+    # The old `--experimental_credential_helper` spelling aliases to the same
+    # Bazel option, so it must suppress the injected auth too.
+    _eq(
+        "owned bes + experimental credential helper for host",
+        bes_backend_auth_flags(
+            ctx,
+            _fake_rc({"--bes_backend": "grpcs://" + _BES, "--experimental_credential_helper": [_BES + "=/usr/bin/helper"]}),
+            "build",
+        ),
+        [],
+    )
+
     # A credential helper for a different host does not suppress the injected auth.
     _eq(
         "owned bes + credential helper for other host still injects",

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
@@ -289,6 +289,15 @@ def _test_remote_cache_auth_flags(_):
         [],
     )
     _eq(
+        "owned cache + credential helper for host",
+        remote_cache_auth_flags(
+            ctx,
+            _fake_rc({"--remote_cache": "grpcs://" + _CACHE, "--credential_helper": ["*.acme.aspect.build=/usr/bin/helper"]}),
+            "build",
+        ),
+        [],
+    )
+    _eq(
         "owned cache + not logged in",
         remote_cache_auth_flags(
             _fake_auth_ctx(owned_hosts = [_CACHE]),
@@ -317,6 +326,37 @@ def _test_bes_backend_auth_flags(_):
             "build",
         ),
         [],
+    )
+
+    # A `--credential_helper` registered for the BES host means Bazel will add its
+    # own `authorization`, so the CLI must not inject a second one (issue #1325).
+    _eq(
+        "owned bes + credential helper for host",
+        bes_backend_auth_flags(
+            ctx,
+            _fake_rc({"--bes_backend": "grpcs://" + _BES, "--credential_helper": [_BES + "=/usr/bin/helper"]}),
+            "build",
+        ),
+        [],
+    )
+    _eq(
+        "owned bes + unscoped credential helper",
+        bes_backend_auth_flags(
+            ctx,
+            _fake_rc({"--bes_backend": "grpcs://" + _BES, "--credential_helper": ["/usr/bin/helper"]}),
+            "build",
+        ),
+        [],
+    )
+    # A credential helper for a different host does not suppress the injected auth.
+    _eq(
+        "owned bes + credential helper for other host still injects",
+        bes_backend_auth_flags(
+            ctx,
+            _fake_rc({"--bes_backend": "grpcs://" + _BES, "--credential_helper": ["remote.buildbuddy.io=/usr/bin/helper"]}),
+            "build",
+        ),
+        ["--bes_header=authorization=Bearer " + _TOK],
     )
 
 def _test_aspect_endpoint_auth_flags(_):


### PR DESCRIPTION
## Problem

Fixes #1325.

When the Aspect CLI wraps a Bazel build whose effective `--bes_backend` (or `--remote_cache`) points at a configured-deployment host, and the user hasn't supplied their own `authorization` header, the CLI injects `--bes_header=authorization=Bearer <jwt>` (`--remote_header` for the cache).

The "already authenticated" gate only inspected explicit `--bes_header`/`--remote_header=authorization` values. It did not account for a `--credential_helper` registered for that host — which makes Bazel add its **own** `authorization` to the same gRPC channel. gRPC concatenates the two duplicate metadata entries into a single comma-joined value (`Bearer …, Bearer …`), which a standard JWT-validating reverse proxy rejects:

```
UNAUTHENTICATED: Jwt is not in the form of Header.Payload.Signature with two dots and 3 sections
```

Because BEP upload retries all fail, the build task exits non-zero even though the build and remote cache/exec succeeded.

## Fix

Extend the "already authenticated" detection in `_endpoint_auth_flags` (`lib/bazel_flags.axl`) so it also treats the stream as authenticated when a `--credential_helper` covers the endpoint host — suppressing the injected header so exactly one `authorization` is on the wire.

A new `credential_helper_covers_host` in `lib/aspect_endpoint_auth.axl` mirrors Bazel's per-URI helper resolution:

- an unscoped default helper (`<path>`, no `=`) covers every host;
- an exact-host scope (`bes.example.com=<path>`) covers that host;
- a `*.<domain>=<path>` wildcard covers `<domain>` and its subdomains.

The check is applied to both the BES (`--bes_header`) and remote-cache (`--remote_header`) paths, since both flow through the same helper and Bazel's credential helpers apply to every gRPC channel.

## Tests

- `lib/aspect_endpoint_auth_test.axl`: unit coverage for `credential_helper_covers_host` (default/exact/wildcard scopes, case-insensitivity, non-matches).
- `lib/bazel_flags_test.axl`: `bes_backend_auth_flags` / `remote_cache_auth_flags` now assert that a credential helper covering the host suppresses the injected auth, while a helper scoped to a different host still injects it.

Both dev test suites pass:

```
aspect dev test-aspect-endpoint-auth   # OK (6 sections)
aspect dev test-bazel-flags            # OK (18 sections)
```

## Note on the reported second path

The issue flags an additional, non-reproducible observation of duplication with only a single injected `--bes_header` and no credential helper. That could not be attributed from the client side and isn't addressed here; this change fixes the concrete, reproducible credential-helper case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgus4JS7xDYB3rN6CUSh9c)_