### PR TITLE
feat(cli): report a backtrace on fatal signals before dying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "clap",
  "dirs",
  "include_dir",
+ "libc",
  "names",
  "opentelemetry",
  "opentelemetry-appender-tracing",

--- a/crates/aspect-cli/BUILD.bazel
+++ b/crates/aspect-cli/BUILD.bazel
@@ -23,6 +23,7 @@ rust_binary(
         "@crates//:clap",
         "@crates//:dirs",
         "@crates//:include_dir",
+        "@crates//:libc",
         "@crates//:names",
         "@crates//:opentelemetry",
         "@crates//:opentelemetry-appender-tracing",

--- a/crates/aspect-cli/Cargo.toml
+++ b/crates/aspect-cli/Cargo.toml
@@ -42,5 +42,8 @@ serde_json = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 dirs = "6.0.0"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aspect-cli/src/crash_handler.rs
+++ b/crates/aspect-cli/src/crash_handler.rs
@@ -1,0 +1,176 @@
+//! Fatal-signal crash reporter.
+//!
+//! Installs handlers for the fatal signals (SIGSEGV, SIGBUS, SIGILL, SIGFPE,
+//! SIGABRT) that print the signal name, fault address, and a best-effort
+//! backtrace to stderr, then re-deliver the signal with its default
+//! disposition so the process still dies with the original signal and CI
+//! harnesses observe the same exit status they do today.
+//!
+//! Motivation: a native crash on a CI runner otherwise surfaces as a bare
+//! `Received "segmentation fault" signal` line from the CI harness — nothing
+//! to debug from, and kernel logs / core dumps on ephemeral runners are
+//! usually gone before anyone can look. With this handler the crash report
+//! lands in the task log itself.
+//!
+//! Async-signal-safety: capturing and symbolizing a backtrace allocates,
+//! which is formally undefined inside a signal handler (the crashing thread
+//! may hold the allocator lock). This is a deliberate best-effort trade,
+//! same as rustc's own fatal-signal handler: the process is already dying,
+//! a marker naming the signal is written with raw `write(2)` *before* the
+//! allocating section so even a wedged backtrace capture identifies the
+//! signal, and a re-entrancy guard turns a fault inside the handler into an
+//! immediate default-action death. Handlers run on the alternate signal
+//! stack Rust's runtime installs per thread (`SA_ONSTACK`), so stack-overflow
+//! SIGSEGVs are reported too — the backtrace then shows the overflowing
+//! recursion in place of std's one-line overflow message.
+//!
+//! `ASPECT_NO_CRASH_HANDLER` (any non-empty value) skips installation.
+
+/// Install the fatal-signal handlers. Call first thing in `main`, before
+/// any runtime machinery, so the reporter covers everything after it.
+/// No-op on non-unix platforms and under `ASPECT_NO_CRASH_HANDLER`.
+pub fn install() {
+    #[cfg(unix)]
+    unix::install();
+}
+
+/// Test hook: crash the process immediately when `ASPECT_INTERNAL_TEST_CRASH`
+/// is set (`segv` or `abort`), so integration tests can exercise the handler
+/// end-to-end through a real spawned binary. Called from `main` right after
+/// [`install`] — deliberately outside it, so the `ASPECT_NO_CRASH_HANDLER`
+/// opt-out path is testable (handler skipped, crash still triggered).
+#[doc(hidden)]
+pub fn trigger_test_crash() {
+    #[cfg(unix)]
+    unix::trigger_test_crash();
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    const FATAL_SIGNALS: &[(libc::c_int, &str)] = &[
+        (libc::SIGSEGV, "SIGSEGV (segmentation fault)"),
+        (libc::SIGBUS, "SIGBUS (bus error)"),
+        (libc::SIGILL, "SIGILL (illegal instruction)"),
+        (libc::SIGFPE, "SIGFPE (arithmetic exception)"),
+        (libc::SIGABRT, "SIGABRT (abort)"),
+    ];
+
+    /// True once a handler is running; a second entry (fault inside the
+    /// handler, or a simultaneous crash on another thread) skips the report
+    /// and goes straight to the default action.
+    static HANDLING: AtomicBool = AtomicBool::new(false);
+
+    pub(super) fn install() {
+        if std::env::var_os("ASPECT_NO_CRASH_HANDLER").is_some_and(|v| !v.is_empty()) {
+            return;
+        }
+        let f: extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) = handler;
+        for &(sig, _) in FATAL_SIGNALS {
+            // SAFETY: standard handler registration; `sa` is fully
+            // initialized before use.
+            unsafe {
+                let mut sa: libc::sigaction = std::mem::zeroed();
+                sa.sa_sigaction = f as usize;
+                sa.sa_flags = libc::SA_SIGINFO | libc::SA_ONSTACK;
+                libc::sigemptyset(&mut sa.sa_mask);
+                libc::sigaction(sig, &sa, std::ptr::null_mut());
+            }
+        }
+    }
+
+    pub(super) fn trigger_test_crash() {
+        match std::env::var("ASPECT_INTERNAL_TEST_CRASH").as_deref() {
+            // SAFETY: intentional null-pointer write to raise SIGSEGV.
+            Ok("segv") => unsafe { std::ptr::null_mut::<u8>().write_volatile(1) },
+            Ok("abort") => std::process::abort(),
+            _ => {}
+        }
+    }
+
+    fn signal_name(sig: libc::c_int) -> &'static str {
+        FATAL_SIGNALS
+            .iter()
+            .find(|(s, _)| *s == sig)
+            .map(|(_, name)| *name)
+            .unwrap_or("unknown fatal signal")
+    }
+
+    /// Write directly to stderr with `write(2)`, ignoring errors.
+    /// Async-signal-safe.
+    fn write_stderr(bytes: &[u8]) {
+        let mut off = 0;
+        while off < bytes.len() {
+            // SAFETY: in-bounds pointer/length into `bytes` for fd 2.
+            let n = unsafe {
+                libc::write(
+                    libc::STDERR_FILENO,
+                    bytes[off..].as_ptr().cast(),
+                    bytes.len() - off,
+                )
+            };
+            if n <= 0 {
+                return;
+            }
+            off += n as usize;
+        }
+    }
+
+    fn fault_addr(info: *mut libc::siginfo_t) -> usize {
+        if info.is_null() {
+            return 0;
+        }
+        // SAFETY: the kernel passes a valid siginfo_t to SA_SIGINFO handlers.
+        #[cfg(target_os = "linux")]
+        return unsafe { (*info).si_addr() as usize };
+        #[cfg(not(target_os = "linux"))]
+        return unsafe { (*info).si_addr as usize };
+    }
+
+    /// Restore the default disposition, unblock the signal (it is blocked
+    /// while its own handler runs), and re-raise — the process dies with the
+    /// original signal, so the exit status CI harnesses see is unchanged.
+    fn reset_and_reraise(sig: libc::c_int) -> ! {
+        // SAFETY: sigaction/pthread_sigmask/raise are async-signal-safe;
+        // structs are fully initialized before use.
+        unsafe {
+            let mut sa: libc::sigaction = std::mem::zeroed();
+            sa.sa_sigaction = libc::SIG_DFL;
+            libc::sigemptyset(&mut sa.sa_mask);
+            libc::sigaction(sig, &sa, std::ptr::null_mut());
+
+            let mut set: libc::sigset_t = std::mem::zeroed();
+            libc::sigemptyset(&mut set);
+            libc::sigaddset(&mut set, sig);
+            libc::pthread_sigmask(libc::SIG_UNBLOCK, &set, std::ptr::null_mut());
+            libc::raise(sig);
+            // Unreachable unless delivery was somehow deferred; exit with
+            // the conventional 128+signal code rather than continuing.
+            libc::_exit(128 + sig);
+        }
+    }
+
+    extern "C" fn handler(sig: libc::c_int, info: *mut libc::siginfo_t, _ctx: *mut libc::c_void) {
+        if HANDLING.swap(true, Ordering::SeqCst) {
+            reset_and_reraise(sig);
+        }
+
+        write_stderr(b"\naspect-cli: fatal signal: ");
+        write_stderr(signal_name(sig).as_bytes());
+        write_stderr(b"\naspect-cli: collecting backtrace (best effort)...\n");
+
+        // Allocating from here on — see the module docstring for why that
+        // is an acceptable trade inside a crash handler.
+        let thread = std::thread::current();
+        let report = format!(
+            "fault address: {:#x}\nthread: {}\nbacktrace:\n{}\naspect-cli crashed; please report this at https://github.com/aspect-build/aspect-cli/issues including the output above.\n",
+            fault_addr(info),
+            thread.name().unwrap_or("<unnamed>"),
+            std::backtrace::Backtrace::force_capture(),
+        );
+        write_stderr(report.as_bytes());
+
+        reset_and_reraise(sig);
+    }
+}

--- a/crates/aspect-cli/src/crash_handler.rs
+++ b/crates/aspect-cli/src/crash_handler.rs
@@ -2,43 +2,41 @@
 //!
 //! Installs handlers for the fatal signals (SIGSEGV, SIGBUS, SIGILL, SIGFPE,
 //! SIGABRT) that print the signal name, fault address, and a best-effort
-//! backtrace to stderr, then re-deliver the signal with its default
-//! disposition so the process still dies with the original signal and CI
-//! harnesses observe the same exit status they do today.
+//! backtrace to stderr, then re-raise the signal with its default disposition
+//! so the process still dies with the original signal and exit statuses are
+//! unchanged.
 //!
-//! Motivation: a native crash on a CI runner otherwise surfaces as a bare
-//! `Received "segmentation fault" signal` line from the CI harness — nothing
-//! to debug from, and kernel logs / core dumps on ephemeral runners are
-//! usually gone before anyone can look. With this handler the crash report
-//! lands in the task log itself.
+//! Motivation: a native crash on a CI runner otherwise surfaces only as a bare
+//! `Received "segmentation fault" signal` line from the CI harness, with no
+//! stack to debug from — kernel logs and core dumps on ephemeral runners are
+//! usually gone before anyone can look. This lands a crash report in the task
+//! log itself.
 //!
-//! Async-signal-safety: capturing and symbolizing a backtrace allocates,
-//! which is formally undefined inside a signal handler (the crashing thread
-//! may hold the allocator lock). This is a deliberate best-effort trade,
-//! same as rustc's own fatal-signal handler: the process is already dying,
-//! a marker naming the signal is written with raw `write(2)` *before* the
-//! allocating section so even a wedged backtrace capture identifies the
-//! signal, and a re-entrancy guard turns a fault inside the handler into an
-//! immediate default-action death. Handlers run on the alternate signal
-//! stack Rust's runtime installs per thread (`SA_ONSTACK`), so stack-overflow
-//! SIGSEGVs are reported too — the backtrace then shows the overflowing
-//! recursion in place of std's one-line overflow message.
+//! Async-signal-safety: capturing and symbolizing a backtrace allocates, which
+//! is not async-signal-safe (the crashing thread may hold the allocator lock).
+//! This is a deliberate best-effort trade — the process is already dying. Two
+//! guards contain the risk: a fixed marker naming the signal is written with
+//! raw `write(2)` before the allocating section, so the signal is identified
+//! even if backtrace capture wedges; and a re-entrancy flag turns any fault
+//! inside the handler into an immediate default-action death. Handlers run on
+//! the alternate signal stack (`SA_ONSTACK`) that Rust's std installs per
+//! thread, so stack-overflow SIGSEGVs are reported rather than double-faulting.
 //!
 //! `ASPECT_NO_CRASH_HANDLER` (any non-empty value) skips installation.
 
-/// Install the fatal-signal handlers. Call first thing in `main`, before
-/// any runtime machinery, so the reporter covers everything after it.
-/// No-op on non-unix platforms and under `ASPECT_NO_CRASH_HANDLER`.
+/// Install the fatal-signal handlers. Call first thing in `main`, before any
+/// runtime machinery, so the reporter covers everything after it. No-op on
+/// non-unix platforms and under `ASPECT_NO_CRASH_HANDLER`.
 pub fn install() {
     #[cfg(unix)]
     unix::install();
 }
 
 /// Test hook: crash the process immediately when `ASPECT_INTERNAL_TEST_CRASH`
-/// is set (`segv` or `abort`), so integration tests can exercise the handler
-/// end-to-end through a real spawned binary. Called from `main` right after
-/// [`install`] — deliberately outside it, so the `ASPECT_NO_CRASH_HANDLER`
-/// opt-out path is testable (handler skipped, crash still triggered).
+/// is `segv` or `abort`, otherwise a no-op. Lets the end-to-end tests drive a
+/// real crash through a spawned binary. Kept separate from [`install`] so a
+/// test can exercise the `ASPECT_NO_CRASH_HANDLER` opt-out (handler skipped)
+/// while still triggering the crash.
 #[doc(hidden)]
 pub fn trigger_test_crash() {
     #[cfg(unix)]
@@ -49,6 +47,12 @@ pub fn trigger_test_crash() {
 mod unix {
     use std::sync::atomic::{AtomicBool, Ordering};
 
+    /// Environment variable that, when set to any non-empty value, skips
+    /// handler installation.
+    const OPT_OUT_ENV: &str = "ASPECT_NO_CRASH_HANDLER";
+
+    /// The signals we install handlers for, paired with the label printed in
+    /// the crash report.
     const FATAL_SIGNALS: &[(libc::c_int, &str)] = &[
         (libc::SIGSEGV, "SIGSEGV (segmentation fault)"),
         (libc::SIGBUS, "SIGBUS (bus error)"),
@@ -57,24 +61,34 @@ mod unix {
         (libc::SIGABRT, "SIGABRT (abort)"),
     ];
 
-    /// True once a handler is running; a second entry (fault inside the
-    /// handler, or a simultaneous crash on another thread) skips the report
-    /// and goes straight to the default action.
+    /// Set once a handler is running. A second entry — a fault inside the
+    /// handler, or a concurrent crash on another thread — skips the report and
+    /// goes straight to the default action.
     static HANDLING: AtomicBool = AtomicBool::new(false);
 
+    /// Whether the opt-out environment variable is set to a non-empty value.
+    fn opt_out() -> bool {
+        std::env::var_os(OPT_OUT_ENV).is_some_and(|v| !v.is_empty())
+    }
+
     pub(super) fn install() {
-        if std::env::var_os("ASPECT_NO_CRASH_HANDLER").is_some_and(|v| !v.is_empty()) {
+        if opt_out() {
             return;
         }
         let f: extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) = handler;
         for &(sig, _) in FATAL_SIGNALS {
-            // SAFETY: standard handler registration; `sa` is fully
-            // initialized before use.
+            // SAFETY: standard sigaction registration; `sa` is fully
+            // initialized before use. `sa_mask` blocks the other fatal signals
+            // for the duration of the handler so a sibling signal can't
+            // re-enter it (the HANDLING guard is the backstop if one does).
             unsafe {
                 let mut sa: libc::sigaction = std::mem::zeroed();
                 sa.sa_sigaction = f as usize;
                 sa.sa_flags = libc::SA_SIGINFO | libc::SA_ONSTACK;
                 libc::sigemptyset(&mut sa.sa_mask);
+                for &(other, _) in FATAL_SIGNALS {
+                    libc::sigaddset(&mut sa.sa_mask, other);
+                }
                 libc::sigaction(sig, &sa, std::ptr::null_mut());
             }
         }
@@ -82,7 +96,7 @@ mod unix {
 
     pub(super) fn trigger_test_crash() {
         match std::env::var("ASPECT_INTERNAL_TEST_CRASH").as_deref() {
-            // SAFETY: intentional null-pointer write to raise SIGSEGV.
+            // SAFETY: intentional null write to raise SIGSEGV.
             Ok("segv") => unsafe { std::ptr::null_mut::<u8>().write_volatile(1) },
             Ok("abort") => std::process::abort(),
             _ => {}
@@ -97,12 +111,22 @@ mod unix {
             .unwrap_or("unknown fatal signal")
     }
 
-    /// Write directly to stderr with `write(2)`, ignoring errors.
-    /// Async-signal-safe.
+    /// The report body written after the signal-name marker. Pure so it can be
+    /// unit-tested; the handler supplies the live fault address and thread name.
+    fn format_report(fault_addr: usize, thread_name: &str) -> String {
+        format!(
+            "fault address: {fault_addr:#x}\nthread: {thread_name}\nbacktrace:\n{}\n\
+             aspect-cli crashed; please report this at \
+             https://github.com/aspect-build/aspect-cli/issues including the output above.\n",
+            std::backtrace::Backtrace::force_capture(),
+        )
+    }
+
+    /// Write `bytes` to stderr via `write(2)`, ignoring errors. Async-signal-safe.
     fn write_stderr(bytes: &[u8]) {
         let mut off = 0;
         while off < bytes.len() {
-            // SAFETY: in-bounds pointer/length into `bytes` for fd 2.
+            // SAFETY: in-bounds pointer/length into `bytes`, written to fd 2.
             let n = unsafe {
                 libc::write(
                     libc::STDERR_FILENO,
@@ -128,9 +152,9 @@ mod unix {
         return unsafe { (*info).si_addr as usize };
     }
 
-    /// Restore the default disposition, unblock the signal (it is blocked
-    /// while its own handler runs), and re-raise — the process dies with the
-    /// original signal, so the exit status CI harnesses see is unchanged.
+    /// Restore the default disposition for `sig`, unblock it (it is blocked
+    /// while its own handler runs), and re-raise so the process dies with the
+    /// original signal.
     fn reset_and_reraise(sig: libc::c_int) -> ! {
         // SAFETY: sigaction/pthread_sigmask/raise are async-signal-safe;
         // structs are fully initialized before use.
@@ -144,9 +168,11 @@ mod unix {
             libc::sigemptyset(&mut set);
             libc::sigaddset(&mut set, sig);
             libc::pthread_sigmask(libc::SIG_UNBLOCK, &set, std::ptr::null_mut());
+
             libc::raise(sig);
-            // Unreachable unless delivery was somehow deferred; exit with
-            // the conventional 128+signal code rather than continuing.
+            // Only reached if delivery was somehow deferred; exit with the
+            // conventional 128+signal code rather than returning into faulted
+            // state.
             libc::_exit(128 + sig);
         }
     }
@@ -160,17 +186,59 @@ mod unix {
         write_stderr(signal_name(sig).as_bytes());
         write_stderr(b"\naspect-cli: collecting backtrace (best effort)...\n");
 
-        // Allocating from here on — see the module docstring for why that
-        // is an acceptable trade inside a crash handler.
+        // Allocating from here — see the module docstring for why that trade
+        // is acceptable inside a dying process.
         let thread = std::thread::current();
-        let report = format!(
-            "fault address: {:#x}\nthread: {}\nbacktrace:\n{}\naspect-cli crashed; please report this at https://github.com/aspect-build/aspect-cli/issues including the output above.\n",
-            fault_addr(info),
-            thread.name().unwrap_or("<unnamed>"),
-            std::backtrace::Backtrace::force_capture(),
+        write_stderr(
+            format_report(fault_addr(info), thread.name().unwrap_or("<unnamed>")).as_bytes(),
         );
-        write_stderr(report.as_bytes());
 
         reset_and_reraise(sig);
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn signal_name_maps_known_and_unknown() {
+            assert_eq!(signal_name(libc::SIGSEGV), "SIGSEGV (segmentation fault)");
+            assert_eq!(signal_name(libc::SIGABRT), "SIGABRT (abort)");
+            assert_eq!(signal_name(libc::SIGILL), "SIGILL (illegal instruction)");
+            assert_eq!(signal_name(9999), "unknown fatal signal");
+        }
+
+        #[test]
+        fn every_fatal_signal_has_a_name() {
+            for &(sig, label) in FATAL_SIGNALS {
+                assert_eq!(signal_name(sig), label);
+            }
+        }
+
+        #[test]
+        fn format_report_includes_address_thread_and_pointer() {
+            let report = format_report(0xdead_beef, "worker-3");
+            assert!(report.contains("fault address: 0xdeadbeef"), "{report}");
+            assert!(report.contains("thread: worker-3"), "{report}");
+            assert!(report.contains("backtrace:"), "{report}");
+            assert!(
+                report.contains("github.com/aspect-build/aspect-cli/issues"),
+                "{report}"
+            );
+        }
+
+        #[test]
+        fn opt_out_detects_nonempty_only() {
+            // SAFETY: single-threaded test; no other thread reads the env here.
+            unsafe {
+                std::env::remove_var(OPT_OUT_ENV);
+                assert!(!opt_out());
+                std::env::set_var(OPT_OUT_ENV, "");
+                assert!(!opt_out());
+                std::env::set_var(OPT_OUT_ENV, "1");
+                assert!(opt_out());
+                std::env::remove_var(OPT_OUT_ENV);
+            }
+        }
     }
 }

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod builtins;
 mod cmd;
+mod crash_handler;
 mod credential_helper;
 mod helpers;
 mod trace;
@@ -246,6 +247,11 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
 }
 
 fn main() -> ExitCode {
+    // First, before any other machinery, so fatal-signal reporting covers
+    // everything after it (see `crash_handler` module docs).
+    crash_handler::install();
+    crash_handler::trigger_test_crash();
+
     // Intercept the Bazel credential helper (`aspect get`) before the async
     // runtime and workspace discovery so it stays fast (see `credential_helper`).
     if credential_helper::is_invocation() {

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -247,8 +247,8 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
 }
 
 fn main() -> ExitCode {
-    // First, before any other machinery, so fatal-signal reporting covers
-    // everything after it (see `crash_handler` module docs).
+    // Install first, before any other machinery, so fatal-signal reporting
+    // covers everything after it (see the `crash_handler` module docs).
     crash_handler::install();
     crash_handler::trigger_test_crash();
 

--- a/crates/aspect-cli/tests/crash_handler.rs
+++ b/crates/aspect-cli/tests/crash_handler.rs
@@ -1,0 +1,70 @@
+//! End-to-end tests for the fatal-signal crash reporter: spawn the real CLI
+//! binary with the internal crash trigger (`ASPECT_INTERNAL_TEST_CRASH`) and
+//! assert the report reaches stderr while the process still dies with the
+//! original signal (so CI harnesses observe an unchanged exit status).
+
+#![cfg(unix)]
+
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Command, Output};
+
+fn run_with_trigger(kind: &str, extra_env: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_aspect-cli"));
+    cmd.env("ASPECT_INTERNAL_TEST_CRASH", kind);
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("failed to spawn aspect-cli")
+}
+
+#[test]
+fn segv_reports_backtrace_and_dies_with_original_signal() {
+    let out = run_with_trigger("segv", &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("fatal signal: SIGSEGV (segmentation fault)"),
+        "missing signal line in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("backtrace:"),
+        "missing backtrace in stderr: {stderr}"
+    );
+    assert_eq!(
+        out.status.signal(),
+        Some(libc::SIGSEGV),
+        "expected death by SIGSEGV, got {:?}",
+        out.status
+    );
+}
+
+#[test]
+fn abort_reports_and_dies_with_original_signal() {
+    let out = run_with_trigger("abort", &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("fatal signal: SIGABRT (abort)"),
+        "missing signal line in stderr: {stderr}"
+    );
+    assert_eq!(
+        out.status.signal(),
+        Some(libc::SIGABRT),
+        "expected death by SIGABRT, got {:?}",
+        out.status
+    );
+}
+
+#[test]
+fn opt_out_env_skips_the_report_but_not_the_crash() {
+    let out = run_with_trigger("segv", &[("ASPECT_NO_CRASH_HANDLER", "1")]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("fatal signal"),
+        "handler ran despite opt-out: {stderr}"
+    );
+    assert_eq!(
+        out.status.signal(),
+        Some(libc::SIGSEGV),
+        "expected death by SIGSEGV, got {:?}",
+        out.status
+    );
+}

--- a/crates/aspect-cli/tests/crash_handler.rs
+++ b/crates/aspect-cli/tests/crash_handler.rs
@@ -2,6 +2,10 @@
 //! binary with the internal crash trigger (`ASPECT_INTERNAL_TEST_CRASH`) and
 //! assert the report reaches stderr while the process still dies with the
 //! original signal (so CI harnesses observe an unchanged exit status).
+//!
+//! These run under `cargo test` (they need the built binary via
+//! `CARGO_BIN_EXE_*`). The handler's pure logic is unit-tested inside
+//! `crash_handler.rs`, which is what the Bazel `:test` target covers.
 
 #![cfg(unix)]
 


### PR DESCRIPTION
When aspect-cli crashes on a fatal signal, the only signal a CI runner surfaces is the harness's bare `Received "segmentation fault" signal` line — no stack, and ephemeral runners rarely retain a core dump or kernel log to debug from.

This installs handlers for SIGSEGV, SIGBUS, SIGILL, SIGFPE, and SIGABRT that print the signal name, fault address, crashing thread, and a best-effort symbolized backtrace to stderr, then re-raise the signal with its default disposition. The process still dies with the original signal, so exit statuses observed by CI harnesses are unchanged — the crash just self-reports in the task log first.

The backtrace capture allocates, which is not async-signal-safe, so this is a deliberate best-effort trade: a fixed marker naming the signal is written with raw `write(2)` before the allocating section (so the signal is identified even if capture wedges), and a re-entrancy guard turns any fault inside the handler into an immediate default-action death. Handlers run on the alternate signal stack (`SA_ONSTACK`) std installs per thread, so stack-overflow SIGSEGVs are reported rather than double-faulting. `ASPECT_NO_CRASH_HANDLER=1` skips installation.

Sample report:

```
aspect-cli: fatal signal: SIGSEGV (segmentation fault)
aspect-cli: collecting backtrace (best effort)...
fault address: 0x0
thread: main
backtrace:
   ...
aspect-cli crashed; please report this at https://github.com/aspect-build/aspect-cli/issues including the output above.
```

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (crash output is self-describing; env vars are documented in the module docstring)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- feat: aspect-cli now prints the signal, fault address, and a backtrace when it crashes on a fatal signal (SIGSEGV/SIGBUS/SIGILL/SIGFPE/SIGABRT), before exiting with the original signal. Set `ASPECT_NO_CRASH_HANDLER=1` to disable.

### Test plan

- New test cases added:
  - Unit tests (in `crash_handler.rs`, covered by the Bazel `:test` target): signal-name mapping, report formatting, and opt-out detection.
  - End-to-end tests (`cargo test`): spawn the real binary via an internal crash trigger and assert the report reaches stderr, that death is still by the original signal, and that `ASPECT_NO_CRASH_HANDLER` skips the report without altering the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
