### PR TITLE
fix(launcher): reject empty/truncated downloads so a poisoned cache can't ENOEXEC

### DIFF
--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -146,6 +146,25 @@ async fn _download_into_cache(
         eprintln!("\rdownloaded {size_str} in {time_str}\x1b[K");
     }
 
+    // A 0-byte (or truncated) body would `exec` into an ENOEXEC "Exec format
+    // error" downstream. Reject it here so the caller's retry loop re-fetches
+    // instead of caching and punting to an empty binary. GitHub's release CDN
+    // can briefly serve an empty 200 for an asset that isn't fully propagated.
+    if downloaded == 0 {
+        let _ = tokio::fs::remove_file(&tmp_file).await;
+        return Err(miette::miette!(
+            "downloaded an empty file (0 bytes) — refusing to cache it"
+        ));
+    }
+    if let Some(total) = total_size {
+        if downloaded != total {
+            let _ = tokio::fs::remove_file(&tmp_file).await;
+            return Err(miette::miette!(
+                "download truncated: got {downloaded} bytes, expected {total}"
+            ));
+        }
+    }
+
     // And move it into the cache
     tokio::fs::rename(&tmp_file, &cache_entry)
         .await


### PR DESCRIPTION
## Summary

CI hit an `Exec format error` ("failed to punt to the `aspect-cli`, Os { code: 8, ... }`) that looked like an arch mismatch but wasn't — the launcher downloaded a **0-byte file** (`downloaded 0 KB in 0ms`), cached it, and `exec`'d it. `exec` on an empty file returns **ENOEXEC (os code 8) → "Exec format error"**.

GitHub's release CDN can briefly serve an empty `200` for a just-published asset (here, `v2026.30.4`) that hasn't fully propagated. `_download_into_cache` returned `Ok(())` on an empty stream, so the caller's existing 3-attempt exponential-backoff retry loop never fired — the empty download was treated as success and poisoned the cache.

The fix rejects an empty or truncated download before renaming it into the cache: `downloaded == 0`, or a body whose length disagrees with `Content-Length`, removes the tmp file and returns `Err`, so the existing retry loop re-fetches instead of caching a broken binary. This closes the pre-existing `// FIXME: Check download integrity/signatures?` gap for the length case.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- The launcher no longer caches and executes an empty or truncated download. A transient empty/short response from GitHub's release CDN is now retried instead of surfacing as a confusing "Exec format error".

### Test plan

- Covered by existing test cases (launcher unit suite passes: 63 passed)
- Manual testing; please provide instructions so we can reproduce:
  - The empty-download path depends on a transient CDN state and isn't easily reproduced locally. Clearing the poisoned tool cache on the affected runner (forcing a clean re-download) unblocks CI immediately; with this fix an empty/truncated response self-heals via the retry loop.
