### PR TITLE
fix(github): request Actions access for status comments

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -20,8 +20,8 @@ render → post under a local time lease), so a single job still renders a
 correct comment.
 
 Requires the Aspect GitHub App with `prs.write` (issue-comment
-POST/PATCH/DELETE/GET) and Aspect credentials (ASPECT_API_TOKEN) for the
-contribute call.
+POST/PATCH/DELETE/GET), `actions.read` (GitHub Actions job deep-links), and
+Aspect credentials (ASPECT_API_TOKEN) for the contribute call.
 
 Comment shape is precomputed in AXL; the Jinja2 template is a pure
 renderer. `_prepare_for_render` decorates each entry with:
@@ -107,6 +107,8 @@ load(
     "tip_shows_on",
     "tip_to_payload",
 )
+
+GITHUB_STATUS_COMMENT_ROLES = ["prs.write", "actions.read"]
 
 _MARKER_FMT = "<!-- aspect-ci-status:pr-%d -->"
 
@@ -1744,7 +1746,7 @@ def _github_status_comments(ctx: FeatureContext):
             ctx,
             owner = owner,
             repo = repo,
-            roles = ["prs.write"],
+            roles = GITHUB_STATUS_COMMENT_ROLES,
             _reason = auth_reason,
             _extra = auth_extra,
         )

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -26,6 +26,7 @@ load(
     "@aspect//feature/github_status_comments.axl",
     "DEFAULT_BODY_TEMPLATE",
     "DEFAULT_STATUS_BADGES",
+    "GITHUB_STATUS_COMMENT_ROLES",
     "MARKER_FMT",
     "bucket_entries",
     "by_task_overflow",
@@ -1668,6 +1669,12 @@ def _check_repro_dedup_consecutive_headings(ctx):
         fail("repro dedup: install hint missing from body")
 
 def _test_impl(ctx):
+    _eq(
+        "status-comment token roles include job-link access",
+        GITHUB_STATUS_COMMENT_ROLES,
+        ["prs.write", "actions.read"],
+    )
+
     sep = "=" * 70
 
     _check_collect_tip_rows(ctx)


### PR DESCRIPTION
## Summary

- request `actions.read` alongside `prs.write` for GitHub status comments
- document the role requirement
- add a regression assertion for the combined role set

## Root cause

The status-comment feature authenticates with a `prs.write` App token, then passes the same token to `resolve_build_url`. GitHub Actions job URL discovery calls the Actions jobs API, which requires `actions.read`. Reusing the narrower token returns `403 Resource not accessible by integration`, even when the App installation supports Actions read.

## Validation

- `cargo build -p aspect-cli`
- `./target/debug/aspect-cli dev test-pr-comment-snapshots` (20 scenarios)
- `./target/debug/aspect-cli tests axl`
