### PR TITLE
fix(github): gate actions.read to GitHub Actions for status surfaces

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -60,6 +60,13 @@ load("../private/lib/tips.axl", "SURFACE_GITHUB_STATUS_CHECKS", "collect_tips_so
 
 _LOG = feature_logger("GitHub status checks")
 
+# `checks.write` (create/update the check run) is always required.
+# `actions.read` (job deep-link) is added only on GitHub Actions by
+# `github.with_job_link_role`; off-GHA the Actions API is never called and
+# requesting it would needlessly fail the mint on installations that don't
+# grant it.
+GITHUB_STATUS_CHECK_ROLES = ["checks.write"]
+
 # Cadence for re-registering (heartbeating) a check run with the orphan-cleanup
 # backend. A tight fraction of the backend's staleness window so a live task
 # beats several times before it could be judged stale; the register upsert is
@@ -166,7 +173,6 @@ def _github_status_checks(ctx: FeatureContext):
         _state["_started_ms"] = now_ms(ctx)
         _state["_triggered_by"] = _detect_triggered_by(ctx.std.env)
 
-        # actions.read is for the job deep-link only — fails gracefully.
         # `_extra` captures the installation id + proof from the mint, forwarded
         # on the register heartbeat so the backend can attribute this check.
         auth_reason = {}
@@ -175,7 +181,7 @@ def _github_status_checks(ctx: FeatureContext):
             ctx,
             owner = owner,
             repo = repo,
-            roles = ["checks.write", "actions.read"],
+            roles = github.with_job_link_role(ctx.std.env, GITHUB_STATUS_CHECK_ROLES),
             _reason = auth_reason,
             _extra = auth_extra,
         )

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -20,8 +20,9 @@ render → post under a local time lease), so a single job still renders a
 correct comment.
 
 Requires the Aspect GitHub App with `prs.write` (issue-comment
-POST/PATCH/DELETE/GET), `actions.read` (GitHub Actions job deep-links), and
-Aspect credentials (ASPECT_API_TOKEN) for the contribute call.
+POST/PATCH/DELETE/GET) and Aspect credentials (ASPECT_API_TOKEN) for the
+contribute call. On GitHub Actions it additionally requests `actions.read`
+for the job deep-link (gated so non-GHA hosts don't require it).
 
 Comment shape is precomputed in AXL; the Jinja2 template is a pure
 renderer. `_prepare_for_render` decorates each entry with:
@@ -108,7 +109,11 @@ load(
     "tip_to_payload",
 )
 
-GITHUB_STATUS_COMMENT_ROLES = ["prs.write", "actions.read"]
+# `prs.write` (issue-comment CRUD) is always required. `actions.read` (job
+# deep-link) is added only on GitHub Actions by `github.with_job_link_role`;
+# off-GHA the Actions API is never called and requesting it would needlessly
+# fail the mint on installations that don't grant it.
+GITHUB_STATUS_COMMENT_ROLES = ["prs.write"]
 
 _MARKER_FMT = "<!-- aspect-ci-status:pr-%d -->"
 
@@ -1746,7 +1751,7 @@ def _github_status_comments(ctx: FeatureContext):
             ctx,
             owner = owner,
             repo = repo,
-            roles = GITHUB_STATUS_COMMENT_ROLES,
+            roles = github.with_job_link_role(ctx.std.env, GITHUB_STATUS_COMMENT_ROLES),
             _reason = auth_reason,
             _extra = auth_extra,
         )

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -1670,9 +1670,9 @@ def _check_repro_dedup_consecutive_headings(ctx):
 
 def _test_impl(ctx):
     _eq(
-        "status-comment token roles include job-link access",
+        "status-comment base roles are prs.write only (job-link role gated to GHA)",
         GITHUB_STATUS_COMMENT_ROLES,
-        ["prs.write", "actions.read"],
+        ["prs.write"],
     )
 
     sep = "=" * 70

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -222,6 +222,20 @@ def validate_role(role):
     """Validate that a role is in the known set."""
     return role in VALID_ROLES
 
+# Role that authorizes the GitHub Actions job-URL deep-link upgrade
+# (`resolve_build_url` → `detect_github_actions_build_url`). Only meaningful on
+# GitHub Actions; off-GHA the Actions API is never called, so requesting it
+# there would needlessly fail the whole token mint (all-or-nothing) on
+# installations that don't grant it. Gate it with `with_job_link_role`.
+JOB_LINK_ROLE = "actions.read"
+
+def with_job_link_role(env, base_roles):
+    """Append `JOB_LINK_ROLE` to `base_roles` only when running on GitHub
+    Actions, where the job-URL deep-link upgrade actually fires."""
+    if env.var("GITHUB_ACTIONS"):
+        return base_roles + [JOB_LINK_ROLE]
+    return base_roles
+
 # Stable `_reason["kind"]` identifiers; downstream discriminates on these,
 # not the human-readable `reason` string.
 _AUTH_KIND_NO_OWNER_REPO = "no-owner-repo"
@@ -2327,6 +2341,8 @@ def delete_review_comment(ctx, token, owner, repo, comment_id, api_base = DEFAUL
 
 github = struct(
     VALID_ROLES = VALID_ROLES,
+    JOB_LINK_ROLE = JOB_LINK_ROLE,
+    with_job_link_role = with_job_link_role,
     authenticate = _authenticate,
     status_comment_contribute = _status_comment_contribute,
     status_check_register = _status_check_register,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github_detect_test.axl
@@ -626,6 +626,21 @@ def _test_impl(ctx):
         ("gha-fallback", None, "env"),
     )
 
+    # ── with_job_link_role: actions.read only on GitHub Actions ───────
+    # Off-GHA the Actions API is never called, so the job-link role must
+    # not be requested there (it would fail the whole mint on
+    # installations that don't grant it).
+    _eq(
+        "with_job_link_role: appends actions.read on GitHub Actions",
+        github.with_job_link_role(_ctx_with_env({"GITHUB_ACTIONS": "true"}).std.env, ["prs.write"]),
+        ["prs.write", github.JOB_LINK_ROLE],
+    )
+    _eq(
+        "with_job_link_role: unchanged off GitHub Actions",
+        github.with_job_link_role(_ctx_with_env({}).std.env, ["prs.write"]),
+        ["prs.write"],
+    )
+
     # ── Failure-kind gate for tip_add_aspect_api_token ────────────────
     # `_authenticate` classifies failures via a stable `kind` field;
     # `_preferred_token_pair` keys the missing-credentials tip off


### PR DESCRIPTION
Follow-up to #1342.

#1342 added `actions.read` to the GitHub status-comments token mint so the run-level CI URL could be upgraded to a per-job deep-link. But the App-token mint is all-or-nothing: on an installation that doesn't grant `actions.read`, requesting it fails the *entire* mint, and `_init` returns before publishing — disabling the status-comment surface. Off GitHub Actions this is pure downside: `resolve_build_url` returns the env-derived URL and never calls the Actions API, so Buildkite/CircleCI jobs only ever needed `prs.write`.

This gates `actions.read` to GitHub Actions. A new helper `github.with_job_link_role(env, base_roles)` appends the role only when `GITHUB_ACTIONS` is set — matching the exact condition under which the job-deep-link upgrade actually fires — and both the status-comments and status-checks mints route through it. The magic role lists are replaced with named base-role constants (`GITHUB_STATUS_COMMENT_ROLES` / `GITHUB_STATUS_CHECK_ROLES`), and the stale "fails gracefully" comment in status checks is removed (it didn't — that was the bug).

Addresses the P2 raised by Codex on #1342.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed GitHub PR status comments being disabled on non-GitHub-Actions CI hosts (Buildkite, CircleCI) when the Aspect GitHub App installation doesn't grant `actions.read`. The `actions.read` permission is now requested only on GitHub Actions, where it's actually used.

### Test plan

- Covered by existing test cases
- New test cases added

New on/off-GitHub-Actions unit tests for `with_job_link_role` in `github_detect_test.axl` (`aspect dev test-github-detect`); `aspect dev test-pr-comment-snapshots` updated and passing.
