### PR TITLE
fix(github): filter lint comments to reviewable diff ranges

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
@@ -49,7 +49,7 @@ CIRCLE_BUILD_NUM): siblings in separate jobs would then see each other as
 load("@aspect//lint.axl", "LintTrait")
 load("../private/lib/environment.axl", "color_enabled", "feature_logger")
 load("../private/lib/github.axl", "github")
-load("../private/lib/lint_comments.axl", lc_build_marker = "build_marker", lc_extract_marker = "extract_marker", lc_parse_marker = "parse_marker", lc_suggestion_block = "suggestion_block")
+load("../private/lib/lint_comments.axl", lc_build_marker = "build_marker", lc_extract_marker = "extract_marker", lc_is_commentable = "is_commentable", lc_parse_marker = "parse_marker", lc_suggestion_block = "suggestion_block")
 load("../private/lib/patch.axl", patch_hunk_edit_blocks = "hunk_edit_blocks", patch_parse = "parse")
 load("../private/lib/sarif.axl", "parse_sarif", "parse_sarif_diagnostics", "sarif_to_review_comments")
 
@@ -383,8 +383,7 @@ def _cleanup_comments(ctx, gh, relevant_diagnostics, run_id, task_key, suggestio
         # empty and only patch-derived suggestion_markers remain.
         if destination in ("auto", "both") and not diag.get("has_fix"):
             continue
-        lines = gh["changed_lines"].get(diag["file"])
-        if lines and (diag["line"] - 1) in lines:
+        if lc_is_commentable(diag["file"], diag["line"], gh["changed_lines"], prefix = gh.get("prefix", "")):
             marker = lc_build_marker(run_id, task_key, diag["tool"], diag["file"], diag["line"], diag["rule_id"])
             desired[marker] = True
 
@@ -565,6 +564,11 @@ def _github_lint_impl(ctx: FeatureContext):
         if gh and gh["stale"]:
             return
         comments = _build_comments(ctx, filepath, run_id, ctx.task.name, destination = destination)
+        comments = [
+            c
+            for c in comments
+            if lc_is_commentable(c.get("path", ""), c.get("line", 0), gh["changed_lines"], gh.get("prefix", ""), c.get("start_line"))
+        ]
         state["all_comments_count"] += len(comments)
 
         cap_exhausted = bool(gh) and state["posted"] >= max_pr_comments
@@ -587,15 +591,10 @@ def _github_lint_impl(ctx: FeatureContext):
         if not errors_in_batch:
             return
 
-        # No diff-region pre-filter: try every comment. Out-of-hunk attempts 422,
-        # collected in state["errors"] (logged, non-fatal). The strategy filter
-        # already keeps relevant_diagnostics aligned with the diff window.
-        ready = errors_in_batch
-
         # Cap accounting — _post_individually skips already-posted markers, so
         # dupes don't consume budget; count only new postable comments.
         new_only = []
-        for c in ready:
+        for c in errors_in_batch:
             marker = lc_extract_marker(c.get("body", ""), task_key = ctx.task.name)
             if marker and marker in gh["existing_markers"]:
                 continue
@@ -790,14 +789,16 @@ def _github_lint_impl(ctx: FeatureContext):
                     suggestion_comments = []
                 else:
                     suggestion_comments = _build_suggestion_comments(ctx, relevant_diagnostics)
+                    suggestion_comments = [
+                        c
+                        for c in suggestion_comments
+                        if lc_is_commentable(c.get("path", ""), c.get("line", 0), gh["changed_lines"], gh.get("prefix", ""), c.get("start_line"))
+                    ]
                 non_errors = [c for c in state["all_comments"] if c.get("_severity") != "error"] + suggestion_comments
 
                 # Intra-run dedup by marker (within-run dupes; the existing-markers
                 # check below handles prior-run dupes).
                 non_errors = _dedup_by_marker(non_errors, ctx.task.name)
-
-                # No diff-region pre-filter (see _lint_report); out-of-hunk 422s
-                # are tolerated via _post_individually's error collection.
 
                 # 1. Dedup against existing markers (now include just-streamed errors).
                 deduped_skipped = 0

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
@@ -97,3 +97,16 @@ def suggestion_block(replacement, current, start_line, end_line, vcs):
     else:
         fence = "```suggestion"
     return "%s\n%s\n```" % (fence, replacement)
+
+def is_commentable(path: str, line: int, changed_lines: dict, prefix: str = "", start_line = None) -> bool:
+    """Whether GitHub can anchor a review comment on this path and range."""
+    lines = changed_lines.get(path)
+    if lines == None and prefix:
+        lines = changed_lines.get(prefix + path)
+    first_line = start_line or line
+    if lines == None or first_line < 1 or line < first_line:
+        return False
+    for current_line in range(first_line, line + 1):
+        if current_line - 1 not in lines:
+            return False
+    return True

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
@@ -4,7 +4,7 @@ Run with:
   aspect dev test-lint-comments
 """
 
-load("./lint_comments.axl", "build_marker", "extract_marker", "parse_marker", "suggestion_block")
+load("./lint_comments.axl", "build_marker", "extract_marker", "is_commentable", "parse_marker", "suggestion_block")
 
 def _eq(label, got, want):
     if got != want:
@@ -36,6 +36,19 @@ def _test_impl(ctx):
     _eq("github suggestion", suggestion_block("foo", current = 10, start_line = 10, end_line = 10, vcs = "github"), "```suggestion\nfoo\n```")
     _eq("gitlab suggestion single", suggestion_block("foo", current = 10, start_line = 10, end_line = 10, vcs = "gitlab"), "```suggestion:-0+0\nfoo\n```")
     _eq("gitlab suggestion multi", suggestion_block("foo\nbar\nbaz", current = 12, start_line = 10, end_line = 12, vcs = "gitlab"), "```suggestion:-2+0\nfoo\nbar\nbaz\n```")
+
+    changed_lines = {
+        "pkg/direct.ts": [9],
+        "pkg/gapped.ts": [39, 41],
+        "pkg/range.ts": [29, 30, 31],
+        "apps/docs/pkg/prefixed.ts": [19],
+    }
+    _eq("direct changed line", is_commentable("pkg/direct.ts", 10, changed_lines), True)
+    _eq("prefixed changed line", is_commentable("pkg/prefixed.ts", 20, changed_lines, prefix = "apps/docs/"), True)
+    _eq("outside changed hunk", is_commentable("pkg/direct.ts", 11, changed_lines), False)
+    _eq("unchanged file", is_commentable("pkg/missing.ts", 10, changed_lines), False)
+    _eq("commentable range", is_commentable("pkg/range.ts", 32, changed_lines, start_line = 30), True)
+    _eq("range crosses collapsed diff", is_commentable("pkg/gapped.ts", 42, changed_lines, start_line = 40), False)
 
     print("lint_comments.axl: OK")
     return 0


### PR DESCRIPTION
## Summary

- filter streamed SARIF review comments to lines GitHub can anchor in the PR diff
- apply the same boundary to patch-derived suggestions and stale-comment cleanup
- support nested workspace prefixes and validate complete multi-line suggestion ranges
- keep the existing `LintTrait` lifecycle and lint strategy behavior unchanged

## Root cause

`GithubLintComments.lint_report` receives each raw SARIF report before the lint strategy's aggregate filtering is available.

The feature previously filtered review comments at the GitHub API boundary because GitHub rejects comments outside the displayed diff with HTTP 422. That filter was later removed under the assumption that strategy-filtered `relevant_diagnostics` also constrained the streaming callback. However, `relevant_diagnostics` reaches only `lint_end`; streamed SARIF comments remained unfiltered.

This restores the API-specific boundary without adding another lint lifecycle hook.

## Behavior

Only GitHub PR review-comment delivery changes:

- comments outside displayed diff hunks are not submitted to GitHub
- multi-line suggestions are submitted only when their complete range is visible
- the PR-comment cap is applied after commentability filtering
- task exit status, diagnostics, check annotations, and local output remain unchanged
- hard/soft findings outside the diff remain available through non-review-comment surfaces

## Validation

- `./target/debug/aspect-cli dev test-lint-comments`
- `./target/debug/aspect-cli tests axl` — 896 tests passed
- Bazel-built Buildifier check on all three changed AXL files
- `git diff --check upstream/main`

## Suggested release note

`GithubLintComments` no longer attempts to post review comments outside GitHub's displayed PR diff, preventing non-fatal HTTP 422 warnings while preserving all lint findings on their existing status surfaces.
