### PR TITLE
fix(github): correct the lint-comment diff filter and share it with GitLab

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
@@ -304,10 +304,12 @@ def _get_existing_markers(ctx, gh, task_key):
 def _postable(gh, comments):
     """Drop comments GitHub can't anchor in the PR diff (it 422s them).
 
-    Applied at the API boundary rather than in the lint strategy: the strategy's
-    `relevant_diagnostics` only reaches `_lint_end`, and `hold-the-file`
-    deliberately keeps findings on unchanged lines of a changed file, which are
-    valid diagnostics but not valid review-comment anchors.
+    Gating belongs at the API boundary, not in the lint strategy: `_lint_report`
+    streams raw SARIF and the strategy's `relevant_diagnostics` only reaches
+    `_lint_end`, so findings for untouched files arrive here regardless of
+    strategy. Even scoped strategies produce valid diagnostics that are not valid
+    comment anchors — `hold-the-file` keeps findings on unchanged lines of a
+    changed file. Those still surface on the other status surfaces.
     """
     return [
         c
@@ -397,9 +399,8 @@ def _cleanup_comments(ctx, gh, relevant_diagnostics, run_id, task_key, suggestio
         # empty and only patch-derived suggestion_markers remain.
         if destination in ("auto", "both") and not diag.get("has_fix"):
             continue
-        # Must match `_postable`'s gate exactly: `desired` decides what survives
-        # reaping, so a narrower rule here would delete comments this same run
-        # just posted (e.g. every one of them on an unscoped run).
+        # Same predicate as `_postable`: `desired` decides what survives reaping,
+        # so a narrower rule here would delete comments this run just posted.
         if lc_can_attempt_comment(gh["window"], diag["file"], diag["line"]):
             marker = lc_build_marker(run_id, task_key, diag["tool"], diag["file"], diag["line"], diag["rule_id"])
             desired[marker] = True
@@ -559,7 +560,7 @@ def _github_lint_impl(ctx: FeatureContext):
     if gh:
         # Workspace prefix relative to the git root. _post_individually prepends it
         # (SARIF paths are workspace-relative, GitHub wants repo-relative); the
-        # diff window uses it to reconcile mixed-relativity changed-file keys.
+        # diff window strips it to canonicalize changed-file keys.
         git_out = ctx.std.process.command("git").arg("rev-parse").arg("--show-prefix").current_dir(ctx.std.env.aspect_root_dir()).stdout("piped").stderr("null").spawn().wait_with_output()
         if git_out.status.success:
             gh["prefix"] = git_out.stdout.strip()
@@ -569,7 +570,11 @@ def _github_lint_impl(ctx: FeatureContext):
         # avoid a duplicate PR Files API call / git diff.
         if not gh:
             return
-        gh["window"] = lc_diff_window(lint_trait.changed_files, prefix = gh["prefix"])
+        gh["window"] = lc_diff_window(
+            lint_trait.changed_files,
+            prefix = gh["prefix"],
+            scoped = lint_trait.changed_files_scoped,
+        )
 
     def _lint_report(ctx, filepath):
         # Per-SARIF-file callback. Errors stream immediately (fast feedback);

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
@@ -564,12 +564,16 @@ def _github_lint_impl(ctx: FeatureContext):
         if gh and gh["stale"]:
             return
         comments = _build_comments(ctx, filepath, run_id, ctx.task.name, destination = destination)
+
+        # Count before the commentability filter so the reported total keeps
+        # matching the diagnostic count; findings outside the displayed diff
+        # still surface on the non-review-comment status surfaces.
+        state["all_comments_count"] += len(comments)
         comments = [
             c
             for c in comments
             if lc_is_commentable(c.get("path", ""), c.get("line", 0), gh["changed_lines"], gh.get("prefix", ""), c.get("start_line"))
         ]
-        state["all_comments_count"] += len(comments)
 
         cap_exhausted = bool(gh) and state["posted"] >= max_pr_comments
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
@@ -49,7 +49,7 @@ CIRCLE_BUILD_NUM): siblings in separate jobs would then see each other as
 load("@aspect//lint.axl", "LintTrait")
 load("../private/lib/environment.axl", "color_enabled", "feature_logger")
 load("../private/lib/github.axl", "github")
-load("../private/lib/lint_comments.axl", lc_build_marker = "build_marker", lc_extract_marker = "extract_marker", lc_is_commentable = "is_commentable", lc_parse_marker = "parse_marker", lc_suggestion_block = "suggestion_block")
+load("../private/lib/lint_comments.axl", lc_build_marker = "build_marker", lc_can_attempt_comment = "can_attempt_comment", lc_diff_window = "diff_window", lc_extract_marker = "extract_marker", lc_parse_marker = "parse_marker", lc_suggestion_block = "suggestion_block")
 load("../private/lib/patch.axl", patch_hunk_edit_blocks = "hunk_edit_blocks", patch_parse = "parse")
 load("../private/lib/sarif.axl", "parse_sarif", "parse_sarif_diagnostics", "sarif_to_review_comments")
 
@@ -301,6 +301,20 @@ def _get_existing_markers(ctx, gh, task_key):
             markers[marker] = c.get("html_url", "") or ""
     return markers
 
+def _postable(gh, comments):
+    """Drop comments GitHub can't anchor in the PR diff (it 422s them).
+
+    Applied at the API boundary rather than in the lint strategy: the strategy's
+    `relevant_diagnostics` only reaches `_lint_end`, and `hold-the-file`
+    deliberately keeps findings on unchanged lines of a changed file, which are
+    valid diagnostics but not valid review-comment anchors.
+    """
+    return [
+        c
+        for c in comments
+        if lc_can_attempt_comment(gh["window"], c.get("path", ""), c.get("line", 0), c.get("start_line"))
+    ]
+
 def _post_individually(ctx, gh, comments, existing_markers, task_key):
     """Post each comment via the GitHub API. Mutates dicts in place, setting
     `_html_url` on success or on dedup-against-prior-run (via existing_markers[marker])
@@ -383,7 +397,10 @@ def _cleanup_comments(ctx, gh, relevant_diagnostics, run_id, task_key, suggestio
         # empty and only patch-derived suggestion_markers remain.
         if destination in ("auto", "both") and not diag.get("has_fix"):
             continue
-        if lc_is_commentable(diag["file"], diag["line"], gh["changed_lines"], prefix = gh.get("prefix", "")):
+        # Must match `_postable`'s gate exactly: `desired` decides what survives
+        # reaping, so a narrower rule here would delete comments this same run
+        # just posted (e.g. every one of them on an unscoped run).
+        if lc_can_attempt_comment(gh["window"], diag["file"], diag["line"]):
             marker = lc_build_marker(run_id, task_key, diag["tool"], diag["file"], diag["line"], diag["rule_id"])
             desired[marker] = True
 
@@ -490,7 +507,7 @@ def _github_lint_impl(ctx: FeatureContext):
                 "repo": pr["repo"],
                 "head_sha": pr["sha"],
                 "pr_number": pr["pr_number"],
-                "changed_lines": {},
+                "window": lc_diff_window([]),
                 "prefix": "",
                 "stale": False,
             }
@@ -540,8 +557,9 @@ def _github_lint_impl(ctx: FeatureContext):
                 state["dropped_per_severity"][sev] = state["dropped_per_severity"].get(sev, 0) + 1
 
     if gh:
-        # Workspace prefix relative to the git root; _post_individually prepends
-        # it since SARIF paths are workspace-relative but GitHub wants repo-relative.
+        # Workspace prefix relative to the git root. _post_individually prepends it
+        # (SARIF paths are workspace-relative, GitHub wants repo-relative); the
+        # diff window uses it to reconcile mixed-relativity changed-file keys.
         git_out = ctx.std.process.command("git").arg("rev-parse").arg("--show-prefix").current_dir(ctx.std.env.aspect_root_dir()).stdout("piped").stderr("null").spawn().wait_with_output()
         if git_out.status.success:
             gh["prefix"] = git_out.stdout.strip()
@@ -551,11 +569,7 @@ def _github_lint_impl(ctx: FeatureContext):
         # avoid a duplicate PR Files API call / git diff.
         if not gh:
             return
-
-        # Use `hunk_lines` (added + ±3 context) not `lines` (added only): GitHub
-        # accepts comments anywhere in the displayed hunk, and findings often land
-        # next to an edit (e.g. SC2164 on the line after an edited comment).
-        gh["changed_lines"] = {f["file"]: f.get("hunk_lines") or f["lines"] for f in lint_trait.changed_files}
+        gh["window"] = lc_diff_window(lint_trait.changed_files, prefix = gh["prefix"])
 
     def _lint_report(ctx, filepath):
         # Per-SARIF-file callback. Errors stream immediately (fast feedback);
@@ -565,15 +579,10 @@ def _github_lint_impl(ctx: FeatureContext):
             return
         comments = _build_comments(ctx, filepath, run_id, ctx.task.name, destination = destination)
 
-        # Count before the commentability filter so the reported total keeps
-        # matching the diagnostic count; findings outside the displayed diff
-        # still surface on the non-review-comment status surfaces.
+        # Count before filtering so the reported total keeps matching the
+        # diagnostic count; out-of-diff findings still reach the other surfaces.
         state["all_comments_count"] += len(comments)
-        comments = [
-            c
-            for c in comments
-            if lc_is_commentable(c.get("path", ""), c.get("line", 0), gh["changed_lines"], gh.get("prefix", ""), c.get("start_line"))
-        ]
+        comments = _postable(gh, comments)
 
         cap_exhausted = bool(gh) and state["posted"] >= max_pr_comments
 
@@ -792,12 +801,7 @@ def _github_lint_impl(ctx: FeatureContext):
                 if destination == "annotations":
                     suggestion_comments = []
                 else:
-                    suggestion_comments = _build_suggestion_comments(ctx, relevant_diagnostics)
-                    suggestion_comments = [
-                        c
-                        for c in suggestion_comments
-                        if lc_is_commentable(c.get("path", ""), c.get("line", 0), gh["changed_lines"], gh.get("prefix", ""), c.get("start_line"))
-                    ]
+                    suggestion_comments = _postable(gh, _build_suggestion_comments(ctx, relevant_diagnostics))
                 non_errors = [c for c in state["all_comments"] if c.get("_severity") != "error"] + suggestion_comments
 
                 # Intra-run dedup by marker (within-run dupes; the existing-markers
@@ -910,11 +914,12 @@ def _github_lint_impl(ctx: FeatureContext):
                 trace.log("inactive reason:  %s" % gh_inactive_reason)
             trace.log("found comments:   %s" % state["all_comments_count"])
             if gh:
-                trace.log("git prefix:       %r" % gh.get("prefix", ""))
+                trace.log("git prefix:       %r" % gh["prefix"])
+                lines_by_path = gh["window"].lines_by_path
                 changed_line_count = 0
-                for v in gh["changed_lines"].values():
+                for v in lines_by_path.values():
                     changed_line_count += len(v)
-                trace.log("changed lines:    %s across %s file(s)" % (changed_line_count, len(gh["changed_lines"])))
+                trace.log("changed lines:    %s across %s file(s)" % (changed_line_count, len(lines_by_path)))
                 trace.log("destination:      %s" % destination)
             trace.log("posted comments:  %s" % state["posted"])
             if outcome:

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_lint_comments.axl
@@ -399,6 +399,7 @@ def _cleanup_comments(ctx, gh, relevant_diagnostics, run_id, task_key, suggestio
         # empty and only patch-derived suggestion_markers remain.
         if destination in ("auto", "both") and not diag.get("has_fix"):
             continue
+
         # Same predicate as `_postable`: `desired` decides what survives reaping,
         # so a narrower rule here would delete comments this run just posted.
         if lc_can_attempt_comment(gh["window"], diag["file"], diag["line"]):

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
@@ -446,6 +446,7 @@ def _cleanup_and_resolve(ctx, gl, relevant_diagnostics, run_id, task_key, sugges
             continue
         if destination in ("auto", "both") and not diag.get("has_fix"):
             continue
+
         # Same predicate as `_post_comments`, so cleanup can't reap a comment
         # this very run just posted.
         if can_attempt_comment(gl["window"], diag["file"], diag["line"]):

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
@@ -215,10 +215,10 @@ def _post_comments(ctx, gl, comments, existing_markers, task_key):
         path = c.get("path", "")
         line = c.get("line", 0)
 
-        # Gate on the unprefixed (workspace-relative) path; the repo prefix is
-        # applied only when building the GitLab position below. Single-line only
-        # (no start_line): a GitLab position anchors one line and encodes the
-        # span in the suggestion fence, so only the anchor must be displayed.
+        # Pass the workspace-relative path; the window applies the repo prefix
+        # itself so the check matches the `new_path` built below. Single-line
+        # only (no start_line): a GitLab position anchors one line and encodes
+        # the span in the suggestion fence, so only the anchor must be displayed.
         if not can_attempt_comment(gl["window"], path, line):
             continue
         prefix = gl["prefix"]

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
@@ -215,10 +215,9 @@ def _post_comments(ctx, gl, comments, existing_markers, task_key):
         path = c.get("path", "")
         line = c.get("line", 0)
 
-        # Pass the workspace-relative path; the window applies the repo prefix
-        # itself so the check matches the `new_path` built below. Single-line
-        # only (no start_line): a GitLab position anchors one line and encodes
-        # the span in the suggestion fence, so only the anchor must be displayed.
+        # Single-line check (no start_line): a GitLab position anchors one line
+        # and encodes the span in the suggestion fence, so only the anchor needs
+        # to be displayed.
         if not can_attempt_comment(gl["window"], path, line):
             continue
         prefix = gl["prefix"]
@@ -546,7 +545,11 @@ def _gitlab_lint_impl(ctx: FeatureContext):
     state = {"all_comments": [], "posted": 0, "errors": [], "pending_patches": []}
 
     def _lint_start(ctx):
-        gl["window"] = diff_window(lint_trait.changed_files, prefix = gl["prefix"])
+        gl["window"] = diff_window(
+            lint_trait.changed_files,
+            prefix = gl["prefix"],
+            scoped = lint_trait.changed_files_scoped,
+        )
 
     def _lint_report(ctx, filepath):
         comments = _build_comments(ctx, filepath, run_id, ctx.task.name, destination = destination)

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_lint_comments.axl
@@ -21,7 +21,7 @@ load("../private/lib/environment.axl", "feature_logger")
 load("../private/lib/gitlab.axl", "gitlab")
 load("../private/lib/gitlab_detect.axl", "detect_gitlab_mr")
 load("../private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
-load("../private/lib/lint_comments.axl", "build_marker", "extract_marker", "parse_marker", "suggestion_block")
+load("../private/lib/lint_comments.axl", "build_marker", "can_attempt_comment", "diff_window", "extract_marker", "parse_marker", "suggestion_block")
 load("../private/lib/patch.axl", patch_hunk_edit_blocks = "hunk_edit_blocks", patch_parse = "parse")
 load("../private/lib/sarif.axl", "parse_sarif_diagnostics", "sarif_to_review_comments")
 
@@ -208,7 +208,6 @@ def _post_comments(ctx, gl, comments, existing_markers, task_key):
     """
     errors = []
     diff_refs = gl["diff_refs"]
-    changed = gl["changed_lines"]
     for c in comments:
         marker = extract_marker(c.get("body", ""), task_key = task_key)
         if marker and marker in existing_markers:
@@ -216,13 +215,13 @@ def _post_comments(ctx, gl, comments, existing_markers, task_key):
         path = c.get("path", "")
         line = c.get("line", 0)
 
-        # Gate on the unprefixed (workspace-relative) path — `changed_lines`
-        # is keyed by the same SARIF/changed-files convention. The repo
-        # prefix is applied only when building the GitLab position below.
-        lines = changed.get(path)
-        if lines != None and (line - 1) not in lines:
+        # Gate on the unprefixed (workspace-relative) path; the repo prefix is
+        # applied only when building the GitLab position below. Single-line only
+        # (no start_line): a GitLab position anchors one line and encodes the
+        # span in the suggestion fence, so only the anchor must be displayed.
+        if not can_attempt_comment(gl["window"], path, line):
             continue
-        prefix = gl.get("prefix", "")
+        prefix = gl["prefix"]
 
         # line_maps are keyed by the repo-relative (prefixed) path, matching
         # the position's new_path.
@@ -448,13 +447,9 @@ def _cleanup_and_resolve(ctx, gl, relevant_diagnostics, run_id, task_key, sugges
             continue
         if destination in ("auto", "both") and not diag.get("has_fix"):
             continue
-        lines = gl["changed_lines"].get(diag["file"])
-
-        # Match _post_comments' gate: it posts when the file is absent from
-        # changed_lines (lines == None) OR the line is within the window. The
-        # desired set must keep those same findings so cleanup doesn't reap a
-        # comment this very run just posted.
-        if lines == None or (diag["line"] - 1) in lines:
+        # Same predicate as `_post_comments`, so cleanup can't reap a comment
+        # this very run just posted.
+        if can_attempt_comment(gl["window"], diag["file"], diag["line"]):
             desired[build_marker(run_id, task_key, diag["tool"], diag["file"], diag["line"], diag["rule_id"])] = True
     for m in suggestion_markers:
         desired[m] = True
@@ -534,7 +529,7 @@ def _gitlab_lint_impl(ctx: FeatureContext):
         "mr_iid": mr["mr_iid"],
         "api_base": api_base,
         "diff_refs": diff_refs,
-        "changed_lines": {},
+        "window": diff_window([]),
         "prefix": "",
         "line_maps": line_maps,
     }
@@ -551,7 +546,7 @@ def _gitlab_lint_impl(ctx: FeatureContext):
     state = {"all_comments": [], "posted": 0, "errors": [], "pending_patches": []}
 
     def _lint_start(ctx):
-        gl["changed_lines"] = {f["file"]: f.get("hunk_lines") or f["lines"] for f in lint_trait.changed_files}
+        gl["window"] = diff_window(lint_trait.changed_files, prefix = gl["prefix"])
 
     def _lint_report(ctx, filepath):
         comments = _build_comments(ctx, filepath, run_id, ctx.task.name, destination = destination)

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -322,6 +322,13 @@ LintTrait = trait(
     # Shape: [{"file": str, "lines": [int 0-based added line indices]}].
     changed_files = attr(list, default = []),
 
+    # False when change detection could not determine the changed-file set (e.g.
+    # a shallow checkout), which also forces `strategy=hard`. Distinguishes an
+    # empty `changed_files` meaning "no change context" from a scoped run where a
+    # file's absence genuinely means "unchanged" — features gating per-line
+    # surfaces must not treat the two alike.
+    changed_files_scoped = attr(bool, default = True),
+
     # Suggested-fix comment records posted by GithubLintComments during lint_end,
     # threaded into data["lint"]["suggestions"]. Each record:
     #   {tool, file, start_line, end_line (1-based new-side incl),
@@ -785,6 +792,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     else:
         changed_files = detect_result["files"]
     lint_trait.changed_files = changed_files
+    lint_trait.changed_files_scoped = not detect_result.get("unscoped")
     data["lint"]["changed_files"] = changed_files
 
     # Shared changed-file listing (announces source, prints sorted entries).

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
@@ -99,12 +99,30 @@ def suggestion_block(replacement, current, start_line, end_line, vcs):
     return "%s\n%s\n```" % (fence, replacement)
 
 def is_commentable(path: str, line: int, changed_lines: dict, prefix: str = "", start_line = None) -> bool:
-    """Whether GitHub can anchor a review comment on this path and range."""
+    """Whether GitHub can anchor a review comment on this path and range.
+
+    Fails OPEN when there is no line-set for `path`: an absent entry means "no
+    change context for this file", not "nothing is commentable". Change
+    detection can legitimately come up empty (shallow checkout ⇒ `strategy=hard`
+    with `changed_files = []`), and suppressing every comment there would hide
+    findings the run is deliberately surfacing. Out-of-hunk attempts 422, which
+    callers already tolerate as non-fatal. Matches the GitLab sibling's
+    `lines != None` gate.
+
+    `changed_lines` is 0-based (`hunk_lines`); `line`/`start_line` are 1-based
+    SARIF. Keys may be workspace- or repo-relative, so `prefix` is tried as a
+    fallback. A multi-line range needs every line displayed, since GitHub
+    anchors the whole span.
+    """
     lines = changed_lines.get(path)
     if lines == None and prefix:
         lines = changed_lines.get(prefix + path)
-    first_line = start_line or line
-    if lines == None or first_line < 1 or line < first_line:
+    if lines == None:
+        return True
+
+    # Explicit None check: start_line == 0 is an invalid range, not "absent".
+    first_line = line if start_line == None else start_line
+    if first_line < 1 or line < first_line:
         return False
     for current_line in range(first_line, line + 1):
         if current_line - 1 not in lines:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
@@ -1,7 +1,7 @@
 """VCS-agnostic helpers shared by the GitHub and GitLab lint-comment
 features.
 
-Two pieces are genuinely pure (string in, string out) and worth sharing
+Three pieces are genuinely pure (data in, data out) and worth sharing
 so both features stay byte-identical and a single test covers them:
 
   * Marker build/parse — the hidden HTML comment that uniquely
@@ -9,6 +9,8 @@ so both features stay byte-identical and a single test covers them:
   * Suggestion-block rendering — GitHub uses a bare ```suggestion fence
     (replaces the commented-on line); GitLab uses ```suggestion:-X+Y
     (replaces `current-X` through `current+Y`).
+  * Diff-window lookup (`DiffWindow`) — whether a review comment's
+    anchor range falls where the host can display it.
 
 The orchestration (discovery, dedup state machine, API calls) stays in
 each feature file — it's API-coupled and not shareable as-is.
@@ -98,33 +100,74 @@ def suggestion_block(replacement, current, start_line, end_line, vcs):
         fence = "```suggestion"
     return "%s\n%s\n```" % (fence, replacement)
 
-def is_commentable(path: str, line: int, changed_lines: dict, prefix: str = "", start_line = None) -> bool:
-    """Whether GitHub can anchor a review comment on this path and range.
+DiffWindow = record(
+    # {path: {0-based line: True}} — the lines the host will display, keyed as
+    # `changed_files` reported them. See `diff_window` for the keying caveat.
+    lines_by_path = field(dict),
+    # Workspace prefix relative to the repo root ("" at the root), used to
+    # reconcile repo-relative keys with workspace-relative comment paths.
+    prefix = field(str, default = ""),
+)
 
-    Fails OPEN when there is no line-set for `path`: an absent entry means "no
-    change context for this file", not "nothing is commentable". Change
-    detection can legitimately come up empty (shallow checkout ⇒ `strategy=hard`
-    with `changed_files = []`), and suppressing every comment there would hide
-    findings the run is deliberately surfacing. Out-of-hunk attempts 422, which
-    callers already tolerate as non-fatal. Matches the GitLab sibling's
-    `lines != None` gate.
+def diff_window(changed_files: list, prefix: str = "") -> DiffWindow:
+    """Index `changed_files` into a `DiffWindow` for anchor lookups.
 
-    `changed_lines` is 0-based (`hunk_lines`); `line`/`start_line` are 1-based
-    SARIF. Keys may be workspace- or repo-relative, so `prefix` is tried as a
-    fallback. A multi-line range needs every line displayed, since GitHub
-    anchors the whole span.
+    Uses `hunk_lines` (added + ±3 context) rather than `lines` (added only):
+    hosts accept comments anywhere in a displayed hunk, and findings often land
+    beside an edit (e.g. SC2164 on the line after an edited comment). Falls back
+    to `lines` for older fixtures that predate `hunk_lines`.
+
+    Keys are whatever `changed_files` carries, which is NOT uniformly relative:
+    `detect_changed_files`' PR Files API path strips the workspace prefix, while
+    its local `git diff` paths stay repo-relative (no `--relative`). Comment
+    paths are always workspace-relative, so lookups try the bare path first and
+    then `prefix + path`.
     """
-    lines = changed_lines.get(path)
-    if lines == None and prefix:
-        lines = changed_lines.get(prefix + path)
+    lines_by_path = {}
+    for f in changed_files:
+        path = f.get("file", "")
+        if not path:
+            continue
+        region = f.get("hunk_lines") or f.get("lines") or []
+        lines_by_path[path] = {line: True for line in region}
+    return DiffWindow(lines_by_path = lines_by_path, prefix = prefix)
+
+def _displayed_lines(window: DiffWindow, path: str):
+    """The 0-based displayed-line set for `path`, or None when the window holds
+    no entry for it (no change context — distinct from an empty set).
+    """
+    lines = window.lines_by_path.get(path)
+    if lines == None and window.prefix:
+        lines = window.lines_by_path.get(window.prefix + path)
+    return lines
+
+def can_attempt_comment(window: DiffWindow, path: str, line: int, start_line = None) -> bool:
+    """Whether a review comment anchored at `[start_line or line, line]` is
+    worth sending for `path`.
+
+    Requires the whole span to be displayed, because hosts anchor a multi-line
+    comment on its full range rather than just its endpoints.
+
+    Fails OPEN when the window has no entry for `path`. An absent entry means
+    "no change context for this file", not "nothing is commentable": change
+    detection legitimately comes up empty (a shallow checkout degrades lint to
+    `strategy=hard` with `changed_files = []`), and suppressing every comment
+    there would hide findings the run is deliberately surfacing. An out-of-window
+    attempt costs a non-fatal 422 that callers already collect, so guessing wrong
+    is cheap; staying silent is not.
+
+    Callers that gate comment *retention* must reuse this exact predicate: a
+    narrower rule would reap comments the same run just posted.
+    """
+    lines = _displayed_lines(window, path)
     if lines == None:
         return True
 
-    # Explicit None check: start_line == 0 is an invalid range, not "absent".
+    # `start_line == 0` is an invalid range, not "absent", so test against None.
     first_line = line if start_line == None else start_line
     if first_line < 1 or line < first_line:
         return False
     for current_line in range(first_line, line + 1):
-        if current_line - 1 not in lines:
+        if (current_line - 1) not in lines:
             return False
     return True

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
@@ -117,11 +117,14 @@ def diff_window(changed_files: list, prefix: str = "") -> DiffWindow:
     beside an edit (e.g. SC2164 on the line after an edited comment). Falls back
     to `lines` for older fixtures that predate `hunk_lines`.
 
+    Regions are indexed into dicts once here so membership stays constant-time:
+    validating an N-line suggestion against an N-line hunk would otherwise scan
+    the region list per line.
+
     Keys are whatever `changed_files` carries, which is NOT uniformly relative:
     `detect_changed_files`' PR Files API path strips the workspace prefix, while
-    its local `git diff` paths stay repo-relative (no `--relative`). Comment
-    paths are always workspace-relative, so lookups try the bare path first and
-    then `prefix + path`.
+    its local `git diff` paths stay repo-relative (no `--relative`). See
+    `_displayed_lines` for how a lookup reconciles the two.
     """
     lines_by_path = {}
     for f in changed_files:
@@ -133,13 +136,22 @@ def diff_window(changed_files: list, prefix: str = "") -> DiffWindow:
     return DiffWindow(lines_by_path = lines_by_path, prefix = prefix)
 
 def _displayed_lines(window: DiffWindow, path: str):
-    """The 0-based displayed-line set for `path`, or None when the window holds
-    no entry for it (no change context — distinct from an empty set).
+    """The 0-based displayed-line set for the workspace-relative `path`, or None
+    when the window holds no entry for it (no change context — distinct from an
+    empty set).
+
+    Tries `prefix + path` FIRST so the check matches the repo-relative path the
+    comment is actually posted to. Preferring the bare key would, in a nested
+    workspace whose repo root has a same-named file, validate against the wrong
+    file's line set — suppressing a valid comment or admitting an off-diff one.
+    The bare key is the fallback for change sets already normalized to
+    workspace-relative paths (the PR Files API strips the prefix).
     """
-    lines = window.lines_by_path.get(path)
-    if lines == None and window.prefix:
+    if window.prefix:
         lines = window.lines_by_path.get(window.prefix + path)
-    return lines
+        if lines != None:
+            return lines
+    return window.lines_by_path.get(path)
 
 def can_attempt_comment(window: DiffWindow, path: str, line: int, start_line = None) -> bool:
     """Whether a review comment anchored at `[start_line or line, line]` is

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments.axl
@@ -101,15 +101,15 @@ def suggestion_block(replacement, current, start_line, end_line, vcs):
     return "%s\n%s\n```" % (fence, replacement)
 
 DiffWindow = record(
-    # {path: {0-based line: True}} — the lines the host will display, keyed as
-    # `changed_files` reported them. See `diff_window` for the keying caveat.
+    # {workspace-relative path: {0-based line: True}} — the lines the host will
+    # display. Canonicalized by `diff_window`; comment paths key in directly.
     lines_by_path = field(dict),
-    # Workspace prefix relative to the repo root ("" at the root), used to
-    # reconcile repo-relative keys with workspace-relative comment paths.
-    prefix = field(str, default = ""),
+    # False when change detection could not determine the changed-file set, so an
+    # absent path means "unknown" rather than "unchanged".
+    scoped = field(bool, default = True),
 )
 
-def diff_window(changed_files: list, prefix: str = "") -> DiffWindow:
+def diff_window(changed_files: list, prefix: str = "", scoped: bool = True) -> DiffWindow:
     """Index `changed_files` into a `DiffWindow` for anchor lookups.
 
     Uses `hunk_lines` (added + ±3 context) rather than `lines` (added only):
@@ -117,63 +117,56 @@ def diff_window(changed_files: list, prefix: str = "") -> DiffWindow:
     beside an edit (e.g. SC2164 on the line after an edited comment). Falls back
     to `lines` for older fixtures that predate `hunk_lines`.
 
-    Regions are indexed into dicts once here so membership stays constant-time:
-    validating an N-line suggestion against an N-line hunk would otherwise scan
-    the region list per line.
+    Keys are canonicalized to workspace-relative so lookups need no fallback
+    guessing. `changed_files` is not uniformly relative: `detect_changed_files`'
+    PR Files API path strips `prefix` already, while its local `git diff` paths
+    stay repo-relative (no `--relative`). Stripping a leading `prefix` when
+    present normalizes both, and matters in a nested workspace where the two
+    conventions would otherwise collide (workspace `sub/`, keys `foo.ts` and
+    `sub/foo.ts`, denoting different files).
 
-    Keys are whatever `changed_files` carries, which is NOT uniformly relative:
-    `detect_changed_files`' PR Files API path strips the workspace prefix, while
-    its local `git diff` paths stay repo-relative (no `--relative`). See
-    `_displayed_lines` for how a lookup reconciles the two.
+    Regions are indexed into dicts once so membership stays constant-time;
+    validating an N-line span would otherwise scan the region list per line.
+
+    Args:
+      changed_files: `LintTrait.changed_files` entries.
+      prefix:        workspace path relative to the repo root ("" at the root).
+      scoped:        `LintTrait.changed_files_scoped` — False disables gating
+                     entirely (see `can_attempt_comment`).
     """
     lines_by_path = {}
     for f in changed_files:
         path = f.get("file", "")
         if not path:
             continue
+        if prefix and path.startswith(prefix):
+            path = path[len(prefix):]
         region = f.get("hunk_lines") or f.get("lines") or []
         lines_by_path[path] = {line: True for line in region}
-    return DiffWindow(lines_by_path = lines_by_path, prefix = prefix)
-
-def _displayed_lines(window: DiffWindow, path: str):
-    """The 0-based displayed-line set for the workspace-relative `path`, or None
-    when the window holds no entry for it (no change context — distinct from an
-    empty set).
-
-    Tries `prefix + path` FIRST so the check matches the repo-relative path the
-    comment is actually posted to. Preferring the bare key would, in a nested
-    workspace whose repo root has a same-named file, validate against the wrong
-    file's line set — suppressing a valid comment or admitting an off-diff one.
-    The bare key is the fallback for change sets already normalized to
-    workspace-relative paths (the PR Files API strips the prefix).
-    """
-    if window.prefix:
-        lines = window.lines_by_path.get(window.prefix + path)
-        if lines != None:
-            return lines
-    return window.lines_by_path.get(path)
+    return DiffWindow(lines_by_path = lines_by_path, scoped = scoped)
 
 def can_attempt_comment(window: DiffWindow, path: str, line: int, start_line = None) -> bool:
-    """Whether a review comment anchored at `[start_line or line, line]` is
-    worth sending for `path`.
+    """Whether a review comment on workspace-relative `path` anchored at
+    `[start_line or line, line]` is worth sending.
 
     Requires the whole span to be displayed, because hosts anchor a multi-line
     comment on its full range rather than just its endpoints.
 
-    Fails OPEN when the window has no entry for `path`. An absent entry means
-    "no change context for this file", not "nothing is commentable": change
-    detection legitimately comes up empty (a shallow checkout degrades lint to
-    `strategy=hard` with `changed_files = []`), and suppressing every comment
-    there would hide findings the run is deliberately surfacing. An out-of-window
-    attempt costs a non-fatal 422 that callers already collect, so guessing wrong
-    is cheap; staying silent is not.
+    Unconditionally True for an unscoped window: change detection failed, so
+    every path is "unknown" rather than "unchanged" and suppressing comments
+    would hide findings the run is deliberately surfacing (lint degrades to
+    `strategy=hard` in that state). An out-of-window attempt costs a non-fatal
+    422 the callers already collect. When the window IS scoped, an absent path
+    means unchanged and gets no comment — the 422s this guard exists to prevent.
 
     Callers that gate comment *retention* must reuse this exact predicate: a
     narrower rule would reap comments the same run just posted.
     """
-    lines = _displayed_lines(window, path)
-    if lines == None:
+    if not window.scoped:
         return True
+    lines = window.lines_by_path.get(path)
+    if lines == None:
+        return False
 
     # `start_line == 0` is an invalid range, not "absent", so test against None.
     first_line = line if start_line == None else start_line

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
@@ -4,11 +4,92 @@ Run with:
   aspect dev test-lint-comments
 """
 
-load("./lint_comments.axl", "build_marker", "extract_marker", "is_commentable", "parse_marker", "suggestion_block")
+load("./lint_comments.axl", "build_marker", "can_attempt_comment", "diff_window", "extract_marker", "parse_marker", "suggestion_block")
 
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
+
+def _changed_file(path, hunk_lines = None, lines = None):
+    """A `changed_files` entry as `detect_changed_files` reports it (0-based
+    line regions). `hunk_lines = None` models pre-`hunk_lines` fixtures.
+    """
+    entry = {"file": path}
+    if hunk_lines != None:
+        entry["hunk_lines"] = hunk_lines
+    if lines != None:
+        entry["lines"] = lines
+    return entry
+
+def _test_diff_window():
+    window = diff_window([
+        _changed_file("pkg/a.ts", hunk_lines = [9, 10], lines = [10]),
+        _changed_file("pkg/legacy.ts", lines = [4]),
+        _changed_file("", hunk_lines = [1]),
+    ])
+
+    # hunk_lines wins over lines; lines is the pre-hunk_lines fallback.
+    _eq("window prefers hunk_lines", window.lines_by_path["pkg/a.ts"], {9: True, 10: True})
+    _eq("window falls back to lines", window.lines_by_path["pkg/legacy.ts"], {4: True})
+    _eq("window skips empty path", "" in window.lines_by_path, False)
+    _eq("window default prefix", window.prefix, "")
+    _eq("window entry count", len(window.lines_by_path), 2)
+
+    # A changed file with no line region is still an entry, and an empty region
+    # means "nothing displayed" — distinct from the path being absent entirely.
+    empty = diff_window([_changed_file("pkg/empty.ts", hunk_lines = [])])
+    _eq("empty region is an entry", "pkg/empty.ts" in empty.lines_by_path, True)
+    _eq("empty region blocks anchoring", can_attempt_comment(empty, "pkg/empty.ts", 10), False)
+    _eq("absent path still fails open", can_attempt_comment(empty, "pkg/other.ts", 10), True)
+
+    _eq("empty changed_files", diff_window([]).lines_by_path, {})
+    _eq("window keeps prefix", diff_window([], prefix = "sub/").prefix, "sub/")
+
+def _test_can_attempt_comment():
+    # 0-based hunk regions; a comment on 1-based line N needs N-1 present.
+    window = diff_window([
+        _changed_file("pkg/direct.ts", hunk_lines = [9]),
+        _changed_file("pkg/gapped.ts", hunk_lines = [39, 41]),
+        _changed_file("pkg/range.ts", hunk_lines = [29, 30, 31]),
+    ])
+
+    _eq("direct changed line", can_attempt_comment(window, "pkg/direct.ts", 10), True)
+    _eq("outside changed hunk", can_attempt_comment(window, "pkg/direct.ts", 11), False)
+    _eq("commentable range", can_attempt_comment(window, "pkg/range.ts", 32, start_line = 30), True)
+    _eq("single-line range in window", can_attempt_comment(window, "pkg/range.ts", 30, start_line = 30), True)
+
+    # Multi-line ranges need every line displayed, since the host anchors the
+    # whole span — line 41 (0-based 40) is not in the gapped hunk.
+    _eq("range crosses collapsed diff", can_attempt_comment(window, "pkg/gapped.ts", 42, start_line = 40), False)
+    _eq("range endpoints only is not enough", can_attempt_comment(window, "pkg/gapped.ts", 42, start_line = 42), True)
+
+    # Fail open with no entry: an absent file has no change context, and an
+    # empty window is the unscoped `strategy=hard` run.
+    _eq("file absent from window", can_attempt_comment(window, "pkg/missing.ts", 10), True)
+    _eq("unscoped run posts everything", can_attempt_comment(diff_window([]), "pkg/direct.ts", 999), True)
+
+    # A known file with a known hunk still gates — the 422 this guard prevents.
+    _eq("known file outside hunk", can_attempt_comment(window, "pkg/gapped.ts", 100), False)
+
+    # start_line == 0 is an invalid range, not "absent".
+    _eq("zero start_line rejected", can_attempt_comment(window, "pkg/direct.ts", 10, start_line = 0), False)
+    _eq("inverted range rejected", can_attempt_comment(window, "pkg/range.ts", 30, start_line = 32), False)
+    _eq("negative line rejected", can_attempt_comment(window, "pkg/direct.ts", -1), False)
+
+    # Nested workspace: changed_files keys stay repo-relative on the local
+    # git-diff path, while comment paths are workspace-relative.
+    prefixed = diff_window([_changed_file("apps/docs/pkg/p.ts", hunk_lines = [19])], prefix = "apps/docs/")
+    _eq("prefix fallback resolves", can_attempt_comment(prefixed, "pkg/p.ts", 20), True)
+    _eq("prefix fallback still gates", can_attempt_comment(prefixed, "pkg/p.ts", 25), False)
+    _eq("prefixed path also resolves", can_attempt_comment(prefixed, "apps/docs/pkg/p.ts", 20), True)
+
+    # Bare path wins when both keys exist, so a prefix can't shadow a real entry.
+    both = diff_window(
+        [_changed_file("pkg/p.ts", hunk_lines = [9]), _changed_file("sub/pkg/p.ts", hunk_lines = [99])],
+        prefix = "sub/",
+    )
+    _eq("bare key preferred", can_attempt_comment(both, "pkg/p.ts", 10), True)
+    _eq("bare key not shadowed", can_attempt_comment(both, "pkg/p.ts", 100), False)
 
 def _test_impl(ctx):
     m = build_marker("gl-123", "lint-bk", "ShellCheck", "a/b.sh", 42, "SC2164")
@@ -37,29 +118,8 @@ def _test_impl(ctx):
     _eq("gitlab suggestion single", suggestion_block("foo", current = 10, start_line = 10, end_line = 10, vcs = "gitlab"), "```suggestion:-0+0\nfoo\n```")
     _eq("gitlab suggestion multi", suggestion_block("foo\nbar\nbaz", current = 12, start_line = 10, end_line = 12, vcs = "gitlab"), "```suggestion:-2+0\nfoo\nbar\nbaz\n```")
 
-    changed_lines = {
-        "pkg/direct.ts": [9],
-        "pkg/gapped.ts": [39, 41],
-        "pkg/range.ts": [29, 30, 31],
-        "apps/docs/pkg/prefixed.ts": [19],
-    }
-    _eq("direct changed line", is_commentable("pkg/direct.ts", 10, changed_lines), True)
-    _eq("prefixed changed line", is_commentable("pkg/prefixed.ts", 20, changed_lines, prefix = "apps/docs/"), True)
-    _eq("outside changed hunk", is_commentable("pkg/direct.ts", 11, changed_lines), False)
-    _eq("commentable range", is_commentable("pkg/range.ts", 32, changed_lines, start_line = 30), True)
-    _eq("range crosses collapsed diff", is_commentable("pkg/gapped.ts", 42, changed_lines, start_line = 40), False)
-
-    # Fail open with no line-set: a file absent from changed_lines has no change
-    # context, and an empty changed_lines is the unscoped `strategy=hard` run.
-    _eq("file absent from changed set", is_commentable("pkg/missing.ts", 10, changed_lines), True)
-    _eq("unscoped run posts everything", is_commentable("pkg/direct.ts", 999, {}), True)
-
-    # A known file with a known hunk still gates — this is the 422 the fix targets.
-    _eq("known file outside hunk", is_commentable("pkg/gapped.ts", 100, changed_lines), False)
-
-    # start_line == 0 is an invalid range, not "absent".
-    _eq("zero start_line rejected", is_commentable("pkg/direct.ts", 10, changed_lines, start_line = 0), False)
-    _eq("inverted range rejected", is_commentable("pkg/range.ts", 30, changed_lines, start_line = 32), False)
+    _test_diff_window()
+    _test_can_attempt_comment()
 
     print("lint_comments.axl: OK")
     return 0

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
@@ -46,9 +46,20 @@ def _test_impl(ctx):
     _eq("direct changed line", is_commentable("pkg/direct.ts", 10, changed_lines), True)
     _eq("prefixed changed line", is_commentable("pkg/prefixed.ts", 20, changed_lines, prefix = "apps/docs/"), True)
     _eq("outside changed hunk", is_commentable("pkg/direct.ts", 11, changed_lines), False)
-    _eq("unchanged file", is_commentable("pkg/missing.ts", 10, changed_lines), False)
     _eq("commentable range", is_commentable("pkg/range.ts", 32, changed_lines, start_line = 30), True)
     _eq("range crosses collapsed diff", is_commentable("pkg/gapped.ts", 42, changed_lines, start_line = 40), False)
+
+    # Fail open with no line-set: a file absent from changed_lines has no change
+    # context, and an empty changed_lines is the unscoped `strategy=hard` run.
+    _eq("file absent from changed set", is_commentable("pkg/missing.ts", 10, changed_lines), True)
+    _eq("unscoped run posts everything", is_commentable("pkg/direct.ts", 999, {}), True)
+
+    # A known file with a known hunk still gates — this is the 422 the fix targets.
+    _eq("known file outside hunk", is_commentable("pkg/gapped.ts", 100, changed_lines), False)
+
+    # start_line == 0 is an invalid range, not "absent".
+    _eq("zero start_line rejected", is_commentable("pkg/direct.ts", 10, changed_lines, start_line = 0), False)
+    _eq("inverted range rejected", is_commentable("pkg/range.ts", 30, changed_lines, start_line = 32), False)
 
     print("lint_comments.axl: OK")
     return 0

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
@@ -32,18 +32,41 @@ def _test_diff_window():
     _eq("window prefers hunk_lines", window.lines_by_path["pkg/a.ts"], {9: True, 10: True})
     _eq("window falls back to lines", window.lines_by_path["pkg/legacy.ts"], {4: True})
     _eq("window skips empty path", "" in window.lines_by_path, False)
-    _eq("window default prefix", window.prefix, "")
     _eq("window entry count", len(window.lines_by_path), 2)
+    _eq("window scoped by default", window.scoped, True)
+    _eq("empty changed_files", diff_window([]).lines_by_path, {})
 
-    # A changed file with no line region is still an entry, and an empty region
-    # means "nothing displayed" — distinct from the path being absent entirely.
+    # A changed file with an empty region is still an entry: "nothing displayed",
+    # which blocks anchoring, unlike a path the window never mentions.
     empty = diff_window([_changed_file("pkg/empty.ts", hunk_lines = [])])
     _eq("empty region is an entry", "pkg/empty.ts" in empty.lines_by_path, True)
     _eq("empty region blocks anchoring", can_attempt_comment(empty, "pkg/empty.ts", 10), False)
-    _eq("absent path still fails open", can_attempt_comment(empty, "pkg/other.ts", 10), True)
 
-    _eq("empty changed_files", diff_window([]).lines_by_path, {})
-    _eq("window keeps prefix", diff_window([], prefix = "sub/").prefix, "sub/")
+    # Keys canonicalize to workspace-relative: the local git-diff path reports
+    # repo-relative paths, the PR Files API already stripped the prefix, and both
+    # must land on the same key.
+    _eq(
+        "repo-relative key stripped",
+        diff_window([_changed_file("sub/pkg/p.ts", hunk_lines = [19])], prefix = "sub/").lines_by_path,
+        {"pkg/p.ts": {19: True}},
+    )
+    _eq(
+        "already-stripped key kept",
+        diff_window([_changed_file("pkg/p.ts", hunk_lines = [19])], prefix = "sub/").lines_by_path,
+        {"pkg/p.ts": {19: True}},
+    )
+
+    # Only a leading prefix is stripped, and only once.
+    _eq(
+        "prefix stripped once",
+        diff_window([_changed_file("sub/sub/p.ts", hunk_lines = [1])], prefix = "sub/").lines_by_path,
+        {"sub/p.ts": {1: True}},
+    )
+    _eq(
+        "interior match not stripped",
+        diff_window([_changed_file("pkg/sub/p.ts", hunk_lines = [1])], prefix = "sub/").lines_by_path,
+        {"pkg/sub/p.ts": {1: True}},
+    )
 
 def _test_can_attempt_comment():
     # 0-based hunk regions; a comment on 1-based line N needs N-1 present.
@@ -63,35 +86,40 @@ def _test_can_attempt_comment():
     _eq("range crosses collapsed diff", can_attempt_comment(window, "pkg/gapped.ts", 42, start_line = 40), False)
     _eq("range endpoints only is not enough", can_attempt_comment(window, "pkg/gapped.ts", 42, start_line = 42), True)
 
-    # Fail open with no entry: an absent file has no change context, and an
-    # empty window is the unscoped `strategy=hard` run.
-    _eq("file absent from window", can_attempt_comment(window, "pkg/missing.ts", 10), True)
-    _eq("unscoped run posts everything", can_attempt_comment(diff_window([]), "pkg/direct.ts", 999), True)
-
-    # A known file with a known hunk still gates — the 422 this guard prevents.
+    # Scoped window: an absent path is unchanged, so no comment. These are the
+    # 422s the guard exists to prevent — findings stream pre-strategy, so raw
+    # SARIF carries diagnostics for files the PR never touched.
+    _eq("unchanged file rejected", can_attempt_comment(window, "pkg/missing.ts", 10), False)
     _eq("known file outside hunk", can_attempt_comment(window, "pkg/gapped.ts", 100), False)
+    _eq("scoped but empty rejects", can_attempt_comment(diff_window([]), "pkg/direct.ts", 10), False)
+
+    # Unscoped: detection failed, so nothing is known to be unchanged and lint is
+    # already degraded to strategy=hard. Gating would hide surfaced findings.
+    unscoped = diff_window([], scoped = False)
+    _eq("unscoped posts everything", can_attempt_comment(unscoped, "pkg/anything.ts", 999), True)
+    _eq("unscoped ignores ranges", can_attempt_comment(unscoped, "pkg/anything.ts", 1, start_line = 999), True)
 
     # start_line == 0 is an invalid range, not "absent".
     _eq("zero start_line rejected", can_attempt_comment(window, "pkg/direct.ts", 10, start_line = 0), False)
     _eq("inverted range rejected", can_attempt_comment(window, "pkg/range.ts", 30, start_line = 32), False)
     _eq("negative line rejected", can_attempt_comment(window, "pkg/direct.ts", -1), False)
 
-    # Nested workspace: changed_files keys stay repo-relative on the local
-    # git-diff path, while comment paths are workspace-relative.
+    # Nested workspace: comment paths are workspace-relative and key in directly
+    # once `diff_window` has canonicalized the changed-file keys.
     prefixed = diff_window([_changed_file("apps/docs/pkg/p.ts", hunk_lines = [19])], prefix = "apps/docs/")
-    _eq("prefix fallback resolves", can_attempt_comment(prefixed, "pkg/p.ts", 20), True)
-    _eq("prefix fallback still gates", can_attempt_comment(prefixed, "pkg/p.ts", 25), False)
-    _eq("prefixed path also resolves", can_attempt_comment(prefixed, "apps/docs/pkg/p.ts", 20), True)
+    _eq("workspace-relative path resolves", can_attempt_comment(prefixed, "pkg/p.ts", 20), True)
+    _eq("workspace-relative path gates", can_attempt_comment(prefixed, "pkg/p.ts", 25), False)
 
-    # Both keys present (repo root and workspace have a same-named file): the
-    # prefixed key wins, because that is the path the comment is posted to.
-    # Preferring the bare key would validate against the repo-root file.
-    both = diff_window(
-        [_changed_file("pkg/p.ts", hunk_lines = [9]), _changed_file("sub/pkg/p.ts", hunk_lines = [99])],
+    # Nested workspace at sub/ where sub/foo.ts and sub/sub/foo.ts both change:
+    # canonicalized to foo.ts and sub/foo.ts, so neither shadows the other.
+    collide = diff_window(
+        [_changed_file("sub/foo.ts", hunk_lines = [9]), _changed_file("sub/sub/foo.ts", hunk_lines = [99])],
         prefix = "sub/",
     )
-    _eq("prefixed key wins on collision", can_attempt_comment(both, "pkg/p.ts", 100), True)
-    _eq("repo-root lines not consulted", can_attempt_comment(both, "pkg/p.ts", 10), False)
+    _eq("workspace file resolves", can_attempt_comment(collide, "foo.ts", 10), True)
+    _eq("nested namesake resolves", can_attempt_comment(collide, "sub/foo.ts", 100), True)
+    _eq("namesake lines not crossed", can_attempt_comment(collide, "foo.ts", 100), False)
+    _eq("workspace lines not crossed", can_attempt_comment(collide, "sub/foo.ts", 10), False)
 
 def _test_impl(ctx):
     m = build_marker("gl-123", "lint-bk", "ShellCheck", "a/b.sh", 42, "SC2164")

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
@@ -83,13 +83,15 @@ def _test_can_attempt_comment():
     _eq("prefix fallback still gates", can_attempt_comment(prefixed, "pkg/p.ts", 25), False)
     _eq("prefixed path also resolves", can_attempt_comment(prefixed, "apps/docs/pkg/p.ts", 20), True)
 
-    # Bare path wins when both keys exist, so a prefix can't shadow a real entry.
+    # Both keys present (repo root and workspace have a same-named file): the
+    # prefixed key wins, because that is the path the comment is posted to.
+    # Preferring the bare key would validate against the repo-root file.
     both = diff_window(
         [_changed_file("pkg/p.ts", hunk_lines = [9]), _changed_file("sub/pkg/p.ts", hunk_lines = [99])],
         prefix = "sub/",
     )
-    _eq("bare key preferred", can_attempt_comment(both, "pkg/p.ts", 10), True)
-    _eq("bare key not shadowed", can_attempt_comment(both, "pkg/p.ts", 100), False)
+    _eq("prefixed key wins on collision", can_attempt_comment(both, "pkg/p.ts", 100), True)
+    _eq("repo-root lines not consulted", can_attempt_comment(both, "pkg/p.ts", 10), False)
 
 def _test_impl(ctx):
     m = build_marker("gl-123", "lint-bk", "ShellCheck", "a/b.sh", 42, "SC2164")


### PR DESCRIPTION
Follow-up to #1345, which restored `GithubLintComments`' diff filter at the GitHub API boundary. This fixes three bugs in that filter and shares it with the GitLab sibling.

**An empty changed-file set silenced all review comments.** The filter rejected any path it had no line-set entry for. But `changed_files = []` has two meanings: change detection failed (shallow checkout), in which case `lint.axl` deliberately forces `strategy=hard` so findings are still surfaced; or detection succeeded and the file is genuinely unchanged. Conflating them meant a shallow-checkout PR received zero review comments while the task still failed on the same errors. `LintTrait.changed_files_scoped` now carries that distinction to features as data, and the filter only fails open when detection was unscoped.

**Cleanup could reap comments the same run just posted.** `_cleanup_comments` builds `desired`, a keep-set gating deletion, so it must admit exactly what the posting path attempts — a narrower rule deletes live comments. GitLab already documented this invariant; the GitHub path did not. Both now call one shared predicate.

**GitLab's filter never matched in a nested workspace.** `_post_comments` looked up the bare path, but `changed_files` keys from the local `git diff` path are repo-relative (`--relative` is not passed), so nothing matched and every comment bypassed the filter.

Changed-file keys are not uniformly relative — the PR Files API strips the workspace prefix, local `git diff` does not — so `diff_window` canonicalizes them to workspace-relative at index time. Comment paths then key in directly, with no per-lookup fallback that could validate a comment against a same-named file elsewhere in the repo.

### Structure

A `DiffWindow` record plus `diff_window()` replaces the loose `changed_lines` dict and the `hunk_lines or lines` comprehension duplicated in both features, and removes the positional-boolean call sites. Regions are indexed into dicts once, so membership is constant-time rather than a linear scan per line. `_postable()` collapses two identical filter comprehensions in the GitHub feature.

One asymmetry is explicit at both call sites: GitHub passes `start_line` because its API takes a real range, so the whole span must be displayed; GitLab does not, because a position anchors a single line and encodes the span in the `suggestion:-X+Y` fence.

### Not changed

GitHub multi-line suggestions require every line in the span to be displayed, which is stricter than GitHub's rule (only the anchor and `start_line` must be in the diff). That behavior comes from #1345 and is pinned by a named test rather than changed here.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no — internal feature behavior, no documented surface changes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Fixed `GithubLintComments` dropping all PR review comments when the changed-file set could not be determined (e.g. a shallow checkout), which silently suppressed findings the run reported as errors.
- Fixed `GithubLintComments` deleting review comments it had just posted when running without change context.
- Fixed `GitlabLintComments` not filtering review comments to the MR diff when the Bazel workspace is a subdirectory of the repository.

### Test plan

- Covered by existing test cases
- New test cases added

`aspect dev test-lint-comments` gains `_test_diff_window` and `_test_can_attempt_comment`, covering `hunk_lines`-over-`lines` precedence, the empty-region vs absent-path distinction, scoped-vs-unscoped gating, prefix stripping (leading-only, once, already-stripped), same-named files in a nested workspace resolving independently, and negative / zero / inverted ranges.

- `aspect dev test-lint-comments` — OK
- `aspect dev test-gitlab-lint-comments` — OK
- `aspect tests axl` — 896 tests passed
- `aspect format` on all changed files — no changes
