### PR TITLE
fix(cli): announce BES sinks and deployment flags with the spawn, not before it

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -1188,9 +1188,10 @@ def _delivery_impl(ctx):
 
     # iter handles are created per attempt inside the retry loop. The
     # CLI-streamed `--bes-backend` sinks stream phase-1 events and are waited
-    # alongside the trait sinks (see `_get_output_shas`).
+    # alongside the trait sinks (see `_get_output_shas`). Announced under the
+    # first phase header below rather than here, so the lines land inside a
+    # phase instead of ahead of the task's first one.
     build_events = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
-    announce_bes_sinks(ctx, build_events)
 
     for handler in bazel_trait.build_start:
         handler(ctx)
@@ -1235,6 +1236,11 @@ def _delivery_impl(ctx):
         phase = Phase(name = "resolve", description = "Resolve targets to deliver", emoji = "🎯"),
         subject = query_expr,
     )
+
+    # After the first phase line. Announced here rather than at the phase-1
+    # spawn because the sinks also stream when phase 1/2 are skipped.
+    announce_bes_sinks(ctx, build_events)
+
     if query_expr:
         # Echo the query so the resolved set (or failure) is attributable to it.
         info(ctx.std, "Running bazel query: {}".format(query_expr))

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -321,7 +321,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Pass build_event_sinks (carries the Aspect backend gRPC sink in CI) so the
     # "✨ Aspect Workflows" link resolves to a real record, not a 404.
     bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
-    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 
@@ -343,6 +342,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data = data,
         phase = Phase(name = "build", description = "Build formatter", emoji = "🔨"),
     )
+
+    # After the phase line, so the streams are announced under the spawn they
+    # belong to.
+    announce_bes_sinks(ctx, bes_sinks)
 
     build = ctx.bazel.build(
         ctx.args.formatter_target,

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -463,7 +463,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # See format.axl for why the trait sinks need to be plumbed in.
     bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
-    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 
@@ -485,6 +484,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data = data,
         phase = Phase(name = "build", description = "Build gazelle", emoji = "🔨"),
     )
+
+    # After the phase line, so the streams are announced under the spawn they
+    # belong to.
+    announce_bes_sinks(ctx, bes_sinks)
 
     build = ctx.bazel.build(
         ctx.args.gazelle_target,

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -803,7 +803,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         hook(ctx)
 
     bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
-    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 
@@ -823,6 +822,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data = data,
         phase = Phase(name = "lint", description = "Run lint aspects", emoji = "🔬"),
     )
+
+    # After the phase line, so the streams are announced under the spawn they
+    # belong to.
+    announce_bes_sinks(ctx, bes_sinks)
 
     # 6. Build + stream events
     # TODO: re-introduce --quiet once we can capture (not only inherit-or-not)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -306,18 +306,13 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     rc = setup_phase(ctx, lifecycle, " ".join(targets), "bazel_results", data, hc_trait, bazel_trait, command, bazel_base_flags = base_flags)
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
-    # Surface which deployment's `--remote_cache` / `--remote_executor` the
-    # `--aspect-*` flags wired in, so the injected base flags aren't silent. (BES
-    # is announced separately, below, by `announce_bes_sinks`.)
-    announce_deployment_flags(ctx, deployment)
-
     # Every CLI-streamed BES sink: explicit `--bes-backend`, the deployment's BES,
-    # and the trait's own sinks (the Workflows runner's env-injected backend). All
-    # are announced now and summarized at build end.
+    # and the trait's own sinks (the Workflows runner's env-injected backend).
+    # Announced with the first spawn below (the streams belong to the spawn) and
+    # summarized at build end.
     bes_sinks = collect_bes_from_args(ctx, extra_backends = deployment.bes_backends)
     if bazel_trait.build_event_sinks:
         bes_sinks.extend(bazel_trait.build_event_sinks)
-    announce_bes_sinks(ctx, bes_sinks)
     need_bes = bool(bazel_trait.build_event) or bool(lifecycle.task_update)
 
     # Per-invocation extras: inject `--remote_header` / `--bes_header` auth for an
@@ -388,6 +383,15 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
                 emoji = "🧪" if command == "test" else "🔨",
             ),
         )
+
+        # Disclose what this bazel call was wired with, after the spawn phase
+        # line so both land under the phase they describe: the deployment's
+        # injected `--remote_cache` / `--remote_executor`, then the CLI-streamed
+        # BES backends. First attempt only — a retry reuses the same flags and
+        # sinks, so re-announcing would imply new ones.
+        if attempt == 0:
+            announce_deployment_flags(ctx, deployment)
+            announce_bes_sinks(ctx, bes_sinks)
 
         # Per-attempt iter handle; single-use, so re-create each retry.
         events = bazel.build_events.iterator() if need_bes else None

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
@@ -120,7 +120,12 @@ def announce_bes_sinks(ctx, sinks: list):
     streamed to it — so a `--bes-backend`, a deployment's BES, and the Workflows
     runner's env-injected backend are all visible at build start (the sinks are
     CLI-side gRPC streams, otherwise invisible in the Bazel command). The
-    end-of-build counterpart is `summarize_bes_upload`."""
+    end-of-build counterpart is `summarize_bes_upload`.
+
+    Call *after* the spawning phase's `task_update`, not before: the streams
+    belong to the spawn, so announcing first strands these lines above the phase
+    header they describe. Callers with a retry loop announce on the first attempt
+    only — a retry reuses the same sinks."""
     for sink in grpc_backends(sinks):
         info(ctx.std, "Streaming build events to %s." % sink.uri)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -182,7 +182,12 @@ def announce_deployment_flags(ctx, flags: DeploymentFlags):
     """Tell the user, in one line, which deployment's base-flag capabilities this
     bazel call is wired to (`--aspect-*`) and the endpoint each uses, so the
     injected --remote_cache / --remote_executor aren't silent. (BES is announced
-    separately by `announce_bes_sinks`.) No-op when nothing was injected."""
+    separately by `announce_bes_sinks`.) No-op when nothing was injected.
+
+    Call *after* the spawning phase's `task_update`, not before: the flags belong
+    to the bazel call, so announcing at resolve time strands this line above the
+    phase header it describes. Callers with a retry loop announce on the first
+    attempt only — a retry reuses the same flags."""
     if not flags.capabilities:
         return
     parts = [label + " (" + uri + ")" for (label, uri) in flags.capabilities]

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -89,7 +89,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # and the target env so `r.spawn` replays them the way `bazel run` does.
     r = runnable(ctx, [target], rc = rc)
     bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
-    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 
@@ -108,6 +107,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data = data,
         phase = Phase(name = "build", description = "Build run target", emoji = "🔨"),
     )
+
+    # After the phase line, so the streams are announced under the spawn they
+    # belong to.
+    announce_bes_sinks(ctx, bes_sinks)
 
     build = ctx.bazel.build(
         target,

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -139,7 +139,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # backend gRPC sink in CI) so the "✨ Aspect Workflows" link resolves to a
     # real record. The local iterator drains BES into `data["bazel"]`.
     bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
-    announce_bes_sinks(ctx, bes_sinks)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 
@@ -158,6 +157,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         data = data,
         phase = Phase(name = "populate", description = "Populate Bazel caches", emoji = "🔨"),
     )
+
+    # After the phase line, so the streams are announced under the spawn they
+    # belong to.
+    announce_bes_sinks(ctx, bes_sinks)
 
     build = ctx.bazel.build(
         flags = ["--nobuild"] + endpoint_auth_flags,


### PR DESCRIPTION
Two `INFO:` lines were landing above the phase header they belong to, so a build's opening output read out of order:

```
INFO: Streaming build events to grpc://buildbarn-frontend.awd.internal:8980.

→ 🧪 Test · Spawning bazel test
```

`announce_bes_sinks` and `announce_deployment_flags` were both called at sink/flag *construction* time, which in every task happens before the `task_update` that emits the spawning phase header. The lines were flushed while the previous phase (`Setup`) was still current, stranding them above the `Spawning bazel <command>` header that describes the very call they document.

Both announcements now fire immediately after the spawning phase's `task_update`, so they land under that header and directly ahead of the `Spawning: bazel …` line whose injected flags and CLI-side streams they disclose. In the shared `build`/`test` retry loop they're gated to the first attempt — a retry reuses the same flags and sinks, so re-announcing would imply new ones. `delivery` announces after its `resolve` phase header rather than at the phase-1 spawn, because its sinks also stream when phase 1/2 are skipped (`--mode=always --dry-run --track-state=false`); announcing at the spawn would have dropped the line entirely in that path.

Both helpers now document the call-after-the-phase-update contract so the next caller doesn't reintroduce the inversion.

Before / after, with a deployment wired:

```
  → 🔧 Setup · Running setup
- INFO: Using deployment 'gcp.awd-gha-test-dev' for remote cache (grpcs://remote.gcp…)
- INFO: Streaming build events to https://remote.gcp…

  → 🔨 Build · Spawning bazel build
+ INFO: Using deployment 'gcp.awd-gha-test-dev' for remote cache (grpcs://remote.gcp…)
+ INFO: Streaming build events to https://remote.gcp…
  INFO: Bazel 9.0.1
  INFO: Spawning: bazel … --remote_cache=grpcs://remote.gcp…
```

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- The `INFO: Streaming build events to …` and `INFO: Using deployment … for remote cache …` lines now appear under the `Spawning bazel <command>` phase header instead of above it, alongside the other spawn disclosures.

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:

Both lines are emitted at spawn time and aren't covered by a golden/snapshot test, so ordering was verified by running the real commands. Existing `aspect dev test-bes-sinks` (6 tests) still passes, and all eight bazel-spawning tasks load cleanly.

```bash
# BES announcement — expect "Streaming build events" AFTER the phase header
aspect build --bes-backend=grpc://127.0.0.1:1 //:all

# Deployment + BES together — expect both AFTER the phase header,
# immediately before "INFO: Bazel <version>" / "INFO: Spawning: bazel …"
aspect build --deployment=<name> --aspect-remote //:all
```
