### PR TITLE
fix(cli): make the crash handler's backtrace signal-safe on musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "anyhow",
  "aspect-telemetry",
  "axl-runtime",
+ "backtrace",
  "chrono",
  "clap",
  "dirs",

--- a/bazel/rust/defs.bzl
+++ b/bazel/rust/defs.bzl
@@ -35,7 +35,12 @@ def rust_binary(name, rustc_env_files = [], version_key = "", crate_features = [
                 "-Ccodegen-units=1",
                 "-Copt-level=3",
                 "-Cpanic=abort",
-                "-Cstrip=symbols",
+                # Keep symbols + debug info in the release binary: the crash
+                # handler prints ASLR-relative offsets that then resolve to
+                # function names and file:line against the shipped binary
+                # (`addr2line`). Stripping would leave crash reports
+                # unsymbolizable (only ~5% larger; worth it for self-diagnosis).
+                "-Cstrip=none",
             ],
             "//conditions:default": [
                 "-Ccodegen-units=1",
@@ -90,7 +95,7 @@ def rust_library(name, rustc_env_files = [], version_key = "", crate_features = 
                 "-Ccodegen-units=1",
                 "-Copt-level=3",
                 "-Cpanic=abort",
-                "-Cstrip=symbols",
+                "-Cstrip=none",
             ],
             "//conditions:default": [
                 "-Ccodegen-units=1",
@@ -118,7 +123,7 @@ def rust_proc_macro(name, crate_features = [], **kwargs):
                 "-Ccodegen-units=1",
                 "-Copt-level=3",
                 "-Cpanic=abort",
-                "-Cstrip=symbols",
+                "-Cstrip=none",
             ],
             "//conditions:default": [
                 "-Ccodegen-units=1",

--- a/crates/aspect-cli/BUILD.bazel
+++ b/crates/aspect-cli/BUILD.bazel
@@ -18,6 +18,7 @@ rust_binary(
         "//crates/aspect-telemetry",
         "//crates/axl-runtime",
         "@crates//:anyhow",
+        "@crates//:backtrace",
         "@crates//:base64",
         "@crates//:chrono",
         "@crates//:clap",

--- a/crates/aspect-cli/Cargo.toml
+++ b/crates/aspect-cli/Cargo.toml
@@ -44,6 +44,7 @@ dirs = "6.0.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+backtrace = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/aspect-cli/src/crash_handler.rs
+++ b/crates/aspect-cli/src/crash_handler.rs
@@ -17,12 +17,16 @@
 //! stack walk uses `backtrace::trace_unsynchronized` (no allocator lock) and
 //! emits raw instruction pointers only — it does NOT symbolize, because
 //! resolving symbols allocates and, on static-musl release builds (the case
-//! this handler exists for), faults inside the handler. Resolve the addresses
-//! offline against the binary with `addr2line -fe aspect-cli <addr>`. A
-//! re-entrancy flag turns any fault inside the handler into an immediate
-//! default-action death. Handlers run on the alternate signal stack
-//! (`SA_ONSTACK`) std installs per thread, so stack-overflow SIGSEGVs are
-//! reported rather than double-faulting.
+//! this handler exists for), faults inside the handler. A re-entrancy flag
+//! turns any fault inside the handler into an immediate default-action death.
+//! Handlers run on the alternate signal stack (`SA_ONSTACK`) std installs per
+//! thread, so stack-overflow SIGSEGVs are reported rather than double-faulting.
+//!
+//! Resolving the report: release binaries are position-independent, so each
+//! code address is printed as `<runtime> (+<static offset>)` where the offset
+//! already has the ASLR load bias removed. Release builds keep their symbols
+//! (see `bazel/rust/defs.bzl`), so the offset resolves to a function and
+//! file:line directly against the binary: `addr2line -fe aspect-cli <offset>`.
 //!
 //! `ASPECT_NO_CRASH_HANDLER` (any non-empty value) skips installation.
 
@@ -182,12 +186,59 @@ mod unix {
         write_stderr(format_hex(value, &mut buf));
     }
 
-    /// Walk the current call stack and write each frame's raw instruction
-    /// pointer to stderr, one `0x…` per line. Signal-safe: it neither allocates
-    /// nor symbolizes (both fault inside a signal handler on static-musl builds
-    /// — the very case this handler exists for). Resolve the addresses offline
-    /// against the binary, e.g. `addr2line -fe aspect-cli <addr>`.
-    fn write_raw_backtrace() {
+    /// The main executable's load bias (the runtime base a position-independent
+    /// executable was mapped at). Subtract it from a runtime address to get the
+    /// static, ASLR-independent offset that resolves against the on-disk binary
+    /// (`addr2line -e aspect-cli <offset>`). Returns 0 on non-Linux or if the
+    /// bias can't be determined — in which case the printed offset equals the
+    /// raw address.
+    fn load_bias() -> usize {
+        #[cfg(target_os = "linux")]
+        {
+            // The first object `dl_iterate_phdr` reports is the main
+            // executable; its `dlpi_addr` is the load bias. Stop after it.
+            extern "C" fn cb(
+                info: *mut libc::dl_phdr_info,
+                _size: libc::size_t,
+                data: *mut libc::c_void,
+            ) -> libc::c_int {
+                // SAFETY: `info` is a valid dl_phdr_info for the callback's
+                // lifetime; `data` is the &mut usize we passed in.
+                unsafe {
+                    *(data as *mut usize) = (*info).dlpi_addr as usize;
+                }
+                1 // non-zero: visit only the first (main executable) entry
+            }
+            let mut bias: usize = 0;
+            // SAFETY: dl_iterate_phdr with a callback that only writes through
+            // the provided pointer; no allocation.
+            unsafe {
+                libc::dl_iterate_phdr(Some(cb), (&mut bias) as *mut usize as *mut libc::c_void);
+            }
+            bias
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            0
+        }
+    }
+
+    /// Write a runtime code address as `<abs> (+<offset>)`, where `offset` is
+    /// `abs - bias` — the static offset that resolves against the on-disk
+    /// binary regardless of ASLR. When `bias` is 0 the offset equals `abs`.
+    fn write_addr(abs: usize, bias: usize) {
+        write_hex(abs);
+        write_stderr(b" (+");
+        write_hex(abs.wrapping_sub(bias));
+        write_stderr(b")");
+    }
+
+    /// Walk the current call stack and write each frame's instruction pointer
+    /// to stderr as `<abs> (+<offset>)` (see [`write_addr`]), one per line.
+    /// Signal-safe: it neither allocates nor symbolizes (both fault inside a
+    /// signal handler on static-musl builds — the very case this handler exists
+    /// for).
+    fn write_raw_backtrace(bias: usize) {
         // SAFETY: single-shot within a dying process; `trace_unsynchronized`
         // avoids the global lock `trace` takes (which could deadlock if the
         // crash happened while that lock was held). The callback only writes
@@ -195,7 +246,7 @@ mod unix {
         unsafe {
             backtrace::trace_unsynchronized(|frame| {
                 write_stderr(b"  ");
-                write_hex(frame.ip() as usize);
+                write_addr(frame.ip() as usize, bias);
                 write_stderr(b"\n");
                 true
             });
@@ -274,19 +325,21 @@ mod unix {
             reset_and_reraise(sig);
         }
 
+        let bias = load_bias();
+
         write_stderr(b"\naspect-cli: fatal signal: ");
         write_stderr(signal_name(sig).as_bytes());
         write_stderr(b"\nfault address: ");
         write_hex(fault_addr(info));
         write_stderr(b"\ncrash pc: ");
-        write_hex(crash_pc(ctx));
+        write_addr(crash_pc(ctx), bias);
         write_stderr(
-            b"\naddresses are raw instruction pointers; resolve with \
-              `addr2line -fe aspect-cli <addr>`.\ncrash pc is the fault site; \
-              the frames below may be truncated to the handler frame on \
-              static-musl builds:\n",
+            b"\ncode addresses print as `<runtime> (+<static offset>)`; resolve the \
+              static offset against this binary:\n  \
+              `addr2line -fe aspect-cli <offset>`.\ncrash pc is the fault site; the \
+              frames below may be truncated to the handler frame on static-musl builds:\n",
         );
-        write_raw_backtrace();
+        write_raw_backtrace(bias);
         write_stderr(
             b"aspect-cli crashed; please report this at \
               https://github.com/aspect-build/aspect-cli/issues including the output above.\n",

--- a/crates/aspect-cli/src/crash_handler.rs
+++ b/crates/aspect-cli/src/crash_handler.rs
@@ -1,7 +1,7 @@
 //! Fatal-signal crash reporter.
 //!
 //! Installs handlers for the fatal signals (SIGSEGV, SIGBUS, SIGILL, SIGFPE,
-//! SIGABRT) that print the signal name, fault address, and a best-effort
+//! SIGABRT) that print the signal name, fault address, and a raw-address
 //! backtrace to stderr, then re-raise the signal with its default disposition
 //! so the process still dies with the original signal and exit statuses are
 //! unchanged.
@@ -12,15 +12,17 @@
 //! usually gone before anyone can look. This lands a crash report in the task
 //! log itself.
 //!
-//! Async-signal-safety: capturing and symbolizing a backtrace allocates, which
-//! is not async-signal-safe (the crashing thread may hold the allocator lock).
-//! This is a deliberate best-effort trade — the process is already dying. Two
-//! guards contain the risk: a fixed marker naming the signal is written with
-//! raw `write(2)` before the allocating section, so the signal is identified
-//! even if backtrace capture wedges; and a re-entrancy flag turns any fault
-//! inside the handler into an immediate default-action death. Handlers run on
-//! the alternate signal stack (`SA_ONSTACK`) that Rust's std installs per
-//! thread, so stack-overflow SIGSEGVs are reported rather than double-faulting.
+//! Async-signal-safety: everything the handler does is signal-safe. Output
+//! goes through raw `write(2)`; integers are formatted in a stack buffer; the
+//! stack walk uses `backtrace::trace_unsynchronized` (no allocator lock) and
+//! emits raw instruction pointers only — it does NOT symbolize, because
+//! resolving symbols allocates and, on static-musl release builds (the case
+//! this handler exists for), faults inside the handler. Resolve the addresses
+//! offline against the binary with `addr2line -fe aspect-cli <addr>`. A
+//! re-entrancy flag turns any fault inside the handler into an immediate
+//! default-action death. Handlers run on the alternate signal stack
+//! (`SA_ONSTACK`) std installs per thread, so stack-overflow SIGSEGVs are
+//! reported rather than double-faulting.
 //!
 //! `ASPECT_NO_CRASH_HANDLER` (any non-empty value) skips installation.
 
@@ -32,11 +34,12 @@ pub fn install() {
     unix::install();
 }
 
-/// Test hook: crash the process immediately when `ASPECT_INTERNAL_TEST_CRASH`
-/// is `segv` or `abort`, otherwise a no-op. Lets the end-to-end tests drive a
-/// real crash through a spawned binary. Kept separate from [`install`] so a
-/// test can exercise the `ASPECT_NO_CRASH_HANDLER` opt-out (handler skipped)
-/// while still triggering the crash.
+/// Test hook: crash the process immediately per `ASPECT_INTERNAL_TEST_CRASH`
+/// (`segv`, `abort`, `segv-thread`, or `stackoverflow-thread`), otherwise a
+/// no-op. Lets the end-to-end tests drive a real crash — on the main thread, a
+/// spawned thread, or via stack overflow — through a spawned binary. Kept
+/// separate from [`install`] so a test can exercise the
+/// `ASPECT_NO_CRASH_HANDLER` opt-out (handler skipped) while still crashing.
 #[doc(hidden)]
 pub fn trigger_test_crash() {
     #[cfg(unix)]
@@ -99,6 +102,26 @@ mod unix {
             // SAFETY: intentional null write to raise SIGSEGV.
             Ok("segv") => unsafe { std::ptr::null_mut::<u8>().write_volatile(1) },
             Ok("abort") => std::process::abort(),
+            // SAFETY: same null write, but on a spawned thread (models the
+            // Starlark task running on a tokio blocking/worker thread).
+            Ok("segv-thread") => {
+                std::thread::spawn(|| unsafe { std::ptr::null_mut::<u8>().write_volatile(1) })
+                    .join()
+                    .ok();
+            }
+            // Unbounded recursion → stack-overflow SIGSEGV, on a spawned thread.
+            Ok("stackoverflow-thread") => {
+                std::thread::spawn(|| {
+                    #[allow(unconditional_recursion)] // intentional overflow
+                    fn recurse(x: u64) -> u64 {
+                        let buf = [x; 1024];
+                        recurse(std::hint::black_box(buf[0]).wrapping_add(1))
+                    }
+                    std::hint::black_box(recurse(0));
+                })
+                .join()
+                .ok();
+            }
             _ => {}
         }
     }
@@ -109,17 +132,6 @@ mod unix {
             .find(|(s, _)| *s == sig)
             .map(|(_, name)| *name)
             .unwrap_or("unknown fatal signal")
-    }
-
-    /// The report body written after the signal-name marker. Pure so it can be
-    /// unit-tested; the handler supplies the live fault address and thread name.
-    fn format_report(fault_addr: usize, thread_name: &str) -> String {
-        format!(
-            "fault address: {fault_addr:#x}\nthread: {thread_name}\nbacktrace:\n{}\n\
-             aspect-cli crashed; please report this at \
-             https://github.com/aspect-build/aspect-cli/issues including the output above.\n",
-            std::backtrace::Backtrace::force_capture(),
-        )
     }
 
     /// Write `bytes` to stderr via `write(2)`, ignoring errors. Async-signal-safe.
@@ -141,6 +153,55 @@ mod unix {
         }
     }
 
+    /// `0x`-prefixed hex of `value`, formatted into `buf` (no allocation). The
+    /// returned slice borrows `buf`. `buf` must be at least 18 bytes (`0x` + 16
+    /// hex digits, the max for a 64-bit usize). Split from [`write_hex`] so the
+    /// formatting is unit-testable without capturing stderr.
+    fn format_hex(value: usize, buf: &mut [u8; 18]) -> &[u8] {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut v = value;
+        let mut i = buf.len();
+        loop {
+            i -= 1;
+            buf[i] = HEX[v & 0xf];
+            v >>= 4;
+            if v == 0 {
+                break;
+            }
+        }
+        i -= 1;
+        buf[i] = b'x';
+        i -= 1;
+        buf[i] = b'0';
+        &buf[i..]
+    }
+
+    /// Write `value` as `0x`-prefixed hex to stderr. Async-signal-safe.
+    fn write_hex(value: usize) {
+        let mut buf = [0u8; 18];
+        write_stderr(format_hex(value, &mut buf));
+    }
+
+    /// Walk the current call stack and write each frame's raw instruction
+    /// pointer to stderr, one `0x…` per line. Signal-safe: it neither allocates
+    /// nor symbolizes (both fault inside a signal handler on static-musl builds
+    /// — the very case this handler exists for). Resolve the addresses offline
+    /// against the binary, e.g. `addr2line -fe aspect-cli <addr>`.
+    fn write_raw_backtrace() {
+        // SAFETY: single-shot within a dying process; `trace_unsynchronized`
+        // avoids the global lock `trace` takes (which could deadlock if the
+        // crash happened while that lock was held). The callback only writes
+        // to stderr.
+        unsafe {
+            backtrace::trace_unsynchronized(|frame| {
+                write_stderr(b"  ");
+                write_hex(frame.ip() as usize);
+                write_stderr(b"\n");
+                true
+            });
+        }
+    }
+
     fn fault_addr(info: *mut libc::siginfo_t) -> usize {
         if info.is_null() {
             return 0;
@@ -150,6 +211,37 @@ mod unix {
         return unsafe { (*info).si_addr() as usize };
         #[cfg(not(target_os = "linux"))]
         return unsafe { (*info).si_addr as usize };
+    }
+
+    /// The program counter at the moment of the fault, read from the signal's
+    /// `ucontext`. This is the address to resolve first — it is where the crash
+    /// actually happened, independent of whether the stack unwinds. Returns 0
+    /// when unavailable (null context, or an arch/OS we don't decode).
+    ///
+    /// A static-musl signal handler often can't unwind *through* the kernel
+    /// signal frame, so [`write_raw_backtrace`] alone may yield only the
+    /// handler's own frame; the ucontext PC is the reliable crash location.
+    fn crash_pc(ctx: *mut libc::c_void) -> usize {
+        if ctx.is_null() {
+            return 0;
+        }
+        // SAFETY: for SA_SIGINFO handlers the kernel passes a valid
+        // ucontext_t*; we read the saved PC register for the target arch.
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        unsafe {
+            let uc = ctx as *mut libc::ucontext_t;
+            return (*uc).uc_mcontext.gregs[libc::REG_RIP as usize] as usize;
+        }
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        unsafe {
+            let uc = ctx as *mut libc::ucontext_t;
+            return (*uc).uc_mcontext.pc as usize;
+        }
+        #[allow(unreachable_code)]
+        {
+            let _ = ctx;
+            0
+        }
     }
 
     /// Restore the default disposition for `sig`, unblock it (it is blocked
@@ -177,20 +269,27 @@ mod unix {
         }
     }
 
-    extern "C" fn handler(sig: libc::c_int, info: *mut libc::siginfo_t, _ctx: *mut libc::c_void) {
+    extern "C" fn handler(sig: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut libc::c_void) {
         if HANDLING.swap(true, Ordering::SeqCst) {
             reset_and_reraise(sig);
         }
 
         write_stderr(b"\naspect-cli: fatal signal: ");
         write_stderr(signal_name(sig).as_bytes());
-        write_stderr(b"\naspect-cli: collecting backtrace (best effort)...\n");
-
-        // Allocating from here — see the module docstring for why that trade
-        // is acceptable inside a dying process.
-        let thread = std::thread::current();
+        write_stderr(b"\nfault address: ");
+        write_hex(fault_addr(info));
+        write_stderr(b"\ncrash pc: ");
+        write_hex(crash_pc(ctx));
         write_stderr(
-            format_report(fault_addr(info), thread.name().unwrap_or("<unnamed>")).as_bytes(),
+            b"\naddresses are raw instruction pointers; resolve with \
+              `addr2line -fe aspect-cli <addr>`.\ncrash pc is the fault site; \
+              the frames below may be truncated to the handler frame on \
+              static-musl builds:\n",
+        );
+        write_raw_backtrace();
+        write_stderr(
+            b"aspect-cli crashed; please report this at \
+              https://github.com/aspect-build/aspect-cli/issues including the output above.\n",
         );
 
         reset_and_reraise(sig);
@@ -216,15 +315,14 @@ mod unix {
         }
 
         #[test]
-        fn format_report_includes_address_thread_and_pointer() {
-            let report = format_report(0xdead_beef, "worker-3");
-            assert!(report.contains("fault address: 0xdeadbeef"), "{report}");
-            assert!(report.contains("thread: worker-3"), "{report}");
-            assert!(report.contains("backtrace:"), "{report}");
-            assert!(
-                report.contains("github.com/aspect-build/aspect-cli/issues"),
-                "{report}"
-            );
+        fn format_hex_matches_std_and_handles_edges() {
+            let mut buf = [0u8; 18];
+            assert_eq!(format_hex(0, &mut buf), b"0x0");
+            assert_eq!(format_hex(0xdead_beef, &mut buf), b"0xdeadbeef");
+            assert_eq!(format_hex(usize::MAX, &mut buf), b"0xffffffffffffffff");
+            for v in [1usize, 0xf, 0x10, 0x1234, 0x8000_0000_0000_0000] {
+                assert_eq!(format_hex(v, &mut buf), format!("{v:#x}").as_bytes());
+            }
         }
 
         #[test]

--- a/crates/aspect-cli/tests/crash_handler.rs
+++ b/crates/aspect-cli/tests/crash_handler.rs
@@ -34,12 +34,15 @@ fn assert_reported(out: &Output, signal_label: &str, signal: libc::c_int) {
     // way, at least one `0x…` instruction pointer must reach stderr — that is
     // the part that previously faulted and printed nothing inside the handler.
     assert!(
-        stderr.contains("crash pc:") && stderr.contains("resolve with `addr2line"),
+        stderr.contains("crash pc:") && stderr.contains("addr2line -fe aspect-cli"),
         "missing crash-site report in stderr: {stderr}"
     );
+    // Code addresses print as `<runtime> (+<static offset>)`; at least one
+    // frame line must reach stderr — this is the part that previously faulted
+    // and printed nothing inside the handler on static-musl builds.
     assert!(
-        stderr.contains("\n  0x"),
-        "no raw frame addresses in backtrace: {stderr}"
+        stderr.contains(" (+0x"),
+        "no resolvable frame offsets in backtrace: {stderr}"
     );
     assert_eq!(
         out.status.signal(),
@@ -78,7 +81,7 @@ fn stack_overflow_on_spawned_thread_is_reported() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("fatal signal:") && stderr.contains("\n  0x"),
+        stderr.contains("fatal signal:") && stderr.contains(" (+0x"),
         "stack-overflow crash produced no backtrace: {stderr}"
     );
 }

--- a/crates/aspect-cli/tests/crash_handler.rs
+++ b/crates/aspect-cli/tests/crash_handler.rs
@@ -21,40 +21,71 @@ fn run_with_trigger(kind: &str, extra_env: &[(&str, &str)]) -> Output {
     cmd.output().expect("failed to spawn aspect-cli")
 }
 
-#[test]
-fn segv_reports_backtrace_and_dies_with_original_signal() {
-    let out = run_with_trigger("segv", &[]);
+/// Assert a crash report was printed and the process died by `signal`.
+fn assert_reported(out: &Output, signal_label: &str, signal: libc::c_int) {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("fatal signal: SIGSEGV (segmentation fault)"),
+        stderr.contains(&format!("fatal signal: {signal_label}")),
         "missing signal line in stderr: {stderr}"
     );
+    // The fault site must be reported. `crash pc` is populated from the
+    // ucontext on Linux (the reliable address where unwinding truncates on
+    // static-musl); elsewhere the raw frame walk supplies the addresses. Either
+    // way, at least one `0x…` instruction pointer must reach stderr — that is
+    // the part that previously faulted and printed nothing inside the handler.
     assert!(
-        stderr.contains("backtrace:"),
-        "missing backtrace in stderr: {stderr}"
+        stderr.contains("crash pc:") && stderr.contains("resolve with `addr2line"),
+        "missing crash-site report in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("\n  0x"),
+        "no raw frame addresses in backtrace: {stderr}"
     );
     assert_eq!(
         out.status.signal(),
-        Some(libc::SIGSEGV),
-        "expected death by SIGSEGV, got {:?}",
+        Some(signal),
+        "expected death by {signal_label}, got {:?}",
         out.status
     );
 }
 
 #[test]
-fn abort_reports_and_dies_with_original_signal() {
-    let out = run_with_trigger("abort", &[]);
+fn segv_on_main_thread_is_reported() {
+    assert_reported(&run_with_trigger("segv", &[]), "SIGSEGV", libc::SIGSEGV);
+}
+
+/// The Starlark task runs on a spawned (tokio blocking/worker) thread, so a
+/// crash there is the realistic case — the handler must report it too.
+#[test]
+fn segv_on_spawned_thread_is_reported() {
+    assert_reported(
+        &run_with_trigger("segv-thread", &[]),
+        "SIGSEGV",
+        libc::SIGSEGV,
+    );
+}
+
+/// Stack overflow lands on the alternate signal stack; the raw-address walk
+/// must still emit frames rather than double-faulting into silence.
+#[test]
+fn stack_overflow_on_spawned_thread_is_reported() {
+    let out = run_with_trigger("stackoverflow-thread", &[]);
+    // SIGSEGV on Linux, SIGBUS on macOS — both are handled fatal signals.
+    let sig = out.status.signal().expect("expected death by signal");
+    assert!(
+        sig == libc::SIGSEGV || sig == libc::SIGBUS,
+        "expected SIGSEGV/SIGBUS, got signal {sig}"
+    );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("fatal signal: SIGABRT (abort)"),
-        "missing signal line in stderr: {stderr}"
+        stderr.contains("fatal signal:") && stderr.contains("\n  0x"),
+        "stack-overflow crash produced no backtrace: {stderr}"
     );
-    assert_eq!(
-        out.status.signal(),
-        Some(libc::SIGABRT),
-        "expected death by SIGABRT, got {:?}",
-        out.status
-    );
+}
+
+#[test]
+fn abort_is_reported() {
+    assert_reported(&run_with_trigger("abort", &[]), "SIGABRT", libc::SIGABRT);
 }
 
 #[test]


### PR DESCRIPTION
The fatal-signal handler from #1338 printed nothing on the crash it was built for. On static-musl release binaries (what the customer runs), `std::backtrace::Backtrace::force_capture()` allocates and symbolizes *inside the signal handler*, which faults; the re-entrancy guard then re-raised and no report appeared. Reproduced on 2026.30.14: the log ends at the bare `Received "segmentation fault" signal` banner with no trace.

This reworks the handler to be fully async-signal-safe **and** makes its output resolvable on the real release binary:

- **Raw addresses, no in-handler symbolization.** Instruction pointers are written via `write(2)` with a stack-buffer hex formatter — no allocation. The frame walk uses `backtrace::trace_unsynchronized` (avoids the global lock `trace` takes, which could deadlock if the crash held it).
- **Crash PC from the signal `ucontext`** (`REG_RIP` on x86_64, `pc` on aarch64). This is the reliable fault site: a musl signal handler frequently can't unwind *through* the kernel signal frame, so the frame walk alone truncates to the handler's own frame — but the ucontext PC always points at where the crash happened.
- **ASLR-relative offsets.** Release binaries are position-independent, so a raw address includes a random load base. The handler computes the load bias via `dl_iterate_phdr` and prints each address as `<runtime> (+<static offset>)`; the offset is ASLR-independent and resolves directly with `addr2line`.
- **Release symbols retained.** `bazel/rust/defs.bzl` now uses `-Cstrip=none` instead of `-Cstrip=symbols`, so offsets resolve to function + file:line against the shipped binary (~5% larger). Follow-up under discussion: ship stripped by default and have the launcher fetch the symbol-bearing binary only under `ASPECT_DEBUG`.

Sample output (opt-mode musl release binary):

```
aspect-cli: fatal signal: SIGSEGV (segmentation fault)
fault address: 0x0
crash pc: 0x7ffffe67f800 (+0xd75800)
code addresses print as `<runtime> (+<static offset>)`; resolve the static offset against this binary:
  `addr2line -fe aspect-cli <offset>`.
crash pc is the fault site; the frames below may be truncated to the handler frame on static-musl builds:
  0x7ffffe6299db (+0xd1f9db)
  0x7ffffe629c5d (+0xd1fc5d)
aspect-cli crashed; please report this at https://github.com/aspect-build/aspect-cli/issues including the output above.
```

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (crash output is self-describing)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- fix: the fatal-signal crash report now prints on static-musl release builds (it previously faulted inside the handler and printed nothing). Output includes the crash program counter and ASLR-relative offsets that resolve to function and file:line via `addr2line` against the (now unstripped) release binary.

### Test plan

- New/updated tests:
  - In-crate unit tests (Bazel `:test`): signal-name mapping, no-alloc hex formatter, opt-out detection.
  - End-to-end tests (`cargo test`): crash on the main thread, on a spawned thread (the realistic case — the Starlark task runs on a tokio worker), via stack overflow, and via abort; each asserts a resolvable crash-site offset reaches stderr and the process still dies by the original signal; plus the `ASPECT_NO_CRASH_HANDLER` opt-out.
- Manual: verified end-to-end on the **opt-mode `x86_64-unknown-linux-musl` release binary** in an Alpine container — the printed crash-pc offset resolves via `addr2line -fe aspect-cli <offset>` to the expected function (the previous handler printed nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
