### PR TITLE
fix(bes): stream an invocation once when bazel and the CLI share a backend

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -155,7 +155,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "expand_config_flags", "resolve_bazel_announce", "sibling_rc")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "bes_get", "now_ms", "process_event", bazel_init_data = "init_data")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/ci.axl", "resolve_build_url")
 load("./private/lib/delivery_results.axl", delivery_add_result = "add_result", delivery_build_manifest = "build_manifest", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
 load(
@@ -1191,7 +1191,12 @@ def _delivery_impl(ctx):
     # alongside the trait sinks (see `_get_output_shas`). Announced under the
     # first phase header below rather than here, so the lines land inside a
     # phase instead of ahead of the task's first one.
-    build_events = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
+    bazel_backend = bazel_bes_backend(rc, "build")
+    build_events = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
+
+    # No sink to the Aspect backend means no sink id is minted, so the Web UI
+    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
+    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
 
     for handler in bazel_trait.build_start:
         handler(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -155,7 +155,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "expand_config_flags", "resolve_bazel_announce", "sibling_rc")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "bes_get", "now_ms", "process_event", bazel_init_data = "init_data")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/ci.axl", "resolve_build_url")
 load("./private/lib/delivery_results.axl", delivery_add_result = "add_result", delivery_build_manifest = "build_manifest", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
 load(
@@ -1191,7 +1191,7 @@ def _delivery_impl(ctx):
     # alongside the trait sinks (see `_get_output_shas`). Announced under the
     # first phase header below rather than here, so the lines land inside a
     # phase instead of ahead of the task's first one.
-    build_events = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    build_events = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
 
     for handler in bazel_trait.build_start:
         handler(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -155,7 +155,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "expand_config_flags", "resolve_bazel_announce", "sibling_rc")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "bes_get", "now_ms", "process_event", bazel_init_data = "init_data")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
 load("./private/lib/ci.axl", "resolve_build_url")
 load("./private/lib/delivery_results.axl", delivery_add_result = "add_result", delivery_build_manifest = "build_manifest", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
 load(
@@ -1191,12 +1191,8 @@ def _delivery_impl(ctx):
     # alongside the trait sinks (see `_get_output_shas`). Announced under the
     # first phase header below rather than here, so the lines land inside a
     # phase instead of ahead of the task's first one.
-    bazel_backend = bazel_bes_backend(rc, "build")
-    build_events = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
-
-    # No sink to the Aspect backend means no sink id is minted, so the Web UI
-    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
-    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
+    build_events = collect_bes_sinks(ctx, bazel_trait, rc)
+    data["bes_streamed_by_bazel"] = bes_streamed_by_bazel(ctx, rc)
 
     for handler in bazel_trait.build_start:
         handler(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -21,7 +21,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("./private/lib/format_results.axl", fmt_init_data = "init_data", format_conclusion = "conclusion")
@@ -320,7 +320,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # Pass build_event_sinks (carries the Aspect backend gRPC sink in CI) so the
     # "✨ Aspect Workflows" link resolves to a real record, not a 404.
-    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -21,7 +21,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("./private/lib/format_results.axl", fmt_init_data = "init_data", format_conclusion = "conclusion")
@@ -318,14 +318,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # changed-file list.
     r = runnable(ctx, [ctx.args.formatter_target], rc = rc)
 
-    # Pass build_event_sinks (carries the Aspect backend gRPC sink in CI) so the
-    # "✨ Aspect Workflows" link resolves to a real record, not a 404.
-    bazel_backend = bazel_bes_backend(rc, "build")
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
-
-    # No sink to the Aspect backend means no sink id is minted, so the Web UI
-    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
-    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
+    bes_sinks = collect_bes_sinks(ctx, bazel_trait, rc)
+    data["bes_streamed_by_bazel"] = bes_streamed_by_bazel(ctx, rc)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -21,7 +21,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("./private/lib/format_results.axl", fmt_init_data = "init_data", format_conclusion = "conclusion")
@@ -320,7 +320,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # Pass build_event_sinks (carries the Aspect backend gRPC sink in CI) so the
     # "✨ Aspect Workflows" link resolves to a real record, not a 404.
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
+    bazel_backend = bazel_bes_backend(rc, "build")
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
+
+    # No sink to the Aspect backend means no sink id is minted, so the Web UI
+    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
+    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -87,7 +87,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
 load("./private/lib/gazelle_results.axl", "dedupe_subtrees", "dir_at_or_below", "extract_changed_dirs", gaz_init_data = "init_data", gazelle_conclusion = "conclusion")
@@ -462,7 +462,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     r = runnable(ctx, [ctx.args.gazelle_target], rc = rc)
 
     # See format.axl for why the trait sinks need to be plumbed in.
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
+    bazel_backend = bazel_bes_backend(rc, "build")
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
+
+    # No sink to the Aspect backend means no sink id is minted, so the Web UI
+    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
+    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -87,7 +87,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
 load("./private/lib/gazelle_results.axl", "dedupe_subtrees", "dir_at_or_below", "extract_changed_dirs", gaz_init_data = "init_data", gazelle_conclusion = "conclusion")
@@ -462,7 +462,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     r = runnable(ctx, [ctx.args.gazelle_target], rc = rc)
 
     # See format.axl for why the trait sinks need to be plumbed in.
-    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -87,7 +87,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
 load("./private/lib/gazelle_results.axl", "dedupe_subtrees", "dir_at_or_below", "extract_changed_dirs", gaz_init_data = "init_data", gazelle_conclusion = "conclusion")
@@ -461,13 +461,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # `args` attribute, and its env so `r.spawn` resolves and replays them.
     r = runnable(ctx, [ctx.args.gazelle_target], rc = rc)
 
-    # See format.axl for why the trait sinks need to be plumbed in.
-    bazel_backend = bazel_bes_backend(rc, "build")
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
-
-    # No sink to the Aspect backend means no sink id is minted, so the Web UI
-    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
-    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
+    bes_sinks = collect_bes_sinks(ctx, bazel_trait, rc)
+    data["bes_streamed_by_bazel"] = bes_streamed_by_bazel(ctx, rc)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -22,7 +22,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "bb_clientd_root", "file_uri_to_path", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "warn")
 load("./private/lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
@@ -802,12 +802,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for hook in lint_trait.lint_start:
         hook(ctx)
 
-    bazel_backend = bazel_bes_backend(rc, "build")
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
-
-    # No sink to the Aspect backend means no sink id is minted, so the Web UI
-    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
-    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
+    bes_sinks = collect_bes_sinks(ctx, bazel_trait, rc)
+    data["bes_streamed_by_bazel"] = bes_streamed_by_bazel(ctx, rc)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -22,7 +22,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "bb_clientd_root", "file_uri_to_path", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "warn")
 load("./private/lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
@@ -802,7 +802,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for hook in lint_trait.lint_start:
         hook(ctx)
 
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
+    bazel_backend = bazel_bes_backend(rc, "build")
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
+
+    # No sink to the Aspect backend means no sink id is minted, so the Web UI
+    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
+    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -22,7 +22,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "bb_clientd_root", "file_uri_to_path", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "warn")
 load("./private/lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
@@ -802,7 +802,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for hook in lint_trait.lint_start:
         hook(ctx)
 
-    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
@@ -15,6 +15,10 @@ the best-effort bearer resolution; the consumers attach the result —
 `--bes_header` / `--remote_header` flag. Best-effort: an owned endpoint with no
 usable credential warns and proceeds unauthenticated rather than failing (the
 server's own rejection then surfaces downstream).
+
+It also owns endpoint identity — `endpoint_authority` / `same_bes_endpoint`,
+used by `bes_sinks.axl` to recognize when a CLI-streamed backend is the same
+endpoint Bazel's own `--bes_backend` already uploads to.
 """
 
 load("./environment.axl", "warn")
@@ -47,6 +51,47 @@ def endpoint_host(uri: str) -> str:
     if ":" in rest:
         rest = rest.rsplit(":", 1)[0]
     return rest.lower()
+
+_DEFAULT_PORTS = {
+    "grpcs": "443",
+    "https": "443",
+    "grpc": "80",
+    "http": "80",
+}
+
+def endpoint_authority(uri: str) -> str:
+    """The `host:port` authority of an endpoint URI, with the scheme's default
+    port made explicit so equivalent spellings compare equal.
+
+    `grpcs://bes.example.com`, `grpcs://bes.example.com:443`, and
+    `bes.example.com:443` all normalize to `bes.example.com:443`. A schemeless
+    URI with no port has no default to apply, so only its host is returned —
+    matching Bazel, which cannot dial it without a port either.
+    """
+    rest = uri.strip()
+    scheme = ""
+    sep = rest.find("://")
+    if sep != -1:
+        scheme = rest[:sep].lower()
+        rest = rest[sep + 3:]
+    rest = rest.split("/")[0]
+    if "@" in rest:
+        rest = rest.split("@")[-1]
+
+    if ":" in rest:
+        (host, _, port) = rest.rpartition(":")
+        return host.lower() + ":" + port
+    return rest.lower() + ":" + _DEFAULT_PORTS[scheme] if scheme in _DEFAULT_PORTS else rest.lower()
+
+def same_bes_endpoint(a: str, b: str) -> bool:
+    """Whether two BES backend URIs address the same endpoint.
+
+    Compares normalized authorities (see `endpoint_authority`), so a default port
+    written out explicitly still matches. Scheme is deliberately ignored: `grpc://`
+    vs `grpcs://` on the same host:port is a TLS misconfiguration, not a second
+    backend, and streaming twice to it is still a duplicate.
+    """
+    return bool(a) and bool(b) and endpoint_authority(a) == endpoint_authority(b)
 
 def is_aspect_host(ctx, host: str) -> bool:
     """Whether `host` is owned by a configured deployment (its advertised

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
@@ -63,13 +63,14 @@ def endpoint_authority(uri: str) -> str:
     """The `host:port` authority of an endpoint URI, with the scheme's default
     port made explicit so equivalent spellings compare equal.
 
-    `grpcs://bes.example.com`, `grpcs://bes.example.com:443`, and
-    `bes.example.com:443` all normalize to `bes.example.com:443`. A schemeless
-    URI with no port has no default to apply, so only its host is returned —
-    matching Bazel, which cannot dial it without a port either.
+    `grpcs://bes.example.com`, `grpcs://bes.example.com:443`, `bes.example.com`,
+    and `bes.example.com:443` all normalize to `bes.example.com:443`. Bazel
+    documents these endpoints as `[SCHEME://]HOST[:PORT]` and assumes `grpcs`
+    when the scheme is omitted, so a schemeless URI takes the same :443 default.
+    An unrecognized scheme has no default to apply and yields the bare host.
     """
     rest = uri.strip()
-    scheme = ""
+    scheme = "grpcs"
     sep = rest.find("://")
     if sep != -1:
         scheme = rest[:sep].lower()

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
@@ -34,24 +34,9 @@ def login_hint(deployment) -> str:
         return "aspect auth login"
     return "aspect auth login --deployment " + deployment
 
-def endpoint_host(uri: str) -> str:
-    """Extract the lowercased host from an endpoint URI.
-
-    Handles `scheme://host[:port][/path]` and a bare `host[:port]`. Scheme,
-    userinfo, port, and path are stripped so the result is just the host for
-    ownership matching. IPv6 literals are not handled (Aspect hosts are DNS names).
-    """
-    rest = uri
-    sep = rest.find("://")
-    if sep != -1:
-        rest = rest[sep + 3:]
-    rest = rest.split("/")[0]
-    if "@" in rest:
-        rest = rest.split("@")[-1]
-    if ":" in rest:
-        rest = rest.rsplit(":", 1)[0]
-    return rest.lower()
-
+# Port a scheme implies when the URI omits one. Bazel spells its TLS gRPC
+# endpoints `grpcs://` and plaintext ones `grpc://`; the HTTP equivalents appear
+# once a URI has been through `build_event_stream`'s transport mapping.
 _DEFAULT_PORTS = {
     "grpcs": "443",
     "https": "443",
@@ -59,18 +44,20 @@ _DEFAULT_PORTS = {
     "http": "80",
 }
 
-def endpoint_authority(uri: str) -> str:
-    """The `host:port` authority of an endpoint URI, with the scheme's default
-    port made explicit so equivalent spellings compare equal.
+# Bazel documents `--bes_backend` / `--remote_cache` as `[SCHEME://]HOST[:PORT]`
+# and assumes TLS gRPC when the scheme is omitted.
+_DEFAULT_SCHEME = "grpcs"
 
-    `grpcs://bes.example.com`, `grpcs://bes.example.com:443`, `bes.example.com`,
-    and `bes.example.com:443` all normalize to `bes.example.com:443`. Bazel
-    documents these endpoints as `[SCHEME://]HOST[:PORT]` and assumes `grpcs`
-    when the scheme is omitted, so a schemeless URI takes the same :443 default.
-    An unrecognized scheme has no default to apply and yields the bare host.
+def _split_endpoint(uri: str) -> tuple:
+    """Split an endpoint URI into its `(scheme, host, port)`.
+
+    Handles `scheme://host[:port][/path]` and a bare `host[:port]`. Userinfo and
+    path are discarded; scheme and host are lowercased. `scheme` falls back to
+    `_DEFAULT_SCHEME` and `port` is `""` when the URI omits them. IPv6 literals
+    are not handled (Aspect hosts are DNS names).
     """
     rest = uri.strip()
-    scheme = "grpcs"
+    scheme = _DEFAULT_SCHEME
     sep = rest.find("://")
     if sep != -1:
         scheme = rest[:sep].lower()
@@ -78,19 +65,37 @@ def endpoint_authority(uri: str) -> str:
     rest = rest.split("/")[0]
     if "@" in rest:
         rest = rest.split("@")[-1]
-
     if ":" in rest:
         (host, _, port) = rest.rpartition(":")
-        return host.lower() + ":" + port
-    return rest.lower() + ":" + _DEFAULT_PORTS[scheme] if scheme in _DEFAULT_PORTS else rest.lower()
+        return (scheme, host.lower(), port)
+    return (scheme, rest.lower(), "")
+
+def endpoint_host(uri: str) -> str:
+    """The lowercased host of an endpoint URI, for ownership matching. Scheme,
+    userinfo, port, and path are stripped."""
+    (_, host, _) = _split_endpoint(uri)
+    return host
+
+def endpoint_authority(uri: str) -> str:
+    """The `host:port` authority of an endpoint URI, with the scheme's default
+    port made explicit so equivalent spellings compare equal.
+
+    `grpcs://bes.example.com`, `grpcs://bes.example.com:443`, `bes.example.com`,
+    and `bes.example.com:443` all normalize to `bes.example.com:443`. A scheme
+    with no known default (e.g. `unix://`) yields the bare host.
+    """
+    (scheme, host, port) = _split_endpoint(uri)
+    if not port:
+        port = _DEFAULT_PORTS.get(scheme, "")
+    return host + ":" + port if port else host
 
 def same_bes_endpoint(a: str, b: str) -> bool:
     """Whether two BES backend URIs address the same endpoint.
 
     Compares normalized authorities (see `endpoint_authority`), so a default port
-    written out explicitly still matches. Scheme is deliberately ignored: `grpc://`
-    vs `grpcs://` on the same host:port is a TLS misconfiguration, not a second
-    backend, and streaming twice to it is still a duplicate.
+    written out explicitly still matches. Scheme is deliberately ignored: one
+    endpoint reached as `grpcs://h:443` and `https://h` is still one endpoint, so
+    streaming to both spellings would duplicate the invocation.
     """
     return bool(a) and bool(b) and endpoint_authority(a) == endpoint_authority(b)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
@@ -44,9 +44,10 @@ def _test_endpoint_authority(_):
     _eq("uppercase lowered", endpoint_authority("GRPCS://BES.Aspect.Build"), "bes.aspect.build:443")
     _eq("surrounding space ignored", endpoint_authority("  grpcs://bes.aspect.build  "), "bes.aspect.build:443")
 
-    # No scheme and no port leaves no default to apply — Bazel could not dial it
-    # either, so the bare host is the most that can be said about it.
-    _eq("schemeless, portless", endpoint_authority("bes.aspect.build"), "bes.aspect.build")
+    # Bazel documents `[SCHEME://]HOST[:PORT]` and assumes grpcs with no scheme,
+    # so a bare host takes :443 — otherwise `--bes_backend=bes.example.com`
+    # would miss a `grpcs://bes.example.com` sink and both would stream.
+    _eq("schemeless, portless", endpoint_authority("bes.aspect.build"), "bes.aspect.build:443")
     _eq("unknown scheme, portless", endpoint_authority("unix://bes.aspect.build"), "bes.aspect.build")
 
 def _test_same_bes_endpoint(_):
@@ -69,6 +70,17 @@ def _test_same_bes_endpoint(_):
     )
     _eq("case insensitive", same_bes_endpoint("GRPCS://BES.ACME.ASPECT.BUILD", "grpcs://bes.acme.aspect.build"), True)
     _eq("path ignored", same_bes_endpoint("grpcs://bes.acme.aspect.build/x", "grpcs://bes.acme.aspect.build"), True)
+
+    # Bazel accepts a schemeless `--bes_backend` and assumes grpcs, so it must
+    # match the runner's `grpcs://` sink however the user spelled it.
+    _eq("schemeless bazel flag", same_bes_endpoint("grpcs://bes.acme.aspect.build", "bes.acme.aspect.build"), True)
+    _eq("schemeless both sides", same_bes_endpoint("bes.acme.aspect.build", "bes.acme.aspect.build:443"), True)
+    _eq(
+        "schemeless vs https sink",
+        same_bes_endpoint("https://bes.acme.aspect.build", "bes.acme.aspect.build"),
+        True,
+    )
+    _eq("schemeless, different host", same_bes_endpoint("grpcs://bes.a.aspect.build", "bes.b.aspect.build"), False)
 
     _eq("different host", same_bes_endpoint("grpcs://bes.a.aspect.build", "grpcs://bes.b.aspect.build"), False)
     _eq("different port", same_bes_endpoint("grpcs://bes.acme.aspect.build:8980", "grpcs://bes.acme.aspect.build"), False)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
@@ -29,6 +29,7 @@ def _test_endpoint_host(_):
     _eq("userinfo stripped", endpoint_host("grpcs://user@bes.aspect.build"), "bes.aspect.build")
     _eq("userinfo + port", endpoint_host("grpcs://user:pw@bes.aspect.build:443/x"), "bes.aspect.build")
     _eq("uppercase lowered", endpoint_host("GRPCS://BES.ASPECT.BUILD"), "bes.aspect.build")
+    _eq("surrounding space ignored", endpoint_host("  grpcs://bes.aspect.build  "), "bes.aspect.build")
 
 def _test_endpoint_authority(_):
     """Authority extraction keeps the port and fills in the scheme's default, so

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
@@ -5,7 +5,7 @@ Run with:
   aspect dev test-aspect-endpoint-auth
 """
 
-load("./aspect_endpoint_auth.axl", "credential_helper_covers_host", "endpoint_host", "headers_have_auth", "is_aspect_host", "login_hint", "needs_aspect_token")
+load("./aspect_endpoint_auth.axl", "credential_helper_covers_host", "endpoint_authority", "endpoint_host", "headers_have_auth", "is_aspect_host", "login_hint", "needs_aspect_token", "same_bes_endpoint")
 
 def _eq(label, got, want):
     if got != want:
@@ -29,6 +29,56 @@ def _test_endpoint_host(_):
     _eq("userinfo stripped", endpoint_host("grpcs://user@bes.aspect.build"), "bes.aspect.build")
     _eq("userinfo + port", endpoint_host("grpcs://user:pw@bes.aspect.build:443/x"), "bes.aspect.build")
     _eq("uppercase lowered", endpoint_host("GRPCS://BES.ASPECT.BUILD"), "bes.aspect.build")
+
+def _test_endpoint_authority(_):
+    """Authority extraction keeps the port and fills in the scheme's default, so
+    the spellings of one endpoint all normalize alike."""
+    _eq("grpcs default port", endpoint_authority("grpcs://bes.aspect.build"), "bes.aspect.build:443")
+    _eq("grpcs explicit port", endpoint_authority("grpcs://bes.aspect.build:443"), "bes.aspect.build:443")
+    _eq("https default port", endpoint_authority("https://bes.aspect.build"), "bes.aspect.build:443")
+    _eq("grpc default port", endpoint_authority("grpc://bes.aspect.build"), "bes.aspect.build:80")
+    _eq("non-default port kept", endpoint_authority("grpcs://bes.aspect.build:8980"), "bes.aspect.build:8980")
+    _eq("bare host:port", endpoint_authority("bes.aspect.build:443"), "bes.aspect.build:443")
+    _eq("path stripped", endpoint_authority("grpcs://bes.aspect.build:443/x"), "bes.aspect.build:443")
+    _eq("userinfo stripped", endpoint_authority("grpcs://user:pw@bes.aspect.build"), "bes.aspect.build:443")
+    _eq("uppercase lowered", endpoint_authority("GRPCS://BES.Aspect.Build"), "bes.aspect.build:443")
+    _eq("surrounding space ignored", endpoint_authority("  grpcs://bes.aspect.build  "), "bes.aspect.build:443")
+
+    # No scheme and no port leaves no default to apply — Bazel could not dial it
+    # either, so the bare host is the most that can be said about it.
+    _eq("schemeless, portless", endpoint_authority("bes.aspect.build"), "bes.aspect.build")
+    _eq("unknown scheme, portless", endpoint_authority("unix://bes.aspect.build"), "bes.aspect.build")
+
+def _test_same_bes_endpoint(_):
+    """Two BES URIs match when they address the same host:port, however the
+    default port and scheme are spelled."""
+    _eq(
+        "implicit vs explicit :443",
+        same_bes_endpoint("grpcs://bes.acme.aspect.build", "grpcs://bes.acme.aspect.build:443"),
+        True,
+    )
+    _eq(
+        "scheme ignored at the same port",
+        same_bes_endpoint("grpc://bes.acme.aspect.build:443", "grpcs://bes.acme.aspect.build"),
+        True,
+    )
+    _eq(
+        "bare host:port vs scheme",
+        same_bes_endpoint("bes.acme.aspect.build:443", "grpcs://bes.acme.aspect.build"),
+        True,
+    )
+    _eq("case insensitive", same_bes_endpoint("GRPCS://BES.ACME.ASPECT.BUILD", "grpcs://bes.acme.aspect.build"), True)
+    _eq("path ignored", same_bes_endpoint("grpcs://bes.acme.aspect.build/x", "grpcs://bes.acme.aspect.build"), True)
+
+    _eq("different host", same_bes_endpoint("grpcs://bes.a.aspect.build", "grpcs://bes.b.aspect.build"), False)
+    _eq("different port", same_bes_endpoint("grpcs://bes.acme.aspect.build:8980", "grpcs://bes.acme.aspect.build"), False)
+
+    # grpc:// defaults to :80 and grpcs:// to :443, so these are genuinely
+    # different endpoints — not a duplicate to suppress.
+    _eq("differing default ports", same_bes_endpoint("grpc://bes.acme.aspect.build", "grpcs://bes.acme.aspect.build"), False)
+
+    _eq("empty never matches", same_bes_endpoint("", "grpcs://bes.acme.aspect.build"), False)
+    _eq("both empty", same_bes_endpoint("", ""), False)
 
 def _test_is_aspect_host(_):
     """A host is Aspect-owned iff a configured deployment claims it (via the
@@ -96,12 +146,14 @@ def _test_login_hint(_):
 
 def _test_impl(ctx):
     _test_endpoint_host(ctx)
+    _test_endpoint_authority(ctx)
+    _test_same_bes_endpoint(ctx)
     _test_is_aspect_host(ctx)
     _test_needs_aspect_token(ctx)
     _test_headers_have_auth(ctx)
     _test_credential_helper_covers_host(ctx)
     _test_login_hint(ctx)
-    print("aspect_endpoint_auth_test.axl: OK (6 sections)")
+    print("aspect_endpoint_auth_test.axl: OK (8 sections)")
     return 0
 
 aspect_endpoint_auth_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -287,6 +287,11 @@ def init_data():
         # bazel_runner.axl after Build::spawn; "" when no sinks. Differs from
         # build_started.uuid (Bazel's server-side UUID).
         "sink_invocation_id": "",
+        # True when the CLI's sink to the Aspect BES backend was suppressed
+        # because Bazel uploads there itself, so no sink id is minted and
+        # `resolve_aspect_url` must key on Bazel's invocation_id instead. Set by
+        # the task before spawning; see bes_sinks.axl::drop_bazel_streamed.
+        "bes_streamed_by_bazel": False,
         # Producer-authored at terminal-emit time. Each entry {command, description};
         # see lib/repro_commands.axl.
         "repro_commands": [],
@@ -453,13 +458,16 @@ def process_event(data, event):
 
     if kind == "build_started":
         # Reset state for the new stream (handles retries). Preserve the
-        # task-managed sink_invocation_id (set before this event) — wiping it
-        # would drop the Aspect Workflows link from every annotation.
+        # task-managed sink_invocation_id and bes_streamed_by_bazel (both set
+        # before this event) — wiping either would drop the Aspect Workflows
+        # link from every annotation.
         preserved_sink_id = data.get("sink_invocation_id", "") or ""
+        preserved_bazel_streamed = data.get("bes_streamed_by_bazel", False)
         fresh = init_data()
         for k in fresh:
             data[k] = fresh[k]
         data["sink_invocation_id"] = preserved_sink_id
+        data["bes_streamed_by_bazel"] = preserved_bazel_streamed
 
         payload = event.payload
         uuid = bes_get(payload, "uuid", "") or ""
@@ -932,15 +940,23 @@ def _join_url(base, id):
 def resolve_aspect_url(links, data):
     """Return the Aspect Web UI URL for an invocation, or "" if unavailable.
 
-    Keyed on `sink_invocation_id`, NOT Bazel's `invocation_id`: the Aspect Web
-    UI indexes by the UUID the gRPC sink (`stream_sink.rs`) mints up-front when
-    spawning BES subscribers — that's the stream-level id the backend sees;
-    Bazel's own UUID is unknown to the backend (would 404).
+    Normally keyed on `sink_invocation_id`, NOT Bazel's `invocation_id`: the
+    Aspect Web UI indexes by the UUID the gRPC sink (`stream_sink.rs`) mints
+    up-front when spawning BES subscribers — that's the stream-level id the
+    backend sees; Bazel's own UUID is unknown to the backend (would 404).
 
     Tasks with sinks active set `data["sink_invocation_id"]` from
     `build.sink_invocation_id` right after `ctx.bazel.build(...)` (the runtime
-    mints it inside `Build::spawn`). See `bazel_runner.axl`. Without sinks the
-    field is empty and we suppress the link.
+    mints it inside `Build::spawn`). See `bazel_runner.axl`.
+
+    The exception is `bes_streamed_by_bazel`: when the CLI sink was suppressed
+    because Bazel uploads to that same backend itself (see
+    `bes_sinks.axl::drop_bazel_streamed`), no sink id is minted, but the backend
+    *does* have the invocation — indexed under Bazel's own UUID, since Bazel is
+    the uploader. Keying on `data["bazel"]["invocation_id"]` there keeps the link
+    alive instead of dropping it for exactly the users who wired BES up twice.
+
+    Without either id the link is suppressed.
 
     `links["results_base_url"]` (from `WorkflowsEnvironment.build_events.results_url`)
     is the prefix, joined as `{base}/{id}` (no `/invocations/` segment). Typical:
@@ -950,6 +966,8 @@ def resolve_aspect_url(links, data):
     if not base:
         return ""
     inv_id = data.get("sink_invocation_id", "") or ""
+    if not inv_id and data.get("bes_streamed_by_bazel"):
+        inv_id = data.get("bazel", {}).get("invocation_id", "") or ""
     if not inv_id:
         return ""
     return _join_url(base, inv_id)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -268,6 +268,11 @@ def _repro_with_prefix(prefix, labels, max_chars):
         return ("", 0)
     return (base + " ".join(included), len(included))
 
+# Keys a task resolves before the build and `process_event` must not clobber
+# when `build_started` resets the accumulator for a new (or retried) stream.
+# Both identify the invocation to the Aspect Web UI; see `resolve_aspect_url`.
+_TASK_OWNED_KEYS = ["sink_invocation_id", "bes_streamed_by_bazel"]
+
 def init_data():
     """Create a fresh data accumulator.
 
@@ -275,6 +280,9 @@ def init_data():
     `["bazel"]`. The rendered "Bazel details" reads `data["bazel"][...]`;
     root scalars stay at the root so non-bazel tasks can populate them too.
     See `crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md` for the schema.
+
+    `_TASK_OWNED_KEYS` names the root scalars that survive a `build_started`
+    reset.
     """
     return {
         # start/finish ms since epoch. build/test: from BES (process_event).
@@ -287,10 +295,10 @@ def init_data():
         # bazel_runner.axl after Build::spawn; "" when no sinks. Differs from
         # build_started.uuid (Bazel's server-side UUID).
         "sink_invocation_id": "",
-        # True when the CLI's sink to the Aspect BES backend was suppressed
-        # because Bazel uploads there itself, so no sink id is minted and
-        # `resolve_aspect_url` must key on Bazel's invocation_id instead. Set by
-        # the task before spawning; see bes_sinks.axl::drop_bazel_streamed.
+        # True when Bazel uploads to the Aspect BES backend itself, so the CLI
+        # streams no sink there and `resolve_aspect_url` keys on Bazel's
+        # invocation_id. Set by the task before spawning; see
+        # bes_sinks.axl::bes_streamed_by_bazel.
         "bes_streamed_by_bazel": False,
         # Producer-authored at terminal-emit time. Each entry {command, description};
         # see lib/repro_commands.axl.
@@ -457,17 +465,14 @@ def process_event(data, event):
     kind = event.kind
 
     if kind == "build_started":
-        # Reset state for the new stream (handles retries). Preserve the
-        # task-managed sink_invocation_id and bes_streamed_by_bazel (both set
-        # before this event) — wiping either would drop the Aspect Workflows
-        # link from every annotation.
-        preserved_sink_id = data.get("sink_invocation_id", "") or ""
-        preserved_bazel_streamed = data.get("bes_streamed_by_bazel", False)
+        # Reset state for the new stream (handles retries), less the keys the
+        # task owns and sets before this event — wiping those would drop the
+        # Aspect Workflows link from every annotation.
+        preserved = {k: data[k] for k in _TASK_OWNED_KEYS if k in data}
         fresh = init_data()
         for k in fresh:
             data[k] = fresh[k]
-        data["sink_invocation_id"] = preserved_sink_id
-        data["bes_streamed_by_bazel"] = preserved_bazel_streamed
+        data.update(preserved)
 
         payload = event.payload
         uuid = bes_get(payload, "uuid", "") or ""
@@ -940,23 +945,17 @@ def _join_url(base, id):
 def resolve_aspect_url(links, data):
     """Return the Aspect Web UI URL for an invocation, or "" if unavailable.
 
-    Normally keyed on `sink_invocation_id`, NOT Bazel's `invocation_id`: the
-    Aspect Web UI indexes by the UUID the gRPC sink (`stream_sink.rs`) mints
-    up-front when spawning BES subscribers — that's the stream-level id the
-    backend sees; Bazel's own UUID is unknown to the backend (would 404).
+    Keyed on whichever id the backend indexed the invocation under:
 
-    Tasks with sinks active set `data["sink_invocation_id"]` from
-    `build.sink_invocation_id` right after `ctx.bazel.build(...)` (the runtime
-    mints it inside `Build::spawn`). See `bazel_runner.axl`.
+      - `sink_invocation_id` when the CLI streamed it — the UUID the gRPC sink
+        (`stream_sink.rs`) mints up-front when spawning BES subscribers. Tasks
+        set it from `build.sink_invocation_id` right after `ctx.bazel.build(...)`
+        (the runtime mints it inside `Build::spawn`); see `bazel_runner.axl`.
+      - `data["bazel"]["invocation_id"]` when `bes_streamed_by_bazel` says Bazel
+        uploaded it instead, in which case no sink — and so no sink id — exists.
 
-    The exception is `bes_streamed_by_bazel`: when the CLI sink was suppressed
-    because Bazel uploads to that same backend itself (see
-    `bes_sinks.axl::drop_bazel_streamed`), no sink id is minted, but the backend
-    *does* have the invocation — indexed under Bazel's own UUID, since Bazel is
-    the uploader. Keying on `data["bazel"]["invocation_id"]` there keeps the link
-    alive instead of dropping it for exactly the users who wired BES up twice.
-
-    Without either id the link is suppressed.
+    The two are not interchangeable: Bazel's UUID is unknown to a backend the CLI
+    streamed to, and would 404. Without either id the link is suppressed.
 
     `links["results_base_url"]` (from `WorkflowsEnvironment.build_events.results_url`)
     is the prefix, joined as `{base}/{id}` (no `/invocations/` segment). Typical:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
@@ -1184,6 +1184,70 @@ def _test_aspect_web_ui_url(ctx):
     env.set_var("ASPECT_WORKFLOWS_BES_RESULTS_URL", "")
     _eq("aspect_web_ui_url empty without base", aspect_web_ui_url(env, {"sink_invocation_id": "abc-123"}), "")
 
+def _test_aspect_web_ui_url_bazel_streamed(ctx):
+    """When the CLI sink was suppressed because Bazel uploads to the same Aspect
+    backend, no sink id is minted — the link keys on Bazel's invocation_id
+    instead, since Bazel is what the backend indexed the invocation under."""
+    env = ctx.std.env
+    env.set_var("ASPECT_WORKFLOWS_BES_RESULTS_URL", "https://app.oss.aspect.build")
+    bazel_streamed = {
+        "sink_invocation_id": "",
+        "bes_streamed_by_bazel": True,
+        "bazel": {"invocation_id": "bazel-uuid-1"},
+    }
+    _eq(
+        "falls back to bazel's invocation id",
+        aspect_web_ui_url(env, bazel_streamed),
+        "https://app.oss.aspect.build/bazel-uuid-1",
+    )
+
+    # Without the flag the sink id is the only key; a bare Bazel id would 404,
+    # so the link stays suppressed.
+    _eq(
+        "no fallback when the flag is unset",
+        aspect_web_ui_url(env, {"sink_invocation_id": "", "bazel": {"invocation_id": "bazel-uuid-1"}}),
+        "",
+    )
+    _eq(
+        "no fallback before build_started supplies the id",
+        aspect_web_ui_url(env, {"sink_invocation_id": "", "bes_streamed_by_bazel": True, "bazel": {}}),
+        "",
+    )
+
+    # A live sink still wins: its id is what that backend indexed.
+    _eq(
+        "sink id takes precedence",
+        aspect_web_ui_url(env, {
+            "sink_invocation_id": "sink-1",
+            "bes_streamed_by_bazel": True,
+            "bazel": {"invocation_id": "bazel-uuid-1"},
+        }),
+        "https://app.oss.aspect.build/sink-1",
+    )
+
+def _test_build_started_preserves_bazel_streamed(ctx):
+    """`process_event`'s build_started reset wipes top-level state for the new
+    stream; `bes_streamed_by_bazel` is task-managed and set before the event, so
+    like `sink_invocation_id` it must survive — otherwise a retry silently drops
+    the Aspect link.
+
+    `bes_get` is a `getattr`, so a struct stands in for the BES event."""
+    data = init_data()
+    data["sink_invocation_id"] = "sink-1"
+    data["bes_streamed_by_bazel"] = True
+    process_event(data, struct(
+        kind = "build_started",
+        payload = struct(
+            uuid = "bazel-uuid-1",
+            build_tool_version = "9.0.1",
+            command = "build",
+            start_time_millis = 1000,
+        ),
+    ))
+    _eq("sink id preserved", data["sink_invocation_id"], "sink-1")
+    _eq("bazel-streamed flag preserved", data["bes_streamed_by_bazel"], True)
+    _eq("bazel invocation id captured", data["bazel"]["invocation_id"], "bazel-uuid-1")
+
 def _test_render_bes_url(ctx):
     """`render_bes_url` joins data['bazel'] bes_results_url + invocation_id,
     and returns "" when either half is missing."""
@@ -1263,6 +1327,8 @@ _UNIT_TESTS = [
     _test_render_summary_or_fallback_degrades,
     _test_status_maps_cover_every_terminal_status,
     _test_aspect_web_ui_url,
+    _test_aspect_web_ui_url_bazel_streamed,
+    _test_build_started_preserves_bazel_streamed,
     _test_render_bes_url,
     _test_failed_status_without_failure_bucket,
     _test_failed_status_with_explicit_action_failure,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -16,7 +16,7 @@ load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
-load("./bes_sinks.axl", "announce_bes_sinks", "collect_bes_from_args", "summarize_bes_upload")
+load("./bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./deployment_flags.axl", "announce_deployment_flags", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
@@ -308,11 +308,12 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
 
     # Every CLI-streamed BES sink: explicit `--bes-backend`, the deployment's BES,
     # and the trait's own sinks (the Workflows runner's env-injected backend).
-    # Announced with the first spawn below (the streams belong to the spawn) and
-    # summarized at build end.
-    bes_sinks = collect_bes_from_args(ctx, extra_backends = deployment.bes_backends)
+    # Any that names the endpoint Bazel's own `--bes_backend` already uploads to
+    # is dropped, so the invocation is streamed once. Announced with the first
+    # spawn below (the streams belong to the spawn) and summarized at build end.
+    bes_sinks = collect_bes_from_args(ctx, extra_backends = deployment.bes_backends, rc = rc, command = command)
     if bazel_trait.build_event_sinks:
-        bes_sinks.extend(bazel_trait.build_event_sinks)
+        bes_sinks.extend(drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, command)))
     need_bes = bool(bazel_trait.build_event) or bool(lifecycle.task_update)
 
     # Per-invocation extras: inject `--remote_header` / `--bes_header` auth for an

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -16,7 +16,7 @@ load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
-load("./bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./deployment_flags.axl", "announce_deployment_flags", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
@@ -311,9 +311,14 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     # Any that names the endpoint Bazel's own `--bes_backend` already uploads to
     # is dropped, so the invocation is streamed once. Announced with the first
     # spawn below (the streams belong to the spawn) and summarized at build end.
+    bazel_backend = bazel_bes_backend(rc, command)
     bes_sinks = collect_bes_from_args(ctx, extra_backends = deployment.bes_backends, rc = rc, command = command)
     if bazel_trait.build_event_sinks:
-        bes_sinks.extend(drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, command)))
+        bes_sinks.extend(drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend))
+
+    # No sink to the Aspect backend means no sink id is minted, so the Web UI
+    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
+    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
     need_bes = bool(bazel_trait.build_event) or bool(lifecycle.task_update)
 
     # Per-invocation extras: inject `--remote_header` / `--bes_header` auth for an
@@ -360,9 +365,12 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
 
             # Re-init for the new attempt; `process_event` increments
             # BES counters in-place, so without a fresh dict the retry
-            # would double-count everything from the failed run.
+            # would double-count everything from the failed run. The
+            # bazel-streams-BES verdict is a property of the flags, not the
+            # attempt, so it carries over.
             data = init_data()
             data["bazel_attempts"] = prior_attempts
+            data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
 
         spawn_status = _pick_status(command, data, had_failure = False, terminal = False)
         task_update(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -16,7 +16,7 @@ load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
-load("./bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./bes_sinks.axl", "announce_bes_sinks", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
 load("./deployment_flags.axl", "announce_deployment_flags", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
@@ -306,20 +306,15 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     rc = setup_phase(ctx, lifecycle, " ".join(targets), "bazel_results", data, hc_trait, bazel_trait, command, bazel_base_flags = base_flags)
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
-    # Every CLI-streamed BES sink: explicit `--bes-backend`, the deployment's BES,
-    # and the trait's own sinks (the Workflows runner's env-injected backend).
-    # Any that names the endpoint Bazel's own `--bes_backend` already uploads to
-    # is dropped, so the invocation is streamed once. Announced with the first
-    # spawn below (the streams belong to the spawn) and summarized at build end.
-    bazel_backend = bazel_bes_backend(rc, command)
-    bes_sinks = collect_bes_from_args(ctx, extra_backends = deployment.bes_backends, rc = rc, command = command)
-    if bazel_trait.build_event_sinks:
-        bes_sinks.extend(drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend))
-
-    # No sink to the Aspect backend means no sink id is minted, so the Web UI
-    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
-    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
+    # Announced with the first spawn below (the streams belong to the spawn) and
+    # summarized at build end.
+    bes_sinks = collect_bes_sinks(ctx, bazel_trait, rc, command, extra_backends = deployment.bes_backends)
     need_bes = bool(bazel_trait.build_event) or bool(lifecycle.task_update)
+
+    # A property of the resolved flags, so it holds for every attempt and is
+    # restored onto each retry's fresh `data`.
+    bazel_streams_bes = bes_streamed_by_bazel(ctx, rc, command)
+    data["bes_streamed_by_bazel"] = bazel_streams_bes
 
     # Per-invocation extras: inject `--remote_header` / `--bes_header` auth for an
     # Aspect-owned remote cache or Bazel-streamed `--bes_backend` (appended after
@@ -365,12 +360,10 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
 
             # Re-init for the new attempt; `process_event` increments
             # BES counters in-place, so without a fresh dict the retry
-            # would double-count everything from the failed run. The
-            # bazel-streams-BES verdict is a property of the flags, not the
-            # attempt, so it carries over.
+            # would double-count everything from the failed run.
             data = init_data()
             data["bazel_attempts"] = prior_attempts
-            data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
+            data["bes_streamed_by_bazel"] = bazel_streams_bes
 
         spawn_status = _pick_status(command, data, had_failure = False, terminal = False)
         task_update(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
@@ -6,6 +6,12 @@ bazel-spawning task that exposes the flags (`bes_args`) builds the sinks here
 (`collect_bes_from_args`), splices them into its `build_events` list, and
 `wait()`s them after the build.
 
+The two paths are mutually exclusive per endpoint: when Bazel's own
+`--bes_backend` names an endpoint the CLI would also stream to, the CLI sink is
+dropped so the invocation is uploaded once rather than twice
+(`drop_bazel_streamed` for backends collected here, `drop_bazel_streamed_sinks`
+for sinks a feature already pushed onto `BazelTrait.build_event_sinks`).
+
 The Aspect login JWT is attached to an Aspect-owned backend's sink metadata when
 the user has not supplied their own `authorization` header — see
 `aspect_endpoint_auth.axl` for the host gate and best-effort credential
@@ -14,7 +20,7 @@ resolution. (The companion case — BES routed through Bazel via
 `bazel_flags.axl` instead.)
 """
 
-load("./aspect_endpoint_auth.axl", "endpoint_host", "headers_have_auth", "is_aspect_host", "resolve_aspect_bearer")
+load("./aspect_endpoint_auth.axl", "endpoint_host", "headers_have_auth", "is_aspect_host", "resolve_aspect_bearer", "same_bes_endpoint")
 load("./environment.axl", "info")
 
 def bes_args() -> dict:
@@ -32,7 +38,67 @@ def bes_args() -> dict:
         ),
     }
 
-def collect_bes_from_args(ctx, extra_backends = []) -> list:
+_DUPLICATE_MSG = ("Not streaming build events to %s from the CLI: Bazel is already " +
+                  "uploading them there via --bes_backend=%s.")
+
+def drop_bazel_streamed(ctx, backends: list, bazel_backend: str) -> list:
+    """`backends` minus any that name the same endpoint as Bazel's own
+    `bazel_backend`, announcing each one dropped.
+
+    Both the CLI sink and Bazel's uploader stream the *same* invocation, so a
+    backend configured on both paths receives two streams for one build. The
+    backend then sees a duplicate invocation, and the two streams race to finish
+    — losing that race is how the CLI-side stream ends up truncated.
+
+    Bazel wins the tie because it is the more explicit request: the CLI's
+    backends are auto-wired (a Workflows runner's `ASPECT_WORKFLOWS_BES_BACKEND`,
+    a `--deployment`'s advertised host) while `--bes_backend` is set by hand. A
+    no-op when `bazel_backend` is empty.
+    """
+    if not bazel_backend:
+        return backends
+
+    kept = []
+    for backend in backends:
+        if same_bes_endpoint(backend, bazel_backend):
+            info(ctx.std, _DUPLICATE_MSG % (backend, bazel_backend))
+        else:
+            kept.append(backend)
+    return kept
+
+def drop_bazel_streamed_sinks(ctx, sinks: list, bazel_backend: str) -> list:
+    """`sinks` minus any gRPC sink already covered by Bazel's `bazel_backend`,
+    announcing each one dropped.
+
+    The list-of-URIs `drop_bazel_streamed` handles backends the CLI is about to
+    build sinks for; this handles ones a feature already built and pushed onto
+    `BazelTrait.build_event_sinks` (the Workflows runner's env-injected backend).
+    File sinks have no `uri` and are always kept — a local BEP dump is not a
+    second upload.
+    """
+    if not bazel_backend:
+        return sinks
+
+    kept = []
+    for sink in sinks:
+        if sink.uri and same_bes_endpoint(sink.uri, bazel_backend):
+            info(ctx.std, _DUPLICATE_MSG % (sink.uri, bazel_backend))
+        else:
+            kept.append(sink)
+    return kept
+
+def bazel_bes_backend(rc, command: str) -> str:
+    """The effective `--bes_backend` Bazel itself will upload to, or `""`.
+
+    Reads through the run command, so it sees the flag wherever it came from —
+    `--bazel-flag=--bes_backend=…`, a `.bazelrc`, or an expanded `--config`.
+    `rc` may be `None` for a caller that has no run command to consult.
+    """
+    if rc == None:
+        return ""
+    return rc.flag_value("--bes_backend", command = command) or ""
+
+def collect_bes_from_args(ctx, extra_backends = [], rc = None, command: str = "build") -> list:
     """Build the CLI-streamed BES sinks from `--bes-backend` / `--bes-header`.
 
     Attaches the Aspect login JWT as `Authorization: Bearer <jwt>` to each backend
@@ -44,6 +110,12 @@ def collect_bes_from_args(ctx, extra_backends = []) -> list:
     `extra_backends` are additional BES backend URIs to stream to (e.g. the BES
     host `--deployment` wires up), unioned with `--bes-backend` and deduped so a
     URI passed both ways yields one sink.
+
+    `rc` / `command` identify the effective Bazel `--bes_backend`; when a
+    CLI-streamed backend names that same endpoint it is dropped, since Bazel is
+    already uploading the build's events there and a second stream would
+    duplicate the invocation (see `drop_bazel_streamed`). Pass `rc = None` to skip
+    the check.
 
     Returns a list of sinks to splice into a task's `build_events`; the caller
     `wait()`s them after the build.
@@ -64,6 +136,8 @@ def collect_bes_from_args(ctx, extra_backends = []) -> list:
     for b in extra_backends:
         if b not in backends:
             backends.append(b)
+
+    backends = drop_bazel_streamed(ctx, backends, bazel_bes_backend(rc, command))
 
     sinks = []
     for bes_backend in backends:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
@@ -87,6 +87,21 @@ def drop_bazel_streamed_sinks(ctx, sinks: list, bazel_backend: str) -> list:
             kept.append(sink)
     return kept
 
+def aspect_bes_streamed_by_bazel(ctx, bazel_backend: str) -> bool:
+    """Whether Bazel's own `--bes_backend` is the Aspect BES backend this runner
+    reports results for — i.e. the CLI's sink to it was (or would be) suppressed,
+    yet the Aspect Web UI still holds the invocation because Bazel uploaded it.
+
+    Callers set `data["bes_streamed_by_bazel"]` from this so `resolve_aspect_url`
+    keys the link on Bazel's `invocation_id` rather than the sink id that was
+    never minted. Gated on the runner's own `ASPECT_WORKFLOWS_BES_BACKEND`:
+    suppressing a third-party BES says nothing about what the Aspect UI has.
+    """
+    if not bazel_backend:
+        return False
+    aspect_backend = ctx.std.env.var("ASPECT_WORKFLOWS_BES_BACKEND") or ""
+    return same_bes_endpoint(aspect_backend, bazel_backend)
+
 def bazel_bes_backend(rc, command: str) -> str:
     """The effective `--bes_backend` Bazel itself will upload to, or `""`.
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
@@ -3,14 +3,14 @@
 `--bes-backend` makes the aspect-cli stream BEP to the backend through its own
 gRPC sink (distinct from Bazel's `--bes_backend`, which makes Bazel upload). Every
 bazel-spawning task that exposes the flags (`bes_args`) builds the sinks here
-(`collect_bes_from_args`), splices them into its `build_events` list, and
-`wait()`s them after the build.
+(`collect_bes_sinks`), splices them into its `build_events` list, and `wait()`s
+them after the build.
 
-The two paths are mutually exclusive per endpoint: when Bazel's own
-`--bes_backend` names an endpoint the CLI would also stream to, the CLI sink is
-dropped so the invocation is uploaded once rather than twice
-(`drop_bazel_streamed` for backends collected here, `drop_bazel_streamed_sinks`
-for sinks a feature already pushed onto `BazelTrait.build_event_sinks`).
+The two paths are mutually exclusive per endpoint: a CLI sink to the endpoint
+Bazel's own `--bes_backend` uploads to is dropped, so the invocation is streamed
+once rather than twice. Because that can leave no sink at all — and the Aspect
+Web UI link keys on an id only a sink mints — a task pairs the collect call with
+`bes_streamed_by_bazel`, which redirects the link to Bazel's invocation id.
 
 The Aspect login JWT is attached to an Aspect-owned backend's sink metadata when
 the user has not supplied their own `authorization` header — see
@@ -26,7 +26,7 @@ load("./environment.axl", "info")
 def bes_args() -> dict:
     """The `bes_backends` / `bes_headers` CLI args every BES-capable task
     declares, with one canonical description each. Splat into a task's
-    `args = {...}`; read back by `collect_bes_from_args`."""
+    `args = {...}`; read back by `collect_bes_sinks`."""
     return {
         "bes_backends": args.string_list(
             long = "bes-backend",
@@ -41,80 +41,86 @@ def bes_args() -> dict:
 _DUPLICATE_MSG = ("Not streaming build events to %s from the CLI: Bazel is already " +
                   "uploading them there via --bes_backend=%s.")
 
-def drop_bazel_streamed(ctx, backends: list, bazel_backend: str) -> list:
-    """`backends` minus any that name the same endpoint as Bazel's own
-    `bazel_backend`, announcing each one dropped.
-
-    Both the CLI sink and Bazel's uploader stream the *same* invocation, so a
-    backend configured on both paths receives two streams for one build. The
-    backend then sees a duplicate invocation, and the two streams race to finish
-    — losing that race is how the CLI-side stream ends up truncated.
-
-    Bazel wins the tie because it is the more explicit request: the CLI's
-    backends are auto-wired (a Workflows runner's `ASPECT_WORKFLOWS_BES_BACKEND`,
-    a `--deployment`'s advertised host) while `--bes_backend` is set by hand. A
-    no-op when `bazel_backend` is empty.
-    """
-    if not bazel_backend:
-        return backends
-
-    kept = []
-    for backend in backends:
-        if same_bes_endpoint(backend, bazel_backend):
-            info(ctx.std, _DUPLICATE_MSG % (backend, bazel_backend))
-        else:
-            kept.append(backend)
-    return kept
-
-def drop_bazel_streamed_sinks(ctx, sinks: list, bazel_backend: str) -> list:
-    """`sinks` minus any gRPC sink already covered by Bazel's `bazel_backend`,
-    announcing each one dropped.
-
-    The list-of-URIs `drop_bazel_streamed` handles backends the CLI is about to
-    build sinks for; this handles ones a feature already built and pushed onto
-    `BazelTrait.build_event_sinks` (the Workflows runner's env-injected backend).
-    File sinks have no `uri` and are always kept — a local BEP dump is not a
-    second upload.
-    """
-    if not bazel_backend:
-        return sinks
-
-    kept = []
-    for sink in sinks:
-        if sink.uri and same_bes_endpoint(sink.uri, bazel_backend):
-            info(ctx.std, _DUPLICATE_MSG % (sink.uri, bazel_backend))
-        else:
-            kept.append(sink)
-    return kept
-
-def aspect_bes_streamed_by_bazel(ctx, bazel_backend: str) -> bool:
-    """Whether Bazel's own `--bes_backend` is the Aspect BES backend this runner
-    reports results for — i.e. the CLI's sink to it was (or would be) suppressed,
-    yet the Aspect Web UI still holds the invocation because Bazel uploaded it.
-
-    Callers set `data["bes_streamed_by_bazel"]` from this so `resolve_aspect_url`
-    keys the link on Bazel's `invocation_id` rather than the sink id that was
-    never minted. Gated on the runner's own `ASPECT_WORKFLOWS_BES_BACKEND`:
-    suppressing a third-party BES says nothing about what the Aspect UI has.
-    """
-    if not bazel_backend:
-        return False
-    aspect_backend = ctx.std.env.var("ASPECT_WORKFLOWS_BES_BACKEND") or ""
-    return same_bes_endpoint(aspect_backend, bazel_backend)
-
 def bazel_bes_backend(rc, command: str) -> str:
     """The effective `--bes_backend` Bazel itself will upload to, or `""`.
 
     Reads through the run command, so it sees the flag wherever it came from —
     `--bazel-flag=--bes_backend=…`, a `.bazelrc`, or an expanded `--config`.
-    `rc` may be `None` for a caller that has no run command to consult.
+    `rc` may be `None` for a caller with no run command to consult.
+
+    Public so `bes_sinks_test.axl` can assert the resolution.
     """
     if rc == None:
         return ""
     return rc.flag_value("--bes_backend", command = command) or ""
 
-def collect_bes_from_args(ctx, extra_backends = [], rc = None, command: str = "build") -> list:
-    """Build the CLI-streamed BES sinks from `--bes-backend` / `--bes-header`.
+def _drop_bazel_streamed(ctx, items: list, uri_of, bazel_backend: str) -> list:
+    """`items` minus those whose `uri_of(item)` names the same endpoint as Bazel's
+    own `bazel_backend`, announcing each one dropped.
+
+    Both the CLI sink and Bazel's uploader stream the *same* invocation, so an
+    endpoint configured on both paths receives two streams for one build: the
+    backend records a duplicate invocation, and the two streams race to close.
+
+    Bazel wins the tie because it is the more explicit request — the CLI's
+    backends are auto-wired (a Workflows runner's `ASPECT_WORKFLOWS_BES_BACKEND`,
+    a `--deployment`'s advertised host) while `--bes_backend` is set by hand.
+
+    `uri_of` returning `""`/`None` keeps the item: a file sink (a local BEP dump)
+    is not a second upload. A no-op when `bazel_backend` is empty.
+    """
+    if not bazel_backend:
+        return items
+
+    kept = []
+    for item in items:
+        uri = uri_of(item)
+        if uri and same_bes_endpoint(uri, bazel_backend):
+            info(ctx.std, _DUPLICATE_MSG % (uri, bazel_backend))
+        else:
+            kept.append(item)
+    return kept
+
+def bes_streamed_by_bazel(ctx, rc, command: str = "build") -> bool:
+    """Whether Bazel's own `--bes_backend` is the Aspect BES backend this runner
+    reports results for, so the CLI streams no sink of its own to it.
+
+    Tasks store this as `data["bes_streamed_by_bazel"]`, which tells
+    `resolve_aspect_url` to key the Web UI link on Bazel's `invocation_id`: with
+    no sink there is no sink id, but the backend still holds the invocation —
+    indexed under Bazel's UUID, since Bazel uploaded it.
+
+    Gated on the runner's own `ASPECT_WORKFLOWS_BES_BACKEND`, because suppressing
+    a third-party BES says nothing about what the Aspect Web UI has.
+    """
+    bazel_backend = bazel_bes_backend(rc, command)
+    if not bazel_backend:
+        return False
+    return same_bes_endpoint(ctx.std.env.var("ASPECT_WORKFLOWS_BES_BACKEND") or "", bazel_backend)
+
+def collect_bes_sinks(ctx, bazel_trait, rc, command: str = "build", extra_backends = []) -> list:
+    """Every CLI-streamed BES sink for one bazel spawn, in the order a task
+    splices them into `build_events`: those built from `--bes-backend` /
+    `--bes-header` and `extra_backends`, then the ones features already pushed
+    onto `BazelTrait.build_event_sinks` (a Workflows runner's env-injected
+    backend, a `--bep-file` dump).
+
+    Sinks to the endpoint Bazel's own `--bes_backend` uploads to are dropped from
+    both groups so the invocation is streamed once — see `_drop_bazel_streamed`.
+
+    The one call a bazel-spawning task makes; pair it with
+    `bes_streamed_by_bazel` to keep the Aspect Web UI link resolvable. The caller
+    `wait()`s the returned sinks after the build.
+    """
+    bazel_backend = bazel_bes_backend(rc, command)
+    return (
+        collect_bes_from_args(ctx, extra_backends = extra_backends, bazel_backend = bazel_backend) +
+        _drop_bazel_streamed(ctx, list(bazel_trait.build_event_sinks), lambda s: s.uri, bazel_backend)
+    )
+
+def collect_bes_from_args(ctx, extra_backends = [], bazel_backend: str = "") -> list:
+    """The CLI-streamed BES sinks from `--bes-backend` / `--bes-header`. Most
+    callers want `collect_bes_sinks`, which also covers the trait's own sinks.
 
     Attaches the Aspect login JWT as `Authorization: Bearer <jwt>` to each backend
     a configured deployment owns when the user has not supplied their own
@@ -126,14 +132,8 @@ def collect_bes_from_args(ctx, extra_backends = [], rc = None, command: str = "b
     host `--deployment` wires up), unioned with `--bes-backend` and deduped so a
     URI passed both ways yields one sink.
 
-    `rc` / `command` identify the effective Bazel `--bes_backend`; when a
-    CLI-streamed backend names that same endpoint it is dropped, since Bazel is
-    already uploading the build's events there and a second stream would
-    duplicate the invocation (see `drop_bazel_streamed`). Pass `rc = None` to skip
-    the check.
-
-    Returns a list of sinks to splice into a task's `build_events`; the caller
-    `wait()`s them after the build.
+    `bazel_backend` is the endpoint Bazel uploads to itself (`""` when it does
+    not); a backend naming it is dropped rather than streamed twice.
     """
     metadata = {}
     for bes_header in ctx.args.bes_headers:
@@ -152,7 +152,7 @@ def collect_bes_from_args(ctx, extra_backends = [], rc = None, command: str = "b
         if b not in backends:
             backends.append(b)
 
-    backends = drop_bazel_streamed(ctx, backends, bazel_bes_backend(rc, command))
+    backends = _drop_bazel_streamed(ctx, backends, lambda b: b, bazel_backend)
 
     sinks = []
     for bes_backend in backends:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
@@ -1,15 +1,30 @@
-"""Tests for `lib/bes_sinks.axl` — the BES upload summary line and the gRPC-sink
-filter shared by the announce/summary helpers.
+"""Tests for `lib/bes_sinks.axl` — the BES upload summary line, the gRPC-sink
+filter shared by the announce/summary helpers, and the duplicate-stream drop that
+keeps the CLI from streaming to an endpoint Bazel's own `--bes_backend` already
+uploads to.
 
 Run with:
   aspect dev test-bes-sinks
 """
 
-load("./bes_sinks.axl", "bes_upload_line", "grpc_backends")
+load("./bes_sinks.axl", "bazel_bes_backend", "bes_upload_line", "drop_bazel_streamed", "drop_bazel_streamed_sinks", "grpc_backends")
 
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
+
+def _fake_ctx():
+    """Stand-in for `ctx`: the drop helpers touch it only to `info(ctx.std, …)`,
+    which reads `std.io.stdout.is_tty` and `std.env.var` to decide on color."""
+    return struct(std = struct(
+        io = struct(stdout = struct(is_tty = False)),
+        env = struct(var = lambda name: None),
+    ))
+
+def _fake_rc(values):
+    """Stand-in for a `RunCommand`: `bazel_bes_backend` calls only `flag_value`.
+    `values` maps a flag name to its effective value."""
+    return struct(flag_value = lambda name, command: values.get(name))
 
 def _test_clean_stream(_):
     """A clean stream reports the sent count and names the backend."""
@@ -94,6 +109,66 @@ def _test_grpc_backends_filters_file_sinks(_):
     _eq("only gRPC-backend sinks survive", [s.uri for s in got], ["grpcs://bes.a", "grpcs://bes.b"])
     _eq("no gRPC sinks → empty", grpc_backends([file_sink]), [])
 
+def _test_bazel_bes_backend(_):
+    """The effective Bazel `--bes_backend` is read off the run command; a missing
+    flag or absent run command both mean "Bazel is not uploading"."""
+    rc = _fake_rc({"--bes_backend": "grpcs://bes.acme.aspect.build"})
+    _eq("flag set", bazel_bes_backend(rc, "build"), "grpcs://bes.acme.aspect.build")
+    _eq("flag unset", bazel_bes_backend(_fake_rc({}), "build"), "")
+    _eq("no run command", bazel_bes_backend(None, "build"), "")
+
+def _test_drop_bazel_streamed(_):
+    """A CLI backend naming the same endpoint as Bazel's `--bes_backend` is
+    dropped — the duplicate-stream fix — while others survive."""
+    ctx = _fake_ctx()
+    backends = ["grpcs://bes.acme.aspect.build", "grpcs://bes.other.example.com"]
+
+    _eq(
+        "exact match dropped",
+        drop_bazel_streamed(ctx, backends, "grpcs://bes.acme.aspect.build"),
+        ["grpcs://bes.other.example.com"],
+    )
+
+    # The customer's case: the runner injects the implicit-port spelling while the
+    # user writes `:443` (or the reverse). Both name one endpoint.
+    _eq(
+        "default port spelled out still matches",
+        drop_bazel_streamed(ctx, backends, "grpcs://bes.acme.aspect.build:443"),
+        ["grpcs://bes.other.example.com"],
+    )
+    _eq(
+        "explicit-port backend vs implicit bazel flag",
+        drop_bazel_streamed(ctx, ["grpcs://bes.acme.aspect.build:443"], "grpcs://bes.acme.aspect.build"),
+        [],
+    )
+
+    _eq("unrelated backend kept", drop_bazel_streamed(ctx, backends, "grpcs://bes.third.example.com"), backends)
+    _eq("different port kept", drop_bazel_streamed(ctx, backends, "grpcs://bes.acme.aspect.build:8980"), backends)
+    _eq("no bazel backend is a no-op", drop_bazel_streamed(ctx, backends, ""), backends)
+    _eq("empty backend list", drop_bazel_streamed(ctx, [], "grpcs://bes.acme.aspect.build"), [])
+
+def _test_drop_bazel_streamed_sinks(_):
+    """The already-built-sink variant drops the same duplicates (the Workflows
+    runner's env-injected backend) but never a file sink, which is a local BEP
+    dump rather than a second upload."""
+    ctx = _fake_ctx()
+    workflows = struct(uri = "grpcs://bes.acme.aspect.build")
+    other = struct(uri = "grpcs://bes.other.example.com")
+    file_sink = struct(uri = None)
+    sinks = [workflows, file_sink, other]
+
+    _eq(
+        "duplicate gRPC sink dropped, file sink kept",
+        [s.uri for s in drop_bazel_streamed_sinks(ctx, sinks, "grpcs://bes.acme.aspect.build:443")],
+        [None, "grpcs://bes.other.example.com"],
+    )
+    _eq("no bazel backend is a no-op", drop_bazel_streamed_sinks(ctx, sinks, ""), sinks)
+    _eq(
+        "file sink alone survives",
+        drop_bazel_streamed_sinks(ctx, [file_sink], "grpcs://bes.acme.aspect.build"),
+        [file_sink],
+    )
+
 _UNIT_TESTS = [
     _test_clean_stream,
     _test_failed_stream,
@@ -101,6 +176,9 @@ _UNIT_TESTS = [
     _test_connect_failure,
     _test_missing_uri,
     _test_grpc_backends_filters_file_sinks,
+    _test_bazel_bes_backend,
+    _test_drop_bazel_streamed,
+    _test_drop_bazel_streamed_sinks,
 ]
 
 def _test_impl(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
@@ -1,32 +1,44 @@
 """Tests for `lib/bes_sinks.axl` — the BES upload summary line, the gRPC-sink
-filter shared by the announce/summary helpers, and the duplicate-stream drop that
-keeps the CLI from streaming to an endpoint Bazel's own `--bes_backend` already
-uploads to.
+filter shared by the announce/summary helpers, sink collection, and the
+duplicate-stream drop that keeps the CLI from streaming to an endpoint Bazel's
+own `--bes_backend` already uploads to.
 
 Run with:
   aspect dev test-bes-sinks
 """
 
-load("./bes_sinks.axl", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_upload_line", "drop_bazel_streamed", "drop_bazel_streamed_sinks", "grpc_backends")
+load("./bes_sinks.axl", "bazel_bes_backend", "bes_streamed_by_bazel", "bes_upload_line", "collect_bes_from_args", "collect_bes_sinks", "grpc_backends")
 
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
 
-def _fake_ctx(env = {}):
-    """Stand-in for `ctx`: the drop helpers touch it only to `info(ctx.std, …)`,
-    which reads `std.io.stdout.is_tty` and `std.env.var` to decide on color;
-    `aspect_bes_streamed_by_bazel` additionally reads
-    `ASPECT_WORKFLOWS_BES_BACKEND` out of `env`."""
-    return struct(std = struct(
-        io = struct(stdout = struct(is_tty = False)),
-        env = struct(var = lambda name: env.get(name)),
-    ))
+def _fake_ctx(env = {}, bes_backends = [], bes_headers = []):
+    """Stand-in for `ctx`. `info(ctx.std, …)` reads `std.io.stdout.is_tty` and
+    `std.env.var` to decide on color, `bes_streamed_by_bazel` reads
+    `ASPECT_WORKFLOWS_BES_BACKEND` from `env`, and the collect helpers read the
+    `--bes-backend` / `--bes-header` args.
+
+    `aspect.auth.deployment_for_host` returns None throughout: these tests cover
+    endpoint matching, not the JWT attachment `aspect_endpoint_auth_test.axl`
+    owns, and an unowned host skips credential resolution entirely."""
+    return struct(
+        std = struct(
+            io = struct(stdout = struct(is_tty = False)),
+            env = struct(var = lambda name: env.get(name)),
+        ),
+        args = struct(bes_backends = bes_backends, bes_headers = bes_headers),
+        aspect = struct(auth = struct(deployment_for_host = lambda host: None)),
+    )
 
 def _fake_rc(values):
     """Stand-in for a `RunCommand`: `bazel_bes_backend` calls only `flag_value`.
     `values` maps a flag name to its effective value."""
     return struct(flag_value = lambda name, command: values.get(name))
+
+def _fake_trait(sinks):
+    """Stand-in for `BazelTrait`: `collect_bes_sinks` reads only its sink list."""
+    return struct(build_event_sinks = sinks)
 
 def _test_clean_stream(_):
     """A clean stream reports the sent count and names the backend."""
@@ -119,84 +131,87 @@ def _test_bazel_bes_backend(_):
     _eq("flag unset", bazel_bes_backend(_fake_rc({}), "build"), "")
     _eq("no run command", bazel_bes_backend(None, "build"), "")
 
-def _test_drop_bazel_streamed(_):
-    """A CLI backend naming the same endpoint as Bazel's `--bes_backend` is
-    dropped — the duplicate-stream fix — while others survive."""
-    ctx = _fake_ctx()
-    backends = ["grpcs://bes.acme.aspect.build", "grpcs://bes.other.example.com"]
+def _test_collect_drops_duplicate_backends(_):
+    """A `--bes-backend` naming the same endpoint as Bazel's `--bes_backend` is
+    dropped — the duplicate-stream fix — while others still get a sink."""
+    duplicate = "grpcs://bes.acme.aspect.build"
+    other = "grpcs://bes.other.example.com"
 
-    _eq(
-        "exact match dropped",
-        drop_bazel_streamed(ctx, backends, "grpcs://bes.acme.aspect.build"),
-        ["grpcs://bes.other.example.com"],
-    )
+    def uris(bazel_backend, backends = [duplicate, other]):
+        ctx = _fake_ctx(bes_backends = backends)
+        return [s.uri for s in collect_bes_from_args(ctx, bazel_backend = bazel_backend)]
 
-    # The customer's case: the runner injects the implicit-port spelling while the
-    # user writes `:443` (or the reverse). Both name one endpoint.
+    _eq("exact match dropped", uris(duplicate), [other])
+
+    # The customer's case: the runner injects the implicit-port spelling while
+    # the user writes `:443` (or the reverse). Both name one endpoint.
+    _eq("bazel spells the default port", uris(duplicate + ":443"), [other])
     _eq(
-        "default port spelled out still matches",
-        drop_bazel_streamed(ctx, backends, "grpcs://bes.acme.aspect.build:443"),
-        ["grpcs://bes.other.example.com"],
-    )
-    _eq(
-        "explicit-port backend vs implicit bazel flag",
-        drop_bazel_streamed(ctx, ["grpcs://bes.acme.aspect.build:443"], "grpcs://bes.acme.aspect.build"),
+        "backend spells the default port",
+        uris(duplicate, backends = [duplicate + ":443"]),
         [],
     )
+    _eq("schemeless bazel flag", uris("bes.acme.aspect.build"), [other])
 
-    _eq("unrelated backend kept", drop_bazel_streamed(ctx, backends, "grpcs://bes.third.example.com"), backends)
-    _eq("different port kept", drop_bazel_streamed(ctx, backends, "grpcs://bes.acme.aspect.build:8980"), backends)
-    _eq("no bazel backend is a no-op", drop_bazel_streamed(ctx, backends, ""), backends)
-    _eq("empty backend list", drop_bazel_streamed(ctx, [], "grpcs://bes.acme.aspect.build"), [])
+    _eq("unrelated backend kept", uris("grpcs://bes.third.example.com"), [duplicate, other])
+    _eq("different port kept", uris(duplicate + ":8980"), [duplicate, other])
+    _eq("no bazel backend is a no-op", uris(""), [duplicate, other])
+    _eq("no backends", uris(duplicate, backends = []), [])
 
-def _test_drop_bazel_streamed_sinks(_):
-    """The already-built-sink variant drops the same duplicates (the Workflows
-    runner's env-injected backend) but never a file sink, which is a local BEP
-    dump rather than a second upload."""
-    ctx = _fake_ctx()
-    workflows = struct(uri = "grpcs://bes.acme.aspect.build")
-    other = struct(uri = "grpcs://bes.other.example.com")
-    file_sink = struct(uri = None)
-    sinks = [workflows, file_sink, other]
+def _test_collect_bes_sinks(_):
+    """`collect_bes_sinks` returns the `--bes-backend` sinks then the trait's own,
+    dropping duplicates from both groups. A file sink (no `uri`) is a local BEP
+    dump, not a second upload, so it always survives."""
+    duplicate = "grpcs://bes.acme.aspect.build"
+    trait_sinks = [
+        struct(uri = duplicate),
+        struct(uri = None),
+        struct(uri = "grpcs://bes.other.example.com"),
+    ]
+
+    def uris(bazel_backend, backends = [duplicate, "grpcs://bes.cli.example.com"]):
+        ctx = _fake_ctx(bes_backends = backends)
+        rc = _fake_rc({"--bes_backend": bazel_backend} if bazel_backend else {})
+        return [s.uri for s in collect_bes_sinks(ctx, _fake_trait(trait_sinks), rc)]
 
     _eq(
-        "duplicate gRPC sink dropped, file sink kept",
-        [s.uri for s in drop_bazel_streamed_sinks(ctx, sinks, "grpcs://bes.acme.aspect.build:443")],
+        "duplicates dropped from both groups, file sink kept",
+        uris(duplicate + ":443"),
+        ["grpcs://bes.cli.example.com", None, "grpcs://bes.other.example.com"],
+    )
+    _eq(
+        "nothing dropped without a bazel backend",
+        uris(""),
+        [duplicate, "grpcs://bes.cli.example.com", duplicate, None, "grpcs://bes.other.example.com"],
+    )
+
+    # Suppressing every gRPC sink is the case that costs the Web UI its sink id;
+    # the file sink still comes back so a --bep-file dump keeps working.
+    _eq(
+        "all gRPC sinks suppressed",
+        uris(duplicate, backends = [duplicate]),
         [None, "grpcs://bes.other.example.com"],
     )
-    _eq("no bazel backend is a no-op", drop_bazel_streamed_sinks(ctx, sinks, ""), sinks)
-    _eq(
-        "file sink alone survives",
-        drop_bazel_streamed_sinks(ctx, [file_sink], "grpcs://bes.acme.aspect.build"),
-        [file_sink],
-    )
 
-def _test_aspect_bes_streamed_by_bazel(_):
+def _test_bes_streamed_by_bazel(_):
     """True only when Bazel's `--bes_backend` is the runner's own Aspect BES
     backend — the case where the Web UI still holds the invocation (under
-    Bazel's id) despite the CLI sink being suppressed."""
-    runner = {"ASPECT_WORKFLOWS_BES_BACKEND": "grpcs://bes.acme.aspect.build"}
+    Bazel's id) despite the CLI streaming no sink to it."""
+    aspect_backend = "grpcs://bes.acme.aspect.build"
 
-    _eq(
-        "bazel uploads to the Aspect backend",
-        aspect_bes_streamed_by_bazel(_fake_ctx(runner), "grpcs://bes.acme.aspect.build"),
-        True,
-    )
-    _eq(
-        "default-port spelling still matches",
-        aspect_bes_streamed_by_bazel(_fake_ctx(runner), "bes.acme.aspect.build:443"),
-        True,
-    )
+    def check(bazel_backend, runner_backend = aspect_backend):
+        env = {"ASPECT_WORKFLOWS_BES_BACKEND": runner_backend} if runner_backend else {}
+        rc = _fake_rc({"--bes_backend": bazel_backend} if bazel_backend else {})
+        return bes_streamed_by_bazel(_fake_ctx(env = env), rc)
+
+    _eq("bazel uploads to the Aspect backend", check(aspect_backend), True)
+    _eq("default-port spelling still matches", check("bes.acme.aspect.build:443"), True)
 
     # Suppressing a third-party BES says nothing about what the Aspect UI holds,
     # so the link must stay keyed on the (absent) sink id and be dropped.
-    _eq(
-        "bazel uploads elsewhere",
-        aspect_bes_streamed_by_bazel(_fake_ctx(runner), "grpcs://bes.buildbuddy.io"),
-        False,
-    )
-    _eq("no bazel backend", aspect_bes_streamed_by_bazel(_fake_ctx(runner), ""), False)
-    _eq("off a runner", aspect_bes_streamed_by_bazel(_fake_ctx(), "grpcs://bes.acme.aspect.build"), False)
+    _eq("bazel uploads elsewhere", check("grpcs://bes.buildbuddy.io"), False)
+    _eq("no bazel backend", check(""), False)
+    _eq("off a runner", check(aspect_backend, runner_backend = ""), False)
 
 _UNIT_TESTS = [
     _test_clean_stream,
@@ -206,9 +221,9 @@ _UNIT_TESTS = [
     _test_missing_uri,
     _test_grpc_backends_filters_file_sinks,
     _test_bazel_bes_backend,
-    _test_drop_bazel_streamed,
-    _test_drop_bazel_streamed_sinks,
-    _test_aspect_bes_streamed_by_bazel,
+    _test_collect_drops_duplicate_backends,
+    _test_collect_bes_sinks,
+    _test_bes_streamed_by_bazel,
 ]
 
 def _test_impl(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
@@ -7,18 +7,20 @@ Run with:
   aspect dev test-bes-sinks
 """
 
-load("./bes_sinks.axl", "bazel_bes_backend", "bes_upload_line", "drop_bazel_streamed", "drop_bazel_streamed_sinks", "grpc_backends")
+load("./bes_sinks.axl", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_upload_line", "drop_bazel_streamed", "drop_bazel_streamed_sinks", "grpc_backends")
 
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
 
-def _fake_ctx():
+def _fake_ctx(env = {}):
     """Stand-in for `ctx`: the drop helpers touch it only to `info(ctx.std, …)`,
-    which reads `std.io.stdout.is_tty` and `std.env.var` to decide on color."""
+    which reads `std.io.stdout.is_tty` and `std.env.var` to decide on color;
+    `aspect_bes_streamed_by_bazel` additionally reads
+    `ASPECT_WORKFLOWS_BES_BACKEND` out of `env`."""
     return struct(std = struct(
         io = struct(stdout = struct(is_tty = False)),
-        env = struct(var = lambda name: None),
+        env = struct(var = lambda name: env.get(name)),
     ))
 
 def _fake_rc(values):
@@ -169,6 +171,33 @@ def _test_drop_bazel_streamed_sinks(_):
         [file_sink],
     )
 
+def _test_aspect_bes_streamed_by_bazel(_):
+    """True only when Bazel's `--bes_backend` is the runner's own Aspect BES
+    backend — the case where the Web UI still holds the invocation (under
+    Bazel's id) despite the CLI sink being suppressed."""
+    runner = {"ASPECT_WORKFLOWS_BES_BACKEND": "grpcs://bes.acme.aspect.build"}
+
+    _eq(
+        "bazel uploads to the Aspect backend",
+        aspect_bes_streamed_by_bazel(_fake_ctx(runner), "grpcs://bes.acme.aspect.build"),
+        True,
+    )
+    _eq(
+        "default-port spelling still matches",
+        aspect_bes_streamed_by_bazel(_fake_ctx(runner), "bes.acme.aspect.build:443"),
+        True,
+    )
+
+    # Suppressing a third-party BES says nothing about what the Aspect UI holds,
+    # so the link must stay keyed on the (absent) sink id and be dropped.
+    _eq(
+        "bazel uploads elsewhere",
+        aspect_bes_streamed_by_bazel(_fake_ctx(runner), "grpcs://bes.buildbuddy.io"),
+        False,
+    )
+    _eq("no bazel backend", aspect_bes_streamed_by_bazel(_fake_ctx(runner), ""), False)
+    _eq("off a runner", aspect_bes_streamed_by_bazel(_fake_ctx(), "grpcs://bes.acme.aspect.build"), False)
+
 _UNIT_TESTS = [
     _test_clean_stream,
     _test_failed_stream,
@@ -179,6 +208,7 @@ _UNIT_TESTS = [
     _test_bazel_bes_backend,
     _test_drop_bazel_streamed,
     _test_drop_bazel_streamed_sinks,
+    _test_aspect_bes_streamed_by_bazel,
 ]
 
 def _test_impl(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -6,7 +6,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
 load("./private/lib/environment.axl", "error")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
@@ -88,12 +88,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # flags + aspect injection that capture the executable, the `args` attribute,
     # and the target env so `r.spawn` replays them the way `bazel run` does.
     r = runnable(ctx, [target], rc = rc)
-    bazel_backend = bazel_bes_backend(rc, "build")
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
-
-    # No sink to the Aspect backend means no sink id is minted, so the Web UI
-    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
-    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
+    bes_sinks = collect_bes_sinks(ctx, bazel_trait, rc)
+    data["bes_streamed_by_bazel"] = bes_streamed_by_bazel(ctx, rc)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -6,7 +6,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/environment.axl", "error")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
@@ -88,7 +88,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # flags + aspect injection that capture the executable, the `args` attribute,
     # and the target env so `r.spawn` replays them the way `bazel run` does.
     r = runnable(ctx, [target], rc = rc)
-    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -6,7 +6,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/environment.axl", "error")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
@@ -88,7 +88,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # flags + aspect injection that capture the executable, the `args` attribute,
     # and the target env so `r.spawn` replays them the way `bazel run` does.
     r = runnable(ctx, [target], rc = rc)
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
+    bazel_backend = bazel_bes_backend(rc, "build")
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
+
+    # No sink to the Aspect backend means no sink id is minted, so the Web UI
+    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
+    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -32,7 +32,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
 load("./private/lib/environment.axl", "error", "warn")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
@@ -135,15 +135,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         _clean_storage_mount(ctx, mount)
         data["warming"]["cleaned"] = True
 
-    # Populate phase: `bazel build --nobuild`. Pass build_event_sinks (the Aspect
-    # backend gRPC sink in CI) so the "✨ Aspect Workflows" link resolves to a
-    # real record. The local iterator drains BES into `data["bazel"]`.
-    bazel_backend = bazel_bes_backend(rc, "build")
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
-
-    # No sink to the Aspect backend means no sink id is minted, so the Web UI
-    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
-    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
+    # Populate phase: `bazel build --nobuild`. The local iterator drains BES
+    # into `data["bazel"]`.
+    bes_sinks = collect_bes_sinks(ctx, bazel_trait, rc)
+    data["bes_streamed_by_bazel"] = bes_streamed_by_bazel(ctx, rc)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -32,7 +32,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "aspect_bes_streamed_by_bazel", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/environment.axl", "error", "warn")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
@@ -138,7 +138,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Populate phase: `bazel build --nobuild`. Pass build_event_sinks (the Aspect
     # backend gRPC sink in CI) so the "✨ Aspect Workflows" link resolves to a
     # real record. The local iterator drains BES into `data["bazel"]`.
-    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
+    bazel_backend = bazel_bes_backend(rc, "build")
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_backend)
+
+    # No sink to the Aspect backend means no sink id is minted, so the Web UI
+    # link has to key on Bazel's invocation_id instead (Bazel is the uploader).
+    data["bes_streamed_by_bazel"] = aspect_bes_streamed_by_bazel(ctx, bazel_backend)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -32,7 +32,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
-load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
+load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bazel_bes_backend", "bes_args", "collect_bes_from_args", "drop_bazel_streamed_sinks", "summarize_bes_upload")
 load("./private/lib/environment.axl", "error", "warn")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
@@ -138,7 +138,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Populate phase: `bazel build --nobuild`. Pass build_event_sinks (the Aspect
     # backend gRPC sink in CI) so the "✨ Aspect Workflows" link resolves to a
     # real record. The local iterator drains BES into `data["bazel"]`.
-    bes_sinks = collect_bes_from_args(ctx) + list(bazel_trait.build_event_sinks)
+    bes_sinks = collect_bes_from_args(ctx, rc = rc) + drop_bazel_streamed_sinks(ctx, bazel_trait.build_event_sinks, bazel_bes_backend(rc, "build"))
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
 

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -1061,7 +1061,10 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
     /// numbers. The BES protocol's per-stream dedup makes replay safe.
     ///
     /// # Arguments
-    /// * `uri` - BES endpoint. `grpcs://` is rewritten to `https://`.
+    /// * `uri` - BES endpoint, kept verbatim: it is what `sink.uri` reports and
+    ///   what user-facing logs name. `grpcs://` / `grpc://` are mapped to their
+    ///   HTTP equivalents at dial time (see `build_event_stream::client`), TLS
+    ///   following from the scheme.
     /// * `metadata` - Headers attached to every request.
     /// * `max_retries` - Max consecutive reconnect attempts without ack
     ///   progress before giving up (default `4`). An attempt during which the
@@ -1100,7 +1103,7 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
             Some(timeout_dur)
         };
         Ok(build::BuildEventSink::new_grpc(
-            uri.replace("grpcs://", "https://"),
+            uri,
             HashMap::from_iter(metadata.entries),
             sink::retry::RetryConfig {
                 max_retries: max_retries as u32,

--- a/crates/build-event-stream/src/client.rs
+++ b/crates/build-event-stream/src/client.rs
@@ -40,12 +40,31 @@ pub enum ClientError {
     Status(#[from] tonic::Status),
 }
 
+/// The transport URI tonic can dial for a BES `endpoint`.
+///
+/// `Channel::from_shared` only understands `http`/`https`, while Bazel spells a
+/// TLS BES backend `grpcs://` (and plaintext `grpc://`), so those are mapped to
+/// their HTTP equivalents. TLS follows from the resulting scheme: tonic applies
+/// the `tls_config` below only to an `https` URI, leaving `grpc://` plaintext.
+///
+/// Confined to this function on purpose — the caller's `endpoint` string is also
+/// what user-facing logs report, and rewriting it there would tell a user their
+/// `grpcs://` backend is an `https://` one they never configured.
+fn transport_uri(endpoint: &str) -> String {
+    for (scheme, replacement) in [("grpcs://", "https://"), ("grpc://", "http://")] {
+        if let Some(rest) = endpoint.strip_prefix(scheme) {
+            return format!("{replacement}{rest}");
+        }
+    }
+    endpoint.to_string()
+}
+
 impl Client {
     pub async fn new(
         endpoint: String,
         headers: HashMap<String, String>,
     ) -> Result<Self, ClientError> {
-        let channel = Channel::from_shared(endpoint)?
+        let channel = Channel::from_shared(transport_uri(&endpoint))?
             .user_agent("AXL")?
             .connect_timeout(CONNECT_TIMEOUT)
             .tcp_keepalive(Some(KEEP_ALIVE_INTERVAL))
@@ -85,5 +104,67 @@ impl Client {
             .publish_build_tool_event_stream(Request::new(events))
             .await?;
         Ok(x)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every form must survive `Channel::from_shared`, which is what actually
+    /// rejects a scheme tonic doesn't know.
+    fn dialable(endpoint: &str) -> bool {
+        Channel::from_shared(transport_uri(endpoint)).is_ok()
+    }
+
+    #[test]
+    fn grpc_schemes_map_to_their_http_equivalents() {
+        assert_eq!(
+            transport_uri("grpcs://bes.example.com"),
+            "https://bes.example.com"
+        );
+        assert_eq!(
+            transport_uri("grpcs://bes.example.com:443/x"),
+            "https://bes.example.com:443/x"
+        );
+        assert_eq!(
+            transport_uri("grpc://buildbarn-frontend.awd.internal:8980"),
+            "http://buildbarn-frontend.awd.internal:8980"
+        );
+    }
+
+    #[test]
+    fn http_schemes_pass_through_untouched() {
+        assert_eq!(
+            transport_uri("https://bes.example.com"),
+            "https://bes.example.com"
+        );
+        assert_eq!(
+            transport_uri("http://localhost:8080"),
+            "http://localhost:8080"
+        );
+    }
+
+    /// Only the leading scheme is rewritten; a `grpcs://` appearing later in the
+    /// string (a path or query) is left alone.
+    #[test]
+    fn only_the_leading_scheme_is_rewritten() {
+        assert_eq!(
+            transport_uri("https://proxy.example.com/to/grpcs://inner"),
+            "https://proxy.example.com/to/grpcs://inner"
+        );
+    }
+
+    #[test]
+    fn every_supported_spelling_is_dialable() {
+        for endpoint in [
+            "grpcs://bes.example.com",
+            "grpcs://bes.example.com:443",
+            "grpc://buildbarn-frontend.awd.internal:8980",
+            "https://bes.example.com",
+            "http://localhost:8080",
+        ] {
+            assert!(dialable(endpoint), "{endpoint} should be dialable");
+        }
     }
 }

--- a/crates/build-event-stream/src/client.rs
+++ b/crates/build-event-stream/src/client.rs
@@ -40,18 +40,20 @@ pub enum ClientError {
     Status(#[from] tonic::Status),
 }
 
+/// How Bazel's gRPC URI schemes map onto the HTTP ones tonic understands.
+const SCHEME_ALIASES: [(&str, &str); 2] = [("grpcs://", "https://"), ("grpc://", "http://")];
+
 /// The transport URI tonic can dial for a BES `endpoint`.
 ///
 /// `Channel::from_shared` only understands `http`/`https`, while Bazel spells a
-/// TLS BES backend `grpcs://` (and plaintext `grpc://`), so those are mapped to
-/// their HTTP equivalents. TLS follows from the resulting scheme: tonic applies
-/// the `tls_config` below only to an `https` URI, leaving `grpc://` plaintext.
+/// TLS BES backend `grpcs://` and a plaintext one `grpc://`. TLS then follows
+/// from the mapped scheme, since tonic applies a `tls_config` only to `https`.
 ///
 /// Confined to this function on purpose — the caller's `endpoint` string is also
 /// what user-facing logs report, and rewriting it there would tell a user their
 /// `grpcs://` backend is an `https://` one they never configured.
 fn transport_uri(endpoint: &str) -> String {
-    for (scheme, replacement) in [("grpcs://", "https://"), ("grpc://", "http://")] {
+    for (scheme, replacement) in SCHEME_ALIASES {
         if let Some(rest) = endpoint.strip_prefix(scheme) {
             return format!("{replacement}{rest}");
         }


### PR DESCRIPTION
Configuring one BES endpoint on both upload paths — Bazel's `--bes_backend` and the CLI's own sink — makes both stream the *same* invocation. The backend records a duplicate, and the two streams race to close; the CLI-side one typically loses and shows up truncated. A customer hit this on a Workflows runner by setting `--bes_backend` to the URL the runner already injects as `ASPECT_WORKFLOWS_BES_BACKEND`.

The CLI now drops its sink to an endpoint Bazel is already uploading to, so the invocation is streamed once. Bazel wins the tie because it's the more explicit request: the CLI's backends are auto-wired (the runner's env var, a `--deployment`'s advertised host) while `--bes_backend` is set by hand. Each drop prints an `INFO:` line. Both sink groups are covered — those built from `--bes-backend`/`--deployment`, and those features push onto `BazelTrait.build_event_sinks` (the runner's env-injected one, the customer's actual path). A file sink is a local BEP dump, not an upload, so it always survives.

Bazel's effective backend is read through the run command, catching it from `--bazel-flag`, a `.bazelrc`, or an expanded `--config`. Endpoints match on `host:port` with the scheme's default port made explicit, so `grpcs://h`, `grpcs://h:443`, `h`, and `h:443` are one endpoint (Bazel documents these as `[SCHEME://]HOST[:PORT]` and assumes `grpcs` when the scheme is omitted). Scheme is ignored at equal ports; `grpc://h` and `grpcs://h` still differ, their defaults being 80 and 443.

Suppression can leave a build with no gRPC sink at all, and the id the Aspect Web UI keys on is only minted when one exists — so a naive drop would delete the "✨ Aspect Workflows" link for exactly these users. The backend still holds the invocation, indexed under Bazel's UUID because Bazel uploaded it, so `resolve_aspect_url` falls back to `data["bazel"]["invocation_id"]` when the suppressed backend was the runner's own `ASPECT_WORKFLOWS_BES_BACKEND`. Dropping a third-party BES says nothing about what the Aspect UI holds, so the link stays suppressed there.

**Endpoints are also now reported as configured.** `bazel.build_events.grpc` rewrote `grpcs://` to `https://` *before storing* the URI on the sink, but that string is also what `sink.uri` returns and what every user-facing line names, so a runner set to `grpcs://remote.foobar.aspect.build` logged `Streaming build events to https://remote.foobar.aspect.build`. The rewrite is a transport concern — tonic's `Channel::from_shared` only understands http/https — so it moved to `build_event_stream::client`, at the one point the string becomes a channel. `grpc://` maps to `http://` for the same reason, which it previously did not.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- The CLI no longer opens its own Build Event Service stream to a backend Bazel is already uploading to via `--bes_backend`. Configuring the same endpoint on both paths (for example, setting `--bes_backend` to the URL a Workflows runner injects as `ASPECT_WORKFLOWS_BES_BACKEND`) previously produced two streams for one invocation, recorded a duplicate on the backend, and could leave the CLI-side stream truncated. Matching accounts for default ports and an omitted scheme, so `grpcs://bes.example.com`, `grpcs://bes.example.com:443`, and `bes.example.com` are recognized as one endpoint. The Aspect Web UI link is preserved, and an `INFO:` line reports each suppressed stream.
- BES endpoints are now reported as configured. A `grpcs://` backend was previously logged as `https://` — naming an endpoint that was never set — because the scheme mapping tonic needs was applied to the stored URI rather than only at dial time.

### Test plan

- New test cases added — `bes_sinks_test.axl` covers sink collection, duplicate dropping across both sink groups (including when every gRPC sink is suppressed), and the Aspect-backend gate; `aspect_endpoint_auth_test.axl` covers authority normalization and endpoint equivalence (default ports in both spellings, omitted scheme, differing ports, empty inputs); `bazel_results_test.axl` covers the Web UI link fallback, its third-party negative case, sink-id precedence, and survival of the `build_started` reset; `client.rs` covers the scheme mapping, http pass-through, leading-scheme-only rewriting, and that every spelling survives `Channel::from_shared`.
- Covered by existing test cases — all 42 `aspect dev test-*` suites and 414 Rust tests across `aspect-cli`, `axl-runtime`, and `build-event-stream` pass.
- Manual testing; end-to-end against real builds:

```bash
# The customer's case: runner-injected backend + the same URL on Bazel's flag.
# Suppressed, and the ✨ Aspect Web UI link still renders (on Bazel's id) even
# though ASPECT_DEBUG=1 reports "0 gRPC sinks configured".
ASPECT_WORKFLOWS_BES_BACKEND=grpcs://bes.example.com \
ASPECT_WORKFLOWS_BES_RESULTS_URL=https://app.example.com ASPECT_DEBUG=1 \
  aspect build --bazel-flag=--bes_backend=grpcs://bes.example.com:443 //some:target

# Same endpoint via --bes-backend — both default-port spellings, and schemeless.
aspect build --bes-backend=grpcs://bes.example.com:443 \
  --bazel-flag=--bes_backend=grpcs://bes.example.com //some:target
aspect build --bes-backend=grpcs://bes.example.com \
  --bazel-flag=--bes_backend=bes.example.com //some:target

# Negative controls: distinct endpoints both stream; an env sink with no Bazel
# flag is untouched.
aspect build --bes-backend=grpcs://bes.cli-only.example.com \
  --bazel-flag=--bes_backend=grpcs://bes.example.com //some:target
ASPECT_WORKFLOWS_BES_BACKEND=grpcs://bes.example.com aspect build //some:target

# Endpoints reported as configured. Verified against a live TLS backend that
# grpcs:// still negotiates TLS (server acks "build_enqueued ack'd in 115ms")
# and against a local listener that grpc:// still opens a plaintext connection.
ASPECT_WORKFLOWS_BES_BACKEND=grpcs://remote.foobar.aspect.build aspect build //some:target
#   INFO: Streaming build events to grpcs://remote.foobar.aspect.build.
ASPECT_WORKFLOWS_BES_BACKEND=grpc://buildbarn-frontend.awd.internal:8980 aspect build //some:target
#   INFO: Streaming build events to grpc://buildbarn-frontend.awd.internal:8980.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
