### PR TITLE
fix(lint): reject partially-materialized lint outputs and bound patch hunks

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3,7 +3,7 @@ Exercise axl
 """
 
 load("@aspect//delivery.axl", delivery_UncacheableAction = "UncacheableAction", delivery_collect_blocking_culprits = "collect_blocking_culprits", delivery_count_unexplained_unresolved = "count_unexplained_unresolved", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
-load("@aspect//lint.axl", "filter_all", "filter_changeset", "linter_error_message")
+load("@aspect//lint.axl", "filter_all", "filter_changeset", "linter_error_message", "parse_patch_hunks")
 load("@aspect//private/lib/artifacts.axl", "artifact_name", "build_log_header", "build_log_relpath", "collect_build_action_logs", "dedup_path", "testlog_dest_dir")
 load("@aspect//private/lib/bazel_results.axl", "bb_clientd_root", "compute_reproducer_command", "file_uri_to_path", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
 load(
@@ -32,7 +32,7 @@ load("@aspect//private/lib/prompt.axl", "prompt_choice")
 load("@aspect//private/lib/repro_commands.axl", "build_aspect_command", "dedup_and_attribute", "patch_download_cmd", "task_cli_path")
 load("@aspect//private/lib/result_text.axl", "severity_for_status")
 load("@aspect//private/lib/runnable.axl", "apparent_label", "runnable")
-load("@aspect//private/lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics", "sarif_to_review_comments")
+load("@aspect//private/lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics", "sarif_diagnostics", "sarif_to_review_comments")
 load("@aspect//private/lib/tips.axl", "tips")
 load("@demo//answer.axl", "ANSWER")
 load("@std//base64.axl", "base64")
@@ -2655,6 +2655,46 @@ def test_lint_filters(tc: int) -> int:
 
     return tc
 
+def test_parse_patch_hunks(tc: int) -> int:
+    """Coverage for lint.parse_patch_hunks — hunk spans and the count clamp."""
+    patch = "\n".join([
+        "--- a/src/x.ts",
+        "+++ b/src/x.ts",
+        "@@ -1,2 +1,3 @@",
+        " ctx",
+        "+added one",
+        "+added two",
+    ])
+    hunks = parse_patch_hunks(patch)
+    tc = test_case(tc, len(hunks) == 1, "parse_patch_hunks: one hunk")
+    tc = test_case(tc, hunks[0]["file"] == "src/x.ts", "parse_patch_hunks: strips b/ prefix")
+    tc = test_case(tc, hunks[0]["start_line"] == 1, "parse_patch_hunks: start line")
+    tc = test_case(tc, hunks[0]["end_line"] == 3, "parse_patch_hunks: end line = start + count - 1")
+
+    # `,B` omitted means a single line.
+    single = parse_patch_hunks("--- a/y\n+++ b/y\n@@ -5 +7 @@\n+z")
+    tc = test_case(tc, len(single) == 1 and single[0]["start_line"] == 7, "parse_patch_hunks: implicit count start")
+    tc = test_case(tc, single[0]["end_line"] == 7, "parse_patch_hunks: implicit count spans one line")
+
+    # A declared count far larger than the patch body is clamped to the number
+    # of lines actually present. Callers expand hunks one entry per line, so an
+    # unclamped count from a truncated/malformed patch would allocate without
+    # bound.
+    huge = parse_patch_hunks("--- a/z\n+++ b/z\n@@ -1,1 +1,200000000 @@\n+only one line")
+    tc = test_case(tc, len(huge) == 1, "parse_patch_hunks: bogus count still yields a hunk")
+    span = huge[0]["end_line"] - huge[0]["start_line"] + 1
+    tc = test_case(tc, span <= 4, "parse_patch_hunks: clamps count to lines present (got %d)" % span)
+
+    # Non-numeric and non-positive counts are skipped outright.
+    tc = test_case(tc, parse_patch_hunks("--- a/q\n+++ b/q\n@@ -1,1 +x,y @@\n+a") == [], "parse_patch_hunks: non-numeric skipped")
+    tc = test_case(tc, parse_patch_hunks("--- a/q\n+++ b/q\n@@ -1,1 +1,0 @@\n+a") == [], "parse_patch_hunks: zero count skipped")
+
+    # No +++ header → nothing to attribute hunks to.
+    tc = test_case(tc, parse_patch_hunks("@@ -1,1 +1,5 @@\n+a") == [], "parse_patch_hunks: no file header → []")
+    tc = test_case(tc, parse_patch_hunks("") == [], "parse_patch_hunks: empty → []")
+
+    return tc
+
 def test_linter_error_message(tc: int) -> int:
     """Coverage for lint.linter_error_message — the fail_on_linter_error text."""
     single = linter_error_message({"PMD": True}, "hard")
@@ -3253,6 +3293,12 @@ def test_sarif_lib(tc: int) -> int:
     """
 
     diags = parse_sarif_diagnostics(sarif_text)
+
+    # sarif_diagnostics() takes an already-decoded document and must agree with
+    # the string-parsing entry point, so callers that already hold the dict can
+    # skip a second parse.
+    tc = test_case(tc, sarif_diagnostics(parse_sarif(sarif_text)) == diags, "sarif_diagnostics: matches parse_sarif_diagnostics")
+    tc = test_case(tc, sarif_diagnostics({}) == [], "sarif_diagnostics: empty document → []")
     tc = test_case(tc, len(diags) == 2, "parse_sarif_diagnostics: 2 data")
     tc = test_case(tc, diags[0]["tool"] == "shellcheck", "parse_sarif_diagnostics: tool name")
     tc = test_case(tc, diags[0]["file"] == "scripts/build.sh", "parse_sarif_diagnostics: file path")
@@ -3667,6 +3713,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_process_bes_target_completed(ctx, tc)
     tc = test_validate_role(tc)
     tc = test_lint_filters(tc)
+    tc = test_parse_patch_hunks(tc)
     tc = test_linter_error_message(tc)
     tc = test_fmt_elapsed(tc)
     tc = test_summary_title(tc)

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -30,7 +30,7 @@ load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("./private/lib/lint_results.axl", "detect_lint_tool", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
 load("./private/lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "flavor_allows", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
-load("./private/lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics", "sarif_diagnostics")
+load("./private/lib/sarif.axl", "get_sarif_summary", "parse_sarif", "sarif_diagnostics")
 load("./private/lib/tar.axl", "tar_create")
 load("./private/lib/text.axl", "pluralize")
 load("./private/lib/tips.axl", "tips")
@@ -131,16 +131,16 @@ def parse_patch_hunks(content):
     `+++ b/<path>` side (leading `b/` stripped), lines 1-based inclusive.
     Empty list when unparseable — callers treat that as "leave the patch alone".
 
-    A hunk's declared line count is clamped to the number of lines the patch
-    actually contains. The count comes from the `@@` header, and a malformed or
-    truncated patch can declare a span far larger than its body; callers expand
-    each hunk to one entry per line, so an unclamped count would allocate
-    proportional to the declared number rather than the real one.
+    A hunk's declared line count is clamped to the number of lines in the
+    patch, since no hunk can cover more than that. The count comes from the
+    `@@` header, and a malformed or truncated patch can declare a span far
+    larger than its body; callers expand each hunk to one entry per line, so
+    an unclamped count allocates proportional to the declared number.
     """
     hunks = []
     current_file = ""
     lines = content.split("\n")
-    max_span = len(lines)
+    max_count = len(lines)
     for line in lines:
         if line.startswith("+++ "):
             rest = line[4:]
@@ -165,7 +165,7 @@ def parse_patch_hunks(content):
         if not (a_str.isdigit() and b_str.isdigit()):
             continue
         start = int(a_str)
-        count = min(int(b_str), max_span)
+        count = min(int(b_str), max_count)
         if count <= 0:
             continue
         hunks.append({

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -594,35 +594,24 @@ def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS, exp
     drain budget warns and skips it.
 
     `expected_len` is the file's authoritative byte length (BES `File.length`),
-    or -1 when unknown. A read shorter than it means the blob is still
-    materializing: the inode can be exposed before the fetch completes, so a
-    read that succeeds is not proof the contents are whole. Such a read is
-    reported as not-yet-readable and retried, because every consumer here
-    (SARIF parse, patch hunks, exit codes) silently misbehaves on truncated
-    input rather than failing loudly.
+    or -1 when unknown. Both read paths compare the bytes they actually read
+    against it and report a short read as not-yet-readable: a successful read
+    is not proof the contents are whole, because the file can be exposed before
+    its download finishes, and every consumer here (SARIF parse, patch hunks,
+    exit codes) silently misbehaves on truncated input rather than failing
+    loudly.
 
     Anything else is a plain local path — file:// URIs, or the output-tree
-    fallback for bytestream URIs on runners without bb_clientd — read
-    directly: local disk can't stall the way bb_clientd reads can, and the
-    direct path avoids a background probe thread per read. The same
-    completeness check applies, via the file's own size.
+    fallback for bytestream URIs on runners without bb_clientd — read directly
+    via `read_to_string_if_complete`: local disk can't stall the way bb_clientd
+    reads can, so it needs no background probe, only the same length gate.
 
     Either way, None always means unreadable, never empty: a clean linter's
     empty `.out` reads as "".
     """
     root = bb_clientd_root(ctx)
     if root == None or not filepath.startswith(root):
-        if not ctx.std.fs.exists(filepath):
-            return None
-        content = ctx.std.fs.try_read_to_string(filepath)
-        # Size is read after the content so a file still being written is seen
-        # as short rather than matching a stale pre-read size.
-        size = ctx.std.fs.metadata(filepath).size
-        if content == "" and size > 0:
-            return None
-        if expected_len >= 0 and size != expected_len:
-            return None
-        return content
+        return ctx.std.fs.read_to_string_if_complete(filepath, expected_len = expected_len)
     return ctx.std.fs.poll_read_to_string(filepath, timeout_ms, expected_len = expected_len)
 
 def _probe_timeout_ms(ctx, pass_deadline_ms):

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -20,7 +20,7 @@ load("@aspect//bazel.axl", "BazelTrait")
 load("@std//time.axl", "sleep", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
-load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "bb_clientd_root", "file_uri_to_path", "now_ms", "process_event")
+load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "bb_clientd_root", "bes_get", "file_uri_to_path", "now_ms", "process_event")
 load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/bes_sinks.axl", "announce_bes_sinks", "bes_args", "collect_bes_from_args", "summarize_bes_upload")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
@@ -30,7 +30,7 @@ load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("./private/lib/lint_results.axl", "detect_lint_tool", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
 load("./private/lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "flavor_allows", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
-load("./private/lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics")
+load("./private/lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics", "sarif_diagnostics")
 load("./private/lib/tar.axl", "tar_create")
 load("./private/lib/text.axl", "pluralize")
 load("./private/lib/tips.axl", "tips")
@@ -124,16 +124,24 @@ def filter_hunks(diagnostics, changed_files):
         result.append(d)
     return result
 
-def _parse_patch_hunks(content):
+def parse_patch_hunks(content):
     """Extract the (file, line) span of every hunk in a unified diff.
 
     Returns `{file, start_line, end_line}` per hunk; `file` is the post-fix
     `+++ b/<path>` side (leading `b/` stripped), lines 1-based inclusive.
     Empty list when unparseable — callers treat that as "leave the patch alone".
+
+    A hunk's declared line count is clamped to the number of lines the patch
+    actually contains. The count comes from the `@@` header, and a malformed or
+    truncated patch can declare a span far larger than its body; callers expand
+    each hunk to one entry per line, so an unclamped count would allocate
+    proportional to the declared number rather than the real one.
     """
     hunks = []
     current_file = ""
-    for line in content.split("\n"):
+    lines = content.split("\n")
+    max_span = len(lines)
+    for line in lines:
         if line.startswith("+++ "):
             rest = line[4:]
             if rest.startswith("b/"):
@@ -157,7 +165,7 @@ def _parse_patch_hunks(content):
         if not (a_str.isdigit() and b_str.isdigit()):
             continue
         start = int(a_str)
-        count = int(b_str)
+        count = min(int(b_str), max_span)
         if count <= 0:
             continue
         hunks.append({
@@ -185,7 +193,7 @@ def _filter_patches_by_strategy(ctx, patches, strategy, changed_files):
         if content == None:
             warn(ctx.std, "Failed to read lint patch (skipping): %s" % patch_path)
             continue
-        hunks = _parse_patch_hunks(content)
+        hunks = parse_patch_hunks(content)
         if not hunks:
             kept.append(patch_path)
             continue
@@ -572,7 +580,7 @@ def _body_text(status, data):
         return "Lint aborted"
     return ""
 
-def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS):
+def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS, expected_len = -1):
     """Read a lint output file, or None when its contents can't be read yet.
 
     Paths under the bb_clientd mount (bytestream:// URIs resolved by
@@ -585,12 +593,19 @@ def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS):
     the file in the pending queue — retried each tick until the post-build
     drain budget warns and skips it.
 
+    `expected_len` is the file's authoritative byte length (BES `File.length`),
+    or -1 when unknown. A read shorter than it means the blob is still
+    materializing: the inode can be exposed before the fetch completes, so a
+    read that succeeds is not proof the contents are whole. Such a read is
+    reported as not-yet-readable and retried, because every consumer here
+    (SARIF parse, patch hunks, exit codes) silently misbehaves on truncated
+    input rather than failing loudly.
+
     Anything else is a plain local path — file:// URIs, or the output-tree
     fallback for bytestream URIs on runners without bb_clientd — read
     directly: local disk can't stall the way bb_clientd reads can, and the
-    direct path avoids a background probe thread per read. An
-    empty read of a file whose size is non-zero is a failed read, matching
-    the probe's contract.
+    direct path avoids a background probe thread per read. The same
+    completeness check applies, via the file's own size.
 
     Either way, None always means unreadable, never empty: a clean linter's
     empty `.out` reads as "".
@@ -600,10 +615,15 @@ def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS):
         if not ctx.std.fs.exists(filepath):
             return None
         content = ctx.std.fs.try_read_to_string(filepath)
-        if content == "" and ctx.std.fs.metadata(filepath).size > 0:
+        # Size is read after the content so a file still being written is seen
+        # as short rather than matching a stale pre-read size.
+        size = ctx.std.fs.metadata(filepath).size
+        if content == "" and size > 0:
+            return None
+        if expected_len >= 0 and size != expected_len:
             return None
         return content
-    return ctx.std.fs.poll_read_to_string(filepath, timeout_ms)
+    return ctx.std.fs.poll_read_to_string(filepath, timeout_ms, expected_len = expected_len)
 
 def _probe_timeout_ms(ctx, pass_deadline_ms):
     """Per-read probe bound for one drain/event pass: the standard probe
@@ -626,20 +646,33 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
     so the fail_on_linter_error path can report which tool failed.
     SARIF is filtered per-batch against the (pure) strategy scope, so per-batch
     results equal a terminal pass and findings don't flicker as batches arrive.
+
+    Every read is gated on the file's BES-declared length so a
+    still-materializing blob is retried rather than parsed half-written.
     """
+    expected_len = bes_get(file, "length", -1) or -1
+
     if file.name.endswith(".out"):
-        out = _read_lint_file(ctx, filepath, probe_timeout_ms)
+        out = _read_lint_file(ctx, filepath, probe_timeout_ms, expected_len)
         if out == None:
             return None
         ctx.std.io.stderr.write(out)
         return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
     if file.name.endswith(".report"):
-        report = _read_lint_file(ctx, filepath, probe_timeout_ms)
+        report = _read_lint_file(ctx, filepath, probe_timeout_ms, expected_len)
         if report == None:
             return None
         if "sarif-" in report:
-            lint_accumulate(data, strategy.filter(parse_sarif_diagnostics(report), changed_files))
+            sarif = parse_sarif(report)
+            if not sarif:
+                # The read was complete (length-gated), so a document that
+                # still won't decode is malformed rather than in flight —
+                # retrying can't help. Name it instead of dropping its
+                # findings silently.
+                warn(ctx.std, "Ignoring unparseable SARIF report: %s" % filepath)
+                return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
+            lint_accumulate(data, strategy.filter(sarif_diagnostics(sarif), changed_files))
             for hook in lint_trait.lint_report:
                 hook(ctx, filepath)
             return {"interesting": True, "linter_exit_code": 0, "failed_tool": ""}
@@ -649,10 +682,10 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
         return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
     if file.name.endswith(".patch"):
-        # Readability gate (content discarded): requeues the patch until the
-        # blob is materialized, since lint_patch hooks buffer the path and
-        # later re-read it with a plain read_to_string.
-        if _read_lint_file(ctx, filepath, probe_timeout_ms) == None:
+        # Readability gate (content discarded): requeues until the blob is
+        # whole, since lint_patch hooks buffer the path and re-read it later
+        # with a plain read_to_string that has no completeness check.
+        if _read_lint_file(ctx, filepath, probe_timeout_ms, expected_len) == None:
             return None
         patches.append(filepath)
         for hook in lint_trait.lint_patch:
@@ -660,7 +693,7 @@ def _try_process_lint_file(ctx, file, filepath, data, strategy, changed_files, l
         return {"interesting": False, "linter_exit_code": 0, "failed_tool": ""}
 
     if file.name.endswith(".exit_code"):
-        content = _read_lint_file(ctx, filepath, probe_timeout_ms)
+        content = _read_lint_file(ctx, filepath, probe_timeout_ms, expected_len)
         if content == None:
             return None
         stripped = content.rstrip()

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/sarif.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/sarif.axl
@@ -96,7 +96,14 @@ def parse_sarif_diagnostics(content):
     is True when the result carries an inline-fix relatedLocation (see
     `_result_has_fix`).
     """
-    sarif = json.try_decode(content, {})
+    return sarif_diagnostics(json.try_decode(content, {}))
+
+def sarif_diagnostics(sarif):
+    """Flatten an already-decoded SARIF dict into diagnostic dicts.
+
+    Same shape as `parse_sarif_diagnostics`, for callers that already decoded
+    the document (via `parse_sarif`) and would otherwise pay to parse it twice.
+    """
     diagnostics = []
     for run in sarif.get("runs", []):
         tool_name = run.get("tool", {}).get("driver", {}).get("name", "unknown")

--- a/crates/axl-runtime/src/engine/std/fs.rs
+++ b/crates/axl-runtime/src/engine/std/fs.rs
@@ -208,7 +208,13 @@ static READ_PROBES: OnceLock<Mutex<HashMap<String, Arc<ReadProbe>>>> = OnceLock:
 /// Poll a coalesced background read of `path` (see `poll_read_to_string` for
 /// the contract). Only the call that spawns the probe blocks (up to
 /// `timeout`); later polls for the same path return its state immediately.
-fn poll_read(path: &str, timeout: Duration) -> Option<String> {
+///
+/// `expected_len`, when `Some`, is the authoritative byte length the file must
+/// have to count as fully materialized. A read returning fewer bytes is a
+/// partial read — a network-backed filesystem can expose a blob before it has
+/// finished fetching it — and is reported as "not readable yet" so the caller
+/// retries rather than consuming a truncated file.
+fn poll_read(path: &str, timeout: Duration, expected_len: Option<u64>) -> Option<String> {
     let registry = READ_PROBES.get_or_init(Default::default);
     let (probe, spawned_here) = {
         let mut reg = registry.lock().unwrap();
@@ -225,7 +231,13 @@ fn poll_read(path: &str, timeout: Duration) -> Option<String> {
                 let spawned = std::thread::Builder::new()
                     .name("fs-read-probe".to_string())
                     .spawn(move || {
-                        let result = fs::read_to_string(&thread_path).ok();
+                        let result =
+                            fs::read_to_string(&thread_path)
+                                .ok()
+                                .filter(|c| match expected_len {
+                                    Some(want) => c.len() as u64 == want,
+                                    None => true,
+                                });
                         *thread_probe.state.lock().unwrap() = Some(result);
                         thread_probe.done.notify_all();
                     });
@@ -655,14 +667,23 @@ pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
     /// Callers are expected to poll until content or a caller-side deadline:
     /// `None` always means "not readable yet", never "empty file" (an empty
     /// readable file returns `""`).
+    ///
+    /// Pass `expected_len` (bytes) when the caller knows the file's
+    /// authoritative size — e.g. `File.length` from a build event. A read
+    /// returning fewer bytes means the blob is still materializing, and is
+    /// reported as `None` so the caller retries instead of consuming a
+    /// truncated file. Omit it (or pass a negative value) to accept whatever
+    /// the read returns.
     fn poll_read_to_string<'v>(
         #[allow(unused)] this: values::Value<'v>,
         #[starlark(require = pos)] path: values::StringValue,
         #[starlark(require = pos)] timeout_ms: i32,
+        #[starlark(require = named, default = -1)] expected_len: i64,
         heap: Heap<'v>,
     ) -> anyhow::Result<NoneOr<values::StringValue<'v>>> {
         let timeout = Duration::from_millis(timeout_ms.max(0) as u64);
-        Ok(match poll_read(path.as_str(), timeout) {
+        let expected_len = (expected_len >= 0).then_some(expected_len as u64);
+        Ok(match poll_read(path.as_str(), timeout, expected_len) {
             Some(content) => NoneOr::Other(heap.alloc_str(content.as_str())),
             None => NoneOr::None,
         })
@@ -790,12 +811,55 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ok.txt");
         fs::write(&path, "hello").unwrap();
-        let got = poll_read(path.to_str().unwrap(), Duration::from_secs(5));
+        let got = poll_read(path.to_str().unwrap(), Duration::from_secs(5), None);
         assert_eq!(got.as_deref(), Some("hello"));
         // Consumed probes are removed so a later poll re-reads fresh content.
         fs::write(&path, "world").unwrap();
-        let got = poll_read(path.to_str().unwrap(), Duration::from_secs(5));
+        let got = poll_read(path.to_str().unwrap(), Duration::from_secs(5), None);
         assert_eq!(got.as_deref(), Some("world"));
+    }
+
+    /// A read shorter than the authoritative length is a partially-materialized
+    /// blob: report "not readable yet" so the caller retries, and deliver the
+    /// content once the file reaches its full size.
+    #[test]
+    fn poll_read_rejects_reads_shorter_than_expected_len() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("partial.txt");
+        fs::write(&path, "half").unwrap();
+        let p = path.to_str().unwrap();
+
+        assert_eq!(poll_read(p, Duration::from_secs(5), Some(8)), None);
+        // Exact length is accepted.
+        assert_eq!(
+            poll_read(p, Duration::from_secs(5), Some(4)).as_deref(),
+            Some("half")
+        );
+        // Once the rest lands, the full content is delivered.
+        fs::write(&path, "halfhalf").unwrap();
+        assert_eq!(
+            poll_read(p, Duration::from_secs(5), Some(8)).as_deref(),
+            Some("halfhalf")
+        );
+    }
+
+    /// `expected_len` counts bytes, not characters — a multi-byte UTF-8 file
+    /// must not be mistaken for a short read.
+    #[test]
+    fn poll_read_expected_len_is_bytes_not_chars() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("utf8.txt");
+        let content = "héllo→"; // 6 chars, 9 bytes
+        fs::write(&path, content).unwrap();
+        let p = path.to_str().unwrap();
+        assert_eq!(content.chars().count(), 6);
+        assert_eq!(content.len(), 9);
+        // The byte length is accepted; the character count would be rejected.
+        assert_eq!(
+            poll_read(p, Duration::from_secs(5), Some(9)).as_deref(),
+            Some(content)
+        );
+        assert_eq!(poll_read(p, Duration::from_secs(5), Some(6)), None);
     }
 
     #[test]
@@ -804,12 +868,12 @@ mod tests {
         let empty = dir.path().join("empty.txt");
         fs::write(&empty, "").unwrap();
         assert_eq!(
-            poll_read(empty.to_str().unwrap(), Duration::from_secs(5)).as_deref(),
+            poll_read(empty.to_str().unwrap(), Duration::from_secs(5), None).as_deref(),
             Some("")
         );
         let missing = dir.path().join("missing.txt");
         assert_eq!(
-            poll_read(missing.to_str().unwrap(), Duration::from_secs(5)),
+            poll_read(missing.to_str().unwrap(), Duration::from_secs(5), None),
             None
         );
     }
@@ -828,7 +892,7 @@ mod tests {
         let p = path.to_str().unwrap();
 
         let started = std::time::Instant::now();
-        assert_eq!(poll_read(p, Duration::from_millis(200)), None);
+        assert_eq!(poll_read(p, Duration::from_millis(200), None), None);
         assert!(
             started.elapsed() < Duration::from_secs(5),
             "first poll must return at its timeout"
@@ -836,7 +900,7 @@ mod tests {
 
         // Probe is in flight: this must not block for another timeout.
         let started = std::time::Instant::now();
-        assert_eq!(poll_read(p, Duration::from_secs(60)), None);
+        assert_eq!(poll_read(p, Duration::from_secs(60), None), None);
         assert!(
             started.elapsed() < Duration::from_secs(5),
             "in-flight poll must return immediately"
@@ -851,7 +915,7 @@ mod tests {
 
         let deadline = std::time::Instant::now() + Duration::from_secs(10);
         loop {
-            match poll_read(p, Duration::from_millis(100)) {
+            match poll_read(p, Duration::from_millis(100), None) {
                 Some(content) => {
                     assert_eq!(content, "landed");
                     break;

--- a/crates/axl-runtime/src/engine/std/fs.rs
+++ b/crates/axl-runtime/src/engine/std/fs.rs
@@ -650,6 +650,34 @@ pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
         Ok(heap.alloc_str(s.as_str()))
     }
 
+    /// Reads a file only if it is exactly `expected_len` bytes, else `None`.
+    ///
+    /// For local reads of a file that another process may still be writing or
+    /// downloading. Comparing the bytes actually read against the
+    /// authoritative length is the only reliable completeness test: a `stat`
+    /// taken before the read can be stale by the time the read runs, and one
+    /// taken after can have caught up with a writer that finished mid-read, so
+    /// either would accept a prefix. `None` means "not complete yet" — poll
+    /// again. A negative `expected_len` disables the check and accepts
+    /// whatever the read returns.
+    ///
+    /// This is the non-blocking counterpart to `poll_read_to_string`, which
+    /// applies the same length gate to reads that can block indefinitely.
+    fn read_to_string_if_complete<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        #[starlark(require = pos)] path: values::StringValue,
+        #[starlark(require = named, default = -1)] expected_len: i64,
+        heap: Heap<'v>,
+    ) -> anyhow::Result<NoneOr<values::StringValue<'v>>> {
+        let Ok(s) = fs::read_to_string(path.as_str()) else {
+            return Ok(NoneOr::None);
+        };
+        if expected_len >= 0 && s.len() as u64 != expected_len as u64 {
+            return Ok(NoneOr::None);
+        }
+        Ok(NoneOr::Other(heap.alloc_str(s.as_str())))
+    }
+
     /// Reads the entire contents of a file into a string without ever
     /// blocking the caller for more than `timeout_ms`, or returns `None`
     /// when the contents aren't available yet.
@@ -817,6 +845,38 @@ mod tests {
         fs::write(&path, "world").unwrap();
         let got = poll_read(path.to_str().unwrap(), Duration::from_secs(5), None);
         assert_eq!(got.as_deref(), Some("world"));
+    }
+
+    /// The direct-read gate compares the bytes actually read, so a prefix is
+    /// rejected even if the file reaches its full length immediately after.
+    #[test]
+    fn read_to_string_if_complete_gates_on_bytes_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f.txt");
+
+        // Helper mirroring the builtin's body; the starlark wrapper only adds
+        // heap allocation on top of this.
+        fn read_if_complete(path: &std::path::Path, expected_len: i64) -> Option<String> {
+            let s = fs::read_to_string(path).ok()?;
+            if expected_len >= 0 && s.len() as u64 != expected_len as u64 {
+                return None;
+            }
+            Some(s)
+        }
+
+        fs::write(&path, "half").unwrap();
+        assert_eq!(read_if_complete(&path, 8), None, "prefix is rejected");
+        assert_eq!(read_if_complete(&path, 4).as_deref(), Some("half"));
+        // Longer than declared is also wrong (stale or overwritten file).
+        assert_eq!(read_if_complete(&path, 2), None, "over-long is rejected");
+        // A negative length disables the check.
+        assert_eq!(read_if_complete(&path, -1).as_deref(), Some("half"));
+        // A genuinely empty file is content, not an error.
+        let empty = dir.path().join("empty.txt");
+        fs::write(&empty, "").unwrap();
+        assert_eq!(read_if_complete(&empty, 0).as_deref(), Some(""));
+        // A missing file is unreadable regardless of the expected length.
+        assert_eq!(read_if_complete(&dir.path().join("nope"), -1), None);
     }
 
     /// A read shorter than the authoritative length is a partially-materialized


### PR DESCRIPTION
The lint task reads BES-announced output files (`.out` / `.report` / `.patch` / `.exit_code`) as soon as the build event names them. On a network-backed filesystem (bb_clientd) the file is exposed before its download finishes, so a read can succeed while returning only a prefix. Nothing checked for that, and every consumer degrades silently on truncated input rather than failing loudly:

- a torn `.report` fails to decode and its findings vanish, without being requeued;
- a torn `.exit_code` can read `1` of `12` and record the wrong linter status;
- a torn `.patch` passes the readability gate (which discards the content) and is re-read post-build, where a hunk header can declare a span far larger than the body.

**Gate reads on the file's authoritative length.** Lint threads BES `File.length` through to every read, and both read paths compare the bytes they actually read against it:

- `fs.poll_read_to_string(path, timeout_ms, expected_len=…)` rejects a short read inside the reader thread, so a partial read never becomes a cached success.
- `fs.read_to_string_if_complete(path, expected_len=…)` is the new non-blocking counterpart for local/output-tree reads.

Comparing the bytes read is the only reliable test: a `stat` taken before the read can be stale by the time the read runs, and one taken after can have caught up with a writer that finished mid-read — either would accept a prefix. The comparison lives in Rust because it must be in bytes; AXL's `len()` counts codepoints and would falsely reject non-ASCII lint output. A short read reports "not readable yet", so the file stays queued and is retried on the next tick.

**Bound the damage from a malformed patch.** `parse_patch_hunks` clamps a hunk's declared line count to the number of lines in the patch, since no hunk can cover more. Callers expand each hunk to one entry per line, so an unclamped count allocated proportional to the declared number — a patch declaring 200M lines exhausted memory before this change.

**Stop dropping findings silently.** A SARIF document that still won't decode after a length-gated read is malformed rather than in flight, so retrying can't help; it is now reported by name. `parse_sarif_diagnostics` is split so callers holding an already-decoded document can extract diagnostics without a second parse of a multi-MB report.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (internal to lint result processing; the new builtin is documented in its docstring)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- fix: lint no longer consumes partially-downloaded output files from a remote cache — reads are verified against the file's declared length and retried until complete, so findings, auto-fix patches, and linter exit codes can't be silently lost or misread
- fix: a malformed auto-fix patch can no longer exhaust memory while filtering patches by strategy
- fix: an undecodable SARIF report is now reported by name instead of silently dropping its findings

### Test plan

- New test cases added:
  - Rust unit tests for both length gates: a prefix is rejected and retried until the file reaches full size; an over-long read is rejected; a negative length disables the check; an empty file reads as `""` and a missing file as `None`; `expected_len` is compared in bytes, not characters.
  - 12 AXL assertions for `parse_patch_hunks`: hunk spans, implicit `,B` counts, the clamp (a declared 200,000,000-line span resolves to the lines present), and the non-numeric / zero-count / no-header / empty cases.
  - AXL assertions that `sarif_diagnostics` agrees with `parse_sarif_diagnostics`, so the decode/extract split can't drift.
- Covered by existing test cases: full AXL suite (910 passing) and the `axl-runtime` crate tests.
- Manual: verified on the `x86_64-unknown-linux-musl` release binary in a container — the 200M-line patch case went from an OOM kill to 5 entries in 2ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
