### PR TITLE
chore(release): build with debug assertions for one diagnostic release

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,15 @@ common:release --workspace_status_command "${PWD}/bazel/workspace_status.sh"
 common:release --compilation_mode=opt
 common:release --@rules_rust//rust/settings:lto=fat
 
+# TEMPORARY (diagnostic release): compile every crate — including third-party
+# ones such as starlark — with debug assertions on, so a corrupt allocation
+# panics where it happens instead of surfacing later as an allocator abort with
+# no useful stack. This enables `debug_assert!` (notably starlark's arena bounds
+# checks and `Alloca::assert_state`) plus arithmetic overflow checks. Costs
+# ~3.4MB (+7%) on the musl release binary. Remove once the lint segfault under
+# investigation is diagnosed.
+common:release --@rules_rust//rust/settings:extra_rustc_flags=-Cdebug-assertions=y
+
 # Don't stop at the first failure on CI — surface every failing target/test in
 # one run (a failed build action otherwise aborts the test phase before any
 # test executes). Applied via `--config=ci`, injected by .aspect/config.axl when


### PR DESCRIPTION
Temporarily enable `-Cdebug-assertions=y` for release builds to track down an issue with heap corruption. It turns on `debug_assert!` — notably starlark's arena bounds checks and `Alloca::assert_state`, which are the assertions most likely to catch this class of bug — plus arithmetic overflow checks.

Set via the global `@rules_rust//rust/settings:extra_rustc_flags` rather than our own `rust_binary` / `rust_library` macros, because those only cover first-party crates; starlark comes from the `@crates//` universe and would otherwise compile without assertions. Verified with `bazel aquery --config=release` that the flag reaches 375 Rustc actions including starlark's.

Cost: **+3.4MB (+7%)** on the musl release binary (47.4MB → 50.8MB), plus the runtime cost of overflow checks, which is not measurable next to a Bazel build for an I/O-bound CLI.

Intended to be reverted once the crash is diagnosed — it is a single line plus its comment, both marked TEMPORARY.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (build configuration only)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- chore: this release is built with debug assertions enabled to diagnose an intermittent crash. Binaries are ~7% larger; a crash now aborts with a precise assertion message rather than an opaque allocator failure. This will be reverted in a following release.

### Test plan

- Covered by existing test cases (full CI suite runs against the change).
- Manual: `bazel aquery --config=release` confirms `-Cdebug-assertions=y` on 375 Rustc actions including third-party crates such as starlark; the `x86_64-unknown-linux-musl` release binary builds clean and runs (`aspect --version`) in an Alpine container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
