### PR TITLE
fix(bes): bound the CLI's BES replay buffer by bytes, not event count

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -117,7 +117,7 @@ def _workflows_impl(ctx: FeatureContext):
                 metadata = bes_metadata,
                 max_retries = ctx.args.bes_max_retries,
                 retry_min_delay = ctx.args.bes_retry_min_delay,
-                retry_max_buffer_size = ctx.args.bes_retry_max_buffer_size,
+                retry_max_buffer_bytes = ctx.args.bes_retry_max_buffer_bytes,
                 timeout = ctx.args.bes_timeout,
             ))
 
@@ -151,11 +151,12 @@ Workflows = feature(
                           "between BES reconnect attempts. Duration string " +
                           "(e.g. '500ms', '2s', '1m').",
         ),
-        "bes_retry_max_buffer_size": args.int(
-            default = 10000,
-            description = "Cap on the in-flight unacked BES retry buffer. " +
-                          "Exceeding this mid-stream is a terminal failure; " +
-                          "the sink logs to stderr and stops uploading.",
+        "bes_retry_max_buffer_bytes": args.int(
+            default = 268435456,
+            description = "Byte budget for the in-flight unacked BES replay " +
+                          "buffer. Exceeding it evicts the oldest retained " +
+                          "events, so a later reconnect replays an incomplete " +
+                          "range; the upload itself continues.",
         ),
         "bes_timeout": args.string(
             default = "0s",

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -112,12 +112,17 @@ def _workflows_impl(ctx: FeatureContext):
 
         bessie_sinks = []
         if environment.build_events and environment.build_events.backend:
+            # 0 means "not set on the command line": leave the arg off so the
+            # runtime resolves it from ASPECT_BES_RETRY_MAX_BUFFER_BYTES (or
+            # the built-in default). Passing it unconditionally would make this
+            # flag's default silently outrank the runner's environment.
+            buffer_bytes = ctx.args.bes_retry_max_buffer_bytes
             bessie_sinks.append(bazel.build_events.grpc(
                 uri = environment.build_events.backend,
                 metadata = bes_metadata,
                 max_retries = ctx.args.bes_max_retries,
                 retry_min_delay = ctx.args.bes_retry_min_delay,
-                retry_max_buffer_bytes = ctx.args.bes_retry_max_buffer_bytes,
+                retry_max_buffer_bytes = buffer_bytes if buffer_bytes > 0 else None,
                 timeout = ctx.args.bes_timeout,
             ))
 
@@ -152,11 +157,13 @@ Workflows = feature(
                           "(e.g. '500ms', '2s', '1m').",
         ),
         "bes_retry_max_buffer_bytes": args.int(
-            default = 268435456,
+            default = 0,
             description = "Byte budget for the in-flight unacked BES replay " +
                           "buffer. Exceeding it evicts the oldest retained " +
                           "events, so a later reconnect replays an incomplete " +
-                          "range; the upload itself continues.",
+                          "range; the upload itself continues. 0 (the default) " +
+                          "defers to ASPECT_BES_RETRY_MAX_BUFFER_BYTES, or " +
+                          "256MiB when that is unset.",
         ),
         "bes_timeout": args.string(
             default = "0s",

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -113,7 +113,7 @@ def _workflows_impl(ctx: FeatureContext):
         bessie_sinks = []
         if environment.build_events and environment.build_events.backend:
             # 0 means "not set on the command line": leave the arg off so the
-            # runtime resolves it from ASPECT_BES_RETRY_MAX_BUFFER_BYTES (or
+            # runtime resolves it from ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES (or
             # the built-in default). Passing it unconditionally would make this
             # flag's default silently outrank the runner's environment.
             buffer_bytes = ctx.args.bes_retry_max_buffer_bytes
@@ -162,7 +162,7 @@ Workflows = feature(
                           "buffer. Exceeding it evicts the oldest retained " +
                           "events, so a later reconnect replays an incomplete " +
                           "range; the upload itself continues. 0 (the default) " +
-                          "defers to ASPECT_BES_RETRY_MAX_BUFFER_BYTES, or " +
+                          "defers to ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES, or " +
                           "256MiB when that is unset.",
         ),
         "bes_timeout": args.string(

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -112,10 +112,9 @@ def _workflows_impl(ctx: FeatureContext):
 
         bessie_sinks = []
         if environment.build_events and environment.build_events.backend:
-            # 0 means "not set on the command line": leave the arg off so the
-            # runtime resolves it from ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES (or
-            # the built-in default). Passing it unconditionally would make this
-            # flag's default silently outrank the runner's environment.
+            # Passing 0 (unset) through would let this flag's default outrank
+            # ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES, so omit the arg instead and
+            # let the runtime resolve it.
             buffer_bytes = ctx.args.bes_retry_max_buffer_bytes
             bessie_sinks.append(bazel.build_events.grpc(
                 uri = environment.build_events.backend,

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -1268,7 +1268,7 @@ Test = task(implementation = _impl)
     }
 
     /// Omitting the knob is the path that defers to
-    /// `ASPECT_BES_RETRY_MAX_BUFFER_BYTES`, so it must stay valid.
+    /// `ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES`, so it must stay valid.
     #[test]
     fn grpc_accepts_omitted_buffer_bytes() {
         crate::axl_check!(r#"bazel.build_events.grpc(uri = "grpcs://bes.example.com")"#)

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -1267,6 +1267,14 @@ Test = task(implementation = _impl)
         );
     }
 
+    /// Omitting the knob is the path that defers to
+    /// `ASPECT_BES_RETRY_MAX_BUFFER_BYTES`, so it must stay valid.
+    #[test]
+    fn grpc_accepts_omitted_buffer_bytes() {
+        crate::axl_check!(r#"bazel.build_events.grpc(uri = "grpcs://bes.example.com")"#)
+            .expect("omitting retry_max_buffer_bytes should validate");
+    }
+
     #[test]
     fn grpc_rejects_zero_buffer_bytes() {
         let err = crate::axl_check!(

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -1268,14 +1268,14 @@ Test = task(implementation = _impl)
     }
 
     #[test]
-    fn grpc_rejects_zero_buffer_size() {
+    fn grpc_rejects_zero_buffer_bytes() {
         let err = crate::axl_check!(
-            r#"bazel.build_events.grpc(uri = "http://localhost:1", retry_max_buffer_size = 0)"#
+            r#"bazel.build_events.grpc(uri = "http://localhost:1", retry_max_buffer_bytes = 0)"#
         )
         .expect_err("expected validation error")
         .to_string();
         assert!(
-            err.contains("retry_max_buffer_size") && err.contains("> 0"),
+            err.contains("retry_max_buffer_bytes") && err.contains("> 0"),
             "unexpected error: {err}"
         );
     }
@@ -1308,7 +1308,7 @@ Test = task(implementation = _impl)
     metadata = {"x-auth": "tok"},
     max_retries = 0,
     retry_min_delay = "500ms",
-    retry_max_buffer_size = 16,
+    retry_max_buffer_bytes = 1048576,
     timeout = "30s",
 )"#
         )

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -1072,9 +1072,10 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
     /// * `retry_min_delay` - Base delay for exponential backoff
     ///   (default `"1s"`).
     /// * `retry_max_buffer_bytes` - Byte budget for the in-flight unacked
-    ///   replay buffer (default 256 MiB). Exceeding it evicts the oldest
-    ///   retained events, which costs replay coverage on a later reconnect
-    ///   but never fails the upload.
+    ///   replay buffer. Exceeding it evicts the oldest retained events, which
+    ///   costs replay coverage on a later reconnect but never fails the
+    ///   upload. Unset uses `ASPECT_BES_RETRY_MAX_BUFFER_BYTES` if set,
+    ///   otherwise 256 MiB.
     /// * `timeout` - Overall upload deadline (default `"0s"` = no deadline).
     #[starlark(as_type = build::BuildEventSink)]
     fn grpc(
@@ -1083,16 +1084,22 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
         metadata: UnpackDictEntries<String, String>,
         #[starlark(require = named, default = 4)] max_retries: i32,
         #[starlark(require = named, default = "1s")] retry_min_delay: &str,
-        #[starlark(require = named, default = sink::retry::DEFAULT_RETRY_MAX_BUFFER_BYTES as i64)]
-        retry_max_buffer_bytes: i64,
+        #[starlark(require = named, default = NoneOr::None)] retry_max_buffer_bytes: NoneOr<i64>,
         #[starlark(require = named, default = "0s")] timeout: &str,
     ) -> anyhow::Result<build::BuildEventSink> {
         if max_retries < 0 {
             anyhow::bail!("max_retries must be >= 0, got {max_retries}");
         }
-        if retry_max_buffer_bytes <= 0 {
-            anyhow::bail!("retry_max_buffer_bytes must be > 0, got {retry_max_buffer_bytes}");
-        }
+        // Unset falls through to the env-aware default so a runner-level
+        // `ASPECT_BES_RETRY_MAX_BUFFER_BYTES` applies to tasks that don't pin
+        // the knob; an explicit value always wins over the environment.
+        let retry_max_buffer_bytes = match retry_max_buffer_bytes {
+            NoneOr::Other(n) if n <= 0 => {
+                anyhow::bail!("retry_max_buffer_bytes must be > 0, got {n}");
+            }
+            NoneOr::Other(n) => n as usize,
+            NoneOr::None => sink::retry::default_retry_max_buffer_bytes(),
+        };
         let retry_min_delay = sink::retry::parse_duration(retry_min_delay)
             .map_err(|e| anyhow::anyhow!("retry_min_delay: {e}"))?;
         let timeout_dur =
@@ -1108,7 +1115,7 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
             sink::retry::RetryConfig {
                 max_retries: max_retries as u32,
                 retry_min_delay,
-                retry_max_buffer_bytes: retry_max_buffer_bytes as usize,
+                retry_max_buffer_bytes,
                 timeout,
                 ..Default::default()
             },

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -1074,7 +1074,7 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
     /// * `retry_max_buffer_bytes` - Byte budget for the in-flight unacked
     ///   replay buffer. Exceeding it evicts the oldest retained events, which
     ///   costs replay coverage on a later reconnect but never fails the
-    ///   upload. Unset uses `ASPECT_BES_RETRY_MAX_BUFFER_BYTES` if set,
+    ///   upload. Unset uses `ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES` if set,
     ///   otherwise 256 MiB.
     /// * `timeout` - Overall upload deadline (default `"0s"` = no deadline).
     #[starlark(as_type = build::BuildEventSink)]
@@ -1091,7 +1091,7 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
             anyhow::bail!("max_retries must be >= 0, got {max_retries}");
         }
         // Unset falls through to the env-aware default so a runner-level
-        // `ASPECT_BES_RETRY_MAX_BUFFER_BYTES` applies to tasks that don't pin
+        // `ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES` applies to tasks that don't pin
         // the knob; an explicit value always wins over the environment.
         let retry_max_buffer_bytes = match retry_max_buffer_bytes {
             NoneOr::Other(n) if n <= 0 => {

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -1071,8 +1071,10 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
     ///   non-fatal.
     /// * `retry_min_delay` - Base delay for exponential backoff
     ///   (default `"1s"`).
-    /// * `retry_max_buffer_size` - Cap on the in-flight unacked retry buffer
-    ///   (default `10000`). Exceeding it mid-stream is terminal.
+    /// * `retry_max_buffer_bytes` - Byte budget for the in-flight unacked
+    ///   replay buffer (default 256 MiB). Exceeding it evicts the oldest
+    ///   retained events, which costs replay coverage on a later reconnect
+    ///   but never fails the upload.
     /// * `timeout` - Overall upload deadline (default `"0s"` = no deadline).
     #[starlark(as_type = build::BuildEventSink)]
     fn grpc(
@@ -1081,14 +1083,15 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
         metadata: UnpackDictEntries<String, String>,
         #[starlark(require = named, default = 4)] max_retries: i32,
         #[starlark(require = named, default = "1s")] retry_min_delay: &str,
-        #[starlark(require = named, default = 10_000)] retry_max_buffer_size: i32,
+        #[starlark(require = named, default = sink::retry::DEFAULT_RETRY_MAX_BUFFER_BYTES as i64)]
+        retry_max_buffer_bytes: i64,
         #[starlark(require = named, default = "0s")] timeout: &str,
     ) -> anyhow::Result<build::BuildEventSink> {
         if max_retries < 0 {
             anyhow::bail!("max_retries must be >= 0, got {max_retries}");
         }
-        if retry_max_buffer_size <= 0 {
-            anyhow::bail!("retry_max_buffer_size must be > 0, got {retry_max_buffer_size}");
+        if retry_max_buffer_bytes <= 0 {
+            anyhow::bail!("retry_max_buffer_bytes must be > 0, got {retry_max_buffer_bytes}");
         }
         let retry_min_delay = sink::retry::parse_duration(retry_min_delay)
             .map_err(|e| anyhow::anyhow!("retry_min_delay: {e}"))?;
@@ -1105,7 +1108,7 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
             sink::retry::RetryConfig {
                 max_retries: max_retries as u32,
                 retry_min_delay,
-                retry_max_buffer_size: retry_max_buffer_size as usize,
+                retry_max_buffer_bytes: retry_max_buffer_bytes as usize,
                 timeout,
                 ..Default::default()
             },

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -285,10 +285,11 @@ async fn work(
             &endpoint,
             &invocation_id,
             &format!(
-                "entering drive_stream (attempt={}, next_seq={}, buffered={})",
+                "entering drive_stream (attempt={}, next_seq={}, buffered={} events / {} bytes)",
                 attempt,
                 state.next_seq,
-                state.buffer.len()
+                state.buffer.len(),
+                state.buffer.bytes(),
             ),
         );
         let acked_before = state.max_acked;
@@ -707,19 +708,20 @@ async fn drive_stream(
         ),
     );
 
-    // Events evicted to keep the replay buffer under its byte budget can no
-    // longer be resent, so this reconnect leaves a permanent gap in what the
-    // backend receives. Warn rather than debug-log: it is the only signal that
-    // events were lost, and BES upload never fails the build.
-    let evicted = state.buffer.evicted();
+    // Evicted events were streamed on the previous connection but are no longer
+    // retained, so any the server had not yet acked cannot be resent and will be
+    // missing from it. Warn rather than debug-log: BES upload never fails the
+    // build, making this the only signal that data may be incomplete.
+    let evicted = state.buffer.take_evicted();
     if evicted > 0 {
         warn(
             endpoint,
             &format!(
-                "replay buffer exceeded its {} byte budget earlier in this build; \
-                 {evicted} build event(s) could not be replayed after reconnecting \
-                 and are missing from the backend",
-                retry.retry_max_buffer_bytes
+                "replay buffer exceeded its {} byte budget; {evicted} build event(s) \
+                 were dropped from it and cannot be resent on this reconnect. Raise \
+                 {} to retain more.",
+                retry.retry_max_buffer_bytes,
+                super::retry::RETRY_MAX_BUFFER_BYTES_ENV,
             ),
         );
     }

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -25,8 +25,7 @@ use crate::engine::r#async::rt::AsyncRuntime;
 
 use super::super::stream::Subscriber;
 use super::retry::{
-    BufferOverflow, RetryBuffer, RetryConfig, SinkError, SinkOutcome, SinkStats, backoff,
-    is_retryable,
+    RetryBuffer, RetryConfig, SinkError, SinkOutcome, SinkStats, backoff, is_retryable,
 };
 
 #[derive(Debug)]
@@ -42,8 +41,6 @@ enum DriveOutcome {
     Transient(ClientError),
     /// Server returned a non-retryable status; terminal regardless of budget.
     Fatal(ClientError),
-    /// Buffer overflowed while we held unacked events; terminal.
-    BufferFull(BufferOverflow),
     /// Upstream broadcaster closed (subscriber disconnected) without ever
     /// emitting `last_message`. Treat as clean shutdown — no more events to
     /// send, just wait for outstanding acks then exit.
@@ -58,7 +55,6 @@ impl DriveOutcome {
             DriveOutcome::UpstreamClosed => "UpstreamClosed".to_string(),
             DriveOutcome::Transient(e) => format!("Transient({e})"),
             DriveOutcome::Fatal(e) => format!("Fatal({e})"),
-            DriveOutcome::BufferFull(e) => format!("BufferFull({e})"),
         }
     }
 }
@@ -271,7 +267,7 @@ async fn work(
     }
 
     let mut state = StreamState {
-        buffer: RetryBuffer::new(retry.retry_max_buffer_size),
+        buffer: RetryBuffer::new(retry.retry_max_buffer_bytes),
         next_seq: 1,
         max_acked: 0,
         last_message_sent: false,
@@ -370,10 +366,6 @@ async fn work(
                     stats,
                     Err(finalize(&endpoint, format!("non-retryable: {err}"))),
                 );
-            }
-            DriveOutcome::BufferFull(err) => {
-                let stats = SinkStats::from_counters(state.next_seq, state.max_acked);
-                return (stats, Err(finalize(&endpoint, err.to_string())));
             }
         }
     }
@@ -504,9 +496,7 @@ async fn preload_first_event(
                 seq,
                 &event,
             );
-            if let Err(overflow) = state.buffer.push(seq, req.clone()) {
-                return Err(DriveOutcome::BufferFull(overflow));
-            }
+            state.buffer.push(seq, req.clone());
             if sender.send(req).await.is_err() {
                 return Err(DriveOutcome::Transient(ClientError::Status(
                     tonic::Status::unavailable("request stream closed before bidi open"),
@@ -717,6 +707,23 @@ async fn drive_stream(
         ),
     );
 
+    // Events evicted to keep the replay buffer under its byte budget can no
+    // longer be resent, so this reconnect leaves a permanent gap in what the
+    // backend receives. Warn rather than debug-log: it is the only signal that
+    // events were lost, and BES upload never fails the build.
+    let evicted = state.buffer.evicted();
+    if evicted > 0 {
+        warn(
+            endpoint,
+            &format!(
+                "replay buffer exceeded its {} byte budget earlier in this build; \
+                 {evicted} build event(s) could not be replayed after reconnecting \
+                 and are missing from the backend",
+                retry.retry_max_buffer_bytes
+            ),
+        );
+    }
+
     // Replay any buffered (unacked) events under their original sequence
     // numbers. The server dedups via OrderedBuildEvent.sequence_number.
     // Skip the entry `preload_first_event` already sent — server would
@@ -802,9 +809,7 @@ async fn drive_stream(
                     &event,
                 );
 
-                if let Err(overflow) = state.buffer.push(seq, req.clone()) {
-                    return DriveOutcome::BufferFull(overflow);
-                }
+                state.buffer.push(seq, req.clone());
                 ack_deadline.get_or_insert_with(|| {
                     tokio::time::Instant::now() + retry.ack_progress_timeout
                 });
@@ -1155,7 +1160,7 @@ mod tests {
         // `tx` stays alive across the call: upstream must look open, since a
         // closed upstream arms the (already bounded) half-close path instead.
         let mut state = StreamState {
-            buffer: RetryBuffer::new(retry.retry_max_buffer_size),
+            buffer: RetryBuffer::new(retry.retry_max_buffer_bytes),
             next_seq: 1,
             max_acked: 0,
             last_message_sent: false,
@@ -1358,7 +1363,7 @@ mod tests {
         // Upstream stays open but produces nothing; only the replay runs.
         let (_event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<BuildEvent>();
         let mut state = StreamState {
-            buffer: RetryBuffer::new(retry.retry_max_buffer_size),
+            buffer: RetryBuffer::new(retry.retry_max_buffer_bytes),
             next_seq: 101,
             max_acked: 0,
             last_message_sent: false,
@@ -1373,7 +1378,7 @@ mod tests {
                 seq,
                 &progress_event(128 * 1024),
             );
-            state.buffer.push(seq, req).unwrap();
+            state.buffer.push(seq, req);
         }
         let outcome = tokio::time::timeout(
             Duration::from_secs(30),

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -39,7 +39,7 @@ pub const DEFAULT_RETRY_MAX_BUFFER_BYTES: usize = 256 * 1024 * 1024;
 /// the build: a memory-constrained runner may want less, and a fleet that
 /// routinely streams very large events may want more. Setting it per-runner
 /// avoids having to thread a flag through every task definition.
-pub const RETRY_MAX_BUFFER_BYTES_ENV: &str = "ASPECT_BES_RETRY_MAX_BUFFER_BYTES";
+pub const RETRY_MAX_BUFFER_BYTES_ENV: &str = "ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES";
 
 /// Parse a byte size: a plain count (`1048576`) or a suffixed value (`512MB`,
 /// `1GiB`). Suffixes are binary multiples; `KB` and `KiB` are both 1024. Case-
@@ -588,6 +588,31 @@ mod tests {
         assert!(
             parse_byte_size("99999999999999999999GB").is_err(),
             "overflow must be an error, not a wrap"
+        );
+    }
+
+    /// End-to-end check that the resolver reads the real environment variable
+    /// under its documented name — the unit tests below exercise the fallback
+    /// rules but would keep passing if `RETRY_MAX_BUFFER_BYTES_ENV` were
+    /// misspelled or `default_retry_max_buffer_bytes` stopped consulting it.
+    ///
+    /// Cannot call `default_retry_max_buffer_bytes` itself: it caches in a
+    /// process-wide `OnceLock`, so the value it returns depends on whichever
+    /// test touched it first. This drives the same path with an explicit read.
+    #[test]
+    fn env_var_name_is_read_from_the_environment() {
+        // SAFETY: single-threaded within this test, and the value is removed
+        // before returning so no other test observes it.
+        unsafe { std::env::set_var(RETRY_MAX_BUFFER_BYTES_ENV, "7MB") };
+        let raw = std::env::var(RETRY_MAX_BUFFER_BYTES_ENV).ok();
+        let (bytes, warning) = resolve_buffer_bytes_override(raw.as_deref());
+        unsafe { std::env::remove_var(RETRY_MAX_BUFFER_BYTES_ENV) };
+
+        assert_eq!(bytes, 7 * 1024 * 1024);
+        assert!(warning.is_none());
+        assert_eq!(
+            RETRY_MAX_BUFFER_BYTES_ENV, "ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES",
+            "the documented variable name is part of the public interface"
         );
     }
 

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -9,13 +9,24 @@
 //! Terminal failures are surfaced via the sink's outcome — the
 //! caller decides what to do (warn, fail the task, etc.); the runtime never
 //! tries to second-guess the policy.
+//!
+//! The replay buffer is bounded by bytes and evicts its oldest entries when
+//! full; a slow-acking backend degrades replay coverage but never terminates
+//! the upload. See [`RetryBuffer`].
 
 use std::collections::VecDeque;
 use std::time::Duration;
 
 use axl_proto::google::devtools::build::v1::PublishBuildToolEventStreamRequest;
 use build_event_stream::client::ClientError;
+use prost::Message;
 use rand::Rng;
+
+/// Default byte budget for the unacked replay buffer (256 MiB). Sized to hold
+/// a long stream of ordinary events (hundreds of thousands, at a few hundred
+/// bytes each) plus a few of the multi-megabyte outliers that carry action
+/// stdout, so eviction stays rare in practice.
+pub const DEFAULT_RETRY_MAX_BUFFER_BYTES: usize = 256 * 1024 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct RetryConfig {
@@ -24,7 +35,10 @@ pub struct RetryConfig {
     /// the count.
     pub max_retries: u32,
     pub retry_min_delay: Duration,
-    pub retry_max_buffer_size: usize,
+    /// Byte budget for the unacked replay buffer. Exceeding it evicts the
+    /// oldest retained events rather than failing the stream — see
+    /// [`RetryBuffer`].
+    pub retry_max_buffer_bytes: usize,
     pub timeout: Option<Duration>,
     /// How long a single write into the bidi request stream may block before
     /// the connection is declared stalled (server stopped reading; HTTP/2
@@ -49,7 +63,7 @@ impl Default for RetryConfig {
         Self {
             max_retries: 4,
             retry_min_delay: Duration::from_secs(1),
-            retry_max_buffer_size: 10_000,
+            retry_max_buffer_bytes: DEFAULT_RETRY_MAX_BUFFER_BYTES,
             timeout: None,
             send_stall_timeout: Duration::from_secs(60),
             ack_progress_timeout: Duration::from_secs(120),
@@ -99,42 +113,91 @@ pub fn parse_duration(s: &str) -> Result<Duration, String> {
     })
 }
 
-/// Bounded ring of unacked stream events keyed by their original sequence
+/// Byte-bounded ring of unacked stream events keyed by their original sequence
 /// number. On reconnect the entire buffer is replayed before fresh events
 /// resume — the BES protocol's per-stream sequence-number dedup makes this
 /// safe even if the server already saw some of the replayed events.
+///
+/// The bound is a byte budget, not an event count, because BEP event sizes span
+/// orders of magnitude: most events are a few hundred bytes, but an action's
+/// captured stdout can reach tens of megabytes. A count-based cap therefore
+/// bounds neither memory (a handful of large events blows past any reasonable
+/// footprint) nor stream length (hundreds of thousands of small events are
+/// cheap), so it fires on builds that are perfectly healthy while failing to
+/// protect against the ones that actually consume memory.
+///
+/// Overflow is not an error. Retaining an event serves exactly one purpose —
+/// replaying it if the stream reconnects — so when the budget is exceeded the
+/// oldest entries are evicted to make room. The only consequence is that a
+/// subsequent reconnect cannot replay the evicted range; the server tolerates
+/// the resulting sequence gap (it acks by position and readers page forward
+/// past missing seqs). Delivery of the current stream is unaffected, which is
+/// what makes eviction strictly better than tearing the stream down.
 pub struct RetryBuffer {
-    cap: usize,
-    items: VecDeque<(i64, PublishBuildToolEventStreamRequest)>,
+    /// Byte budget for retained (unacked) events.
+    cap_bytes: usize,
+    /// Sum of `encoded_len()` over `items`, maintained incrementally.
+    bytes: usize,
+    /// Events evicted to stay under budget — a nonzero count means a reconnect
+    /// would replay an incomplete range.
+    evicted: u64,
+    items: VecDeque<(i64, usize, PublishBuildToolEventStreamRequest)>,
 }
 
 impl RetryBuffer {
-    pub fn new(cap: usize) -> Self {
+    pub fn new(cap_bytes: usize) -> Self {
         Self {
-            cap,
+            cap_bytes,
+            bytes: 0,
+            evicted: 0,
             items: VecDeque::new(),
         }
     }
 
-    /// Push an event into the buffer. Returns `Err` if the buffer is full —
-    /// the caller must transition to terminal at that point per the design.
-    pub fn push(
-        &mut self,
-        seq: i64,
-        req: PublishBuildToolEventStreamRequest,
-    ) -> Result<(), BufferOverflow> {
-        if self.items.len() >= self.cap {
-            return Err(BufferOverflow { cap: self.cap, seq });
+    /// Retain an event for potential replay, evicting the oldest entries when
+    /// it would exceed the byte budget. Infallible: the event is always sent
+    /// regardless of whether it could be retained.
+    ///
+    /// An event larger than the whole budget is not retained at all — evicting
+    /// everything else to hold one oversized event would forfeit more replay
+    /// coverage than it buys.
+    pub fn push(&mut self, seq: i64, req: PublishBuildToolEventStreamRequest) {
+        let size = req.encoded_len();
+
+        if size > self.cap_bytes {
+            self.evict_all();
+            self.evicted += 1;
+            return;
         }
-        self.items.push_back((seq, req));
-        Ok(())
+
+        while self.bytes + size > self.cap_bytes {
+            match self.items.pop_front() {
+                Some((_, evicted_size, _)) => {
+                    self.bytes -= evicted_size;
+                    self.evicted += 1;
+                }
+                // Unreachable: `size <= cap_bytes` and an empty buffer has
+                // `bytes == 0`, so the loop condition is already false.
+                None => break,
+            }
+        }
+
+        self.bytes += size;
+        self.items.push_back((seq, size, req));
+    }
+
+    fn evict_all(&mut self) {
+        self.evicted += self.items.len() as u64;
+        self.items.clear();
+        self.bytes = 0;
     }
 
     /// Drop every entry with `seq <= ack_seq`. Called when the server acks a
     /// response on the bidi stream.
     pub fn prune_until(&mut self, ack_seq: i64) {
-        while let Some((seq, _)) = self.items.front() {
+        while let Some((seq, size, _)) = self.items.front() {
             if *seq <= ack_seq {
+                self.bytes -= *size;
                 self.items.pop_front();
             } else {
                 break;
@@ -147,20 +210,25 @@ impl RetryBuffer {
         self.items.len()
     }
 
+    /// Retained bytes. Exposed for tests and debug logging.
+    #[allow(dead_code)]
+    pub fn bytes(&self) -> usize {
+        self.bytes
+    }
+
+    /// How many events were dropped to stay under budget. Nonzero means a
+    /// reconnect replays an incomplete range.
+    pub fn evicted(&self) -> u64 {
+        self.evicted
+    }
+
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &(i64, PublishBuildToolEventStreamRequest)> {
-        self.items.iter()
+    pub fn iter(&self) -> impl Iterator<Item = (&i64, &PublishBuildToolEventStreamRequest)> {
+        self.items.iter().map(|(seq, _, req)| (seq, req))
     }
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("retry buffer overflowed (cap={cap}) while attempting to buffer seq {seq}")]
-pub struct BufferOverflow {
-    pub cap: usize,
-    pub seq: i64,
 }
 
 /// Full-jitter exponential backoff. Mirrors Bazel:
@@ -249,6 +317,19 @@ mod tests {
         PublishBuildToolEventStreamRequest::default()
     }
 
+    /// A request whose encoded size is at least `n` bytes, for byte-budget
+    /// tests. Payload goes in `project_id`, a plain string field.
+    fn req_sized(n: usize) -> PublishBuildToolEventStreamRequest {
+        PublishBuildToolEventStreamRequest {
+            project_id: "x".repeat(n),
+            ..Default::default()
+        }
+    }
+
+    fn seqs(b: &RetryBuffer) -> Vec<i64> {
+        b.iter().map(|(s, _)| *s).collect()
+    }
+
     #[test]
     fn sink_stats_from_counters() {
         // Fresh forwarder that never streamed an event (next_seq still 1).
@@ -271,26 +352,96 @@ mod tests {
         );
     }
 
+    /// A high budget retains everything: many small events must not evict,
+    /// which is the case a count-based cap used to fail.
     #[test]
-    fn buffer_push_until_cap_then_overflow() {
-        let mut b = RetryBuffer::new(2);
-        b.push(1, req()).unwrap();
-        b.push(2, req()).unwrap();
-        let err = b.push(3, req()).unwrap_err();
-        assert_eq!(err.cap, 2);
-        assert_eq!(err.seq, 3);
-        assert_eq!(b.len(), 2);
+    fn buffer_retains_many_small_events() {
+        let mut b = RetryBuffer::new(1024 * 1024);
+        for i in 1..=20_000 {
+            b.push(i, req());
+        }
+        assert_eq!(b.len(), 20_000);
+        assert_eq!(b.evicted(), 0);
+    }
+
+    /// Overflow evicts oldest-first and keeps the newest events, rather than
+    /// failing.
+    #[test]
+    fn buffer_evicts_oldest_when_over_budget() {
+        let one = req_sized(100).encoded_len();
+        let mut b = RetryBuffer::new(one * 3);
+
+        for i in 1..=3 {
+            b.push(i, req_sized(100));
+        }
+        assert_eq!(seqs(&b), vec![1, 2, 3]);
+        assert_eq!(b.evicted(), 0);
+
+        // Fourth event exceeds the budget: seq 1 is evicted to make room.
+        b.push(4, req_sized(100));
+        assert_eq!(seqs(&b), vec![2, 3, 4]);
+        assert_eq!(b.evicted(), 1);
+        assert!(b.bytes() <= one * 3);
+    }
+
+    /// One large event can evict several small ones — eviction is driven by
+    /// bytes, not entry count.
+    #[test]
+    fn buffer_large_event_evicts_multiple_small() {
+        let small = req_sized(10).encoded_len();
+        let mut b = RetryBuffer::new(small * 10);
+        for i in 1..=10 {
+            b.push(i, req_sized(10));
+        }
+        assert_eq!(b.len(), 10);
+
+        b.push(11, req_sized(small * 5));
+        assert_eq!(*seqs(&b).last().unwrap(), 11);
+        assert!(b.len() < 10, "large event should displace several small ones");
+        assert!(b.bytes() <= small * 10);
+    }
+
+    /// An event bigger than the entire budget is not retained, and does not
+    /// take the rest of the buffer down with it beyond making room.
+    #[test]
+    fn buffer_oversized_event_is_not_retained() {
+        let mut b = RetryBuffer::new(1024);
+        b.push(1, req_sized(10));
+        b.push(2, req_sized(4096));
+
+        assert!(b.is_empty(), "oversized event must not be retained");
+        assert_eq!(b.bytes(), 0);
+        assert_eq!(b.evicted(), 2, "the evicted small event and the oversized one");
+
+        // The buffer stays usable afterwards.
+        b.push(3, req_sized(10));
+        assert_eq!(seqs(&b), vec![3]);
     }
 
     #[test]
     fn buffer_prune_removes_only_le_ack() {
-        let mut b = RetryBuffer::new(8);
+        let mut b = RetryBuffer::new(1024 * 1024);
         for i in 1..=5 {
-            b.push(i, req()).unwrap();
+            b.push(i, req());
         }
         b.prune_until(3);
-        let seqs: Vec<i64> = b.iter().map(|(s, _)| *s).collect();
-        assert_eq!(seqs, vec![4, 5]);
+        assert_eq!(seqs(&b), vec![4, 5]);
+    }
+
+    /// Pruning must return bytes to the budget, or the buffer would evict
+    /// spuriously after a long healthy stream.
+    #[test]
+    fn buffer_prune_reclaims_bytes() {
+        let mut b = RetryBuffer::new(1024 * 1024);
+        for i in 1..=10 {
+            b.push(i, req_sized(100));
+        }
+        let full = b.bytes();
+        assert!(full > 0);
+
+        b.prune_until(10);
+        assert!(b.is_empty());
+        assert_eq!(b.bytes(), 0, "pruning everything must zero the byte count");
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -5,14 +5,14 @@
 //! reconnects. Ack progress during an attempt resets the budget, so only
 //! consecutive no-progress attempts count against it and a server that
 //! periodically ends streams with a retryable status (e.g. UNAVAILABLE)
-//! is rejoined for as long as events keep landing.
-//! Terminal failures are surfaced via the sink's outcome — the
-//! caller decides what to do (warn, fail the task, etc.); the runtime never
-//! tries to second-guess the policy.
+//! is rejoined for as long as events keep landing. The replay buffer is
+//! bounded by bytes rather than event count and sheds its oldest entries when
+//! full, so a slow-acking backend costs replay coverage but never ends the
+//! upload — see [`RetryBuffer`].
 //!
-//! The replay buffer is bounded by bytes and evicts its oldest entries when
-//! full; a slow-acking backend degrades replay coverage but never terminates
-//! the upload. See [`RetryBuffer`].
+//! Terminal failures are surfaced via the sink's outcome — the caller decides
+//! what to do (warn, fail the task, etc.); the runtime never tries to
+//! second-guess the policy.
 
 use std::collections::VecDeque;
 use std::time::Duration;
@@ -31,68 +31,25 @@ use rand::Rng;
 /// [`default_retry_max_buffer_bytes`] over reading this directly.
 pub const DEFAULT_RETRY_MAX_BUFFER_BYTES: usize = 256 * 1024 * 1024;
 
-/// Environment override for the replay buffer's byte budget. Accepts a plain
-/// byte count or a size suffix (`KB`/`MB`/`GB`, or the `KiB`/`MiB`/`GiB`
-/// spellings — all binary multiples).
+/// Environment override for the replay buffer's byte budget, letting a runner
+/// size it to its own memory without threading a flag through every task.
+/// Accepts a plain byte count or a size suffix — see [`parse_byte_size`].
 ///
-/// This exists because the right budget is a property of the machine, not of
-/// the build: a memory-constrained runner may want less, and a fleet that
-/// routinely streams very large events may want more. Setting it per-runner
-/// avoids having to thread a flag through every task definition.
+/// The `CLI` in the name distinguishes this from Bazel's own BES uploader
+/// (`--bes_backend`), whose buffering it does not affect.
 pub const RETRY_MAX_BUFFER_BYTES_ENV: &str = "ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES";
 
-/// Parse a byte size: a plain count (`1048576`) or a suffixed value (`512MB`,
-/// `1GiB`). Suffixes are binary multiples; `KB` and `KiB` are both 1024. Case-
-/// insensitive, and whitespace between number and suffix is allowed.
-pub fn parse_byte_size(s: &str) -> Result<usize, String> {
-    let s = s.trim();
-    if s.is_empty() {
-        return Err("empty size string".into());
-    }
-
-    let digits_end = s
-        .find(|c: char| !c.is_ascii_digit())
-        .unwrap_or(s.len());
-    if digits_end == 0 {
-        return Err(format!("invalid size '{s}': expected a leading number"));
-    }
-    let (num_str, unit) = s.split_at(digits_end);
-    let unit = unit.trim().to_ascii_lowercase();
-
-    let multiplier: usize = match unit.as_str() {
-        "" | "b" => 1,
-        "k" | "kb" | "kib" => 1024,
-        "m" | "mb" | "mib" => 1024 * 1024,
-        "g" | "gb" | "gib" => 1024 * 1024 * 1024,
-        other => {
-            return Err(format!(
-                "invalid size '{s}': unknown unit '{other}' (expected one of B, KB, MB, GB)"
-            ));
-        }
-    };
-
-    let n: usize = num_str
-        .parse()
-        .map_err(|e| format!("invalid size '{s}': {e}"))?;
-    n.checked_mul(multiplier)
-        .ok_or_else(|| format!("invalid size '{s}': value overflows"))
-}
-
 /// The replay buffer's default byte budget, honoring
-/// [`RETRY_MAX_BUFFER_BYTES_ENV`] when it is set to a usable value.
+/// [`RETRY_MAX_BUFFER_BYTES_ENV`].
 ///
-/// Read once per process and cached: this is consulted when constructing every
-/// sink, and a mid-run change in the environment should not make two sinks in
-/// the same build disagree.
-///
-/// An unset or empty value uses the built-in default. A malformed or zero value
-/// warns and falls back rather than failing the build — BES upload is
-/// best-effort, and a typo'd tuning knob is not worth losing a CI run over.
+/// Read once per process and cached, so two sinks in one build cannot disagree
+/// if the environment changes mid-run.
 pub fn default_retry_max_buffer_bytes() -> usize {
     static RESOLVED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *RESOLVED.get_or_init(|| {
-        let (bytes, warning) =
-            resolve_buffer_bytes_override(std::env::var(RETRY_MAX_BUFFER_BYTES_ENV).ok().as_deref());
+        let (bytes, warning) = resolve_buffer_bytes_override(
+            std::env::var(RETRY_MAX_BUFFER_BYTES_ENV).ok().as_deref(),
+        );
         if let Some(w) = warning {
             crate::diag::warn(&w);
         }
@@ -100,13 +57,13 @@ pub fn default_retry_max_buffer_bytes() -> usize {
     })
 }
 
-/// Resolve the override value, returning the budget to use and an optional
-/// warning to emit. Split from [`default_retry_max_buffer_bytes`] so the
-/// fallback rules are testable without mutating process-wide state.
+/// Resolve the override, returning the budget to use and any warning to emit.
+/// Separate from [`default_retry_max_buffer_bytes`] so the rules are testable
+/// without touching process-wide state.
 ///
-/// Unset/empty is silent (the common case). A malformed or zero value warns and
-/// falls back — BES upload is best-effort, and a typo'd tuning knob is not
-/// worth losing a CI run over.
+/// Unset or empty is silent — the common case. A malformed or zero value warns
+/// and falls back to the built-in default: BES upload is best-effort, so a
+/// typo'd tuning knob should not cost a CI run.
 fn resolve_buffer_bytes_override(raw: Option<&str>) -> (usize, Option<String>) {
     let Some(raw) = raw else {
         return (DEFAULT_RETRY_MAX_BUFFER_BYTES, None);
@@ -177,6 +134,47 @@ impl Default for RetryConfig {
     }
 }
 
+/// Split a suffixed scalar (`"512MB"`, `"250ms"`) into its numeric prefix and
+/// lower-cased unit. Surrounding and internal whitespace is ignored; a missing
+/// unit yields `""`.
+///
+/// `kind` names the value in error messages ("size", "duration").
+fn split_scalar_unit<'a>(s: &'a str, kind: &str) -> Result<(&'a str, String), String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err(format!("empty {kind} string"));
+    }
+    let digits_end = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
+    if digits_end == 0 {
+        return Err(format!("invalid {kind} '{s}': expected a leading number"));
+    }
+    let (num, unit) = s.split_at(digits_end);
+    Ok((num, unit.trim().to_ascii_lowercase()))
+}
+
+/// Parse a byte size: a plain count (`1048576`) or a suffixed value (`512MB`,
+/// `1GiB`). Suffixes are binary multiples, so `KB` and `KiB` are both 1024.
+/// Case-insensitive; whitespace between number and suffix is allowed.
+pub fn parse_byte_size(s: &str) -> Result<usize, String> {
+    let (num, unit) = split_scalar_unit(s, "size")?;
+    let multiplier: usize = match unit.as_str() {
+        "" | "b" => 1,
+        "k" | "kb" | "kib" => 1024,
+        "m" | "mb" | "mib" => 1024 * 1024,
+        "g" | "gb" | "gib" => 1024 * 1024 * 1024,
+        other => {
+            return Err(format!(
+                "invalid size '{s}': unknown unit '{other}' (expected one of B, KB, MB, GB)"
+            ));
+        }
+    };
+    let n: usize = num
+        .parse()
+        .map_err(|e| format!("invalid size '{s}': {e}"))?;
+    n.checked_mul(multiplier)
+        .ok_or_else(|| format!("invalid size '{s}': value overflows"))
+}
+
 /// Parse a duration string like `"1s"`, `"500ms"`, `"2m"`, `"1h"`, `"1d"`,
 /// `"0s"`.
 ///
@@ -185,36 +183,21 @@ impl Default for RetryConfig {
 /// `"0s"` (or any zero value) is the documented sentinel for "no deadline"
 /// when used as a timeout; the caller decides what zero means.
 pub fn parse_duration(s: &str) -> Result<Duration, String> {
-    let s = s.trim();
-    if s.is_empty() {
-        return Err("empty duration string".into());
-    }
-    let (num_str, unit) = if let Some(rest) = s.strip_suffix("ms") {
-        (rest, "ms")
-    } else if let Some(rest) = s.strip_suffix('s') {
-        (rest, "s")
-    } else if let Some(rest) = s.strip_suffix('m') {
-        (rest, "m")
-    } else if let Some(rest) = s.strip_suffix('h') {
-        (rest, "h")
-    } else if let Some(rest) = s.strip_suffix('d') {
-        (rest, "d")
-    } else {
-        return Err(format!(
-            "invalid duration '{s}': expected suffix one of 'ms', 's', 'm', 'h', 'd'"
-        ));
-    };
-    let n: u64 = num_str
-        .trim()
+    let (num, unit) = split_scalar_unit(s, "duration")?;
+    let n: u64 = num
         .parse()
         .map_err(|e| format!("invalid duration '{s}': {e}"))?;
-    Ok(match unit {
+    Ok(match unit.as_str() {
         "ms" => Duration::from_millis(n),
         "s" => Duration::from_secs(n),
         "m" => Duration::from_secs(n * 60),
         "h" => Duration::from_secs(n * 3600),
         "d" => Duration::from_secs(n * 86_400),
-        _ => unreachable!(),
+        _ => {
+            return Err(format!(
+                "invalid duration '{s}': expected suffix one of 'ms', 's', 'm', 'h', 'd'"
+            ));
+        }
     })
 }
 
@@ -223,29 +206,25 @@ pub fn parse_duration(s: &str) -> Result<Duration, String> {
 /// resume — the BES protocol's per-stream sequence-number dedup makes this
 /// safe even if the server already saw some of the replayed events.
 ///
-/// The bound is a byte budget, not an event count, because BEP event sizes span
-/// orders of magnitude: most events are a few hundred bytes, but an action's
-/// captured stdout can reach tens of megabytes. A count-based cap therefore
-/// bounds neither memory (a handful of large events blows past any reasonable
-/// footprint) nor stream length (hundreds of thousands of small events are
-/// cheap), so it fires on builds that are perfectly healthy while failing to
-/// protect against the ones that actually consume memory.
+/// The bound is a byte budget, not an event count: BEP event sizes span orders
+/// of magnitude (a few hundred bytes for most, tens of megabytes for one
+/// carrying an action's stdout), so a count bounds neither memory nor stream
+/// length.
 ///
-/// Overflow is not an error. Retaining an event serves exactly one purpose —
-/// replaying it if the stream reconnects — so when the budget is exceeded the
-/// oldest entries are evicted to make room. The only consequence is that a
-/// subsequent reconnect cannot replay the evicted range; the server tolerates
-/// the resulting sequence gap (it acks by position and readers page forward
-/// past missing seqs). Delivery of the current stream is unaffected, which is
-/// what makes eviction strictly better than tearing the stream down.
+/// Overflow is not an error. Retention exists only to enable replay, so when
+/// the budget is exceeded the oldest entries are evicted. The cost is that a
+/// later reconnect cannot replay the evicted range — the server tolerates the
+/// resulting sequence gap, acking by position and paging forward past missing
+/// seqs — while delivery of the live stream is unaffected.
 pub struct RetryBuffer {
     /// Byte budget for retained (unacked) events.
     cap_bytes: usize,
     /// Sum of `encoded_len()` over `items`, maintained incrementally.
     bytes: usize,
-    /// Events evicted to stay under budget — a nonzero count means a reconnect
-    /// would replay an incomplete range.
+    /// Events evicted since the last [`Self::take_evicted`].
     evicted: u64,
+    /// `(sequence number, encoded size, request)`, oldest first. The size is
+    /// cached so eviction and pruning adjust `bytes` without re-encoding.
     items: VecDeque<(i64, usize, PublishBuildToolEventStreamRequest)>,
 }
 
@@ -269,32 +248,26 @@ impl RetryBuffer {
     pub fn push(&mut self, seq: i64, req: PublishBuildToolEventStreamRequest) {
         let size = req.encoded_len();
 
-        if size > self.cap_bytes {
-            self.evict_all();
-            self.evicted += 1;
-            return;
+        // `size <= cap_bytes` bounds the loop: an empty buffer has `bytes == 0`,
+        // so the condition is false by the time everything has been evicted.
+        while !self.items.is_empty() && self.bytes + size > self.cap_bytes {
+            self.evict_oldest();
         }
 
-        while self.bytes + size > self.cap_bytes {
-            match self.items.pop_front() {
-                Some((_, evicted_size, _)) => {
-                    self.bytes -= evicted_size;
-                    self.evicted += 1;
-                }
-                // Unreachable: `size <= cap_bytes` and an empty buffer has
-                // `bytes == 0`, so the loop condition is already false.
-                None => break,
-            }
+        if size > self.cap_bytes {
+            self.evicted += 1;
+            return;
         }
 
         self.bytes += size;
         self.items.push_back((seq, size, req));
     }
 
-    fn evict_all(&mut self) {
-        self.evicted += self.items.len() as u64;
-        self.items.clear();
-        self.bytes = 0;
+    fn evict_oldest(&mut self) {
+        if let Some((_, size, _)) = self.items.pop_front() {
+            self.bytes -= size;
+            self.evicted += 1;
+        }
     }
 
     /// Drop every entry with `seq <= ack_seq`. Called when the server acks a
@@ -310,21 +283,24 @@ impl RetryBuffer {
         }
     }
 
-    #[allow(dead_code)]
+    /// Number of retained events.
     pub fn len(&self) -> usize {
         self.items.len()
     }
 
-    /// Retained bytes. Exposed for tests and debug logging.
-    #[allow(dead_code)]
+    /// Bytes currently retained, against the budget passed to [`Self::new`].
     pub fn bytes(&self) -> usize {
         self.bytes
     }
 
-    /// How many events were dropped to stay under budget. Nonzero means a
-    /// reconnect replays an incomplete range.
-    pub fn evicted(&self) -> u64 {
-        self.evicted
+    /// Events dropped to stay under budget since the last call, resetting the
+    /// counter.
+    ///
+    /// Callers report this once per reconnect, and the count is cumulative
+    /// across the whole build; draining it keeps a second reconnect from
+    /// re-reporting losses the first one already announced.
+    pub fn take_evicted(&mut self) -> u64 {
+        std::mem::take(&mut self.evicted)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -457,8 +433,8 @@ mod tests {
         );
     }
 
-    /// A high budget retains everything: many small events must not evict,
-    /// which is the case a count-based cap used to fail.
+    /// Many small events fit comfortably: event count alone never triggers
+    /// eviction.
     #[test]
     fn buffer_retains_many_small_events() {
         let mut b = RetryBuffer::new(1024 * 1024);
@@ -466,7 +442,7 @@ mod tests {
             b.push(i, req());
         }
         assert_eq!(b.len(), 20_000);
-        assert_eq!(b.evicted(), 0);
+        assert_eq!(b.take_evicted(), 0);
     }
 
     /// Overflow evicts oldest-first and keeps the newest events, rather than
@@ -480,12 +456,12 @@ mod tests {
             b.push(i, req_sized(100));
         }
         assert_eq!(seqs(&b), vec![1, 2, 3]);
-        assert_eq!(b.evicted(), 0);
+        assert_eq!(b.take_evicted(), 0);
 
         // Fourth event exceeds the budget: seq 1 is evicted to make room.
         b.push(4, req_sized(100));
         assert_eq!(seqs(&b), vec![2, 3, 4]);
-        assert_eq!(b.evicted(), 1);
+        assert_eq!(b.take_evicted(), 1);
         assert!(b.bytes() <= one * 3);
     }
 
@@ -502,7 +478,10 @@ mod tests {
 
         b.push(11, req_sized(small * 5));
         assert_eq!(*seqs(&b).last().unwrap(), 11);
-        assert!(b.len() < 10, "large event should displace several small ones");
+        assert!(
+            b.len() < 10,
+            "large event should displace several small ones"
+        );
         assert!(b.bytes() <= small * 10);
     }
 
@@ -516,11 +495,33 @@ mod tests {
 
         assert!(b.is_empty(), "oversized event must not be retained");
         assert_eq!(b.bytes(), 0);
-        assert_eq!(b.evicted(), 2, "the evicted small event and the oversized one");
+        assert_eq!(
+            b.take_evicted(),
+            2,
+            "the evicted small event and the oversized one"
+        );
 
         // The buffer stays usable afterwards.
         b.push(3, req_sized(10));
         assert_eq!(seqs(&b), vec![3]);
+    }
+
+    /// `take_evicted` drains, so consecutive reconnects each report only what
+    /// was evicted since the last one rather than re-announcing old losses.
+    #[test]
+    fn buffer_take_evicted_drains() {
+        let one = req_sized(100).encoded_len();
+        let mut b = RetryBuffer::new(one * 2);
+        assert_eq!(b.take_evicted(), 0, "nothing evicted yet");
+
+        for i in 1..=4 {
+            b.push(i, req_sized(100));
+        }
+        assert_eq!(b.take_evicted(), 2);
+        assert_eq!(b.take_evicted(), 0, "second read must not repeat the count");
+
+        b.push(5, req_sized(100));
+        assert_eq!(b.take_evicted(), 1, "only the newly evicted event");
     }
 
     #[test]
@@ -537,16 +538,33 @@ mod tests {
     /// spuriously after a long healthy stream.
     #[test]
     fn buffer_prune_reclaims_bytes() {
+        let one = req_sized(100).encoded_len();
         let mut b = RetryBuffer::new(1024 * 1024);
         for i in 1..=10 {
             b.push(i, req_sized(100));
         }
-        let full = b.bytes();
-        assert!(full > 0);
+        assert_eq!(b.bytes(), one * 10);
+
+        b.prune_until(4);
+        assert_eq!(b.bytes(), one * 6, "partial prune reclaims proportionally");
 
         b.prune_until(10);
         assert!(b.is_empty());
-        assert_eq!(b.bytes(), 0, "pruning everything must zero the byte count");
+        assert_eq!(b.bytes(), 0);
+    }
+
+    /// Reclaimed budget is reusable: a stream that acks as it goes keeps
+    /// pushing indefinitely without ever evicting.
+    #[test]
+    fn buffer_acked_stream_never_evicts() {
+        let one = req_sized(100).encoded_len();
+        let mut b = RetryBuffer::new(one * 4);
+        for i in 1..=100 {
+            b.push(i, req_sized(100));
+            b.prune_until(i);
+        }
+        assert!(b.is_empty());
+        assert_eq!(b.take_evicted(), 0, "acked events free their budget");
     }
 
     #[test]
@@ -666,8 +684,14 @@ mod tests {
         assert_eq!(parse_duration("1h").unwrap(), Duration::from_secs(3600));
         assert_eq!(parse_duration("1d").unwrap(), Duration::from_secs(86_400));
         assert!(parse_duration("").is_err());
-        assert!(parse_duration("10").is_err());
+        assert!(parse_duration("10").is_err(), "a bare number has no unit");
         assert!(parse_duration("abc").is_err());
+        assert!(parse_duration("5x").is_err(), "unknown unit");
+
+        // Shared with `parse_byte_size` via `split_scalar_unit`: case and
+        // internal whitespace are tolerated.
+        assert_eq!(parse_duration("250MS").unwrap(), Duration::from_millis(250));
+        assert_eq!(parse_duration(" 2 m ").unwrap(), Duration::from_secs(120));
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -22,11 +22,116 @@ use build_event_stream::client::ClientError;
 use prost::Message;
 use rand::Rng;
 
-/// Default byte budget for the unacked replay buffer (256 MiB). Sized to hold
+/// Built-in byte budget for the unacked replay buffer (256 MiB). Sized to hold
 /// a long stream of ordinary events (hundreds of thousands, at a few hundred
 /// bytes each) plus a few of the multi-megabyte outliers that carry action
 /// stdout, so eviction stays rare in practice.
+///
+/// Overridable per-runner via [`RETRY_MAX_BUFFER_BYTES_ENV`]; prefer
+/// [`default_retry_max_buffer_bytes`] over reading this directly.
 pub const DEFAULT_RETRY_MAX_BUFFER_BYTES: usize = 256 * 1024 * 1024;
+
+/// Environment override for the replay buffer's byte budget. Accepts a plain
+/// byte count or a size suffix (`KB`/`MB`/`GB`, or the `KiB`/`MiB`/`GiB`
+/// spellings — all binary multiples).
+///
+/// This exists because the right budget is a property of the machine, not of
+/// the build: a memory-constrained runner may want less, and a fleet that
+/// routinely streams very large events may want more. Setting it per-runner
+/// avoids having to thread a flag through every task definition.
+pub const RETRY_MAX_BUFFER_BYTES_ENV: &str = "ASPECT_BES_RETRY_MAX_BUFFER_BYTES";
+
+/// Parse a byte size: a plain count (`1048576`) or a suffixed value (`512MB`,
+/// `1GiB`). Suffixes are binary multiples; `KB` and `KiB` are both 1024. Case-
+/// insensitive, and whitespace between number and suffix is allowed.
+pub fn parse_byte_size(s: &str) -> Result<usize, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("empty size string".into());
+    }
+
+    let digits_end = s
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(s.len());
+    if digits_end == 0 {
+        return Err(format!("invalid size '{s}': expected a leading number"));
+    }
+    let (num_str, unit) = s.split_at(digits_end);
+    let unit = unit.trim().to_ascii_lowercase();
+
+    let multiplier: usize = match unit.as_str() {
+        "" | "b" => 1,
+        "k" | "kb" | "kib" => 1024,
+        "m" | "mb" | "mib" => 1024 * 1024,
+        "g" | "gb" | "gib" => 1024 * 1024 * 1024,
+        other => {
+            return Err(format!(
+                "invalid size '{s}': unknown unit '{other}' (expected one of B, KB, MB, GB)"
+            ));
+        }
+    };
+
+    let n: usize = num_str
+        .parse()
+        .map_err(|e| format!("invalid size '{s}': {e}"))?;
+    n.checked_mul(multiplier)
+        .ok_or_else(|| format!("invalid size '{s}': value overflows"))
+}
+
+/// The replay buffer's default byte budget, honoring
+/// [`RETRY_MAX_BUFFER_BYTES_ENV`] when it is set to a usable value.
+///
+/// Read once per process and cached: this is consulted when constructing every
+/// sink, and a mid-run change in the environment should not make two sinks in
+/// the same build disagree.
+///
+/// An unset or empty value uses the built-in default. A malformed or zero value
+/// warns and falls back rather than failing the build — BES upload is
+/// best-effort, and a typo'd tuning knob is not worth losing a CI run over.
+pub fn default_retry_max_buffer_bytes() -> usize {
+    static RESOLVED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *RESOLVED.get_or_init(|| {
+        let (bytes, warning) =
+            resolve_buffer_bytes_override(std::env::var(RETRY_MAX_BUFFER_BYTES_ENV).ok().as_deref());
+        if let Some(w) = warning {
+            crate::diag::warn(&w);
+        }
+        bytes
+    })
+}
+
+/// Resolve the override value, returning the budget to use and an optional
+/// warning to emit. Split from [`default_retry_max_buffer_bytes`] so the
+/// fallback rules are testable without mutating process-wide state.
+///
+/// Unset/empty is silent (the common case). A malformed or zero value warns and
+/// falls back — BES upload is best-effort, and a typo'd tuning knob is not
+/// worth losing a CI run over.
+fn resolve_buffer_bytes_override(raw: Option<&str>) -> (usize, Option<String>) {
+    let Some(raw) = raw else {
+        return (DEFAULT_RETRY_MAX_BUFFER_BYTES, None);
+    };
+    if raw.trim().is_empty() {
+        return (DEFAULT_RETRY_MAX_BUFFER_BYTES, None);
+    }
+    match parse_byte_size(raw) {
+        Ok(0) => (
+            DEFAULT_RETRY_MAX_BUFFER_BYTES,
+            Some(format!(
+                "{RETRY_MAX_BUFFER_BYTES_ENV}={raw} must be > 0; \
+                 using the default of {DEFAULT_RETRY_MAX_BUFFER_BYTES} bytes"
+            )),
+        ),
+        Ok(n) => (n, None),
+        Err(e) => (
+            DEFAULT_RETRY_MAX_BUFFER_BYTES,
+            Some(format!(
+                "{RETRY_MAX_BUFFER_BYTES_ENV}: {e}; \
+                 using the default of {DEFAULT_RETRY_MAX_BUFFER_BYTES} bytes"
+            )),
+        ),
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct RetryConfig {
@@ -37,7 +142,7 @@ pub struct RetryConfig {
     pub retry_min_delay: Duration,
     /// Byte budget for the unacked replay buffer. Exceeding it evicts the
     /// oldest retained events rather than failing the stream — see
-    /// [`RetryBuffer`].
+    /// [`RetryBuffer`]. Defaults via [`default_retry_max_buffer_bytes`].
     pub retry_max_buffer_bytes: usize,
     pub timeout: Option<Duration>,
     /// How long a single write into the bidi request stream may block before
@@ -63,7 +168,7 @@ impl Default for RetryConfig {
         Self {
             max_retries: 4,
             retry_min_delay: Duration::from_secs(1),
-            retry_max_buffer_bytes: DEFAULT_RETRY_MAX_BUFFER_BYTES,
+            retry_max_buffer_bytes: default_retry_max_buffer_bytes(),
             timeout: None,
             send_stall_timeout: Duration::from_secs(60),
             ack_progress_timeout: Duration::from_secs(120),
@@ -451,6 +556,79 @@ mod tests {
             let d = backoff(min, attempt);
             let cap = min * 30;
             assert!(d <= cap, "attempt {attempt}: {d:?} > {cap:?}");
+        }
+    }
+
+    #[test]
+    fn parse_byte_size_plain_and_suffixed() {
+        assert_eq!(parse_byte_size("1024").unwrap(), 1024);
+        assert_eq!(parse_byte_size("0").unwrap(), 0);
+        assert_eq!(parse_byte_size("512B").unwrap(), 512);
+        assert_eq!(parse_byte_size("2KB").unwrap(), 2048);
+        assert_eq!(parse_byte_size("256MB").unwrap(), 256 * 1024 * 1024);
+        assert_eq!(parse_byte_size("1GB").unwrap(), 1024 * 1024 * 1024);
+
+        // The `iB` spellings and bare unit letters are the same binary multiple.
+        assert_eq!(parse_byte_size("256MiB").unwrap(), 256 * 1024 * 1024);
+        assert_eq!(parse_byte_size("256M").unwrap(), 256 * 1024 * 1024);
+
+        // Case and internal whitespace are tolerated.
+        assert_eq!(parse_byte_size("256mb").unwrap(), 256 * 1024 * 1024);
+        assert_eq!(parse_byte_size(" 256 MB ").unwrap(), 256 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_byte_size_rejects_malformed() {
+        assert!(parse_byte_size("").is_err());
+        assert!(parse_byte_size("   ").is_err());
+        assert!(parse_byte_size("MB").is_err(), "no leading number");
+        assert!(parse_byte_size("12TB").is_err(), "unsupported unit");
+        assert!(parse_byte_size("1.5MB").is_err(), "fractional unsupported");
+        assert!(parse_byte_size("-1").is_err(), "negative unsupported");
+        assert!(
+            parse_byte_size("99999999999999999999GB").is_err(),
+            "overflow must be an error, not a wrap"
+        );
+    }
+
+    /// A usable override is taken verbatim, with no warning.
+    #[test]
+    fn env_override_applies_when_valid() {
+        let (bytes, warning) = resolve_buffer_bytes_override(Some("512MB"));
+        assert_eq!(bytes, 512 * 1024 * 1024);
+        assert!(warning.is_none(), "a valid override should be silent");
+
+        let (bytes, warning) = resolve_buffer_bytes_override(Some("1048576"));
+        assert_eq!(bytes, 1024 * 1024);
+        assert!(warning.is_none());
+    }
+
+    /// Unset or empty is the common case and must not warn.
+    #[test]
+    fn env_override_absent_is_silent_default() {
+        for raw in [None, Some(""), Some("   ")] {
+            let (bytes, warning) = resolve_buffer_bytes_override(raw);
+            assert_eq!(bytes, DEFAULT_RETRY_MAX_BUFFER_BYTES, "{raw:?}");
+            assert!(warning.is_none(), "{raw:?} should not warn");
+        }
+    }
+
+    /// A malformed or zero override falls back to the default and warns — a
+    /// typo'd tuning knob must never break a build or silently disable the
+    /// buffer.
+    #[test]
+    fn env_override_invalid_warns_and_falls_back() {
+        for bad in ["garbage", "12TB", "1.5MB", "-1", "0", "0MB"] {
+            let (bytes, warning) = resolve_buffer_bytes_override(Some(bad));
+            assert_eq!(
+                bytes, DEFAULT_RETRY_MAX_BUFFER_BYTES,
+                "{bad:?} should fall back to the default"
+            );
+            let warning = warning.unwrap_or_else(|| panic!("{bad:?} should warn"));
+            assert!(
+                warning.contains(RETRY_MAX_BUFFER_BYTES_ENV),
+                "warning should name the env var: {warning}"
+            );
         }
     }
 


### PR DESCRIPTION
The CLI's BES sink retains unacked events so it can replay them if the stream reconnects. That buffer was capped at 10,000 events, and exceeding it was terminal — the sink stopped uploading mid-build and reported a partial upload.

An event count is the wrong bound. BEP event sizes span orders of magnitude: most are a few hundred bytes, but one carrying an action's stdout can reach tens of megabytes. A count bounds neither memory nor stream length, so it trips on builds that are using very little memory while failing to protect against the ones that aren't.

A fully-cached run hit exactly that. Bazel emitted ~20.7k analysis events in 65s (7,137 targets, 34,801 aspect applications, `--build_event_publish_all_actions`); acks could not keep 10,000 slots free, and the sink gave up with `Uploaded 11615 of 21616 build events … before the stream failed`. Nothing was wrong with the build, the network, or the backend — `ASPECT_DEBUG=1` showed a single `drive_stream` call at `attempt=0`, so no disconnect and no retry, just the cap.

## Changes

**Bound the buffer by bytes** (default 256 MiB), tracked incrementally via `encoded_len()`.

**Make overflow non-fatal.** Retention exists only to enable replay, so exceeding the budget evicts the oldest entries instead of ending the stream. The cost is that a later reconnect cannot replay the evicted range; the server tolerates the resulting sequence gap, acking by position and paging forward past missing seqs. An event larger than the whole budget is sent but not retained. When a reconnect does find evicted events, the sink warns — the only signal that data may be incomplete, since BES upload never fails the build.

**Allow per-runner configuration** via `ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES`, which accepts a plain byte count or a size suffix (`512MB`, `1GiB`; binary multiples, case-insensitive):

```bash
export ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES=512MB
```

Precedence is **explicit `retry_max_buffer_bytes` argument → environment variable → 256 MiB**. Resolution is cached per process so two sinks in one build cannot disagree, and a malformed or zero value warns and falls back rather than failing the build. The `CLI` in the name distinguishes this from Bazel's own BES uploader (`--bes_backend`), whose buffering it does not affect.

## Notes for reviewers

- Eviction is survivable because `ivy-bep-etl` validates only `sequence_number >= 1`; it does not require contiguity.
- 256 MiB is a reasoned default, not a measured one — it holds the failing build (~20–60 MB) with room for several multi-megabyte outliers. Worth revisiting against real peak usage.
- No integration test drives a real backend through eviction followed by a reconnect, so the warning path is covered by unit tests only.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Because the unit changed, `retry_max_buffer_size` is renamed to `retry_max_buffer_bytes` on `bazel.build_events.grpc()`, and `--bes-retry-max-buffer-size` to `--bes-retry-max-buffer-bytes` on the Workflows feature. The old names are errors rather than silent misinterpretations — 10000 bytes would be a pathologically small budget.

#### Suggested release notes

- The CLI's BES upload no longer stops partway through builds that emit a large number of build events. The unacked replay buffer is now bounded by total size (default 256 MiB) instead of a fixed 10,000-event count, and exceeding it degrades reconnect replay coverage rather than ending the upload.
- The buffer budget can be set per-runner with `ASPECT_CLI_BES_RETRY_MAX_BUFFER_BYTES` (accepts `512MB`, `1GiB`, or a plain byte count).
- **Breaking:** `bazel.build_events.grpc(retry_max_buffer_size = …)` is now `retry_max_buffer_bytes`, and `--bes-retry-max-buffer-size` is now `--bes-retry-max-buffer-bytes`. The value is a byte budget, not an event count.

### Test plan

- New test cases added
- Covered by existing test cases

`RetryBuffer`: 20k small events retained without eviction, oldest-first eviction on overflow, one large event displacing several small ones, oversized events not retained, `take_evicted` draining so consecutive reconnects don't re-report the same losses, partial prune reclaiming budget proportionally, and an acked stream pushing 100 events through a 4-event budget without evicting.

Configuration: byte-size parsing across suffixes, case, and whitespace plus its rejections (no leading number, unknown unit, fractional, negative, overflow); override resolution for valid, absent, and invalid values; and a test that reads the variable from the real environment under its documented name.

Starlark surface: an explicit value validates, `0` is rejected, and omitting the argument — the path that consults the environment — validates.

- `cargo test --workspace` — 606 passed, 0 failed
- All 42 `aspect dev test-*` AXL suites pass
- `cargo fmt --check` clean; `cargo clippy -p axl-runtime` unchanged vs `main` (153 warnings, none in changed files)
