### PR TITLE
fix(cli): render ASPECT_API_TOKEN tip doc URLs as markdown links

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/private/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/tips.axl
@@ -291,8 +291,8 @@ _ASPECT_API_TOKEN_HOST_DETAIL = {
             "  with:\n" +
             "    aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}\n" +
             "```\n\n" +
-            "Find the latest release's commit SHA at " +
-            "https://github.com/aspect-build/setup-aspect/releases."
+            "Find the latest release's commit SHA on the " +
+            "[setup-aspect releases page](https://github.com/aspect-build/setup-aspect/releases)."
         ),
     ),
     AspectApiTokenHost("buildkite").value: struct(
@@ -329,7 +329,7 @@ def tip_add_aspect_api_token(ctx, host: AspectApiTokenHost):
             "Without it, " + detail.degraded_features + " degrade. The task itself " +
             "completes regardless — only the GitHub-side surfaces are affected.\n\n" +
             "Issue an `ASPECT_API_TOKEN` from the Aspect Web UI " +
-            "(see https://aspect.build/docs/cli/authentication). " +
+            "(see the [authentication docs](https://aspect.build/docs/cli/authentication)). " +
             detail.host_advice
         ),
     )


### PR DESCRIPTION
## Summary

Two doc references in the `ASPECT_API_TOKEN` tip body are written as bare URLs, while every other reference in the same tip uses a markdown link (`[aspect-build/setup-aspect](...)`, `[Buildkite's secrets docs](...)`, `[context](...)`). This converts the two odd ones out to markdown links for consistency.

The two spots:

- `(see https://aspect.build/docs/cli/authentication).`
- `Find the latest release's commit SHA at https://github.com/aspect-build/setup-aspect/releases.`

Both are bare URLs immediately followed by sentence punctuation. When a viewer autolinks a bare URL without applying GFM's trailing-punctuation rules, the trailing `.` (and the `)`) get absorbed into the link target, producing a broken URL such as `.../authentication).` or `.../releases.`. Wrapping each URL in `[text](url)` gives the link an explicit boundary and renders it as a named link on the surfaces that render the tip body as markdown (GitHub check-run summary, PR summary comment, Buildkite annotation).

## Testing

Message-text only, no behavior change. The `tips_test.axl` body assertions match on substrings (`setup-aspect`, `Buildkite's secrets docs`, `context`) that this change preserves; CI covers the tip tests.
