### PR TITLE
build: strip the primary release binary, add a -debug- variant

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,15 +17,6 @@ common:release --workspace_status_command "${PWD}/bazel/workspace_status.sh"
 common:release --compilation_mode=opt
 common:release --@rules_rust//rust/settings:lto=fat
 
-# TEMPORARY (diagnostic release): compile every crate — including third-party
-# ones such as starlark — with debug assertions on, so a corrupt allocation
-# panics where it happens instead of surfacing later as an allocator abort with
-# no useful stack. This enables `debug_assert!` (notably starlark's arena bounds
-# checks and `Alloca::assert_state`) plus arithmetic overflow checks. Costs
-# ~3.4MB (+7%) on the musl release binary. Remove once the lint segfault under
-# investigation is diagnosed.
-common:release --@rules_rust//rust/settings:extra_rustc_flags=-Cdebug-assertions=y
-
 # Don't stop at the first failure on CI — surface every failing target/test in
 # one run (a failed build action otherwise aborts the test phase before any
 # test executes). Applied via `--config=ci`, injected by .aspect/config.axl when

--- a/.github/workflows/build_release_artifacts.yaml
+++ b/.github/workflows/build_release_artifacts.yaml
@@ -54,13 +54,16 @@ jobs:
         # doesn't need a broader download policy. `:brew` is part of the
         # launcher `:release` graph but is NOT under `:bins`, so it must be
         # listed explicitly — otherwise a remote cache hit leaves `brew.rb`
-        # remote-only and the cp fails with "cannot stat".
+        # remote-only and the cp fails with "cannot stat". Same reasoning for
+        # aspect-cli's `:debug_bins`, which `:release` copies but which is not
+        # reachable from `:bins`.
         run: |
           mkdir -p upload_root/assets
           bazel build --config=release --config=ci --remote_download_outputs=toplevel \
             //crates/aspect-launcher:bins \
             //crates/aspect-launcher:brew \
             //crates/aspect-cli:bins \
+            //crates/aspect-cli:debug_bins \
             //crates/axl-docgen:bins
           bazel run --config=release --config=ci //crates/aspect-launcher:release -- "${PWD}/upload_root/assets"
           bazel run --config=release --config=ci //crates/aspect-cli:release -- "${PWD}/upload_root/assets"

--- a/bazel/rust/defs.bzl
+++ b/bazel/rust/defs.bzl
@@ -3,7 +3,7 @@
 load("@aspect_bazel_lib//lib:expand_template.bzl", _expand_template = "expand_template")
 load("@rules_rust//rust:defs.bzl", _rust_binary = "rust_binary", _rust_library = "rust_library", _rust_proc_macro = "rust_proc_macro", _rust_test = "rust_test")
 
-def rust_binary(name, rustc_env_files = [], version_key = "", crate_features = [], **kwargs):
+def rust_binary(name, rustc_env_files = [], version_key = "", crate_features = [], release_rustc_flags = ["-Cstrip=symbols"], **kwargs):
     """
     Macro for rust_binary defaults.
 
@@ -12,6 +12,10 @@ def rust_binary(name, rustc_env_files = [], version_key = "", crate_features = [
         rustc_env_files: Additional env files to pass to the rust compiler
         version_key: Stamp key to use for version replacement at compile time
         crate_features: Create features to enable for the binary target
+        release_rustc_flags: Flags appended only in release (`-c opt`) builds.
+            Defaults to stripping symbols. A debug-symbol variant of a binary
+            overrides this with `-Cstrip=none` (plus whatever else it needs) so
+            the two variants differ only by these flags.
         **kwargs: Additional args to pass to rust_binary
     """
 
@@ -35,13 +39,7 @@ def rust_binary(name, rustc_env_files = [], version_key = "", crate_features = [
                 "-Ccodegen-units=1",
                 "-Copt-level=3",
                 "-Cpanic=abort",
-                # Keep symbols + debug info in the release binary: the crash
-                # handler prints ASLR-relative offsets that then resolve to
-                # function names and file:line against the shipped binary
-                # (`addr2line`). Stripping would leave crash reports
-                # unsymbolizable (only ~5% larger; worth it for self-diagnosis).
-                "-Cstrip=none",
-            ],
+            ] + release_rustc_flags,
             "//conditions:default": [
                 "-Ccodegen-units=1",
                 "-Copt-level=3",
@@ -95,7 +93,7 @@ def rust_library(name, rustc_env_files = [], version_key = "", crate_features = 
                 "-Ccodegen-units=1",
                 "-Copt-level=3",
                 "-Cpanic=abort",
-                "-Cstrip=none",
+                "-Cstrip=symbols",
             ],
             "//conditions:default": [
                 "-Ccodegen-units=1",
@@ -123,7 +121,7 @@ def rust_proc_macro(name, crate_features = [], **kwargs):
                 "-Ccodegen-units=1",
                 "-Copt-level=3",
                 "-Cpanic=abort",
-                "-Cstrip=none",
+                "-Cstrip=symbols",
             ],
             "//conditions:default": [
                 "-Ccodegen-units=1",

--- a/bazel/rust/multi_platform_rust_binaries.bzl
+++ b/bazel/rust/multi_platform_rust_binaries.bzl
@@ -9,6 +9,18 @@ load("//bazel/release:hashes.bzl", "hashes")
 
 opt_filegroup, _ = with_cfg(native.filegroup).set("compilation_mode", "opt").build()
 
+# Rebuilds everything in the graph — including third-party crates such as
+# starlark — with debug assertions on. `rustc_flags` on a single `rust_binary`
+# only reaches that crate, so a flag set there would leave `debug_assert!` off
+# in every dependency, which is where most of the interesting checks live
+# (starlark's arena bounds checks in particular). A transition on the global
+# rules_rust setting is what applies through the dependency graph.
+debug_assertions_filegroup, _debug_assertions_cfg = (
+    with_cfg(native.filegroup)
+        .extend(Label("@rules_rust//rust/settings:extra_rustc_flags"), ["-Cdebug-assertions=y"])
+        .build()
+)
+
 TARGET_TRIPLES = [
     ("x86_64-unknown-linux-musl", "linux_x86_64_musl"),
     ("aarch64-unknown-linux-musl", "linux_aarch64_musl"),
@@ -19,7 +31,7 @@ TARGET_TRIPLES = [
 # Map a Rust naming scheme to a custom name.
 TARGET_NAMING_SCHEME = {}
 
-def multi_platform_rust_binaries(name, target, name_scheme = TARGET_NAMING_SCHEME, target_triples = TARGET_TRIPLES, prefix = "", pkg_type = "zip", **kwargs):
+def multi_platform_rust_binaries(name, target, name_scheme = TARGET_NAMING_SCHEME, target_triples = TARGET_TRIPLES, prefix = "", pkg_type = "zip", debug_assertions = False, **kwargs):
     """The multi_platform_rust_binaries macro creates a filegroup containing rust binaries that are ready for release.
 
     Args:
@@ -29,6 +41,9 @@ def multi_platform_rust_binaries(name, target, name_scheme = TARGET_NAMING_SCHEM
         target_triples: Map of target tiples to the target platform to build for.
         prefix: An optional prefix added to the output rust binary file name.
         pkg_type: The packaging type that the {name}.packaged target outputs, can be one of 'zip' or 'tar'.
+        debug_assertions: Build every crate in the graph — dependencies
+            included — with `-Cdebug-assertions=y`. For a diagnostic variant of
+            a binary; see `debug_assertions_filegroup`.
         **kwargs: All other args, forwarded to the output filegroups.
     """
 
@@ -52,10 +67,19 @@ def multi_platform_rust_binaries(name, target, name_scheme = TARGET_NAMING_SCHEM
             tags = ["manual"],
         )
 
+        bin_src = transition_build
+        if debug_assertions:
+            bin_src = "{}_{}_debug_assertions".format(bin, target_naming)
+            debug_assertions_filegroup(
+                name = bin_src,
+                srcs = [transition_build],
+                tags = ["manual"],
+            )
+
         bin_name = "{}{}-{}".format(prefix, bin, target_naming)
         copy_file(
             name = "{}_bin".format(bin_name),
-            src = transition_build,
+            src = bin_src,
             out = bin_name,
             tags = ["manual"],
         )

--- a/crates/aspect-cli/BUILD.bazel
+++ b/crates/aspect-cli/BUILD.bazel
@@ -83,8 +83,11 @@ multi_platform_rust_binaries(
 #
 #   -Cstrip=none        keep symbols + debug info, so the crash handler's
 #                       ASLR-relative offsets resolve to function and file:line
-#   -Cdebug-assertions  enable `debug_assert!` (notably starlark's arena bounds
-#                       checks) and arithmetic overflow checks
+#   debug_assertions    a transition rebuilds the whole graph — dependencies
+#                       included — with `-Cdebug-assertions=y`, enabling
+#                       `debug_assert!` (notably starlark's arena bounds checks)
+#                       and arithmetic overflow checks
+#
 # The allocator's secure mode (guard pages, encoded free lists, double-free
 # detection) is on in both variants — Bazel's crate universe builds one
 # mimalloc for the whole graph, so it cannot be switched per target, and its
@@ -97,16 +100,14 @@ rust_binary(
     srcs = SRCS,
     compile_data = COMPILE_DATA,
     crate_root = "src/main.rs",
-    release_rustc_flags = [
-        "-Cstrip=none",
-        "-Cdebug-assertions=y",
-    ],
+    release_rustc_flags = ["-Cstrip=none"],
     version_key = "STABLE_MONOREPO_VERSION",
     deps = DEPS,
 )
 
 multi_platform_rust_binaries(
     name = "debug_bins",
+    debug_assertions = True,
     tags = ["no-macos"],
     target = ":aspect-cli-debug",
 )

--- a/crates/aspect-cli/BUILD.bazel
+++ b/crates/aspect-cli/BUILD.bazel
@@ -2,53 +2,61 @@ load("//bazel/release:release.bzl", "release")
 load("//bazel/rust:defs.bzl", "rust_binary", "rust_test")
 load("//bazel/rust:multi_platform_rust_binaries.bzl", "multi_platform_rust_binaries")
 
+# Shared by the primary binary and the `-debug-` diagnostic variant so the two
+# cannot drift apart.
+DEPS = [
+    "//crates/aspect-telemetry",
+    "//crates/axl-runtime",
+    "@crates//:anyhow",
+    "@crates//:backtrace",
+    "@crates//:base64",
+    "@crates//:chrono",
+    "@crates//:clap",
+    "@crates//:dirs",
+    "@crates//:include_dir",
+    "@crates//:libc",
+    "@crates//:libmimalloc-sys",
+    "@crates//:mimalloc",
+    "@crates//:names",
+    "@crates//:opentelemetry",
+    "@crates//:opentelemetry-appender-tracing",
+    "@crates//:opentelemetry-otlp",
+    "@crates//:opentelemetry-semantic-conventions",
+    "@crates//:opentelemetry_sdk",
+    "@crates//:rand",
+    "@crates//:reqwest",
+    "@crates//:serde",
+    "@crates//:serde_json",
+    "@crates//:sha2",
+    "@crates//:sha256",
+    "@crates//:starlark",
+    "@crates//:thiserror",
+    "@crates//:tokio",
+    "@crates//:tonic",
+    "@crates//:tracing",
+    "@crates//:tracing-core",
+    "@crates//:tracing-opentelemetry",
+    "@crates//:tracing-subscriber",
+    "@crates//:uuid",
+]
+
+SRCS = glob(["src/**/*.rs"])
+
+COMPILE_DATA = glob([
+    "src/builtins/**/*.axl",
+    "src/builtins/**/*.aspect",
+])
+
 rust_binary(
     name = "aspect-cli",
-    srcs = glob(["src/**/*.rs"]),
-    compile_data = glob([
-        "src/builtins/**/*.axl",
-        "src/builtins/**/*.aspect",
-    ]),
+    srcs = SRCS,
+    compile_data = COMPILE_DATA,
     version_key = "STABLE_MONOREPO_VERSION",
     visibility = [
         "//:__pkg__",
         "//examples/deliverable:__pkg__",
     ],
-    deps = [
-        "//crates/aspect-telemetry",
-        "//crates/axl-runtime",
-        "@crates//:anyhow",
-        "@crates//:backtrace",
-        "@crates//:base64",
-        "@crates//:chrono",
-        "@crates//:clap",
-        "@crates//:dirs",
-        "@crates//:include_dir",
-        "@crates//:libc",
-        "@crates//:libmimalloc-sys",
-        "@crates//:mimalloc",
-        "@crates//:names",
-        "@crates//:opentelemetry",
-        "@crates//:opentelemetry-appender-tracing",
-        "@crates//:opentelemetry-otlp",
-        "@crates//:opentelemetry-semantic-conventions",
-        "@crates//:opentelemetry_sdk",
-        "@crates//:rand",
-        "@crates//:reqwest",
-        "@crates//:serde",
-        "@crates//:serde_json",
-        "@crates//:sha2",
-        "@crates//:sha256",
-        "@crates//:starlark",
-        "@crates//:thiserror",
-        "@crates//:tokio",
-        "@crates//:tonic",
-        "@crates//:tracing",
-        "@crates//:tracing-core",
-        "@crates//:tracing-opentelemetry",
-        "@crates//:tracing-subscriber",
-        "@crates//:uuid",
-    ],
+    deps = DEPS,
 )
 
 rust_test(
@@ -59,7 +67,7 @@ rust_test(
     ]),
     crate = ":aspect-cli",
     deps = [
-        "@crates//:tempfile",
+    "@crates//:tempfile",
     ],
 )
 
@@ -69,8 +77,45 @@ multi_platform_rust_binaries(
     target = ":aspect-cli",
 )
 
+# Diagnostic variant, released alongside the primary binary as
+# `aspect-cli-debug-<triple>`. Identical code, built to fail loudly instead of
+# fast, for reproducing a crash that the stripped release build cannot explain:
+#
+#   -Cstrip=none        keep symbols + debug info, so the crash handler's
+#                       ASLR-relative offsets resolve to function and file:line
+#   -Cdebug-assertions  enable `debug_assert!` (notably starlark's arena bounds
+#                       checks) and arithmetic overflow checks
+# The allocator's secure mode (guard pages, encoded free lists, double-free
+# detection) is on in both variants — Bazel's crate universe builds one
+# mimalloc for the whole graph, so it cannot be switched per target, and its
+# cost is ~7% on an allocation-heavy workload with no size change.
+#
+# Larger and slower than the primary binary; not what `aspect` installs by
+# default.
+rust_binary(
+    name = "aspect-cli-debug",
+    srcs = SRCS,
+    compile_data = COMPILE_DATA,
+    crate_root = "src/main.rs",
+    release_rustc_flags = [
+        "-Cstrip=none",
+        "-Cdebug-assertions=y",
+    ],
+    version_key = "STABLE_MONOREPO_VERSION",
+    deps = DEPS,
+)
+
+multi_platform_rust_binaries(
+    name = "debug_bins",
+    tags = ["no-macos"],
+    target = ":aspect-cli-debug",
+)
+
 release(
     name = "release",
     tags = ["no-macos"],
-    targets = [":bins"],
+    targets = [
+        ":bins",
+        ":debug_bins",
+    ],
 )

--- a/crates/aspect-cli/BUILD.bazel
+++ b/crates/aspect-cli/BUILD.bazel
@@ -67,7 +67,7 @@ rust_test(
     ]),
     crate = ":aspect-cli",
     deps = [
-    "@crates//:tempfile",
+        "@crates//:tempfile",
     ],
 )
 

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -15,25 +15,23 @@ mod trace_buffer;
 /// per-thread free lists, so the BES/sink/probe threads stop contending with
 /// the Starlark thread on every allocation.
 ///
-/// Built with mimalloc's `secure` feature (`MI_SECURE=4`): guard pages around
+/// Built in mimalloc's secure mode (`MI_SECURE=4`): guard pages around
 /// metadata, encoded free lists, randomized placement, and double-free
-/// detection.
-///
-/// This preserves a property we would otherwise lose. musl's mallocng
-/// validates a check byte on every allocation, so heap corruption aborted the
-/// process by itself; a default mimalloc build performs no equivalent check
-/// and would let the same corruption pass unnoticed. The secure build restores
-/// that detection.
-///
-/// [`install_allocator_error_handler`] makes those detections fatal.
+/// detection. That restores a property the platform allocator gave us for free
+/// — musl's mallocng validates a check byte on every allocation, so heap
+/// corruption aborted the process by itself, whereas a default mimalloc build
+/// performs no equivalent check and would let the same corruption pass
+/// silently. Costs roughly 7% on an allocation-heavy workload, with no change
+/// in binary size. See [`install_allocator_error_handler`], which makes any
+/// detection fatal rather than merely reported.
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 /// Abort the process when mimalloc detects heap corruption.
 ///
 /// mimalloc's built-in handling is not sufficient on its own. It aborts only
-/// on `EFAULT` (corrupted metadata, corrupted thread-free list, and — under
-/// the `secure` build — a detected buffer overflow), while a double free
+/// on `EFAULT` (corrupted metadata, corrupted thread-free list, and — in
+/// secure mode — a detected buffer overflow), while a double free
 /// (`EAGAIN`) or a free of an invalid pointer (`EINVAL`) is reported and then
 /// execution *continues*. Continuing on a corrupted heap is what makes this
 /// class of bug so hard to trace: the eventual crash lands somewhere


### PR DESCRIPTION
Move debug diagnostics into a separate -debug- variant binary.

- `.bazelrc` applied `-Cdebug-assertions=y` to every release crate (+3.4MB, plus arithmetic-overflow-check runtime), introduced in #1352 as "one diagnostic release";
- `-Cstrip=none` (from #1348) shipped full symbols and debug info in the release binary.

Both are reverted for the primary binary, which drops **53MB → 37MB** on x86_64 musl.

The symbols were genuinely useful, though — they are what makes the crash handler's ASLR-relative offsets resolve to a function and file:line — so rather than lose that capability they move to a second binary, released alongside the first:

| artifact | size | build |
|---|---|---|
| `aspect-cli-<triple>` | 37MB | stripped, assertions off |
| `aspect-cli-debug-<triple>` | 53MB | `-Cstrip=none`, plus `-Cdebug-assertions=y` across the whole dependency graph |

Same code, same version, built for different priorities. When a crash in the primary binary can't be explained, run the `-debug-` one: its offsets symbolize with `addr2line -fe aspect-cli-debug <offset>`, and `debug_assert!`s (notably starlark's arena bounds checks) are live.

`rust_binary` grows a `release_rustc_flags` argument (used here for `-Cstrip=none`, which only concerns the final link) and `aspect-cli`'s `srcs`/`compile_data`/`deps` are hoisted into shared lists so the variants cannot drift apart.

Debug assertions need a different mechanism: `rustc_flags` on a `rust_binary` applies to that crate only, so setting it there would leave `debug_assert!` off in every dependency — including starlark, where the arena bounds checks this variant exists to enable actually live. `multi_platform_rust_binaries` therefore gained a `debug_assertions` parameter that wraps the platform-transitioned target in a `with_cfg` transition extending the global `@rules_rust//rust/settings:extra_rustc_flags`, which does propagate through the graph. Verified by aquery on the release config: **377** target-config Rustc actions carry the flag in the debug graph (starlark included) versus **0** in the primary graph.

**The allocator's secure mode stays on in both**, deliberately. It is what turns silent heap corruption into an abort — replacing a check musl's mallocng performed for free on every allocation. It also cannot be switched per target: Bazel's crate universe builds one mimalloc for the whole graph, so a per-target `crate_features` has no effect on a third-party dep's cargo features. Measured cost is ~7% on an allocation-heavy workload (0.38s → 0.41s on the AXL suite) with no change in binary size, which is worth paying to catch memory issues with the Rust Starlark heap.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (the variant is self-describing in the release asset list; rationale is on the targets)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- perf: the release binary is ~30% smaller again (53MB → 37MB on Linux x86_64) now that the temporary debug assertions and debug symbols added for a crash investigation have been removed.
- feat: releases now also publish `aspect-cli-debug-<platform>` — the same version built with debug symbols and assertions enabled. Use it to get a symbolized backtrace when diagnosing a crash; the default binary is unchanged for normal use.

### Test plan

- Covered by existing test cases (full AXL suite: 910 passing; crash-handler suite: 6 passing, including the allocator-corruption abort).
- Manual, on `x86_64-unknown-linux-musl` release builds of both variants:
  - primary is 37MB with no `symtab`/`debug_line` sections; debug is 49MB with both;
  - both run (`aspect --version`) and both retain the allocator's secure detectors;
  - a crash in the debug variant resolves its printed offset back to a real symbol via `addr2line` (`aspect_cli_debug::main`).

