### PR TITLE
feat(launcher): download the -debug- CLI variant when ASPECT_DEBUG_CLI is set

### DIFF
--- a/.github/workflows/launcher-integration-tests.yaml
+++ b/.github/workflows/launcher-integration-tests.yaml
@@ -1,5 +1,4 @@
 name: Launcher Integration Tests
-
 on:
   push:
     branches: [main]
@@ -9,11 +8,9 @@ on:
       - crates/aspect-launcher/**
       - crates/aspect-telemetry/**
   workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-
 jobs:
   integration-tests:
     name: Integration tests (${{ matrix.os }})
@@ -22,16 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-
     env:
       ASPECT_LAUNCHER_CACHE: /tmp/aspect-launcher-ci-cache
       CARGO_TERM_COLOR: always
       # Use the workflow's GITHUB_TOKEN to avoid rate-limiting on the releases API
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     steps:
       - uses: actions/checkout@v6
-
       - name: Cache cargo registry and build artifacts
         uses: actions/cache@v5
         with:
@@ -42,7 +36,6 @@ jobs:
           key: ${{ runner.os }}-cargo-launcher-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-launcher-
-
       # The published aspect-cli artifacts are named after the Rust target triple
       # (e.g. aspect-cli-x86_64-unknown-linux-musl). LLVM_TRIPLE is baked into
       # the launcher at compile time via build.rs. In production the launcher is
@@ -56,14 +49,11 @@ jobs:
           sudo apt-get install -y musl-tools
           rustup target add x86_64-unknown-linux-musl
           echo "CARGO_TARGET_ARGS=--target x86_64-unknown-linux-musl" >> "$GITHUB_ENV"
-
       - name: Build launcher
         run: cargo build -p aspect-launcher $CARGO_TARGET_ARGS
-
       # ── Test 1: Unpinned first run ────────────────────────────────────────────
       # Fresh cache, no version.axl → must query the releases API and download
       # the latest stable (non-prerelease) release.
-
       - name: "Test 1: Unpinned first run queries releases API"
         run: |
           mkdir -p /tmp/axl-test
@@ -75,10 +65,8 @@ jobs:
           # Must resolve to a stable vYYYY.WW.P tag, not a prerelease
           echo "$output" | grep -q 'downloading aspect cli version v[0-9]' \
             || { echo "FAIL: expected stable version download"; exit 1; }
-
       # ── Test 2: Warm cache ────────────────────────────────────────────────────
       # Hint is fresh, binary is present → no network call.
-
       - name: "Test 2: Warm cache skips API"
         run: |
           output=$(cd /tmp/axl-test && ASPECT_DEBUG=1 \
@@ -89,10 +77,8 @@ jobs:
           if echo "$output" | grep -q "querying releases"; then
             echo "FAIL: should not query API on warm cache"; exit 1
           fi
-
       # ── Test 3: Stale hint ────────────────────────────────────────────────────
       # Backdate hint mtime → must re-query API, then reuse the already-cached binary.
-
       - name: "Test 3: Stale hint triggers API re-query"
         run: |
           python3 -c "
@@ -111,10 +97,8 @@ jobs:
           if echo "$output" | grep -q "^downloading "; then
             echo "FAIL: should not re-download when binary is cached"; exit 1
           fi
-
       # ── Test 4: API failure fallback ──────────────────────────────────────────
       # Stale hint + bad token → must fall back to cached binary and reset expiry.
-
       - name: "Test 4: API failure falls back to stale cached binary"
         run: |
           python3 -c "
@@ -128,10 +112,8 @@ jobs:
           echo "$output"
           echo "$output" | grep -q "API error, falling back to stale cached tag" \
             || { echo "FAIL: expected stale fallback message"; exit 1; }
-
       # ── Test 5: Pinned version (first run) ────────────────────────────────────
       # version.axl with an explicit version → resolve tag directly, no API call.
-
       - name: "Test 5: Pinned version downloads directly without API call"
         run: |
           mkdir -p /tmp/axl-test-pinned/.aspect
@@ -145,10 +127,8 @@ jobs:
           if echo "$output" | grep -q "querying releases"; then
             echo "FAIL: pinned version should not query API"; exit 1
           fi
-
       # ── Test 6: Pinned version (cache hit) ────────────────────────────────────
       # Same pinned version, second run → cache hit, no download, no API call.
-
       - name: "Test 6: Pinned version cache hit"
         run: |
           output=$(cd /tmp/axl-test-pinned && ASPECT_DEBUG=1 \
@@ -159,13 +139,11 @@ jobs:
           if echo "$output" | grep -q "^downloading "; then
             echo "FAIL: should not re-download on cache hit"; exit 1
           fi
-
       # ── Test 7: Debug variant ─────────────────────────────────────────────────
       # ASPECT_DEBUG_CLI → fetch aspect-cli-debug-<triple> instead of the primary
       # binary. Pinned to the first release that published the variant. Note that
       # ASPECT_DEBUG (set by every test above) must NOT have this effect: it means
       # verbose logging only, and the versions pinned above predate the variant.
-
       - name: "Test 7: ASPECT_DEBUG_CLI downloads the debug variant"
         run: |
           mkdir -p /tmp/axl-test-debug/.aspect
@@ -176,10 +154,8 @@ jobs:
           echo "$output"
           echo "$output" | grep -q "aspect-cli-debug-" \
             || { echo "FAIL: expected the -debug- artifact"; exit 1; }
-
       # Same workspace without ASPECT_DEBUG_CLI → primary binary, and a separate
       # cache entry, so the debug run above cannot have overwritten it.
-
       - name: "Test 8: Without ASPECT_DEBUG_CLI the primary binary is used"
         run: |
           output=$(cd /tmp/axl-test-debug && ASPECT_DEBUG=1 \

--- a/.github/workflows/launcher-integration-tests.yaml
+++ b/.github/workflows/launcher-integration-tests.yaml
@@ -140,10 +140,8 @@ jobs:
             echo "FAIL: should not re-download on cache hit"; exit 1
           fi
       # ── Test 7: Debug variant ─────────────────────────────────────────────────
-      # ASPECT_DEBUG_CLI → fetch aspect-cli-debug-<triple> instead of the primary
-      # binary. Pinned to the first release that published the variant. Note that
-      # ASPECT_DEBUG (set by every test above) must NOT have this effect: it means
-      # verbose logging only, and the versions pinned above predate the variant.
+      # ASPECT_DEBUG_CLI → download aspect-cli-debug-<triple>. Pinned to the first
+      # release that published the variant, so no fallback should occur.
       - name: "Test 7: ASPECT_DEBUG_CLI downloads the debug variant"
         run: |
           mkdir -p /tmp/axl-test-debug/.aspect
@@ -152,10 +150,14 @@ jobs:
           output=$(cd /tmp/axl-test-debug && ASPECT_DEBUG=1 ASPECT_DEBUG_CLI=1 \
             cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1) || true
           echo "$output"
-          echo "$output" | grep -q "aspect-cli-debug-" \
-            || { echo "FAIL: expected the -debug- artifact"; exit 1; }
-      # Same workspace without ASPECT_DEBUG_CLI → primary binary, and a separate
-      # cache entry, so the debug run above cannot have overwritten it.
+          echo "$output" | grep -qE "^downloading .* file aspect-cli-debug-" \
+            || { echo "FAIL: expected to download the -debug- artifact"; exit 1; }
+          if echo "$output" | grep -q "falling back"; then
+            echo "FAIL: the variant exists in this release; should not fall back"; exit 1
+          fi
+      # ASPECT_DEBUG alone must not change which binary is used: it means verbose
+      # logging only. Same workspace as test 7, so a distinct cache entry is also
+      # asserted -- the debug run must not have overwritten the primary binary.
       - name: "Test 8: Without ASPECT_DEBUG_CLI the primary binary is used"
         run: |
           output=$(cd /tmp/axl-test-debug && ASPECT_DEBUG=1 \
@@ -163,4 +165,28 @@ jobs:
           echo "$output"
           if echo "$output" | grep -q "aspect-cli-debug-"; then
             echo "FAIL: ASPECT_DEBUG alone must not select the debug variant"; exit 1
+          fi
+      # ── Test 9: Missing variant falls back ────────────────────────────────────
+      # Releases before v2026.31.10 publish no debug asset. A pinned tag is resolved
+      # without consulting the asset list, so the launcher must recover by serving the
+      # primary binary instead of failing.
+      - name: "Test 9: Missing debug variant falls back to the primary binary"
+        run: |
+          mkdir -p /tmp/axl-test-nodebug/.aspect
+          printf 'version("2026.15.2")\n' > /tmp/axl-test-nodebug/.aspect/version.axl
+          touch /tmp/axl-test-nodebug/MODULE.bazel
+          # Unlike the tests above, the exit status matters here: the fallback has to
+          # leave the launcher working, so this must not be swallowed with `|| true`.
+          if ! output=$(cd /tmp/axl-test-nodebug && ASPECT_DEBUG=1 ASPECT_DEBUG_CLI=1 \
+            cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1); then
+            echo "$output"
+            echo "FAIL: launcher should succeed via fallback"; exit 1
+          fi
+          echo "$output"
+          echo "$output" | grep -q "falling back to aspect-cli-" \
+            || { echo "FAIL: expected a fallback message"; exit 1; }
+          echo "$output" | grep -qE "^downloading .* file aspect-cli-" \
+            || { echo "FAIL: expected an artifact download"; exit 1; }
+          if echo "$output" | grep -qE "^downloading .* file aspect-cli-debug-"; then
+            echo "FAIL: the fallback must download the primary artifact"; exit 1
           fi

--- a/.github/workflows/launcher-integration-tests.yaml
+++ b/.github/workflows/launcher-integration-tests.yaml
@@ -159,3 +159,32 @@ jobs:
           if echo "$output" | grep -q "^downloading "; then
             echo "FAIL: should not re-download on cache hit"; exit 1
           fi
+
+      # ── Test 7: Debug variant ─────────────────────────────────────────────────
+      # ASPECT_DEBUG_CLI → fetch aspect-cli-debug-<triple> instead of the primary
+      # binary. Pinned to the first release that published the variant. Note that
+      # ASPECT_DEBUG (set by every test above) must NOT have this effect: it means
+      # verbose logging only, and the versions pinned above predate the variant.
+
+      - name: "Test 7: ASPECT_DEBUG_CLI downloads the debug variant"
+        run: |
+          mkdir -p /tmp/axl-test-debug/.aspect
+          printf 'version("2026.31.10")\n' > /tmp/axl-test-debug/.aspect/version.axl
+          touch /tmp/axl-test-debug/MODULE.bazel
+          output=$(cd /tmp/axl-test-debug && ASPECT_DEBUG=1 ASPECT_DEBUG_CLI=1 \
+            cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1) || true
+          echo "$output"
+          echo "$output" | grep -q "aspect-cli-debug-" \
+            || { echo "FAIL: expected the -debug- artifact"; exit 1; }
+
+      # Same workspace without ASPECT_DEBUG_CLI → primary binary, and a separate
+      # cache entry, so the debug run above cannot have overwritten it.
+
+      - name: "Test 8: Without ASPECT_DEBUG_CLI the primary binary is used"
+        run: |
+          output=$(cd /tmp/axl-test-debug && ASPECT_DEBUG=1 \
+            cargo run --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" -p aspect-launcher $CARGO_TARGET_ARGS -- version 2>&1) || true
+          echo "$output"
+          if echo "$output" | grep -q "aspect-cli-debug-"; then
+            echo "FAIL: ASPECT_DEBUG alone must not select the debug variant"; exit 1
+          fi

--- a/.github/workflows/launcher-integration-tests.yaml
+++ b/.github/workflows/launcher-integration-tests.yaml
@@ -185,8 +185,18 @@ jobs:
           echo "$output"
           echo "$output" | grep -q "falling back to aspect-cli-" \
             || { echo "FAIL: expected a fallback message"; exit 1; }
-          echo "$output" | grep -qE "^downloading .* file aspect-cli-" \
-            || { echo "FAIL: expected an artifact download"; exit 1; }
           if echo "$output" | grep -qE "^downloading .* file aspect-cli-debug-"; then
-            echo "FAIL: the fallback must download the primary artifact"; exit 1
+            echo "FAIL: the fallback must not download the debug artifact"; exit 1
           fi
+          # The primary binary for this pin may already be cached by test 5, so the
+          # fallback either downloads it or serves it from cache. Assert on the binary it
+          # provisioned instead, which holds either way: cache paths are keyed on the
+          # download URL, so the debug entry it first tried and the primary entry it
+          # settled on are different directories.
+          attempted=$(echo "$output" | sed -nE 's/.*downloading "[^"]*aspect-cli-debug-[^"]*" to "([^"]*)".*/\1/p' | head -1)
+          provisioned=$(echo "$output" | sed -nE 's/^provisioned at "([^"]*)".*/\1/p' | head -1)
+          echo "attempted=$attempted"
+          echo "provisioned=$provisioned"
+          [ -n "$provisioned" ] || { echo "FAIL: no provisioned path in output"; exit 1; }
+          [ "$provisioned" != "$attempted" ] \
+            || { echo "FAIL: provisioned the debug cache entry, not the primary"; exit 1; }

--- a/crates/aspect-launcher/README.md
+++ b/crates/aspect-launcher/README.md
@@ -185,3 +185,16 @@ environment variable; the launcher writes its downloader cache to
 ## Debugging
 
 Set `ASPECT_DEBUG=1` to enable verbose logging of the download and caching flow.
+
+Set `ASPECT_DEBUG_CLI=1` to run the `aspect-cli-debug-<target>` release variant
+instead of the primary binary. It is the same code built to fail loudly rather
+than fast — unstripped, so a crash report resolves to function and `file:line`,
+and with debug assertions enabled across the dependency graph. Expect a larger
+download and slower execution, so prefer it only while reproducing a crash.
+
+The variant is cached separately from the primary binary, so switching back and
+forth does not re-download either one. Releases before v2026.31.10 do not
+publish it; on those the launcher logs the fallback and uses the primary binary.
+
+This only applies when the source does not name an `artifact` explicitly — a
+configured artifact name is used verbatim.

--- a/crates/aspect-launcher/src/cache.rs
+++ b/crates/aspect-launcher/src/cache.rs
@@ -121,6 +121,25 @@ mod tests {
         assert_ne!(path1, path2);
     }
 
+    /// The tool name is the same (`aspect-cli`) for both the primary and the
+    /// `-debug-` release variant, so their cache entries are kept apart only by the
+    /// artifact name embedded in the download URL. If this ever stopped holding, a
+    /// debug run would overwrite the primary binary at the same path.
+    #[test]
+    fn test_tool_path_separates_debug_variant() {
+        let cache = AspectCache::from(PathBuf::from("/tmp/cache"));
+        let base = "https://github.com/aspect-build/aspect-cli/releases/download/v2026.31.10";
+        let primary = cache.tool_path(
+            &"aspect-cli".to_string(),
+            &format!("{base}/aspect-cli-x86_64-unknown-linux-musl"),
+        );
+        let debug = cache.tool_path(
+            &"aspect-cli".to_string(),
+            &format!("{base}/aspect-cli-debug-x86_64-unknown-linux-musl"),
+        );
+        assert_ne!(primary, debug);
+    }
+
     #[test]
     fn test_tool_path_different_names_differ() {
         let cache = AspectCache::from(PathBuf::from("/tmp/cache"));

--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -47,12 +47,24 @@ fn debug_mode() -> bool {
     }
 }
 
+/// Whether to fetch the `-debug-` release variant instead of the primary binary.
+///
+/// Deliberately a separate knob from [`debug_mode`]: `ASPECT_DEBUG` only turns on the
+/// launcher's own verbose logging, and is set routinely (our integration tests set it
+/// on every run) where silently swapping in a bigger, slower binary — one that does
+/// not exist in releases before v2026.31.10 — would be a surprise.
+fn debug_cli_mode() -> bool {
+    match var("ASPECT_DEBUG_CLI") {
+        Ok(val) => !val.is_empty(),
+        _ => false,
+    }
+}
+
 /// Default release asset name for a tool, e.g. `aspect-cli-x86_64-unknown-linux-musl`.
 ///
-/// Under `ASPECT_DEBUG` this selects the `-debug-` variant published alongside the
-/// primary binary (unstripped, with debug assertions enabled graph-wide) so that a
-/// crash report from a debug run resolves to function and file:line. The variant is
-/// larger and slower, which is why it is opt-in.
+/// With `debug` set this selects the `-debug-` variant published alongside the primary
+/// binary (unstripped, with debug assertions enabled graph-wide) so that a crash report
+/// resolves to function and file:line. The variant is larger and slower, hence opt-in.
 ///
 /// Only used when the config did not name an `artifact` explicitly; an explicit name
 /// is passed through untouched, since we cannot know whether a debug counterpart of
@@ -330,9 +342,9 @@ async fn configure_tool_task(
 
                     // True only when we picked the `-debug-` name ourselves, which is
                     // what lets the download failure below explain a missing variant.
-                    let chose_debug_variant = artifact.is_empty() && debug_mode();
+                    let chose_debug_variant = artifact.is_empty() && debug_cli_mode();
                     let artifact = if artifact.is_empty() {
-                        default_artifact(repo, debug_mode())
+                        default_artifact(repo, debug_cli_mode())
                     } else {
                         replace_vars(artifact, version_for_vars)
                     };
@@ -602,7 +614,7 @@ async fn configure_tool_task(
                             errs.push(Err(e.wrap_err(format!(
                                 "{artifact} not found in {resolved_tag}; the debug variant is \
                                  only published in releases from v2026.31.10 on. Unset \
-                                 ASPECT_DEBUG or use a newer version."
+                                 ASPECT_DEBUG_CLI or use a newer version."
                             ))));
                         } else {
                             errs.push(Err(e));

--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -49,10 +49,8 @@ fn debug_mode() -> bool {
 
 /// Whether to fetch the `-debug-` release variant instead of the primary binary.
 ///
-/// Deliberately a separate knob from [`debug_mode`]: `ASPECT_DEBUG` only turns on the
-/// launcher's own verbose logging, and is set routinely (our integration tests set it
-/// on every run) where silently swapping in a bigger, slower binary — one that does
-/// not exist in releases before v2026.31.10 — would be a surprise.
+/// Separate from [`debug_mode`] on purpose: `ASPECT_DEBUG` requests verbose logging and
+/// is set routinely, so it must not also swap in a larger, slower binary.
 fn debug_cli_mode() -> bool {
     match var("ASPECT_DEBUG_CLI") {
         Ok(val) => !val.is_empty(),
@@ -62,19 +60,24 @@ fn debug_cli_mode() -> bool {
 
 /// Default release asset name for a tool, e.g. `aspect-cli-x86_64-unknown-linux-musl`.
 ///
-/// With `debug` set this selects the `-debug-` variant published alongside the primary
-/// binary (unstripped, with debug assertions enabled graph-wide) so that a crash report
-/// resolves to function and file:line. The variant is larger and slower, hence opt-in.
+/// With `debug` set, names the `-debug-` variant published alongside the primary binary:
+/// unstripped and built with debug assertions, so a crash report resolves to function
+/// and file:line at the cost of size and speed.
 ///
-/// Only used when the config did not name an `artifact` explicitly; an explicit name
-/// is passed through untouched, since we cannot know whether a debug counterpart of
-/// someone else's asset exists.
+/// Only used when the config did not name an `artifact` explicitly, since a debug
+/// counterpart of an arbitrary asset may not exist.
 fn default_artifact(repo: &str, debug: bool) -> String {
     if debug {
         format!("{}-debug-{}", repo, LLVM_TRIPLE)
     } else {
         format!("{}-{}", repo, LLVM_TRIPLE)
     }
+}
+
+/// Direct download URL for a release asset. Also the cache key for the downloaded
+/// binary, so every caller must build it the same way.
+fn release_asset_url(org: &str, repo: &str, tag: &str, artifact: &str) -> String {
+    format!("https://github.com/{org}/{repo}/releases/download/{tag}/{artifact}")
 }
 
 const ASPECT_LAUNCHER_METHOD_HTTP: &str = "http";
@@ -203,6 +206,40 @@ async fn _download_into_cache(
 
     // FIXME: Check download integrity/signatures?
     Ok(())
+}
+
+/// Retry up to 3 times with exponential backoff (0s, 1s, 2s) to survive transient
+/// failures such as a mid-stream connection reset.
+async fn download_with_retries(
+    client: &Client,
+    url: &str,
+    dest: &PathBuf,
+    download_msg: &str,
+) -> Result<()> {
+    const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
+    let mut last_err = None;
+    for attempt in 0..MAX_DOWNLOAD_ATTEMPTS {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_secs(1 << (attempt - 1))).await;
+            eprintln!(
+                "retrying download (attempt {}/{})",
+                attempt + 1,
+                MAX_DOWNLOAD_ATTEMPTS
+            );
+        }
+        let req = gh_request(client, url.to_owned())
+            .header(
+                HeaderName::from_static("accept"),
+                HeaderValue::from_static("application/octet-stream"),
+            )
+            .build()
+            .into_diagnostic()?;
+        match _download_into_cache(client, dest, req, download_msg).await {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.expect("at least one attempt must have run"))
 }
 
 #[derive(Deserialize, Debug)]
@@ -340,11 +377,11 @@ async fn configure_tool_task(
                     let pinned_version = tool.version();
                     let version_for_vars = pinned_version.unwrap_or(&fallback_version);
 
-                    // True only when we picked the `-debug-` name ourselves, which is
-                    // what lets the download failure below explain a missing variant.
+                    // Gates the fallback below: only a name we chose has a known primary
+                    // counterpart to fall back to.
                     let chose_debug_variant = artifact.is_empty() && debug_cli_mode();
                     let artifact = if artifact.is_empty() {
-                        default_artifact(repo, debug_cli_mode())
+                        default_artifact(repo, chose_debug_variant)
                     } else {
                         replace_vars(artifact, version_for_vars)
                     };
@@ -376,9 +413,8 @@ async fn configure_tool_task(
                         if cache.latest_tag_is_fresh(&hint_path, HINT_MAX_AGE) {
                             if let Ok(cached_tag) = fs::read_to_string(&hint_path) {
                                 let cached_tag = cached_tag.trim().to_owned();
-                                let cached_url = format!(
-                                    "https://github.com/{org}/{repo}/releases/download/{cached_tag}/{artifact}"
-                                );
+                                let cached_url =
+                                    release_asset_url(org, repo, &cached_tag, &artifact);
                                 let cached_dest = cache.tool_path(&tool.name(), &cached_url);
                                 if cached_dest.exists() {
                                     if debug_mode() {
@@ -456,9 +492,7 @@ async fn configure_tool_task(
                             // fall back to it and touch the hint so we don't hammer a down API.
                             if let Ok(stale_tag) = fs::read_to_string(&hint_path) {
                                 let stale_tag = stale_tag.trim().to_owned();
-                                let stale_url = format!(
-                                    "https://github.com/{org}/{repo}/releases/download/{stale_tag}/{artifact}"
-                                );
+                                let stale_url = release_asset_url(org, repo, &stale_tag, &artifact);
                                 let stale_dest = cache.tool_path(&tool.name(), &stale_url);
                                 if stale_dest.exists() {
                                     if debug_mode() {
@@ -525,11 +559,8 @@ async fn configure_tool_task(
                     };
 
                     // Step 2: Download from the direct release URL using the resolved tag.
-                    let direct_url = format!(
-                        "https://github.com/{org}/{repo}/releases/download/{resolved_tag}/{artifact}"
-                    );
-
-                    let tool_dest_file = cache.tool_path(&tool.name(), &direct_url);
+                    let mut direct_url = release_asset_url(org, repo, &resolved_tag, &artifact);
+                    let mut tool_dest_file = cache.tool_path(&tool.name(), &direct_url);
                     let mut extra_envs = HashMap::new();
                     extra_envs.insert("ASPECT_LAUNCHER_ASPECT_CLI_ORG".to_string(), org.clone());
                     extra_envs.insert("ASPECT_LAUNCHER_ASPECT_CLI_REPO".to_string(), repo.clone());
@@ -567,58 +598,50 @@ async fn configure_tool_task(
                             tool_dest_file
                         );
                     };
-                    let download_msg = format!(
-                        "downloading aspect cli version {} file {}",
-                        resolved_tag, artifact
-                    );
+                    let download_msg =
+                        |a: &str| format!("downloading aspect cli version {resolved_tag} file {a}");
 
-                    // Retry up to 3 times with exponential backoff (0 s, 1 s, 2 s) to
-                    // survive transient failures such as a mid-stream connection reset.
-                    const MAX_DOWNLOAD_ATTEMPTS: u32 = 3;
-                    let mut download_err: Option<miette::Error> = None;
-                    for attempt in 0..MAX_DOWNLOAD_ATTEMPTS {
-                        if attempt > 0 {
-                            let delay = std::time::Duration::from_secs(1 << (attempt - 1));
-                            tokio::time::sleep(delay).await;
-                            eprintln!(
-                                "retrying download (attempt {}/{})",
-                                attempt + 1,
-                                MAX_DOWNLOAD_ATTEMPTS
-                            );
-                        }
-                        let req = gh_request(&client, direct_url.clone())
-                            .header(
-                                HeaderName::from_static("accept"),
-                                HeaderValue::from_static("application/octet-stream"),
-                            )
-                            .build()
-                            .into_diagnostic()?;
-                        match _download_into_cache(&client, &tool_dest_file, req, &download_msg)
-                            .await
-                        {
-                            Ok(()) => {
-                                download_err = None;
-                                break;
-                            }
-                            Err(e) => {
-                                download_err = Some(e);
-                            }
-                        }
-                    }
-                    if let Some(e) = download_err {
-                        // The `-debug-` variant only exists in releases from v2026.31.10
-                        // on. A pinned older version resolves its tag without consulting
-                        // the asset list, so the first sign of a missing variant is a 404
-                        // here; say so rather than leaving a bare HTTP status.
-                        if chose_debug_variant {
-                            errs.push(Err(e.wrap_err(format!(
-                                "{artifact} not found in {resolved_tag}; the debug variant is \
-                                 only published in releases from v2026.31.10 on. Unset \
-                                 ASPECT_DEBUG_CLI or use a newer version."
-                            ))));
+                    let mut download_err = download_with_retries(
+                        &client,
+                        &direct_url,
+                        &tool_dest_file,
+                        &download_msg(&artifact),
+                    )
+                    .await
+                    .err();
+
+                    // A pinned tag is resolved without consulting the asset list, so a
+                    // release that predates the `-debug-` variant only fails here. Serve
+                    // the primary binary rather than no CLI at all.
+                    if download_err.is_some() && chose_debug_variant {
+                        let primary = default_artifact(repo, false);
+                        eprintln!(
+                            "{artifact} is unavailable in {resolved_tag}; falling back to {primary}"
+                        );
+                        direct_url = release_asset_url(org, repo, &resolved_tag, &primary);
+                        tool_dest_file = cache.tool_path(&tool.name(), &direct_url);
+                        extra_envs.insert(
+                            "ASPECT_LAUNCHER_ASPECT_CLI_ARTIFACT".to_string(),
+                            primary.clone(),
+                        );
+                        download_err = if tool_dest_file.exists() {
+                            None
                         } else {
-                            errs.push(Err(e));
-                        }
+                            fs::create_dir_all(tool_dest_file.parent().unwrap())
+                                .into_diagnostic()?;
+                            download_with_retries(
+                                &client,
+                                &direct_url,
+                                &tool_dest_file,
+                                &download_msg(&primary),
+                            )
+                            .await
+                            .err()
+                        };
+                    }
+
+                    if let Some(e) = download_err {
+                        errs.push(Err(e));
                         continue;
                     }
                     return Ok((
@@ -841,6 +864,40 @@ mod tests {
         );
     }
 
+    /// The debug variant's fallback target is the primary name for the same release, so
+    /// the two must differ only by the `-debug-` infix.
+    #[test]
+    fn test_default_artifact_debug_is_the_primary_name_plus_infix() {
+        assert_eq!(
+            default_artifact("aspect-cli", true),
+            default_artifact("aspect-cli", false).replace("aspect-cli-", "aspect-cli-debug-")
+        );
+    }
+
+    #[test]
+    fn test_release_asset_url() {
+        assert_eq!(
+            release_asset_url(
+                "aspect-build",
+                "aspect-cli",
+                "v2026.31.10",
+                "aspect-cli-linux"
+            ),
+            "https://github.com/aspect-build/aspect-cli/releases/download/v2026.31.10/aspect-cli-linux"
+        );
+    }
+
+    /// The URL is the cache key, so the debug and primary variants of one release must
+    /// not collide.
+    #[test]
+    fn test_release_asset_url_distinguishes_variants() {
+        let url = |a: &str| release_asset_url("aspect-build", "aspect-cli", "v2026.31.10", a);
+        assert_ne!(
+            url(&default_artifact("aspect-cli", false)),
+            url(&default_artifact("aspect-cli", true))
+        );
+    }
+
     #[test]
     fn test_release_deserialize_with_assets() {
         let json = r#"{
@@ -970,8 +1027,10 @@ mod tests {
         tag: &str,
         artifact: &str,
     ) -> PathBuf {
-        let url = format!("https://github.com/{org}/{repo}/releases/download/{tag}/{artifact}");
-        cache.tool_path(&"aspect-cli".to_string(), &url)
+        cache.tool_path(
+            &"aspect-cli".to_string(),
+            &release_asset_url(org, repo, tag, artifact),
+        )
     }
 
     /// Create a temp dir scoped to this test process so parallel test runs don't collide.

--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -47,6 +47,24 @@ fn debug_mode() -> bool {
     }
 }
 
+/// Default release asset name for a tool, e.g. `aspect-cli-x86_64-unknown-linux-musl`.
+///
+/// Under `ASPECT_DEBUG` this selects the `-debug-` variant published alongside the
+/// primary binary (unstripped, with debug assertions enabled graph-wide) so that a
+/// crash report from a debug run resolves to function and file:line. The variant is
+/// larger and slower, which is why it is opt-in.
+///
+/// Only used when the config did not name an `artifact` explicitly; an explicit name
+/// is passed through untouched, since we cannot know whether a debug counterpart of
+/// someone else's asset exists.
+fn default_artifact(repo: &str, debug: bool) -> String {
+    if debug {
+        format!("{}-debug-{}", repo, LLVM_TRIPLE)
+    } else {
+        format!("{}-{}", repo, LLVM_TRIPLE)
+    }
+}
+
 const ASPECT_LAUNCHER_METHOD_HTTP: &str = "http";
 const ASPECT_LAUNCHER_METHOD_GITHUB: &str = "github";
 const ASPECT_LAUNCHER_METHOD_LOCAL: &str = "local";
@@ -310,8 +328,11 @@ async fn configure_tool_task(
                     let pinned_version = tool.version();
                     let version_for_vars = pinned_version.unwrap_or(&fallback_version);
 
+                    // True only when we picked the `-debug-` name ourselves, which is
+                    // what lets the download failure below explain a missing variant.
+                    let chose_debug_variant = artifact.is_empty() && debug_mode();
                     let artifact = if artifact.is_empty() {
-                        format!("{}-{}", repo, LLVM_TRIPLE)
+                        default_artifact(repo, debug_mode())
                     } else {
                         replace_vars(artifact, version_for_vars)
                     };
@@ -573,7 +594,19 @@ async fn configure_tool_task(
                         }
                     }
                     if let Some(e) = download_err {
-                        errs.push(Err(e));
+                        // The `-debug-` variant only exists in releases from v2026.31.10
+                        // on. A pinned older version resolves its tag without consulting
+                        // the asset list, so the first sign of a missing variant is a 404
+                        // here; say so rather than leaving a bare HTTP status.
+                        if chose_debug_variant {
+                            errs.push(Err(e.wrap_err(format!(
+                                "{artifact} not found in {resolved_tag}; the debug variant is \
+                                 only published in releases from v2026.31.10 on. Unset \
+                                 ASPECT_DEBUG or use a newer version."
+                            ))));
+                        } else {
+                            errs.push(Err(e));
+                        }
                         continue;
                     }
                     return Ok((
@@ -767,6 +800,33 @@ mod tests {
     fn test_replace_vars_no_placeholders() {
         let result = replace_vars("plain-string", "1.0.0");
         assert_eq!(result, "plain-string");
+    }
+
+    #[test]
+    fn test_default_artifact_is_the_primary_binary() {
+        assert_eq!(
+            default_artifact("aspect-cli", false),
+            format!("aspect-cli-{}", LLVM_TRIPLE)
+        );
+    }
+
+    #[test]
+    fn test_default_artifact_debug_selects_the_debug_variant() {
+        assert_eq!(
+            default_artifact("aspect-cli", true),
+            format!("aspect-cli-debug-{}", LLVM_TRIPLE)
+        );
+    }
+
+    /// The two variants must be distinct names so they resolve to different release
+    /// assets and, because the cache key hashes the download URL, different cache
+    /// entries — a debug run must never overwrite the primary binary in place.
+    #[test]
+    fn test_default_artifact_variants_differ() {
+        assert_ne!(
+            default_artifact("aspect-cli", false),
+            default_artifact("aspect-cli", true)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Releases publish an `aspect-cli-debug-<triple>` artifact alongside the primary binary (#1358) — unstripped, with debug assertions enabled across the dependency graph. Nothing fetched it, so putting someone on the diagnostic build meant hand-downloading a binary and swapping it into place.

Setting `ASPECT_DEBUG_CLI=1` now makes the launcher download that variant, so a crash report resolves to function and `file:line` instead of a bare ASLR-relative offset.

Details worth noting for review:

- **A separate variable from `ASPECT_DEBUG`.** That one means "verbose launcher logging" and is set routinely, so it must not also swap in a larger, slower binary.
- **Only the default artifact name is affected.** A source that names an `artifact` explicitly is used verbatim, since a debug counterpart of an arbitrary asset may not exist.
- **The variants cannot collide in the cache.** `tool_path()` hashes the download URL, which contains the artifact name, so the two binaries occupy separate cache entries and a debug run never overwrites the primary binary in place.
- **A missing variant falls back instead of failing.** Releases before v2026.31.10 have no debug asset, and a pinned tag is resolved without consulting the asset list, so the launcher only discovers this at download time. It logs the fallback and serves the primary binary — otherwise `ASPECT_DEBUG_CLI` would break any older pin, including this repo's own `.aspect/version.axl` fallback source on a fresh clone.

Along the way this consolidates the four inline copies of the release-asset URL into `release_asset_url()` and extracts the download retry loop into `download_with_retries()`, which the fallback reuses.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes — documented in the launcher README's Debugging section
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Set `ASPECT_DEBUG_CLI=1` to run the `aspect-cli-debug-<target>` release variant instead of the primary binary — unstripped and built with debug assertions, so crash reports resolve to function and `file:line`. The two variants are cached separately, an explicitly configured `artifact` is unaffected, and releases that do not publish the variant fall back to the primary binary.

### Test plan

- New test cases added — `default_artifact` and `release_asset_url` naming/URL invariants, a `cache.rs` test asserting the two variants map to different cache paths, and launcher integration tests 7-9 covering debug selection, `ASPECT_DEBUG` non-interference, and the fallback (70 launcher unit tests pass)
- Covered by existing test cases — integration tests 1-6 pin pre-v2026.31.10 versions with `ASPECT_DEBUG=1`, so they guard against the two variables being recoupled
- Manual testing; please provide instructions so we can reproduce:

```bash
mkdir -p /tmp/e2e/.aspect && cd /tmp/e2e && touch MODULE.bazel
printf 'version("2026.31.10")\n' > .aspect/version.axl

# downloads aspect-cli-debug-<triple>
ASPECT_DEBUG_CLI=1 XDG_CACHE_HOME=/tmp/e2e/c1 aspect version
# downloads aspect-cli-<triple>
XDG_CACHE_HOME=/tmp/e2e/c2 aspect version

# a release without the variant: logs the fallback and still works
printf 'version("2026.15.2")\n' > .aspect/version.axl
ASPECT_DEBUG_CLI=1 XDG_CACHE_HOME=/tmp/e2e/c3 aspect version
```

Verified against the real releases: the debug run fetched `aspect-cli-debug-aarch64-apple-darwin` (45,137,344 bytes) and the control run `aspect-cli-aarch64-apple-darwin` (40,653,168 bytes), into two distinct cache hash directories. The `2026.15.2` run logs `falling back to aspect-cli-aarch64-apple-darwin`, downloads the primary artifact, exits 0, and serves it from cache on the next run.
