### PR TITLE
feat(cli)!: replace --aspect-remote* with --remote, discover the BES results URL

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -1,5 +1,5 @@
 load("./private/lib/aspect_endpoint_auth.axl", "login_hint")
-load("./private/lib/deployment_flags.axl", "REMOTE_CAPABILITIES", "REMOTE_DEFAULT_CAPS", "capability_label", "join_and")
+load("./private/lib/deployment_flags.axl", "REMOTE_DEFAULT_CAPS", "capability_labels", "join_and")
 load("./private/lib/environment.axl", "error", "info")
 load("./private/lib/prompt.axl", "prompt_choice")
 
@@ -35,20 +35,6 @@ def login_command(d) -> str:
     account, `--deployment <name>` for a deployment."""
     return login_hint(None if d.builtin else d.name)
 
-def capabilities(d, only: list[str] = []) -> list[str]:
-    """The remote capabilities `d` advertises, as prose for a usage hint, using the
-    same labels and order as the `--remote` announcement (see `deployment_flags.axl`).
-
-    `only` restricts the result to those capability names — pass `REMOTE_DEFAULT_CAPS`
-    for what bare `--remote` actually wires, so a hint about it can't promise the
-    opt-in remote execution."""
-    hosts = {"cache": d.cache, "exec": d.exec, "bes": d.bes}
-    return [
-        capability_label(name)
-        for name in REMOTE_CAPABILITIES
-        if hosts.get(name) and (not only or name in only)
-    ]
-
 def status_line(d) -> str:
     """The Status row value for a summary: the logged-in identity + token status,
     or a logged-out note pointing at how to log in."""
@@ -82,8 +68,7 @@ def _print_deployment(d, header = True):
         # The Aspect account has no build endpoints; say what it's for instead.
         _row("Grants", _ACCOUNT_GRANTS)
     else:
-        # Endpoint hosts first, then the build-result viewer — a full URL rather than
-        # a host, and the one row that is a link a user can open.
+        # Short column headers of their own, not the prose `capability_labels` names.
         for (kind, value) in [("Cache", d.cache), ("Exec", d.exec), ("BES", d.bes), ("Results", d.results_url)]:
             if value:
                 _row(kind, value)
@@ -106,7 +91,7 @@ def _print_configured_usage_hint(summary):
     flag = "--remote --deployment=" + summary.name
     print("")
     print("Pass " + flag + " to a task (e.g. `aspect build " + flag + "`)")
-    print("to use this deployment's " + join_and(capabilities(summary, only = REMOTE_DEFAULT_CAPS)) + ".")
+    print("to use this deployment's " + join_and(capability_labels(summary, only = REMOTE_DEFAULT_CAPS)) + ".")
     if summary.exec:
         print("Remote execution is opt-in: use --remote=exec to enable it.")
 

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -35,15 +35,16 @@ def login_command(d) -> str:
     account, `--deployment <name>` for a deployment."""
     return login_hint(None if d.builtin else d.name)
 
-def capabilities(d) -> list[str]:
-    """The remote capabilities a deployment advertises, as prose for a usage hint
-    (cache/bes always for a configured deployment; exec only when served). Same
-    labels the `--aspect-*` announcement uses (see `deployment_flags.axl`)."""
-    caps = []
-    for (label, host) in [("remote cache", d.cache), ("remote execution", d.exec), ("BES backend", d.bes)]:
-        if host:
-            caps.append(label)
-    return caps
+def capabilities(d, default_only: bool = False) -> list[str]:
+    """The remote capabilities a deployment advertises, as prose for a usage hint.
+    Same labels the `--remote` announcement uses (see `deployment_flags.axl`).
+
+    `default_only` drops remote execution, listing just what bare `--remote` wires —
+    exec is opt-in, so a hint about `--remote` must not promise it."""
+    pairs = [("remote cache", d.cache), ("BES backend", d.bes)]
+    if not default_only:
+        pairs.insert(1, ("remote execution", d.exec))
+    return [label for (label, host) in pairs if host]
 
 def status_line(d) -> str:
     """The Status row value for a summary: the logged-in identity + token status,
@@ -83,21 +84,26 @@ def _print_deployment(d, header = True):
                 _row(kind, host)
 
 def _print_default_usage_hint():
-    """The `auth status` footer: how --aspect-remote wires the *default* deployment,
-    and how to target another. Always the full text (independent of how many
-    deployments are configured). Leads with a blank line to set it apart."""
+    """The `auth status` footer: how --remote wires the *default* deployment, how to
+    add remote execution (never implied), and how to target another deployment.
+    Always the full text (independent of how many deployments are configured).
+    Leads with a blank line to set it apart."""
     print("")
-    print("Pass --aspect-remote to a task (e.g. `aspect build --aspect-remote`) to use the")
-    print("default deployment's remote cache, remote execution, and BES backend (when advertised).")
+    print("Pass --remote to a task (e.g. `aspect build --remote`) to use the default")
+    print("deployment's remote cache and BES backend. Add --remote=exec for remote execution.")
     print("Add --deployment <name> to target a specific deployment instead of the default.")
 
 def _print_configured_usage_hint(summary):
     """Post-configure hint naming the just-configured deployment and the remote
-    capabilities it actually advertises. Leads with a blank line to set it apart."""
-    flag = "--aspect-remote --deployment=" + summary.name
+    capabilities it actually advertises. Names `--remote=exec` only when the
+    deployment serves remote execution, since it is never wired by default.
+    Leads with a blank line to set it apart."""
+    flag = "--remote --deployment=" + summary.name
     print("")
     print("Pass " + flag + " to a task (e.g. `aspect build " + flag + "`)")
-    print("to use this deployment's " + join_and(capabilities(summary)) + ".")
+    print("to use this deployment's " + join_and(capabilities(summary, default_only = True)) + ".")
+    if summary.exec:
+        print("Remote execution is opt-in: use --remote=exec to enable it.")
 
 def _login_impl(ctx: TaskContext) -> int:
     if ctx.args.with_token and ctx.args.with_api_token:
@@ -324,7 +330,7 @@ def _use_impl(ctx: TaskContext) -> int:
 use = task(
     group = ["auth"],
     summary = "Set the default Workflows deployment",
-    description = "Make a configured deployment the default, so build/test (and `--deployment`-aware commands) target it — e.g. `aspect build --aspect-remote` — without naming it each time.",
+    description = "Make a configured deployment the default, so build/test (and `--deployment`-aware commands) target it — e.g. `aspect build --remote` — without naming it each time.",
     implementation = _use_impl,
     args = {
         "deployment": args.positional(

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -16,8 +16,8 @@ def _run_browser_login(ctx: TaskContext, deployment: str):
     return session.wait()
 
 # Width of the label column in a deployment's detail block so values align. Must
-# be wider than the longest label ("Status"/"Issuer"/"Grants", all 6) to leave a
-# gap; a label >= this width would collide with its value.
+# be wider than the longest label ("Results", 7) to leave a gap; a label >= this
+# width would collide with its value.
 _LABEL_WIDTH = 8
 
 # What the built-in Aspect account login grants (it has no build endpoints).
@@ -82,9 +82,11 @@ def _print_deployment(d, header = True):
         # The Aspect account has no build endpoints; say what it's for instead.
         _row("Grants", _ACCOUNT_GRANTS)
     else:
-        for (kind, host) in [("Cache", d.cache), ("Exec", d.exec), ("BES", d.bes)]:
-            if host:
-                _row(kind, host)
+        # Endpoint hosts first, then the build-result viewer — a full URL rather than
+        # a host, and the one row that is a link a user can open.
+        for (kind, value) in [("Cache", d.cache), ("Exec", d.exec), ("BES", d.bes), ("Results", d.results_url)]:
+            if value:
+                _row(kind, value)
 
 def _print_default_usage_hint():
     """The `auth status` footer: how --remote wires the *default* deployment, how to

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -1,5 +1,5 @@
 load("./private/lib/aspect_endpoint_auth.axl", "login_hint")
-load("./private/lib/deployment_flags.axl", "join_and")
+load("./private/lib/deployment_flags.axl", "REMOTE_CAPABILITIES", "REMOTE_DEFAULT_CAPS", "capability_label", "join_and")
 load("./private/lib/environment.axl", "error", "info")
 load("./private/lib/prompt.axl", "prompt_choice")
 
@@ -35,16 +35,19 @@ def login_command(d) -> str:
     account, `--deployment <name>` for a deployment."""
     return login_hint(None if d.builtin else d.name)
 
-def capabilities(d, default_only: bool = False) -> list[str]:
-    """The remote capabilities a deployment advertises, as prose for a usage hint.
-    Same labels the `--remote` announcement uses (see `deployment_flags.axl`).
+def capabilities(d, only: list[str] = []) -> list[str]:
+    """The remote capabilities `d` advertises, as prose for a usage hint, using the
+    same labels and order as the `--remote` announcement (see `deployment_flags.axl`).
 
-    `default_only` drops remote execution, listing just what bare `--remote` wires —
-    exec is opt-in, so a hint about `--remote` must not promise it."""
-    pairs = [("remote cache", d.cache), ("BES backend", d.bes)]
-    if not default_only:
-        pairs.insert(1, ("remote execution", d.exec))
-    return [label for (label, host) in pairs if host]
+    `only` restricts the result to those capability names — pass `REMOTE_DEFAULT_CAPS`
+    for what bare `--remote` actually wires, so a hint about it can't promise the
+    opt-in remote execution."""
+    hosts = {"cache": d.cache, "exec": d.exec, "bes": d.bes}
+    return [
+        capability_label(name)
+        for name in REMOTE_CAPABILITIES
+        if hosts.get(name) and (not only or name in only)
+    ]
 
 def status_line(d) -> str:
     """The Status row value for a summary: the logged-in identity + token status,
@@ -101,7 +104,7 @@ def _print_configured_usage_hint(summary):
     flag = "--remote --deployment=" + summary.name
     print("")
     print("Pass " + flag + " to a task (e.g. `aspect build " + flag + "`)")
-    print("to use this deployment's " + join_and(capabilities(summary, default_only = True)) + ".")
+    print("to use this deployment's " + join_and(capabilities(summary, only = REMOTE_DEFAULT_CAPS)) + ".")
     if summary.exec:
         print("Remote execution is opt-in: use --remote=exec to enable it.")
 

--- a/crates/aspect-cli/src/builtins/aspect/auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth_test.axl
@@ -9,8 +9,7 @@ Run with:
   aspect dev test-auth
 """
 
-load("@aspect//auth.axl", "capabilities", "identity", "login_command", "status_line")
-load("./private/lib/deployment_flags.axl", "REMOTE_DEFAULT_CAPS")
+load("@aspect//auth.axl", "identity", "login_command", "status_line")
 
 def _eq(label, got, want):
     if got != want:
@@ -52,19 +51,6 @@ def _test_login_command(_):
     _eq("account → bare", login_command(_summary(builtin = True, name = "aspect")), "aspect auth login")
     _eq("deployment → --deployment", login_command(_summary(name = "gcp.acme")), "aspect auth login --deployment gcp.acme")
 
-def _test_capabilities(_):
-    _eq("cache + bes", capabilities(_summary(cache = "c", bes = "b")), ["remote cache", "BES backend"])
-    _eq("cache + exec + bes order", capabilities(_summary(cache = "c", bes = "b", exec = "e")), ["remote cache", "remote execution", "BES backend"])
-    _eq("none", capabilities(_summary()), [])
-
-    # REMOTE_DEFAULT_CAPS lists what bare --remote wires, so the opt-in remote
-    # execution is dropped even when the deployment serves it.
-    _eq(
-        "restricted to the default caps drops exec",
-        capabilities(_summary(cache = "c", bes = "b", exec = "e"), only = REMOTE_DEFAULT_CAPS),
-        ["remote cache", "BES backend"],
-    )
-
 def _test_status_line(_):
     _eq(
         "logged out → login hint",
@@ -85,7 +71,6 @@ def _test_status_line(_):
 _UNIT_TESTS = [
     _test_identity,
     _test_login_command,
-    _test_capabilities,
     _test_status_line,
 ]
 

--- a/crates/aspect-cli/src/builtins/aspect/auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth_test.axl
@@ -54,6 +54,13 @@ def _test_capabilities(_):
     _eq("cache + exec + bes order", capabilities(_summary(cache = "c", bes = "b", exec = "e")), ["remote cache", "remote execution", "BES backend"])
     _eq("none", capabilities(_summary()), [])
 
+    # default_only lists what bare --remote wires, so exec is dropped even when served.
+    _eq(
+        "default_only drops exec",
+        capabilities(_summary(cache = "c", bes = "b", exec = "e"), default_only = True),
+        ["remote cache", "BES backend"],
+    )
+
 def _test_status_line(_):
     _eq(
         "logged out → login hint",

--- a/crates/aspect-cli/src/builtins/aspect/auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth_test.axl
@@ -26,7 +26,8 @@ def _summary(
         status = "",
         cache = "",
         bes = "",
-        exec = ""):
+        exec = "",
+        results_url = ""):
     return struct(
         name = name,
         builtin = builtin,
@@ -37,6 +38,7 @@ def _summary(
         status = status,
         cache = cache,
         bes = bes,
+        results_url = results_url,
         exec = exec,
     )
 

--- a/crates/aspect-cli/src/builtins/aspect/auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth_test.axl
@@ -10,6 +10,7 @@ Run with:
 """
 
 load("@aspect//auth.axl", "capabilities", "identity", "login_command", "status_line")
+load("./private/lib/deployment_flags.axl", "REMOTE_DEFAULT_CAPS")
 
 def _eq(label, got, want):
     if got != want:
@@ -54,10 +55,11 @@ def _test_capabilities(_):
     _eq("cache + exec + bes order", capabilities(_summary(cache = "c", bes = "b", exec = "e")), ["remote cache", "remote execution", "BES backend"])
     _eq("none", capabilities(_summary()), [])
 
-    # default_only lists what bare --remote wires, so exec is dropped even when served.
+    # REMOTE_DEFAULT_CAPS lists what bare --remote wires, so the opt-in remote
+    # execution is dropped even when the deployment serves it.
     _eq(
-        "default_only drops exec",
-        capabilities(_summary(cache = "c", bes = "b", exec = "e"), default_only = True),
+        "restricted to the default caps drops exec",
+        capabilities(_summary(cache = "c", bes = "b", exec = "e"), only = REMOTE_DEFAULT_CAPS),
         ["remote cache", "BES backend"],
     )
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -951,7 +951,7 @@ def _join_url(base, id):
 def resolve_aspect_url(links, data):
     """Return the Aspect Web UI URL for an invocation, or "" if unavailable.
 
-    Keyed on whichever id the backend indexed the invocation under:
+    Keyed on the id most directly identifying the invocation:
 
       - `sink_invocation_id` when the CLI streamed it — the UUID the gRPC sink
         (`stream_sink.rs`) mints up-front when spawning BES subscribers. Tasks
@@ -960,8 +960,10 @@ def resolve_aspect_url(links, data):
       - `data["bazel"]["invocation_id"]` when `bes_streamed_by_bazel` says Bazel
         uploaded it instead, in which case no sink — and so no sink id — exists.
 
-    The two are not interchangeable: Bazel's UUID is unknown to a backend the CLI
-    streamed to, and would 404. Without either id the link is suppressed.
+    The Web UI resolves `/i/<id>` under either the BES envelope UUID (the sink id) or
+    the Bazel invocation id carried in the events, so both forms land on the same
+    page; the sink id is preferred simply because it is the one this process minted.
+    Without either id the link is suppressed.
 
     `links["results_base_url"]` (from `WorkflowsEnvironment.build_events.results_url`)
     is the prefix, joined as `{base}/{id}` (no `/invocations/` segment). Typical:
@@ -2345,9 +2347,10 @@ def _sorted_dedup(args, allow_env):
 def render_bes_url(data: dict) -> str:
     """Full BES results URL from `data["bazel"]`, or "" when unavailable.
 
-    Keyed on Bazel's own `invocation_id` (the --bes_results_url backend only
-    sees that UUID). BES counterpart to `aspect_web_ui_url`, which keys on
-    sink_invocation_id.
+    Keyed on Bazel's own `invocation_id`, mirroring the link Bazel itself prints from
+    `--bes_results_url`. BES counterpart to `aspect_web_ui_url`, which keys on
+    `sink_invocation_id`; against the Aspect Web UI the two resolve to the same page
+    (see `resolve_aspect_url`).
     """
     base = data["bazel"].get("bes_results_url", "")
     inv = data["bazel"].get("invocation_id", "")

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -57,7 +57,7 @@ load("./log_snippet.axl", "SnippetOptions", "code_fence_for", "extract_junit_fai
 load("./path_glob.axl", "match_path")
 load("./repro_commands.axl", "ASPECT_CLI_INSTALL_HINT_MARKDOWN")
 load("./result_text.axl", "emoji_for_status")
-load("./text.axl", "SUBJECT_TITLE_MAX", "format_int_comma", "pluralize", "truncate_for_title")
+load("./text.axl", "SUBJECT_TITLE_MAX", "format_int_comma", "join_url", "pluralize", "truncate_for_title")
 load("./tips.axl", "decorate_tip")
 
 # Max unique failed-target labels to keep detail for (entries are small).
@@ -942,11 +942,6 @@ def process_event(data, event):
 
     return False
 
-def _join_url(base, id):
-    """Join base URL + invocation id with exactly one slash (tolerates a trailing
-    slash on `base`)."""
-    return (base if base.endswith("/") else base + "/") + id
-
 def resolve_aspect_url(links, data):
     """Return the Aspect Web UI URL for an invocation, or "" if unavailable.
 
@@ -980,7 +975,7 @@ def resolve_aspect_url(links, data):
         inv_id = data.get("bazel", {}).get("invocation_id", "") or ""
     if not inv_id:
         return ""
-    return _join_url(base, inv_id)
+    return join_url(base, inv_id)
 
 def aspect_web_ui_url(env: std.Env, data: dict) -> str:
     """Aspect Web UI invocation URL, or "" when unavailable. Joins
@@ -2355,7 +2350,7 @@ def render_bes_url(data: dict) -> str:
     inv = data["bazel"].get("invocation_id", "")
     if not base or not inv:
         return ""
-    return _join_url(base, inv)
+    return join_url(base, inv)
 
 def format_run_date(ctx, epoch_ms):
     """Format an epoch-ms timestamp as a human-readable date (e.g.
@@ -3468,7 +3463,7 @@ def _build_retry_attempt_rows(data, links):
     rows = []
     for a in attempts:
         sink_id = a.get("sink_invocation_id", "") or ""
-        url = _join_url(base, sink_id) if (base and sink_id) else ""
+        url = join_url(base, sink_id) if (base and sink_id) else ""
         rows.append({
             "attempt": a.get("attempt", 0),
             "outcome": "passed" if a.get("exit_code", 1) == 0 else "failed",

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -301,10 +301,9 @@ def init_data():
         # invocation_id. Set by the task before spawning; see
         # bes_sinks.axl::bes_streamed_by_bazel.
         "bes_streamed_by_bazel": False,
-        # Aspect Web UI base URL advertised by the `--remote` deployment, used by
-        # `resolve_aspect_url` when ASPECT_WORKFLOWS_BES_RESULTS_URL is unset (i.e.
-        # off a runner). Set by bazel_runner.axl; see
-        # deployment_flags.axl::aspect_results_url.
+        # Aspect Web UI base URL for the BES backend this build reports to, the
+        # fallback base for `resolve_aspect_url`. Set by bazel_runner.axl; see
+        # deployment_flags.axl::advertised_results_url.
         "aspect_results_url": "",
         # Producer-authored at terminal-emit time. Each entry {command, description};
         # see lib/repro_commands.axl.
@@ -969,9 +968,9 @@ def resolve_aspect_url(links, data):
     is the prefix, joined as `{base}/{id}` (no `/invocations/` segment). Typical:
         ASPECT_WORKFLOWS_BES_RESULTS_URL=https://app.oss.aspect.build
 
-    Off a runner that env var is unset, so `data["aspect_results_url"]` — the viewer
-    the selected `--remote` deployment advertises — is the fallback base, letting a
-    local build render the same link.
+    `data["aspect_results_url"]` is the fallback base — the viewer advertised for the
+    BES backend this build reports to (see `deployment_flags.axl`) — so a local
+    `--remote` build renders the same link off a runner.
     """
     base = (links.get("results_base_url", "") if links else "") or data.get("aspect_results_url", "")
     if not base:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -270,8 +270,9 @@ def _repro_with_prefix(prefix, labels, max_chars):
 
 # Keys a task resolves before the build and `process_event` must not clobber
 # when `build_started` resets the accumulator for a new (or retried) stream.
-# Both identify the invocation to the Aspect Web UI; see `resolve_aspect_url`.
-_TASK_OWNED_KEYS = ["sink_invocation_id", "bes_streamed_by_bazel"]
+# All three feed the Aspect Web UI link — two identify the invocation, one is its
+# base URL off a runner; see `resolve_aspect_url`.
+_TASK_OWNED_KEYS = ["sink_invocation_id", "bes_streamed_by_bazel", "aspect_results_url"]
 
 def init_data():
     """Create a fresh data accumulator.
@@ -300,6 +301,11 @@ def init_data():
         # invocation_id. Set by the task before spawning; see
         # bes_sinks.axl::bes_streamed_by_bazel.
         "bes_streamed_by_bazel": False,
+        # Aspect Web UI base URL advertised by the `--remote` deployment, used by
+        # `resolve_aspect_url` when ASPECT_WORKFLOWS_BES_RESULTS_URL is unset (i.e.
+        # off a runner). Set by bazel_runner.axl; see
+        # deployment_flags.axl::aspect_results_url.
+        "aspect_results_url": "",
         # Producer-authored at terminal-emit time. Each entry {command, description};
         # see lib/repro_commands.axl.
         "repro_commands": [],
@@ -960,8 +966,12 @@ def resolve_aspect_url(links, data):
     `links["results_base_url"]` (from `WorkflowsEnvironment.build_events.results_url`)
     is the prefix, joined as `{base}/{id}` (no `/invocations/` segment). Typical:
         ASPECT_WORKFLOWS_BES_RESULTS_URL=https://app.oss.aspect.build
+
+    Off a runner that env var is unset, so `data["aspect_results_url"]` — the viewer
+    the selected `--remote` deployment advertises — is the fallback base, letting a
+    local build render the same link.
     """
-    base = links.get("results_base_url", "") if links else ""
+    base = (links.get("results_base_url", "") if links else "") or data.get("aspect_results_url", "")
     if not base:
         return ""
     inv_id = data.get("sink_invocation_id", "") or ""

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
@@ -1225,6 +1225,51 @@ def _test_aspect_web_ui_url_bazel_streamed(ctx):
         "https://app.oss.aspect.build/sink-1",
     )
 
+def _test_aspect_web_ui_url_discovered_base(ctx):
+    """Off a runner `ASPECT_WORKFLOWS_BES_RESULTS_URL` is unset, so the base falls back
+    to the viewer the `--remote` deployment advertised (`data["aspect_results_url"]`,
+    set by bazel_runner.axl). Still keyed on the sink id, which is what the Aspect
+    backend indexed the CLI-streamed invocation under."""
+    env = ctx.std.env
+    env.set_var("ASPECT_WORKFLOWS_BES_RESULTS_URL", "")
+    _eq(
+        "discovered base + sink id",
+        aspect_web_ui_url(env, {
+            "sink_invocation_id": "sink-1",
+            "aspect_results_url": "https://app.gcp.aspect.build/i",
+        }),
+        "https://app.gcp.aspect.build/i/sink-1",
+    )
+    _eq(
+        "discovered base still needs an invocation id",
+        aspect_web_ui_url(env, {"sink_invocation_id": "", "aspect_results_url": "https://app.gcp.aspect.build/i"}),
+        "",
+    )
+
+    # On a runner the env var is the deliberate local config and wins.
+    env.set_var("ASPECT_WORKFLOWS_BES_RESULTS_URL", "https://app.oss.aspect.build")
+    _eq(
+        "runner env base wins over the discovered one",
+        aspect_web_ui_url(env, {
+            "sink_invocation_id": "sink-1",
+            "aspect_results_url": "https://app.gcp.aspect.build/i",
+        }),
+        "https://app.oss.aspect.build/sink-1",
+    )
+    env.set_var("ASPECT_WORKFLOWS_BES_RESULTS_URL", "")
+
+def _test_build_started_preserves_aspect_results_url(ctx):
+    """The discovered base is task-owned like `sink_invocation_id`, so the
+    `build_started` reset must not drop it — otherwise the link vanishes mid-stream."""
+    data = init_data()
+    data["aspect_results_url"] = "https://app.gcp.aspect.build/i"
+    data["sink_invocation_id"] = "sink-1"
+    process_event(data, struct(
+        kind = "build_started",
+        payload = struct(uuid = "bazel-uuid-1", start_time_millis = 1),
+    ))
+    _eq("discovered base survives build_started", data["aspect_results_url"], "https://app.gcp.aspect.build/i")
+
 def _test_build_started_preserves_bazel_streamed(ctx):
     """`process_event`'s build_started reset wipes top-level state for the new
     stream; `bes_streamed_by_bazel` is task-managed and set before the event, so
@@ -1328,6 +1373,8 @@ _UNIT_TESTS = [
     _test_status_maps_cover_every_terminal_status,
     _test_aspect_web_ui_url,
     _test_aspect_web_ui_url_bazel_streamed,
+    _test_aspect_web_ui_url_discovered_base,
+    _test_build_started_preserves_aspect_results_url,
     _test_build_started_preserves_bazel_streamed,
     _test_render_bes_url,
     _test_failed_status_without_failure_bucket,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -17,7 +17,7 @@ load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
 load("./bes_sinks.axl", "announce_bes_sinks", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
-load("./deployment_flags.axl", "announce_deployment_flags", "aspect_results_url", "bes_results_url_flag", "deployment_endpoint_flags")
+load("./deployment_flags.axl", "advertised_results_url", "announce_deployment_flags", "bes_results_url_flag", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "flavor_allows", "print_repro_and_fix", "repro_prefix")
@@ -318,15 +318,15 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
 
     # Per-invocation extras: inject `--remote_header` / `--bes_header` auth for an
     # Aspect-owned remote cache or Bazel-streamed `--bes_backend` (appended after
-    # rc expansion on each bazel build/test call), plus the deployment's advertised
-    # `--bes_results_url` when Bazel itself uploads to its BES.
+    # rc expansion on each bazel build/test call), plus `--bes_results_url` when this
+    # build forwards BES to an advertised backend.
     invocation_flags = aspect_endpoint_auth_flags(ctx, rc, command)
-    invocation_flags.extend(bes_results_url_flag(ctx, rc, deployment, command))
+    invocation_flags.extend(bes_results_url_flag(ctx, rc, bes_sinks, deployment, command))
 
-    # The CLI-streamed counterpart: that invocation is indexed under the sink's UUID,
-    # so the viewer base rides in `data` for `resolve_aspect_url` instead. A property
-    # of the resolved flags, so it is restored onto each retry's fresh `data`.
-    deployment_results_base = aspect_results_url(ctx, deployment)
+    # The Aspect Web UI link keys on the sink's own id, so it needs the same base in
+    # `data` rather than on the command line. A property of the resolved flags, so it
+    # is restored onto each retry's fresh `data`.
+    deployment_results_base = advertised_results_url(ctx, deployment)
     data["aspect_results_url"] = deployment_results_base
 
     for handler in bazel_trait.build_start:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -17,7 +17,7 @@ load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
 load("./bes_sinks.axl", "announce_bes_sinks", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
-load("./deployment_flags.axl", "announce_deployment_flags", "bes_results_url_flag", "deployment_endpoint_flags")
+load("./deployment_flags.axl", "announce_deployment_flags", "aspect_results_url", "bes_results_url_flag", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "flavor_allows", "print_repro_and_fix", "repro_prefix")
@@ -319,10 +319,15 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     # Per-invocation extras: inject `--remote_header` / `--bes_header` auth for an
     # Aspect-owned remote cache or Bazel-streamed `--bes_backend` (appended after
     # rc expansion on each bazel build/test call), plus the deployment's advertised
-    # `--bes_results_url` when this build reports to its BES and nothing else
-    # supplies one.
+    # `--bes_results_url` when Bazel itself uploads to its BES.
     invocation_flags = aspect_endpoint_auth_flags(ctx, rc, command)
     invocation_flags.extend(bes_results_url_flag(ctx, rc, deployment, command))
+
+    # The CLI-streamed counterpart: that invocation is indexed under the sink's UUID,
+    # so the viewer base rides in `data` for `resolve_aspect_url` instead. A property
+    # of the resolved flags, so it is restored onto each retry's fresh `data`.
+    deployment_results_base = aspect_results_url(ctx, deployment)
+    data["aspect_results_url"] = deployment_results_base
 
     for handler in bazel_trait.build_start:
         handler(ctx)
@@ -367,6 +372,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
             data = init_data()
             data["bazel_attempts"] = prior_attempts
             data["bes_streamed_by_bazel"] = bazel_streams_bes
+            data["aspect_results_url"] = deployment_results_base
 
         spawn_status = _pick_status(command, data, had_failure = False, terminal = False)
         task_update(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -323,11 +323,11 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     invocation_flags = aspect_endpoint_auth_flags(ctx, rc, command)
     invocation_flags.extend(bes_results_url_flag(ctx, rc, bes_sinks, deployment, command))
 
-    # The Aspect Web UI link keys on the sink's own id, so it needs the same base in
-    # `data` rather than on the command line. A property of the resolved flags, so it
-    # is restored onto each retry's fresh `data`.
-    deployment_results_base = advertised_results_url(ctx, deployment)
-    data["aspect_results_url"] = deployment_results_base
+    # The same viewer reaches the CI surfaces through `data` — they key the link on the
+    # sink's own id rather than reading it off the command line. A property of the
+    # resolved flags, so it is restored onto each retry's fresh `data`.
+    results_base = advertised_results_url(ctx, rc, bes_sinks, deployment, command)
+    data["aspect_results_url"] = results_base
 
     for handler in bazel_trait.build_start:
         handler(ctx)
@@ -372,7 +372,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
             data = init_data()
             data["bazel_attempts"] = prior_attempts
             data["bes_streamed_by_bazel"] = bazel_streams_bes
-            data["aspect_results_url"] = deployment_results_base
+            data["aspect_results_url"] = results_base
 
         spawn_status = _pick_status(command, data, had_failure = False, terminal = False)
         task_update(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -16,7 +16,7 @@ load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
 load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
-load("./bes_sinks.axl", "announce_bes_sinks", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
+load("./bes_sinks.axl", "announce_bes_results_url", "announce_bes_sinks", "announce_dropped_bes_sinks", "bes_streamed_by_bazel", "collect_bes_sinks", "dropped_bes_backends", "summarize_bes_upload")
 load("./deployment_flags.axl", "advertised_results_url", "announce_deployment_flags", "bes_results_url_flag", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
@@ -307,8 +307,10 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     announce_version, announce_command = resolve_bazel_announce(ctx)
 
     # Announced with the first spawn below (the streams belong to the spawn) and
-    # summarized at build end.
+    # summarized at build end. `dropped_bes` are the endpoints Bazel uploads to
+    # itself, announced there too so the missing sinks aren't a silent omission.
     bes_sinks = collect_bes_sinks(ctx, bazel_trait, rc, command, extra_backends = deployment.bes_backends)
+    dropped_bes = dropped_bes_backends(ctx, bazel_trait, rc, command, extra_backends = deployment.bes_backends)
     need_bes = bool(bazel_trait.build_event) or bool(lifecycle.task_update)
 
     # A property of the resolved flags, so it holds for every attempt and is
@@ -403,6 +405,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
         if attempt == 0:
             announce_deployment_flags(ctx, deployment)
             announce_bes_sinks(ctx, bes_sinks)
+            announce_dropped_bes_sinks(ctx, dropped_bes, rc, command)
 
         # Per-attempt iter handle; single-use, so re-create each retry.
         events = bazel.build_events.iterator() if need_bes else None
@@ -439,6 +442,12 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
         # carries the Aspect Workflows link. Empty when no BES sinks
         # were configured.
         data["sink_invocation_id"] = invocation.sink_invocation_id
+
+        # Bazel prints "Streaming build results to: …" only when it uploads the BES
+        # itself, so say it here for the sinks the CLI streams. First attempt only,
+        # matching the other spawn-time disclosures above.
+        if attempt == 0:
+            announce_bes_results_url(ctx, results_base, invocation.sink_invocation_id)
 
         # Re-emit to the status surfaces only (stream = "" suppresses
         # the CLI line) so the Aspect Workflows link surfaces without

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -17,7 +17,7 @@ load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
 load("./bes_sinks.axl", "announce_bes_sinks", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
-load("./deployment_flags.axl", "announce_deployment_flags", "deployment_endpoint_flags")
+load("./deployment_flags.axl", "announce_deployment_flags", "bes_results_url_flag", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
 load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
 load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "flavor_allows", "print_repro_and_fix", "repro_prefix")
@@ -278,7 +278,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     # user can still override via --bazel-flag=...
     base_flags = ["--isatty=" + str(int(ctx.std.io.stdout.is_tty))]
 
-    # `--deployment <name>` wires the deployment's advertised endpoints:
+    # `--remote` wires the selected deployment's advertised endpoints:
     # --remote_cache / --remote_executor as base flags (user --bazel-flag still
     # overrides, last-wins), and its BES host into the CLI's BES sinks below.
     deployment = deployment_endpoint_flags(ctx)
@@ -318,8 +318,11 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
 
     # Per-invocation extras: inject `--remote_header` / `--bes_header` auth for an
     # Aspect-owned remote cache or Bazel-streamed `--bes_backend` (appended after
-    # rc expansion on each bazel build/test call).
+    # rc expansion on each bazel build/test call), plus the deployment's advertised
+    # `--bes_results_url` when this build reports to its BES and nothing else
+    # supplies one.
     invocation_flags = aspect_endpoint_auth_flags(ctx, rc, command)
+    invocation_flags.extend(bes_results_url_flag(ctx, rc, deployment, command))
 
     for handler in bazel_trait.build_start:
         handler(ctx)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks.axl
@@ -22,6 +22,7 @@ resolution. (The companion case — BES routed through Bazel via
 
 load("./aspect_endpoint_auth.axl", "endpoint_host", "headers_have_auth", "is_aspect_host", "resolve_aspect_bearer", "same_bes_endpoint")
 load("./environment.axl", "info")
+load("./text.axl", "join_url")
 
 def bes_args() -> dict:
     """The `bes_backends` / `bes_headers` CLI args every BES-capable task
@@ -54,9 +55,9 @@ def bazel_bes_backend(rc, command: str) -> str:
         return ""
     return rc.flag_value("--bes_backend", command = command) or ""
 
-def _drop_bazel_streamed(ctx, items: list, uri_of, bazel_backend: str) -> list:
+def _drop_bazel_streamed(items: list, uri_of, bazel_backend: str) -> list:
     """`items` minus those whose `uri_of(item)` names the same endpoint as Bazel's
-    own `bazel_backend`, announcing each one dropped.
+    own `bazel_backend`.
 
     Both the CLI sink and Bazel's uploader stream the *same* invocation, so an
     endpoint configured on both paths receives two streams for one build: the
@@ -67,19 +68,16 @@ def _drop_bazel_streamed(ctx, items: list, uri_of, bazel_backend: str) -> list:
     a `--deployment`'s advertised host) while `--bes_backend` is set by hand.
 
     `uri_of` returning `""`/`None` keeps the item: a file sink (a local BEP dump)
-    is not a second upload. A no-op when `bazel_backend` is empty.
+    is not a second upload. A no-op when `bazel_backend` is empty. Silent — the
+    drops are announced at spawn time by `announce_dropped_bes_sinks`.
     """
     if not bazel_backend:
         return items
-
-    kept = []
-    for item in items:
-        uri = uri_of(item)
-        if uri and same_bes_endpoint(uri, bazel_backend):
-            info(ctx.std, _DUPLICATE_MSG % (uri, bazel_backend))
-        else:
-            kept.append(item)
-    return kept
+    return [
+        item
+        for item in items
+        if not (uri_of(item) and same_bes_endpoint(uri_of(item), bazel_backend))
+    ]
 
 def bes_streamed_by_bazel(ctx, rc, command: str = "build") -> bool:
     """Whether Bazel's own `--bes_backend` is the Aspect BES backend this runner
@@ -115,8 +113,35 @@ def collect_bes_sinks(ctx, bazel_trait, rc, command: str = "build", extra_backen
     bazel_backend = bazel_bes_backend(rc, command)
     return (
         collect_bes_from_args(ctx, extra_backends = extra_backends, bazel_backend = bazel_backend) +
-        _drop_bazel_streamed(ctx, list(bazel_trait.build_event_sinks), lambda s: s.uri, bazel_backend)
+        _drop_bazel_streamed(list(bazel_trait.build_event_sinks), lambda s: s.uri, bazel_backend)
     )
+
+def dropped_bes_backends(ctx, bazel_trait, rc, command: str = "build", extra_backends = []) -> list[str]:
+    """The BES endpoints `collect_bes_sinks` skipped because Bazel uploads to them
+    itself, deduped. Same inputs as that call — pass the same arguments.
+
+    Separate so the "Not streaming …" notice lands with the spawn it describes rather
+    than during collection, which happens while the setup phase is still on screen."""
+    bazel_backend = bazel_bes_backend(rc, command)
+    if not bazel_backend:
+        return []
+
+    candidates = list(ctx.args.bes_backends) + list(extra_backends) + [s.uri for s in bazel_trait.build_event_sinks]
+    dropped = []
+    for uri in candidates:
+        if uri and same_bes_endpoint(uri, bazel_backend) and uri not in dropped:
+            dropped.append(uri)
+    return dropped
+
+def announce_dropped_bes_sinks(ctx, dropped: list[str], rc, command: str = "build"):
+    """Announce, one line per endpoint, that the CLI is *not* streaming there because
+    Bazel already uploads to it — so the absent "Streaming build events to …" line
+    isn't a silent omission. See `_drop_bazel_streamed` for why Bazel wins the tie.
+
+    Call alongside the other spawn-time disclosures; a no-op when nothing was dropped."""
+    bazel_backend = bazel_bes_backend(rc, command)
+    for uri in dropped:
+        info(ctx.std, _DUPLICATE_MSG % (uri, bazel_backend))
 
 def collect_bes_from_args(ctx, extra_backends = [], bazel_backend: str = "") -> list:
     """The CLI-streamed BES sinks from `--bes-backend` / `--bes-header`. Most
@@ -152,7 +177,7 @@ def collect_bes_from_args(ctx, extra_backends = [], bazel_backend: str = "") -> 
         if b not in backends:
             backends.append(b)
 
-    backends = _drop_bazel_streamed(ctx, backends, lambda b: b, bazel_backend)
+    backends = _drop_bazel_streamed(backends, lambda b: b, bazel_backend)
 
     sinks = []
     for bes_backend in backends:
@@ -217,6 +242,28 @@ def announce_bes_sinks(ctx, sinks: list):
     only — a retry reuses the same sinks."""
     for sink in grpc_backends(sinks):
         info(ctx.std, "Streaming build events to %s." % sink.uri)
+
+def bes_results_line(results_url: str, invocation_id: str) -> str:
+    """The "Streaming build results to …" line for a CLI-streamed invocation, or `""`
+    when either half is missing. Public so `bes_sinks_test.axl` can assert the shape."""
+    if not results_url or not invocation_id:
+        return ""
+    return "Streaming build results to %s." % join_url(results_url, invocation_id)
+
+def announce_bes_results_url(ctx, results_url: str, invocation_id: str):
+    """Announce where the invocation the CLI just streamed is viewable, the companion
+    to `announce_bes_sinks`' "Streaming build events to …" line.
+
+    Bazel prints its own "Streaming build results to: …" only when *it* uploads (its
+    BES module is what `--bes_backend` activates), so a CLI-streamed build would
+    otherwise show no URL at all. Keyed on the sink's own invocation id, which is what
+    the backend indexed.
+
+    Call after `ctx.bazel.build(...)` — the runtime mints the id inside `Build::spawn`.
+    A no-op without both halves."""
+    line = bes_results_line(results_url, invocation_id)
+    if line:
+        info(ctx.std, line)
 
 def summarize_bes_upload(ctx, sinks: list):
     """Log one line per CLI-streamed BES backend summarizing how many build events

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bes_sinks_test.axl
@@ -7,7 +7,7 @@ Run with:
   aspect dev test-bes-sinks
 """
 
-load("./bes_sinks.axl", "bazel_bes_backend", "bes_streamed_by_bazel", "bes_upload_line", "collect_bes_from_args", "collect_bes_sinks", "grpc_backends")
+load("./bes_sinks.axl", "bazel_bes_backend", "bes_results_line", "bes_streamed_by_bazel", "bes_upload_line", "collect_bes_from_args", "collect_bes_sinks", "dropped_bes_backends", "grpc_backends")
 
 def _eq(label, got, want):
     if got != want:
@@ -111,6 +111,61 @@ def _test_missing_uri(_):
         bes_upload_line("", 3, 1, True),
         "Uploaded 1 of 3 build events to the BES backend before the stream failed.",
     )
+
+def _test_bes_results_line(_):
+    """The CLI-streamed counterpart to Bazel's own "Streaming build results to:" line,
+    which Bazel prints only when it uploads the BES itself."""
+    _eq(
+        "joins base + sink invocation id",
+        bes_results_line("https://app.acme/i", "sink-1"),
+        "Streaming build results to https://app.acme/i/sink-1.",
+    )
+    _eq(
+        "tolerates a trailing slash on the base",
+        bes_results_line("https://app.acme/i/", "sink-1"),
+        "Streaming build results to https://app.acme/i/sink-1.",
+    )
+
+    # Either half missing → no line, so nothing half-formed is printed.
+    _eq("no viewer advertised", bes_results_line("", "sink-1"), "")
+    _eq("no sink id (no CLI sink)", bes_results_line("https://app.acme/i", ""), "")
+
+def _test_dropped_bes_backends(_):
+    """What `collect_bes_sinks` skipped because Bazel uploads there itself — computed
+    separately so the notice can be printed at spawn time rather than during
+    collection, which happens under the setup phase."""
+    duplicate = "grpcs://bes.acme.aspect.build"
+    other = "grpcs://bes.other.example.com"
+    ctx = _fake_ctx(bes_backends = [duplicate, other])
+    trait = _fake_trait([struct(uri = "grpcs://bes.runner"), struct(uri = None)])
+    rc = _fake_rc({"--bes_backend": duplicate})
+
+    _eq(
+        "the endpoint bazel also uploads to",
+        dropped_bes_backends(ctx, trait, rc, "build"),
+        [duplicate],
+    )
+
+    # Matching is endpoint-wise, and covers `extra_backends` (a --remote deployment's
+    # BES) and the trait's own sinks alongside --bes-backend.
+    _eq(
+        "default-port spelling still matches",
+        dropped_bes_backends(ctx, trait, _fake_rc({"--bes_backend": duplicate + ":443"}), "build"),
+        [duplicate],
+    )
+    _eq(
+        "a deployment's BES counts too",
+        dropped_bes_backends(_fake_ctx(), trait, rc, "build", extra_backends = [duplicate]),
+        [duplicate],
+    )
+    _eq(
+        "a trait sink counts too",
+        dropped_bes_backends(_fake_ctx(), trait, _fake_rc({"--bes_backend": "grpcs://bes.runner"}), "build"),
+        ["grpcs://bes.runner"],
+    )
+
+    _eq("bazel uploads elsewhere → nothing dropped", dropped_bes_backends(ctx, trait, _fake_rc({"--bes_backend": "grpcs://bes.third"}), "build"), [])
+    _eq("bazel not uploading → nothing dropped", dropped_bes_backends(ctx, trait, _fake_rc({}), "build"), [])
 
 def _test_grpc_backends_filters_file_sinks(_):
     """`grpc_backends` keeps only sinks with a backend URI, so a file sink (a
@@ -219,6 +274,8 @@ _UNIT_TESTS = [
     _test_failed_after_full_ack,
     _test_connect_failure,
     _test_missing_uri,
+    _test_bes_results_line,
+    _test_dropped_bes_backends,
     _test_grpc_backends_filters_file_sinks,
     _test_bazel_bes_backend,
     _test_collect_drops_duplicate_backends,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -300,15 +300,16 @@ def deployment_endpoint_flags(ctx) -> DeploymentFlags:
 
 def bes_results_url_flag(ctx, rc, flags: DeploymentFlags, command: str = "build") -> list:
     """`["--bes_results_url=<url>"]` when the selected deployment advertises a
-    build-result viewer and this invocation is reporting to that deployment's BES,
-    else `[]`.
+    build-result viewer and *Bazel itself* uploads to that deployment's BES, else
+    `[]`.
 
-    Bazel renders the "View invocation" link from `--bes_results_url`, and
-    `bazel_results.axl` reads it back off the command line for the same link in PR
-    comments and status checks. On a Workflows runner it comes from
-    `ASPECT_WORKFLOWS_BES_RESULTS_URL`; discovery is the second path to it, so a
-    local `--remote` build gets the link too, and a runner whose env var is unset
-    recovers it.
+    Bazel renders its "View invocation" line from `--bes_results_url`, joining the
+    base with its own `invocation_id`; `render_bes_url` reads the flag back for the
+    same link on the CI surfaces. Both key on Bazel's UUID, which is only the id the
+    backend indexed when Bazel was the uploader — so this flag is gated on exactly
+    that. When the CLI streams the sink instead, the invocation is indexed under the
+    sink's own UUID, and `aspect_results_url` (below) carries the base to
+    `resolve_aspect_url`, which keys on `sink_invocation_id`.
 
     Precedence, most specific first:
       1. A `--bes_results_url` the user already set (command line, `.bazelrc`, or an
@@ -317,12 +318,6 @@ def bes_results_url_flag(ctx, rc, flags: DeploymentFlags, command: str = "build"
       2. `ASPECT_WORKFLOWS_BES_RESULTS_URL` — the runner's own deliberate config,
          which `bazel_flags.axl` already injects.
       3. The deployment's advertised `aspect_bes_results_url`.
-
-    Gated on actually reporting there, so the link can't point at an invocation the
-    backend never received. Either path counts: the CLI's own sink to the
-    deployment's BES, or Bazel uploading to that same endpoint via its own
-    `--bes_backend` (also the case where the CLI's duplicate sink was dropped).
-    `--remote=no-bes` with no Bazel-side upload contributes no results URL.
     """
     if not flags.results_url:
         return []
@@ -331,11 +326,30 @@ def bes_results_url_flag(ctx, rc, flags: DeploymentFlags, command: str = "build"
     if ctx.std.env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL"):
         return []
 
-    reporting = bool(flags.bes_backends) or same_bes_endpoint(flags.bes_uri, bazel_bes_backend(rc, command))
-    if not reporting:
+    # Only Bazel-side uploads are indexed under the UUID this flag's consumers use.
+    if not same_bes_endpoint(flags.bes_uri, bazel_bes_backend(rc, command)):
         return []
 
     return ["--bes_results_url=" + flags.results_url]
+
+def aspect_results_url(ctx, flags: DeploymentFlags) -> str:
+    """The Aspect Web UI base URL for `data["aspect_results_url"]`, or `""`.
+
+    The counterpart to `bes_results_url_flag` for the CLI-streamed path: the
+    invocation is indexed under the sink's own UUID, so the base is carried in `data`
+    for `resolve_aspect_url` (which keys on `sink_invocation_id`) rather than passed
+    to Bazel as `--bes_results_url`.
+
+    Empty unless the deployment advertises a viewer AND the CLI is streaming to that
+    deployment's BES — with no sink there is no sink id, and a base alone renders
+    nothing. Yields to `ASPECT_WORKFLOWS_BES_RESULTS_URL`, which the CI surfaces
+    already read as `links["results_base_url"]`.
+    """
+    if not flags.results_url or not flags.bes_backends:
+        return ""
+    if ctx.std.env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL"):
+        return ""
+    return flags.results_url
 
 def join_and(items: list[str], oxford: bool = False) -> str:
     """Join with commas and a trailing "and": [a] → "a"; [a,b,c] → "a, b, and c".

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -1,172 +1,315 @@
-"""`--deployment` + per-capability `--aspect-*` wiring for Bazel-spawning tasks.
+"""`--deployment` + `--remote` wiring for Bazel-spawning tasks.
 
-`--deployment <name>` selects WHICH configured Aspect Workflows deployment (see `aspect
-auth configure`) a build runs against, defaulting to the current default
-deployment. It injects nothing on its own.
+Two flags, one for each half of the decision. `--deployment <name>` selects WHICH
+configured Aspect Workflows deployment (see `aspect auth configure`) to draw
+endpoints from, defaulting to the current default deployment — the same flag the
+non-Bazel commands (`aspect auth …`, `aspect cache-diff`) use as a pure selector.
+`--remote` says WHAT to wire from it, as a comma-separated capability list:
 
-WHAT gets injected is opt-in per capability, from the deployment's advertised
-endpoints (`aspect_endpoints`, read via `ctx.aspect.auth.deployment_endpoints`):
+  - `--remote`                             → cache + BES, from the default deployment
+  - `--remote=exec`                        → cache + BES + remote execution
+  - `--remote=exec,no-bes`                 → cache + remote execution
+  - `--remote=no-cache`                    → BES only
+  - `--deployment=acme --remote`           → cache + BES, from `acme`
+  - `--deployment=acme --remote=exec`      → + remote execution, from `acme`
+  - `--remote=none`                        → nothing (overrides a `config.axl` default)
+  - omitted                                → nothing wired
 
-  - `--aspect-remote-cache`  → `--remote_cache=grpcs://<cache>`
-  - `--aspect-bes-backend`   → stream BEP to `grpcs://<bes>` (the CLI BES sink)
-  - `--aspect-remote-exec`   → `--remote_executor=grpcs://<exec>`
-  - `--aspect-remote`        → umbrella: turn on every capability the deployment
-                               advertises (cache + bes, and exec if advertised).
+Nothing is wired unless `--remote` appears; `--deployment` alone is an error on
+these commands, since selecting a deployment without saying what to use it for
+can't do anything (see `deployment_endpoint_flags`).
 
-All default off; a repo's `config.axl` can default them on. An explicit granular
-flag overrides `--aspect-remote` for that one capability (e.g. `--aspect-remote
---aspect-remote-exec=false`). The injected `--remote_cache` / `--remote_executor`
-are Bazel base flags, so an explicit `--bazel-flag=--remote_cache=…` still wins
-(last-wins).
+Within `--remote`, the two accelerators that can't change build semantics — the
+remote cache and the BES reporting sink — are on, and `exec` is additive on top.
+Remote execution is never implied: it relocates every action, so it only ever
+comes from naming `exec`.
+
+Each capability has a `no-` form (`no-cache`, `no-bes`, `no-exec`) that subtracts
+it, so adjusting one capability doesn't mean restating the set. `no-exec` is
+redundant on the command line but lets an invocation opt out of a `config.axl`
+default of `exec`.
+
+Capabilities map to endpoints the deployment advertises (`aspect_endpoints`, read
+via `ctx.aspect.auth.deployment_endpoints`):
+
+  - `cache` → `--remote_cache=grpcs://<cache>`
+  - `bes`   → stream BEP to `grpcs://<bes>` (the CLI BES sink)
+  - `exec`  → `--remote_executor=grpcs://<exec>`
+
+`exec` implies no other capability. Bazel routes CAS/AC through
+`--remote_executor` when `--remote_cache` is unset, so exec alone is still cached
+— via the exec endpoint (the same equivalence `delivery.axl` and `cache_diff.axl`
+rely on). The default `cache` additionally points CAS/AC at the deployment's
+dedicated cache host.
+
+The injected `--remote_cache` / `--remote_executor` are Bazel base flags, so an
+explicit `--bazel-flag=--remote_cache=…` still wins (last-wins).
 
 Failures:
-  - Any `--aspect-*` flag with no deployment to draw from — no `--deployment` and
-    no default Workflows deployment configured (the target resolves to the
-    built-in Aspect account, which has no endpoints).
-  - An *explicitly-set* granular flag whose capability the selected deployment
-    doesn't advertise (e.g. `--aspect-remote-cache` against a deployment with no
-    cache). The `--aspect-remote` umbrella never fails on a missing capability —
-    it means "use whatever this deployment offers", so it silently skips any of
-    cache/bes/exec the deployment doesn't advertise.
+  - An unrecognized capability token, or `none` combined with anything else.
+  - `--deployment` with no `--remote` (nothing to wire).
+  - `--remote` with no deployment to draw from — no `--deployment` and no default
+    Workflows deployment configured (the target resolves to the built-in Aspect
+    account, which has no endpoints).
+  - A capability the user *named* that the deployment doesn't advertise (e.g.
+    `--remote=exec` against a deployment with no remote execution). A defaulted
+    capability is skipped silently instead: bare `--remote` means "use what this
+    deployment offers", so a deployment with no cache or no BES is not an error.
 
 Auth attaches automatically: the injected hosts are the deployment's own, so they
 match the endpoint-auth host gate and receive its login JWT (see
 `aspect_endpoint_auth.axl`).
 """
 
+load("./aspect_endpoint_auth.axl", "same_bes_endpoint")
+load("./bes_sinks.axl", "bazel_bes_backend")
 load("./environment.axl", "info")
 
 # Bazel-facing Aspect endpoints are TLS gRPC.
 _SCHEME = "grpcs://"
+
+# Capabilities `--remote` accepts, each with a `no-` form that subtracts it.
+# `cache`/`bes` are on unless subtracted; `exec` is additive. `none` wires nothing
+# (an escape hatch from a config.axl default).
+_CAPABILITIES = ["cache", "bes", "exec"]
+_DEFAULT_ON = ["cache", "bes"]
+
+# What clap substitutes for a valueless `--remote` (`args.string(bare = …)`), so an
+# empty string keeps meaning "flag absent" and the two stay distinguishable without
+# consulting `is_explicit`.
+BARE = "default"
 
 # What `deployment_endpoint_flags` hands back to `run_bazel_task`: Bazel base
 # flags to prepend (--remote_cache / --remote_executor) and extra CLI-streamed
 # BES backend URIs, plus the deployment name and the base-flag capabilities as
 # `(label, uri)` pairs for the "Using deployment …" line. BES is wired via
 # `bes_backends` and announced by its own streaming line, so it is not in
-# `capabilities`.
+# `capabilities`. `results_url` is the deployment's advertised build-result
+# viewer, passed to `--bes_results_url` when nothing else supplies one;
+# `deployment_bes` is the deployment's BES URI whether or not a sink was wired to
+# it, so `bes_results_url_flag` can still recognize Bazel uploading there itself.
 DeploymentFlags = record(
     base_flags = field(list),
     bes_backends = field(list),
     deployment = field(str, default = ""),
     capabilities = field(list, default = []),
+    results_url = field(str, default = ""),
+    deployment_bes = field(list, default = []),
 )
 
+# Which capabilities `--remote` resolved to. `explicit` are the ones the user named
+# (and didn't later negate), so an unadvertised one fails; a defaulted capability is
+# absent from it and is skipped silently when the deployment lacks it.
+RemoteSpec = record(
+    cache = field(bool),
+    bes = field(bool),
+    exec = field(bool),
+    explicit = field(list),
+)
+
+_OFF = RemoteSpec(cache = False, bes = False, exec = False, explicit = [])
+
 def deployment_flag_args() -> dict:
-    """The `--deployment` selector plus the per-capability `--aspect-*` toggles
-    every Bazel-spawning task declares. Splat into a task's `args = {...}`; read
-    back by `deployment_endpoint_flags`."""
+    """The `--deployment` selector plus the `--remote` capability list every
+    Bazel-spawning task declares. Splat into a task's `args = {...}`; read back by
+    `deployment_endpoint_flags`."""
     return {
         "deployment": args.string(
-            description = "Configured Aspect Workflows deployment (see `aspect auth configure`) to run against. Defaults to the current default deployment. Selects which deployment the --aspect-* capability flags draw endpoints from; injects nothing on its own.",
+            description = "Configured Aspect Workflows deployment (see `aspect auth configure`) to draw remote endpoints from. Defaults to the current default deployment. Requires --remote, which says what to wire from it.",
         ),
-        "aspect_remote": args.boolean(
-            default = False,
-            description = "Use every remote capability the selected deployment advertises: --remote_cache, the BES backend, and --remote_executor (when advertised). Shorthand for the --aspect-remote-* flags; an explicit --aspect-remote-* overrides it for that capability.",
-        ),
-        "aspect_remote_cache": args.boolean(
-            default = False,
-            description = "Wire --remote_cache from the selected deployment's advertised cache endpoint. Fails if no deployment advertising a cache is configured.",
-        ),
-        "aspect_bes_backend": args.boolean(
-            default = False,
-            description = "Stream build events to the selected deployment's advertised BES backend. Fails if no deployment advertising a BES backend is configured.",
-        ),
-        "aspect_remote_exec": args.boolean(
-            default = False,
-            description = "Wire --remote_executor from the selected deployment's advertised remote-execution endpoint. Fails if the selected deployment does not advertise remote execution.",
+        "remote": args.string(
+            default = "",
+            # A bare `--remote` resolves to the default capability set. Empty stays
+            # the "flag absent" value, so `parse_remote` can tell the two apart.
+            bare = BARE,
+            description = (
+                "Use the selected deployment's remote infrastructure. Bare --remote wires " +
+                "its remote cache and BES backend; add `exec` for remote execution (never " +
+                "implied), subtract with no-cache / no-bes / no-exec, or pass `none` to " +
+                "wire nothing. e.g. --remote=exec, --remote=exec,no-bes. Omitted wires nothing."
+            ),
         ),
     }
 
-def _want(ctx, name: str, umbrella: bool) -> (bool, bool):
-    """Resolve capability arg `name` to `(on, explicit)`: an explicitly-set
-    granular flag wins (and is explicit); otherwise it follows the
-    `--aspect-remote` umbrella (not explicit).
+def parse_remote(value: str) -> RemoteSpec:
+    """Parse a `--remote` value into a [`RemoteSpec`].
 
-    The distinction drives error handling: an explicitly-requested capability the
-    deployment can't serve is an error, whereas the umbrella silently skips a
-    capability the deployment doesn't advertise ("use whatever it offers")."""
-    if ctx.args.is_explicit(name):
-        return (getattr(ctx.args, name), True)
-    return (umbrella, False)
+    An empty `value` means the flag was omitted (→ nothing wired); a bare `--remote`
+    arrives as `BARE` (→ the default capabilities), so the two are distinguishable
+    without consulting `is_explicit`.
+
+    `cache`/`bes` start on and `exec` off; each named token turns its capability on
+    and each `no-` token turns it off, applied left to right so the last mention of a
+    capability wins. Only *named* capabilities land in `explicit` — a defaulted one
+    the deployment lacks is skipped rather than failing.
+
+    `fail`s on an unrecognized token and on `none` combined with anything else.
+    Public so `deployment_flags_test.axl` can assert the grammar.
+    """
+    if not value:
+        return _OFF
+
+    # The bare-flag sentinel carries no tokens, leaving the defaults in place.
+    tokens = [] if value == BARE else [t.strip() for t in value.split(",") if t.strip()]
+
+    if "none" in tokens:
+        if len(tokens) > 1:
+            fail("--remote: 'none' cannot be combined with other capabilities; got '%s'." % value)
+        return _OFF
+
+    on = {c: c in _DEFAULT_ON for c in _CAPABILITIES}
+    explicit = []
+    for token in tokens:
+        negated = token.startswith("no-")
+        capability = token[len("no-"):] if negated else token
+        if capability not in _CAPABILITIES:
+            fail("--remote: unknown capability '%s'. Expected %s (each also as no-<capability>), or none." %
+                 (token, ", ".join(_CAPABILITIES)))
+        on[capability] = not negated
+
+        # A negated capability isn't a request the deployment must satisfy, and a
+        # capability named twice is still one request.
+        if not negated and capability not in explicit:
+            explicit.append(capability)
+
+    return RemoteSpec(
+        cache = on["cache"],
+        bes = on["bes"],
+        exec = on["exec"],
+        explicit = [c for c in explicit if on[c]],
+    )
 
 def deployment_endpoint_flags(ctx) -> DeploymentFlags:
-    """Resolve the selected deployment + per-capability flags into the
-    [`DeploymentFlags`] to inject (`base_flags`: --remote_cache / --remote_executor
-    to prepend; `bes_backends`: extra CLI-streamed BES backend URIs).
+    """Resolve `--remote` into the [`DeploymentFlags`] to inject (`base_flags`:
+    --remote_cache / --remote_executor to prepend; `bes_backends`: extra
+    CLI-streamed BES backend URIs; `results_url`: the advertised build-result
+    viewer).
 
-    `fail`s only when an *explicitly-requested* capability can't be satisfied; the
-    `--aspect-remote` umbrella skips any capability the deployment doesn't
-    advertise (see module docstring).
+    `fail`s when `--deployment` is passed without `--remote`, and when a *named*
+    capability can't be satisfied; a defaulted capability the deployment doesn't
+    advertise is skipped (see module docstring).
     """
-    if not hasattr(ctx.args, "deployment"):
+    if not hasattr(ctx.args, "remote"):
         return DeploymentFlags(base_flags = [], bes_backends = [])
 
-    umbrella = ctx.args.aspect_remote
-    (want_cache, cache_explicit) = _want(ctx, "aspect_remote_cache", umbrella)
-    (want_bes, bes_explicit) = _want(ctx, "aspect_bes_backend", umbrella)
-    (want_exec, exec_explicit) = _want(ctx, "aspect_remote_exec", umbrella)
+    spec = parse_remote(ctx.args.remote)
 
-    if not (want_cache or want_bes or want_exec):
+    # Selecting a deployment without saying what to use it for wires nothing, which
+    # reads as a silent no-op; make it a clear error instead. `--remote=none` counts
+    # as saying so (it deliberately wires nothing).
+    if ctx.args.deployment and not ctx.args.remote:
+        fail("--deployment=%s selects a deployment but wires nothing on its own. " % ctx.args.deployment +
+             "Add --remote for its remote cache and BES backend, or --remote=exec to add remote execution.")
+
+    if not (spec.cache or spec.bes or spec.exec):
         return DeploymentFlags(base_flags = [], bes_backends = [])
 
     endpoints = ctx.aspect.auth.deployment_endpoints(deployment = ctx.args.deployment)
 
-    # A capability flag needs a deployment to draw endpoints from. With no
-    # explicit --deployment the target is the current default; if that resolves to
-    # something with no endpoints (the built-in Aspect account — i.e. no default
-    # deployment is configured), fail clearly rather than blaming a capability.
+    # --remote needs a deployment to draw endpoints from. With no --deployment the
+    # target is the current default; if that resolves to something with no
+    # endpoints (the built-in Aspect account — i.e. no default deployment is
+    # configured), fail clearly rather than blaming a capability.
     no_endpoints = not (endpoints.cache or endpoints.bes or endpoints.exec)
     if no_endpoints and not ctx.args.deployment:
-        fail("--aspect-remote* requires a Workflows deployment, but no default is set. " +
+        fail("--remote requires a Workflows deployment, but no default is set. " +
              "Run `aspect auth configure <host>` to add one. " +
              "If you already have deployments (see `aspect auth status`), set a default with " +
              "`aspect auth use <name>` or pass an explicit --deployment <name>.")
 
     named = "deployment '" + endpoints.name + "'"
 
-    def _require(explicit, flag, capability):
-        # An explicit request the deployment can't serve is an error; the umbrella
-        # just skips an unadvertised capability.
-        if explicit:
-            fail(flag + ": " + named + " does not advertise " + capability + ". Run `aspect auth configure <host>` for a deployment that serves one.")
+    def _require(capability, what):
+        # A capability the user named and the deployment can't serve is an error; a
+        # defaulted one is skipped silently.
+        if capability in spec.explicit:
+            fail("--remote=%s: %s does not advertise %s. Run `aspect auth configure <host>` for a deployment that serves one." %
+                 (capability, named, what))
 
     # The "Using deployment …" capabilities are reported cache then exec (BES is
     # wired below but announced via its own streaming line, not here).
     base_flags = []
     bes_backends = []
     capabilities = []
-    if want_cache:
+    if spec.cache:
         if endpoints.cache:
             uri = _SCHEME + endpoints.cache
             base_flags.append("--remote_cache=" + uri)
             capabilities.append(("remote cache", uri))
         else:
-            _require(cache_explicit, "--aspect-remote-cache", "a remote cache")
+            _require("cache", "a remote cache")
 
-    if want_exec:
+    if spec.exec:
         if endpoints.exec:
             uri = _SCHEME + endpoints.exec
             base_flags.append("--remote_executor=" + uri)
             capabilities.append(("remote execution", uri))
         else:
-            _require(exec_explicit, "--aspect-remote-exec", "remote execution")
+            _require("exec", "remote execution")
 
-    if want_bes:
+    if spec.bes:
         if endpoints.bes:
             # Wired as a CLI-streamed BES sink; its own "Streaming build events to
             # …" line announces it (and the end-of-build summary reports it), so it
             # is deliberately left out of the `capabilities` display below.
             bes_backends.append(_SCHEME + endpoints.bes)
         else:
-            _require(bes_explicit, "--aspect-bes-backend", "a BES backend")
+            _require("bes", "a BES backend")
 
     return DeploymentFlags(
         base_flags = base_flags,
         bes_backends = bes_backends,
         deployment = endpoints.name,
         capabilities = capabilities,
+        results_url = endpoints.results_url,
+        deployment_bes = [_SCHEME + endpoints.bes] if endpoints.bes else [],
     )
+
+def bes_results_url_flag(ctx, rc, flags: DeploymentFlags, command: str = "build") -> list:
+    """`["--bes_results_url=<url>"]` when the selected deployment advertises a
+    build-result viewer and this invocation is reporting to that deployment's BES,
+    else `[]`.
+
+    Bazel renders the "View invocation" link from `--bes_results_url`, and
+    `bazel_results.axl` reads it back off the command line for the same link in PR
+    comments and status checks. On a Workflows runner it comes from
+    `ASPECT_WORKFLOWS_BES_RESULTS_URL`; discovery is the second path to it, so a
+    local `--remote` build gets the link too, and a runner whose env var is unset
+    recovers it.
+
+    Precedence, most specific first:
+      1. A `--bes_results_url` the user already set (command line, `.bazelrc`, or an
+         expanded `--config`) — never overridden. Read through `rc`, so it is seen
+         wherever it came from.
+      2. `ASPECT_WORKFLOWS_BES_RESULTS_URL` — the runner's own deliberate config,
+         which `bazel_flags.axl` already injects.
+      3. The deployment's advertised `aspect_bes_results_url`.
+
+    Gated on actually reporting there, so the link can't point at an invocation the
+    backend never received. Either path counts: the CLI's own sink to the
+    deployment's BES (`flags.bes_backends`, i.e. `--remote` included `bes`), or
+    Bazel uploading to that same endpoint via its own `--bes_backend` — which is
+    also the case where the CLI's duplicate sink was dropped. `--remote=no-bes`
+    with no Bazel-side upload contributes no results URL.
+    """
+    if not flags.results_url:
+        return []
+    if rc != None and rc.flag_value("--bes_results_url", command = command):
+        return []
+    if ctx.std.env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL"):
+        return []
+
+    reporting = bool(flags.bes_backends)
+    if not reporting:
+        # No CLI sink of our own; Bazel may still be uploading to this deployment's
+        # BES, which the viewer URL describes just as well.
+        bazel_backend = bazel_bes_backend(rc, command)
+        reporting = bool([b for b in flags.deployment_bes if same_bes_endpoint(b, bazel_backend)])
+
+    if not reporting:
+        return []
+
+    return ["--bes_results_url=" + flags.results_url]
 
 def join_and(items: list[str], oxford: bool = False) -> str:
     """Join with commas and a trailing "and": [a] → "a"; [a,b,c] → "a, b, and c".
@@ -180,7 +323,7 @@ def join_and(items: list[str], oxford: bool = False) -> str:
 
 def announce_deployment_flags(ctx, flags: DeploymentFlags):
     """Tell the user, in one line, which deployment's base-flag capabilities this
-    bazel call is wired to (`--aspect-*`) and the endpoint each uses, so the
+    bazel call is wired to (`--remote`) and the endpoint each uses, so the
     injected --remote_cache / --remote_executor aren't silent. (BES is announced
     separately by `announce_bes_sinks`.) No-op when nothing was injected.
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -358,14 +358,20 @@ def advertised_results_url(ctx, rc, bes_sinks: list, flags: DeploymentFlags, com
     return ""
 
 def bes_results_url_flag(ctx, rc, bes_sinks: list, flags: DeploymentFlags, command: str = "build") -> list:
-    """`["--bes_results_url=<url>"]` for [`advertised_results_url`], else `[]`.
+    """`["--bes_results_url=<url>"]` when *Bazel* uploads the BES itself, else `[]`.
 
-    Bazel renders its "View invocation" line from this flag, and `render_bes_url` reads
-    it back for the same link on the CI surfaces. A `--bes_results_url` the user already
-    set — command line, `.bazelrc`, or an expanded `--config`, all seen through `rc` —
-    is never overridden.
+    Only Bazel consumes this flag, and only its BES module — the one `--bes_backend`
+    activates — reads it, to print "Streaming build results to: …" and to key the link
+    on its own `invocation_id`. Passing it on the CLI-streamed path would inject a flag
+    nothing acts on, so that path announces the URL itself; see
+    `bes_sinks.axl::announce_bes_results_url`.
+
+    A `--bes_results_url` the user already set — command line, `.bazelrc`, or an
+    expanded `--config`, all seen through `rc` — is never overridden.
     """
     if rc != None and rc.flag_value("--bes_results_url", command = command):
+        return []
+    if not bazel_bes_backend(rc, command):
         return []
 
     results_url = advertised_results_url(ctx, rc, bes_sinks, flags, command)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -52,7 +52,8 @@ viewer becomes `--bes_results_url`; see [`advertised_results_url`], which pairs 
 viewer with the backend it serves.
 
 Failures:
-  - An unrecognized capability token, or `none` combined with anything else.
+  - An unrecognized capability token, a value naming no capabilities at all, or
+    `none` combined with anything else.
   - `--deployment` with no `--remote` (nothing to wire).
   - `--remote` with no deployment to draw from — no `--deployment` and no default
     Workflows deployment configured (the target resolves to the built-in Aspect
@@ -123,10 +124,23 @@ REMOTE_CAPABILITIES = list(_CAPABILITY_SPECS)
 # What bare `--remote` wires: the accelerators that can't change build semantics.
 REMOTE_DEFAULT_CAPS = ["cache", "bes"]
 
-def capability_label(name: str) -> str:
-    """How `name` is named to users, or `""` when it isn't a capability."""
-    capability = _CAPABILITY_SPECS.get(name)
-    return capability.label if capability else ""
+def capability_labels(endpoints, only: list[str] = []) -> list[str]:
+    """The capabilities `endpoints` advertises, as the labels users see, in
+    [`REMOTE_CAPABILITIES`] order. Reads each capability's own endpoint field, so a new
+    capability needs no change here.
+
+    `only` restricts the result to those capability names — pass
+    [`REMOTE_DEFAULT_CAPS`] for what bare `--remote` wires, so a hint about it can't
+    promise the opt-in remote execution.
+
+    Takes anything carrying the endpoint fields: a `DeploymentEndpoints` or the
+    `DeploymentSummary` behind `aspect auth status`.
+    """
+    return [
+        capability.label
+        for (name, capability) in _CAPABILITY_SPECS.items()
+        if getattr(endpoints, capability.endpoint) and (not only or name in only)
+    ]
 
 # What clap substitutes for a valueless `--remote` (`args.string(bare = …)`), so an
 # empty string keeps meaning "flag absent" and the two stay distinguishable. Not a
@@ -160,18 +174,16 @@ DeploymentFlags = record(
 # named capability the deployment can't serve is an error, a defaulted one is skipped.
 RemoteSpec = record(
     on = field(dict),
-    named = field(list),
+    named = field(list, default = []),
 )
 
-def _spec(on: dict, named: list = []) -> RemoteSpec:
-    return RemoteSpec(on = on, named = named)
+# Wire nothing: an omitted `--remote`, or an explicit `--remote=none`.
+_OFF = RemoteSpec(on = {c: False for c in REMOTE_CAPABILITIES})
 
 def _endpoint_uri(endpoints, capability: Capability) -> str:
     """`capability`'s gRPC URI on `endpoints`, or `""` when unadvertised."""
     host = getattr(endpoints, capability.endpoint)
     return _SCHEME + host if host else ""
-
-_OFF = _spec({c: False for c in REMOTE_CAPABILITIES})
 
 def deployment_flag_args() -> dict:
     """The `--deployment` selector plus the `--remote` capability list every
@@ -205,14 +217,20 @@ def parse_remote(value: str) -> RemoteSpec:
     `no-` token turns it off, applied left to right so the last mention of a
     capability wins.
 
-    `fail`s on an unrecognized token and on `none` combined with anything else.
-    Public so `deployment_flags_test.axl` can assert the grammar.
+    `fail`s on an unrecognized token, on a value naming no capabilities at all (an
+    empty or separator-only list, which would otherwise pass silently as the
+    defaults), and on `none` combined with anything else. Public so
+    `deployment_flags_test.axl` can assert the grammar.
     """
     if not value:
         return _OFF
+    if value == BARE:
+        # A bare `--remote` carries no tokens, leaving the defaults in place.
+        return RemoteSpec(on = {c: c in REMOTE_DEFAULT_CAPS for c in REMOTE_CAPABILITIES})
 
-    # The bare-flag sentinel carries no tokens, leaving the defaults in place.
-    tokens = [] if value == BARE else [t.strip() for t in value.split(",") if t.strip()]
+    tokens = [t.strip() for t in value.split(",") if t.strip()]
+    if not tokens:
+        fail("--remote='%s' names no capabilities. Pass bare --remote for the defaults, or --remote=none to wire nothing." % value)
 
     if "none" in tokens:
         if len(tokens) > 1:
@@ -232,26 +250,24 @@ def parse_remote(value: str) -> RemoteSpec:
             named.append(capability)
 
     # A capability negated after being named is no longer a request.
-    return _spec(on, [c for c in named if on[c]])
+    return RemoteSpec(on = on, named = [c for c in named if on[c]])
 
 def deployment_endpoint_flags(ctx) -> DeploymentFlags:
-    """Resolve `--remote` into the [`DeploymentFlags`] to inject (`base_flags`:
-    --remote_cache / --remote_executor to prepend; `bes_backends`: extra
-    CLI-streamed BES backend URIs; `results_url`: the advertised build-result
-    viewer).
+    """Resolve `--deployment` + `--remote` into the [`DeploymentFlags`] to inject.
 
-    `fail`s when `--deployment` is passed without `--remote`, and when a *named*
-    capability can't be satisfied; a defaulted capability the deployment doesn't
-    advertise is skipped (see module docstring).
+    `fail`s when `--deployment` is passed without `--remote`, when no deployment is
+    available to draw endpoints from, and when a *named* capability can't be satisfied;
+    a defaulted capability the deployment doesn't advertise is skipped (see module
+    docstring).
     """
     if not hasattr(ctx.args, "remote"):
         return DeploymentFlags(base_flags = [], bes_backends = [])
 
     spec = parse_remote(ctx.args.remote)
 
-    # Selecting a deployment without saying what to use it for wires nothing, which
-    # reads as a silent no-op; make it a clear error instead. An explicit
-    # `--remote=none` says so deliberately and is left alone.
+    # Selecting a deployment with no `--remote` at all wires nothing, which reads as a
+    # silent no-op; make it a clear error. `--remote=none` (or an all-negated list)
+    # asks for nothing deliberately and is left alone.
     if ctx.args.deployment and not ctx.args.remote:
         fail("--deployment=%s selects a deployment but wires nothing on its own. " % ctx.args.deployment +
              "Add --remote for its remote cache and BES backend, or --remote=exec to add remote execution.")

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -45,6 +45,12 @@ dedicated cache host.
 The injected `--remote_cache` / `--remote_executor` are Bazel base flags, so an
 explicit `--bazel-flag=--remote_cache=…` still wins (last-wins).
 
+A deployment also advertises where its build results are viewable
+(`aspect_bes_results_url`). Whenever this build forwards BES to an advertised
+backend — through Bazel's own `--bes_backend` or the CLI's internal client — that
+viewer becomes `--bes_results_url`; see [`advertised_results_url`], which pairs each
+viewer with the backend it serves.
+
 Failures:
   - An unrecognized capability token, or `none` combined with anything else.
   - `--deployment` with no `--remote` (nothing to wire).
@@ -136,8 +142,8 @@ BARE = "<bare>"
 # `capabilities`.
 #
 # `bes_uri` is the deployment's BES endpoint whether or not a sink was wired to it
-# (`--remote=no-bes` leaves `bes_backends` empty), so `bes_results_url_flag` can
-# still tell that Bazel is uploading there itself. `results_url` is the advertised
+# (`--remote=no-bes` leaves `bes_backends` empty), so `advertised_results_url` can
+# still recognize Bazel uploading there itself. `results_url` is the advertised
 # build-result viewer that pairs with it.
 DeploymentFlags = record(
     base_flags = field(list),
@@ -149,9 +155,9 @@ DeploymentFlags = record(
 )
 
 # Which capabilities `--remote` resolved to: `on` maps every capability in
-# `REMOTE_CAPABILITIES` to whether to wire it, and `named` holds the subset the user asked
-# for by name (and didn't later negate). The split drives error handling — a named
-# capability the deployment can't serve is an error, a defaulted one is skipped.
+# `REMOTE_CAPABILITIES` to whether to wire it, and `named` holds the subset the user
+# asked for by name (and didn't later negate). The split drives error handling — a
+# named capability the deployment can't serve is an error, a defaulted one is skipped.
 RemoteSpec = record(
     on = field(dict),
     named = field(list),
@@ -298,9 +304,8 @@ def deployment_endpoint_flags(ctx) -> DeploymentFlags:
         bes_uri = _endpoint_uri(endpoints, _CAPABILITY_SPECS["bes"]),
     )
 
-def advertised_bes_sources(ctx, flags: DeploymentFlags) -> list[(str, str)]:
-    """The `(backend, results_url)` pairs this invocation could report to, each pair
-    from a single source so a viewer is never quoted for a backend it doesn't serve:
+def _advertised_bes_sources(ctx, flags: DeploymentFlags) -> list[(str, str)]:
+    """The `(backend, results_url)` pairs a build-result viewer could be drawn from:
     the runner environment first (`ASPECT_WORKFLOWS_BES_BACKEND` +
     `ASPECT_WORKFLOWS_BES_RESULTS_URL`), then the `--remote` deployment's advertised
     endpoint + `aspect_bes_results_url`.
@@ -315,39 +320,40 @@ def advertised_bes_sources(ctx, flags: DeploymentFlags) -> list[(str, str)]:
     ]
     return [(backend, url) for (backend, url) in pairs if backend and url]
 
-def advertised_results_url(ctx, flags: DeploymentFlags) -> str:
-    """The build-result viewer base for `data["aspect_results_url"]`, preferring the
-    runner's `ASPECT_WORKFLOWS_BES_RESULTS_URL` over the deployment's advertised
-    value. `""` when neither exists."""
-    return ctx.std.env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL") or flags.results_url
+def advertised_results_url(ctx, rc, bes_sinks: list, flags: DeploymentFlags, command: str = "build") -> str:
+    """The build-result viewer for this invocation, or `""`.
 
-def bes_results_url_flag(ctx, rc, bes_sinks: list, flags: DeploymentFlags, command: str = "build") -> list:
-    """`["--bes_results_url=<url>"]` when this invocation forwards BES to an advertised
-    backend and the user set no `--bes_results_url` of their own, else `[]`.
+    Keeping each `(backend, viewer)` pair together means the URL always belongs to the
+    BES that actually received the invocation: a build streaming to the deployment's
+    BES gets the deployment's viewer even on a runner whose environment advertises a
+    different backend. The environment wins when both sources name the same backend.
 
-    Forwarding counts either way round — Bazel uploading via its own `--bes_backend`,
-    or the CLI streaming through its internal client — and the backend may be
-    advertised by the runner environment or by the `--remote` deployment. A build
-    reporting only to some third-party BES gets nothing, since no results URL
-    describes it.
-
-    The URL is taken from whichever source advertised the backend being reported to,
-    so the viewer always belongs to the BES that received the invocation; the
-    environment wins when both name it. A `--bes_results_url` the user already set —
-    command line, `.bazelrc`, or an expanded `--config`, all seen through `rc` — is
-    never overridden.
+    `""` when nothing this build reports to has an advertised viewer — a third-party
+    BES, or a source naming only one half of the pair.
     """
-    if rc != None and rc.flag_value("--bes_results_url", command = command):
-        return []
 
     # Everywhere this invocation reports BES: the CLI's own sinks (internal client)
     # plus whatever Bazel uploads to itself.
     reporting_to = [sink.uri for sink in bes_sinks if sink.uri] + [bazel_bes_backend(rc, command)]
 
-    for (backend, results_url) in advertised_bes_sources(ctx, flags):
+    for (backend, results_url) in _advertised_bes_sources(ctx, flags):
         if [target for target in reporting_to if same_bes_endpoint(backend, target)]:
-            return ["--bes_results_url=" + results_url]
-    return []
+            return results_url
+    return ""
+
+def bes_results_url_flag(ctx, rc, bes_sinks: list, flags: DeploymentFlags, command: str = "build") -> list:
+    """`["--bes_results_url=<url>"]` for [`advertised_results_url`], else `[]`.
+
+    Bazel renders its "View invocation" line from this flag, and `render_bes_url` reads
+    it back for the same link on the CI surfaces. A `--bes_results_url` the user already
+    set — command line, `.bazelrc`, or an expanded `--config`, all seen through `rc` —
+    is never overridden.
+    """
+    if rc != None and rc.flag_value("--bes_results_url", command = command):
+        return []
+
+    results_url = advertised_results_url(ctx, rc, bes_sinks, flags, command)
+    return ["--bes_results_url=" + results_url] if results_url else []
 
 def join_and(items: list[str], oxford: bool = False) -> str:
     """Join with commas and a trailing "and": [a] → "a"; [a,b,c] → "a, b, and c".

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -68,46 +68,104 @@ load("./environment.axl", "info")
 # Bazel-facing Aspect endpoints are TLS gRPC.
 _SCHEME = "grpcs://"
 
+# One capability `--remote` can wire.
+#
+#   endpoint  the `DeploymentEndpoints` field holding its host
+#   flag      Bazel flag to inject, or "" when the CLI wires it itself (BES, as a
+#             CLI-streamed sink rather than a flag)
+#   label     how it is named to users
+#   announced whether the "Using deployment …" line lists it; BES is false because
+#             `announce_bes_sinks` gives it its own "Streaming build events to …"
+#   needs     completes "<deployment> does not advertise …" when a named capability
+#             is unavailable
+Capability = record(
+    endpoint = field(str),
+    label = field(str),
+    needs = field(str),
+    flag = field(str, default = ""),
+    announced = field(bool, default = True),
+)
+
 # Capabilities `--remote` accepts, each with a `no-` form that subtracts it.
-# `cache`/`bes` are on unless subtracted; `exec` is additive. `none` wires nothing
-# (an escape hatch from a config.axl default).
-_CAPABILITIES = ["cache", "bes", "exec"]
-_DEFAULT_ON = ["cache", "bes"]
+# `cache`/`bes` are on unless subtracted; `exec` is additive (never implied, since it
+# relocates every action). `none` wires nothing — an escape hatch from a config.axl
+# default. Order is the order capabilities are wired and announced.
+_CAPABILITY_SPECS = {
+    "cache": Capability(
+        endpoint = "cache",
+        flag = "--remote_cache",
+        label = "remote cache",
+        needs = "a remote cache",
+    ),
+    "exec": Capability(
+        endpoint = "exec",
+        flag = "--remote_executor",
+        label = "remote execution",
+        needs = "remote execution",
+    ),
+    "bes": Capability(
+        endpoint = "bes",
+        label = "BES backend",
+        needs = "a BES backend",
+        announced = False,
+    ),
+}
+
+# Capability names in the order they are wired, announced, and listed to users.
+REMOTE_CAPABILITIES = list(_CAPABILITY_SPECS)
+
+# What bare `--remote` wires: the accelerators that can't change build semantics.
+REMOTE_DEFAULT_CAPS = ["cache", "bes"]
+
+def capability_label(name: str) -> str:
+    """How `name` is named to users, or `""` when it isn't a capability."""
+    capability = _CAPABILITY_SPECS.get(name)
+    return capability.label if capability else ""
 
 # What clap substitutes for a valueless `--remote` (`args.string(bare = …)`), so an
-# empty string keeps meaning "flag absent" and the two stay distinguishable without
-# consulting `is_explicit`.
-BARE = "default"
+# empty string keeps meaning "flag absent" and the two stay distinguishable. Not a
+# spellable capability list, so a user typing it verbatim can't reach this path by
+# accident.
+BARE = "<bare>"
 
 # What `deployment_endpoint_flags` hands back to `run_bazel_task`: Bazel base
 # flags to prepend (--remote_cache / --remote_executor) and extra CLI-streamed
 # BES backend URIs, plus the deployment name and the base-flag capabilities as
 # `(label, uri)` pairs for the "Using deployment …" line. BES is wired via
 # `bes_backends` and announced by its own streaming line, so it is not in
-# `capabilities`. `results_url` is the deployment's advertised build-result
-# viewer, passed to `--bes_results_url` when nothing else supplies one;
-# `deployment_bes` is the deployment's BES URI whether or not a sink was wired to
-# it, so `bes_results_url_flag` can still recognize Bazel uploading there itself.
+# `capabilities`.
+#
+# `bes_uri` is the deployment's BES endpoint whether or not a sink was wired to it
+# (`--remote=no-bes` leaves `bes_backends` empty), so `bes_results_url_flag` can
+# still tell that Bazel is uploading there itself. `results_url` is the advertised
+# build-result viewer that pairs with it.
 DeploymentFlags = record(
     base_flags = field(list),
     bes_backends = field(list),
     deployment = field(str, default = ""),
     capabilities = field(list, default = []),
     results_url = field(str, default = ""),
-    deployment_bes = field(list, default = []),
+    bes_uri = field(str, default = ""),
 )
 
-# Which capabilities `--remote` resolved to. `explicit` are the ones the user named
-# (and didn't later negate), so an unadvertised one fails; a defaulted capability is
-# absent from it and is skipped silently when the deployment lacks it.
+# Which capabilities `--remote` resolved to: `on` maps every capability in
+# `REMOTE_CAPABILITIES` to whether to wire it, and `named` holds the subset the user asked
+# for by name (and didn't later negate). The split drives error handling — a named
+# capability the deployment can't serve is an error, a defaulted one is skipped.
 RemoteSpec = record(
-    cache = field(bool),
-    bes = field(bool),
-    exec = field(bool),
-    explicit = field(list),
+    on = field(dict),
+    named = field(list),
 )
 
-_OFF = RemoteSpec(cache = False, bes = False, exec = False, explicit = [])
+def _spec(on: dict, named: list = []) -> RemoteSpec:
+    return RemoteSpec(on = on, named = named)
+
+def _endpoint_uri(endpoints, capability: Capability) -> str:
+    """`capability`'s gRPC URI on `endpoints`, or `""` when unadvertised."""
+    host = getattr(endpoints, capability.endpoint)
+    return _SCHEME + host if host else ""
+
+_OFF = _spec({c: False for c in REMOTE_CAPABILITIES})
 
 def deployment_flag_args() -> dict:
     """The `--deployment` selector plus the `--remote` capability list every
@@ -135,13 +193,11 @@ def parse_remote(value: str) -> RemoteSpec:
     """Parse a `--remote` value into a [`RemoteSpec`].
 
     An empty `value` means the flag was omitted (→ nothing wired); a bare `--remote`
-    arrives as `BARE` (→ the default capabilities), so the two are distinguishable
-    without consulting `is_explicit`.
+    arrives as `BARE` (→ the default capabilities).
 
-    `cache`/`bes` start on and `exec` off; each named token turns its capability on
-    and each `no-` token turns it off, applied left to right so the last mention of a
-    capability wins. Only *named* capabilities land in `explicit` — a defaulted one
-    the deployment lacks is skipped rather than failing.
+    `cache`/`bes` start on and `exec` off; each token turns its capability on and each
+    `no-` token turns it off, applied left to right so the last mention of a
+    capability wins.
 
     `fail`s on an unrecognized token and on `none` combined with anything else.
     Public so `deployment_flags_test.axl` can assert the grammar.
@@ -157,27 +213,20 @@ def parse_remote(value: str) -> RemoteSpec:
             fail("--remote: 'none' cannot be combined with other capabilities; got '%s'." % value)
         return _OFF
 
-    on = {c: c in _DEFAULT_ON for c in _CAPABILITIES}
-    explicit = []
+    on = {c: c in REMOTE_DEFAULT_CAPS for c in REMOTE_CAPABILITIES}
+    named = []
     for token in tokens:
         negated = token.startswith("no-")
         capability = token[len("no-"):] if negated else token
-        if capability not in _CAPABILITIES:
+        if capability not in REMOTE_CAPABILITIES:
             fail("--remote: unknown capability '%s'. Expected %s (each also as no-<capability>), or none." %
-                 (token, ", ".join(_CAPABILITIES)))
+                 (token, ", ".join(REMOTE_CAPABILITIES)))
         on[capability] = not negated
+        if not negated and capability not in named:
+            named.append(capability)
 
-        # A negated capability isn't a request the deployment must satisfy, and a
-        # capability named twice is still one request.
-        if not negated and capability not in explicit:
-            explicit.append(capability)
-
-    return RemoteSpec(
-        cache = on["cache"],
-        bes = on["bes"],
-        exec = on["exec"],
-        explicit = [c for c in explicit if on[c]],
-    )
+    # A capability negated after being named is no longer a request.
+    return _spec(on, [c for c in named if on[c]])
 
 def deployment_endpoint_flags(ctx) -> DeploymentFlags:
     """Resolve `--remote` into the [`DeploymentFlags`] to inject (`base_flags`:
@@ -195,13 +244,13 @@ def deployment_endpoint_flags(ctx) -> DeploymentFlags:
     spec = parse_remote(ctx.args.remote)
 
     # Selecting a deployment without saying what to use it for wires nothing, which
-    # reads as a silent no-op; make it a clear error instead. `--remote=none` counts
-    # as saying so (it deliberately wires nothing).
+    # reads as a silent no-op; make it a clear error instead. An explicit
+    # `--remote=none` says so deliberately and is left alone.
     if ctx.args.deployment and not ctx.args.remote:
         fail("--deployment=%s selects a deployment but wires nothing on its own. " % ctx.args.deployment +
              "Add --remote for its remote cache and BES backend, or --remote=exec to add remote execution.")
 
-    if not (spec.cache or spec.bes or spec.exec):
+    if not any(spec.on.values()):
         return DeploymentFlags(base_flags = [], bes_backends = [])
 
     endpoints = ctx.aspect.auth.deployment_endpoints(deployment = ctx.args.deployment)
@@ -210,51 +259,35 @@ def deployment_endpoint_flags(ctx) -> DeploymentFlags:
     # target is the current default; if that resolves to something with no
     # endpoints (the built-in Aspect account — i.e. no default deployment is
     # configured), fail clearly rather than blaming a capability.
-    no_endpoints = not (endpoints.cache or endpoints.bes or endpoints.exec)
-    if no_endpoints and not ctx.args.deployment:
+    advertises_none = not any([_endpoint_uri(endpoints, c) for c in _CAPABILITY_SPECS.values()])
+    if advertises_none and not ctx.args.deployment:
         fail("--remote requires a Workflows deployment, but no default is set. " +
              "Run `aspect auth configure <host>` to add one. " +
              "If you already have deployments (see `aspect auth status`), set a default with " +
              "`aspect auth use <name>` or pass an explicit --deployment <name>.")
 
-    named = "deployment '" + endpoints.name + "'"
-
-    def _require(capability, what):
-        # A capability the user named and the deployment can't serve is an error; a
-        # defaulted one is skipped silently.
-        if capability in spec.explicit:
-            fail("--remote=%s: %s does not advertise %s. Run `aspect auth configure <host>` for a deployment that serves one." %
-                 (capability, named, what))
-
-    # The "Using deployment …" capabilities are reported cache then exec (BES is
-    # wired below but announced via its own streaming line, not here).
     base_flags = []
     bes_backends = []
     capabilities = []
-    if spec.cache:
-        if endpoints.cache:
-            uri = _SCHEME + endpoints.cache
-            base_flags.append("--remote_cache=" + uri)
-            capabilities.append(("remote cache", uri))
-        else:
-            _require("cache", "a remote cache")
+    for (name, capability) in _CAPABILITY_SPECS.items():
+        if not spec.on[name]:
+            continue
 
-    if spec.exec:
-        if endpoints.exec:
-            uri = _SCHEME + endpoints.exec
-            base_flags.append("--remote_executor=" + uri)
-            capabilities.append(("remote execution", uri))
-        else:
-            _require("exec", "remote execution")
+        uri = _endpoint_uri(endpoints, capability)
+        if not uri:
+            # A capability the user named and the deployment can't serve is an error;
+            # a defaulted one is skipped silently.
+            if name in spec.named:
+                fail("--remote=%s: deployment '%s' does not advertise %s. Run `aspect auth configure <host>` for a deployment that serves one." %
+                     (name, endpoints.name, capability.needs))
+            continue
 
-    if spec.bes:
-        if endpoints.bes:
-            # Wired as a CLI-streamed BES sink; its own "Streaming build events to
-            # …" line announces it (and the end-of-build summary reports it), so it
-            # is deliberately left out of the `capabilities` display below.
-            bes_backends.append(_SCHEME + endpoints.bes)
+        if capability.flag:
+            base_flags.append(capability.flag + "=" + uri)
         else:
-            _require("bes", "a BES backend")
+            bes_backends.append(uri)
+        if capability.announced:
+            capabilities.append((capability.label, uri))
 
     return DeploymentFlags(
         base_flags = base_flags,
@@ -262,7 +295,7 @@ def deployment_endpoint_flags(ctx) -> DeploymentFlags:
         deployment = endpoints.name,
         capabilities = capabilities,
         results_url = endpoints.results_url,
-        deployment_bes = [_SCHEME + endpoints.bes] if endpoints.bes else [],
+        bes_uri = _endpoint_uri(endpoints, _CAPABILITY_SPECS["bes"]),
     )
 
 def bes_results_url_flag(ctx, rc, flags: DeploymentFlags, command: str = "build") -> list:
@@ -287,10 +320,9 @@ def bes_results_url_flag(ctx, rc, flags: DeploymentFlags, command: str = "build"
 
     Gated on actually reporting there, so the link can't point at an invocation the
     backend never received. Either path counts: the CLI's own sink to the
-    deployment's BES (`flags.bes_backends`, i.e. `--remote` included `bes`), or
-    Bazel uploading to that same endpoint via its own `--bes_backend` — which is
-    also the case where the CLI's duplicate sink was dropped. `--remote=no-bes`
-    with no Bazel-side upload contributes no results URL.
+    deployment's BES, or Bazel uploading to that same endpoint via its own
+    `--bes_backend` (also the case where the CLI's duplicate sink was dropped).
+    `--remote=no-bes` with no Bazel-side upload contributes no results URL.
     """
     if not flags.results_url:
         return []
@@ -299,13 +331,7 @@ def bes_results_url_flag(ctx, rc, flags: DeploymentFlags, command: str = "build"
     if ctx.std.env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL"):
         return []
 
-    reporting = bool(flags.bes_backends)
-    if not reporting:
-        # No CLI sink of our own; Bazel may still be uploading to this deployment's
-        # BES, which the viewer URL describes just as well.
-        bazel_backend = bazel_bes_backend(rc, command)
-        reporting = bool([b for b in flags.deployment_bes if same_bes_endpoint(b, bazel_backend)])
-
+    reporting = bool(flags.bes_backends) or same_bes_endpoint(flags.bes_uri, bazel_bes_backend(rc, command))
     if not reporting:
         return []
 
@@ -321,6 +347,14 @@ def join_and(items: list[str], oxford: bool = False) -> str:
         return items[0] + (", and " if oxford else " and ") + items[1]
     return ", ".join(items[:-1]) + ", and " + items[-1]
 
+def deployment_announcement(flags: DeploymentFlags) -> str:
+    """The "Using deployment …" line for `flags`, or `""` when nothing was injected.
+    Split from `announce_deployment_flags` so the wording is unit-testable."""
+    if not flags.capabilities:
+        return ""
+    parts = [label + " (" + uri + ")" for (label, uri) in flags.capabilities]
+    return "Using deployment '" + flags.deployment + "' for " + join_and(parts, oxford = True)
+
 def announce_deployment_flags(ctx, flags: DeploymentFlags):
     """Tell the user, in one line, which deployment's base-flag capabilities this
     bazel call is wired to (`--remote`) and the endpoint each uses, so the
@@ -331,7 +365,6 @@ def announce_deployment_flags(ctx, flags: DeploymentFlags):
     to the bazel call, so announcing at resolve time strands this line above the
     phase header it describes. Callers with a retry loop announce on the first
     attempt only — a retry reuses the same flags."""
-    if not flags.capabilities:
-        return
-    parts = [label + " (" + uri + ")" for (label, uri) in flags.capabilities]
-    info(ctx.std, "Using deployment '" + flags.deployment + "' for " + join_and(parts, oxford = True))
+    line = deployment_announcement(flags)
+    if line:
+        info(ctx.std, line)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags.axl
@@ -298,58 +298,56 @@ def deployment_endpoint_flags(ctx) -> DeploymentFlags:
         bes_uri = _endpoint_uri(endpoints, _CAPABILITY_SPECS["bes"]),
     )
 
-def bes_results_url_flag(ctx, rc, flags: DeploymentFlags, command: str = "build") -> list:
-    """`["--bes_results_url=<url>"]` when the selected deployment advertises a
-    build-result viewer and *Bazel itself* uploads to that deployment's BES, else
-    `[]`.
+def advertised_bes_sources(ctx, flags: DeploymentFlags) -> list[(str, str)]:
+    """The `(backend, results_url)` pairs this invocation could report to, each pair
+    from a single source so a viewer is never quoted for a backend it doesn't serve:
+    the runner environment first (`ASPECT_WORKFLOWS_BES_BACKEND` +
+    `ASPECT_WORKFLOWS_BES_RESULTS_URL`), then the `--remote` deployment's advertised
+    endpoint + `aspect_bes_results_url`.
 
-    Bazel renders its "View invocation" line from `--bes_results_url`, joining the
-    base with its own `invocation_id`; `render_bes_url` reads the flag back for the
-    same link on the CI surfaces. Both key on Bazel's UUID, which is only the id the
-    backend indexed when Bazel was the uploader — so this flag is gated on exactly
-    that. When the CLI streams the sink instead, the invocation is indexed under the
-    sink's own UUID, and `aspect_results_url` (below) carries the base to
-    `resolve_aspect_url`, which keys on `sink_invocation_id`.
+    A source contributes only when it names both halves — a backend with no viewer has
+    no URL to offer, and a viewer with no backend describes nothing this build reports
+    to. Ordered, so the environment wins when both sources name the same backend."""
+    env = ctx.std.env
+    pairs = [
+        (env.var("ASPECT_WORKFLOWS_BES_BACKEND") or "", env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL") or ""),
+        (flags.bes_uri, flags.results_url),
+    ]
+    return [(backend, url) for (backend, url) in pairs if backend and url]
 
-    Precedence, most specific first:
-      1. A `--bes_results_url` the user already set (command line, `.bazelrc`, or an
-         expanded `--config`) — never overridden. Read through `rc`, so it is seen
-         wherever it came from.
-      2. `ASPECT_WORKFLOWS_BES_RESULTS_URL` — the runner's own deliberate config,
-         which `bazel_flags.axl` already injects.
-      3. The deployment's advertised `aspect_bes_results_url`.
+def advertised_results_url(ctx, flags: DeploymentFlags) -> str:
+    """The build-result viewer base for `data["aspect_results_url"]`, preferring the
+    runner's `ASPECT_WORKFLOWS_BES_RESULTS_URL` over the deployment's advertised
+    value. `""` when neither exists."""
+    return ctx.std.env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL") or flags.results_url
+
+def bes_results_url_flag(ctx, rc, bes_sinks: list, flags: DeploymentFlags, command: str = "build") -> list:
+    """`["--bes_results_url=<url>"]` when this invocation forwards BES to an advertised
+    backend and the user set no `--bes_results_url` of their own, else `[]`.
+
+    Forwarding counts either way round — Bazel uploading via its own `--bes_backend`,
+    or the CLI streaming through its internal client — and the backend may be
+    advertised by the runner environment or by the `--remote` deployment. A build
+    reporting only to some third-party BES gets nothing, since no results URL
+    describes it.
+
+    The URL is taken from whichever source advertised the backend being reported to,
+    so the viewer always belongs to the BES that received the invocation; the
+    environment wins when both name it. A `--bes_results_url` the user already set —
+    command line, `.bazelrc`, or an expanded `--config`, all seen through `rc` — is
+    never overridden.
     """
-    if not flags.results_url:
-        return []
     if rc != None and rc.flag_value("--bes_results_url", command = command):
         return []
-    if ctx.std.env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL"):
-        return []
 
-    # Only Bazel-side uploads are indexed under the UUID this flag's consumers use.
-    if not same_bes_endpoint(flags.bes_uri, bazel_bes_backend(rc, command)):
-        return []
+    # Everywhere this invocation reports BES: the CLI's own sinks (internal client)
+    # plus whatever Bazel uploads to itself.
+    reporting_to = [sink.uri for sink in bes_sinks if sink.uri] + [bazel_bes_backend(rc, command)]
 
-    return ["--bes_results_url=" + flags.results_url]
-
-def aspect_results_url(ctx, flags: DeploymentFlags) -> str:
-    """The Aspect Web UI base URL for `data["aspect_results_url"]`, or `""`.
-
-    The counterpart to `bes_results_url_flag` for the CLI-streamed path: the
-    invocation is indexed under the sink's own UUID, so the base is carried in `data`
-    for `resolve_aspect_url` (which keys on `sink_invocation_id`) rather than passed
-    to Bazel as `--bes_results_url`.
-
-    Empty unless the deployment advertises a viewer AND the CLI is streaming to that
-    deployment's BES — with no sink there is no sink id, and a base alone renders
-    nothing. Yields to `ASPECT_WORKFLOWS_BES_RESULTS_URL`, which the CI surfaces
-    already read as `links["results_base_url"]`.
-    """
-    if not flags.results_url or not flags.bes_backends:
-        return ""
-    if ctx.std.env.var("ASPECT_WORKFLOWS_BES_RESULTS_URL"):
-        return ""
-    return flags.results_url
+    for (backend, results_url) in advertised_bes_sources(ctx, flags):
+        if [target for target in reporting_to if same_bes_endpoint(backend, target)]:
+            return ["--bes_results_url=" + results_url]
+    return []
 
 def join_and(items: list[str], oxford: bool = False) -> str:
     """Join with commas and a trailing "and": [a] → "a"; [a,b,c] → "a, b, and c".

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -207,6 +207,7 @@ def _test_announcement_line(ctx):
         line,
         "Using deployment 'gcp' for remote cache (grpcs://cache.gcp), and remote execution (grpcs://remote.gcp)",
     )
+
     # BES is announced by its own "Streaming build events to …" line, not this one.
     if "bes.gcp" in line:
         fail("announcement should not mention the BES backend: %r" % line)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -9,9 +9,10 @@ struct, and `ctx.std.env.var` from a fixed map.
 deployment doesn't advertise, `--deployment` with no `--remote`, a bad capability
 token, a value naming no capabilities) are exercised by the CLI end-to-end, not here.
 These cover the resolution matrix: the default capability set, `exec` as additive,
-`no-` subtraction, `none`, and the build-result URL — which forwarding paths set
-`--bes_results_url`, and that its value comes from the same source as the backend
-being reported to.
+`no-` subtraction, `none`, and the build-result URL — that it comes from the same
+source as the backend being reported to, and that `--bes_results_url` is injected only
+when Bazel is the uploader (the CLI-streamed path announces the URL itself; see
+`bes_sinks.axl::announce_bes_results_url`).
 """
 
 load("./deployment_flags.axl", "BARE", "REMOTE_DEFAULT_CAPS", "advertised_results_url", "bes_results_url_flag", "capability_labels", "deployment_announcement", "deployment_endpoint_flags", "join_and", "parse_remote")
@@ -174,38 +175,30 @@ def _test_results_url_carried_off_discovery(ctx):
     flags = deployment_endpoint_flags(_ctx(_ALL, remote = BARE))
     _eq("results_url carried off discovery", flags.results_url, "https://app.gcp/i/")
 
-def _test_bes_flag_either_forwarding_path(ctx):
-    """Set whenever BES reaches an advertised backend — the CLI's internal client or
-    Bazel's own uploader."""
+def _test_bes_flag_only_when_bazel_uploads(ctx):
+    """Only Bazel reads `--bes_results_url`, and only when its own `--bes_backend`
+    activates the BES module — so the CLI-streamed path gets no flag (it announces the
+    URL itself instead)."""
     ctx_ = _ctx(_ALL, remote = BARE)
     flags = deployment_endpoint_flags(ctx_)
-    wanted = ["--bes_results_url=https://app.gcp/i/"]
 
-    # The CLI streams the deployment's BES itself (`--remote` wired the sink).
-    _eq(
-        "cli internal client → wired",
-        bes_results_url_flag(ctx_, _rc(), _sinks("grpcs://bes.gcp"), flags),
-        wanted,
-    )
-
-    # Bazel uploads to the same endpoint (the CLI's duplicate sink was dropped).
     _eq(
         "bazel-side upload → wired",
         bes_results_url_flag(ctx_, _rc({"--bes_backend": "grpcs://bes.gcp"}), [], flags),
-        wanted,
+        ["--bes_results_url=https://app.gcp/i/"],
+    )
+    _eq(
+        "cli internal client → no flag for Bazel to read",
+        bes_results_url_flag(ctx_, _rc(), _sinks("grpcs://bes.gcp"), flags),
+        [],
     )
 
 def _test_bes_flag_needs_an_advertised_backend(ctx):
-    """A build reporting only to some third-party BES gets nothing — no results URL
-    describes it."""
+    """Bazel uploading to some third-party BES gets nothing — no results URL describes
+    it."""
     ctx_ = _ctx(_ALL, remote = BARE)
     flags = deployment_endpoint_flags(ctx_)
 
-    _eq(
-        "third-party sink → not wired",
-        bes_results_url_flag(ctx_, _rc(), _sinks("grpcs://bes.elsewhere"), flags),
-        [],
-    )
     _eq(
         "third-party bazel backend → not wired",
         bes_results_url_flag(ctx_, _rc({"--bes_backend": "grpcs://bes.elsewhere"}), [], flags),
@@ -223,13 +216,13 @@ def _test_bes_flag_env_advertised_backend(ctx):
     flags = deployment_endpoint_flags(runner)
     _eq(
         "env-advertised backend + env results url → wired",
-        bes_results_url_flag(runner, _rc(), _sinks("grpcs://bes.runner"), flags),
+        bes_results_url_flag(runner, _rc({"--bes_backend": "grpcs://bes.runner"}), [], flags),
         ["--bes_results_url=https://app.runner"],
     )
 
-def _test_bes_flag_url_matches_backend_source(ctx):
-    """The URL comes from whichever source advertised the backend being reported to, so
-    a viewer is never quoted for a BES it doesn't serve."""
+def _test_results_url_matches_backend_source(ctx):
+    """The viewer comes from whichever source advertised the backend being reported to,
+    so it is never quoted for a BES it doesn't serve."""
 
     # Env and deployment name *different* backends. Streaming to the deployment's must
     # use the deployment's viewer, not the env one that describes another backend.
@@ -240,13 +233,13 @@ def _test_bes_flag_url_matches_backend_source(ctx):
     flags = deployment_endpoint_flags(split)
     _eq(
         "deployment backend → deployment viewer",
-        bes_results_url_flag(split, _rc(), _sinks("grpcs://bes.gcp"), flags),
-        ["--bes_results_url=https://app.gcp/i/"],
+        advertised_results_url(split, _rc(), _sinks("grpcs://bes.gcp"), flags),
+        "https://app.gcp/i/",
     )
     _eq(
         "env backend → env viewer",
-        bes_results_url_flag(split, _rc(), _sinks("grpcs://bes.runner"), flags),
-        ["--bes_results_url=https://app.runner"],
+        advertised_results_url(split, _rc(), _sinks("grpcs://bes.runner"), flags),
+        "https://app.runner",
     )
 
     # Both sources name the same backend: the environment is the more deliberate
@@ -257,19 +250,19 @@ def _test_bes_flag_url_matches_backend_source(ctx):
     })
     _eq(
         "same backend from both → env viewer wins",
-        bes_results_url_flag(same, _rc(), _sinks("grpcs://bes.gcp"), deployment_endpoint_flags(same)),
-        ["--bes_results_url=https://app.runner"],
+        advertised_results_url(same, _rc(), _sinks("grpcs://bes.gcp"), deployment_endpoint_flags(same)),
+        "https://app.runner",
     )
 
-def _test_bes_flag_requires_both_halves(ctx):
+def _test_results_url_requires_both_halves(ctx):
     """A source contributes only when it names a backend *and* a viewer."""
 
     # Deployment advertises a BES but no viewer.
     no_viewer = _ctx(_endpoints("aws", cache = "cache.aws", bes = "bes.aws"), remote = BARE)
     _eq(
-        "backend without a viewer → not wired",
-        bes_results_url_flag(no_viewer, _rc(), _sinks("grpcs://bes.aws"), deployment_endpoint_flags(no_viewer)),
-        [],
+        "backend without a viewer → nothing",
+        advertised_results_url(no_viewer, _rc(), _sinks("grpcs://bes.aws"), deployment_endpoint_flags(no_viewer)),
+        "",
     )
 
     # A results URL in the env with no env backend describes nothing we report to.
@@ -279,9 +272,9 @@ def _test_bes_flag_requires_both_halves(ctx):
         env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://app.runner"},
     )
     _eq(
-        "viewer without a backend → not wired",
-        bes_results_url_flag(url_only, _rc(), _sinks("grpcs://bes.aws"), deployment_endpoint_flags(url_only)),
-        [],
+        "viewer without a backend → nothing",
+        advertised_results_url(url_only, _rc(), _sinks("grpcs://bes.aws"), deployment_endpoint_flags(url_only)),
+        "",
     )
 
 def _test_bes_flag_yields_to_user_flag(ctx):
@@ -293,35 +286,21 @@ def _test_bes_flag_yields_to_user_flag(ctx):
         [],
     )
 
-def _test_results_url_and_flag_agree(ctx):
-    """`data["aspect_results_url"]` (the CI surfaces' base) and the injected
-    `--bes_results_url` are always the same value, so the two links can't disagree.
-
-    Exercised on the case that separates them: the environment advertises a backend
-    this build is *not* streaming to, so its viewer must not be borrowed for the
-    deployment's BES. (On a real runner the env backend is itself a sink — see
-    `workflows.axl` — and then the environment legitimately wins by ordering.)"""
-    split = _ctx(_ALL, remote = BARE, env = {
+def _test_results_url_on_a_runner(ctx):
+    """The runner shape: the env backend is itself a sink (see `workflows.axl`), so both
+    sources match what this build streams to and the environment wins by ordering."""
+    runner = _ctx(_ALL, remote = BARE, env = {
         "ASPECT_WORKFLOWS_BES_BACKEND": "grpcs://bes.runner",
         "ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://app.runner",
     })
-    flags = deployment_endpoint_flags(split)
-    sinks = _sinks("grpcs://bes.gcp")
-
-    base = advertised_results_url(split, _rc(), sinks, flags)
-    _eq("base tracks the backend actually streamed to", base, "https://app.gcp/i/")
-    _eq(
-        "the flag carries that same base",
-        bes_results_url_flag(split, _rc(), sinks, flags),
-        ["--bes_results_url=" + base],
-    )
-
-    # Streaming to both (the runner shape): the environment is the more deliberate
-    # config and wins.
-    both = _sinks("grpcs://bes.gcp", "grpcs://bes.runner")
     _eq(
         "both streamed → env viewer wins",
-        advertised_results_url(split, _rc(), both, flags),
+        advertised_results_url(
+            runner,
+            _rc(),
+            _sinks("grpcs://bes.gcp", "grpcs://bes.runner"),
+            deployment_endpoint_flags(runner),
+        ),
         "https://app.runner",
     )
 
@@ -404,13 +383,13 @@ _UNIT_TESTS = [
     _test_capability_labels,
     _test_announcement_line,
     _test_results_url_carried_off_discovery,
-    _test_bes_flag_either_forwarding_path,
+    _test_bes_flag_only_when_bazel_uploads,
     _test_bes_flag_needs_an_advertised_backend,
     _test_bes_flag_env_advertised_backend,
-    _test_bes_flag_url_matches_backend_source,
-    _test_bes_flag_requires_both_halves,
+    _test_results_url_matches_backend_source,
+    _test_results_url_requires_both_halves,
     _test_bes_flag_yields_to_user_flag,
-    _test_results_url_and_flag_agree,
+    _test_results_url_on_a_runner,
     _test_results_url_absent_without_a_match,
     _test_join_and,
 ]

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -9,10 +9,11 @@ struct, and `ctx.std.env.var` from a fixed map.
 deployment doesn't advertise, `--deployment` with no `--remote`, a bad capability
 token) are exercised by the CLI end-to-end, not here. These cover the resolution
 matrix: the default capability set, `exec` as additive, `no-` subtraction, `none`,
-and the `--bes_results_url` precedence chain.
+and both build-result URL paths (Bazel-uploaded → `--bes_results_url`, CLI-streamed
+→ the sink-keyed `data["aspect_results_url"]`).
 """
 
-load("./deployment_flags.axl", "BARE", "bes_results_url_flag", "deployment_announcement", "deployment_endpoint_flags", "join_and", "parse_remote")
+load("./deployment_flags.axl", "BARE", "aspect_results_url", "bes_results_url_flag", "deployment_announcement", "deployment_endpoint_flags", "join_and", "parse_remote")
 
 def _eq(label, got, want):
     if got != want:
@@ -153,39 +154,24 @@ def _test_reports_injected_capabilities(ctx):
         ("remote execution", "grpcs://remote.gcp"),
     ])
 
-def _test_results_url_from_discovery(ctx):
-    ctx_ = _ctx(_ALL, remote = BARE)
-    flags = deployment_endpoint_flags(ctx_)
+def _test_results_url_carried_off_discovery(ctx):
+    flags = deployment_endpoint_flags(_ctx(_ALL, remote = BARE))
     _eq("results_url carried off discovery", flags.results_url, "https://app.gcp/i/")
-    _eq(
-        "wired when streaming to the deployment's bes",
-        bes_results_url_flag(ctx_, _rc(), flags),
-        ["--bes_results_url=https://app.gcp/i/"],
-    )
 
-def _test_results_url_yields_to_user_flag(ctx):
+def _test_bes_flag_only_for_bazel_side_upload(ctx):
+    """`--bes_results_url` is joined with Bazel's own invocation_id, so it may only be
+    injected when Bazel is the uploader. A CLI sink indexes under its own UUID, which
+    that flag's consumers never see."""
     ctx_ = _ctx(_ALL, remote = BARE)
     flags = deployment_endpoint_flags(ctx_)
-    rc = _rc({"--bes_results_url": "https://mine.example"})
-    _eq("a user-set --bes_results_url wins", bes_results_url_flag(ctx_, rc, flags), [])
 
-def _test_results_url_yields_to_runner_env(ctx):
-    ctx_ = _ctx(_ALL, remote = BARE, env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://runner.example"})
-    flags = deployment_endpoint_flags(ctx_)
-    _eq("the runner env var wins over discovery", bes_results_url_flag(ctx_, _rc(), flags), [])
+    # The CLI is streaming the sink itself → the flag would render a dead link.
+    _eq("cli-streamed sink → no --bes_results_url", bes_results_url_flag(ctx_, _rc(), flags), [])
 
-def _test_results_url_needs_reporting(ctx):
-    # --remote=no-bes with no Bazel-side upload: nothing reports to this
-    # deployment's BES, so a viewer link would point at an invocation it never got.
-    ctx_ = _ctx(_ALL, remote = "no-bes")
-    flags = deployment_endpoint_flags(ctx_)
-    _eq("no sink → no results url", bes_results_url_flag(ctx_, _rc(), flags), [])
-
-    # ...but Bazel uploading to that same endpoint counts as reporting.
-    rc = _rc({"--bes_backend": "grpcs://bes.gcp"})
+    # Bazel uploading to the deployment's BES is the case the flag describes.
     _eq(
         "bazel-side upload to the deployment's bes → wired",
-        bes_results_url_flag(ctx_, rc, flags),
+        bes_results_url_flag(ctx_, _rc({"--bes_backend": "grpcs://bes.gcp"}), flags),
         ["--bes_results_url=https://app.gcp/i/"],
     )
 
@@ -193,10 +179,48 @@ def _test_results_url_needs_reporting(ctx):
     other = _rc({"--bes_backend": "grpcs://bes.elsewhere"})
     _eq("unrelated bazel backend → not wired", bes_results_url_flag(ctx_, other, flags), [])
 
-def _test_results_url_absent_when_unadvertised(ctx):
-    ctx_ = _ctx(_endpoints("aws", cache = "cache.aws", bes = "bes.aws"), remote = BARE)
+def _test_bes_flag_yields_to_existing_sources(ctx):
+    bazel_uploads = _rc({"--bes_backend": "grpcs://bes.gcp"})
+
+    ctx_ = _ctx(_ALL, remote = BARE)
     flags = deployment_endpoint_flags(ctx_)
-    _eq("no advertised viewer → no flag", bes_results_url_flag(ctx_, _rc(), flags), [])
+    user_set = _rc({"--bes_backend": "grpcs://bes.gcp", "--bes_results_url": "https://mine.example"})
+    _eq("a user-set --bes_results_url wins", bes_results_url_flag(ctx_, user_set, flags), [])
+
+    runner = _ctx(_ALL, remote = BARE, env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://runner.example"})
+    _eq(
+        "the runner env var wins over discovery",
+        bes_results_url_flag(runner, bazel_uploads, deployment_endpoint_flags(runner)),
+        [],
+    )
+
+    no_viewer = _ctx(_endpoints("aws", cache = "cache.aws", bes = "bes.aws"), remote = BARE)
+    _eq(
+        "no advertised viewer → no flag",
+        bes_results_url_flag(no_viewer, bazel_uploads, deployment_endpoint_flags(no_viewer)),
+        [],
+    )
+
+def _test_aspect_results_url_for_cli_streamed_sink(ctx):
+    """The CLI-streamed counterpart: the base rides in `data` for
+    `resolve_aspect_url`, which keys on the sink's own UUID."""
+    ctx_ = _ctx(_ALL, remote = BARE)
+    _eq(
+        "streaming a sink → base carried for the sink-keyed link",
+        aspect_results_url(ctx_, deployment_endpoint_flags(ctx_)),
+        "https://app.gcp/i/",
+    )
+
+    # No sink means no sink id, so a base alone would render nothing.
+    no_bes = _ctx(_ALL, remote = "no-bes")
+    _eq("no sink → no base", aspect_results_url(no_bes, deployment_endpoint_flags(no_bes)), "")
+
+    # On a runner the CI surfaces already read the env var as results_base_url.
+    runner = _ctx(_ALL, remote = BARE, env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://runner.example"})
+    _eq("runner env var wins", aspect_results_url(runner, deployment_endpoint_flags(runner)), "")
+
+    no_viewer = _ctx(_endpoints("aws", cache = "cache.aws", bes = "bes.aws"), remote = BARE)
+    _eq("no advertised viewer → no base", aspect_results_url(no_viewer, deployment_endpoint_flags(no_viewer)), "")
 
 def _test_announcement_line(ctx):
     """The "Using deployment …" line names each injected base-flag capability with
@@ -242,11 +266,10 @@ _UNIT_TESTS = [
     _test_default_skips_unadvertised,
     _test_reports_injected_capabilities,
     _test_announcement_line,
-    _test_results_url_from_discovery,
-    _test_results_url_yields_to_user_flag,
-    _test_results_url_yields_to_runner_env,
-    _test_results_url_needs_reporting,
-    _test_results_url_absent_when_unadvertised,
+    _test_results_url_carried_off_discovery,
+    _test_bes_flag_only_for_bazel_side_upload,
+    _test_bes_flag_yields_to_existing_sources,
+    _test_aspect_results_url_for_cli_streamed_sink,
     _test_join_and,
 ]
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -7,13 +7,14 @@ struct, and `ctx.std.env.var` from a fixed map.
 
 `fail()` cannot be caught in Starlark, so the error paths (a named capability the
 deployment doesn't advertise, `--deployment` with no `--remote`, a bad capability
-token) are exercised by the CLI end-to-end, not here. These cover the resolution
-matrix: the default capability set, `exec` as additive, `no-` subtraction, `none`,
-and the build-result URL — which forwarding paths set `--bes_results_url`, and that
-its value comes from the same source as the backend being reported to.
+token, a value naming no capabilities) are exercised by the CLI end-to-end, not here.
+These cover the resolution matrix: the default capability set, `exec` as additive,
+`no-` subtraction, `none`, and the build-result URL — which forwarding paths set
+`--bes_results_url`, and that its value comes from the same source as the backend
+being reported to.
 """
 
-load("./deployment_flags.axl", "BARE", "advertised_results_url", "bes_results_url_flag", "deployment_announcement", "deployment_endpoint_flags", "join_and", "parse_remote")
+load("./deployment_flags.axl", "BARE", "REMOTE_DEFAULT_CAPS", "advertised_results_url", "bes_results_url_flag", "capability_labels", "deployment_announcement", "deployment_endpoint_flags", "join_and", "parse_remote")
 
 def _eq(label, got, want):
     if got != want:
@@ -98,6 +99,17 @@ def _test_parse_none(ctx):
     _eq("none → cache off", spec.on["cache"], False)
     _eq("none → bes off", spec.on["bes"], False)
     _eq("none → exec off", spec.on["exec"], False)
+
+def _test_parse_all_negated_wires_nothing(ctx):
+    # Negating every default is a longhand `none`: legal, and wires nothing.
+    spec = parse_remote("no-cache,no-bes")
+    _eq("all negated → nothing on", [v for v in spec.on.values() if v], [])
+    _eq("all negated → nothing named", spec.named, [])
+    _eq(
+        "and so injects nothing",
+        deployment_endpoint_flags(_ctx(_ALL, remote = "no-cache,no-bes")).base_flags,
+        [],
+    )
 
 def _test_no_remote_injects_nothing(ctx):
     got = deployment_endpoint_flags(_ctx(_ALL))
@@ -326,6 +338,25 @@ def _test_results_url_absent_without_a_match(ctx):
         "",
     )
 
+def _test_capability_labels(ctx):
+    """The prose labels behind `aspect auth status`' usage hint, in wiring order and
+    covering only what the deployment advertises."""
+    _eq("cache + bes", capability_labels(_endpoints("x", cache = "c", bes = "b")), ["remote cache", "BES backend"])
+    _eq(
+        "cache/exec/bes order",
+        capability_labels(_ALL),
+        ["remote cache", "remote execution", "BES backend"],
+    )
+    _eq("nothing advertised", capability_labels(_endpoints("x")), [])
+
+    # REMOTE_DEFAULT_CAPS is what bare --remote wires, so the opt-in remote execution
+    # is dropped even when the deployment serves it.
+    _eq(
+        "restricted to the default caps drops exec",
+        capability_labels(_ALL, only = REMOTE_DEFAULT_CAPS),
+        ["remote cache", "BES backend"],
+    )
+
 def _test_announcement_line(ctx):
     """The "Using deployment …" line names each injected base-flag capability with
     its endpoint, and is empty when nothing was injected (so nothing is printed)."""
@@ -361,6 +392,7 @@ _UNIT_TESTS = [
     _test_parse_negation,
     _test_parse_last_mention_wins,
     _test_parse_none,
+    _test_parse_all_negated_wires_nothing,
     _test_parse_tolerates_whitespace,
     _test_no_remote_injects_nothing,
     _test_default_wires_cache_and_bes,
@@ -369,6 +401,7 @@ _UNIT_TESTS = [
     _test_exec_without_cache_wires_executor_only,
     _test_default_skips_unadvertised,
     _test_reports_injected_capabilities,
+    _test_capability_labels,
     _test_announcement_line,
     _test_results_url_carried_off_discovery,
     _test_bes_flag_either_forwarding_path,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -3,106 +3,184 @@
 A struct-based fake `ctx` substitutes for a real `TaskContext` (like
 `repro_commands_test.axl`), so tests run without the CLI / auth engine. The
 `ctx.aspect.auth.deployment_endpoints` call is faked to return a fixed endpoints
-struct; `ctx.args.is_explicit` is faked from a set of explicitly-set arg names.
+struct, and `ctx.std.env.var` from a fixed map.
 
-`fail()` cannot be caught in Starlark, so the error paths (an explicitly-set
-capability the deployment doesn't advertise) are exercised by the CLI end-to-end,
-not here. These cover the resolution matrix: explicit-wins-over-umbrella, the
-umbrella skipping unadvertised capabilities, and positive injection.
+`fail()` cannot be caught in Starlark, so the error paths (a named capability the
+deployment doesn't advertise, `--deployment` with no `--remote`, a bad capability
+token) are exercised by the CLI end-to-end, not here. These cover the resolution
+matrix: the default capability set, `exec` as additive, `no-` subtraction, `none`,
+and the `--bes_results_url` precedence chain.
 """
 
-load("./deployment_flags.axl", "deployment_endpoint_flags", "join_and")
+load("./deployment_flags.axl", "BARE", "bes_results_url_flag", "deployment_endpoint_flags", "join_and", "parse_remote")
 
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
 
-def _endpoints(name, cache = "", bes = "", exec = ""):
-    return struct(name = name, cache = cache, bes = bes, exec = exec)
+def _endpoints(name, cache = "", bes = "", exec = "", results_url = ""):
+    return struct(name = name, cache = cache, bes = bes, exec = exec, results_url = results_url)
 
-def _ctx(endpoints, deployment = "", explicit = [], aspect_remote = False, aspect_remote_cache = False, aspect_bes_backend = False, aspect_remote_exec = False):
-    """A fake ctx: fixed deployment_endpoints, and args whose is_explicit reports
-    the names in `explicit` and whose booleans are as given."""
-    explicit_set = {n: True for n in explicit}
+def _ctx(endpoints, deployment = "", remote = "", env = {}):
+    """A fake ctx: fixed deployment_endpoints, args carrying --deployment/--remote,
+    and an env map for the ASPECT_WORKFLOWS_BES_RESULTS_URL lookup. Pass
+    `remote = BARE` for a valueless `--remote`, matching what clap substitutes."""
     return struct(
         args = struct(
-            is_explicit = lambda name: name in explicit_set,
             deployment = deployment,
-            aspect_remote = aspect_remote,
-            aspect_remote_cache = aspect_remote_cache,
-            aspect_bes_backend = aspect_bes_backend,
-            aspect_remote_exec = aspect_remote_exec,
+            remote = remote,
         ),
+        std = struct(env = struct(var = lambda name: env.get(name, ""))),
         aspect = struct(auth = struct(
             deployment_endpoints = lambda deployment: endpoints,
         )),
     )
 
-def _test_no_flags_injects_nothing(ctx):
-    got = deployment_endpoint_flags(_ctx(_endpoints("gcp", cache = "c", bes = "b", exec = "e")))
-    _eq("no capability flags → no base flags", got.base_flags, [])
-    _eq("no capability flags → no bes", got.bes_backends, [])
+def _rc(flags = {}):
+    """A fake run command whose `flag_value` reads from a fixed map."""
+    return struct(flag_value = lambda name, command = "build": flags.get(name, ""))
 
-def _test_umbrella_injects_everything_advertised(ctx):
-    got = deployment_endpoint_flags(_ctx(
-        _endpoints("gcp", cache = "remote.gcp", bes = "bes.gcp", exec = "remote.gcp"),
-        aspect_remote = True,
-    ))
+_ALL = _endpoints("gcp", cache = "cache.gcp", bes = "bes.gcp", exec = "remote.gcp", results_url = "https://app.gcp/i/")
+
+def _test_parse_defaults(ctx):
+    # Bare --remote arrives as the sentinel: the two accelerators on, exec off.
+    # Neither is "explicit", so an unadvertised one is skipped rather than failing.
+    spec = parse_remote(BARE)
+    _eq("bare --remote → cache", spec.cache, True)
+    _eq("bare --remote → bes", spec.bes, True)
+    _eq("bare --remote → no exec", spec.exec, False)
+    _eq("bare --remote names nothing explicitly", spec.explicit, [])
+
+def _test_parse_omitted_is_off(ctx):
+    spec = parse_remote("")
+    _eq("omitted → cache off", spec.cache, False)
+    _eq("omitted → bes off", spec.bes, False)
+    _eq("omitted → exec off", spec.exec, False)
+
+def _test_parse_exec_is_additive(ctx):
+    # The case that motivated the grammar: `exec` adds to the defaults rather than
+    # replacing them, and is explicit (so an exec-less deployment is an error).
+    spec = parse_remote("exec")
+    _eq("exec keeps cache", spec.cache, True)
+    _eq("exec keeps bes", spec.bes, True)
+    _eq("exec on", spec.exec, True)
+    _eq("exec is named explicitly", spec.explicit, ["exec"])
+
+def _test_parse_negation(ctx):
+    spec = parse_remote("exec,no-bes")
+    _eq("no-bes subtracts bes", spec.bes, False)
+    _eq("cache still on", spec.cache, True)
+    _eq("exec still on", spec.exec, True)
+    _eq("a negated capability is not a request", spec.explicit, ["exec"])
+
+    only_bes = parse_remote("no-cache")
+    _eq("no-cache subtracts cache", only_bes.cache, False)
+    _eq("no-cache leaves bes", only_bes.bes, True)
+
+def _test_parse_last_mention_wins(ctx):
+    # Tokens apply left to right, so a re-enable after a negation sticks (and is
+    # then a named request).
+    spec = parse_remote("no-exec,exec")
+    _eq("re-enabled exec", spec.exec, True)
+    _eq("re-enabled exec is explicit", spec.explicit, ["exec"])
+
+    off = parse_remote("exec,no-exec")
+    _eq("negated last → off", off.exec, False)
+    _eq("negated last → not explicit", off.explicit, [])
+
+def _test_parse_none(ctx):
+    spec = parse_remote("none")
+    _eq("none → cache off", spec.cache, False)
+    _eq("none → bes off", spec.bes, False)
+    _eq("none → exec off", spec.exec, False)
+
+def _test_no_remote_injects_nothing(ctx):
+    got = deployment_endpoint_flags(_ctx(_ALL))
+    _eq("no --remote → no base flags", got.base_flags, [])
+    _eq("no --remote → no bes", got.bes_backends, [])
+
+def _test_default_wires_cache_and_bes(ctx):
+    got = deployment_endpoint_flags(_ctx(_ALL, remote = BARE))
+    _eq("bare --remote → cache only in base flags", got.base_flags, ["--remote_cache=grpcs://cache.gcp"])
+    _eq("bare --remote → bes backend", got.bes_backends, ["grpcs://bes.gcp"])
+    _eq("no executor without exec", [f for f in got.base_flags if "executor" in f], [])
+
+def _test_exec_adds_executor(ctx):
+    got = deployment_endpoint_flags(_ctx(_ALL, remote = "exec"))
     _eq(
-        "umbrella → cache + exec base flags",
+        "exec → cache + executor",
         got.base_flags,
-        ["--remote_cache=grpcs://remote.gcp", "--remote_executor=grpcs://remote.gcp"],
+        ["--remote_cache=grpcs://cache.gcp", "--remote_executor=grpcs://remote.gcp"],
     )
-    _eq("umbrella → bes backend", got.bes_backends, ["grpcs://bes.gcp"])
+    _eq("exec keeps bes", got.bes_backends, ["grpcs://bes.gcp"])
 
-def _test_umbrella_skips_unadvertised_capability(ctx):
-    # Deployment advertises cache + bes but NO exec: umbrella must skip exec
-    # silently (no fail), injecting only what's advertised.
-    got = deployment_endpoint_flags(_ctx(
-        _endpoints("aws", cache = "remote.aws", bes = "bes.aws"),
-        aspect_remote = True,
-    ))
-    _eq("umbrella, no exec → cache only in base flags", got.base_flags, ["--remote_cache=grpcs://remote.aws"])
-    _eq("umbrella, no exec → bes backend", got.bes_backends, ["grpcs://bes.aws"])
+def _test_no_bes_skips_sink(ctx):
+    got = deployment_endpoint_flags(_ctx(_ALL, remote = "exec,no-bes"))
+    _eq("no-bes → no sink", got.bes_backends, [])
+    _eq("no-bes still records the deployment's bes", got.deployment_bes, ["grpcs://bes.gcp"])
 
-def _test_granular_cache_only(ctx):
-    got = deployment_endpoint_flags(_ctx(
-        _endpoints("gcp", cache = "remote.gcp", bes = "bes.gcp", exec = "remote.gcp"),
-        explicit = ["aspect_remote_cache"],
-        aspect_remote_cache = True,
-    ))
-    _eq("granular cache → only cache", got.base_flags, ["--remote_cache=grpcs://remote.gcp"])
-    _eq("granular cache → no bes", got.bes_backends, [])
+def _test_default_skips_unadvertised(ctx):
+    # A deployment with no exec and no bes: bare --remote names neither, so both are
+    # skipped silently rather than failing.
+    got = deployment_endpoint_flags(_ctx(_endpoints("aws", cache = "cache.aws"), remote = BARE))
+    _eq("skips unadvertised bes", got.bes_backends, [])
+    _eq("wires the cache it does have", got.base_flags, ["--remote_cache=grpcs://cache.aws"])
 
-def _test_explicit_false_overrides_umbrella(ctx):
-    # --aspect-remote --aspect-remote-exec=false → everything but exec.
-    got = deployment_endpoint_flags(_ctx(
-        _endpoints("gcp", cache = "remote.gcp", bes = "bes.gcp", exec = "remote.gcp"),
-        explicit = ["aspect_remote_exec"],
-        aspect_remote = True,
-        aspect_remote_exec = False,
-    ))
-    _eq(
-        "explicit exec=false overrides umbrella → cache only, no executor",
-        got.base_flags,
-        ["--remote_cache=grpcs://remote.gcp"],
-    )
-    _eq("still gets bes from umbrella", got.bes_backends, ["grpcs://bes.gcp"])
-
-def _test_umbrella_reports_injected_capabilities(ctx):
+def _test_reports_injected_capabilities(ctx):
     # The "Using deployment …" capabilities are (label, uri) pairs in cache/exec
     # order. BES is wired (bes_backends) but announced via its own streaming line,
     # so it is not among the reported capabilities.
-    got = deployment_endpoint_flags(_ctx(
-        _endpoints("gcp", cache = "remote.gcp", bes = "bes.gcp", exec = "remote.gcp"),
-        aspect_remote = True,
-    ))
+    got = deployment_endpoint_flags(_ctx(_ALL, remote = "exec"))
     _eq("deployment name carried", got.deployment, "gcp")
     _eq("capabilities carry label + uri in cache/exec order (no bes)", got.capabilities, [
-        ("remote cache", "grpcs://remote.gcp"),
+        ("remote cache", "grpcs://cache.gcp"),
         ("remote execution", "grpcs://remote.gcp"),
     ])
-    _eq("bes still wired as a backend", got.bes_backends, ["grpcs://bes.gcp"])
+
+def _test_results_url_from_discovery(ctx):
+    ctx_ = _ctx(_ALL, remote = BARE)
+    flags = deployment_endpoint_flags(ctx_)
+    _eq("results_url carried off discovery", flags.results_url, "https://app.gcp/i/")
+    _eq(
+        "wired when streaming to the deployment's bes",
+        bes_results_url_flag(ctx_, _rc(), flags),
+        ["--bes_results_url=https://app.gcp/i/"],
+    )
+
+def _test_results_url_yields_to_user_flag(ctx):
+    ctx_ = _ctx(_ALL, remote = BARE)
+    flags = deployment_endpoint_flags(ctx_)
+    rc = _rc({"--bes_results_url": "https://mine.example"})
+    _eq("a user-set --bes_results_url wins", bes_results_url_flag(ctx_, rc, flags), [])
+
+def _test_results_url_yields_to_runner_env(ctx):
+    ctx_ = _ctx(_ALL, remote = BARE, env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://runner.example"})
+    flags = deployment_endpoint_flags(ctx_)
+    _eq("the runner env var wins over discovery", bes_results_url_flag(ctx_, _rc(), flags), [])
+
+def _test_results_url_needs_reporting(ctx):
+    # --remote=no-bes with no Bazel-side upload: nothing reports to this
+    # deployment's BES, so a viewer link would point at an invocation it never got.
+    ctx_ = _ctx(_ALL, remote = "no-bes")
+    flags = deployment_endpoint_flags(ctx_)
+    _eq("no sink → no results url", bes_results_url_flag(ctx_, _rc(), flags), [])
+
+    # ...but Bazel uploading to that same endpoint counts as reporting.
+    rc = _rc({"--bes_backend": "grpcs://bes.gcp"})
+    _eq(
+        "bazel-side upload to the deployment's bes → wired",
+        bes_results_url_flag(ctx_, rc, flags),
+        ["--bes_results_url=https://app.gcp/i/"],
+    )
+
+    # A third-party --bes_backend is not this deployment's BES.
+    other = _rc({"--bes_backend": "grpcs://bes.elsewhere"})
+    _eq("unrelated bazel backend → not wired", bes_results_url_flag(ctx_, other, flags), [])
+
+def _test_results_url_absent_when_unadvertised(ctx):
+    ctx_ = _ctx(_endpoints("aws", cache = "cache.aws", bes = "bes.aws"), remote = BARE)
+    flags = deployment_endpoint_flags(ctx_)
+    _eq("no advertised viewer → no flag", bes_results_url_flag(ctx_, _rc(), flags), [])
 
 def _test_join_and(ctx):
     _eq("empty", join_and([]), "")
@@ -112,12 +190,23 @@ def _test_join_and(ctx):
     _eq("three", join_and(["remote cache", "remote execution", "bes backend"]), "remote cache, remote execution, and bes backend")
 
 _UNIT_TESTS = [
-    _test_no_flags_injects_nothing,
-    _test_umbrella_injects_everything_advertised,
-    _test_umbrella_skips_unadvertised_capability,
-    _test_granular_cache_only,
-    _test_explicit_false_overrides_umbrella,
-    _test_umbrella_reports_injected_capabilities,
+    _test_parse_defaults,
+    _test_parse_omitted_is_off,
+    _test_parse_exec_is_additive,
+    _test_parse_negation,
+    _test_parse_last_mention_wins,
+    _test_parse_none,
+    _test_no_remote_injects_nothing,
+    _test_default_wires_cache_and_bes,
+    _test_exec_adds_executor,
+    _test_no_bes_skips_sink,
+    _test_default_skips_unadvertised,
+    _test_reports_injected_capabilities,
+    _test_results_url_from_discovery,
+    _test_results_url_yields_to_user_flag,
+    _test_results_url_yields_to_runner_env,
+    _test_results_url_needs_reporting,
+    _test_results_url_absent_when_unadvertised,
     _test_join_and,
 ]
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -281,17 +281,50 @@ def _test_bes_flag_yields_to_user_flag(ctx):
         [],
     )
 
-def _test_advertised_results_url_precedence(ctx):
-    """The same base feeds `data["aspect_results_url"]` for the sink-keyed Web UI
-    link, with identical precedence."""
+def _test_results_url_and_flag_agree(ctx):
+    """`data["aspect_results_url"]` (the CI surfaces' base) and the injected
+    `--bes_results_url` are always the same value, so the two links can't disagree.
+
+    Exercised on the case that separates them: the environment advertises a backend
+    this build is *not* streaming to, so its viewer must not be borrowed for the
+    deployment's BES. (On a real runner the env backend is itself a sink — see
+    `workflows.axl` — and then the environment legitimately wins by ordering.)"""
+    split = _ctx(_ALL, remote = BARE, env = {
+        "ASPECT_WORKFLOWS_BES_BACKEND": "grpcs://bes.runner",
+        "ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://app.runner",
+    })
+    flags = deployment_endpoint_flags(split)
+    sinks = _sinks("grpcs://bes.gcp")
+
+    base = advertised_results_url(split, _rc(), sinks, flags)
+    _eq("base tracks the backend actually streamed to", base, "https://app.gcp/i/")
+    _eq(
+        "the flag carries that same base",
+        bes_results_url_flag(split, _rc(), sinks, flags),
+        ["--bes_results_url=" + base],
+    )
+
+    # Streaming to both (the runner shape): the environment is the more deliberate
+    # config and wins.
+    both = _sinks("grpcs://bes.gcp", "grpcs://bes.runner")
+    _eq(
+        "both streamed → env viewer wins",
+        advertised_results_url(split, _rc(), both, flags),
+        "https://app.runner",
+    )
+
+def _test_results_url_absent_without_a_match(ctx):
     ctx_ = _ctx(_ALL, remote = BARE)
-    _eq("advertised value", advertised_results_url(ctx_, deployment_endpoint_flags(ctx_)), "https://app.gcp/i/")
-
-    runner = _ctx(_ALL, remote = BARE, env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://app.runner"})
-    _eq("env wins", advertised_results_url(runner, deployment_endpoint_flags(runner)), "https://app.runner")
-
-    no_viewer = _ctx(_endpoints("aws", cache = "cache.aws", bes = "bes.aws"), remote = BARE)
-    _eq("neither → empty", advertised_results_url(no_viewer, deployment_endpoint_flags(no_viewer)), "")
+    _eq(
+        "third-party BES → no base",
+        advertised_results_url(ctx_, _rc(), _sinks("grpcs://bes.elsewhere"), deployment_endpoint_flags(ctx_)),
+        "",
+    )
+    _eq(
+        "no forwarding at all → no base",
+        advertised_results_url(ctx_, _rc(), [], deployment_endpoint_flags(ctx_)),
+        "",
+    )
 
 def _test_announcement_line(ctx):
     """The "Using deployment …" line names each injected base-flag capability with
@@ -344,7 +377,8 @@ _UNIT_TESTS = [
     _test_bes_flag_url_matches_backend_source,
     _test_bes_flag_requires_both_halves,
     _test_bes_flag_yields_to_user_flag,
-    _test_advertised_results_url_precedence,
+    _test_results_url_and_flag_agree,
+    _test_results_url_absent_without_a_match,
     _test_join_and,
 ]
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -12,7 +12,7 @@ matrix: the default capability set, `exec` as additive, `no-` subtraction, `none
 and the `--bes_results_url` precedence chain.
 """
 
-load("./deployment_flags.axl", "BARE", "bes_results_url_flag", "deployment_endpoint_flags", "join_and", "parse_remote")
+load("./deployment_flags.axl", "BARE", "bes_results_url_flag", "deployment_announcement", "deployment_endpoint_flags", "join_and", "parse_remote")
 
 def _eq(label, got, want):
     if got != want:
@@ -44,55 +44,55 @@ _ALL = _endpoints("gcp", cache = "cache.gcp", bes = "bes.gcp", exec = "remote.gc
 
 def _test_parse_defaults(ctx):
     # Bare --remote arrives as the sentinel: the two accelerators on, exec off.
-    # Neither is "explicit", so an unadvertised one is skipped rather than failing.
+    # Neither is named, so an unadvertised one is skipped rather than failing.
     spec = parse_remote(BARE)
-    _eq("bare --remote → cache", spec.cache, True)
-    _eq("bare --remote → bes", spec.bes, True)
-    _eq("bare --remote → no exec", spec.exec, False)
-    _eq("bare --remote names nothing explicitly", spec.explicit, [])
+    _eq("bare --remote → cache", spec.on["cache"], True)
+    _eq("bare --remote → bes", spec.on["bes"], True)
+    _eq("bare --remote → no exec", spec.on["exec"], False)
+    _eq("bare --remote names nothing", spec.named, [])
 
 def _test_parse_omitted_is_off(ctx):
     spec = parse_remote("")
-    _eq("omitted → cache off", spec.cache, False)
-    _eq("omitted → bes off", spec.bes, False)
-    _eq("omitted → exec off", spec.exec, False)
+    _eq("omitted → cache off", spec.on["cache"], False)
+    _eq("omitted → bes off", spec.on["bes"], False)
+    _eq("omitted → exec off", spec.on["exec"], False)
 
 def _test_parse_exec_is_additive(ctx):
     # The case that motivated the grammar: `exec` adds to the defaults rather than
-    # replacing them, and is explicit (so an exec-less deployment is an error).
+    # replacing them, and counts as named (so an exec-less deployment is an error).
     spec = parse_remote("exec")
-    _eq("exec keeps cache", spec.cache, True)
-    _eq("exec keeps bes", spec.bes, True)
-    _eq("exec on", spec.exec, True)
-    _eq("exec is named explicitly", spec.explicit, ["exec"])
+    _eq("exec keeps cache", spec.on["cache"], True)
+    _eq("exec keeps bes", spec.on["bes"], True)
+    _eq("exec on", spec.on["exec"], True)
+    _eq("exec counts as named", spec.named, ["exec"])
 
 def _test_parse_negation(ctx):
     spec = parse_remote("exec,no-bes")
-    _eq("no-bes subtracts bes", spec.bes, False)
-    _eq("cache still on", spec.cache, True)
-    _eq("exec still on", spec.exec, True)
-    _eq("a negated capability is not a request", spec.explicit, ["exec"])
+    _eq("no-bes subtracts bes", spec.on["bes"], False)
+    _eq("cache still on", spec.on["cache"], True)
+    _eq("exec still on", spec.on["exec"], True)
+    _eq("a negated capability is not a request", spec.named, ["exec"])
 
     only_bes = parse_remote("no-cache")
-    _eq("no-cache subtracts cache", only_bes.cache, False)
-    _eq("no-cache leaves bes", only_bes.bes, True)
+    _eq("no-cache subtracts cache", only_bes.on["cache"], False)
+    _eq("no-cache leaves bes", only_bes.on["bes"], True)
 
 def _test_parse_last_mention_wins(ctx):
     # Tokens apply left to right, so a re-enable after a negation sticks (and is
     # then a named request).
     spec = parse_remote("no-exec,exec")
-    _eq("re-enabled exec", spec.exec, True)
-    _eq("re-enabled exec is explicit", spec.explicit, ["exec"])
+    _eq("re-enabled exec", spec.on["exec"], True)
+    _eq("re-enabled exec counts as named", spec.named, ["exec"])
 
     off = parse_remote("exec,no-exec")
-    _eq("negated last → off", off.exec, False)
-    _eq("negated last → not explicit", off.explicit, [])
+    _eq("negated last → off", off.on["exec"], False)
+    _eq("negated last → not named", off.named, [])
 
 def _test_parse_none(ctx):
     spec = parse_remote("none")
-    _eq("none → cache off", spec.cache, False)
-    _eq("none → bes off", spec.bes, False)
-    _eq("none → exec off", spec.exec, False)
+    _eq("none → cache off", spec.on["cache"], False)
+    _eq("none → bes off", spec.on["bes"], False)
+    _eq("none → exec off", spec.on["exec"], False)
 
 def _test_no_remote_injects_nothing(ctx):
     got = deployment_endpoint_flags(_ctx(_ALL))
@@ -117,7 +117,23 @@ def _test_exec_adds_executor(ctx):
 def _test_no_bes_skips_sink(ctx):
     got = deployment_endpoint_flags(_ctx(_ALL, remote = "exec,no-bes"))
     _eq("no-bes → no sink", got.bes_backends, [])
-    _eq("no-bes still records the deployment's bes", got.deployment_bes, ["grpcs://bes.gcp"])
+    _eq("no-bes still records the deployment's bes", got.bes_uri, "grpcs://bes.gcp")
+
+def _test_exec_without_cache_wires_executor_only(ctx):
+    # `no-cache,exec` leaves Bazel to route CAS/AC through --remote_executor (the
+    # equivalence delivery.axl and cache_diff.axl rely on), so no --remote_cache is
+    # injected and the announcement names only remote execution.
+    got = deployment_endpoint_flags(_ctx(_ALL, remote = "no-cache,exec"))
+    _eq("exec alone → executor only", got.base_flags, ["--remote_executor=grpcs://remote.gcp"])
+    _eq("exec alone → announced as execution only", got.capabilities, [
+        ("remote execution", "grpcs://remote.gcp"),
+    ])
+
+def _test_parse_tolerates_whitespace(ctx):
+    # A quoted list from a config.axl or shell alias may carry spaces.
+    spec = parse_remote(" exec , no-bes ")
+    _eq("spaced tokens still parse", [spec.on["exec"], spec.on["bes"]], [True, False])
+    _eq("spaced tokens still count as named", spec.named, ["exec"])
 
 def _test_default_skips_unadvertised(ctx):
     # A deployment with no exec and no bes: bare --remote names neither, so both are
@@ -182,6 +198,26 @@ def _test_results_url_absent_when_unadvertised(ctx):
     flags = deployment_endpoint_flags(ctx_)
     _eq("no advertised viewer → no flag", bes_results_url_flag(ctx_, _rc(), flags), [])
 
+def _test_announcement_line(ctx):
+    """The "Using deployment …" line names each injected base-flag capability with
+    its endpoint, and is empty when nothing was injected (so nothing is printed)."""
+    line = deployment_announcement(deployment_endpoint_flags(_ctx(_ALL, remote = "exec")))
+    _eq(
+        "names the deployment and each base-flag capability",
+        line,
+        "Using deployment 'gcp' for remote cache (grpcs://cache.gcp), and remote execution (grpcs://remote.gcp)",
+    )
+    # BES is announced by its own "Streaming build events to …" line, not this one.
+    if "bes.gcp" in line:
+        fail("announcement should not mention the BES backend: %r" % line)
+
+    _eq("nothing injected → no line", deployment_announcement(deployment_endpoint_flags(_ctx(_ALL))), "")
+    _eq(
+        "bes-only → no line (nothing to announce here)",
+        deployment_announcement(deployment_endpoint_flags(_ctx(_ALL, remote = "no-cache"))),
+        "",
+    )
+
 def _test_join_and(ctx):
     _eq("empty", join_and([]), "")
     _eq("one", join_and(["remote cache"]), "remote cache")
@@ -196,12 +232,15 @@ _UNIT_TESTS = [
     _test_parse_negation,
     _test_parse_last_mention_wins,
     _test_parse_none,
+    _test_parse_tolerates_whitespace,
     _test_no_remote_injects_nothing,
     _test_default_wires_cache_and_bes,
     _test_exec_adds_executor,
     _test_no_bes_skips_sink,
+    _test_exec_without_cache_wires_executor_only,
     _test_default_skips_unadvertised,
     _test_reports_injected_capabilities,
+    _test_announcement_line,
     _test_results_url_from_discovery,
     _test_results_url_yields_to_user_flag,
     _test_results_url_yields_to_runner_env,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -9,11 +9,11 @@ struct, and `ctx.std.env.var` from a fixed map.
 deployment doesn't advertise, `--deployment` with no `--remote`, a bad capability
 token) are exercised by the CLI end-to-end, not here. These cover the resolution
 matrix: the default capability set, `exec` as additive, `no-` subtraction, `none`,
-and both build-result URL paths (Bazel-uploaded → `--bes_results_url`, CLI-streamed
-→ the sink-keyed `data["aspect_results_url"]`).
+and the build-result URL — which forwarding paths set `--bes_results_url`, and that
+its value comes from the same source as the backend being reported to.
 """
 
-load("./deployment_flags.axl", "BARE", "aspect_results_url", "bes_results_url_flag", "deployment_announcement", "deployment_endpoint_flags", "join_and", "parse_remote")
+load("./deployment_flags.axl", "BARE", "advertised_results_url", "bes_results_url_flag", "deployment_announcement", "deployment_endpoint_flags", "join_and", "parse_remote")
 
 def _eq(label, got, want):
     if got != want:
@@ -40,6 +40,10 @@ def _ctx(endpoints, deployment = "", remote = "", env = {}):
 def _rc(flags = {}):
     """A fake run command whose `flag_value` reads from a fixed map."""
     return struct(flag_value = lambda name, command = "build": flags.get(name, ""))
+
+def _sinks(*uris):
+    """Fake CLI-streamed BES sinks; only `.uri` is read."""
+    return [struct(uri = uri) for uri in uris]
 
 _ALL = _endpoints("gcp", cache = "cache.gcp", bes = "bes.gcp", exec = "remote.gcp", results_url = "https://app.gcp/i/")
 
@@ -158,69 +162,136 @@ def _test_results_url_carried_off_discovery(ctx):
     flags = deployment_endpoint_flags(_ctx(_ALL, remote = BARE))
     _eq("results_url carried off discovery", flags.results_url, "https://app.gcp/i/")
 
-def _test_bes_flag_only_for_bazel_side_upload(ctx):
-    """`--bes_results_url` is joined with Bazel's own invocation_id, so it may only be
-    injected when Bazel is the uploader. A CLI sink indexes under its own UUID, which
-    that flag's consumers never see."""
+def _test_bes_flag_either_forwarding_path(ctx):
+    """Set whenever BES reaches an advertised backend — the CLI's internal client or
+    Bazel's own uploader."""
+    ctx_ = _ctx(_ALL, remote = BARE)
+    flags = deployment_endpoint_flags(ctx_)
+    wanted = ["--bes_results_url=https://app.gcp/i/"]
+
+    # The CLI streams the deployment's BES itself (`--remote` wired the sink).
+    _eq(
+        "cli internal client → wired",
+        bes_results_url_flag(ctx_, _rc(), _sinks("grpcs://bes.gcp"), flags),
+        wanted,
+    )
+
+    # Bazel uploads to the same endpoint (the CLI's duplicate sink was dropped).
+    _eq(
+        "bazel-side upload → wired",
+        bes_results_url_flag(ctx_, _rc({"--bes_backend": "grpcs://bes.gcp"}), [], flags),
+        wanted,
+    )
+
+def _test_bes_flag_needs_an_advertised_backend(ctx):
+    """A build reporting only to some third-party BES gets nothing — no results URL
+    describes it."""
     ctx_ = _ctx(_ALL, remote = BARE)
     flags = deployment_endpoint_flags(ctx_)
 
-    # The CLI is streaming the sink itself → the flag would render a dead link.
-    _eq("cli-streamed sink → no --bes_results_url", bes_results_url_flag(ctx_, _rc(), flags), [])
-
-    # Bazel uploading to the deployment's BES is the case the flag describes.
     _eq(
-        "bazel-side upload to the deployment's bes → wired",
-        bes_results_url_flag(ctx_, _rc({"--bes_backend": "grpcs://bes.gcp"}), flags),
+        "third-party sink → not wired",
+        bes_results_url_flag(ctx_, _rc(), _sinks("grpcs://bes.elsewhere"), flags),
+        [],
+    )
+    _eq(
+        "third-party bazel backend → not wired",
+        bes_results_url_flag(ctx_, _rc({"--bes_backend": "grpcs://bes.elsewhere"}), [], flags),
+        [],
+    )
+    _eq("no forwarding at all → not wired", bes_results_url_flag(ctx_, _rc(), [], flags), [])
+
+def _test_bes_flag_env_advertised_backend(ctx):
+    """The advertised backend may come from the runner env rather than a deployment:
+    `--remote` is absent here, so everything is read off the environment."""
+    runner = _ctx(_ALL, env = {
+        "ASPECT_WORKFLOWS_BES_BACKEND": "grpcs://bes.runner",
+        "ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://app.runner",
+    })
+    flags = deployment_endpoint_flags(runner)
+    _eq(
+        "env-advertised backend + env results url → wired",
+        bes_results_url_flag(runner, _rc(), _sinks("grpcs://bes.runner"), flags),
+        ["--bes_results_url=https://app.runner"],
+    )
+
+def _test_bes_flag_url_matches_backend_source(ctx):
+    """The URL comes from whichever source advertised the backend being reported to, so
+    a viewer is never quoted for a BES it doesn't serve."""
+
+    # Env and deployment name *different* backends. Streaming to the deployment's must
+    # use the deployment's viewer, not the env one that describes another backend.
+    split = _ctx(_ALL, remote = BARE, env = {
+        "ASPECT_WORKFLOWS_BES_BACKEND": "grpcs://bes.runner",
+        "ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://app.runner",
+    })
+    flags = deployment_endpoint_flags(split)
+    _eq(
+        "deployment backend → deployment viewer",
+        bes_results_url_flag(split, _rc(), _sinks("grpcs://bes.gcp"), flags),
         ["--bes_results_url=https://app.gcp/i/"],
     )
-
-    # A third-party --bes_backend is not this deployment's BES.
-    other = _rc({"--bes_backend": "grpcs://bes.elsewhere"})
-    _eq("unrelated bazel backend → not wired", bes_results_url_flag(ctx_, other, flags), [])
-
-def _test_bes_flag_yields_to_existing_sources(ctx):
-    bazel_uploads = _rc({"--bes_backend": "grpcs://bes.gcp"})
-
-    ctx_ = _ctx(_ALL, remote = BARE)
-    flags = deployment_endpoint_flags(ctx_)
-    user_set = _rc({"--bes_backend": "grpcs://bes.gcp", "--bes_results_url": "https://mine.example"})
-    _eq("a user-set --bes_results_url wins", bes_results_url_flag(ctx_, user_set, flags), [])
-
-    runner = _ctx(_ALL, remote = BARE, env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://runner.example"})
     _eq(
-        "the runner env var wins over discovery",
-        bes_results_url_flag(runner, bazel_uploads, deployment_endpoint_flags(runner)),
+        "env backend → env viewer",
+        bes_results_url_flag(split, _rc(), _sinks("grpcs://bes.runner"), flags),
+        ["--bes_results_url=https://app.runner"],
+    )
+
+    # Both sources name the same backend: the environment is the more deliberate
+    # config and wins.
+    same = _ctx(_ALL, remote = BARE, env = {
+        "ASPECT_WORKFLOWS_BES_BACKEND": "grpcs://bes.gcp",
+        "ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://app.runner",
+    })
+    _eq(
+        "same backend from both → env viewer wins",
+        bes_results_url_flag(same, _rc(), _sinks("grpcs://bes.gcp"), deployment_endpoint_flags(same)),
+        ["--bes_results_url=https://app.runner"],
+    )
+
+def _test_bes_flag_requires_both_halves(ctx):
+    """A source contributes only when it names a backend *and* a viewer."""
+
+    # Deployment advertises a BES but no viewer.
+    no_viewer = _ctx(_endpoints("aws", cache = "cache.aws", bes = "bes.aws"), remote = BARE)
+    _eq(
+        "backend without a viewer → not wired",
+        bes_results_url_flag(no_viewer, _rc(), _sinks("grpcs://bes.aws"), deployment_endpoint_flags(no_viewer)),
         [],
     )
 
-    no_viewer = _ctx(_endpoints("aws", cache = "cache.aws", bes = "bes.aws"), remote = BARE)
+    # A results URL in the env with no env backend describes nothing we report to.
+    url_only = _ctx(
+        _endpoints("aws", cache = "cache.aws", bes = "bes.aws"),
+        remote = BARE,
+        env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://app.runner"},
+    )
     _eq(
-        "no advertised viewer → no flag",
-        bes_results_url_flag(no_viewer, bazel_uploads, deployment_endpoint_flags(no_viewer)),
+        "viewer without a backend → not wired",
+        bes_results_url_flag(url_only, _rc(), _sinks("grpcs://bes.aws"), deployment_endpoint_flags(url_only)),
         [],
     )
 
-def _test_aspect_results_url_for_cli_streamed_sink(ctx):
-    """The CLI-streamed counterpart: the base rides in `data` for
-    `resolve_aspect_url`, which keys on the sink's own UUID."""
+def _test_bes_flag_yields_to_user_flag(ctx):
     ctx_ = _ctx(_ALL, remote = BARE)
+    user_set = _rc({"--bes_results_url": "https://mine.example"})
     _eq(
-        "streaming a sink → base carried for the sink-keyed link",
-        aspect_results_url(ctx_, deployment_endpoint_flags(ctx_)),
-        "https://app.gcp/i/",
+        "a user-set --bes_results_url is never overridden",
+        bes_results_url_flag(ctx_, user_set, _sinks("grpcs://bes.gcp"), deployment_endpoint_flags(ctx_)),
+        [],
     )
 
-    # No sink means no sink id, so a base alone would render nothing.
-    no_bes = _ctx(_ALL, remote = "no-bes")
-    _eq("no sink → no base", aspect_results_url(no_bes, deployment_endpoint_flags(no_bes)), "")
+def _test_advertised_results_url_precedence(ctx):
+    """The same base feeds `data["aspect_results_url"]` for the sink-keyed Web UI
+    link, with identical precedence."""
+    ctx_ = _ctx(_ALL, remote = BARE)
+    _eq("advertised value", advertised_results_url(ctx_, deployment_endpoint_flags(ctx_)), "https://app.gcp/i/")
 
-    # On a runner the CI surfaces already read the env var as results_base_url.
-    runner = _ctx(_ALL, remote = BARE, env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://runner.example"})
-    _eq("runner env var wins", aspect_results_url(runner, deployment_endpoint_flags(runner)), "")
+    runner = _ctx(_ALL, remote = BARE, env = {"ASPECT_WORKFLOWS_BES_RESULTS_URL": "https://app.runner"})
+    _eq("env wins", advertised_results_url(runner, deployment_endpoint_flags(runner)), "https://app.runner")
 
     no_viewer = _ctx(_endpoints("aws", cache = "cache.aws", bes = "bes.aws"), remote = BARE)
-    _eq("no advertised viewer → no base", aspect_results_url(no_viewer, deployment_endpoint_flags(no_viewer)), "")
+    _eq("neither → empty", advertised_results_url(no_viewer, deployment_endpoint_flags(no_viewer)), "")
 
 def _test_announcement_line(ctx):
     """The "Using deployment …" line names each injected base-flag capability with
@@ -267,9 +338,13 @@ _UNIT_TESTS = [
     _test_reports_injected_capabilities,
     _test_announcement_line,
     _test_results_url_carried_off_discovery,
-    _test_bes_flag_only_for_bazel_side_upload,
-    _test_bes_flag_yields_to_existing_sources,
-    _test_aspect_results_url_for_cli_streamed_sink,
+    _test_bes_flag_either_forwarding_path,
+    _test_bes_flag_needs_an_advertised_backend,
+    _test_bes_flag_env_advertised_backend,
+    _test_bes_flag_url_matches_backend_source,
+    _test_bes_flag_requires_both_halves,
+    _test_bes_flag_yields_to_user_flag,
+    _test_advertised_results_url_precedence,
     _test_join_and,
 ]
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/text.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/text.axl
@@ -6,6 +6,7 @@ Currently:
     with thousands-separated count.
   - `truncate_for_title(text, max_len)` — word-boundary truncation with a
     `…` suffix, for status-surface titles.
+  - `join_url(base, segment)` — single-slash URL join.
 
 All are stateless, pure-string helpers. Add a new function here when
 it's wanted by more than one module and not specific to any one
@@ -70,3 +71,8 @@ def truncate_for_title(text, max_len = SUBJECT_TITLE_MAX):
     if last_space > max_len // 2:
         return window[:last_space] + "…"
     return window + "…"
+
+def join_url(base: str, segment: str) -> str:
+    """Join `base` + `segment` with exactly one slash, tolerating a trailing slash on
+    `base` (an advertised results URL may or may not carry one)."""
+    return (base if base.endswith("/") else base + "/") + segment

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -360,6 +360,7 @@ fn arg_to_clap(scope: Scope<'_>, name: &str, arg: &Arg) -> ClapArg {
             short,
             values,
             description,
+            bare,
             ..
         } => {
             let mut it = ClapArg::new(id.clone())
@@ -374,6 +375,16 @@ fn arg_to_clap(scope: Scope<'_>, name: &str, arg: &Arg) -> ClapArg {
             } else {
                 it.value_parser(value_parser!(String))
             };
+            // `bare = "…"` makes a valueless `--flag` legal. `require_equals` keeps
+            // the next argv token from being swallowed as the value, so
+            // `--remote //foo` parses as bare flag + target rather than
+            // `--remote=//foo` (same shape as the Boolean arm below).
+            if let Some(bare) = bare {
+                it = it
+                    .num_args(0..=1)
+                    .require_equals(true)
+                    .default_missing_value(bare.clone());
+            }
             it
         }
         Arg::Boolean {
@@ -1188,6 +1199,7 @@ mod tests {
             long: None,
             values: None,
             description: None,
+            bare: None,
         }
     }
 
@@ -1714,10 +1726,78 @@ mod tests {
             long: Some("custom-flag".to_owned()),
             values: None,
             description: None,
+            bare: None,
         };
         assert_eq!(
             clap_id(Scope::Feature("artifact-upload"), "mode", &arg),
             "custom-flag"
+        );
+    }
+
+    /// `args.string(bare = …)` makes a valueless `--flag` legal, which is what lets
+    /// `--remote` be the short form of `--remote=cache,bes`. The `default` must stay
+    /// reachable so "absent" and "passed bare" remain distinguishable, and
+    /// `require_equals` must keep the following argv token from being eaten as the
+    /// value (`--remote //foo` is a bare flag plus a target, not `--remote=//foo`).
+    #[test]
+    fn string_arg_with_bare_accepts_valueless_flag() {
+        let arg = Arg::String {
+            required: false,
+            default: String::new(),
+            short: None,
+            long: None,
+            values: None,
+            description: None,
+            bare: Some("default".to_owned()),
+        };
+        let cmd = || {
+            Command::new("t")
+                .no_binary_name(true)
+                .arg(arg_to_clap(Scope::Task, "remote", &arg))
+                .arg(ClapArg::new("targets").num_args(0..))
+        };
+        let get = |m: &ArgMatches| m.get_one::<String>("remote").cloned().unwrap_or_default();
+
+        // Absent → the default; bare → the `bare` value; explicit → that value.
+        assert_eq!(get(&cmd().try_get_matches_from([] as [&str; 0]).unwrap()), "");
+        assert_eq!(get(&cmd().try_get_matches_from(["--remote"]).unwrap()), "default");
+        assert_eq!(
+            get(&cmd().try_get_matches_from(["--remote=exec,no-bes"]).unwrap()),
+            "exec,no-bes"
+        );
+
+        // A following positional is not swallowed as the flag's value.
+        let m = cmd().try_get_matches_from(["--remote", "//foo"]).unwrap();
+        assert_eq!(get(&m), "default");
+        assert_eq!(
+            m.get_many::<String>("targets")
+                .unwrap()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["//foo".to_string()]
+        );
+
+        // Space-separated values are rejected rather than silently misparsed.
+        assert!(
+            Command::new("t")
+                .no_binary_name(true)
+                .arg(arg_to_clap(Scope::Task, "remote", &arg))
+                .try_get_matches_from(["--remote", "exec"])
+                .is_err()
+        );
+    }
+
+    /// Without `bare`, a string flag still requires its value — the pre-existing
+    /// behavior every other `args.string` flag depends on.
+    #[test]
+    fn string_arg_without_bare_still_requires_a_value() {
+        let arg = arg_string("");
+        assert!(
+            Command::new("t")
+                .no_binary_name(true)
+                .arg(arg_to_clap(Scope::Task, "mode", &arg))
+                .try_get_matches_from(["--mode"])
+                .is_err()
         );
     }
 }

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -1734,11 +1734,11 @@ mod tests {
         );
     }
 
-    /// `args.string(bare = …)` makes a valueless `--flag` legal, which is what lets
-    /// `--remote` be the short form of `--remote=cache,bes`. The `default` must stay
-    /// reachable so "absent" and "passed bare" remain distinguishable, and
-    /// `require_equals` must keep the following argv token from being eaten as the
-    /// value (`--remote //foo` is a bare flag plus a target, not `--remote=//foo`).
+    /// `args.string(bare = …)` makes a valueless `--flag` legal — what lets `--remote`
+    /// stand alone. The `default` must stay reachable so "absent" and "passed bare"
+    /// remain distinguishable, and `require_equals` must keep the following argv token
+    /// from being eaten as the value (`--remote //foo` is a bare flag plus a target,
+    /// not `--remote=//foo`).
     #[test]
     fn string_arg_with_bare_accepts_valueless_flag() {
         let arg = Arg::String {

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -1759,10 +1759,18 @@ mod tests {
         let get = |m: &ArgMatches| m.get_one::<String>("remote").cloned().unwrap_or_default();
 
         // Absent → the default; bare → the `bare` value; explicit → that value.
-        assert_eq!(get(&cmd().try_get_matches_from([] as [&str; 0]).unwrap()), "");
-        assert_eq!(get(&cmd().try_get_matches_from(["--remote"]).unwrap()), "default");
         assert_eq!(
-            get(&cmd().try_get_matches_from(["--remote=exec,no-bes"]).unwrap()),
+            get(&cmd().try_get_matches_from([] as [&str; 0]).unwrap()),
+            ""
+        );
+        assert_eq!(
+            get(&cmd().try_get_matches_from(["--remote"]).unwrap()),
+            "default"
+        );
+        assert_eq!(
+            get(&cmd()
+                .try_get_matches_from(["--remote=exec,no-bes"])
+                .unwrap()),
             "exec,no-bes"
         );
 

--- a/crates/axl-runtime/src/engine/arg.rs
+++ b/crates/axl-runtime/src/engine/arg.rs
@@ -31,6 +31,12 @@ pub enum Arg {
         long: Option<String>,
         values: Option<Vec<String>>,
         description: Option<String>,
+        /// Value to use when the flag is given with no `=value`, making a bare
+        /// `--flag` legal (`args.string(bare = "…")`). `None` keeps the default
+        /// behavior, where the flag requires a value. Distinct from `default`,
+        /// which applies when the flag is absent entirely — a flag with both can
+        /// tell "not passed" from "passed bare".
+        bare: Option<String>,
     },
     Boolean {
         required: bool,
@@ -361,6 +367,12 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
     /// Defines a string flag that can be specified as `--flag_name=flag_value`.
     ///
     /// Use `long = "override-name"` to override the default kebab-case derivation.
+    ///
+    /// `bare = "value"` additionally makes a valueless `--flag_name` legal,
+    /// resolving to `value` — for a flag whose common case needs no argument
+    /// (`--remote` meaning "the usual capabilities"). Without it, omitting the
+    /// value is an error. `bare` and `default` are independent, so a flag can
+    /// distinguish "absent" from "passed with no value".
     fn string<'v>(
         #[starlark(require = named, default = false)] required: bool,
         #[starlark(require = named)] default: Option<String>,
@@ -368,6 +380,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         #[starlark(require = named, default = NoneOr::None)] long: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] values: NoneOr<UnpackList<String>>,
         #[starlark(require = named, default = NoneOr::None)] description: NoneOr<String>,
+        #[starlark(require = named, default = NoneOr::None)] bare: NoneOr<String>,
     ) -> starlark::Result<Arg> {
         if required && default.is_some() {
             return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
@@ -379,6 +392,16 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
                 anyhow::anyhow!("`short` must be a 1-character string."),
             )));
         }
+        let bare = bare.into_option();
+        // A `values` list constrains what the flag accepts, so a `bare` outside it
+        // would be unreachable-but-injected — reject it at declaration instead.
+        if let (Some(bare), NoneOr::Other(allowed)) = (bare.as_ref(), &values) {
+            if !allowed.items.contains(bare) {
+                return Err(starlark::Error::new_kind(starlark::ErrorKind::Function(
+                    anyhow::anyhow!("`bare` value {bare:?} is not among the allowed `values`."),
+                )));
+            }
+        }
         Ok(Arg::String {
             required,
             default: default.unwrap_or_default(),
@@ -386,6 +409,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             long: validated_long(long)?,
             values: values.into_option().map(|it| it.items),
             description: description.into_option(),
+            bare,
         })
     }
 

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -73,6 +73,14 @@ const DEFAULT_LOGIN_SCOPES: &[&str] = &["openid", "profile", "email", "offline_a
 /// the remote executor (`--remote_executor`), present only when the deployment
 /// serves remote execution. Any field may be empty (the capability isn't served
 /// or predates endpoint advertisement).
+///
+/// `results_url` is the odd one out: the build-result viewer
+/// (`--bes_results_url`), advertised as a top-level `aspect_bes_results_url`
+/// rather than an `aspect_endpoints` entry because it is a full URL, not a bare
+/// host. It is carried here so one struct describes everything BES-adjacent a
+/// deployment offers, but it is never host-normalized and never joins the
+/// auth-gate `hosts` — it addresses a web UI, not a gRPC endpoint the login JWT
+/// is sent to. Empty when the deployment has no web UI.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 struct Endpoints {
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -81,11 +89,16 @@ struct Endpoints {
     bes: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     exec: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    results_url: String,
 }
 
 impl Endpoints {
     fn is_empty(&self) -> bool {
-        self.cache.is_empty() && self.bes.is_empty() && self.exec.is_empty()
+        self.cache.is_empty()
+            && self.bes.is_empty()
+            && self.exec.is_empty()
+            && self.results_url.is_empty()
     }
 }
 
@@ -243,7 +256,7 @@ fn select_deployment(deployments: &[Deployment], name: Option<&str>) -> anyhow::
 /// *account* by default rather than the default *deployment*: an explicit
 /// `name` picks that deployment (erroring if unknown); an empty `name` resolves
 /// the built-in Aspect account (the seed). The default-deployment concept (set by
-/// `auth use`) governs builds (`--aspect-remote`), not the account login — so a
+/// `auth use`) governs builds (`--remote`), not the account login — so a
 /// bare `auth login` always means the account, never a configured default.
 fn select_account_or_deployment(
     deployments: &[Deployment],
@@ -417,6 +430,11 @@ struct ProtectedResource {
     scopes_supported: Vec<String>,
     #[serde(default)]
     aspect_endpoints: Endpoints,
+    /// Where this deployment's build results are viewable (`--bes_results_url`).
+    /// Top-level rather than an `aspect_endpoints` entry because it is a URL, not
+    /// a bare host; omitted by a deployment with no web UI.
+    #[serde(default)]
+    aspect_bes_results_url: String,
 }
 
 impl ProtectedResource {
@@ -629,6 +647,10 @@ fn deployment_from_discovery(
         cache: endpoint_host_str(&info.aspect_endpoints.cache),
         bes: endpoint_host_str(&info.aspect_endpoints.bes),
         exec: endpoint_host_str(&info.aspect_endpoints.exec),
+        // A viewer URL, kept verbatim: it is passed to --bes_results_url, not
+        // dialed as a gRPC endpoint, so it is neither host-normalized nor pushed
+        // onto the auth gate below.
+        results_url: info.aspect_bes_results_url.clone(),
     };
     push(&endpoints.cache);
     push(&endpoints.bes);
@@ -2156,7 +2178,10 @@ fn one_deployment_summary(name: &str) -> anyhow::Result<Option<DeploymentSummary
 /// `cache` (→ --remote_cache), `bes` (→ the CLI BES sink / --bes_backend), and
 /// `exec` (→ --remote_executor). Each is a bare host, or "" when the deployment
 /// doesn't advertise/serve that capability. `name` is the resolved deployment
-/// name. Consumed by bazel-spawning tasks' `--deployment` to auto-wire the flags.
+/// name. Consumed by bazel-spawning tasks' `--remote` to auto-wire the flags.
+///
+/// `results_url` is a full URL rather than a host — the build-result viewer
+/// (→ --bes_results_url), "" when the deployment advertises no web UI.
 #[derive(Debug, Display, ProvidesStaticType, NoSerialize, Allocative, Clone)]
 #[display("<aspect.DeploymentEndpoints>")]
 pub struct DeploymentEndpoints {
@@ -2164,6 +2189,7 @@ pub struct DeploymentEndpoints {
     pub cache: String,
     pub bes: String,
     pub exec: String,
+    pub results_url: String,
 }
 
 starlark_simple_value!(DeploymentEndpoints);
@@ -2196,6 +2222,11 @@ fn deployment_endpoints_methods(registry: &mut MethodsBuilder) {
     #[starlark(attribute)]
     fn exec<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
         attr_str!(this, DeploymentEndpoints, exec)
+    }
+
+    #[starlark(attribute)]
+    fn results_url<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
+        attr_str!(this, DeploymentEndpoints, results_url)
     }
 }
 
@@ -2502,12 +2533,13 @@ fn auth_methods(registry: &mut MethodsBuilder) {
     }
 
     /// The Bazel-facing endpoints (`cache`/`bes`/`exec` hosts) advertised by the
-    /// deployment named `deployment` (or the default when omitted), so
-    /// `aspect <build|test> --deployment <name>` can auto-wire --remote_cache,
-    /// the BES backend, and --remote_executor. Errors if the deployment names no
-    /// configured deployment. A deployment that advertised no endpoints (an older
-    /// discovery, or the built-in Aspect seed) returns empty strings — the task
-    /// then injects nothing and relies on the user's own flags.
+    /// deployment named `deployment` (or the default when omitted), plus its
+    /// `results_url` viewer, so `aspect <build|test> --remote` can auto-wire
+    /// --remote_cache, the BES backend, --remote_executor, and --bes_results_url.
+    /// Errors if the deployment names no configured deployment. A deployment that
+    /// advertised no endpoints (an older discovery, or the built-in Aspect seed)
+    /// returns empty strings — the task then injects nothing and relies on the
+    /// user's own flags.
     fn deployment_endpoints<'v>(
         #[allow(unused)] this: values::Value<'v>,
         #[starlark(require = named, default = NoneOr::None)] deployment: NoneOr<String>,
@@ -2520,6 +2552,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
             cache: selected.endpoints.cache,
             bes: selected.endpoints.bes,
             exec: selected.endpoints.exec,
+            results_url: selected.endpoints.results_url,
         }))
     }
 
@@ -2889,6 +2922,7 @@ mod tests {
                 cache: "remote.acme.aspect.build".to_string(),
                 ..Default::default()
             },
+            aspect_bes_results_url: String::new(),
         }
     }
 
@@ -2939,6 +2973,47 @@ mod tests {
         ));
     }
 
+    /// The wire contract with the deployment's `/.well-known/oauth-protected-resource`
+    /// document (see aspect-build/silo#11571): `aspect_bes_results_url` is top-level,
+    /// beside `aspect_endpoints`, because it is a full URL rather than a bare host.
+    /// Parsing it by the wrong name would silently drop the Web UI link, so assert the
+    /// JSON shape rather than only the struct.
+    #[test]
+    fn parses_advertised_bes_results_url_from_discovery_json() {
+        let doc = r#"{
+            "resource": "https://remote.acme.aspect.build",
+            "authorization_servers": ["https://acme.auth.aspect.build"],
+            "client_id": "abc",
+            "aspect_endpoints": {
+                "cache": "remote.acme.aspect.build",
+                "bes": "bes.acme.aspect.build"
+            },
+            "aspect_bes_results_url": "https://app.acme.aspect.build/i/"
+        }"#;
+        let info: ProtectedResource = serde_json::from_str(doc).unwrap();
+        assert_eq!(
+            info.aspect_bes_results_url,
+            "https://app.acme.aspect.build/i/"
+        );
+        // It rides on the deployment record through the endpoints struct, unnormalized.
+        let d = deployment_from_discovery(
+            "acme".to_string(),
+            "remote.acme.aspect.build",
+            &info,
+            None,
+        );
+        assert_eq!(d.endpoints.results_url, "https://app.acme.aspect.build/i/");
+
+        // A deployment with no web UI omits the key: absent parses as empty, and
+        // `bes_results_url_flag` then injects nothing.
+        let no_ui = r#"{
+            "resource": "https://remote.acme.aspect.build",
+            "aspect_endpoints": {"cache": "remote.acme.aspect.build"}
+        }"#;
+        let info: ProtectedResource = serde_json::from_str(no_ui).unwrap();
+        assert!(info.aspect_bes_results_url.is_empty());
+    }
+
     #[test]
     fn deployment_from_discovery_records_issuer_client_and_all_hosts() {
         // A deployment advertising an authorization server + client_id + endpoints
@@ -2955,7 +3030,9 @@ mod tests {
                 cache: "https://remote.acme.aspect.build".to_string(),
                 bes: "bes.acme.aspect.build".to_string(),
                 exec: "https://remote.acme.aspect.build".to_string(),
+                results_url: String::new(),
             },
+            aspect_bes_results_url: "https://app.acme.aspect.build/i/".to_string(),
         };
         let d = configure_from(&advertised, None);
         assert_eq!(d.issuer.as_deref(), Some("https://acme.auth.aspect.build"));
@@ -2982,6 +3059,13 @@ mod tests {
         assert_eq!(d.endpoints.cache, "remote.acme.aspect.build");
         assert_eq!(d.endpoints.bes, "bes.acme.aspect.build");
         assert_eq!(d.endpoints.exec, "remote.acme.aspect.build");
+        // The viewer URL comes off the top-level `aspect_bes_results_url` and is kept
+        // verbatim — it is passed to --bes_results_url, not dialed, so it keeps its
+        // scheme and path where the endpoint hosts above are normalized to bare hosts.
+        assert_eq!(d.endpoints.results_url, "https://app.acme.aspect.build/i/");
+        // ...and it is NOT an auth-gate host: the login JWT goes to gRPC endpoints,
+        // not the web UI (the `hosts` assertion above already covers the full set).
+        assert!(!d.hosts.iter().any(|h| h.contains("app.acme")));
         assert!(auth_env_from(&d).is_ok());
 
         // An endpoint that advertises no authorization server: hosts recorded, but
@@ -2996,7 +3080,10 @@ mod tests {
                 cache: "remote.acme.aspect.build".to_string(),
                 bes: "bes.acme.aspect.build".to_string(),
                 exec: String::new(),
+                results_url: String::new(),
             },
+            // A deployment with no web UI omits it entirely.
+            aspect_bes_results_url: String::new(),
         };
         let d = configure_from(&bare, None);
         assert!(d.issuer.is_none() && d.client_id.is_none());
@@ -3400,6 +3487,7 @@ mod tests {
             cache: "remote.acme".to_string(),
             bes: "bes.acme".to_string(),
             exec: String::new(),
+            results_url: String::new(),
         };
         let s = summarize_deployment(&acme, &creds, true);
         assert!(s.logged_in && s.default && !s.builtin);

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -2027,6 +2027,9 @@ pub struct DeploymentSummary {
     pub cache: String,
     pub bes: String,
     pub exec: String,
+    /// Advertised build-result viewer (a full URL, not a host), empty when the
+    /// deployment serves no web UI.
+    pub results_url: String,
 }
 
 starlark_simple_value!(DeploymentSummary);
@@ -2095,6 +2098,11 @@ fn deployment_summary_methods(registry: &mut MethodsBuilder) {
     fn exec<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
         attr_str!(this, DeploymentSummary, exec)
     }
+
+    #[starlark(attribute)]
+    fn results_url<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
+        attr_str!(this, DeploymentSummary, results_url)
+    }
 }
 
 /// Build the summaries for `ctx.aspect.auth.list()`: the built-in Aspect account
@@ -2156,6 +2164,7 @@ fn summarize_deployment(
         cache: d.endpoints.cache.clone(),
         bes: d.endpoints.bes.clone(),
         exec: d.endpoints.exec.clone(),
+        results_url: d.endpoints.results_url.clone(),
     }
 }
 
@@ -3483,13 +3492,16 @@ mod tests {
             cache: "remote.acme".to_string(),
             bes: "bes.acme".to_string(),
             exec: String::new(),
-            results_url: String::new(),
+            results_url: "https://app.acme/i/".to_string(),
         };
         let s = summarize_deployment(&acme, &creds, true);
         assert!(s.logged_in && s.default && !s.builtin);
         assert_eq!(s.email, "u@x.io");
         assert_eq!(s.cache, "remote.acme");
         assert!(s.exec.is_empty());
+        // Carried through so `auth status` can show the build-result viewer; kept
+        // verbatim as a URL rather than normalized to a host like the endpoints.
+        assert_eq!(s.results_url, "https://app.acme/i/");
 
         // A logged-out deployment: credential-derived fields are empty.
         let s = summarize_deployment(&dep("other", false), &creds, true);

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -2996,12 +2996,8 @@ mod tests {
             "https://app.acme.aspect.build/i/"
         );
         // It rides on the deployment record through the endpoints struct, unnormalized.
-        let d = deployment_from_discovery(
-            "acme".to_string(),
-            "remote.acme.aspect.build",
-            &info,
-            None,
-        );
+        let d =
+            deployment_from_discovery("acme".to_string(), "remote.acme.aspect.build", &info, None);
         assert_eq!(d.endpoints.results_url, "https://app.acme.aspect.build/i/");
 
         // A deployment with no web UI omits the key: absent parses as empty, and


### PR DESCRIPTION
`--remote` opts a build into an Aspect Workflows deployment's remote infrastructure, as a single comma-separated capability list. The remote cache and BES backend — the two accelerators that can't change build semantics — are on; remote execution is named explicitly, since relocating every action changes toolchain assumptions, `local` tags, and network access:

```
--remote                          # cache + BES, default deployment
--remote=exec                     # + remote execution
--remote=exec,no-bes              # cache + exec
--remote=no-cache                 # BES only
--deployment=acme --remote        # cache + BES from acme
--remote=none                     # nothing (overrides a config.axl default)
(omitted)                         # nothing wired
```

`exec` is additive rather than a set you restate, and every capability has a `no-` form so adjusting one doesn't mean respelling the rest — useful against a `config.axl` default. `--deployment` remains the selector it already is on `aspect auth …`, and errors on build/test when passed with no `--remote` to act on.

Capabilities live in one table — endpoint field, Bazel flag, label, error prose — so flag wiring, the "Using deployment …" line, and `aspect auth status`' usage hint all derive from the same source. Adding a capability is a table row.

### Build-result URL

Deployments now advertise `aspect_bes_results_url` in their discovery document (aspect-build/silo#11571), so the CLI can find the build-result viewer without `ASPECT_WORKFLOWS_BES_RESULTS_URL` — including on a local `--remote` build. `aspect auth status` shows it as a `Results` row beside Cache/Exec/BES.

Whichever way a build reports BES, it now says where to see the results:

- **Bazel uploads** (`--bes_backend`) → `--bes_results_url` is injected, and Bazel prints its own "Streaming build results to: …".
- **The CLI streams** (internal client) → the CLI prints the line itself, keyed on the sink invocation id. Bazel's BES module is inactive here, so it would print nothing.

The viewer is always taken from the same source as the backend being reported to — runner environment or deployment — so it can never describe a BES that didn't receive the invocation; the environment wins when both name the same backend. A user's own `--bes_results_url` is never overridden, and a build reporting only to a third-party BES gets no URL.

Also moves the "Not streaming build events to … Bazel is already uploading" notice under the Build phase it describes, rather than the setup phase that happened to be on screen when sinks were collected.

Supporting change: `args.string(bare = "…")` makes a valueless `--flag` legal, which is what lets `--remote` stand alone. Opt-in, so no other string flag changes.

> [!NOTE]
> On the CLI-streamed path the two links use different ids — the Aspect Web UI keys on the BES envelope UUID, Bazel's `render_bes_url` on the invocation id.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no — docsite PR to follow
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

#### Release notes

- New `--remote` flag replaces `--aspect-remote`, `--aspect-remote-cache`, `--aspect-bes-backend`, and `--aspect-remote-exec`. Bare `--remote` wires the deployment's remote cache and BES backend; add `exec` for remote execution, subtract with `no-cache` / `no-bes` / `no-exec`, or pass `none` to wire nothing.
- **Remote execution is now opt-in.** `--remote` requires naming `exec` to enable it. A `config.axl` setting `aspect_remote = True` fails to load — replace it with `remote = "exec"` to keep remote execution, or `remote = ""` for cache + BES only.
- `--deployment` on build/test now errors when passed without `--remote`, instead of silently wiring nothing.
- Builds now report where to view their results whether Bazel or the CLI streams the build events, and `aspect auth status` shows each deployment's build-result URL. No `ASPECT_WORKFLOWS_BES_RESULTS_URL` required — the CLI reads it from the deployment's discovery document.

### Test plan

- New test cases added
- `cargo test -p axl-runtime -p aspect-cli` — 431 pass. Covers the discovery-document JSON shape (a wrong field name would silently drop the link), that the viewer URL is kept verbatim rather than host-normalized and stays out of the auth-gate hosts, and `bare` flag parsing — including that `--remote //foo` is a bare flag plus a target rather than `--remote=//foo`.
- `aspect dev test-deployment-flags` — 27 cases over the capability grammar, `no-` subtraction and last-mention-wins, the named-vs-defaulted error split, exec-without-cache, capability labels and the announcement wording, and the per-source viewer pairing.
- `aspect dev test-bes-sinks` — 12 cases including the new results line and the dropped-backend set. `aspect dev test-bazel-results` covers the sink-keyed link and its survival across the `build_started` reset. Full `aspect dev test-*` sweep passes.
- Manually exercised against a configured deployment: CLI-streamed and Bazel-uploaded builds each print their results URL exactly once; a runner-shaped environment advertising a second backend picks the env viewer; `--remote=exec` errors naming the unadvertised capability; `--remote=bogus`, `--remote=,` and a lone `--deployment` error as designed; `--remote=none` and `--remote=no-cache,no-bes` wire nothing; `auth status` renders the `Results` row aligned with the endpoint rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
