### PR TITLE
feat(cli): mark the debug build in version and banner output

### DIFF
--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -17,6 +17,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::ExitCode;
 
+use aspect_telemetry::cargo_pkg_display_version;
 use axl_runtime::banner;
 use axl_runtime::diag;
 use axl_runtime::engine::arg::Arg;
@@ -107,7 +108,8 @@ impl<'a, 'v> Cmd<'a, 'v> {
             .about("Aspect's programmable task runner built on top of Bazel\n{ Correct, Fast, Usable } -- Choose three")
             .subcommand_value_name("TASK|GROUP|COMMAND")
             .disable_help_subcommand(true)
-            .version(version.to_owned())
+            // Display only; `version` stays the bare number for AXL and telemetry.
+            .version(cargo_pkg_display_version())
             .disable_version_flag(true)
             .arg(
                 ClapArg::new("version")
@@ -1304,7 +1306,15 @@ mod tests {
         };
         let mut root = cmd.build("1.2.3").expect("build ok");
 
-        let banner = "Aspect CLI v1.2.3 — https://aspect.build/docs/cli";
+        // `banner::line` marks debug builds, and tests always build with debug
+        // assertions on, so derive the suffix rather than hardcoding the whole line.
+        let debug = if aspect_telemetry::is_debug_build() {
+            " (debug build)"
+        } else {
+            ""
+        };
+        let banner = format!("Aspect CLI v1.2.3{debug} — https://aspect.build/docs/cli");
+        let banner = banner.as_str();
         let rendered = |c: &mut Command| c.render_help().to_string();
 
         assert!(

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -60,7 +60,9 @@ use std::path::Path;
 use std::process::ExitCode;
 use std::time::Duration;
 
-use aspect_telemetry::{cargo_pkg_short_version, do_not_track, send_telemetry};
+use aspect_telemetry::{
+    cargo_pkg_display_version, cargo_pkg_short_version, do_not_track, send_telemetry,
+};
 use axl_runtime::bazel_live;
 use axl_runtime::ci::on_recognized_ci;
 use axl_runtime::eval::{Loader, ModuleEnv, MultiPhaseEval};
@@ -226,7 +228,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
 
             match matches.subcommand_name() {
                 Some("version") => {
-                    println!("{}", cargo_pkg_short_version());
+                    println!("{}", cargo_pkg_display_version());
                     return Ok(ExitCode::SUCCESS);
                 }
                 Some("help") => {

--- a/crates/aspect-telemetry/src/lib.rs
+++ b/crates/aspect-telemetry/src/lib.rs
@@ -43,6 +43,27 @@ pub fn cargo_pkg_short_version() -> String {
     }
 }
 
+/// Whether this binary is the `-debug-` release variant (or a local dev build).
+///
+/// The variant is built with `-Cdebug-assertions=y` applied across the whole graph,
+/// which the stripped `-c opt` release never sets, so the flag identifies the build
+/// itself. Deliberately not an environment check: `ASPECT_DEBUG_CLI` is the launcher's
+/// request for the variant, not proof that the running binary is one.
+pub fn is_debug_build() -> bool {
+    cfg!(debug_assertions)
+}
+
+/// Version for display, suffixed when running a build that trades speed for
+/// diagnostics so it is obvious which binary produced a log or crash report.
+pub fn cargo_pkg_display_version() -> String {
+    let v = cargo_pkg_short_version();
+    if is_debug_build() {
+        format!("{v} (debug build)")
+    } else {
+        v
+    }
+}
+
 pub fn do_not_track() -> bool {
     var("DO_NOT_TRACK").is_ok()
 }
@@ -196,6 +217,26 @@ fn build_payload() -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The suffix must track how this test binary was built, not an env var, so the
+    /// marker cannot be faked on or spuriously appear on a release build.
+    #[test]
+    fn display_version_is_suffixed_only_for_debug_builds() {
+        let display = cargo_pkg_display_version();
+        let bare = cargo_pkg_short_version();
+        if is_debug_build() {
+            assert_eq!(display, format!("{bare} (debug build)"));
+        } else {
+            assert_eq!(display, bare);
+        }
+    }
+
+    /// Whatever the build, the bare version stays a parseable prefix — telemetry and
+    /// AXL compare against it.
+    #[test]
+    fn display_version_starts_with_the_bare_version() {
+        assert!(cargo_pkg_display_version().starts_with(&cargo_pkg_short_version()));
+    }
 
     #[test]
     fn payload_is_wrapped_under_aspect_cli_with_core_keys() {

--- a/crates/axl-runtime/src/banner.rs
+++ b/crates/axl-runtime/src/banner.rs
@@ -8,7 +8,7 @@
 
 use std::io::IsTerminal;
 
-use aspect_telemetry::cargo_pkg_short_version;
+use aspect_telemetry::{cargo_pkg_short_version, is_debug_build};
 
 use crate::ci::on_recognized_ci;
 
@@ -23,9 +23,17 @@ const DOCS_URL: &str = "https://aspect.build/docs/cli";
 /// The grey banner line for `version`, e.g.
 /// `Aspect CLI v1.2.3 — https://aspect.build/docs/cli`, wrapped in ANSI grey.
 ///
+/// A `-debug-` build is marked here too: it is slower and larger than the primary
+/// binary, so a run that unexpectedly used one should be obvious from its output.
+///
 /// No trailing newline — callers place it within their own layout.
 pub fn line(version: &str) -> String {
-    format!("{GREY}Aspect CLI v{version} — {DOCS_URL}{RESET}")
+    let debug = if is_debug_build() {
+        " (debug build)"
+    } else {
+        ""
+    };
+    format!("{GREY}Aspect CLI v{version}{debug} — {DOCS_URL}{RESET}")
 }
 
 /// [`line`] resolving the version from workspace crate metadata. For call
@@ -63,8 +71,23 @@ mod tests {
     #[test]
     fn line_renders_grey_version_and_docs_url() {
         let s = line("9.9.9");
-        assert_eq!(s, format!("{GREY}Aspect CLI v9.9.9 — {DOCS_URL}{RESET}"));
+        // Tests build with debug assertions on, so the marker is expected here; the
+        // release binary renders the same line without it.
+        let debug = if is_debug_build() {
+            " (debug build)"
+        } else {
+            ""
+        };
+        assert_eq!(
+            s,
+            format!("{GREY}Aspect CLI v9.9.9{debug} — {DOCS_URL}{RESET}")
+        );
         assert!(s.starts_with(GREY) && s.ends_with(RESET));
+    }
+
+    #[test]
+    fn line_marks_debug_builds() {
+        assert_eq!(line("9.9.9").contains("(debug build)"), is_debug_build());
     }
 
     #[test]


### PR DESCRIPTION
The launcher can now fetch the `aspect-cli-debug-<triple>` variant (#1359), but nothing distinguished it once installed — a run that unexpectedly used the slower, larger binary looked identical to a normal one.

`aspect version`, `--version`, the `--help` header, and the runtime task banner now render `(debug build)`:

```
$ aspect version
2026.31.12 (debug build)

$ aspect --help
Aspect CLI v2026.31.12 (debug build) — https://aspect.build/docs/cli
```

The marker keys off `cfg!(debug_assertions)`, which is set graph-wide only by the `-debug-` variant's build transition and never by the stripped `-c opt` release. Deliberately *not* an `ASPECT_DEBUG_CLI` check: that variable is the launcher's request for the variant, not proof of which binary is running, so reading it would both miss a directly-invoked debug binary and falsely mark a primary one.

Machine-readable surfaces are unchanged — the telemetry span field and the AXL-visible `cli_version` stay the bare number, so version comparisons keep working. All banner surfaces render through `banner::line`, so they cannot drift apart.

A local `cargo build` is also marked, which is accurate: it is a debug build too.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes — no in-repo docs quote the version output
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`aspect version`, `--version`, and the CLI banner now show `(debug build)` when running the `aspect-cli-debug-<target>` release variant, so it is obvious which binary produced a log or crash report.

### Test plan

- New test cases added — `cargo_pkg_display_version` suffixing and bare-version-prefix invariants in `aspect-telemetry`, plus `banner::line` debug marking
- Covered by existing test cases — the two tests that assert the exact banner text now derive the suffix instead of hardcoding it, so they track the implementation
- Manual testing; please provide instructions so we can reproduce:

Verified against real Bazel release builds of both variants, on all three surfaces:

| build | `version` | `--version` | `--help` banner |
|---|---|---|---|
| primary (`-c opt`, stripped) | `2026.31.12` | `aspect 2026.31.12` | `Aspect CLI v2026.31.12 — …` |
| `-debug-` variant (via `debug_bins`) | `2026.31.12 (debug build)` | `aspect 2026.31.12 (debug build)` | `Aspect CLI v2026.31.12 (debug build) — …` |

```bash
bazel build --config=release //crates/aspect-cli:aspect-cli
bazel build --config=release //crates/aspect-cli:aspect-cli-debug-aarch64-apple-darwin_bin
bazel-bin/crates/aspect-cli/aspect-cli version
bazel-bin/crates/aspect-cli/aspect-cli-debug-aarch64-apple-darwin version
```

Also ran the 910-test AXL suite (`aspect tests axl`) to confirm nothing compares against the version string.
