### PR TITLE
feat(axl): add now_ms, hashable trait types, and `in` on ctx.traits

### DIFF
--- a/crates/axl-runtime/src/builtins/std/time.axl
+++ b/crates/axl-runtime/src/builtins/std/time.axl
@@ -3,9 +3,11 @@ sleep = _t.sleep
 sleep_iter = _t.sleep_iter
 monotonic = _t.monotonic
 monotonic_ns = _t.monotonic_ns
+now_ms = _t.now_ms
 time = struct(
     sleep = _t.sleep,
     sleep_iter = _t.sleep_iter,
     monotonic = _t.monotonic,
     monotonic_ns = _t.monotonic_ns,
+    now_ms = _t.now_ms,
 )

--- a/crates/axl-runtime/src/engine/builtins.rs
+++ b/crates/axl-runtime/src/engine/builtins.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
+use std::time::SystemTime;
 
 use allocative::Allocative;
 use base64::{
@@ -484,6 +485,27 @@ fn builtins_time_methods(registry: &mut MethodsBuilder) {
             .get_or_init(Instant::now)
             .elapsed()
             .as_nanos() as i64)
+    }
+
+    /// Returns the wall-clock time in milliseconds since the Unix epoch.
+    ///
+    /// Unlike `monotonic*`, this is real calendar time and is comparable
+    /// across processes — use it to stamp events, not to measure elapsed
+    /// time (a clock adjustment can make it jump). Returns 0 if the system
+    /// clock is set before the epoch.
+    ///
+    /// # Examples
+    ///
+    /// ```python
+    /// load("@std//time.axl", "now_ms")
+    /// stamped_at = now_ms()
+    /// ```
+    fn now_ms(this: Value<'_>) -> anyhow::Result<i64> {
+        let _ = this;
+        Ok(SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0))
     }
 }
 

--- a/crates/axl-runtime/src/engine/trait.rs
+++ b/crates/axl-runtime/src/engine/trait.rs
@@ -1,10 +1,12 @@
 use std::cell::Cell;
 use std::fmt::{self, Display, Write};
+use std::hash::Hasher;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use allocative::Allocative;
 use dupe::Dupe;
 
+use starlark::collections::StarlarkHasher;
 use starlark::environment::{GlobalsBuilder, Methods, MethodsBuilder, MethodsStatic};
 use starlark::starlark_module;
 use starlark::values::dict::AllocDict;
@@ -246,6 +248,16 @@ impl<'v> StarlarkValue<'v> for TraitType<'v> {
         write!(collector, "{}", self).unwrap();
     }
 
+    // Keyed by the trait's unique id so a trait type can key a dict or set.
+    fn write_hash(&self, hasher: &mut StarlarkHasher) -> starlark::Result<()> {
+        hasher.write_u64(self.id);
+        Ok(())
+    }
+
+    fn equals(&self, other: Value<'v>) -> starlark::Result<bool> {
+        Ok(extract_trait_type_id(other) == Some(self.id))
+    }
+
     fn export_as(
         &self,
         variable_name: &str,
@@ -369,6 +381,15 @@ impl<'v> StarlarkValue<'v> for FrozenTraitType {
 
     fn collect_repr(&self, collector: &mut String) {
         write!(collector, "{}", self).unwrap();
+    }
+
+    fn write_hash(&self, hasher: &mut StarlarkHasher) -> starlark::Result<()> {
+        hasher.write_u64(self.id);
+        Ok(())
+    }
+
+    fn equals(&self, other: Value<'v>) -> starlark::Result<bool> {
+        Ok(extract_trait_type_id(other) == Some(self.id))
     }
 
     fn invoke(

--- a/crates/axl-runtime/src/engine/trait_map.rs
+++ b/crates/axl-runtime/src/engine/trait_map.rs
@@ -185,6 +185,12 @@ impl<'v> StarlarkValue<'v> for TraitMap<'v> {
         Ok(instance)
     }
 
+    /// `Trait in ctx.traits` — declared on the task, whether or not its
+    /// instance has been constructed. A non-trait key is absent, not an error.
+    fn is_in(&self, other: Value<'v>) -> starlark::Result<bool> {
+        Ok(extract_trait_type_id(other).is_some_and(|id| self.contains(id)))
+    }
+
     fn set_at(&self, index: Value<'v>, new_value: Value<'v>) -> starlark::Result<()> {
         let type_id = extract_trait_type_id(index).ok_or_else(|| {
             starlark::Error::new_other(anyhow::anyhow!(
@@ -279,5 +285,9 @@ impl<'v> StarlarkValue<'v> for FrozenTraitMap {
                 )))
             }
         }
+    }
+
+    fn is_in(&self, other: Value<'v>) -> starlark::Result<bool> {
+        Ok(extract_trait_type_id(other).is_some_and(|id| self.entries.contains_key(&id)))
     }
 }


### PR DESCRIPTION
Three independent runtime primitives extracted from #1326:

- `std//time.axl` gains `now_ms()` — wall-clock milliseconds since the Unix epoch, for stamping events (`monotonic*` stays the right tool for measuring elapsed time).
- `TraitType` / `FrozenTraitType` implement `write_hash` and `equals` keyed on the trait's unique id, so a trait type can key a dict or set (e.g. faking `ctx.traits[SomeTrait]` in a unit test).
- `TraitMap` implements `is_in`, enabling `SomeTrait in ctx.traits` — True iff the trait is declared on the task, whether or not its instance has been constructed. A non-trait key is simply absent rather than an error.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
