### PR TITLE
perf(bazel): filter build events send-side, add a heartbeat tick

### DIFF
--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -7,6 +7,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 use allocative::Allocative;
 use axl_types::stream::Writable;
@@ -42,6 +43,7 @@ use super::sink::tracing as tracing_sink;
 use super::stream::BuildEventStream;
 use super::stream::ExecLogStream;
 use super::stream::Subscriber;
+use super::stream::SubscriberFilter;
 use super::stream::WorkspaceEventStream;
 
 /// Convert a Starlark `Writable` handle to a `std::process::Stdio` for use
@@ -426,8 +428,15 @@ pub(crate) fn build_event_sink_methods(registry: &mut MethodsBuilder) {
 #[derive(Clone)]
 struct IterConfig {
     /// `None` means no filter — every event yields. `Some(set)` keeps only
-    /// events whose payload tag is in the set.
+    /// events whose payload tag is in the set. Applied SEND-side at `bind`
+    /// time (see `BuildEventStream::subscribe_filtered`), so a filtered
+    /// iterator's buffer never holds events of other kinds.
     kinds: Option<Arc<HashSet<i32>>>,
+    /// When `Some(ms)`, blocking iteration (`for event in iter`) yields a
+    /// Starlark `None` after `ms` of silence instead of blocking forever, so
+    /// callers get a heartbeat tick even while Bazel is quiet. `None` blocks
+    /// until the next event or stream close (the historical behavior).
+    tick_ms: Option<u64>,
 }
 
 enum IterState {
@@ -467,22 +476,31 @@ impl std::fmt::Debug for IterState {
 }
 
 impl BuildEventIter {
-    pub fn new(kinds: Option<HashSet<i32>>) -> Self {
+    pub fn new(kinds: Option<HashSet<i32>>, tick_ms: Option<u64>) -> Self {
         Self {
             config: IterConfig {
                 kinds: kinds.map(Arc::new),
+                tick_ms,
             },
             state: Arc::new(Mutex::new(IterState::Pending)),
         }
     }
 
     /// Subscribe the iterator's receiver. Must run before bazel opens the
-    /// BEP FIFO so the early burst is buffered.
+    /// BEP FIFO so the early burst is buffered. The `kinds=` filter is
+    /// installed here as a send-side predicate, so the reader thread drops
+    /// unwanted kinds before they ever enter this iterator's buffer.
     fn bind(&self, stream: &BuildEventStream) -> anyhow::Result<()> {
         let mut state = self.state.lock().unwrap();
         match *state {
             IterState::Pending => {
-                let recv = stream.subscribe();
+                let filter: Option<SubscriberFilter<BuildEvent>> =
+                    self.config.kinds.clone().map(|kinds| {
+                        let f: SubscriberFilter<BuildEvent> =
+                            Arc::new(move |event: &BuildEvent| event_kind_in(event, &kinds));
+                        f
+                    });
+                let recv = stream.subscribe_filtered(filter);
                 *state = IterState::Live { recv };
                 Ok(())
             }
@@ -536,36 +554,48 @@ impl<'v> values::StarlarkValue<'v> for BuildEventIter {
     }
 
     unsafe fn iter_next(&self, _i: usize, heap: Heap<'v>) -> Option<Value<'v>> {
-        // Loop because `kinds=` may filter out events.
-        loop {
-            // Take recv out of the Mutex so we don't hold the lock across
-            // the blocking call.
-            let recv = {
-                let mut state = self.state.lock().unwrap();
-                match std::mem::replace(&mut *state, IterState::Pending) {
-                    IterState::Live { recv } => recv,
-                    other => {
-                        *state = other;
-                        return None;
-                    }
-                }
-            };
-
-            let result = recv.recv();
-            match result {
-                Ok(event) => {
-                    // Put recv back before deciding whether to filter or yield.
-                    *self.state.lock().unwrap() = IterState::Live { recv };
-                    if matches_kinds(&event, self.config.kinds.as_ref()) {
-                        return Some(event.alloc_value(heap));
-                    }
-                    // Otherwise loop and read the next event.
-                }
-                Err(_) => {
-                    *self.state.lock().unwrap() = IterState::Done;
+        // Take recv out of the Mutex so we don't hold the lock across the
+        // blocking call. Events are pre-filtered send-side (see `bind`), so
+        // whatever arrives is already a kind the caller asked for.
+        let recv = {
+            let mut state = self.state.lock().unwrap();
+            match std::mem::replace(&mut *state, IterState::Pending) {
+                IterState::Live { recv } => recv,
+                other => {
+                    *state = other;
                     return None;
                 }
             }
+        };
+
+        match self.config.tick_ms {
+            // Heartbeat mode: yield an event, or a Starlark `None` when the
+            // stream goes quiet for `ms`, so the caller's loop keeps ticking.
+            Some(ms) => match recv.recv_timeout(Duration::from_millis(ms)) {
+                Ok(event) => {
+                    *self.state.lock().unwrap() = IterState::Live { recv };
+                    Some(event.alloc_value(heap))
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    *self.state.lock().unwrap() = IterState::Live { recv };
+                    Some(Value::new_none())
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    *self.state.lock().unwrap() = IterState::Done;
+                    None
+                }
+            },
+            // Blocking mode: yield events until the stream closes.
+            None => match recv.recv() {
+                Ok(event) => {
+                    *self.state.lock().unwrap() = IterState::Live { recv };
+                    Some(event.alloc_value(heap))
+                }
+                Err(_) => {
+                    *self.state.lock().unwrap() = IterState::Done;
+                    None
+                }
+            },
         }
     }
 
@@ -586,40 +616,32 @@ pub(crate) fn build_event_iter_methods(registry: &mut MethodsBuilder) {
         Ok(NoneOr::None)
     }
 
-    /// Non-blocking pop. Returns `None` when empty or disconnected. Honors
-    /// the `kinds=` filter.
+    /// Non-blocking pop. Returns `None` when empty or disconnected. Events are
+    /// already `kinds=`-filtered send-side, so whatever is buffered is wanted.
     fn try_pop<'v>(this: Value<'v>) -> anyhow::Result<NoneOr<BuildEvent>> {
         let iter = this
             .downcast_ref_err::<BuildEventIter>()
             .into_anyhow_result()?;
-        let kinds = iter.config.kinds.clone();
-        loop {
-            let mut state = iter.state.lock().unwrap();
-            let recv = match &*state {
-                IterState::Live { recv } => recv,
-                _ => return Ok(NoneOr::None),
-            };
-            match recv.try_recv() {
-                Ok(event) => {
-                    drop(state);
-                    if matches_kinds(&event, kinds.as_ref()) {
-                        return Ok(NoneOr::Other(event));
-                    }
-                }
-                Err(std::sync::mpsc::TryRecvError::Empty) => return Ok(NoneOr::None),
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                    *state = IterState::Done;
-                    return Ok(NoneOr::None);
-                }
+        let mut state = iter.state.lock().unwrap();
+        let recv = match &*state {
+            IterState::Live { recv } => recv,
+            _ => return Ok(NoneOr::None),
+        };
+        match recv.try_recv() {
+            Ok(event) => Ok(NoneOr::Other(event)),
+            Err(std::sync::mpsc::TryRecvError::Empty) => Ok(NoneOr::None),
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                *state = IterState::Done;
+                Ok(NoneOr::None)
             }
         }
     }
 }
 
-fn matches_kinds(event: &BuildEvent, kinds: Option<&Arc<HashSet<i32>>>) -> bool {
-    let Some(kinds) = kinds else {
-        return true;
-    };
+/// True when `event`'s payload kind is in `kinds`. A payload-less event never
+/// matches a filter (there's no kind to test). Used to build the send-side
+/// subscriber filter in `BuildEventIter::bind`.
+fn event_kind_in(event: &BuildEvent, kinds: &HashSet<i32>) -> bool {
     let Some(payload) = event.payload.as_ref() else {
         return false;
     };

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -1138,6 +1138,7 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
         #[starlark(require = named, default = NoneOr::None)] kinds: NoneOr<
             UnpackList<values::Value>,
         >,
+        #[starlark(require = named, default = NoneOr::None)] tick_ms: NoneOr<i32>,
     ) -> anyhow::Result<build::BuildEventIter> {
         let kinds = match kinds {
             NoneOr::None => None,
@@ -1154,7 +1155,12 @@ fn register_build_events(globals: &mut GlobalsBuilder) {
                 Some(set)
             }
         };
-        Ok(build::BuildEventIter::new(kinds))
+        let tick_ms = match tick_ms {
+            NoneOr::None => None,
+            NoneOr::Other(ms) if ms > 0 => Some(ms as u64),
+            NoneOr::Other(ms) => anyhow::bail!("tick_ms must be a positive integer; got {ms}"),
+        };
+        Ok(build::BuildEventIter::new(kinds, tick_ms))
     }
 }
 

--- a/crates/axl-runtime/src/engine/bazel/stream/broadcaster.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/broadcaster.rs
@@ -57,12 +57,10 @@
 //!
 //! When a [`Subscriber`] is dropped (either explicitly or because it went out
 //! of scope), the broadcaster automatically cleans up its sender on the next
-//! [`Broadcaster::send`] call. This happens because:
-//!
-//! 1. The subscriber's `Receiver` is dropped
-//! 2. The next `send()` attempts to send to all subscribers
-//! 3. Sending to a dropped receiver returns `Err`
-//! 4. Failed senders are removed from the subscriber list via `retain()`
+//! [`Broadcaster::send`] call. Each subscriber holds a liveness token whose
+//! `Weak` half lives in the subscriber list, so a dead subscriber is detected
+//! before its filter runs — a filtered subscriber that never matches another
+//! event is still pruned on the very next `send()`.
 //!
 //! This lazy cleanup approach is efficient - no explicit "unsubscribe" is needed,
 //! and cleanup happens naturally during normal operation.
@@ -181,19 +179,37 @@
 //! - The `close()` method immediately frees all sender resources
 
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
+
+/// A per-subscriber send-side predicate. When present, `send` evaluates it
+/// against each event BEFORE cloning/enqueuing, so an event the subscriber
+/// doesn't want never enters its buffer (no clone, no memory). `None` means
+/// "every event". Shared (`Arc`) and thread-safe because `send` runs on the
+/// producer thread.
+pub type SubscriberFilter<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
+
+/// A subscription's broadcaster-side half.
+struct Subscription<T> {
+    /// `Some` applies send-side so a filtered subscriber's buffer only ever
+    /// holds events it wants. Any back-pressure / drop policy beyond that is
+    /// the consumer's responsibility.
+    filter: Option<SubscriberFilter<T>>,
+
+    /// Plain unbounded sender; the broadcaster fire-and-forgets via `send`.
+    tx: mpsc::Sender<T>,
+
+    /// Upgradeable half of the [`Subscriber`]'s liveness token. Dead once the
+    /// subscriber is dropped, independently of whether `filter` accepts the
+    /// event currently being sent.
+    alive: Weak<()>,
+}
 
 /// Internal state shared between the broadcaster and its clones.
 ///
 /// Protected by a mutex to ensure thread-safe access.
-#[derive(Debug)]
 struct BroadcasterInner<T> {
-    /// Active subscriber senders. Each is a plain unbounded `mpsc::Sender`;
-    /// the broadcaster fire-and-forgets via `send` and prunes senders whose
-    /// receiver has been dropped. Any back-pressure / buffering / drop
-    /// policy is the consumer's responsibility — the broadcaster doesn't
-    /// know or care how a subscriber handles a slow consumer.
-    subscribers: Vec<mpsc::Sender<T>>,
+    /// Active subscriptions, pruned during `send` as subscribers die.
+    subscribers: Vec<Subscription<T>>,
 
     /// Whether the broadcaster has been explicitly closed.
     /// When true:
@@ -202,7 +218,45 @@ struct BroadcasterInner<T> {
     closed: bool,
 }
 
-pub type Subscriber<T> = mpsc::Receiver<T>;
+impl<T> std::fmt::Debug for BroadcasterInner<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BroadcasterInner")
+            .field("subscribers", &self.subscribers.len())
+            .field("closed", &self.closed)
+            .finish()
+    }
+}
+
+/// The consumer half of a subscription. Derefs to the underlying
+/// `mpsc::Receiver`, so `recv`, `recv_timeout` and `try_recv` are used as
+/// usual. Dropping it unsubscribes: the token it carries is what lets
+/// [`Broadcaster::send`] prune the subscription without having to enqueue an
+/// event first.
+pub struct Subscriber<T> {
+    rx: mpsc::Receiver<T>,
+    /// Held only for its strong count; the broadcaster watches the `Weak`.
+    _alive: Arc<()>,
+}
+
+impl<T> Subscriber<T> {
+    /// A subscriber attached to nothing: `recv` returns `Err` immediately.
+    pub fn disconnected() -> Self {
+        let (tx, rx) = mpsc::channel();
+        drop(tx);
+        Self {
+            rx,
+            _alive: Arc::new(()),
+        }
+    }
+}
+
+impl<T> std::ops::Deref for Subscriber<T> {
+    type Target = mpsc::Receiver<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.rx
+    }
+}
 
 /// A thread-safe broadcaster that fans out events to multiple subscribers.
 ///
@@ -297,21 +351,36 @@ impl<T: Clone> Broadcaster<T> {
     ///
     /// broadcaster.send(3);
     /// ```
+    // Unfiltered convenience wrapper. Production subscribers go through
+    // `subscribe_filtered`; kept for tests and any consumer wanting every event.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn subscribe(&self) -> Subscriber<T> {
+        self.subscribe_filtered(None)
+    }
+
+    /// Like [`subscribe`](Self::subscribe), but only events for which `filter`
+    /// returns `true` are enqueued into this subscriber's buffer. The filter
+    /// runs send-side (on the producer thread), so filtered-out events are
+    /// never cloned or buffered for this subscriber — a subscriber that wants
+    /// two of twenty event kinds pays for two. `None` filter = every event.
+    pub fn subscribe_filtered(&self, filter: Option<SubscriberFilter<T>>) -> Subscriber<T> {
         let mut inner = self.inner.lock().unwrap();
 
         // If closed, return an immediately-disconnected channel.
         // This ensures subscribers created after close() don't block forever
         // waiting for events that will never come.
         if inner.closed {
-            let (tx, rx) = mpsc::channel();
-            drop(tx); // Drop sender immediately to disconnect the receiver
-            return rx;
+            return Subscriber::disconnected();
         }
 
         let (tx, rx) = mpsc::channel();
-        inner.subscribers.push(tx);
-        rx
+        let alive = Arc::new(());
+        inner.subscribers.push(Subscription {
+            filter,
+            tx,
+            alive: Arc::downgrade(&alive),
+        });
+        Subscriber { rx, _alive: alive }
     }
 
     /// Sends an event to all current subscribers.
@@ -353,11 +422,21 @@ impl<T: Clone> Broadcaster<T> {
     pub fn send(&self, event: T) {
         let mut inner = self.inner.lock().unwrap();
 
-        // Fire-and-forget into every subscriber. The unbounded `send` only
-        // fails when the receiver has been dropped; drop such subs.
-        inner
-            .subscribers
-            .retain(|tx| tx.send(event.clone()).is_ok());
+        // Fire-and-forget into every live subscriber. Liveness is checked
+        // first so a filtered subscriber is pruned as soon as it dies, even if
+        // no later event would have passed its filter. A live subscriber whose
+        // filter rejects this event is kept but skipped (no clone, no enqueue).
+        inner.subscribers.retain(|sub| {
+            if sub.alive.strong_count() == 0 {
+                return false;
+            }
+            if let Some(f) = &sub.filter {
+                if !f(&event) {
+                    return true;
+                }
+            }
+            sub.tx.send(event.clone()).is_ok()
+        });
     }
 
     /// Closes the broadcaster, disconnecting all subscribers.
@@ -438,6 +517,59 @@ mod tests {
     /// Returns true when the channel has been disconnected (all senders dropped).
     fn is_disconnected<T>(rx: &mpsc::Receiver<T>) -> bool {
         matches!(rx.try_recv(), Err(TryRecvError::Disconnected))
+    }
+
+    #[test]
+    fn test_filtered_subscriber_only_buffers_matching_events() {
+        let broadcaster: Broadcaster<i32> = Broadcaster::new();
+        // Keep only even numbers.
+        let filter: SubscriberFilter<i32> = Arc::new(|n: &i32| n % 2 == 0);
+        let even_sub = broadcaster.subscribe_filtered(Some(filter));
+        let all_sub = broadcaster.subscribe(); // unfiltered peer
+
+        for i in 0..10 {
+            broadcaster.send(i);
+        }
+        broadcaster.close();
+
+        // The filtered subscriber's buffer never held the odd events — draining
+        // yields exactly the evens (queue depth = 5), proving the drop happened
+        // send-side, not on read.
+        let got: Vec<_> = std::iter::from_fn(|| even_sub.recv().ok()).collect();
+        assert_eq!(got, vec![0, 2, 4, 6, 8]);
+
+        // The unfiltered peer still sees everything.
+        let all: Vec<_> = std::iter::from_fn(|| all_sub.recv().ok()).collect();
+        assert_eq!(all, (0..10).collect::<Vec<_>>());
+    }
+
+    /// A dropped filtered subscriber must be pruned on the next `send`, not
+    /// only once an event happens to pass its filter — otherwise a drained
+    /// one-shot iterator keeps its predicate running for the rest of the build.
+    #[test]
+    fn test_dropped_filtered_subscriber_is_pruned_on_non_matching_event() {
+        let broadcaster: Broadcaster<i32> = Broadcaster::new();
+        let evaluations = Arc::new(AtomicUsize::new(0));
+        let seen = evaluations.clone();
+        // Matches only 0, so nothing after the first event would ever pass.
+        let filter: SubscriberFilter<i32> = Arc::new(move |n: &i32| {
+            seen.fetch_add(1, Ordering::SeqCst);
+            *n == 0
+        });
+
+        {
+            let _sub = broadcaster.subscribe_filtered(Some(filter));
+            broadcaster.send(0);
+        }
+
+        // First post-drop send prunes; later sends never touch the filter.
+        broadcaster.send(1);
+        let after_prune = evaluations.load(Ordering::SeqCst);
+        broadcaster.send(2);
+        broadcaster.send(3);
+
+        assert_eq!(evaluations.load(Ordering::SeqCst), after_prune);
+        assert_eq!(broadcaster.inner.lock().unwrap().subscribers.len(), 0);
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use thiserror::Error;
 
-use super::broadcaster::{Broadcaster, Subscriber};
+use super::broadcaster::{Broadcaster, Subscriber, SubscriberFilter};
 use super::redaction::redact_event;
 use super::util::{MultiWriter, read_varint};
 
@@ -287,14 +287,22 @@ impl BuildEventStream {
     /// and don't need history replay. Use `subscribe()` for user-facing APIs
     /// where late subscription support is needed.
     pub fn subscribe(&self) -> Subscriber<BuildEvent> {
+        self.subscribe_filtered(None)
+    }
+
+    /// Subscribe with an optional send-side filter (see
+    /// [`Broadcaster::subscribe_filtered`]). A filtered subscriber's buffer
+    /// only holds events the filter accepts — the reader thread skips the rest
+    /// before cloning them, so a `kinds=`-scoped AXL iterator never pays for
+    /// the event kinds it doesn't consume.
+    pub fn subscribe_filtered(
+        &self,
+        filter: Option<SubscriberFilter<BuildEvent>>,
+    ) -> Subscriber<BuildEvent> {
         match self.broadcaster.as_ref() {
-            Some(b) => b.subscribe(),
-            None => {
-                // Stream has already been joined; return an immediately-disconnected channel.
-                let (tx, rx) = std::sync::mpsc::channel();
-                drop(tx);
-                rx
-            }
+            Some(b) => b.subscribe_filtered(filter),
+            // Stream has already been joined.
+            None => Subscriber::disconnected(),
         }
     }
 

--- a/crates/axl-runtime/src/engine/bazel/stream/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/mod.rs
@@ -5,7 +5,7 @@ pub mod redaction;
 mod util;
 pub mod workspace_event;
 
-pub use broadcaster::Subscriber;
+pub use broadcaster::{Subscriber, SubscriberFilter};
 pub use build_event::BuildEventStream;
 pub use execlog::ExecLogStream;
 pub use workspace_event::WorkspaceEventStream;


### PR DESCRIPTION
Extracted from #1326.

`kinds=` on `ctx.bazel.build_events()` used to filter on the read side: every subscriber buffered every event and the iterator discarded the unwanted ones after the fact. The broadcaster now takes an optional per-subscriber `SubscriberFilter` predicate evaluated on the producer thread before the clone, so a `kinds=`-scoped iterator's buffer only ever holds events it asked for — a subscriber that wants two of twenty kinds pays for two.

Also adds `tick_ms=` to `build_events()`: in blocking iteration, yield `None` after that many milliseconds of silence instead of blocking until the next event, so a caller's loop keeps ticking while Bazel is quiet. Omitting it preserves the existing block-until-event behaviour.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
