### PR TITLE
refactor(bazel): move the hook dispatchers next to the trait they fire

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/bazel.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazel.axl
@@ -10,6 +10,8 @@ load(
     _BazelTrait = "BazelTrait",
     _DEFAULT_BAZEL_RETRY_ATTEMPTS = "DEFAULT_BAZEL_RETRY_ATTEMPTS",
     _default_retry = "default_retry",
+    _dispatch_bazel_attempt_end = "dispatch_bazel_attempt_end",
+    _dispatch_bazel_build_end = "dispatch_bazel_build_end",
     _exit_codes = "exit_codes",
 )
 
@@ -17,4 +19,6 @@ BAZEL_RETRY_ATTEMPTS_DESCRIPTION = _BAZEL_RETRY_ATTEMPTS_DESCRIPTION
 BazelTrait = _BazelTrait
 DEFAULT_BAZEL_RETRY_ATTEMPTS = _DEFAULT_BAZEL_RETRY_ATTEMPTS
 default_retry = _default_retry
+dispatch_bazel_attempt_end = _dispatch_bazel_attempt_end
+dispatch_bazel_build_end = _dispatch_bazel_build_end
 exit_codes = _exit_codes

--- a/crates/aspect-cli/src/builtins/aspect/bazel/trait.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazel/trait.axl
@@ -1,4 +1,5 @@
-"""The `BazelTrait` interface, Bazel exit codes, and the retry budget constants.
+"""The `BazelTrait` interface, Bazel exit codes, the retry budget constants, and
+the `dispatch_*` helpers that fire the trait's lifecycle hooks.
 
 Exit codes correspond to Bazel's ExitCode.java:
 https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/util/ExitCode.java
@@ -85,3 +86,13 @@ BazelTrait = trait(
     bazel_attempt_end = attr(list[typing.Callable[[TaskContext, int], None]], default = [], description = "Hooks called once after EACH Bazel invocation attempt (including retries), with that attempt's exit code. Runs after the wait() returns and before the retry decision, so a hook can take corrective action (e.g. clean stranded sandbox state) that might let the next retry succeed. Distinct from `build_end`, which fires once after the final attempt."),
     build_end = attr(list[typing.Callable[[TaskContext, int], None]], default = [], description = "Hooks called once after the Bazel invocation completes (after all retries), with the final exit code"),
 )
+
+def dispatch_bazel_attempt_end(ctx: TaskContext, bazel_trait: BazelTrait, exit_code: int) -> None:
+    """Fire every `bazel_attempt_end` hook with `exit_code`."""
+    for handler in bazel_trait.bazel_attempt_end:
+        handler(ctx, exit_code)
+
+def dispatch_bazel_build_end(ctx: TaskContext, bazel_trait: BazelTrait, exit_code: int) -> None:
+    """Fire every `build_end` hook with `exit_code`."""
+    for handler in bazel_trait.build_end:
+        handler(ctx, exit_code)

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -150,14 +150,13 @@ User-facing migration guide: https://aspect.build/docs/cli/migration/delivery
 """
 
 load("@aspect//bazel/build_events.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
-load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
+load("@aspect//bazel.axl", "BAZEL_RETRY_ATTEMPTS_DESCRIPTION", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@bazel//proto/remote_logging.axl", "remote_logging")
 load("@std//time.axl", "sleep_iter", "time")
 load("./private/lib/ansi.axl", "ansi")
 load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "expand_config_flags", "resolve_bazel_announce", "sibling_rc")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "bes_get", "now_ms", "process_event", bazel_init_data = "init_data")
-load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/ci.axl", "resolve_build_url")
 load("./private/lib/delivery_results.axl", delivery_add_result = "add_result", delivery_build_manifest = "build_manifest", delivery_conclusion = "conclusion", delivery_init_data = "init_data")
 load(

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -16,12 +16,11 @@ Usage:
 """
 
 load("@aspect//bazel/build_events.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
-load("@aspect//bazel.axl", "BazelTrait")
+load("@aspect//bazel.axl", "BazelTrait", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@std//time.axl", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
-load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "error", "info", "warn")
 load("./private/lib/format_results.axl", fmt_init_data = "init_data", format_conclusion = "conclusion")

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -82,12 +82,11 @@ https://github.com/bazel-contrib/bazel-gazelle#lazy-indexing-in-fix-and-update
 """
 
 load("@aspect//bazel/build_events.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
-load("@aspect//bazel.axl", "BazelTrait")
+load("@aspect//bazel.axl", "BazelTrait", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@std//time.axl", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
-load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "info", "warn")
 load("./private/lib/gazelle_results.axl", "dedupe_subtrees", "dir_at_or_below", "extract_changed_dirs", gaz_init_data = "init_data", gazelle_conclusion = "conclusion")

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -17,13 +17,12 @@ Usage:
 """
 
 load("@aspect//bazel/build_events.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
-load("@aspect//bazel.axl", "BazelTrait")
+load("@aspect//bazel.axl", "BazelTrait", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@std//time.axl", "sleep", "sleep_iter")
 load("./private/lib/ansi.axl", "ansi")
 load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "bb_clientd_root", "bes_get", "file_uri_to_path", "now_ms", "process_event")
-load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "warn")
 load("./private/lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -13,7 +13,7 @@ applies uniformly to both tasks.
 """
 
 load("@aspect//bazel/build_events.axl", "announce_bes_results_url", "announce_bes_sinks", "announce_dropped_bes_sinks", "bes_streamed_by_bazel", "collect_bes_sinks", "dropped_bes_backends", "summarize_bes_upload")
-load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS")
+load("@aspect//bazel.axl", "BazelTrait", "DEFAULT_BAZEL_RETRY_ATTEMPTS", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@std//time.axl", "sleep_iter")
 load("./bazel_flags.axl", "aspect_endpoint_auth_flags", "resolve_bazel_announce")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
@@ -217,32 +217,6 @@ def _emit_terminal(ctx, lifecycle, command, data, exit_code, targets = []):
         text = bookend,
         flagged = final_status == "warning",
     )
-
-def dispatch_bazel_attempt_end(ctx, bazel_trait, exit_code):
-    """Fire every `bazel_trait.bazel_attempt_end` hook with `exit_code`.
-
-    Call after a `ctx.bazel.build(...).wait()` (or `ctx.bazel.test(...).wait()`)
-    has returned and any per-invocation work that must complete before the
-    NEXT attempt is done (notably BES sink draining — re-binding a Live sink
-    errors). Inside a retry loop, fires BEFORE the retry decision so a hook
-    can repair state that would otherwise make the next attempt fail the same
-    way (e.g. `bazel.recover_poisoned_sandbox` for bazelbuild/bazel#23880).
-    Outside a retry loop (single-attempt tasks), fires exactly once.
-    """
-    for handler in bazel_trait.bazel_attempt_end:
-        handler(ctx, exit_code)
-
-def dispatch_bazel_build_end(ctx, bazel_trait, exit_code):
-    """Fire every `bazel_trait.build_end` hook with the FINAL `exit_code`.
-
-    Call after the retry loop has exited (or, for single-attempt tasks, after
-    the only `wait()`). Features hang task-finalization logic on this hook —
-    e.g. `ArtifactUpload._on_build_end` runs the Profile / BEP / Execlog /
-    Testlogs upload step here, and `sandbox_recovery.make_final_status_hook`
-    signals the runner unhealthy on a final server-internal-error exit.
-    """
-    for handler in bazel_trait.build_end:
-        handler(ctx, exit_code)
 
 def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclusion:
     """Shared impl for build/test tasks.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner_test.axl
@@ -10,7 +10,7 @@ Run with:
   aspect dev test-bazel-runner
 """
 
-load("./bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
+load("@aspect//bazel.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 
 def _eq(label, got, want):
     if got != want:

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -1,12 +1,11 @@
 """A default 'run' task that builds a target with `bazel build` and runs the resulting binary."""
 
 load("@aspect//bazel/build_events.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
-load("@aspect//bazel.axl", "BazelTrait")
+load("@aspect//bazel.axl", "BazelTrait", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@std//time.axl", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
-load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/environment.axl", "error")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -27,12 +27,11 @@ output base, and isn't a surface phase of its own. See `_impl`.)
 """
 
 load("@aspect//bazel/build_events.axl", "announce_bes_sinks", "bes_args", "bes_streamed_by_bazel", "collect_bes_sinks", "summarize_bes_upload")
-load("@aspect//bazel.axl", "BazelTrait")
+load("@aspect//bazel.axl", "BazelTrait", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("@std//time.axl", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_flags.axl", "announce_bazel_args", "aspect_endpoint_auth_flags", "bazel_flag_args", "resolve_bazel_announce")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
-load("./private/lib/bazel_runner.axl", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end")
 load("./private/lib/environment.axl", "error", "warn")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")


### PR DESCRIPTION
`dispatch_bazel_attempt_end` / `dispatch_bazel_build_end` walk `BazelTrait.bazel_attempt_end` / `.build_end`, so they belong with the trait definition rather than with the build/test task runner. Every task that drives its own spawn loop already loads `@aspect//bazel.axl`, so they now reach the dispatchers through that facade instead of importing the private `bazel_runner.axl`.

No behaviour change.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
