### PR TITLE
refactor(lifecycle): drive tasks through a `phases` handle

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -43,7 +43,7 @@ load("@aspect//private/lib/tips_test.axl", "tips_tests")
 load("@aspect//private/lib/warming_results_test.axl", "warming_template_snapshot_tests")
 load("@aspect//private/lib/wrapper_test.axl", "wrapper_tests")
 load("@aspect//tips.axl", "TASK_SCREENS", "TIP_SUGGESTION", "TIP_TEMPLATE_RAW", "add_tip")
-load("@aspect//traits.axl", "BazelTrait", "DeliveryTrait", "LintTrait", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixInfo", "ReproFixSuggestion", "TaskLifecycleTrait", "TaskUpdate", "repro_fix_replace")
+load("@aspect//traits.axl", "BazelTrait", "DeliveryTrait", "LintTrait", "Phases", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixInfo", "ReproFixSuggestion", "TaskUpdate", "repro_fix_replace")
 load("./lambda.axl", "lambda_with_global_bind")
 
 def _user_task_impl(ctx: TaskContext) -> int:
@@ -231,7 +231,7 @@ def config(ctx: ConfigContext):
 
     # Customize repro/fix suggestions; order matters — rewrite first (aspect →
     # bazel buildifier), then drop vanilla-bazel alternates.
-    lifecycle = ctx.traits[TaskLifecycleTrait]
+    lifecycle = ctx.traits[Phases]
     lifecycle.repro_fix_suggestion.append(_buildifier_repro_fix)
     lifecycle.repro_fix_suggestion.append(_shorten_delivery_local_preview)
 

--- a/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
+++ b/crates/aspect-cli/src/builtins/aspect/DEVELOPMENT.md
@@ -66,7 +66,7 @@ Tasks own the *flow* (which Bazel command runs when, what extra processing happe
 
 ## The per-task lifecycle
 
-`TaskLifecycleTrait` (defined in [`private/lib/lifecycle.axl`](private/lib/lifecycle.axl)) has a **single** slot, **`task_update(ctx, TaskUpdate)`**, fired zero or more times during the task. The *first* and *last* updates carry extra meaning, so one hook covers the whole lifecycle:
+`Phases` (defined in [`private/lib/lifecycle.axl`](private/lib/lifecycle.axl)) has a **single** slot, **`task_update(ctx, TaskUpdate)`**, fired zero or more times during the task. The *first* and *last* updates carry extra meaning, so one hook covers the whole lifecycle:
 
 - **First update → init.** A handler's first `task_update` is its cue to initialize: authenticate, create the GitHub check run / first BK annotation, and read `update.subject` for the rendered title. `setup_phase` (see below) emits this first update — the `🔧 Setup` phase mark — at the very start of every task, so init always lands inside the Setup phase. Each handler guards init with a private `_state["_initialized"]` flag.
 
@@ -112,7 +112,7 @@ return <TaskConclusion>
 
 ## Customizing repro & fix suggestions
 
-`TaskLifecycleTrait` has a second slot, `repro_fix_suggestion`, that lets a user `config.axl` accept, reject, or modify the `aspect …` / `bazel …` repro and fix commands tasks emit at terminal-emit time. Common uses: rewrite `aspect …` to an internal wrapper command, strip flags the user wants kept private, suppress fix suggestions deemed unsafe in their CI environment.
+`Phases` has a second slot, `repro_fix_suggestion`, that lets a user `config.axl` accept, reject, or modify the `aspect …` / `bazel …` repro and fix commands tasks emit at terminal-emit time. Common uses: rewrite `aspect …` to an internal wrapper command, strip flags the user wants kept private, suppress fix suggestions deemed unsafe in their CI environment.
 
 Built-in tasks populate `data["repro_commands"]` / `data["fix_commands"]` with `ReproFixCommand` records (defined in [`private/lib/lifecycle.axl`](private/lib/lifecycle.axl)). The framework runs every registered handler over un-hooked entries on each surface emit via `dispatch_task_update`, so no downstream consumer — CLI printer, GHSC check-run body, BK annotation, GitHub PR-comment rollup — ever sees an un-hooked entry. The `_hooked` flag on each record guarantees the hook chain runs at most once per entry, so producers and surfaces can emit freely.
 
@@ -142,7 +142,7 @@ load("@aspect//:traits.axl",
      "REPRO_FIX_REJECT",
      "ReproFixInfo",
      "ReproFixSuggestion",
-     "TaskLifecycleTrait",
+     "Phases",
      "repro_fix_replace")
 
 # Suggestion slugs you want to drop globally.
@@ -161,7 +161,7 @@ def _rewrite_aspect_for_lint(ctx: TaskContext, info: ReproFixInfo) -> ReproFixSu
     )
 
 def config(ctx: ConfigContext):
-    lifecycle = ctx.traits[TaskLifecycleTrait]
+    lifecycle = ctx.traits[Phases]
     lifecycle.repro_fix_suggestion.append(_reject_dropped_slugs)
     lifecycle.repro_fix_suggestion.append(_rewrite_aspect_for_lint)
 ```
@@ -180,7 +180,7 @@ Multiple handlers chain in registration order — handler N sees handler N-1's p
 |------------------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|------------------|
 | **`BazelTrait`**             | [bazel.axl](bazel.axl)                                                    | `build_start`, `build_event`, `build_end`, `build_retry`, `build_event_sinks`, `task_flags`, `flags`, `startup_flags`, `extra_flags`, `extra_startup_flags`, `execution_log_sinks` | ✅ Clean. Shape every Bazel invocation in the task: extra flags, BES sinks, per-event hooks, build-end cleanup. All fields are callables / hook lists / declarative config the task reads. |
 | **`HealthCheckTrait`**       | [private/lib/health_check.axl](private/lib/health_check.axl)                              | `health_check`                                                                                              | ✅ Clean. Hook lists only. |
-| **`TaskLifecycleTrait`**     | [private/lib/lifecycle.axl](private/lib/lifecycle.axl)                                    | `task_update`, `repro_fix_suggestion`                                                                       | ✅ Clean. Hook lists only. `task_update` drives status surfaces (first update inits, `final=True` concludes — see lifecycle section above). `repro_fix_suggestion` lets a user `config.axl` accept / reject / modify repro & fix command suggestions — see [Customizing repro & fix suggestions](#customizing-repro--fix-suggestions). |
+| **`Phases`**     | [private/lib/lifecycle.axl](private/lib/lifecycle.axl)                                    | `task_update`, `repro_fix_suggestion`                                                                       | ✅ Clean. Hook lists only. `task_update` drives status surfaces (first update inits, `final=True` concludes — see lifecycle section above). `repro_fix_suggestion` lets a user `config.axl` accept / reject / modify repro & fix command suggestions — see [Customizing repro & fix suggestions](#customizing-repro--fix-suggestions). |
 | **`DeliveryTrait`**          | [delivery.axl](delivery.axl)                                              | `delivery_start`, `delivery_target`, `delivery_end`, `delivery_manifest`, `render_manifest_file`, `upload_manifest` | ✅ Clean. Hook callables only. |
 | **`ArtifactsTrait`**         | [private/lib/artifacts.axl](private/lib/artifacts.axl)                                    | `artifacts_browse_url`, `artifact_urls`, `testlogs_label_urls`                                              | ⚠️ **Legacy** — data fields used as cross-feature state. Migrating to Pattern 2 (feature-owned + Callable trait). See [Artifact uploads](#artifact-uploads). |
 | **`GitHubStatusChecksTrait`**| [feature/github_status_checks.axl](feature/github_status_checks.axl)      | `templates`, `metadata_keys`                                                                                | ⚠️ **Legacy** — user-facing config on a trait. Migrating to feature `args`. |
@@ -199,7 +199,7 @@ Tasks declare which traits they *use* in the `traits = [...]` arg of the `task(.
 ```python
 build = task(
     name = "build",
-    traits = [BazelTrait, HealthCheckTrait, TaskLifecycleTrait,
+    traits = [BazelTrait, HealthCheckTrait, Phases,
               GitHubStatusChecksTrait, ArtifactsTrait],
     implementation = _impl,
     ...
@@ -329,7 +329,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 
 def task():
     return Task(
-        traits = [BazelTrait, TaskLifecycleTrait, ...] + tips.TRAITS + artifacts.TRAITS,
+        traits = [BazelTrait, Phases, ...] + tips.TRAITS + artifacts.TRAITS,
         # NO `features = [...]` — see "Rules: what tasks must not do" below.
         ...
     )
@@ -743,7 +743,7 @@ The canonical flow, with annotations. Use it as a checklist when reading or writ
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     bazel_trait = ctx.traits[BazelTrait]
     hc_trait    = ctx.traits[HealthCheckTrait]
-    lifecycle   = ctx.traits[TaskLifecycleTrait]
+    lifecycle   = ctx.traits[Phases]
 
     data = init_data()
     data["start_time_ms"]  = now_ms(ctx)
@@ -820,7 +820,7 @@ The `lint.axl` impl is the closest to this template; `format.axl` and `gazelle.a
 ## How to add a new task
 
 1. Create `crates/aspect-cli/src/builtins/aspect/<task_name>.axl` and follow the [canonical flow](#anatomy-of-a-task-_impl).
-2. **Declare the trait surface.** If your task drives Bazel, declare `BazelTrait`. If it surfaces data in CI, declare `TaskLifecycleTrait`. If it should print runner-env / health-check sections on Buildkite, declare `HealthCheckTrait`. For artifact uploads, splat `+ artifacts.TRAITS` (NOT `ArtifactsTrait` — that's the legacy data-field shape being migrated out). Same for tips: `+ tips.TRAITS`.
+2. **Declare the trait surface.** If your task drives Bazel, declare `BazelTrait`. If it surfaces data in CI, declare `Phases`. If it should print runner-env / health-check sections on Buildkite, declare `HealthCheckTrait`. For artifact uploads, splat `+ artifacts.TRAITS` (NOT `ArtifactsTrait` — that's the legacy data-field shape being migrated out). Same for tips: `+ tips.TRAITS`.
 3. **Do NOT list features** in the task constructor. Tasks declare trait surfaces only; feature loading happens through a separate channel (framework default, user `.aspect/config.axl`). See [Rules: what tasks must not do](#rules-what-tasks-must-not-do).
 4. Decide the `task_update.kind`. If your task's data shape matches an existing renderer (build/test → `bazel_results`, lint → `lint_results`, etc.), reuse it. Otherwise add a new kind — see [How to add a new task kind](#how-to-add-a-new-task-kind-new-renderer).
 5. Wire the task in `MODULE.aspect`'s task registry.

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -8,7 +8,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_runner.axl", "run_bazel_task")
 load("./private/lib/deployment_flags.axl", "deployment_flag_args")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
-load("./private/lib/lifecycle.axl", "TaskLifecycleTrait")
+load("./private/lib/lifecycle.axl", "phases")
 load("./private/lib/repro_commands.axl", "repro_flavor_args")
 load("./private/lib/tips.axl", "tips")
 
@@ -41,7 +41,6 @@ build = task(
     traits = [
         BazelTrait,
         HealthCheckTrait,
-        TaskLifecycleTrait,
-    ] + artifacts.TRAITS + tips.TRAITS,
+    ] + phases.TRAITS + artifacts.TRAITS + tips.TRAITS,
     implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -168,7 +168,7 @@ load(
 load("./private/lib/environment.axl", "apply_output_base_suffix", "color_enabled", "error", "info", "sanitize_filename", "warn")
 load("./private/lib/github.axl", "detect_commit_sha")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
-load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
+load("./private/lib/lifecycle.axl", "phases")
 load("./private/lib/remote_executor.axl", "start_dummy_executor", "stop_dummy_executor")
 load("./private/lib/repro_commands.axl", "build_aspect_command", "print_repro_and_fix", "repro_prefix", "task_cli_path")
 load("./private/lib/runnable.axl", "apparent_label", "runnable")
@@ -486,7 +486,7 @@ def _surface_phase_stderr(ctx, phase, log_path):
     ctx.std.io.stderr.write(ctx.std.fs.read_to_string(log_path))
     artifacts.upload_file(ctx, "delivery_phase{}_log".format(phase), "phase{}-stderr.log".format(phase), log_path)
 
-def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, user_remote_executor_uri, color, data):
+def _get_output_shas(bazel_trait, ph, build_events, targets, rc, user_remote_executor_uri, color):
     """Run phase 1 (build) + phase 2 (digest extraction); return
     `(output_shas, non_hermetic_misses, uncacheable_actions, exit_code)`.
     Phase-1 BES events drive `data`; phase-2's gRPC log yields the per-target
@@ -499,6 +499,8 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
     `should_surface_phase2_stderr`). The gRPC log uploads per
     `ctx.args.upload_grpc_log`. Uploads no-op off-CI.
     """
+    ctx = ph.ctx
+    data = ph.data
 
     # The change-detection aspect. `ctx.bazel.aspect(...)` materializes it into
     # `@bazel_tools` (already in the repo graph, in both bzlmod and WORKSPACE
@@ -561,30 +563,26 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
         targets_label = pluralize(len(targets), "target")
         status = _pick_status(data, had_failure = False, terminal = False)
         if attempt == 0:
-            task_update(
-                ctx,
-                lifecycle,
+            ph.update(
                 status,
-                ProgressStyles(
+                phases.ProgressStyles(
                     body = "Building {} for delivery...".format(targets_label),
                     stream = "Building {} for delivery".format(targets_label),
                 ),
                 kind = "delivery_results",
                 data = data,
-                phase = Phase(name = "build", description = "Build delivery targets", emoji = "🔨"),
+                phase = phases.Phase(name = "build", description = "Build delivery targets", emoji = "🔨"),
             )
         else:
-            task_update(
-                ctx,
-                lifecycle,
+            ph.update(
                 status,
-                ProgressStyles(
+                phases.ProgressStyles(
                     body = "Retrying delivery build... (attempt {}, {})".format(attempt + 1, targets_label),
                     stream = "Retrying delivery build (attempt {}, {})".format(attempt + 1, targets_label),
                 ),
                 kind = "delivery_results",
                 data = data,
-                phase = Phase(
+                phase = phases.Phase(
                     name = "build_retry_" + str(attempt + 1),
                     description = "Retry attempt — Build delivery targets",
                     emoji = "🔨",
@@ -618,7 +616,7 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
                 for handler in bazel_trait.build_event:
                     handler(ctx, event)
             if interesting or now_ms(ctx) - last_emit_ms >= MIN_HEARTBEAT_INTERVAL_MS:
-                _emit_update(ctx, lifecycle, data)
+                _emit_update(ph)
                 last_emit_ms = now_ms(ctx)
             if events.done:
                 break
@@ -647,17 +645,15 @@ def _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, use
     # just means DeliveryHash wasn't cached yet, normal on first delivery.
     targets_label = pluralize(len(targets), "target")
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Checksuming delivery digests for {}...".format(targets_label),
             stream = "Checksuming delivery digests for {}".format(targets_label),
         ),
         kind = "delivery_results",
         data = data,
-        phase = Phase(name = "checksum", description = "Checksum delivery digests", emoji = "💯"),
+        phase = phases.Phase(name = "checksum", description = "Checksum delivery digests", emoji = "💯"),
     )
     _t_phase2 = time.monotonic()
     log_path = _GRPC_LOG_PATH.format(ctx.task.name)
@@ -935,25 +931,28 @@ def _fire_target_hook(data, delivery_trait, run_tracker, label):
     for k, v in extras.items():
         entry["custom"][k] = v
 
-def _emit_update(ctx, lifecycle, data, had_failure = False):
+def _emit_update(ph, had_failure = False):
     """Emit a bare task_update carrying accumulating delivery data.
 
     For data-only refreshes during phase-1 BES streaming: an empty
     `update.progress` keeps the surface's latched phase label, so `data`
     updates without disturbing the "Last update" line. Phase transitions go
     through `task_update()`."""
+    data = ph.data
     status = _pick_status(data, had_failure = had_failure, terminal = False)
-    dispatch_task_update(ctx, lifecycle, TaskUpdate(
+    ph.dispatch(phases.Update(
         kind = "delivery_results",
         status = status,
         data = data,
-        progress = ProgressStyles(),
+        progress = phases.ProgressStyles(),
     ))
 
-def _emit_final(ctx, lifecycle, data, exit_code):
+def _emit_final(ph, exit_code):
     """Emit the terminal `task_update(final=True)` plus the manifest. Called
     on every return path out of `_delivery_impl` so a check run is always
     completed, even on early error exits before any per-target data exist."""
+    ctx = ph.ctx
+    data = ph.data
     if not data.get("finish_time_ms"):
         data["finish_time_ms"] = now_ms(ctx)
     if not data.get("wall_time_ms") and data.get("start_time_ms"):
@@ -977,7 +976,7 @@ def _emit_final(ctx, lifecycle, data, exit_code):
             if ctx.args.mode != "always":
                 desc = "CI ran --mode=%s; --mode=always --track-state=false for off-runner with no state backend." % ctx.args.mode
             prefix = repro_prefix(ctx)
-            data["repro_commands"].append(ReproFixCommand(
+            data["repro_commands"].append(phases.ReproFixCommand(
                 command = prefix + repro,
                 description = desc,
                 slug = "delivery-repro-local-preview",
@@ -988,12 +987,9 @@ def _emit_final(ctx, lifecycle, data, exit_code):
 
     # Pre-hook with rich `ReproFixInfo` the dispatch safety-net can't supply;
     # entries hooked here are skipped on dispatch via `_hooked`.
-    apply_repro_fix_hooks(
-        ctx,
-        lifecycle,
-        data,
-        kind = "delivery_results",
-        status = final_status,
+    ph.suggest_fixes(
+        "delivery_results",
+        final_status,
         exit_code = exit_code,
         targets = list(ctx.args.targets),
         extras = {
@@ -1006,13 +1002,13 @@ def _emit_final(ctx, lifecycle, data, exit_code):
     # is registered when the GHSC / BK annotation snapshot their artifact_urls.
     manifest = _publish_manifest(ctx, data)
 
-    dispatch_task_update(ctx, lifecycle, TaskUpdate(
+    ph.dispatch(phases.Update(
         kind = "delivery_results",
         status = final_status,
         final = True,
         conclusion = bookend,
         data = data,
-        progress = ProgressStyles(
+        progress = phases.ProgressStyles(
             body = _body_text(final_status, data),
         ),
     ))
@@ -1095,13 +1091,12 @@ def _publish_manifest(ctx, data):
     return manifest
 
 def _delivery_impl(ctx):
-    hc_trait = ctx.traits[HealthCheckTrait]
     bazel_trait = ctx.traits[BazelTrait]
-    lifecycle = ctx.traits[TaskLifecycleTrait]
 
-    # Build the data shell up front so an early failure (before setup_phase
+    # Build the data shell up front so an early failure (before phases.setup
     # opens the surface) still has data to render.
     data = delivery_init_data()
+    ph = phases.new(ctx, data)
     data["start_time_ms"] = now_ms(ctx)
     data["delivery"]["commit_sha"] = ctx.args.commit_sha
     data["delivery"]["build_url"] = ctx.args.build_url
@@ -1115,7 +1110,7 @@ def _delivery_impl(ctx):
 
     color = color_enabled(ctx.std)
 
-    # Requested targets feed setup_phase's `subject` (rendered in the status
+    # Requested targets feed phases.setup's `subject` (rendered in the status
     # check's "Explicit command line"). Often empty for query-based delivery —
     # the resolved set lands in `data` later.
     targets_subject = " ".join(list(ctx.args.targets)) if ctx.args.targets else ""
@@ -1124,14 +1119,9 @@ def _delivery_impl(ctx):
 
     # Single pre-task setup phase (surface, rc parse + use_rc, health checks);
     # returns the active RunCommand. A failed health check fails the task inside.
-    rc = setup_phase(
-        ctx,
-        lifecycle,
+    rc = ph.setup(
         targets_subject,
         "delivery_results",
-        data,
-        hc_trait,
-        bazel_trait,
         "build",
     )
     announce_version, announce_command = bzl.announce.resolve(ctx)
@@ -1147,7 +1137,7 @@ def _delivery_impl(ctx):
 
     if mode == "selective" and not track_state:
         msg = "--mode=selective requires --track-state=true. Change detection cannot decide what to deliver without persisted state. Either use --track-state=true (the default), or switch to --mode=always to deliver without change detection (combine with --dry-run for a preview)."
-        _emit_final(ctx, lifecycle, data, exit_code = 1)
+        _emit_final(ph, exit_code = 1)
         fail(msg)
 
     # phase 1/2 runs whenever digests are needed (recorded or previewed).
@@ -1159,7 +1149,7 @@ def _delivery_impl(ctx):
     # deliveryd state backend; Workflows runners expose its Unix socket here.
     endpoint = ctx.std.env.var("ASPECT_WORKFLOWS_DELIVERY_API_ENDPOINT")
     if not endpoint and track_state:
-        _emit_final(ctx, lifecycle, data, exit_code = 1)
+        _emit_final(ph, exit_code = 1)
         fail("ASPECT_WORKFLOWS_DELIVERY_API_ENDPOINT is not set. The delivery state backend must be running. (Pass --track-state=false to run without state tracking; allowed in combination with --dry-run or --mode=always.)")
 
     # commit-sha / build-url auto-detect from CI env. commit_sha is only
@@ -1168,7 +1158,7 @@ def _delivery_impl(ctx):
     commit_sha = ctx.args.commit_sha or detect_commit_sha(ctx.std)
     if not commit_sha and track_state:
         msg = "Could not determine commit SHA. Pass --commit-sha=<sha>, or run on a CI host that exposes GITHUB_SHA, BUILDKITE_COMMIT, CIRCLE_SHA1, or CI_COMMIT_SHA."
-        _emit_final(ctx, lifecycle, data, exit_code = 1)
+        _emit_final(ph, exit_code = 1)
         fail(msg)
     if not commit_sha:
         commit_sha = "-"
@@ -1223,24 +1213,22 @@ def _delivery_impl(ctx):
         else:
             error(ctx.std, "Delivery requires a remote cache but no --remote_cache or --remote_executor was found." +
                            " (Use --mode=always --track-state=false to deliver every target without change detection.)")
-            return _emit_final(ctx, lifecycle, data, exit_code = 1)
+            return _emit_final(ph, exit_code = 1)
 
     # Resolve the delivery set (via `--query` or positional targets) under a
     # single `resolve` phase. The phase update is the opening bookend, emitted
     # before the query runs; the resolved set is recorded into `data` within
     # the same phase and surfaces on the next phase's update.
     query_expr = ctx.args.query
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         _pick_status(data, had_failure = False, terminal = False),
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Resolving targets to deliver...",
             stream = "Resolving targets to deliver",
         ),
         kind = "delivery_results",
         data = data,
-        phase = Phase(name = "resolve", description = "Resolve targets to deliver", emoji = "🎯"),
+        phase = phases.Phase(name = "resolve", description = "Resolve targets to deliver", emoji = "🎯"),
         subject = query_expr,
     )
 
@@ -1284,7 +1272,7 @@ def _delivery_impl(ctx):
 
     # Emit within the resolve phase (no `phase`, so no boundary/`→`) — just
     # latches the resolved data and refined subject.
-    dispatch_task_update(ctx, lifecycle, TaskUpdate(
+    ph.dispatch(phases.Update(
         kind = "delivery_results",
         data = data,
         subject = data["target_pattern"],
@@ -1292,14 +1280,14 @@ def _delivery_impl(ctx):
 
     if not targets:
         info(ctx.std, "No targets to deliver")
-        return _emit_final(ctx, lifecycle, data, exit_code = 0)
+        return _emit_final(ph, exit_code = 0)
 
     # Hard-fail on forced labels not in the resolved set: force-target only
     # flips change detection, it doesn't add labels — catches typos at startup.
     unmatched_forced = [t for t in forced_targets if t not in targets]
     if unmatched_forced:
         msg = "--force-target / ASPECT_WORKFLOWS_DELIVERY_FORCE_TARGETS labels not in the resolved delivery set: " + ", ".join(unmatched_forced) + ". Force-target re-delivers labels already selected by --query or positional args; it does not add new labels. Either fix the typo or update --query / positional targets to include them."
-        _emit_final(ctx, lifecycle, data, exit_code = 1)
+        _emit_final(ph, exit_code = 1)
         fail(msg)
 
     _print_header(color, endpoint, ci_host, commit_sha, prefix, prefix_source, build_url, rc.expand(command = "build"), targets, forced_targets, mode, dry_run, track_state)
@@ -1314,7 +1302,7 @@ def _delivery_impl(ctx):
     # Phase 1/2 — skipped only in --mode=always + --track-state=false.
     if phase_1_2_runs:
         _t_build = time.monotonic()
-        output_shas, non_hermetic_misses, uncacheable_actions, build_code = _get_output_shas(ctx, bazel_trait, lifecycle, build_events, targets, rc, user_remote_executor_uri or "", color, data)
+        output_shas, non_hermetic_misses, uncacheable_actions, build_code = _get_output_shas(bazel_trait, ph, build_events, targets, rc, user_remote_executor_uri or "", color)
         info(ctx.std, "Build+checksum total: {}.".format(fmt_elapsed(time.monotonic() - _t_build)))
 
         for handler in bazel_trait.build_end:
@@ -1332,7 +1320,7 @@ def _delivery_impl(ctx):
                     message = "build failed (exit {})".format(build_code),
                 )
                 _fire_target_hook(data, delivery_trait, None, label)
-            return _emit_final(ctx, lifecycle, data, exit_code = build_code)
+            return _emit_final(ph, exit_code = build_code)
     else:
         output_shas = {}
         non_hermetic_misses = {}
@@ -1354,17 +1342,15 @@ def _delivery_impl(ctx):
     # Record each target's digest with deliveryd. Skipped when --track-state=false.
     if track_state:
         status = _pick_status(data, had_failure = False, terminal = False)
-        task_update(
-            ctx,
-            lifecycle,
+        ph.update(
             status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = "Recording delivery digests...",
                 stream = "Recording delivery digests",
             ),
             kind = "delivery_results",
             data = data,
-            phase = Phase(name = "record", description = "Record delivery digests", emoji = "📝"),
+            phase = phases.Phase(name = "record", description = "Record delivery digests", emoji = "📝"),
         )
         for label in targets:
             if label in output_shas:
@@ -1375,17 +1361,15 @@ def _delivery_impl(ctx):
     # or --mode=always (every target is a candidate).
     if track_state and mode != "always":
         status = _pick_status(data, had_failure = False, terminal = False)
-        task_update(
-            ctx,
-            lifecycle,
+        ph.update(
             status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = "Detecting which targets have already been delivered...",
                 stream = "Detecting which targets have already been delivered",
             ),
             kind = "delivery_results",
             data = data,
-            phase = Phase(name = "detect", description = "Detect already-delivered targets", emoji = "🔬"),
+            phase = phases.Phase(name = "detect", description = "Detect already-delivered targets", emoji = "🔬"),
         )
         delivery_state = deliveryd_query(ctx, endpoint, ci_host, commit_sha, prefix)
     else:
@@ -1410,21 +1394,19 @@ def _delivery_impl(ctx):
     max_par = ctx.args.max_parallelization
     if max_par < 1:
         error(ctx.std, "--max-parallelization must be >= 1, got {}.".format(max_par))
-        return _emit_final(ctx, lifecycle, data, exit_code = 1)
+        return _emit_final(ph, exit_code = 1)
     capture = max_par > 1
 
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Delivering targets...",
             stream = "Delivering targets",
         ),
         kind = "delivery_results",
         data = data,
-        phase = Phase(name = "deliver", description = "Deliver targets", emoji = "🚚"),
+        phase = phases.Phase(name = "deliver", description = "Deliver targets", emoji = "🚚"),
     )
 
     rows = []
@@ -1712,11 +1694,9 @@ def _delivery_impl(ctx):
             # priority=False throttles surface PATCHes; the per-target lines
             # already tick the CLI.
             if interesting or now_ms(ctx) - last_emit_ms >= MIN_HEARTBEAT_INTERVAL_MS:
-                task_update(
-                    ctx,
-                    lifecycle,
+                ph.update(
                     _pick_status(data, had_failure = failed_count > 0, terminal = False),
-                    ProgressStyles(
+                    phases.ProgressStyles(
                         body = "Delivered {} of {}...".format(success_count + failed_count, pluralize(total_deliverable, "target")),
                     ),
                     kind = "delivery_results",
@@ -1797,7 +1777,7 @@ def _delivery_impl(ctx):
 
     # A failed build fails the task even though its targets are WARN, not FAIL.
     exit_code = build_exit_code or (1 if failed_count > 0 else 0)
-    return _emit_final(ctx, lifecycle, data, exit_code = exit_code)
+    return _emit_final(ph, exit_code = exit_code)
 
 delivery = task(
     kind = "delivery",
@@ -1905,7 +1885,6 @@ Currently """ + ansi.ITALIC + "only" + ansi.ITALIC_OFF + """ supported on Aspect
         BazelTrait,
         DeliveryTrait,
         HealthCheckTrait,
-        TaskLifecycleTrait,
-    ] + artifacts.TRAITS + tips.TRAITS,
+    ] + phases.TRAITS + artifacts.TRAITS + tips.TRAITS,
     implementation = _delivery_impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -1,7 +1,7 @@
 """Buildkite Annotations feature for Aspect tasks.
 
 Creates and updates a Buildkite annotation reflecting the live state of a task.
-Parallel to `GithubStatusChecks` — subscribes to the same `TaskLifecycleTrait`
+Parallel to `GithubStatusChecks` — subscribes to the same `Phases`
 hooks and reuses the same per-kind renderers so the rendered body stays in
 sync with the GitHub check-run body.
 
@@ -22,7 +22,7 @@ Usage in `.aspect/config.axl`:
 
 ## Suppressing, restyling or rewriting an annotation
 
-`TaskLifecycleTrait.status_surface_update` is consulted before every write
+`Phases.status_surface_update` is consulted before every write
 and returns a verdict — publish (optionally with a rewritten body or style), or
 remove. To drop the annotation for tasks that finished clean, so the
 Annotations tab only lists what needs attention:
@@ -32,7 +32,7 @@ Annotations tab only lists what needs attention:
         "SURFACE_PUBLISH",
         "SURFACE_REMOVE",
         "StatusSurfaceUpdate",
-        "TaskLifecycleTrait",
+        "Phases",
     )
 
     def _drop_when_passed(ctx: TaskContext, info: StatusSurfaceUpdate):
@@ -41,7 +41,7 @@ Annotations tab only lists what needs attention:
         return SURFACE_PUBLISH
 
     def config(ctx):
-        ctx.traits[TaskLifecycleTrait].status_surface_update.append(_drop_when_passed)
+        ctx.traits[Phases].status_surface_update.append(_drop_when_passed)
 
 A `remove` verdict *replaces* the write rather than following it, so the
 annotation never flickers into view. Anything this task already published is
@@ -112,10 +112,10 @@ load("../private/lib/ci.axl", "resolve_build_url")
 load("../private/lib/environment.axl", "feature_logger", "workflows_results_url")
 load(
     "../private/lib/lifecycle.axl",
+    "Phases",
     "StatusSurfaceAction",
-    "TaskLifecycleTrait",
     "TaskUpdate",
-    "publish_expanded_phases",
+    "phases",
     "resolve_surface_update",
 )
 load("../private/lib/rate_limit.axl", "usage_footer")
@@ -313,7 +313,7 @@ def _remove_annotation(ctx, context_id):
 # ─── Feature implementation ───────────────────────────────────────────────────
 
 def _buildkite_annotations(ctx: FeatureContext):
-    lifecycle = ctx.traits[TaskLifecycleTrait]
+    lifecycle = ctx.traits[Phases]
 
     templates = ctx.args.templates or {}
     metadata_keys = list(ctx.args.metadata_keys or [])
@@ -338,7 +338,7 @@ def _buildkite_annotations(ctx: FeatureContext):
     # headers are printed by the task lifecycle, not by this feature — so set it
     # before the probe can early-return. No-op off Buildkite (the section
     # emitter is itself BK-gated), so it's safe under any `mode`.
-    publish_expanded_phases(ctx, ctx.args.expand_phases)
+    phases.publish_expanded_phases(ctx, ctx.args.expand_phases)
 
     # Probe buildkite-agent — on a Workflows runner it always exists,
     # so this is a clean rc check; elsewhere `.spawn()` raises before
@@ -393,7 +393,7 @@ def _buildkite_annotations(ctx: FeatureContext):
                    (ctx.task.name, subject_str, _state["_context_id"]))
 
     def _task_update(ctx, update):
-        # Latch the subject before init/render: `setup_phase` sets it on the
+        # Latch the subject before init/render: `phases.setup` sets it on the
         # first update, but a later update may refine it (e.g. a query task
         # resolving its targets). Empty means "no change", so keep the prior
         # value. Init reads `_state["_subject"]`, so this must run first.

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -10,13 +10,13 @@ new task kinds plug in there.
 
 ## Restyling or rewriting the check run
 
-`TaskLifecycleTrait.status_surface_update` is consulted before every write and
+`Phases.status_surface_update` is consulted before every write and
 returns a verdict — publish, or publish with a different style or body. Here
 `update.body` is the check run's details text and `update.style` is the conclusion
 this write would land (`""` when it lands none, e.g. a mid-run PATCH). A
 restyle overrides the conclusion, which decides whether the check blocks a PR:
 
-    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceUpdate", "TaskLifecycleTrait", "surface_restyle")
+    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceUpdate", "Phases", "surface_restyle")
 
     # Report lint findings without blocking the PR.
     def _lint_never_blocks(ctx: TaskContext, info: StatusSurfaceUpdate):
@@ -25,7 +25,7 @@ restyle overrides the conclusion, which decides whether the check blocks a PR:
         return SURFACE_PUBLISH
 
     def config(ctx):
-        ctx.traits[TaskLifecycleTrait].status_surface_update.append(_lint_never_blocks)
+        ctx.traits[Phases].status_surface_update.append(_lint_never_blocks)
 
 `remove` isn't supported — GitHub can't delete a check run — so a removal is
 downgraded to a publish and logged. Only `BuildkiteAnnotations` honors it.
@@ -71,7 +71,7 @@ load("../private/lib/environment.axl", "feature_logger", "workflows_results_url"
 load("../private/lib/github.axl", "detect_commit_sha", "detect_github_repo", "github")
 load(
     "../private/lib/lifecycle.axl",
-    "TaskLifecycleTrait",
+    "Phases",
     "TaskUpdate",
     "resolve_surface_update",
 )
@@ -159,7 +159,7 @@ def _collect_ci_links(ctx, results_base_url):
     }
 
 def _github_status_checks(ctx: FeatureContext):
-    lifecycle = ctx.traits[TaskLifecycleTrait]
+    lifecycle = ctx.traits[Phases]
 
     templates = ctx.args.templates or {}
     metadata_keys = list(ctx.args.metadata_keys or [])
@@ -424,7 +424,7 @@ def _github_status_checks(ctx: FeatureContext):
         # under budget pressure; the conclusion-setting calls above always land.
         github.status_checks.update(ctx, token, owner, repo, check_run_id, output = output, skippable = True)
 
-    # TaskLifecycleTrait hooks
+    # Phases hooks
 
     def _init(ctx):
         # One-time init on first task_update: stash the task name (FeatureContext

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -82,7 +82,7 @@ load("../private/lib/checkrun.axl", "checkrun")
 load("../private/lib/ci.axl", "detect_ci_host", "resolve_build_url")
 load("../private/lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../private/lib/github.axl", "github")
-load("../private/lib/lifecycle.axl", "TaskLifecycleTrait")
+load("../private/lib/lifecycle.axl", "Phases")
 load("../private/lib/log_snippet.axl", "code_fence_for")
 load(
     "../private/lib/rate_limit.axl",
@@ -1293,7 +1293,7 @@ def _merge_comment_only_state(existing_state, head_sha, run_id, workflow_name, o
     return _merge_state(existing_state, head_sha, run_id, workflow_name, my_entries, {})
 
 def _github_status_comments(ctx: FeatureContext):
-    lifecycle = ctx.traits[TaskLifecycleTrait]
+    lifecycle = ctx.traits[Phases]
 
     # GHSC publishes the check-run URL via `checkrun.set_url`;
     # `checkrun.url(ctx)` returns "" until then.

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -43,19 +43,19 @@ future feature that wants merge-blocking semantics.
 
 ## Restyling or rewriting the commit status
 
-`TaskLifecycleTrait.status_surface_update` is consulted before every write and
+`Phases.status_surface_update` is consulted before every write and
 returns a verdict — publish, or publish with a different style or body. A commit
 status carries no body, only the one-line description, so that is `update.body`
 (re-truncated to 255 chars after a rewrite); `update.style` is the state this
 write would post, from the table above:
 
-    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceUpdate", "TaskLifecycleTrait", "surface_replace")
+    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceUpdate", "Phases", "surface_replace")
 
     def _prefix_team(ctx: TaskContext, info: StatusSurfaceUpdate):
         return surface_replace("[platform] " + info.body)
 
     def config(ctx):
-        ctx.traits[TaskLifecycleTrait].status_surface_update.append(_prefix_team)
+        ctx.traits[Phases].status_surface_update.append(_prefix_team)
 
 `remove` isn't supported — commit statuses are post-only — so a removal is
 downgraded to a publish and logged. Only `BuildkiteAnnotations` honors it.
@@ -106,7 +106,7 @@ load("../private/lib/gitlab_detect.axl", "detect_gitlab_mr")
 load("../private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
 load(
     "../private/lib/lifecycle.axl",
-    "TaskLifecycleTrait",
+    "Phases",
     "TaskUpdate",
     "resolve_surface_update",
 )
@@ -181,7 +181,7 @@ def _state_for(status, final):
     return None
 
 def _gitlab_commit_statuses(ctx: FeatureContext):
-    lifecycle = ctx.traits[TaskLifecycleTrait]
+    lifecycle = ctx.traits[Phases]
 
     templates = ctx.args.templates or {}
     metadata_keys = list(ctx.args.metadata_keys or [])
@@ -361,7 +361,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         _post_status(ctx, initial_state, initial_desc, initial_links)
 
     def _task_update(ctx, update):
-        # Latch the subject (raw) before init/render: setup_phase sets
+        # Latch the subject (raw) before init/render: phases.setup sets
         # it on the first update, but a later update may refine it.
         # Empty means "no change", keep prior.
         if update.subject:

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -69,7 +69,7 @@ load("../private/lib/github.axl", "github")
 load("../private/lib/gitlab.axl", "gitlab")
 load("../private/lib/gitlab_detect.axl", "detect_gitlab_mr")
 load("../private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
-load("../private/lib/lifecycle.axl", "TaskLifecycleTrait")
+load("../private/lib/lifecycle.axl", "Phases")
 load(
     "../private/lib/rate_limit.axl",
     "BUCKET_APP",
@@ -122,7 +122,7 @@ def _own_entry(ctx, _state, run_id, run_attempt, job_name):
     return snapshot
 
 def _gitlab_status_comments(ctx: FeatureContext):
-    lifecycle = ctx.traits[TaskLifecycleTrait]
+    lifecycle = ctx.traits[Phases]
 
     mode = ctx.args.mode
     is_ci = bool(ctx.std.env.var("CI"))

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -26,7 +26,7 @@ load("./private/lib/format_results.axl", fmt_init_data = "init_data", format_con
 load("./private/lib/format_spawn.axl", "compute_spawn_args")
 load("./private/lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
-load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
+load("./private/lib/lifecycle.axl", "phases", "pick_task_status", "resolve_severity")
 load("./private/lib/path_glob.axl", "match_any")
 load("./private/lib/path_normalize.axl", "normalize_files_for_cwd")
 load("./private/lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
@@ -166,7 +166,7 @@ def _append_repro_command(ctx, data):
              explicit_flags(ctx, _DETECTION_PAIRS) +
              _surfaced_base_ref_flag(ctx))
     prefix = repro_prefix(ctx)
-    data["repro_commands"].append(ReproFixCommand(
+    data["repro_commands"].append(phases.ReproFixCommand(
         command = prefix + build_aspect_command(task_cli_path(ctx.task), flags, []),
         slug = "format-repro",
     ))
@@ -193,14 +193,14 @@ def _append_fix_commands(ctx, data):
     positional_flags = ([("--severity", "info")] +
                         explicit_flags(ctx, [("formatter_target", "--formatter-target")]))
     if len(affected) <= _FIX_FILES_LIMIT:
-        data["fix_commands"].append(ReproFixCommand(
+        data["fix_commands"].append(phases.ReproFixCommand(
             command = prefix + build_aspect_command(task_path, positional_flags, affected, max_chars = 4096),
             slug = "format-fix",
         ))
     else:
         shown = affected[:_FIX_FILES_LIMIT]
         remaining = len(affected) - _FIX_FILES_LIMIT
-        data["fix_commands"].append(ReproFixCommand(
+        data["fix_commands"].append(phases.ReproFixCommand(
             command = prefix + build_aspect_command(task_path, positional_flags, shown, max_chars = 4096),
             description = "First %d of %d affected files (plus %d other%s)" % (
                 _FIX_FILES_LIMIT,
@@ -214,7 +214,7 @@ def _append_fix_commands(ctx, data):
         detection = ([("--severity", "info")] +
                      explicit_flags(ctx, _DETECTION_PAIRS) +
                      _surfaced_base_ref_flag(ctx))
-        data["fix_commands"].append(ReproFixCommand(
+        data["fix_commands"].append(phases.ReproFixCommand(
             command = prefix + build_aspect_command(task_path, detection, []),
             description = "Or re-discover and format all %d affected files" % len(affected),
             slug = "format-fix-rediscover",
@@ -226,7 +226,7 @@ def _append_fix_commands(ctx, data):
     if not has_tools_bazel_wrapper(ctx):
         bazel_flags = ["--run_in_cwd"] if ctx.args.run_in == "cwd" else []
         bazel_run_args = [ctx.args.formatter_target] + list(ctx.args.formatter_args) + affected
-        data["fix_commands"].append(ReproFixCommand(
+        data["fix_commands"].append(phases.ReproFixCommand(
             command = prefix + build_bazel_command(
                 "run",
                 bazel_run_args,
@@ -237,8 +237,10 @@ def _append_fix_commands(ctx, data):
             slug = "format-fix-vanilla-bazel",
         ))
 
-def _emit_final(ctx, lifecycle, data, exit_code):
+def _emit_final(ph, exit_code):
     """Emit the terminal task_update for status-check consumers."""
+    ctx = ph.ctx
+    data = ph.data
     status = _pick_status(data, had_failure = exit_code != 0, terminal = True)
     if not data.get("finish_time_ms"):
         data["finish_time_ms"] = now_ms(ctx)
@@ -254,27 +256,24 @@ def _emit_final(ctx, lifecycle, data, exit_code):
 
     bookend = format_conclusion(status, data)
 
-    # Pre-hook with rich ReproFixInfo (exit_code/extras) the dispatch_task_update
+    # Pre-hook with rich ReproFixInfo (exit_code/extras) the ph.dispatch
     # safety-net can't supply; hooked entries skip dispatch via `_hooked`.
-    apply_repro_fix_hooks(
-        ctx,
-        lifecycle,
-        data,
-        kind = "format_results",
-        status = status,
+    ph.suggest_fixes(
+        "format_results",
+        status,
         exit_code = exit_code,
         extras = {
             "affected_files": (data.get("format", {}) or {}).get("affected_files", []) or [],
         },
     )
 
-    dispatch_task_update(ctx, lifecycle, TaskUpdate(
+    ph.dispatch(phases.Update(
         kind = "format_results",
         status = status,
         final = True,
         conclusion = bookend,
         data = data,
-        progress = ProgressStyles(
+        progress = phases.ProgressStyles(
             body = _body_text(status, data),
         ),
     ))
@@ -289,16 +288,15 @@ def _emit_final(ctx, lifecycle, data, exit_code):
 # buildifier: disable=function-docstring
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     bazel_trait = ctx.traits[BazelTrait]
-    hc_trait = ctx.traits[HealthCheckTrait]
-    lifecycle = ctx.traits[TaskLifecycleTrait]
     ansi = color_enabled(ctx.std)
 
-    # Resolve --run-in up front: a bad value must fail before setup_phase opens
+    # Resolve --run-in up front: a bad value must fail before phases.setup opens
     # status surfaces and the build spends time.
     spawn_cwd = resolve_run_in(ctx, ctx.args.run_in)
 
     # Initialize data for status-check emission.
     data = fmt_init_data()
+    ph = phases.new(ctx, data)
     data["start_time_ms"] = now_ms(ctx)
     data["format"]["scope"] = ctx.args.scope
     data["format"]["formatter_target"] = ctx.args.formatter_target
@@ -307,7 +305,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # Single pre-task setup phase (status surface, rc parse, health checks);
     # returns resolved flags (a failed health check fails the task inside).
-    rc = setup_phase(ctx, lifecycle, ctx.args.formatter_target, "format_results", data, hc_trait, bazel_trait)
+    rc = ph.setup(ctx.args.formatter_target, "format_results")
     announce_version, announce_command = bzl.announce.resolve(ctx)
     endpoint_auth_flags = bzl.endpoint_auth_flags(ctx, rc, "build")
 
@@ -327,17 +325,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         hook(ctx)
 
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Building formatter... (%s)" % ctx.args.formatter_target,
             stream = "Building formatter (%s)" % ctx.args.formatter_target,
         ),
         kind = "format_results",
         data = data,
-        phase = Phase(name = "build", description = "Build formatter", emoji = "🔨"),
+        phase = phases.Phase(name = "build", description = "Build formatter", emoji = "🔨"),
     )
 
     # After the phase line, so the streams are announced under the spawn they
@@ -362,11 +358,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Re-emit now the link is known, but only to status surfaces — empty
     # `stream` suppresses the duplicate CLI line.
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Building formatter... (%s)" % ctx.args.formatter_target,
         ),
         kind = "format_results",
@@ -390,11 +384,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 interesting = True
         if interesting or now_ms(ctx) - last_emit_ms >= MIN_HEARTBEAT_INTERVAL_MS:
             heartbeat_status = _pick_status(data, had_failure = False, terminal = False)
-            dispatch_task_update(ctx, lifecycle, TaskUpdate(
+            ph.dispatch(phases.Update(
                 kind = "format_results",
                 status = heartbeat_status,
                 data = data,
-                progress = ProgressStyles(),
+                progress = phases.ProgressStyles(),
             ))
             last_emit_ms = now_ms(ctx)
         if events.done:
@@ -408,12 +402,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 
     if not build_status.success:
-        _emit_final(ctx, lifecycle, data, build_status.code or 1)
+        _emit_final(ph, build_status.code or 1)
         fail("Building the formatter has failed.")
 
     ep = r.determine_entrypoint(ctx.args.formatter_target)
     if not ep:
-        _emit_final(ctx, lifecycle, data, 1)
+        _emit_final(ph, 1)
         fail("Failed to determine the formatter entrypoint.")
 
     exclude_patterns = list(ctx.args.exclude_patterns)
@@ -437,17 +431,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         # host), else local `git diff <merge-base> --diff-filter=d --name-only`.
         # --base-ref / --merge-base apply only to that fallback.
         status = _pick_status(data, had_failure = False, terminal = False)
-        task_update(
-            ctx,
-            lifecycle,
+        ph.update(
             status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = "Detecting changed files...",
                 stream = "Detecting changed files",
             ),
             kind = "format_results",
             data = data,
-            phase = Phase(name = "detect", description = "Detect changed files", emoji = "🔍"),
+            phase = phases.Phase(name = "detect", description = "Detect changed files", emoji = "🔍"),
         )
         detect_result = detect_changed_files(
             ctx,
@@ -481,7 +473,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             if not changed_files:
                 info(ctx.std, "No files to format")
                 data["format"]["no_files_to_format"] = True
-                return _emit_final(ctx, lifecycle, data, 0)
+                return _emit_final(ph, 0)
 
             # Post-filter count for the Configuration row's `Scope: changed — N file(s)`.
             data["changed_files_count"] = len(changed_files)
@@ -495,31 +487,27 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         files_label = pluralize(len(format_args), "file")
         scope_label = "" if explicit_files else " in scope"
         status = _pick_status(data, had_failure = False, terminal = False)
-        task_update(
-            ctx,
-            lifecycle,
+        ph.update(
             status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = "Formatting %s%s..." % (files_label, scope_label),
                 stream = "Formatting %s%s" % (files_label, scope_label),
             ),
             kind = "format_results",
             data = data,
-            phase = Phase(name = "format", description = "Format files", emoji = "✨"),
+            phase = phases.Phase(name = "format", description = "Format files", emoji = "✨"),
         )
     else:
         status = _pick_status(data, had_failure = False, terminal = False)
-        task_update(
-            ctx,
-            lifecycle,
+        ph.update(
             status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = "Formatting all files...",
                 stream = "Formatting all files",
             ),
             kind = "format_results",
             data = data,
-            phase = Phase(name = "format", description = "Format files", emoji = "✨"),
+            phase = phases.Phase(name = "format", description = "Format files", emoji = "✨"),
         )
 
     spawn_args = compute_spawn_args(
@@ -535,7 +523,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         error(ctx.std, "Formatter exited with code %d." % exit.code)
         data["format"]["formatter_error"] = True
         data["format"]["formatter_error_code"] = exit.code
-        return _emit_final(ctx, lifecycle, data, exit.code)
+        return _emit_final(ph, exit.code)
 
     # No HEAD (no git repo / no initial commit) → no snapshot, can't diff. The
     # formatter ran; degrade detection with a warning rather than failing.
@@ -545,22 +533,20 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                       "whether it changed anything. Make at least one commit (or run inside a git repo) " +
                       "and re-run if you want `aspect format` to surface formatter-induced changes.")
         data["format"]["no_git"] = True
-        return _emit_final(ctx, lifecycle, data, 0)
+        return _emit_final(ph, 0)
 
     # Diff post-format tree vs the pre-format snapshot; non-empty = formatting
     # required. Empty pre_snap (was clean) → `git diff HEAD`, same answer.
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Computing format diff...",
             stream = "Computing format diff",
         ),
         kind = "format_results",
         data = data,
-        phase = Phase(name = "diff", description = "Detect formatter-induced changes", emoji = "📋"),
+        phase = phases.Phase(name = "diff", description = "Detect formatter-induced changes", emoji = "📋"),
     )
     formatter_diff = _diff_against(ctx, pre_snap)
     if not formatter_diff:
@@ -573,7 +559,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         else:
             scope_text = ""
         print("No files%s were modified." % scope_text)
-        return _emit_final(ctx, lifecycle, data, 0)
+        return _emit_final(ph, 0)
 
     # Pattern filters hide files from the affected list + failure decision; they
     # don't undo changes (still in the tree), just stop unexpected files failing.
@@ -590,7 +576,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if not affected:
         if filtered_count > 0:
             info(ctx.std, "Formatter modified %d file(s), all filtered by pattern rules; treating as OK." % filtered_count)
-        return _emit_final(ctx, lifecycle, data, 0)
+        return _emit_final(ph, 0)
 
     n = len(affected)
     if explicit_files:
@@ -639,12 +625,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     data["applied"] = True
     if severity_resolved == "fail":
         error(ctx.std, "Formatting required.")
-        return _emit_final(ctx, lifecycle, data, 1)
+        return _emit_final(ph, 1)
     if severity_resolved == "warn":
         info(ctx.std, "Formatter modified %d file(s). --severity=warn → exiting 0 with a warning signal." % len(affected))
     else:
         print("Formatted %d file(s). Review and commit the changes." % len(affected))
-    return _emit_final(ctx, lifecycle, data, 0)
+    return _emit_final(ph, 0)
 
 format = task(
     summary = "Format source files with the configured formatter target. Formats changed files by default; `--scope=all` for the whole tree.",
@@ -717,7 +703,6 @@ format = task(
     traits = [
         BazelTrait,
         HealthCheckTrait,
-        TaskLifecycleTrait,
-    ] + artifacts.TRAITS + tips.TRAITS,
+    ] + phases.TRAITS + artifacts.TRAITS + tips.TRAITS,
     implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -91,7 +91,7 @@ load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "in
 load("./private/lib/gazelle_results.axl", "dedupe_subtrees", "dir_at_or_below", "extract_changed_dirs", gaz_init_data = "init_data", gazelle_conclusion = "conclusion")
 load("./private/lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
-load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "pick_task_status", "resolve_severity", "setup_phase", "task_update")
+load("./private/lib/lifecycle.axl", "phases", "pick_task_status", "resolve_severity")
 load("./private/lib/path_glob.axl", "match_any")
 load("./private/lib/repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "has_tools_bazel_wrapper", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
 load("./private/lib/runnable.axl", "runnable")
@@ -207,7 +207,7 @@ def _append_repro_command(ctx, data):
     """
     effective_dirs = (data.get("gazelle", {}) or {}).get("dirs", []) or []
     prefix = repro_prefix(ctx)
-    data["repro_commands"].append(ReproFixCommand(
+    data["repro_commands"].append(phases.ReproFixCommand(
         command = prefix + build_aspect_command(
             task_cli_path(ctx.task),
             _detection_flags(ctx, "check"),
@@ -237,14 +237,14 @@ def _append_fix_commands(ctx, data):
     prefix = repro_prefix(ctx)
 
     if len(fix_dirs) <= _FIX_DIRS_LIMIT:
-        data["fix_commands"].append(ReproFixCommand(
+        data["fix_commands"].append(phases.ReproFixCommand(
             command = prefix + build_aspect_command(task_path, explicit_flags, fix_dirs, max_chars = 4096),
             slug = "gazelle-fix",
         ))
     else:
         shown = fix_dirs[:_FIX_DIRS_LIMIT]
         remaining = len(fix_dirs) - _FIX_DIRS_LIMIT
-        data["fix_commands"].append(ReproFixCommand(
+        data["fix_commands"].append(phases.ReproFixCommand(
             command = prefix + build_aspect_command(task_path, explicit_flags, shown, max_chars = 4096),
             description = "First %d of %d affected dirs (plus %d other%s)" % (
                 _FIX_DIRS_LIMIT,
@@ -254,7 +254,7 @@ def _append_fix_commands(ctx, data):
             ),
             slug = "gazelle-fix-truncated",
         ))
-        data["fix_commands"].append(ReproFixCommand(
+        data["fix_commands"].append(phases.ReproFixCommand(
             command = prefix + build_aspect_command(task_path, _detection_flags(ctx, "apply"), []),
             description = "Or re-discover and update all %d affected dirs" % len(fix_dirs),
             slug = "gazelle-fix-rediscover",
@@ -263,7 +263,7 @@ def _append_fix_commands(ctx, data):
     # Vanilla-bazel alternate. Skipped under the `tools/bazel` wrapper — there
     # `bazel run` re-routes through `aspect run`, so "vanilla" would mislead.
     if not has_tools_bazel_wrapper(ctx):
-        data["fix_commands"].append(ReproFixCommand(
+        data["fix_commands"].append(phases.ReproFixCommand(
             command = prefix + build_bazel_command("run", [ctx.args.gazelle_target]),
             description = "vanilla bazel",
             slug = "gazelle-fix-vanilla-bazel",
@@ -279,7 +279,7 @@ def _resolve_check_only(ctx):
         return bool(detect_ci(ctx.std.env))
     return val == "true"
 
-def _resolve_effective_dirs(ctx, lifecycle, data):
+def _resolve_effective_dirs(ph):
     """Combine --scope/--dirs/--scope-all-on-change/--changed-file-pattern into
     the effective dir list. Returns (effective_dirs, no_op); no_op=True → exit 0
     cleanly (--scope=changed found no dirs, or --scope=all positionals all
@@ -290,6 +290,8 @@ def _resolve_effective_dirs(ctx, lifecycle, data):
     --scope=changed: detect changed files, escalate to whole-repo on a
         --scope-all-on-change match, filter by --changed-file-pattern, derive
         parent dirs, intersect with user_dirs, dedupe overlapping subtrees."""
+    ctx = ph.ctx
+    data = ph.data
     raw_user_dirs = list(ctx.args.dirs or [])
     user_dirs = []
     for d in raw_user_dirs:
@@ -309,17 +311,15 @@ def _resolve_effective_dirs(ctx, lifecycle, data):
 
     # --scope=changed
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Detecting changed files...",
             stream = "Detecting changed files",
         ),
         kind = "gazelle_results",
         data = data,
-        phase = Phase(name = "detect", description = "Detect changed files", emoji = "🔍"),
+        phase = phases.Phase(name = "detect", description = "Detect changed files", emoji = "🔍"),
     )
     detect_result = detect_changed_files(
         ctx,
@@ -369,9 +369,11 @@ def _resolve_effective_dirs(ctx, lifecycle, data):
 
     return effective, False
 
-def _emit_final(ctx, lifecycle, data, exit_code):
+def _emit_final(ph, exit_code):
     """Emit the terminal task_update and return a TaskConclusion. Always
     appends the repro command; appends fix commands when gazelle had updates."""
+    ctx = ph.ctx
+    data = ph.data
     status = _pick_status(data, had_failure = exit_code != 0, terminal = True)
     if not data.get("finish_time_ms"):
         data["finish_time_ms"] = now_ms(ctx)
@@ -387,27 +389,24 @@ def _emit_final(ctx, lifecycle, data, exit_code):
 
     bookend = gazelle_conclusion(status, data)
 
-    # Pre-hook with rich ReproFixInfo (exit_code/extras) the dispatch_task_update
+    # Pre-hook with rich ReproFixInfo (exit_code/extras) the phases.dispatch
     # safety-net can't supply; hooked entries skip dispatch via `_hooked`.
-    apply_repro_fix_hooks(
-        ctx,
-        lifecycle,
-        data,
-        kind = "gazelle_results",
-        status = status,
+    ph.suggest_fixes(
+        "gazelle_results",
+        status,
         exit_code = exit_code,
         extras = {
             "affected_files": (data.get("gazelle", {}) or {}).get("affected_files", []) or [],
         },
     )
 
-    dispatch_task_update(ctx, lifecycle, TaskUpdate(
+    ph.dispatch(phases.Update(
         kind = "gazelle_results",
         status = status,
         final = True,
         conclusion = bookend,
         data = data,
-        progress = ProgressStyles(
+        progress = phases.ProgressStyles(
             body = _body_text(status, data),
         ),
     ))
@@ -422,12 +421,11 @@ def _emit_final(ctx, lifecycle, data, exit_code):
 # buildifier: disable=function-docstring
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     bazel_trait = ctx.traits[BazelTrait]
-    hc_trait = ctx.traits[HealthCheckTrait]
-    lifecycle = ctx.traits[TaskLifecycleTrait]
     ansi = color_enabled(ctx.std)
 
     # Initialize data for status-check emission.
     data = gaz_init_data()
+    ph = phases.new(ctx, data)
     data["start_time_ms"] = now_ms(ctx)
     data["gazelle"]["gazelle_target"] = ctx.args.gazelle_target
     data["gazelle"]["gazelle_command"] = ctx.args.gazelle_command or ""
@@ -441,18 +439,18 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     # Single pre-task setup phase (status surface, rc parse, health checks);
     # returns resolved flags (a failed health check fails the task inside).
-    rc = setup_phase(ctx, lifecycle, ctx.args.gazelle_target, "gazelle_results", data, hc_trait, bazel_trait)
+    rc = ph.setup(ctx.args.gazelle_target, "gazelle_results")
     announce_version, announce_command = bzl.announce.resolve(ctx)
     endpoint_auth_flags = bzl.endpoint_auth_flags(ctx, rc, "build")
 
     # Resolve dirs before the build: gazelle needs them when spawned, the no-op
     # short-circuit skips the build entirely, and the repro/fix builders read
     # data["gazelle"]["dirs"].
-    effective_dirs, no_op = _resolve_effective_dirs(ctx, lifecycle, data)
+    effective_dirs, no_op = _resolve_effective_dirs(ph)
     data["gazelle"]["dirs"] = list(effective_dirs)
     if no_op:
         data["gazelle"]["no_changed_dirs"] = True
-        return _emit_final(ctx, lifecycle, data, 0)
+        return _emit_final(ph, 0)
 
     # `rc=` opts into the runinfo aspect: `r.flags` captures the gazelle
     # target's executable (the sh_binary, not its `-runner.bash` helper), its
@@ -470,17 +468,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         hook(ctx)
 
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Building gazelle... (%s)" % ctx.args.gazelle_target,
             stream = "Building gazelle (%s)" % ctx.args.gazelle_target,
         ),
         kind = "gazelle_results",
         data = data,
-        phase = Phase(name = "build", description = "Build gazelle", emoji = "🔨"),
+        phase = phases.Phase(name = "build", description = "Build gazelle", emoji = "🔨"),
     )
 
     # After the phase line, so the streams are announced under the spawn they
@@ -505,11 +501,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Re-emit now the link is known, but only to status surfaces — empty
     # `stream` suppresses the duplicate CLI line.
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Building gazelle... (%s)" % ctx.args.gazelle_target,
         ),
         kind = "gazelle_results",
@@ -533,11 +527,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
                 interesting = True
         if interesting or now_ms(ctx) - last_emit_ms >= MIN_HEARTBEAT_INTERVAL_MS:
             heartbeat_status = _pick_status(data, had_failure = False, terminal = False)
-            dispatch_task_update(ctx, lifecycle, TaskUpdate(
+            ph.dispatch(phases.Update(
                 kind = "gazelle_results",
                 status = heartbeat_status,
                 data = data,
-                progress = ProgressStyles(),
+                progress = phases.ProgressStyles(),
             ))
             last_emit_ms = now_ms(ctx)
         if events.done:
@@ -551,12 +545,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 
     if not build_status.success:
-        _emit_final(ctx, lifecycle, data, build_status.code or 1)
+        _emit_final(ph, build_status.code or 1)
         fail("Building the gazelle target has failed.")
 
     ep = r.determine_entrypoint(ctx.args.gazelle_target)
     if not ep:
-        _emit_final(ctx, lifecycle, data, 1)
+        _emit_final(ph, 1)
         fail("Failed to determine the gazelle target's entrypoint.")
 
     # Diff phase: -mode=diff yields the verdict + patch without touching the
@@ -582,17 +576,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     diff_args.append("-mode=diff")
     diff_args.extend(effective_dirs)
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Running gazelle... (-mode=diff)",
             stream = "Running gazelle (-mode=diff)",
         ),
         kind = "gazelle_results",
         data = data,
-        phase = Phase(name = "diff", description = "Compute BUILD-file diff", emoji = "📋"),
+        phase = phases.Phase(name = "diff", description = "Compute BUILD-file diff", emoji = "📋"),
     )
     diff_proc = r.spawn(ep, diff_args, capture = True)
     diff_stdout = diff_proc.stdout().read_to_string()
@@ -611,12 +603,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         error(ctx.std, "Gazelle (-mode=diff) exited %d with no diff output (likely a configuration error)." % diff_status.code)
         data["gazelle"]["gazelle_error"] = True
         data["gazelle"]["gazelle_error_code"] = diff_status.code
-        return _emit_final(ctx, lifecycle, data, diff_status.code)
+        return _emit_final(ph, diff_status.code)
 
     if not diff_stdout.strip():
         # Clean, regardless of --severity / --check-only.
         print("✅ All BUILD files are up to date.")
-        return _emit_final(ctx, lifecycle, data, 0)
+        return _emit_final(ph, 0)
 
     affected = _parse_diff_paths(diff_stdout)
 
@@ -628,17 +620,16 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if not check_only:
         files_label = pluralize(len(affected), "file")
         status = _pick_status(data, had_failure = False, terminal = False)
-        task_update(
+        phases.update(
             ctx,
-            lifecycle,
             status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = "Applying gazelle patch... (%s)" % files_label,
                 stream = "Applying gazelle patch (%s)" % files_label,
             ),
             kind = "gazelle_results",
             data = data,
-            phase = Phase(name = "apply", description = "Apply gazelle patch", emoji = "📦"),
+            phase = phases.Phase(name = "apply", description = "Apply gazelle patch", emoji = "📦"),
         )
         tmp = ctx.std.env.temp_dir()
         patch_path = tmp + "/gazelle-" + ctx.task.name + ".patch"
@@ -652,7 +643,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             data["gazelle"]["affected_files"] = affected
             data["gazelle"]["apply_error"] = True
             data["gazelle"]["apply_error_msg"] = apply_result.stderr.strip()
-            return _emit_final(ctx, lifecycle, data, apply_result.status.code)
+            return _emit_final(ph, apply_result.status.code)
 
     verb = "would update" if check_only else "updated"
     if affected:
@@ -679,13 +670,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Verdict from --severity (resolved at entry).
     if severity_resolved == "fail":
         error(ctx.std, "BUILD files are out of date.")
-        return _emit_final(ctx, lifecycle, data, 1)
+        return _emit_final(ph, 1)
     if severity_resolved == "warn":
         info(ctx.std, "BUILD files are out of date. --severity=warn → exiting 0 with a warning signal.")
     elif not check_only:
         # Local apply: tree already updated, don't tell them to re-run.
         print("Gazelle updated %d file(s). Review and commit the changes." % len(affected))
-    return _emit_final(ctx, lifecycle, data, 0)
+    return _emit_final(ph, 0)
 
 gazelle = task(
     summary = "Generate and update BUILD files with gazelle. Applies the patch locally; detect-only on CI (`--check-only`).",
@@ -747,7 +738,6 @@ gazelle = task(
     traits = [
         BazelTrait,
         HealthCheckTrait,
-        TaskLifecycleTrait,
-    ] + artifacts.TRAITS + tips.TRAITS,
+    ] + phases.TRAITS + artifacts.TRAITS + tips.TRAITS,
     implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -26,7 +26,7 @@ load("./private/lib/change_detection.axl", "BASE_REF_DESCRIPTION_TAIL")
 load("./private/lib/environment.axl", "color_enabled", "detect_ci", "error", "warn")
 load("./private/lib/github.axl", "detect_changed_files", "detect_ci_base_ref", "print_changed_files_listing")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
-load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
+load("./private/lib/lifecycle.axl", "phases")
 load("./private/lib/lint_results.axl", "detect_lint_tool", lint_accumulate = "accumulate", lint_conclusion = "conclusion", lint_init_data = "init_data")
 load("./private/lib/repro_commands.axl", "build_aspect_command", "explicit_flags", "flavor_allows", "print_repro_and_fix", "repro_flavor_args", "repro_prefix", "task_cli_path")
 load("./private/lib/sarif.axl", "get_sarif_summary", "parse_sarif", "sarif_diagnostics")
@@ -740,19 +740,18 @@ def _drain_pending_files(ctx, bb_root, pending, pending_meta, data, strategy, ch
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     lint_trait = ctx.traits[LintTrait]
     bazel_trait = ctx.traits[BazelTrait]
-    hc_trait = ctx.traits[HealthCheckTrait]
-    lifecycle = ctx.traits[TaskLifecycleTrait]
     strategy = _STRATEGIES[ctx.args.strategy]
 
     # Validate up front so a typo doesn't fail after the build has run.
     validate_findings_destination(lint_trait.findings_destination)
 
     data = lint_init_data()
+    ph = phases.new(ctx, data)
     data["start_time_ms"] = now_ms(ctx)
     data["lint"]["strategy"] = _strategy_name(strategy)
     data["target_pattern"] = " ".join(list(ctx.args.targets)) if ctx.args.targets else ""
 
-    # Base flags computed before setup_phase, which forwards them to bazel.setup_command.
+    # Base flags computed before phases.setup, which forwards them to bzl.setup_command.
     base_flags = ["--remote_download_regex='.*AspectRulesLint.*'"]
     for aspect in ctx.args.aspects:
         base_flags.append("--aspects=" + aspect)
@@ -775,8 +774,8 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         base_flags.append("--output_groups=rules_lint_machine")
 
     # Pre-task setup phase (status surface, rc parse, health checks); returns
-    # resolved flags (a failed health check fails the task inside setup_phase).
-    rc = setup_phase(ctx, lifecycle, data["target_pattern"], "lint_results", data, hc_trait, bazel_trait, "build", bazel_base_flags = base_flags)
+    # resolved flags (a failed health check fails the task inside phases.setup).
+    rc = ph.setup(data["target_pattern"], "lint_results", "build", base_flags = base_flags)
     announce_version, announce_command = bzl.announce.resolve(ctx)
     endpoint_auth_flags = bzl.endpoint_auth_flags(ctx, rc, "build")
 
@@ -784,17 +783,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # lint_trait.changed_files. Prefers GitHub PR Files API, falls back to local
     # `git diff <base> --unified=0`. Lives in lib/github.axl (format wants it too).
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Detecting changed files...",
             stream = "Detecting changed files",
         ),
         kind = "lint_results",
         data = data,
-        phase = Phase(name = "detect", description = "Detect changed files", emoji = "🔍"),
+        phase = phases.Phase(name = "detect", description = "Detect changed files", emoji = "🔍"),
     )
     detect_result = detect_changed_files(
         ctx,
@@ -831,17 +828,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         hook(ctx)
 
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Running lint aspects...",
             stream = "Running lint aspects",
         ),
         kind = "lint_results",
         data = data,
-        phase = Phase(name = "lint", description = "Run lint aspects", emoji = "🔬"),
+        phase = phases.Phase(name = "lint", description = "Run lint aspects", emoji = "🔬"),
     )
 
     # After the phase line, so the streams are announced under the spawn they
@@ -867,11 +862,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # Re-emit now that sink_invocation_id is known (Web UI link); status surfaces
     # only — empty `stream` suppresses the duplicate CLI line.
     status = _pick_status(data, had_failure = False, terminal = False)
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         status,
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Running lint aspects...",
         ),
         kind = "lint_results",
@@ -959,11 +952,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             # Flip to "failing" on mid-build action failure so the breakdown tags Lint.
             had_action_failure = data["bazel"].get("failed_actions_total", 0) > 0
             heartbeat_status = _pick_status(data, had_failure = had_action_failure, terminal = False)
-            dispatch_task_update(ctx, lifecycle, TaskUpdate(
+            ph.dispatch(phases.Update(
                 kind = "lint_results",
                 status = heartbeat_status,
                 data = data,
-                progress = ProgressStyles(),
+                progress = phases.ProgressStyles(),
             ))
             last_emit_ms = now_ms(ctx)
         if events.done:
@@ -1044,17 +1037,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if not build_failed and fix_apply and scoped_patches:
         patches_label = pluralize(len(scoped_patches), "auto-fix patch", plural = "auto-fix patches")
         status = _pick_status(data, had_failure = False, terminal = False)
-        task_update(
-            ctx,
-            lifecycle,
+        ph.update(
             status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = "Applying %s..." % patches_label,
                 stream = "Applying " + patches_label,
             ),
             kind = "lint_results",
             data = data,
-            phase = Phase(name = "apply", description = "Apply auto-fix patches", emoji = "📦"),
+            phase = phases.Phase(name = "apply", description = "Apply auto-fix patches", emoji = "📦"),
         )
         for patch in scoped_patches:
             ctx.std.process.command("patch").arg("-p1").arg("--input=" + patch) \
@@ -1066,17 +1057,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # instead of Lint; without it the lint phase stays active so Lint is tagged.
     if not build_failed and lint_tools_run:
         status = _pick_status(data, had_failure = False, terminal = False)
-        task_update(
-            ctx,
-            lifecycle,
+        ph.update(
             status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = "Filtering diagnostics...",
                 stream = "Filtering diagnostics",
             ),
             kind = "lint_results",
             data = data,
-            phase = Phase(name = "filter", description = "Filter diagnostics", emoji = "🔎"),
+            phase = phases.Phase(name = "filter", description = "Filter diagnostics", emoji = "🔎"),
         )
 
     # diagnostics were already filtered per-batch as SARIF streamed in, so the
@@ -1150,12 +1139,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     task_path = task_cli_path(ctx.task)
     prefix = repro_prefix(ctx)
     if flavor_allows(ctx.args.repro_flavors, "lint-repro"):
-        data["repro_commands"].append(ReproFixCommand(
+        data["repro_commands"].append(phases.ReproFixCommand(
             command = prefix + build_aspect_command(task_path, repro_flags, targets),
             slug = "lint-repro",
         ))
     if data["lint"]["suggestions"] and flavor_allows(ctx.args.fix_flavors, "lint-fix"):
-        data["fix_commands"].append(ReproFixCommand(
+        data["fix_commands"].append(phases.ReproFixCommand(
             command = prefix + build_aspect_command(task_path, [("--fix", None)] + repro_flags, targets),
             slug = "lint-fix",
         ))
@@ -1165,13 +1154,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     bookend = lint_conclusion(final_status, data)
 
     # Pre-hook with rich ReproFixInfo (exit_code/targets/extras) that the
-    # dispatch_task_update safety-net can't supply; these are skipped on dispatch.
-    apply_repro_fix_hooks(
-        ctx,
-        lifecycle,
-        data,
-        kind = "lint_results",
-        status = final_status,
+    # ph.dispatch safety-net can't supply; these are skipped on dispatch.
+    ph.suggest_fixes(
+        "lint_results",
+        final_status,
         exit_code = exit_code,
         targets = targets,
         extras = {
@@ -1180,13 +1166,13 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         },
     )
 
-    dispatch_task_update(ctx, lifecycle, TaskUpdate(
+    ph.dispatch(phases.Update(
         kind = "lint_results",
         status = final_status,
         final = True,
         conclusion = bookend,
         data = data,
-        progress = ProgressStyles(
+        progress = phases.ProgressStyles(
             body = _body_text(final_status, data),
         ),
     ))
@@ -1251,7 +1237,6 @@ lint = task(
         BazelTrait,
         HealthCheckTrait,
         LintTrait,
-        TaskLifecycleTrait,
-    ] + artifacts.TRAITS + tips.TRAITS,
+    ] + phases.TRAITS + artifacts.TRAITS + tips.TRAITS,
     implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -18,7 +18,7 @@ contracts a config writes against:
     "details" are independent, per-task-kind blocks overlay the flat keys,
     every renderer module exports the templates a config patches, and a broken
     template degrades to a fallback.
-  - `TaskLifecycleTrait.status_surface_update` — verdicts resolve, chain, and
+  - `Phases.status_surface_update` — verdicts resolve, chain, and
     compose across surfaces, and a `remove` no surface can honor downgrades to
     a publish.
 """

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/test_fixtures.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/test_fixtures.axl
@@ -97,7 +97,7 @@ def make_test_failed():
 def make_build_failing_actions():
     """Build invocation in flight, BES has already reported a failed action.
 
-    Mirrors the live `bazel_runner.axl` path that emits `status="failing"`
+    Mirrors the live bazel build that emits `status="failing"`
     when `failed_actions_total > 0` — used to drive the early-feedback red
     stripe before the bazel invocation completes.
     """
@@ -122,7 +122,7 @@ def make_test_failing_test_fails():
 def make_test_running_flaky_only():
     """Test invocation streaming events, BES has reported flakes but no real failures.
 
-    `bazel_runner.axl` keeps the live status as "running" (not "failing")
+    the bazel build keeps the live status as "running" (not "failing")
     when only flakes are observed, so the stripe should be yellow rather
     than red.
     """

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner.axl
@@ -18,7 +18,7 @@ load("@std//time.axl", "sleep_iter")
 load("./bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "archive_bazel_attempt", "collapse_repro_targets", "failed_labels", "failed_labels_by_subcommand", "init_data", "now_ms", "process_event", bazel_conclusion = "conclusion")
 load("./deployment_flags.axl", "advertised_results_url", "announce_deployment_flags", "bes_results_url_flag", "deployment_endpoint_flags")
 load("./health_check.axl", "HealthCheckTrait")
-load("./lifecycle.axl", "Phase", "ProgressStyles", "ReproFixCommand", "TaskLifecycleTrait", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "setup_phase", "task_update")
+load("./lifecycle.axl", "Phases", "phases")
 load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "flavor_allows", "print_repro_and_fix", "repro_prefix")
 load("./text.axl", "format_int_comma", "pluralize")
 
@@ -168,40 +168,39 @@ def _live_progress(data, command, status):
         if tail:
             body = body + " (" + tail + ")"
 
-    return ProgressStyles(
+    return phases.ProgressStyles(
         body = body,
         stream = "",
     )
 
-def _emit_terminal(ctx, lifecycle, command, data, exit_code, targets = []):
-    """Fire the terminal `task_update(final=True)` and return a
+def _emit_terminal(ph, command, exit_code, targets = []):
+    """Fire the terminal `ph.update(final=True)` and return a
     `TaskConclusion` for `run_bazel_task` to return, so status surfaces
     conclude rather than stick at "running". (A failed setup health check
-    concludes the surface separately, inside `setup_phase`.)
+    concludes the surface separately, inside `phases.setup`.)
 
     `targets` is the resolved Bazel target patterns; forwarded to
-    `apply_repro_fix_hooks` for `repro_fix_suggestion` hooks to scope by.
+    `ph.suggest_fixes` for `repro_fix_suggestion` hooks to scope by.
     """
+    ctx = ph.ctx
+    data = ph.data
     final_status = _pick_status(command, data, had_failure = exit_code != 0, terminal = True)
     bookend = bazel_conclusion(final_status, data)
 
     # Pre-hook with rich `ReproFixInfo` (exit_code / bazel_subcommand /
-    # targets / failed_targets) the safety-net call inside
-    # `dispatch_task_update` can't supply. Entries hooked here are
-    # skipped on dispatch via the `_hooked` flag.
-    apply_repro_fix_hooks(
-        ctx,
-        lifecycle,
-        data,
-        kind = "bazel_results",
-        status = final_status,
+    # targets / failed_targets) the safety-net call inside `ph.dispatch`
+    # can't supply. Entries hooked here are skipped on dispatch via the
+    # `_hooked` flag.
+    ph.suggest_fixes(
+        "bazel_results",
+        final_status,
         exit_code = exit_code,
         bazel_subcommand = command,
         targets = targets,
         failed_targets = failed_labels(data),
     )
 
-    dispatch_task_update(ctx, lifecycle, TaskUpdate(
+    ph.dispatch(phases.Update(
         kind = "bazel_results",
         status = final_status,
         final = True,
@@ -273,7 +272,6 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     """
     hc_trait = ctx.traits[HealthCheckTrait]
     bazel_trait = ctx.traits[BazelTrait]
-    lifecycle = ctx.traits[TaskLifecycleTrait]
 
     # Runner-injected base flags Bazel must see verbatim: the TTY signal
     # for progress rendering and, optionally, --target_pattern_file=…
@@ -298,12 +296,13 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
         subject = ""
 
     data = init_data()
+    ph = phases.new(ctx, data)
 
     # The single pre-task `setup` phase: status-surface init + first render, rc
     # parse + `use_rc`, health checks. The active run command drives the
     # build/test below (a failed health check concludes the surface and fails
-    # the task inside setup_phase).
-    rc = setup_phase(ctx, lifecycle, subject, "bazel_results", data, hc_trait, bazel_trait, command, bazel_base_flags = base_flags)
+    # the task inside phases.setup).
+    rc = ph.setup(subject, "bazel_results", command = command, base_flags = base_flags)
     announce_version, announce_command = bzl.announce.resolve(ctx)
 
     # Announced with the first spawn below (the streams belong to the spawn) and
@@ -311,7 +310,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     # itself, announced there too so the missing sinks aren't a silent omission.
     bes_sinks = collect_bes_sinks(ctx, bazel_trait, rc, command, extra_backends = deployment.bes_backends)
     dropped_bes = dropped_bes_backends(ctx, bazel_trait, rc, command, extra_backends = deployment.bes_backends)
-    need_bes = bool(bazel_trait.build_event) or bool(lifecycle.task_update)
+    need_bes = bool(bazel_trait.build_event) or bool(ctx.traits[Phases].task_update)
 
     # A property of the resolved flags, so it holds for every attempt and is
     # restored onto each retry's fresh `data`.
@@ -390,24 +389,23 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
 
             # Re-init for the new attempt; `process_event` increments
             # BES counters in-place, so without a fresh dict the retry
-            # would double-count everything from the failed run.
-            data = init_data()
+            # would double-count everything from the failed run. `ph.reset`
+            # refills in place, so `data` and `ph.data` stay the same object.
+            ph.reset(init_data())
             data["bazel_attempts"] = prior_attempts
             data["bes_streamed_by_bazel"] = bazel_streams_bes
             data["aspect_results_url"] = results_base
 
         spawn_status = _pick_status(command, data, had_failure = False, terminal = False)
-        task_update(
-            ctx,
-            lifecycle,
+        ph.update(
             spawn_status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = phase_label,
                 stream = phase_cli,
             ),
             kind = "bazel_results",
             data = data,
-            phase = Phase(
+            phase = phases.Phase(
                 name = phase_id,
                 description = phase_desc,
                 # `build` / `test` (and their `<command>_retry_N` variants)
@@ -477,11 +475,9 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
         # the CLI line) so the Aspect Workflows link surfaces without
         # duplicating the CLI spawn line.
         spawn_status = _pick_status(command, data, had_failure = False, terminal = False)
-        task_update(
-            ctx,
-            lifecycle,
+        ph.update(
             spawn_status,
-            ProgressStyles(
+            phases.ProgressStyles(
                 body = phase_label,
             ),
             kind = "bazel_results",
@@ -519,14 +515,14 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
                     # the spawn label; priority=True bypasses throttle.
                     is_first = not saw_first_event
                     saw_first_event = True
-                    update = TaskUpdate(
+                    update = phases.Update(
                         kind = "bazel_results",
                         status = live_status,
                         progress = _live_progress(data, command, live_status),
                         priority = is_first,
                         data = data,
                     )
-                    dispatch_task_update(ctx, lifecycle, update)
+                    ph.dispatch(update)
                     last_emit_ms = now_ms(ctx)
                 if events.done:
                     break
@@ -559,7 +555,7 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
     def _add_repro(cmd, slug, description = "", target = ""):
         """Append a repro command unless its flavor is suppressed (slug-derived)."""
         if cmd and flavor_allows(_flavors, slug):
-            data["repro_commands"].append(ReproFixCommand(
+            data["repro_commands"].append(phases.ReproFixCommand(
                 command = cmd,
                 description = description,
                 slug = slug,
@@ -603,4 +599,4 @@ def run_bazel_task(ctx: TaskContext, command: str, targets = None) -> TaskConclu
         for _label in _by_sub[_sub]:
             _add_pair(_sub, [_label], target = _label)
 
-    return _emit_terminal(ctx, lifecycle, command, data, invocation_status.code, targets = targets)
+    return _emit_terminal(ph, command, invocation_status.code, targets = targets)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
@@ -2,7 +2,7 @@
 
 `GithubStatusChecks` (`feature/github_status_checks.axl`) and
 `BuildkiteAnnotations` (`feature/buildkite_annotations.axl`) both
-subscribe to the same `TaskLifecycleTrait` slots, dispatch on
+subscribe to the same `Phases` slots, dispatch on
 `task_update.kind`, and share the same throttle / link-augmentation
 logic. This module hosts the parts that should stay in lockstep when a
 new task kind is added or a renderer's signature evolves.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/health_check.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/health_check.axl
@@ -1,7 +1,7 @@
 """HealthCheckTrait and the Workflows runner-agent health check.
 
 `HealthCheckTrait` lets features register `health_check` hooks that run
-during the task's Setup phase (via `lib/lifecycle.axl::setup_phase`); a
+during the task's Setup phase (via `phases.setup`); a
 hook returning a non-None message fails the task. `agent_health_check`
 is the Workflows-registered hook that:
 
@@ -14,7 +14,7 @@ is the Workflows-registered hook that:
 
 The `assert_ctx_bazel_ready_for_health_check` guard is exported so
 custom tasks composing `BazelTrait` + `HealthCheckTrait` get the same
-fail-loud contract enforcement — see `bazel/flags.axl` for the
+fail-loud contract enforcement — see `bazel.axl` for the
 canonical helpers that satisfy it.
 """
 
@@ -298,7 +298,7 @@ def run_health_checks(ctx, hc_trait):
     Every hook runs even after one reports an error, so diagnostic hooks (e.g.
     the Workflows runner-env table) always print. A non-None result means the
     environment is unhealthy; the hook has already signaled the agent, and the
-    caller (`lifecycle.setup_phase`) fails the task on it."""
+    caller (`phases.setup`) fails the task on it."""
     if hc_trait == None:
         return None
     health_error = None
@@ -334,17 +334,17 @@ def assert_ctx_bazel_ready_for_health_check(ctx, environment):
     """Fail if a Workflows runner is in use and the active run command
     (`ctx.bazel.active_rc()`) is missing `--output_base`.
 
-    Built-in tasks satisfy this via `lib/lifecycle.axl::setup_phase`, which
+    Built-in tasks satisfy this via `phases.setup`, which
     registers the active run command (through `bazel.setup_command` →
     `ctx.bazel.use_rc`) before running the `health_check` hooks. Custom tasks
-    running the health check outside `setup_phase` must `use_rc` first.
+    running the health check outside `phases.setup` must `use_rc` first.
     """
     if ctx_bazel_ready_for_health_check(ctx, environment):
         return
     fail(
         "Bazel health check would target the wrong server: the active run " +
         "command is missing --output_base on a Workflows runner. Run the " +
-        "health check via lib/lifecycle.axl::setup_phase, or set an active " +
+        "health check via phases.setup, or set an active " +
         "run command via ctx.bazel.use_rc (e.g. through bazel.setup_command) " +
         "before the health_check hooks.",
     )
@@ -366,11 +366,11 @@ def agent_health_check(ctx, environment):
         print("--- :thermometer: Workflows runner health check")
 
     # Snapshot job-history before `_wait_for_warming` re-reads the
-    # environment. `setup_phase` runs `append_runner_job_history` ahead
+    # environment. `phases.setup` runs `append_runner_job_history` ahead
     # of this hook, so the file already contains the current task's
     # entry — but Vigor's saved snapshot in `last_health_check` was
     # written before this task ran. The feature-time `environment` was
-    # captured in phase 3 (before phase 4 ran setup_phase), so this
+    # captured in phase 3 (before phase 4 ran phases.setup), so this
     # field still reflects the pre-append state. Re-reading would
     # desync the rewritten Job History count from Vigor's report.
     job_history = environment.runner.runner_job_history

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -1,15 +1,23 @@
-"""Task lifecycle: TaskUpdate record, TaskLifecycleTrait, the canonical
-`task_update()` emitter, and the repro/fix suggestion records + helpers.
+"""Task lifecycle: the `phases` namespace tasks drive their setup/update
+flow through, the `Phases` trait features observe it with, the TaskUpdate
+record, and the repro/fix suggestion records + helpers.
 
-`TaskLifecycleTrait` has two hooks: `task_update` (every structured
-update during a task) and `repro_fix_suggestion` (per surface emit, so
-a user's `config.axl` can accept/reject/modify each repro/fix
-suggestion). See `apply_repro_fix_hooks` / `dispatch_task_update`.
+A task opens its `_impl` with `ph = phases.new(ctx, data)` and drives every
+phase and emit through the handle — `ctx` and the mutable `data` dict are held
+once, so `ph.setup(...)` / `ph.update(...)` / `ph.dispatch(...)` /
+`ph.suggest_fixes(...)` never re-pass them, and `ph` threads through the
+task's own helpers as one value. `ph.reset(fresh)` swaps the held data in
+place (Bazel retries). The `Phases` handler list and the health-check / bazel
+traits are read from `ctx.traits`. See `phases.new`.
 
-`task_update(ctx, lifecycle, status, progress, ...)` both prints
-`→ <progress>` to stderr and emits a `TaskUpdate` to every
-`lifecycle.task_update` handler — paired to keep CI logs and the
-BK annotation / GHSC "Last update" line in sync.
+The `Phases` trait has two hooks: `task_update` (every structured update
+during a task) and `repro_fix_suggestion` (per surface emit, so a user's
+`config.axl` can accept/reject/modify each repro/fix suggestion). See
+`ph.suggest_fixes` / `ph.dispatch`.
+
+`ph.update(status, progress, ...)` both prints `→ <progress>` to stderr and
+emits a `TaskUpdate` to every `Phases.task_update` handler — paired to keep
+CI logs and the BK annotation / GHSC "Last update" line in sync.
 
 `progress` is either a str (same text every surface; stream verbatim,
 body ANSI-stripped) or a `ProgressStyles` (per-style; unset → "").
@@ -21,16 +29,17 @@ every handler so non-template observers see it.
 The closing `→ Completed/Failed <Task> task in <duration>` line is
 emitted automatically by the runtime after `implementation` returns.
 Status surfaces flip to the verdict via the task's own terminal
-`task_update(..., "passed"|"failed", ...)`.
+`phases.update(..., "passed"|"failed", ...)`.
 """
 
-# Record, trait, and emitter sit together here; `traits.axl` re-exports
-# them for user `config.axl` files.
+# Record, trait, and emitter sit together here; the `phases` namespace at
+# the bottom is the task-facing surface, and `traits.axl` re-exports the
+# trait + repro records for user `config.axl` files.
 
-load("@aspect//bazel.axl", bzl = "bazel")
+load("@aspect//bazel.axl", "BazelTrait", "bazel")
 load("./ansi.axl", "ansi")
 load("./environment.axl", "color_enabled", "detect_ci", "feature_logger")
-load("./health_check.axl", "run_health_checks")
+load("./health_check.axl", "HealthCheckTrait", "run_health_checks")
 load("./runner_job_history.axl", "append_runner_job_history")
 
 # Multi-style progress message. Producers set whichever variants they
@@ -50,7 +59,7 @@ ProgressStyles = record(
 #   failing — hard failure in-flight; passed/failed — terminal;
 #   aborted — bazel terminated (timeout, OOM, ctrl-c).
 # `warning` is both live and terminal — read `TaskUpdate.final` to tell.
-# `task_update(...)` validates against this enum; `TaskUpdate.status`
+# `phases.update(...)` validates against this enum; `TaskUpdate.status`
 # stays `str` so surfaces compare with plain literals.
 Status = enum("running", "failing", "warning", "passed", "failed", "aborted")
 
@@ -61,7 +70,7 @@ TaskUpdate = record(
     priority = field(bool, default = False),
     # Task subject (target patterns / formatter target / etc.), rendered in
     # the status-surface title. Empty means "no change" — handlers latch the
-    # last non-empty value, so check it on EVERY update. `setup_phase` sets it
+    # last non-empty value, so check it on EVERY update. `phases.setup` sets it
     # first; a later update may refine it (e.g. query task's resolved targets).
     subject = field(str, default = ""),
     # True iff this update crossed a phase boundary (set when `phase.name`
@@ -80,7 +89,7 @@ TaskUpdate = record(
     data = field(dict, default = {}),
 )
 
-# Input-only record for `task_update(..., phase = Phase(...))`. The runtime
+# Input-only record for `phases.update(..., phase = Phase(...))`. The runtime
 # records the boundary and exposes it back via `ctx.task.phases()` /
 # `current_phase()` as the output-only Rust `TaskPhase` (same fields plus
 # runtime-set `duration_ms` + `interrupted`).
@@ -138,7 +147,7 @@ ReproFixCommand = record(
     # sections render only `target == ""` entries; `target`-set ones render only
     # inline, correlated by label.
     target = field(str, default = ""),
-    # Idempotence flag flipped by `apply_repro_fix_hooks` after the entry
+    # Idempotence flag flipped by `phases.suggest_fixes` after the entry
     # passes through `lifecycle.repro_fix_suggestion`, so each entry hooks at
     # most once. Producers leave `False`; user hooks must not read it.
     _hooked = field(bool, default = False),
@@ -170,7 +179,7 @@ ReproFixInfo = record(
     command_kind = field(ReproFixCommandKind),
 
     # The entry the hook is deciding on. Scope by `slug`, not by parsing
-    # `command`. (`slug` catalogue is in `apply_repro_fix_hooks`.)
+    # `command`. (`slug` catalogue is in `phases.suggest_fixes`.)
     command = field(str),
     description = field(str),
     slug = field(str),
@@ -188,7 +197,7 @@ ReproFixInfo = record(
     targets = field(list[str], default = []),
     failed_targets = field(list[str], default = []),
 
-    # Task-stamped curated keys, stable per-task — see `apply_repro_fix_hooks`
+    # Task-stamped curated keys, stable per-task — see `phases.suggest_fixes`
     # call sites. E.g. lint: {"aspects", "suggestion_count"}; format/gazelle:
     # {"affected_files"}; delivery: {"mode", "targets_total"}.
     extras = field(dict, default = {}),
@@ -427,22 +436,23 @@ def resolve_surface_update(ctx, lifecycle, surface, status, final, style, body) 
     ))
 
 # Lifecycle hooks any task can fire, so features like GithubStatusChecks
-# observe progress without coupling to Bazel-specific hooks.
-TaskLifecycleTrait = trait(
+# observe progress without coupling to Bazel-specific hooks. Tasks add it to
+# their trait list via `phases.TRAITS`; features index `ctx.traits[Phases]`.
+Phases = trait(
     # Primary hook: `(ctx, update: TaskUpdate) -> None`, called for every
     # structured update. Features close over their own state.
     #
     # The FIRST update a handler sees is its init cue (create the GHSC check
-    # run / BK annotation, read `update.subject` for the title); `setup_phase`
+    # run / BK annotation, read `update.subject` for the title); `phases.setup`
     # emits it (Setup phase mark) at task start. The `final = True` update is
     # the last — handlers conclude there. No separate started/complete hook.
     task_update = attr(list[typing.Callable[[TaskContext, TaskUpdate], None]], default = []),
 
     # `(ctx: TaskContext, info: ReproFixInfo) -> ReproFixSuggestion`, called
     # once per repro/fix suggestion to let `config.axl` accept/reject/replace
-    # it. `dispatch_task_update` runs it on every emit; the `_hooked` flag
+    # it. `phases.dispatch` runs it on every emit; the `_hooked` flag
     # makes it idempotent. Handlers chain in order; `reject` short-circuits.
-    # See `apply_repro_fix_hooks`.
+    # See `phases.suggest`.
     repro_fix_suggestion = attr(list[typing.Callable[[TaskContext, ReproFixInfo], ReproFixSuggestion]], default = []),
 
     # `(ctx: TaskContext, update: StatusSurfaceUpdate) -> StatusSurfaceDecision`,
@@ -468,11 +478,11 @@ TaskLifecycleTrait = trait(
     status_surface_update = attr(list[typing.Callable[[TaskContext, StatusSurfaceUpdate], StatusSurfaceDecision]], default = []),
 )
 
-# Lives next to `task_update()` so every surface emit routes through
-# `dispatch_task_update`, which runs un-hooked repro/fix entries through
-# the user hook chain first. Idempotent via the `_hooked` flag.
+# Lives next to `phases.update` so every surface emit routes through
+# `phases.dispatch`, which runs un-hooked repro/fix entries through the user
+# hook chain first. Idempotent via the `_hooked` flag.
 
-def apply_repro_fix_hooks(
+def _suggest_fixes(
         ctx,
         lifecycle,
         data,
@@ -484,9 +494,9 @@ def apply_repro_fix_hooks(
         failed_targets = [],
         extras = {}):
     """Filter / rewrite `data["repro_commands"]` and `data["fix_commands"]`
-    through every handler on `lifecycle.repro_fix_suggestion`.
+    through every handler on the task's `Phases.repro_fix_suggestion`.
 
-    Called automatically on every emit via `dispatch_task_update`.
+    Called automatically on every emit via `phases.dispatch`.
     Producers MAY call it explicitly before a terminal emit to supply rich
     `info` (exit_code, bazel_subcommand, …); the `_hooked` flag makes it
     idempotent, so each entry hooks at most once (surviving entries come
@@ -524,7 +534,7 @@ def apply_repro_fix_hooks(
 
     Args:
         ctx:              passed to each handler.
-        lifecycle:        source of the hook list.
+        lifecycle:        source of the `repro_fix_suggestion` hook list.
         data:             task `data` dict. Mutated in place.
         kind:             result kind, matches `TaskUpdate.kind`.
         status:           status about to be emitted.
@@ -600,19 +610,19 @@ def _apply_chain(ctx, info_base, command_kind, entry, handlers):
                 description = verdict.description
     return ReproFixCommand(command = command, description = description, slug = slug, target = entry.target, _hooked = True)
 
-def dispatch_task_update(ctx, lifecycle, update):
-    """Run any un-hooked repro/fix entries through
-    `lifecycle.repro_fix_suggestion`, then deliver `update` to every
-    `lifecycle.task_update` handler.
+def _dispatch(ctx, lifecycle, update):
+    """Run any un-hooked repro/fix entries through the task's
+    `Phases.repro_fix_suggestion`, then deliver `update` to every
+    `Phases.task_update` handler.
 
-    Single dispatch point (used by `task_update()` and the direct-emit
+    Single dispatch point (used by `ph.update` and the direct-emit
     paths) so surfaces never see an un-hooked entry. Producers may
-    pre-hook with rich `ReproFixInfo` via `apply_repro_fix_hooks(...)`;
+    pre-hook with rich `ReproFixInfo` via `ph.suggest_fixes(...)`;
     those entries are skipped here (idempotent).
     """
     data = update.data
     if data and (data.get("repro_commands") or data.get("fix_commands")):
-        apply_repro_fix_hooks(
+        _suggest_fixes(
             ctx,
             lifecycle,
             data,
@@ -627,7 +637,7 @@ def dispatch_task_update(ctx, lifecycle, update):
 # emoji still get a section marker.
 _ASPECT_BK_SHORTCODE = ":aspect:"
 
-def publish_expanded_phases(ctx, phase_names: list) -> None:
+def _publish_expanded_phases(ctx, phase_names: list) -> None:
     """Record `phase_names` as the phases whose Buildkite section headers should
     be emitted expanded (`+++`), read later by `_emit_bk_phase_section` during the
     task `_impl`. Called by the `BuildkiteAnnotations` feature from its config.
@@ -638,7 +648,7 @@ def publish_expanded_phases(ctx, phase_names: list) -> None:
     so the value always reflects the current run's resolved config."""
     ctx.std.env.set_var(_BK_EXPANDED_PHASES_ENV, ",".join([n for n in phase_names if n]))
 
-def bk_phase_section_marker(ctx, phase) -> str:
+def _bk_phase_section_marker(ctx, phase) -> str:
     """Resolve `phase`'s Buildkite section-header marker: `"+++"` (expanded) or
     `"---"` (collapsed).
 
@@ -662,7 +672,7 @@ def _emit_bk_phase_section(ctx, phase, progress_styles = None):
     `→` print (`progress_styles.stream`, falling back to `.body`).
     `phase.emoji` → `:aspect:`, `phase.display_name` → titlecase(name).
 
-    `<marker>` is `+++` (expanded) when `bk_phase_section_marker` resolves it for
+    `<marker>` is `+++` (expanded) when `_bk_phase_section_marker` resolves it for
     this phase — either `Phase.expanded` or a `--buildkite-annotations:expand-phase`
     entry — else `---` (collapsed). Note BK only auto-expands the last collapsed
     `---` group when no group is explicitly expanded, so a `+++` here suppresses
@@ -678,7 +688,7 @@ def _emit_bk_phase_section(ctx, phase, progress_styles = None):
         cli = progress_styles.stream or progress_styles.body
         if cli:
             suffix = " · " + cli
-    marker = bk_phase_section_marker(ctx, phase)
+    marker = _bk_phase_section_marker(ctx, phase)
     print(marker + " " + (phase.emoji or _ASPECT_BK_SHORTCODE) + " " + label + suffix)
 
 def _titlecase_phase(phase):
@@ -701,15 +711,14 @@ def _resolve_progress_styles(progress):
     # Wrong type → downstream field access raises with the offending value.
     return progress
 
-def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priority = True, phase = None, final = False, conclusion = "", exit_code = 0, subject = ""):
-    """Emit a TaskUpdate to all `lifecycle.task_update` handlers and print
+def _update(ctx, status, progress, kind = "", data = None, priority = True, phase = None, final = False, conclusion = "", exit_code = 0, subject = ""):
+    """Emit a TaskUpdate to all `Phases.task_update` handlers and print
     `→ <progress>` to stderr. When `final = True`, returns a
     `TaskConclusion(exit_code, text=conclusion, flagged=(status=="warning"))`
     that `_impl` returns to drive the runtime's closing bookend (else None).
 
     Args:
-        ctx:       The TaskContext.
-        lifecycle: TaskLifecycleTrait with task_update handlers.
+        ctx:       The TaskContext; `Phases` handler list read from `ctx.traits`.
         status:    Required lifecycle status (Status enum value).
         progress:  str (same everywhere) or `ProgressStyles` (per-style).
         kind:      Template dispatch key (e.g. "bazel_results"). Empty (default)
@@ -794,7 +803,7 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
         data = data if data != None else {},
         subject = subject,
     )
-    dispatch_task_update(ctx, lifecycle, update)
+    _dispatch(ctx, ctx.traits[Phases], update)
 
     if final:
         return TaskConclusion(
@@ -806,7 +815,9 @@ def task_update(ctx, lifecycle, status, progress, kind = "", data = None, priori
 
 # --severity policy for drift-gating tasks (format, gazelle, …) that
 # expose `--severity=auto|info|warn|fail`. `resolve_severity` resolves
-# `auto`; `pick_task_status` derives the lifecycle status.
+# `auto`; `pick_task_status` derives the lifecycle status. These are the
+# severity-gating helpers for format/gazelle — not part of the `phases`
+# emission surface — so they stay plain module functions those tasks import.
 
 def resolve_severity(ctx):
     """Resolve `--severity=auto` to `info|warn|fail`: `fail` on CI (gates
@@ -838,51 +849,49 @@ def pick_task_status(data, kind_key, had_failure, terminal):
             return "failed" if terminal else "failing"
     return "passed" if terminal else "running"
 
-def setup_phase(ctx, lifecycle, subject, kind, data, hc_trait = None, bazel_trait = None, bazel_command = "build", bazel_base_flags = []):
+def _setup(ctx, subject, kind, data, command = "build", base_flags = []):
     """Run the `setup` phase — all pre-task work — and return the resolved
     Bazel command flags (or `None` for a non-building task).
 
-    Every built-in task opens with this as the first thing in `_impl`.
-    Steps, in execution order:
+    Every built-in task opens with this as the first thing in `_impl`. The
+    `Phases`, `HealthCheckTrait`, and `BazelTrait` traits are read from
+    `ctx.traits`; a task that omits `HealthCheckTrait`/`BazelTrait` simply
+    skips that step. Steps, in execution order:
 
       1. `append_runner_job_history` — self-gates on the Workflows env var.
       2. Open the `🔧 Setup` phase mark, carrying `kind`/`data`/`subject`.
-         Always emitted. This is the task's first `task_update`: handlers
+         Always emitted. This is the task's first `phases.update`: handlers
          self-init (GHSC check run / BK annotation) and render the first
          surface body from `data`. Runs before the steps that can fail
          (rc parse, health check) so failures surface on a created check run.
-      3. Bazel setup (only with `bazel_trait`): `bazel.setup_command`
+      3. Bazel setup (only when `BazelTrait` is declared): `bazel.setup_command`
          resolves flags, parses `.bazelrc`, populates
          `ctx.bazel.startup_flags`, and returns the flag list. Else `None`.
-      4. `hc_trait.health_check` hooks (only with `hc_trait`) — must run
-         after step 3 (they read its startup flags). On unhealthy, concludes
+      4. `health_check` hooks (only when `HealthCheckTrait` is declared) — must
+         run after step 3 (they read its startup flags). On unhealthy, concludes
          the surface ("Health check failed") and `fail()`s — never returns.
 
     Args:
-      ctx:         TaskContext.
-      lifecycle:   TaskLifecycleTrait — phase-boundary dispatch target.
-      subject:     Task subject for the first `task_update`; may be refined
+      ctx:         TaskContext (source of the trait handlers).
+      subject:     Task subject for the first `phases.update`; may be refined
                    later (see `TaskUpdate.subject`).
       kind:        result-library kind (e.g. `"bazel_results"`) for renderer dispatch.
       data:        results dict (from `init_data()`); rendered on the first
                    surface body and the health-failure terminal.
-      hc_trait:    HealthCheckTrait or `None`.
-      bazel_trait:      BazelTrait or `None` (non-Bazel tasks).
-      bazel_command:    rc sections to expand ("build"/"test"); ignored sans bazel_trait.
-      bazel_base_flags: default flags for `bazel.setup_command`; ignored sans bazel_trait.
+      command:     rc sections to expand ("build"/"test"); ignored sans BazelTrait.
+      base_flags:  default flags for `bazel.setup_command`; ignored sans BazelTrait.
 
     Returns:
-      RunCommand | None: the active run command with `bazel_trait` (also
-      registered via `ctx.bazel.use_rc`), else `None`. Does not return when a
-      health check fails (step 4).
+      RunCommand | None: the active run command when `BazelTrait` is declared
+      (also registered via `ctx.bazel.use_rc`), else `None`. Does not return
+      when a health check fails (step 4).
     """
     append_runner_job_history(ctx)
 
-    # Open the Setup phase — the task's first `task_update`. `kind`+`data`
+    # Open the Setup phase — the task's first `phases.update`. `kind`+`data`
     # both init the surfaces and render their first body.
-    task_update(
+    _update(
         ctx,
-        lifecycle,
         "running",
         ProgressStyles(
             body = "Running setup...",
@@ -901,26 +910,71 @@ def setup_phase(ctx, lifecycle, subject, kind, data, hc_trait = None, bazel_trai
     # Bazel rc parse + use_rc (building tasks only). Must precede the health
     # checks, which inspect the active run command's startup flags.
     rc = None
-    if bazel_trait != None:
-        rc = bzl.setup_command(ctx, bazel_command, base_flags = bazel_base_flags)
+    if BazelTrait in ctx.traits:
+        rc = bazel.setup_command(ctx, command, base_flags = base_flags)
 
     # Health checks last. A non-None result is fatal: concludes the surface
     # and fails the task — never returns.
+    hc_trait = ctx.traits[HealthCheckTrait] if HealthCheckTrait in ctx.traits else None
     health_error = run_health_checks(ctx, hc_trait)
     if health_error != None:
-        _fail_health_check(ctx, lifecycle, kind, data, health_error)
+        _fail_health_check(ctx, kind, data, health_error)
 
     return rc
+
+def _setup_surface(ctx, subject, kind, data):
+    """Surface half of `_setup`: everything except the Bazel rc parse.
+
+    For tasks that resolve the active `RunCommand` themselves BEFORE the
+    lifecycle surface opens — e.g. the `bazel.build(ctx)` / `bazel.test(ctx)`
+    invocation handle owns the flag → `parse_rc` → `use_rc` pipeline, then hands
+    the live rc here. Runs, in order:
+
+      1. `append_runner_job_history`.
+      2. Open the `🔧 Setup` phase mark (the task's first `phases.update`, so
+         surfaces self-init and render their first body from `data`).
+      3. `health_check` hooks — they read the ALREADY-active run command
+         (`ctx.bazel.active_rc()`, set by the caller's rc pipeline), so this
+         must run after the caller has `use_rc`'d. On unhealthy, concludes the
+         surface and `fail()`s — never returns.
+
+    Unlike `_setup`, this never touches `ctx.bazel` flags itself; the caller
+    owns the rc so the same active run command drives both the health check and
+    every subsequent spawn.
+    """
+    append_runner_job_history(ctx)
+
+    _update(
+        ctx,
+        "running",
+        ProgressStyles(
+            body = "Running setup...",
+            stream = "Running setup",
+        ),
+        kind = kind,
+        data = data,
+        phase = Phase(
+            name = "setup",
+            description = "Prepare the task environment",
+            emoji = "🔧",
+        ),
+        subject = subject,
+    )
+
+    hc_trait = ctx.traits[HealthCheckTrait] if HealthCheckTrait in ctx.traits else None
+    health_error = run_health_checks(ctx, hc_trait)
+    if health_error != None:
+        _fail_health_check(ctx, kind, data, health_error)
 
 # Uniform surface body/conclusion on health-check failure; the detailed
 # reason goes to the CLI/log instead.
 _HEALTH_CHECK_FAILED = "Health check failed"
 
-def _fail_health_check(ctx, lifecycle, kind, data, reason):
-    """Conclude the surface for a failed `setup_phase` health check, then
-    `fail(reason)`. Emits a terminal `task_update` so the surface flips to
+def _fail_health_check(ctx, kind, data, reason):
+    """Conclude the surface for a failed `phases.setup` health check, then
+    `fail(reason)`. Emits a terminal `phases.update` so the surface flips to
     failed instead of sticking at "running"; `reason` is the CLI/log message."""
-    dispatch_task_update(ctx, lifecycle, TaskUpdate(
+    _dispatch(ctx, ctx.traits[Phases], TaskUpdate(
         kind = kind,
         status = "failed",
         final = True,
@@ -929,3 +983,105 @@ def _fail_health_check(ctx, lifecycle, kind, data, reason):
         progress = ProgressStyles(body = _HEALTH_CHECK_FAILED),
     ))
     fail(reason)
+
+def _new(ctx, data):
+    """The task-facing lifecycle handle, bound to `ctx` and the task's mutable
+    `data` dict. A task opens its `_impl` with `ph = phases.new(ctx, data)` and
+    drives every phase/emit through it — `ctx` and `data` are held once, so no
+    call re-passes them, and the handle threads through the task's own helpers
+    as a single value in place of the old `(ctx, lifecycle, data)` trio.
+
+    The health-check / bazel traits (for `setup`) and the `Phases` handler list
+    (for `update`/`dispatch`/`suggest_fixes`) are read from `ctx.traits`.
+
+    Methods:
+      ph.ctx  — the bound TaskContext (for helpers that also need ctx directly).
+      ph.data — the bound data dict. Kept a stable reference across `reset`.
+      ph.setup(subject, kind, command="build", base_flags=[]) -> RunCommand|None
+      ph.update(status, progress, kind="", data=None, priority=True, phase=None,
+                final=False, conclusion="", exit_code=0, subject="")
+                — `data=None` uses the held dict; pass `data={}` for a data-less
+                  phase transition.
+      ph.dispatch(update)              — emit a pre-built `phases.Update`.
+      ph.suggest_fixes(kind, status, …) — pre-hook repro/fix entries.
+      ph.reset(fresh)  — replace the held data IN PLACE (clear + refill) so
+                         `ph.data` stays the same object; used between Bazel
+                         retries where each attempt re-inits `data`.
+    """
+
+    def setup(subject, kind, command = "build", base_flags = []):
+        return _setup(ctx, subject, kind, data, command, base_flags)
+
+    def setup_surface(subject, kind):
+        _setup_surface(ctx, subject, kind, data)
+
+    def update(status, progress, kind = "", data = None, priority = True, phase = None, final = False, conclusion = "", exit_code = 0, subject = ""):
+        return _update(
+            ctx,
+            status,
+            progress,
+            kind = kind,
+            data = _data if data == None else data,
+            priority = priority,
+            phase = phase,
+            final = final,
+            conclusion = conclusion,
+            exit_code = exit_code,
+            subject = subject,
+        )
+
+    def dispatch(update):
+        _dispatch(ctx, ctx.traits[Phases], update)
+
+    def suggest_fixes(kind, status, exit_code = 0, bazel_subcommand = "", targets = [], failed_targets = [], extras = {}):
+        _suggest_fixes(
+            ctx,
+            ctx.traits[Phases],
+            _data,
+            kind,
+            status,
+            exit_code = exit_code,
+            bazel_subcommand = bazel_subcommand,
+            targets = targets,
+            failed_targets = failed_targets,
+            extras = extras,
+        )
+
+    def reset(fresh):
+        _data.clear()
+        _data.update(fresh)
+
+    _data = data
+    return struct(
+        ctx = ctx,
+        data = _data,
+        setup = setup,
+        setup_surface = setup_surface,
+        update = update,
+        dispatch = dispatch,
+        suggest_fixes = suggest_fixes,
+        reset = reset,
+    )
+
+# The task-facing lifecycle surface. `phases.new(ctx, data)` returns the handle
+# above; tasks import only `phases`, splat `phases.TRAITS` into their trait
+# list, and construct records off it (`phases.Phase` / `.ProgressStyles` /
+# `.Update` / `.ReproFixCommand`) — so `lifecycle.axl` is a single import at
+# the use site. `publish_expanded_phases` / `bk_phase_section_marker` stay
+# free functions (they're ctx/phase utilities, not bound to a task's data).
+phases = namespace(
+    new = _new,
+    TRAITS = [Phases],
+    publish_expanded_phases = _publish_expanded_phases,
+    bk_phase_section_marker = _bk_phase_section_marker,
+    Phase = Phase,
+    ProgressStyles = ProgressStyles,
+    Update = TaskUpdate,
+    ReproFixCommand = ReproFixCommand,
+)
+
+# Direct handles to the hook-chain internals for unit tests (`repro_commands_test`),
+# which exercise the chain with a fake `lifecycle` handler list instead of a real
+# `ctx.traits[Phases]`. Not part of the public surface.
+testonly_suggest_fixes = _suggest_fixes
+testonly_dispatch = _dispatch

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle_test.axl
@@ -18,7 +18,7 @@ Run with:
   aspect dev test-lifecycle
 """
 
-load("./lifecycle.axl", "Phase", "bk_phase_section_marker", "publish_expanded_phases")
+load("./lifecycle.axl", "Phase", "phases")
 
 _ENV_KEY = "ASPECT_BK_EXPANDED_PHASES"
 
@@ -35,25 +35,25 @@ def _test_marker(ctx):
     build_expanded = Phase(name = "build", expanded = True)
 
     # No config, no Phase.expanded → collapsed.
-    _eq("default collapsed", bk_phase_section_marker(ctx, build), "---")
+    _eq("default collapsed", phases.bk_phase_section_marker(ctx, build), "---")
 
     # Phase.expanded wins on its own.
-    _eq("Phase.expanded → expanded", bk_phase_section_marker(ctx, build_expanded), "+++")
+    _eq("Phase.expanded → expanded", phases.bk_phase_section_marker(ctx, build_expanded), "+++")
 
     # Config names the phase → expanded; an unnamed phase stays collapsed.
-    publish_expanded_phases(ctx, ["build"])
-    _eq("config match → expanded", bk_phase_section_marker(ctx, build), "+++")
-    _eq("config miss → collapsed", bk_phase_section_marker(ctx, test), "---")
+    phases.publish_expanded_phases(ctx, ["build"])
+    _eq("config match → expanded", phases.bk_phase_section_marker(ctx, build), "+++")
+    _eq("config miss → collapsed", phases.bk_phase_section_marker(ctx, test), "---")
 
     # Whitespace around configured ids is tolerated.
-    publish_expanded_phases(ctx, [" build ", "test"])
-    _eq("config whitespace tolerated", bk_phase_section_marker(ctx, build), "+++")
-    _eq("config second entry matches", bk_phase_section_marker(ctx, test), "+++")
+    phases.publish_expanded_phases(ctx, [" build ", "test"])
+    _eq("config whitespace tolerated", phases.bk_phase_section_marker(ctx, build), "+++")
+    _eq("config second entry matches", phases.bk_phase_section_marker(ctx, test), "+++")
 
     # Empty list clears the channel → back to Phase.expanded only.
-    publish_expanded_phases(ctx, [])
-    _eq("cleared config → collapsed", bk_phase_section_marker(ctx, build), "---")
-    _eq("cleared config, Phase.expanded still wins", bk_phase_section_marker(ctx, build_expanded), "+++")
+    phases.publish_expanded_phases(ctx, [])
+    _eq("cleared config → collapsed", phases.bk_phase_section_marker(ctx, build), "---")
+    _eq("cleared config, Phase.expanded still wins", phases.bk_phase_section_marker(ctx, build_expanded), "+++")
 
     if prior == None:
         ctx.std.env.remove_var(_ENV_KEY)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/repro_commands.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/repro_commands.axl
@@ -16,7 +16,7 @@ terminal-emit time:
 `ReproFixCommand` carries `command` (the shell-ready line),
 `description` (optional, rendered as a `# <description>` comment above
 the command), and `slug` (a stable kebab-case identifier — catalogued
-in `apply_repro_fix_hooks` below — that lets
+in `phases.suggest_fixes` below — that lets
 `lifecycle.repro_fix_suggestion` hooks scope decisions without
 parsing the command string).
 
@@ -42,10 +42,10 @@ the per-task lists into a single rolled-up view across tasks: two
 contributions of the same `(command, description)` collapse into one
 row that lists every contributing task name.
 
-`apply_repro_fix_hooks` and `dispatch_task_update` live in
-`lib/lifecycle.axl` next to `TaskLifecycleTrait`. The framework runs
-hooks automatically on every surface emit via `dispatch_task_update`;
-producers MAY call `apply_repro_fix_hooks` explicitly at terminal
+`phases.suggest_fixes` and `phases.dispatch` live in
+`lib/lifecycle.axl` next to `Phases`. The framework runs
+hooks automatically on every surface emit via `phases.dispatch`;
+producers MAY call `phases.suggest_fixes` explicitly at terminal
 emit to supply rich `info` (exit_code, bazel_subcommand, targets,
 failed_targets, extras). The `_hooked` flag on each `ReproFixCommand`
 makes both paths idempotent.
@@ -824,6 +824,6 @@ def _print_repro_entry(color, entry):
         print(line)
     print("```")
 
-# `apply_repro_fix_hooks` and `dispatch_task_update` are defined in
-# `./lifecycle.axl`, next to `TaskLifecycleTrait`. See the module
+# `phases.suggest_fixes` and `phases.dispatch` are defined in
+# `./lifecycle.axl`, next to `Phases`. See the module
 # docstring above for the contract.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/repro_commands_test.axl
@@ -6,7 +6,7 @@ through clap's `ValueSource::CommandLine` is covered by the Rust unit
 tests on `Arguments`.
 """
 
-load("./lifecycle.axl", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixCommand", "TaskUpdate", "apply_repro_fix_hooks", "dispatch_task_update", "repro_fix_replace")
+load("./lifecycle.axl", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixCommand", "TaskUpdate", "repro_fix_replace", "testonly_dispatch", "testonly_suggest_fixes")
 load("./repro_commands.axl", "build_aspect_command", "build_bazel_command", "explicit_flags", "filter_by_flavor", "flavor_allows", "has_tools_bazel_wrapper", "is_vanilla_bazel_slug", "rehydrate_commands", "repro_prefix", "slug_flavor", "subdir_prefix")
 
 def _eq(label, got, want):
@@ -613,7 +613,7 @@ def _seed_data():
 
 def _test_no_handlers_is_noop(_ctx):
     data = _seed_data()
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([]),
         data,
@@ -626,7 +626,7 @@ def _test_no_handlers_is_noop(_ctx):
 
 def _test_accept_keeps_entry(_ctx):
     data = _seed_data()
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([lambda ctx, info: REPRO_FIX_ACCEPT]),
         data,
@@ -644,7 +644,7 @@ def _test_reject_drops_entry(_ctx):
     def reject_fix(ctx, info):
         return REPRO_FIX_REJECT if info.command_kind.value == "fix" else REPRO_FIX_ACCEPT
 
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([reject_fix]),
         data,
@@ -661,7 +661,7 @@ def _test_replace_rewrites_entry(_ctx):
     def rewrite(ctx, info):
         return repro_fix_replace(command = info.command.replace("aspect ", "wrapper "))
 
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([rewrite]),
         data,
@@ -692,7 +692,7 @@ def _test_replace_description_only(_ctx):
         "repro_commands": [ReproFixCommand(command = "x", description = "old", slug = "lint-repro")],
         "fix_commands": [],
     }
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([lambda ctx, info: repro_fix_replace(description = "new")]),
         data,
@@ -709,7 +709,7 @@ def _test_replace_both_none_is_noop(_ctx):
         "repro_commands": [ReproFixCommand(command = "x", description = "y", slug = "lint-repro")],
         "fix_commands": [],
     }
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([lambda ctx, info: repro_fix_replace()]),
         data,
@@ -733,7 +733,7 @@ def _test_chain_passes_through_replacements(_ctx):
     def step2(ctx, info):
         return repro_fix_replace(command = info.command + "2")
 
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([step1, step2]),
         data,
@@ -760,7 +760,7 @@ def _test_chain_short_circuits_on_reject(_ctx):
         calls.append("step2")
         return REPRO_FIX_ACCEPT
 
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([step1, step2]),
         data,
@@ -797,7 +797,7 @@ def _test_info_exposes_typed_fields(_ctx):
         })
         return REPRO_FIX_ACCEPT
 
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([capture]),
         data,
@@ -839,7 +839,7 @@ def _test_empty_lists_skip_chain(_ctx):
         seen.append(info.command_kind.value)
         return REPRO_FIX_ACCEPT
 
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([capture]),
         data,
@@ -863,7 +863,7 @@ def _test_slug_visible_to_hook(_ctx):
     def reject_vanilla(ctx, info):
         return REPRO_FIX_REJECT if info.slug == "test-repro-vanilla-bazel" else REPRO_FIX_ACCEPT
 
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([reject_vanilla]),
         data,
@@ -882,7 +882,7 @@ def _test_slug_preserved_through_replace(_ctx):
         "repro_commands": [ReproFixCommand(command = "aspect buildifier", slug = "format-repro")],
         "fix_commands": [],
     }
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([lambda ctx, info: repro_fix_replace(command = info.command.replace("aspect ", "bazel "))]),
         data,
@@ -909,7 +909,7 @@ def _test_slug_visible_after_replace_in_chain(_ctx):
         later_saw.append(info.slug)
         return REPRO_FIX_ACCEPT
 
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([first, second]),
         data,
@@ -960,7 +960,7 @@ def _test_post_hook_entries_carry_hooked_flag(_ctx):
     `_hooked = True` so re-calls (e.g. from `dispatch_task_update`)
     short-circuit."""
     data = _seed_data()
-    apply_repro_fix_hooks(
+    testonly_suggest_fixes(
         _fake_apply_ctx(),
         _fake_lifecycle([lambda ctx, info: REPRO_FIX_ACCEPT]),
         data,
@@ -984,9 +984,9 @@ def _test_second_apply_skips_already_hooked(_ctx):
         return REPRO_FIX_ACCEPT
 
     handlers = [counting_hook]
-    apply_repro_fix_hooks(_fake_apply_ctx(), _fake_lifecycle(handlers), data, kind = "lint_results", status = "failed", exit_code = 1)
+    testonly_suggest_fixes(_fake_apply_ctx(), _fake_lifecycle(handlers), data, kind = "lint_results", status = "failed", exit_code = 1)
     first = call_count[0]
-    apply_repro_fix_hooks(_fake_apply_ctx(), _fake_lifecycle(handlers), data, kind = "lint_results", status = "failed", exit_code = 1)
+    testonly_suggest_fixes(_fake_apply_ctx(), _fake_lifecycle(handlers), data, kind = "lint_results", status = "failed", exit_code = 1)
     _eq("first pass invoked hook once per entry (4 entries)", first, 4)
     _eq("second pass invoked hook zero additional times", call_count[0], first)
 
@@ -1000,11 +1000,11 @@ def _test_mixed_new_and_hooked_entries(_ctx):
         seen.append(info.command)
         return REPRO_FIX_ACCEPT
 
-    apply_repro_fix_hooks(_fake_apply_ctx(), _fake_lifecycle([capture]), data, kind = "lint_results", status = "failed", exit_code = 1)
+    testonly_suggest_fixes(_fake_apply_ctx(), _fake_lifecycle([capture]), data, kind = "lint_results", status = "failed", exit_code = 1)
     seen_first = list(seen)
 
     data["repro_commands"].append(ReproFixCommand(command = "added-later", slug = "lint-repro"))
-    apply_repro_fix_hooks(_fake_apply_ctx(), _fake_lifecycle([capture]), data, kind = "lint_results", status = "failed", exit_code = 1)
+    testonly_suggest_fixes(_fake_apply_ctx(), _fake_lifecycle([capture]), data, kind = "lint_results", status = "failed", exit_code = 1)
 
     _eq("first pass saw seed entries", seen_first, [
         "aspect lint -- //a:a",
@@ -1041,7 +1041,7 @@ def _test_dispatch_hooks_then_fans_out(_ctx):
         task_update = [task_update_handler],
     )
     update = TaskUpdate(kind = "lint_results", status = "failed", data = data)
-    dispatch_task_update(_fake_apply_ctx(), lifecycle, update)
+    testonly_dispatch(_fake_apply_ctx(), lifecycle, update)
 
     _eq("hook saw original command", hook_saw, ["x"])
     _eq("handler saw post-hook command", handler_saw, ["x-rewritten"])
@@ -1065,8 +1065,8 @@ def _test_dispatch_idempotent_across_emits(_ctx):
         task_update = [],
     )
     update = TaskUpdate(kind = "lint_results", status = "running", data = data)
-    dispatch_task_update(_fake_apply_ctx(), lifecycle, update)
-    dispatch_task_update(_fake_apply_ctx(), lifecycle, update)
+    testonly_dispatch(_fake_apply_ctx(), lifecycle, update)
+    testonly_dispatch(_fake_apply_ctx(), lifecycle, update)
     _eq("hook invoked exactly once across two dispatches", hook_calls[0], 1)
 
 def _test_dispatch_skips_hook_when_lists_empty(_ctx):
@@ -1087,7 +1087,7 @@ def _test_dispatch_skips_hook_when_lists_empty(_ctx):
         task_update = [handler],
     )
     update = TaskUpdate(kind = "lint_results", status = "running", data = {})
-    dispatch_task_update(_fake_apply_ctx(), lifecycle, update)
+    testonly_dispatch(_fake_apply_ctx(), lifecycle, update)
     _eq("hook not called when lists are empty", hook_count[0], 0)
     _eq("handler still called", handler_count[0], 1)
 
@@ -1187,7 +1187,7 @@ def _test_hook_preserves_target(_ctx):
         "repro_commands": [ReproFixCommand(command = "aspect test -- //x", slug = "test-repro-aspect", target = "//x")],
         "fix_commands": [],
     }
-    apply_repro_fix_hooks(_fake_apply_ctx(), lifecycle, data, kind = "bazel_results", status = "failed")
+    testonly_suggest_fixes(_fake_apply_ctx(), lifecycle, data, kind = "bazel_results", status = "failed")
     out = data["repro_commands"][0]
     _eq("hook rewrote command", out.command, "EDITED aspect test -- //x")
     _eq("hook preserved target", out.target, "//x")

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/runnable.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/runnable.axl
@@ -673,7 +673,7 @@ def runfiles_env(ep: struct) -> dict:
 def runnable(ctx, targets: list[str], rc = None) -> struct:
     """Build a BES event tracker that resolves entrypoints for `targets`.
 
-    Pass the active `RunCommand` as `rc` (the value `setup_phase` returns) to opt
+    Pass the active `RunCommand` as `rc` (the value `phases.setup` returns) to opt
     into the `runinfo` aspect: `aspects` then carries it (applied via
     `ctx.bazel.build(aspects = ...)`). Omit `rc` (unit tests) for the BES-only
     heuristic with no aspect.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/runner_job_history.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/runner_job_history.axl
@@ -24,7 +24,7 @@ Plumbing:
     off-runner; we silently skip. Default on Workflows runners is
     `/etc/aspect/workflows/platform/runner_job_history`.
   - `append_runner_job_history(ctx)` — single entry-point, designed to
-    be called once per task from the lifecycle's `setup_phase`.
+    be called once per task from the lifecycle's `phases.setup`.
 
 Hard invariant: a failure to write the history file must NEVER fail
 the task. Every error path here is a silent no-op — missing env var,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/tips.axl
@@ -156,7 +156,7 @@ def tip_shows_on(tip, surface):
 #
 # A `tip_suggestion` hook (on the public `TipsTrait`) fires on every
 # `add_tip`, letting `config.axl` accept/reject/rewrite any tip — same
-# shape as `repro_fix_suggestion` on `TaskLifecycleTrait`.
+# shape as `repro_fix_suggestion` on `Phases`.
 
 # `accept` keeps, `reject` drops (never stored/surfaced), `replace`
 # overrides the set fields on the returned `TipSuggestion`.

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -4,81 +4,34 @@ load("@aspect//bazel/build_events.axl", "announce_bes_sinks", "bes_args", "bes_s
 load("@aspect//bazel.axl", "BazelTrait", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end", bzl = "bazel")
 load("@std//time.axl", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
-load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event", bazel_conclusion = "conclusion")
+load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event")
 load("./private/lib/environment.axl", "error")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
-load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
+load("./private/lib/lifecycle.axl", "phases")
 load("./private/lib/runnable.axl", "RUN_IN_DESCRIPTION", "resolve_run_in", "runnable")
 load("./private/lib/tips.axl", "tips")
 
-def _terminal_status(data, exit_code):
-    """Lifecycle status for the run task's terminal emit.
-
-    `aborted` wins when bazel terminated the build (timeout/OOM/ctrl-c);
-    otherwise a non-zero exit (build failure, run-setup failure, or a
-    non-zero exit from the spawned binary) is `failed`, and zero is
-    `passed`. The run task has no flaky/warning outcome.
-    """
-    if data.get("bazel", {}).get("aborted"):
-        return "aborted"
-    return "passed" if exit_code == 0 else "failed"
-
-def _emit_terminal(ctx, lifecycle, data, exit_code, conclusion_text = None):
-    """Fire the terminal `task_update(final=True)` and return a
-    `TaskConclusion` for `_impl` to return.
-
-    Mirrors `bazel_runner._emit_terminal` so the run task concludes its
-    status surfaces (GitHub check runs, Buildkite annotations) the same
-    way `build`/`test` do — without this the surfaces stay stuck at
-    "running" because nothing ever delivers a final update. Called from
-    every exit path (build failure, run-setup failure, and the spawned
-    binary's exit).
-
-    `conclusion_text` overrides the bookend summary for cases the bazel
-    bucket logic can't describe (e.g. a built target whose binary exits
-    non-zero — not a build failure). When None, falls back to the bazel
-    conclusion derived from the accumulated BES counters.
-    """
-    status = _terminal_status(data, exit_code)
-    bookend = conclusion_text if conclusion_text != None else bazel_conclusion(status, data)
-
-    dispatch_task_update(ctx, lifecycle, TaskUpdate(
-        kind = "bazel_results",
-        status = status,
-        final = True,
-        conclusion = bookend,
-        data = data,
-        progress = ProgressStyles(body = bookend),
-    ))
-
-    return TaskConclusion(
-        exit_code = exit_code,
-        text = bookend,
-        flagged = status == "warning",
-    )
-
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     bazel_trait = ctx.traits[BazelTrait]
-    hc_trait = ctx.traits[HealthCheckTrait]
-    lifecycle = ctx.traits[TaskLifecycleTrait]
 
     target = ctx.args.target[0]
     forward_args = list(ctx.args.run_args)
 
     # Resolve --run-in up front: a bad value (typo, `git-root` outside
-    # a git repo) must fail before setup_phase opens status surfaces
+    # a git repo) must fail before phases.setup opens status surfaces
     # and before the build spends time.
     spawn_cwd = resolve_run_in(ctx, ctx.args.run_in)
 
     data = init_data()
+    ph = phases.new(ctx, data)
 
     # The single pre-task setup phase (status surface, rc parse, health
     # checks); returns the resolved flags (a failed health check fails the task
-    # inside setup_phase). Expand the "build" rc section, not "run": this task
+    # inside phases.setup). Expand the "build" rc section, not "run": this task
     # ultimately invokes `ctx.bazel.build`, which spawns a literal `bazel
     # build`. The `run:` rc section can contain options Bazel's `build` command
     # rejects as unrecognized (e.g. `--script_path`).
-    rc = setup_phase(ctx, lifecycle, target, "bazel_results", data, hc_trait, bazel_trait, "build")
+    rc = ph.setup(target, "bazel_results", "build")
     announce_version, announce_command = bzl.announce.resolve(ctx)
     endpoint_auth_flags = bzl.endpoint_auth_flags(ctx, rc, "build")
 
@@ -94,17 +47,14 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for hook in bazel_trait.build_start:
         hook(ctx)
 
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         "running",
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Building %s..." % target,
             stream = "Building %s" % target,
         ),
         kind = "bazel_results",
-        data = data,
-        phase = Phase(name = "build", description = "Build run target", emoji = "🔨"),
+        phase = phases.Phase(name = "build", description = "Build run target", emoji = "🔨"),
     )
 
     # After the phase line, so the streams are announced under the spawn they
@@ -140,27 +90,23 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 
     if not build_status.success:
-        return _emit_terminal(ctx, lifecycle, data, build_status.code or 1)
+        return build_status.code
 
     entrypoint = r.determine_entrypoint(target)
     if entrypoint == None:
         error(ctx.std, "Failed to determine the run entrypoint for %s." % target)
-        return _emit_terminal(ctx, lifecycle, data, 1, conclusion_text = "Failed to determine run entrypoint")
+        return 1
 
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         "running",
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Running %s..." % target,
             stream = "Running %s" % target,
         ),
-        phase = Phase(name = "run", description = "Run target", emoji = "🚀"),
+        phase = phases.Phase(name = "run", description = "Run target", emoji = "🚀"),
     )
 
-    code = r.spawn(entrypoint, forward_args, cwd = spawn_cwd).wait().code
-    bookend = "Ran %s" % target if code == 0 else "%s exited with code %d" % (target, code)
-    return _emit_terminal(ctx, lifecycle, data, code, conclusion_text = bookend)
+    return r.spawn(entrypoint, forward_args, cwd = spawn_cwd).wait().code
 
 run = task(
     summary = "Build a target with bazel and run the resulting binary.",
@@ -189,7 +135,6 @@ run = task(
     traits = [
         BazelTrait,
         HealthCheckTrait,
-        TaskLifecycleTrait,
-    ] + artifacts.TRAITS + tips.TRAITS,
+    ] + phases.TRAITS + artifacts.TRAITS + tips.TRAITS,
     implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -8,7 +8,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_runner.axl", "run_bazel_task")
 load("./private/lib/deployment_flags.axl", "deployment_flag_args")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
-load("./private/lib/lifecycle.axl", "TaskLifecycleTrait")
+load("./private/lib/lifecycle.axl", "phases")
 load("./private/lib/repro_commands.axl", "repro_flavor_args")
 load("./private/lib/tips.axl", "tips")
 
@@ -142,7 +142,6 @@ test = task(
     traits = [
         BazelTrait,
         HealthCheckTrait,
-        TaskLifecycleTrait,
-    ] + artifacts.TRAITS + tips.TRAITS,
+    ] + phases.TRAITS + artifacts.TRAITS + tips.TRAITS,
     implementation = _impl,
 )

--- a/crates/aspect-cli/src/builtins/aspect/traits.axl
+++ b/crates/aspect-cli/src/builtins/aspect/traits.axl
@@ -6,7 +6,7 @@ files can load the full trait set with a single import:
 
     load("@aspect//traits.axl",
          "BazelTrait",
-         "TaskLifecycleTrait",
+         "Phases",
          "DeliveryTrait",
          "HealthCheckTrait",
          "REPRO_FIX_ACCEPT",
@@ -45,6 +45,7 @@ load("@aspect//lint.axl", _LintTrait = "LintTrait")
 load("./private/lib/health_check.axl", _HealthCheckTrait = "HealthCheckTrait")
 load(
     "./private/lib/lifecycle.axl",
+    _Phases = "Phases",
     _REPRO_FIX_ACCEPT = "REPRO_FIX_ACCEPT",
     _REPRO_FIX_REJECT = "REPRO_FIX_REJECT",
     _ReproFixAction = "ReproFixAction",
@@ -58,7 +59,6 @@ load(
     _StatusSurfaceAction = "StatusSurfaceAction",
     _StatusSurfaceDecision = "StatusSurfaceDecision",
     _StatusSurfaceUpdate = "StatusSurfaceUpdate",
-    _TaskLifecycleTrait = "TaskLifecycleTrait",
     _TaskUpdate = "TaskUpdate",
     _repro_fix_replace = "repro_fix_replace",
     _surface_replace = "surface_replace",
@@ -76,13 +76,13 @@ ReproFixCommand = _ReproFixCommand
 ReproFixCommandKind = _ReproFixCommandKind
 ReproFixInfo = _ReproFixInfo
 ReproFixSuggestion = _ReproFixSuggestion
+Phases = _Phases
 SURFACE_PUBLISH = _SURFACE_PUBLISH
 SURFACE_REMOVE = _SURFACE_REMOVE
 StatusSurface = _StatusSurface
 StatusSurfaceAction = _StatusSurfaceAction
 StatusSurfaceDecision = _StatusSurfaceDecision
 StatusSurfaceUpdate = _StatusSurfaceUpdate
-TaskLifecycleTrait = _TaskLifecycleTrait
 TaskUpdate = _TaskUpdate
 repro_fix_replace = _repro_fix_replace
 surface_replace = _surface_replace

--- a/crates/aspect-cli/src/builtins/aspect/warming.axl
+++ b/crates/aspect-cli/src/builtins/aspect/warming.axl
@@ -10,7 +10,7 @@ runner it then runs the warming archiver
 the warming bucket — so a CI workflow only needs to call `aspect ci warming`.
 
 Like every other task that calls Bazel, it resolves its flags through
-`setup_phase` (which folds in the Workflows runner metadata — the per-runner
+`phases.setup` (which folds in the Workflows runner metadata — the per-runner
 `--output_base`, repository cache, and identity header — and runs the
 `HealthCheckTrait` health checks before building). It is therefore not given an
 `--output-base` flag of its own; on a Workflows runner the output base comes
@@ -21,7 +21,7 @@ The whole run surfaces as a single status check / Buildkite annotation
 spanning the 🔨 populate and 📦 archive phases, so the check reflects the
 archive-upload outcome, not just the build. Off a Workflows runner the archive
 step is reported as skipped and the task still passes. (The prior-state cleanup
-runs after `setup_phase` — so the health check runs first — but before the
+runs after `phases.setup` — so the health check runs first — but before the
 populate build; it shuts down the health check's Bazel server before wiping the
 output base, and isn't a surface phase of its own. See `_impl`.)
 """
@@ -33,7 +33,7 @@ load("./private/lib/artifacts.axl", "artifacts")
 load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "MIN_HEARTBEAT_INTERVAL_MS", "now_ms", "process_event")
 load("./private/lib/environment.axl", "error", "warn")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
-load("./private/lib/lifecycle.axl", "Phase", "ProgressStyles", "TaskLifecycleTrait", "TaskUpdate", "dispatch_task_update", "setup_phase", "task_update")
+load("./private/lib/lifecycle.axl", "phases")
 load("./private/lib/tips.axl", "tips")
 load("./private/lib/warming_results.axl", warming_conclusion = "conclusion", warming_init_data = "init_data")
 
@@ -56,9 +56,11 @@ def _pick_status(data, had_failure, terminal):
         return "failed" if terminal else "failing"
     return "passed" if terminal else "running"
 
-def _emit_final(ctx, lifecycle, data, exit_code):
+def _emit_final(ph, exit_code):
     """Emit the terminal task_update for status-check consumers and return the
     TaskConclusion `_impl` returns."""
+    ctx = ph.ctx
+    data = ph.data
     status = _pick_status(data, had_failure = exit_code != 0, terminal = True)
     if not data.get("finish_time_ms"):
         data["finish_time_ms"] = now_ms(ctx)
@@ -66,11 +68,9 @@ def _emit_final(ctx, lifecycle, data, exit_code):
         data["bazel"]["wall_time_ms"] = data["finish_time_ms"] - data["start_time_ms"]
 
     bookend = warming_conclusion(status, data)
-    return task_update(
-        ctx,
-        lifecycle,
+    return ph.update(
         status,
-        ProgressStyles(body = bookend),
+        phases.ProgressStyles(body = bookend),
         kind = _KIND,
         data = data,
         final = True,
@@ -96,13 +96,12 @@ def _clean_storage_mount(ctx, mount: str):
 
 def _impl(ctx: TaskContext) -> int | TaskConclusion:
     bazel_trait = ctx.traits[BazelTrait]
-    hc_trait = ctx.traits[HealthCheckTrait]
-    lifecycle = ctx.traits[TaskLifecycleTrait]
 
     on_workflows_runner = bool(ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER"))
     targets = list(ctx.args.targets)
 
     data = warming_init_data()
+    ph = phases.new(ctx, data)
     data["start_time_ms"] = now_ms(ctx)
     data["target_pattern"] = " ".join(targets)
     data["warming"]["on_runner"] = on_workflows_runner
@@ -111,12 +110,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # body, resolves Bazel flags + parses the workspace .bazelrc (folding in the
     # runner metadata, incl. --output_base), and runs the health_check hooks (a
     # failed check concludes the surface and fails the task inside).
-    rc = setup_phase(ctx, lifecycle, data["target_pattern"], _KIND, data, hc_trait, bazel_trait, "build")
+    rc = ph.setup(data["target_pattern"], _KIND, "build")
     announce_version, announce_command = bzl.announce.resolve(ctx)
     endpoint_auth_flags = bzl.endpoint_auth_flags(ctx, rc, "build")
 
     # Clean the prior Bazel state under the runner storage mount AFTER
-    # `setup_phase` — the health check must run first (the Workflows
+    # `phases.setup` — the health check must run first (the Workflows
     # `agent_health_check` validates the runner before warming touches its
     # state). The health check (`ctx.bazel.health_check()`) starts/uses the
     # Bazel server in the runner `--output_base` under this same mount, so
@@ -143,17 +142,15 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     for hook in bazel_trait.build_start:
         hook(ctx)
 
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         "running",
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Populating caches... (bazel build --nobuild)",
             stream = "Populating caches (bazel build --nobuild)",
         ),
         kind = _KIND,
         data = data,
-        phase = Phase(name = "populate", description = "Populate Bazel caches", emoji = "🔨"),
+        phase = phases.Phase(name = "populate", description = "Populate Bazel caches", emoji = "🔨"),
     )
 
     # After the phase line, so the streams are announced under the spawn they
@@ -172,11 +169,9 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     # re-emit (status-surface only, empty stream) so the Workflows link surfaces
     # at spawn rather than at build.wait().
     data["sink_invocation_id"] = build.sink_invocation_id
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         "running",
-        ProgressStyles(body = "Populating caches... (bazel build --nobuild)"),
+        phases.ProgressStyles(body = "Populating caches... (bazel build --nobuild)"),
         kind = _KIND,
         data = data,
     )
@@ -196,11 +191,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             if process_event(data, event):
                 interesting = True
         if interesting or now_ms(ctx) - last_emit_ms >= MIN_HEARTBEAT_INTERVAL_MS:
-            dispatch_task_update(ctx, lifecycle, TaskUpdate(
+            ph.dispatch(phases.Update(
                 kind = _KIND,
                 status = _pick_status(data, had_failure = False, terminal = False),
                 data = data,
-                progress = ProgressStyles(),
+                progress = phases.ProgressStyles(),
             ))
             last_emit_ms = now_ms(ctx)
         if events.done:
@@ -219,7 +214,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
 
     if not build_status.success:
         data["warming"]["build_failed"] = True
-        return _emit_final(ctx, lifecycle, data, build_status.code or 1)
+        return _emit_final(ph, build_status.code or 1)
 
     # Archive phase: upload the populated caches to the warming bucket. Only on
     # an Aspect Workflows runner; off-runner it's reported as skipped.
@@ -233,19 +228,17 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
             "Workflows runner this task also uploads the populated caches to the " +
             "warming bucket.",
         )
-        return _emit_final(ctx, lifecycle, data, 0)
+        return _emit_final(ph, 0)
 
-    task_update(
-        ctx,
-        lifecycle,
+    ph.update(
         "running",
-        ProgressStyles(
+        phases.ProgressStyles(
             body = "Uploading warming archive...",
             stream = "Uploading warming archive",
         ),
         kind = _KIND,
         data = data,
-        phase = Phase(name = "archive", description = "Upload warming archive", emoji = "📦"),
+        phase = phases.Phase(name = "archive", description = "Upload warming archive", emoji = "📦"),
     )
 
     archiver = ctx.std.env.var("ASPECT_WORKFLOWS_RUNNER_WARMING_ARCHIVER") or _DEFAULT_WARMING_ARCHIVER
@@ -255,16 +248,16 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         msg = "the warming archiver was not found at %s. Upgrade to the latest aspect-cli to enable warming: %s" % (archiver, ASPECT_CLI_RELEASES_URL)
         error(ctx.std, "Cannot upload the warming archive: " + msg)
         data["warming"]["archive_error"] = msg
-        return _emit_final(ctx, lifecycle, data, 1)
+        return _emit_final(ph, 1)
 
     # Inherits the script's stdout/stderr so the user sees its progress in real time.
     archive = ctx.std.process.command(archiver).spawn().wait()
     if archive.code != 0:
         data["warming"]["archive_error"] = "the warming archiver exited with code %d" % archive.code
-        return _emit_final(ctx, lifecycle, data, archive.code)
+        return _emit_final(ph, archive.code)
 
     data["warming"]["archive_succeeded"] = True
-    return _emit_final(ctx, lifecycle, data, 0)
+    return _emit_final(ph, 0)
 
 warming = task(
     group = ["ci"],
@@ -274,8 +267,7 @@ warming = task(
     traits = [
         BazelTrait,
         HealthCheckTrait,
-        TaskLifecycleTrait,
-    ] + artifacts.TRAITS + tips.TRAITS,
+    ] + phases.TRAITS + artifacts.TRAITS + tips.TRAITS,
     args = {
         "targets": args.positional(
             minimum = 1,


### PR DESCRIPTION
`TaskLifecycleTrait` becomes `Phases`, and a task opens its `_impl` with `ph = phases.new(ctx, data)` instead of threading `(ctx, lifecycle, data)` through every call:

    setup_phase(ctx, lifecycle, subject, kind, data, hc, bz, cmd)
        -> ph.setup(subject, kind, command = cmd)
    task_update(ctx, lifecycle, status, progress, ...)
        -> ph.update(status, progress, ...)
    dispatch_task_update(ctx, lifecycle, update)   -> ph.dispatch(update)
    apply_repro_fix_hooks(ctx, lifecycle, data, ...)
        -> ph.suggest_fixes(kind, status, ...)

The records move behind the same namespace (`phases.Update` / `.ProgressStyles` / `.Phase` / `.ReproFixCommand`), so `lifecycle.axl` is a single import at the use site, and a task splats `phases.TRAITS` into its trait list. `ph.reset(fresh)` refills the held dict in place, which is what the Bazel retry loop needs between attempts.

`traits.axl` re-exports `Phases` for user config.axl files.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
