### PR TITLE
fix(axl): resolve rc command flags in ctx.bazel.info, surface its stderr

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -25,7 +25,7 @@ _REPORT_PLACEHOLDERS = ["{report}", "{lcov}"]
 
 def _resolve_report(ctx):
     """Locate the merged LCOV report; empty string when unavailable."""
-    output_path = ctx.bazel.info().get("output_path")
+    output_path = ctx.bazel.info(keys = ["output_path"]).get("output_path")
     if not output_path:
         return ""
     report = output_path + "/" + _COMBINED_REPORT_RELPATH

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -25,7 +25,8 @@ _REPORT_PLACEHOLDERS = ["{report}", "{lcov}"]
 
 def _resolve_report(ctx):
     """Locate the merged LCOV report; empty string when unavailable."""
-    output_path = ctx.bazel.info(keys = ["output_path"]).get("output_path")
+    key = "output_path"
+    output_path = ctx.bazel.info(keys = [key]).get(key)
     if not output_path:
         return ""
     report = output_path + "/" + _COMBINED_REPORT_RELPATH

--- a/crates/axl-runtime/src/engine/bazel/info.rs
+++ b/crates/axl-runtime/src/engine/bazel/info.rs
@@ -3,6 +3,13 @@ use std::process::Stdio;
 use std::sync::OnceLock;
 
 use anyhow::anyhow;
+use starlark::collections::SmallMap;
+
+/// Keys [`server_info`] requests and then looks up in the parsed output. Shared
+/// so the two sides can't drift — a lookup that misses the requested spelling
+/// reads as "bazel didn't report it".
+const SERVER_PID_KEY: &str = "server_pid";
+const RELEASE_KEY: &str = "release";
 
 /// Parse the value of `bazel info release` into a semver version.
 ///
@@ -21,6 +28,30 @@ fn parse_release(value: &str) -> Option<semver::Version> {
     semver::Version::parse(ver_str).ok()
 }
 
+/// Parse `bazel info` stdout into a key/value map.
+///
+/// Bazel formats the output by how many keys were requested: exactly one key
+/// prints the bare value, while zero (all keys) or two or more print
+/// `key: value` lines. A single key is therefore taken from the request rather
+/// than the output — parsing it as a pair would yield nothing, or split a value
+/// that itself contains `": "` (e.g. a Windows path).
+pub fn parse_output<S: AsRef<str>>(stdout: &str, keys: &[S]) -> SmallMap<String, String> {
+    let mut map = SmallMap::new();
+    if let [key] = keys {
+        let value = stdout.trim();
+        if !value.is_empty() {
+            map.insert(key.as_ref().to_string(), value.to_string());
+        }
+        return map;
+    }
+    for line in stdout.lines() {
+        if let Some((key, value)) = line.split_once(": ") {
+            map.insert(key.trim().to_string(), value.trim().to_string());
+        }
+    }
+    map
+}
+
 /// Query bazel server info (server_pid, release version).
 ///
 /// The version is `None` when Bazel reports a non-release build (see
@@ -36,8 +67,8 @@ pub fn server_info_with_startup_flags(
     let mut cmd = super::bazel_command();
     cmd.args(startup_flags);
     cmd.arg("info");
-    cmd.arg("server_pid");
-    cmd.arg("release");
+    cmd.arg(SERVER_PID_KEY);
+    cmd.arg(RELEASE_KEY);
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
     cmd.stdin(Stdio::null());
@@ -61,35 +92,35 @@ pub fn server_info_with_startup_flags(
         )));
     }
 
-    // When bazel info is called with multiple keys it emits "key: value" lines.
     let stdout = String::from_utf8_lossy(&c.stdout);
-    let mut pid: Option<u32> = None;
-    let mut version: Option<semver::Version> = None;
-    for line in stdout.lines() {
-        if let Some((key, value)) = line.split_once(": ") {
-            match key.trim() {
-                "server_pid" => {
-                    pid = value.trim().parse::<u32>().ok();
-                }
-                "release" => {
-                    version = parse_release(value);
-                    if version.is_none() {
-                        // Not an error; version-conditional flags assume latest.
-                        // Logged for diagnosability when flag resolution looks off.
-                        tracing::debug!(
-                            release = %value.trim(),
-                            "bazel reported a non-release version; \
-                             version-conditional flags will assume latest"
-                        );
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
+    parse_server_info(&stdout)
+}
 
-    let pid =
-        pid.ok_or_else(|| io::Error::other(anyhow!("bazel info did not return server_pid")))?;
+/// Pull `(server_pid, release)` out of `bazel info server_pid release` stdout.
+///
+/// A missing or unparseable `server_pid` is an error — callers need the pid.
+/// A missing or non-release version is not: version-conditional flags fall
+/// back to assuming latest.
+fn parse_server_info(stdout: &str) -> io::Result<(u32, Option<semver::Version>)> {
+    let info = parse_output(stdout, &[SERVER_PID_KEY, RELEASE_KEY]);
+
+    let version = info.get(RELEASE_KEY).and_then(|v| {
+        let version = parse_release(v);
+        if version.is_none() {
+            // Logged for diagnosability when flag resolution looks off.
+            tracing::debug!(
+                release = %v,
+                "bazel reported a non-release version; \
+                 version-conditional flags will assume latest"
+            );
+        }
+        version
+    });
+
+    let pid = info
+        .get(SERVER_PID_KEY)
+        .and_then(|v| v.parse::<u32>().ok())
+        .ok_or_else(|| io::Error::other(anyhow!("bazel info did not return server_pid")))?;
 
     Ok((pid, version))
 }
@@ -184,7 +215,92 @@ pub fn server_pid_nonblocking(startup_flags: &[String]) -> Option<u32> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_release;
+    use super::{parse_output, parse_release, parse_server_info};
+
+    #[test]
+    fn server_info_reads_pid_and_version() {
+        let (pid, version) =
+            parse_server_info("server_pid: 12345\nrelease: release 9.0.0\n").unwrap();
+        assert_eq!(pid, 12345);
+        assert_eq!(version, Some(semver::Version::new(9, 0, 0)));
+    }
+
+    #[test]
+    fn server_info_tolerates_a_non_release_version() {
+        let (pid, version) =
+            parse_server_info("server_pid: 7\nrelease: development version\n").unwrap();
+        assert_eq!(pid, 7);
+        assert_eq!(version, None);
+    }
+
+    #[test]
+    fn server_info_requires_a_parseable_pid() {
+        for stdout in ["release: release 9.0.0\n", "server_pid: not-a-pid\n", ""] {
+            let err = parse_server_info(stdout).unwrap_err();
+            assert!(
+                err.to_string().contains("did not return server_pid"),
+                "unexpected error for {stdout:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn single_key_is_taken_from_the_request() {
+        // `bazel info <key>` prints the bare value with no `key: ` prefix.
+        let map = parse_output("/tmp/ws/bazel-out\n", &["output_path"]);
+        assert_eq!(
+            map.get("output_path").map(String::as_str),
+            Some("/tmp/ws/bazel-out")
+        );
+    }
+
+    #[test]
+    fn single_key_value_containing_a_colon_is_not_split() {
+        let map = parse_output("C:\\ws\\out: dir/command.log\n", &["command_log"]);
+        assert_eq!(
+            map.get("command_log").map(String::as_str),
+            Some("C:\\ws\\out: dir/command.log")
+        );
+    }
+
+    #[test]
+    fn multiple_keys_are_parsed_as_pairs() {
+        let map = parse_output(
+            "output_path: /tmp/ws/bazel-out\noutput_base: /tmp/ws\n",
+            &["output_path", "output_base"],
+        );
+        assert_eq!(
+            map.get("output_path").map(String::as_str),
+            Some("/tmp/ws/bazel-out")
+        );
+        assert_eq!(map.get("output_base").map(String::as_str), Some("/tmp/ws"));
+    }
+
+    #[test]
+    fn no_keys_parses_every_pair() {
+        let map = parse_output::<&str>(
+            "bazel-bin: /tmp/ws/bin\noutput_path: /tmp/ws/bazel-out\n",
+            &[],
+        );
+        assert_eq!(map.len(), 2);
+        assert_eq!(
+            map.get("bazel-bin").map(String::as_str),
+            Some("/tmp/ws/bin")
+        );
+    }
+
+    #[test]
+    fn lines_without_a_pair_separator_are_skipped() {
+        let map = parse_output::<&str>("a bare line\noutput_base: /tmp/ws\n", &[]);
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("output_base").map(String::as_str), Some("/tmp/ws"));
+    }
+
+    #[test]
+    fn empty_output_yields_no_entries() {
+        assert!(parse_output("\n", &["output_path"]).is_empty());
+        assert!(parse_output::<&str>("", &[]).is_empty());
+    }
 
     #[test]
     fn parses_a_plain_release() {

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -270,29 +270,21 @@ impl<'v> values::StarlarkValue<'v> for FrozenBazel {
     }
 }
 
-/// Parse `bazel info` stdout into a key/value map.
+/// Bazel's `stderr` rendered as a trailing detail for a spawn-failure error,
+/// on its own line. Empty when Bazel wrote nothing, so a command that died
+/// without diagnostics still yields a clean exit-code message.
 ///
-/// Bazel formats the output differently depending on how many keys were asked
-/// for: requesting exactly one key prints the bare value with no `key: ` prefix,
-/// while zero keys (all of them) or two or more print `key: value` lines. The
-/// single-key case is therefore keyed from the request rather than the output —
-/// parsing it would yield nothing, or worse, split a value that itself contains
-/// `": "`.
-fn parse_info_output<S: AsRef<str>>(stdout: &str, keys: &[S]) -> SmallMap<String, String> {
-    let mut map = SmallMap::new();
-    if let [key] = keys {
-        let value = stdout.trim();
-        if !value.is_empty() {
-            map.insert(key.as_ref().to_string(), value.to_string());
-        }
-        return map;
+/// Bazel reuses a handful of exit codes across unrelated causes (`2` covers
+/// every command-line error — unknown startup option, unrecognized flag,
+/// unknown `info` key, running outside a workspace), so the code alone rarely
+/// identifies the failure.
+pub(crate) fn stderr_detail(stderr: &str) -> String {
+    let stderr = stderr.trim();
+    if stderr.is_empty() {
+        String::new()
+    } else {
+        format!("\n{stderr}")
     }
-    for line in stdout.lines() {
-        if let Some((key, value)) = line.split_once(": ") {
-            map.insert(key.trim().to_string(), value.trim().to_string());
-        }
-    }
-    map
 }
 
 /// The startup flags for an invocation: sourced from the active `RunCommand`
@@ -736,27 +728,23 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         )
     }
 
-    /// Run `bazel info` and return all key/value pairs as a dict.
+    /// Run `bazel info` and return its key/value pairs as a dict.
     ///
-    /// Blocks until the command completes. Raises an error if Bazel exits
-    /// with a non-zero code; the error carries Bazel's own stderr, since the
-    /// exit code alone (`2` for every command-line error) doesn't say what
-    /// went wrong.
+    /// Blocks until the command completes. Raises an error carrying Bazel's own
+    /// stderr if it exits non-zero.
     ///
     /// Runs under the active `RunCommand` (`use_rc`) or the per-call `rc=`,
-    /// exactly like `build` / `query`: both its startup flags and its
-    /// `info`-applicable command flags are replayed. That matters because
-    /// those startup flags carry `--ignore_all_rc_files` — without the command
-    /// flags the on-disk rc would be suppressed and nothing put back, so this
-    /// invocation would resolve keys like `output_path` under different flags
-    /// than the build it is reporting on.
+    /// replaying both its startup flags and its `info`-applicable command flags
+    /// exactly like `build` / `query`. Those startup flags carry
+    /// `--ignore_all_rc_files`, so the command flags are what put the rc's
+    /// options back — without them this would resolve flag-sensitive keys like
+    /// `output_path` under different flags than the build it describes.
     ///
     /// # Arguments
     /// * `keys`: `info` keys to request (default: all). Narrowing to the keys
     ///   actually needed keeps an unknown-key error from a Bazel version that
-    ///   dropped some unrelated key out of the picture. The result is keyed the
-    ///   same way regardless of how many keys are requested, even though Bazel
-    ///   prints a bare value for a single key and `key: value` lines otherwise.
+    ///   dropped some unrelated key out of the picture. The result is keyed
+    ///   identically however many keys are requested.
     /// * `rc`: run command to resolve flags from; overrides the active one.
     /// * `directory`: working directory to run `bazel info` in; selects the
     ///   workspace / server (default: the parent process cwd).
@@ -783,13 +771,13 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             None => (read_startup_flags(this)?, Vec::new()),
         };
 
+        let requested: Vec<&str> = keys.items.iter().map(|k| k.as_str()).collect();
+
         let mut cmd = bazel_command();
         cmd.args(&startup_flags);
         cmd.arg("info");
         cmd.args(&command_flags);
-        for key in &keys.items {
-            cmd.arg(key.as_str());
-        }
+        cmd.args(&requested);
         if let Some(dir) = directory.into_option() {
             cmd.current_dir(dir);
         }
@@ -805,22 +793,17 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             .map_err(|e| anyhow::anyhow!("failed to wait on bazel: {}", e))?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let detail = stderr.trim();
+            let detail = stderr_detail(&String::from_utf8_lossy(&output.stderr));
             anyhow::bail!(
-                "bazel info failed with exit code {:?}{}",
-                output.status.code(),
-                if detail.is_empty() {
-                    String::new()
-                } else {
-                    format!("\n{detail}")
-                }
+                "bazel info failed with exit code {:?}{detail}",
+                output.status.code()
             );
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let requested: Vec<&str> = keys.items.iter().map(|k| k.as_str()).collect();
-        Ok(parse_info_output(&stdout, &requested))
+        Ok(info::parse_output(
+            &String::from_utf8_lossy(&output.stdout),
+            &requested,
+        ))
     }
 
     /// Shut down the Bazel server for the active run command (`bazel shutdown`),
@@ -1331,52 +1314,21 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
 
 #[cfg(test)]
 mod tests {
-    use super::{constraint_matches, parse_info_output};
+    use super::{constraint_matches, stderr_detail};
 
     fn version(s: &str) -> semver::Version {
         semver::Version::parse(s).unwrap()
     }
 
     #[test]
-    fn single_key_output_is_keyed_from_the_request() {
-        // `bazel info <key>` prints the bare value with no `key: ` prefix, so
-        // parsing it as `key: value` would return an empty map and silently
-        // strand callers like the `--coverage` report lookup.
-        let map = parse_info_output("/tmp/ws/bazel-out\n", &["output_path"]);
-        assert_eq!(
-            map.get("output_path").map(String::as_str),
-            Some("/tmp/ws/bazel-out")
-        );
+    fn stderr_detail_is_a_trailing_line_when_present() {
+        assert_eq!(stderr_detail("ERROR: boom\n"), "\nERROR: boom");
     }
 
     #[test]
-    fn single_key_value_containing_a_colon_is_not_split() {
-        let map = parse_info_output("C:\\ws\\out: dir/command.log\n", &["command_log"]);
-        assert_eq!(
-            map.get("command_log").map(String::as_str),
-            Some("C:\\ws\\out: dir/command.log")
-        );
-    }
-
-    #[test]
-    fn multi_key_and_all_key_output_is_parsed_as_pairs() {
-        let stdout = "output_path: /tmp/ws/bazel-out\noutput_base: /tmp/ws\n";
-
-        let map = parse_info_output(stdout, &["output_path", "output_base"]);
-        assert_eq!(
-            map.get("output_path").map(String::as_str),
-            Some("/tmp/ws/bazel-out")
-        );
-        assert_eq!(map.get("output_base").map(String::as_str), Some("/tmp/ws"));
-
-        // No keys requested: Bazel prints every key in the same pair form.
-        let map = parse_info_output::<&str>(stdout, &[]);
-        assert_eq!(map.len(), 2);
-    }
-
-    #[test]
-    fn empty_single_key_output_yields_no_entry() {
-        assert!(parse_info_output("\n", &["output_path"]).is_empty());
+    fn stderr_detail_is_empty_without_diagnostics() {
+        assert_eq!(stderr_detail(""), "");
+        assert_eq!(stderr_detail("  \n\t "), "");
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -270,6 +270,31 @@ impl<'v> values::StarlarkValue<'v> for FrozenBazel {
     }
 }
 
+/// Parse `bazel info` stdout into a key/value map.
+///
+/// Bazel formats the output differently depending on how many keys were asked
+/// for: requesting exactly one key prints the bare value with no `key: ` prefix,
+/// while zero keys (all of them) or two or more print `key: value` lines. The
+/// single-key case is therefore keyed from the request rather than the output —
+/// parsing it would yield nothing, or worse, split a value that itself contains
+/// `": "`.
+fn parse_info_output<S: AsRef<str>>(stdout: &str, keys: &[S]) -> SmallMap<String, String> {
+    let mut map = SmallMap::new();
+    if let [key] = keys {
+        let value = stdout.trim();
+        if !value.is_empty() {
+            map.insert(key.as_ref().to_string(), value.to_string());
+        }
+        return map;
+    }
+    for line in stdout.lines() {
+        if let Some((key, value)) = line.split_once(": ") {
+            map.insert(key.trim().to_string(), value.trim().to_string());
+        }
+    }
+    map
+}
+
 /// The startup flags for an invocation: sourced from the active `RunCommand`
 /// (set by `use_rc`), or empty when none is active.
 fn read_startup_flags<'v>(this: values::Value<'v>) -> anyhow::Result<Vec<String>> {
@@ -729,7 +754,9 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     /// # Arguments
     /// * `keys`: `info` keys to request (default: all). Narrowing to the keys
     ///   actually needed keeps an unknown-key error from a Bazel version that
-    ///   dropped some unrelated key out of the picture.
+    ///   dropped some unrelated key out of the picture. The result is keyed the
+    ///   same way regardless of how many keys are requested, even though Bazel
+    ///   prints a bare value for a single key and `key: value` lines otherwise.
     /// * `rc`: run command to resolve flags from; overrides the active one.
     /// * `directory`: working directory to run `bazel info` in; selects the
     ///   workspace / server (default: the parent process cwd).
@@ -792,13 +819,8 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let mut map = SmallMap::new();
-        for line in stdout.lines() {
-            if let Some((key, value)) = line.split_once(": ") {
-                map.insert(key.trim().to_string(), value.trim().to_string());
-            }
-        }
-        Ok(map)
+        let requested: Vec<&str> = keys.items.iter().map(|k| k.as_str()).collect();
+        Ok(parse_info_output(&stdout, &requested))
     }
 
     /// Shut down the Bazel server for the active run command (`bazel shutdown`),
@@ -1309,10 +1331,52 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
 
 #[cfg(test)]
 mod tests {
-    use super::constraint_matches;
+    use super::{constraint_matches, parse_info_output};
 
     fn version(s: &str) -> semver::Version {
         semver::Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn single_key_output_is_keyed_from_the_request() {
+        // `bazel info <key>` prints the bare value with no `key: ` prefix, so
+        // parsing it as `key: value` would return an empty map and silently
+        // strand callers like the `--coverage` report lookup.
+        let map = parse_info_output("/tmp/ws/bazel-out\n", &["output_path"]);
+        assert_eq!(
+            map.get("output_path").map(String::as_str),
+            Some("/tmp/ws/bazel-out")
+        );
+    }
+
+    #[test]
+    fn single_key_value_containing_a_colon_is_not_split() {
+        let map = parse_info_output("C:\\ws\\out: dir/command.log\n", &["command_log"]);
+        assert_eq!(
+            map.get("command_log").map(String::as_str),
+            Some("C:\\ws\\out: dir/command.log")
+        );
+    }
+
+    #[test]
+    fn multi_key_and_all_key_output_is_parsed_as_pairs() {
+        let stdout = "output_path: /tmp/ws/bazel-out\noutput_base: /tmp/ws\n";
+
+        let map = parse_info_output(stdout, &["output_path", "output_base"]);
+        assert_eq!(
+            map.get("output_path").map(String::as_str),
+            Some("/tmp/ws/bazel-out")
+        );
+        assert_eq!(map.get("output_base").map(String::as_str), Some("/tmp/ws"));
+
+        // No keys requested: Bazel prints every key in the same pair form.
+        let map = parse_info_output::<&str>(stdout, &[]);
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn empty_single_key_output_yields_no_entry() {
+        assert!(parse_info_output("\n", &["output_path"]).is_empty());
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -714,9 +714,23 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     /// Run `bazel info` and return all key/value pairs as a dict.
     ///
     /// Blocks until the command completes. Raises an error if Bazel exits
-    /// with a non-zero code.
+    /// with a non-zero code; the error carries Bazel's own stderr, since the
+    /// exit code alone (`2` for every command-line error) doesn't say what
+    /// went wrong.
+    ///
+    /// Runs under the active `RunCommand` (`use_rc`) or the per-call `rc=`,
+    /// exactly like `build` / `query`: both its startup flags and its
+    /// `info`-applicable command flags are replayed. That matters because
+    /// those startup flags carry `--ignore_all_rc_files` — without the command
+    /// flags the on-disk rc would be suppressed and nothing put back, so this
+    /// invocation would resolve keys like `output_path` under different flags
+    /// than the build it is reporting on.
     ///
     /// # Arguments
+    /// * `keys`: `info` keys to request (default: all). Narrowing to the keys
+    ///   actually needed keeps an unknown-key error from a Bazel version that
+    ///   dropped some unrelated key out of the picture.
+    /// * `rc`: run command to resolve flags from; overrides the active one.
     /// * `directory`: working directory to run `bazel info` in; selects the
     ///   workspace / server (default: the parent process cwd).
     ///
@@ -727,21 +741,33 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
     ///     info = ctx.bazel.info()
     ///     print(info["output_base"])
     ///     print(info["execution_root"])
+    ///     only = ctx.bazel.info(keys = ["output_path"])
     /// ```
     fn info<'v>(
         this: values::Value<'v>,
+        #[starlark(require = named, default = UnpackList::default())] keys: UnpackList<
+            values::StringValue<'v>,
+        >,
+        #[starlark(require = named, default = NoneOr::None)] rc: NoneOr<values::Value<'v>>,
         #[starlark(require = named, default = NoneOr::None)] directory: NoneOr<String>,
     ) -> anyhow::Result<SmallMap<String, String>> {
-        let startup_flags = read_startup_flags(this)?;
+        let (startup_flags, command_flags) = match effective_rc(this, rc) {
+            Some(rc) => rc.resolve_for_command("info")?,
+            None => (read_startup_flags(this)?, Vec::new()),
+        };
 
         let mut cmd = bazel_command();
         cmd.args(&startup_flags);
         cmd.arg("info");
+        cmd.args(&command_flags);
+        for key in &keys.items {
+            cmd.arg(key.as_str());
+        }
         if let Some(dir) = directory.into_option() {
             cmd.current_dir(dir);
         }
         cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::null());
+        cmd.stderr(Stdio::piped());
         cmd.stdin(Stdio::null());
         // Register with the live-bazel registry so OS-signal cancellation
         // can reach this `bazel info` even if the daemon is busy.
@@ -752,9 +778,16 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
             .map_err(|e| anyhow::anyhow!("failed to wait on bazel: {}", e))?;
 
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let detail = stderr.trim();
             anyhow::bail!(
-                "bazel info failed with exit code {:?}",
-                output.status.code()
+                "bazel info failed with exit code {:?}{}",
+                output.status.code(),
+                if detail.is_empty() {
+                    String::new()
+                } else {
+                    format!("\n{detail}")
+                }
             );
         }
 

--- a/crates/axl-runtime/src/engine/bazel/query.rs
+++ b/crates/axl-runtime/src/engine/bazel/query.rs
@@ -139,17 +139,9 @@ impl<'v> values::StarlarkValue<'v> for Query {
 ///
 /// A failed query (bad expression, BUILD evaluation error, …) must not
 /// be mistaken for one that legitimately matched nothing, so the error
-/// carries Bazel's own `stderr` when it's available. `stderr` is
-/// best-effort: it's trimmed and appended only when non-empty, so a
-/// query that died without writing diagnostics still yields a usable
-/// exit-code message.
+/// carries Bazel's own `stderr` when it's available.
 fn query_failure_error(expr: &str, exit_code: Option<i32>, stderr: &str) -> anyhow::Error {
-    let stderr = stderr.trim();
-    let detail = if stderr.is_empty() {
-        String::new()
-    } else {
-        format!("\n{stderr}")
-    };
+    let detail = super::stderr_detail(stderr);
     anyhow!("bazel query failed with exit code {exit_code:?}: {expr}{detail}")
 }
 

--- a/crates/bazelrc/src/lib.rs
+++ b/crates/bazelrc/src/lib.rs
@@ -1642,6 +1642,39 @@ build:opt --compilation_mode=opt
     }
 
     #[test]
+    fn info_resolves_its_own_command_flags() {
+        // Regression: `ctx.bazel.info()` replayed only the startup flags, which
+        // carry `--ignore_all_rc_files`. The on-disk rc was suppressed with
+        // nothing put back, so `info` resolved keys like `output_path` under
+        // different flags than the build it reports on (and a `common:` entry
+        // the workspace needs went missing entirely).
+        let dir = make_workspace();
+        let root = dir.path();
+        fs::write(
+            &root.join(".bazelrc"),
+            "common --remote_download_outputs=minimal\ninfo --show_make_env\n",
+        )
+        .unwrap();
+
+        let rc = BazelRC::new(root, ISOLATE, &[]).unwrap();
+        let (startup, command_flags) = rc.resolve_for_command("info").unwrap();
+        assert!(
+            startup.contains(&"--ignore_all_rc_files".to_string()),
+            "the rc is absorbed, so the spawn must suppress the on-disk one: {startup:?}",
+        );
+        assert!(
+            command_flags.contains(
+                &"--default_override=0:common=--remote_download_outputs=minimal".to_string()
+            ),
+            "`common` options must reach info, not just build: {command_flags:?}",
+        );
+        assert!(
+            command_flags.contains(&"--show_make_env".to_string()),
+            "`info`-section options must reach info: {command_flags:?}",
+        );
+    }
+
+    #[test]
     fn config_expansion_cycle_detected() {
         let dir = make_workspace();
         let root = dir.path();

--- a/crates/bazelrc/src/lib.rs
+++ b/crates/bazelrc/src/lib.rs
@@ -1643,11 +1643,9 @@ build:opt --compilation_mode=opt
 
     #[test]
     fn info_resolves_its_own_command_flags() {
-        // Regression: `ctx.bazel.info()` replayed only the startup flags, which
-        // carry `--ignore_all_rc_files`. The on-disk rc was suppressed with
-        // nothing put back, so `info` resolved keys like `output_path` under
-        // different flags than the build it reports on (and a `common:` entry
-        // the workspace needs went missing entirely).
+        // The startup flags suppress the on-disk rc, so the command flags are
+        // what put its options back. `info` must get both, or it resolves
+        // flag-sensitive keys like `output_path` under the wrong flags.
         let dir = make_workspace();
         let root = dir.path();
         fs::write(


### PR DESCRIPTION
Brings `ctx.bazel.info` in line with the other Bazel spawn paths and makes its failures legible.

**Flag resolution.** `info` replayed startup flags alone, while `build` and `query` resolve the full run command. Those startup flags carry `--ignore_all_rc_files`, so without the command flags the on-disk rc was suppressed with nothing put back — `common:`/`info:` options the workspace defines never reached the invocation. Since values like `output_path` are flag-sensitive, `info` could report a path resolved under different flags than the build it describes. It now resolves through `effective_rc(...).resolve_for_command("info")` like `query`.

**Error reporting.** Failures sent stderr to `/dev/null` and reported only the exit code, but Bazel uses exit 2 for every command-line error — unknown startup option, unrecognized flag, unknown info key, running outside a workspace. Failures now carry Bazel's stderr.

**New arguments.** `keys` requests specific info keys; `rc` overrides the active run command. The coverage path in `test.axl` uses `keys` to request just `output_path`, so an unrelated key dropped by some Bazel version can't break it. Note that Bazel prints a bare value for a single key and `key: value` lines otherwise — the parser handles both, keying the result identically either way.

Also consolidates two pieces of duplication this touched: `bazel info` output parsing now lives in `info.rs` and is shared with the `server_pid`/`release` probe that open-coded the same loop, and `stderr_detail` replaces the repeated "append stderr on its own line" formatting in `info` and `query`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

```
- `ctx.bazel.info` now resolves the run command's rc flags like `build` and `query`, instead of suppressing the on-disk `.bazelrc` without replacing it.
- `bazel info` failures now report Bazel's own error message rather than just an exit code.
- `ctx.bazel.info` accepts `keys = [...]` to request specific info keys, and `rc =` to override the active run command.
```

### Test plan

- Covered by existing test cases
- New test cases added:
  - `info_resolves_its_own_command_flags` (`crates/bazelrc`) — verified to fail against startup-flags-only resolution.
  - `bazel::info` parser — single key, colon-in-value, multi-key, all-keys, separator-less lines, empty output.
  - `parse_server_info` — pid + version, non-release version, missing/unparseable pid.
  - `stderr_detail` — present and empty.
- Manual testing:
  1. `aspect test --coverage --coverage-report=out.lcov //:t` on a passing test prints `Coverage report written to out.lcov` and writes the file.
  2. With a `tools/bazel` wrapper that exits 2 with a message on `info output_path`, the error reads `bazel info failed with exit code Some(2)` followed by Bazel's message.
