### PR TITLE
feat(cli): make the CLI surface discoverable and pipe-safe for AI agents

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -275,6 +275,32 @@ logout = task(
     },
 )
 
+def _entry_json(d) -> dict:
+    """One credential entry as a JSON object.
+
+    `login_command` is the point of the whole document: a caller that finds
+    `logged_in = False` (or a non-empty `status` like "expired") gets the exact
+    command that fixes it, with no string parsing.
+    """
+    doc = {
+        "name": d.name,
+        "builtin": d.builtin,
+        "default": d.default and not d.builtin,
+        "logged_in": d.logged_in,
+        "status": d.status,
+        "identity": identity(d),
+        "display_name": d.display_name,
+        "email": d.email,
+        "issuer": d.issuer,
+        "login_command": login_command(d),
+    }
+    if not d.builtin:
+        doc["cache"] = d.cache
+        doc["exec"] = d.exec
+        doc["bes"] = d.bes
+        doc["results_url"] = d.results_url
+    return doc
+
 def _status_impl(ctx: TaskContext) -> int:
     entries = ctx.aspect.auth.list()
 
@@ -282,6 +308,16 @@ def _status_impl(ctx: TaskContext) -> int:
     # Workflows *deployments* are two different things — show them apart.
     account = [d for d in entries if d.builtin]
     deployments = [d for d in entries if not d.builtin]
+
+    if ctx.args.output == "json":
+        default_names = [d.name for d in deployments if d.default]
+        doc = {
+            "account": [_entry_json(d) for d in account],
+            "deployments": [_entry_json(d) for d in deployments],
+            "default_deployment": default_names[0] if default_names else None,
+        }
+        ctx.std.io.stdout.write(json.encode(doc, indent = 2) + "\n")
+        return 0
 
     print("Aspect account:")
     for d in account:
@@ -306,7 +342,13 @@ status = task(
     summary = "Show your Aspect account and deployment login status",
     description = "Show your Aspect account and every configured Workflows deployment — the identity and token status of each, the default deployment (●), and how to log in to any that are logged out.",
     implementation = _status_impl,
-    args = {},
+    args = {
+        "output": args.string(
+            default = "text",
+            values = ["text", "json"],
+            description = "stdout format. `text` (default): the aligned human-readable listing. `json`: one document with `{account, deployments, default_deployment}`, each entry carrying `logged_in`, `status`, `identity`, the endpoints, and the `login_command` that re-authenticates it — so a script or agent can decide what to do without parsing prose.",
+        ),
+    },
 )
 
 def _use_impl(ctx: TaskContext) -> int:

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -17,7 +17,6 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     return run_bazel_task(ctx, command = "build")
 
 build = task(
-    summary = "Build Bazel targets. Wraps `bazel build` with retries, remote cache/BES wiring, and CI status reporting.",
     args = {
         # TODO: Support - (list from stdin)
         "targets": args.positional(
@@ -39,6 +38,7 @@ build = task(
             description = "Cancel any running Bazel invocation before starting the build.",
         ),
     } | bazel_flag_args("the build") | announce_bazel_args("the build") | bes_args() | deployment_flag_args() | repro_flavor_args(),
+    summary = "Build Bazel targets. Wraps `bazel build` with retries, remote cache/BES wiring, and CI status reporting.",
     traits = [
         BazelTrait,
         HealthCheckTrait,

--- a/crates/aspect-cli/src/builtins/aspect/build.axl
+++ b/crates/aspect-cli/src/builtins/aspect/build.axl
@@ -17,6 +17,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     return run_bazel_task(ctx, command = "build")
 
 build = task(
+    summary = "Build Bazel targets. Wraps `bazel build` with retries, remote cache/BES wiring, and CI status reporting.",
     args = {
         # TODO: Support - (list from stdin)
         "targets": args.positional(

--- a/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
+++ b/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
@@ -396,13 +396,12 @@ def _impl(ctx: TaskContext) -> int:
         return 1
 
     # `--format` is the pre-`--output` spelling, kept working so existing
-    # scripts don't break. It loses to an explicit `--output`; since an
-    # unset `--output` is indistinguishable from one passed as its default,
-    # "still at the default" is what yields to it.
+    # scripts don't break. An explicitly typed `--output` always wins, even
+    # when its value happens to equal the default.
     fmt = ctx.args.output
     if ctx.args.format:
         warn(ctx.std, "`--format` is deprecated; use `--output` instead.")
-        if ctx.args.output == _OUTPUT_DEFAULT:
+        if not ctx.args.is_explicit("output"):
             fmt = ctx.args.format
     using_exec = bool(ctx.args.exec)
 

--- a/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
+++ b/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
@@ -13,7 +13,7 @@ Output contract (built for pipes):
   - stdout — the affected test labels, one per line, nothing else. Pipe it:
         aspect cache diff | xargs bazel test
   - stderr — progress, per-target reasons, the summary, and errors.
-  - --format=json — one document on stdout instead of bare lines.
+  - --output=json — one document on stdout instead of bare lines.
   - --exec="<cmd>" — run `<cmd> <labels...>` instead of writing stdout.
 
 Modes (`--mode`):
@@ -73,10 +73,11 @@ load(
     "resolve_flags",
     "resolve_startup_flags",
 )
-load("./private/lib/environment.axl", "color_enabled")
+load("./private/lib/environment.axl", "color_enabled", "warn")
 load("./private/lib/remote_executor.axl", "start_dummy_executor", "stop_dummy_executor")
 load("./private/lib/runnable.axl", "apparent_label")
 
+_OUTPUT_DEFAULT = "lines"
 _GRPC_GET_ACTION_RESULT = "build.bazel.remote.execution.v2.ActionCache/GetActionResult"
 _TEST_MNEMONIC = "TestRunner"
 
@@ -394,7 +395,15 @@ def _impl(ctx: TaskContext) -> int:
     if entries == None:
         return 1
 
-    fmt = ctx.args.format
+    # `--format` is the pre-`--output` spelling, kept working so existing
+    # scripts don't break. It loses to an explicit `--output`; since an
+    # unset `--output` is indistinguishable from one passed as its default,
+    # "still at the default" is what yields to it.
+    fmt = ctx.args.output
+    if ctx.args.format:
+        warn(ctx.std, "`--format` is deprecated; use `--output` instead.")
+        if ctx.args.output == _OUTPUT_DEFAULT:
+            fmt = ctx.args.format
     using_exec = bool(ctx.args.exec)
 
     # stdout carries the result: stream bare labels only for `lines` (and not
@@ -484,8 +493,8 @@ diff = task(
                 "genuine input change)."
             ),
         ),
-        "format": args.string(
-            default = "lines",
+        "output": args.string(
+            default = _OUTPUT_DEFAULT,
             values = ["lines", "json"],
             description = (
                 "stdout format. `lines`: affected labels, one per line (pipeable; " +
@@ -494,12 +503,20 @@ diff = task(
                 "[{target, mnemonic}]}]}` for scripting (parse with jq)."
             ),
         ),
+        "format": args.string(
+            default = "",
+            values = ["", "lines", "json"],
+            description = (
+                "Deprecated alias for --output; still accepted, and warns when " +
+                "set. Use --output instead."
+            ),
+        ),
         "exec": args.string(
             default = "",
             description = (
                 "Run this command with the affected labels appended as arguments " +
                 "(e.g. --exec=\"bazel test\") instead of writing stdout. No-op when " +
-                "nothing is affected. Overrides --format. For anything fancier, omit " +
+                "nothing is affected. Overrides --output. For anything fancier, omit " +
                 "it and pipe stdout."
             ),
         ),

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -649,6 +649,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     return _emit_final(ctx, lifecycle, data, 0)
 
 format = task(
+    summary = "Format source files with the configured formatter target. Formats changed files by default; `--scope=all` for the whole tree.",
     args = {
         "scope": args.string(
             default = "changed",

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -690,6 +690,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     return _emit_final(ctx, lifecycle, data, 0)
 
 gazelle = task(
+    summary = "Generate and update BUILD files with gazelle. Applies the patch locally; detect-only on CI (`--check-only`).",
     args = {
         "severity": args.string(
             default = "auto",

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -1201,6 +1201,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     )
 
 lint = task(
+    summary = "Lint targets using rules_lint aspects and report findings on the terminal or as code-review comments.",
     args = {
         "aspects": args.string_list(
             long = "aspect",

--- a/crates/aspect-cli/src/builtins/aspect/test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/test.axl
@@ -101,6 +101,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     return conclusion
 
 test = task(
+    summary = "Run Bazel tests. Wraps `bazel test` with retries, remote cache/BES wiring, and CI status reporting.",
     args = {
         # TODO: Support - (list from stdin)
         "targets": args.positional(

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -19,6 +19,7 @@ use std::process::ExitCode;
 
 use aspect_telemetry::cargo_pkg_display_version;
 use axl_runtime::banner;
+use axl_runtime::color;
 use axl_runtime::diag;
 use axl_runtime::engine::arg::Arg;
 use axl_runtime::engine::arguments::Arguments;
@@ -262,7 +263,10 @@ impl<'a, 'v> Cmd<'a, 'v> {
 
         match name {
             None => {
-                print!("{}", render_feature_list(version, &blocks));
+                print!(
+                    "{}",
+                    render_feature_list(version, &blocks, color::stdout_supports_color())
+                );
                 ExitCode::SUCCESS
             }
             Some(name) => match blocks.iter().find(|(f, _)| f.name() == name) {
@@ -756,18 +760,30 @@ fn feature_block(feat: &dyn FeatureLike<'_>) -> Option<FeatureBlock> {
 
 /// Render the `aspect feature` listing: one row per feature, keyed by the
 /// kebab slug the user passes to `aspect feature <name>`, with its summary.
-fn render_feature_list(version: &str, blocks: &[(&dyn FeatureLike<'_>, FeatureBlock)]) -> String {
+fn render_feature_list(
+    version: &str,
+    blocks: &[(&dyn FeatureLike<'_>, FeatureBlock)],
+    color: bool,
+) -> String {
     let width = blocks
         .iter()
         .map(|(f, _)| f.name().len())
         .max()
         .unwrap_or(0);
-    let mut out = format!("{}\n\n\x1b[1;4mFeatures:\x1b[0m\n", banner::line(version));
+    let (bold, bold_underline, reset) = if color {
+        ("\x1b[1m", "\x1b[1;4m", "\x1b[0m")
+    } else {
+        ("", "", "")
+    };
+    let mut out = format!(
+        "{}\n\n{bold_underline}Features:{reset}\n",
+        banner::line_colored(version, color)
+    );
     for (feat, _) in blocks {
         let slug = feat.name();
         let pad = " ".repeat(width - slug.len() + 2);
         out.push_str(&format!(
-            "  \x1b[1m{}\x1b[0m{}{}\n",
+            "  {bold}{}{reset}{}{}\n",
             slug,
             pad,
             feat.summary()
@@ -1482,7 +1498,7 @@ mod tests {
             .collect();
         let mut sorted = blocks;
         sorted.sort_by(|(a, _), (b, _)| a.name().cmp(&b.name()));
-        let out = render_feature_list("1.2.3", &sorted);
+        let out = render_feature_list("1.2.3", &sorted, true);
         let au_at = out.find("artifact-upload").expect("artifact-upload listed");
         let tips_at = out.find("tips").expect("tips listed");
         assert!(au_at < tips_at, "rows should be alphabetical by slug");

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -40,11 +40,16 @@ use thiserror::Error;
 const TASK_ID_KEY: &str = "@@@$'__AXL_TASK_ID__'$@@@";
 /// `aspect feature [<name>]`: routed to the feature-help renderer in `main`.
 const FEATURE_COMMAND: &str = "feature";
+/// `aspect describe`: routed to the machine-readable surface dump in `main`.
+const DESCRIBE_COMMAND: &str = "describe";
 /// Top-level command names `main` intercepts before task parsing; a top-level
 /// task of any of these kinds would be unreachable, so it is rejected at build
 /// time (see `Tree::insert`). Reachable when nested under a group.
-const RESERVED_TOP_LEVEL_COMMANDS: &[&str] =
-    &[FEATURE_COMMAND, crate::credential_helper::GET_COMMAND];
+const RESERVED_TOP_LEVEL_COMMANDS: &[&str] = &[
+    FEATURE_COMMAND,
+    DESCRIBE_COMMAND,
+    crate::credential_helper::GET_COMMAND,
+];
 const TASK_COMMAND_DISPLAY_ORDER: usize = 0;
 const TASK_GROUP_DISPLAY_ORDER: usize = 1;
 
@@ -183,6 +188,25 @@ impl<'a, 'v> Cmd<'a, 'v> {
                             .hide(true),
                     ),
             )
+            .subcommand(
+                // `describe` is not a task: parsing exists only so `main` can
+                // route to `Cmd::print_describe`. The whole point is that a
+                // reader with no prior knowledge of this repo can enumerate the
+                // surface in one call, so it defaults to JSON rather than
+                // requiring the flag to be known up front.
+                Command::new(DESCRIBE_COMMAND)
+                    .about("Print the resolved task, flag and feature surface as JSON")
+                    .hide(true)
+                    .arg(
+                        ClapArg::new("output")
+                            .long("output")
+                            .short('o')
+                            .value_name("FORMAT")
+                            .default_value("json")
+                            .value_parser(PossibleValuesParser::new(["json"]))
+                            .help("Output format."),
+                    ),
+            )
             .subcommand(Command::new("version").about("Print version").hide(true))
             .subcommand(
                 Command::new("help")
@@ -190,7 +214,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
                     .hide(true),
             )
             .help_template(format!(
-                "{cli_header}\n\n{{about-with-newline}}\n{{usage-heading}} {{usage}}\n\n\x1b[1;4mTasks:\x1b[0m\n{{subcommands}}{group_section}\n\x1b[1;4mCommands:\x1b[0m\n  \x1b[1mfeature\x1b[0m  List features and their flags\n  \x1b[1mversion\x1b[0m  Print version\n  \x1b[1mhelp\x1b[0m     Print this message or the help of the given subcommand(s)\n\n\x1b[1;4mOptions:\x1b[0m\n{{options}}"
+                "{cli_header}\n\n{{about-with-newline}}\n{{usage-heading}} {{usage}}\n\n\x1b[1;4mTasks:\x1b[0m\n{{subcommands}}{group_section}\n\x1b[1;4mCommands:\x1b[0m\n  \x1b[1mdescribe\x1b[0m  Print the resolved task, flag and feature surface as JSON\n  \x1b[1mfeature\x1b[0m   List features and their flags\n  \x1b[1mversion\x1b[0m   Print version\n  \x1b[1mhelp\x1b[0m      Print this message or the help of the given subcommand(s)\n\n\x1b[1;4mOptions:\x1b[0m\n{{options}}"
             ));
 
         tree.attach(root, version)
@@ -253,6 +277,30 @@ impl<'a, 'v> Cmd<'a, 'v> {
     /// With no name, lists every active feature (keyed by the kebab slug the
     /// user passes back in). With a name, prints just that feature's flags. An
     /// unknown name lists the valid ones on stderr and exits 2.
+    /// Print the resolved surface as JSON (`aspect describe`).
+    ///
+    /// Pretty-printed rather than compact: the output is read far more often
+    /// than it is piped into another program, and diffs of it are useful.
+    pub fn print_describe(&self, version: &str) -> ExitCode {
+        let doc = describe_json(
+            version,
+            &self.tasks,
+            &self.features,
+            self.aspect_root,
+            self.modules,
+        );
+        match serde_json::to_string_pretty(&doc) {
+            Ok(s) => {
+                println!("{s}");
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("error: failed to serialize the CLI surface: {e}");
+                ExitCode::FAILURE
+            }
+        }
+    }
+
     pub fn print_feature_help(&self, version: &str, name: Option<&str>) -> ExitCode {
         let mut blocks: Vec<(&dyn FeatureLike<'_>, FeatureBlock)> = self
             .features
@@ -753,6 +801,219 @@ fn feature_block(feat: &dyn FeatureLike<'_>) -> Option<FeatureBlock> {
         args,
         heading,
         prefix: feat.name(),
+    })
+}
+
+// ── `aspect describe` rendering ────────────────────────────────────────────
+
+/// One CLI argument, described by the flag string a caller would actually type.
+///
+/// `scope` decides that string: task args are bare kebab (`--scope`), feature
+/// args carry their feature prefix (`--tips:silence`). Both go through
+/// [`long_flag`], the same helper that builds the real Clap arg, so what is
+/// described and what parses cannot drift.
+fn describe_arg(scope: Scope<'_>, name: &str, arg: &Arg) -> serde_json::Value {
+    use serde_json::json;
+
+    let flag = match arg {
+        Arg::Positional { .. } | Arg::TrailingVarArgs { .. } => None,
+        _ => Some(format!("--{}", long_flag(scope, name, arg))),
+    };
+    let (kind, default, values, description, short) = match arg {
+        Arg::String {
+            default,
+            values,
+            description,
+            short,
+            ..
+        } => ("string", json!(default), json!(values), description, short),
+        Arg::Boolean {
+            default,
+            description,
+            short,
+            ..
+        } => ("boolean", json!(default), json!(null), description, short),
+        Arg::Int {
+            default,
+            description,
+            short,
+            ..
+        } => ("int", json!(default), json!(null), description, short),
+        Arg::UInt {
+            default,
+            description,
+            short,
+            ..
+        } => ("uint", json!(default), json!(null), description, short),
+        Arg::StringList {
+            default,
+            description,
+            short,
+            ..
+        } => (
+            "string_list",
+            json!(default),
+            json!(null),
+            description,
+            short,
+        ),
+        Arg::BooleanList {
+            default,
+            description,
+            short,
+            ..
+        } => (
+            "boolean_list",
+            json!(default),
+            json!(null),
+            description,
+            short,
+        ),
+        Arg::IntList {
+            default,
+            description,
+            short,
+            ..
+        } => ("int_list", json!(default), json!(null), description, short),
+        Arg::UIntList {
+            default,
+            description,
+            short,
+            ..
+        } => ("uint_list", json!(default), json!(null), description, short),
+        Arg::Positional {
+            default,
+            description,
+            ..
+        } => (
+            "positional",
+            json!(default),
+            json!(null),
+            description,
+            &None,
+        ),
+        Arg::TrailingVarArgs { description } => (
+            "trailing_var_args",
+            json!(null),
+            json!(null),
+            description,
+            &None,
+        ),
+        // Filtered out by `is_cli_exposed` before reaching here.
+        Arg::Custom { description, .. } => ("custom", json!(null), json!(null), description, &None),
+    };
+    json!({
+        "name": name,
+        "type": kind,
+        "flag": flag,
+        "short": short.as_ref().map(|s| format!("-{s}")),
+        "required": arg.is_required(),
+        "default": default,
+        "allowed_values": values,
+        "description": description,
+    })
+}
+
+/// Re-type a `config.axl` override for the JSON `default` field.
+///
+/// [`stringify_overrides`] flattens every override to `Vec<String>` for Clap's
+/// benefit. Handing that back verbatim would describe an int default as
+/// `["2"]`, so scalars collapse to a single value parsed back to the arg's own
+/// type and only genuine list args stay arrays.
+fn override_as_default(arg: &Arg, over: &[String]) -> serde_json::Value {
+    use serde_json::json;
+
+    match arg {
+        Arg::StringList { .. } => json!(over),
+        Arg::BooleanList { .. } => json!(over.iter().map(|v| v == "true").collect::<Vec<_>>()),
+        Arg::IntList { .. } | Arg::UIntList { .. } | Arg::Positional { .. } => json!(over),
+        _ => match over.first() {
+            None => json!(null),
+            Some(first) => match arg {
+                Arg::Boolean { .. } => json!(first == "true"),
+                Arg::Int { .. } | Arg::UInt { .. } => first
+                    .parse::<i64>()
+                    .map(|n| json!(n))
+                    .unwrap_or_else(|_| json!(first)),
+                _ => json!(first),
+            },
+        },
+    }
+}
+
+/// The full resolved surface as JSON: every task reachable in this repo, the
+/// flags each accepts, and the feature flags accepted everywhere.
+///
+/// This exists because the Aspect surface is per-repo — a caller cannot know
+/// what `aspect <task>` means here without asking. One call answers it.
+fn describe_json(
+    version: &str,
+    tasks: &[&dyn TaskLike<'_>],
+    features: &[&dyn FeatureLike<'_>],
+    aspect_root: &Path,
+    modules: &[Mod],
+) -> serde_json::Value {
+    use serde_json::json;
+
+    let described_tasks: Vec<serde_json::Value> = tasks
+        .iter()
+        .map(|task| {
+            let kind = task.kind();
+            let mut path = task.group().clone();
+            path.push(kind.clone());
+            let overrides = stringify_overrides(task.overrides());
+            let args: Vec<serde_json::Value> = task
+                .cli_args()
+                .into_iter()
+                .map(|(arg_name, arg)| {
+                    let mut described = describe_arg(Scope::Task, arg_name, arg);
+                    // A config.axl override is what the caller will actually
+                    // get, so report it as the default and say where it came
+                    // from rather than showing the unreachable schema value.
+                    if let Some(over) = overrides.get(arg_name)
+                        && let Some(obj) = described.as_object_mut()
+                    {
+                        obj.insert("default".into(), override_as_default(arg, over));
+                        obj.insert("default_from_config".into(), json!(true));
+                    }
+                    described
+                })
+                .collect();
+            json!({
+                "command": format!("aspect {}", path.join(" ")),
+                "path": path,
+                "name": kind,
+                "summary": task.summary(),
+                "description": task.description(),
+                "defined_in": defined_in_label(task.path(), aspect_root, modules),
+                "args": args,
+            })
+        })
+        .collect();
+
+    let described_features: Vec<serde_json::Value> = features
+        .iter()
+        .filter_map(|feat| {
+            let block = feature_block(*feat)?;
+            let flags: Vec<serde_json::Value> = block
+                .args
+                .iter()
+                .map(|(arg_name, arg)| describe_arg(Scope::Feature(&block.prefix), arg_name, arg))
+                .collect();
+            Some(json!({
+                "name": feat.name(),
+                "summary": feat.summary(),
+                "description": feat.description(),
+                "defined_in": defined_in_label(feat.path(), aspect_root, modules),
+                "flags": flags,
+            }))
+        })
+        .collect();
+
+    json!({
+        "aspect_cli_version": version,
+        "tasks": described_tasks,
+        "features": described_features,
     })
 }
 
@@ -1504,6 +1765,87 @@ mod tests {
         assert!(au_at < tips_at, "rows should be alphabetical by slug");
         assert!(out.contains("Upload artifacts."), "summary missing");
         assert!(out.contains("aspect feature <NAME>"), "footer missing");
+    }
+
+    #[test]
+    fn describe_emits_runnable_commands_and_real_flag_strings() {
+        let mut args: SmallMap<String, Arg> = SmallMap::new();
+        args.insert("base_ref".to_owned(), arg_string("main"));
+        args.insert(
+            "targets".to_owned(),
+            Arg::Positional {
+                minimum: 0,
+                maximum: 8,
+                default: Some(vec!["//...".to_owned()]),
+                description: None,
+            },
+        );
+        let task = stub_task("login", &["auth"], args);
+        let tasks: Vec<&dyn TaskLike> = vec![&task];
+
+        let doc = describe_json("1.2.3", &tasks, &[], Path::new("/repo"), &[]);
+        let t = &doc["tasks"][0];
+
+        // The command string is the whole point: an agent copies it verbatim.
+        assert_eq!(t["command"], "aspect auth login");
+        assert_eq!(t["path"], serde_json::json!(["auth", "login"]));
+        assert_eq!(doc["aspect_cli_version"], "1.2.3");
+
+        let by_name = |n: &str| {
+            t["args"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|a| a["name"] == n)
+                .unwrap()
+                .clone()
+        };
+        // `_` becomes `-` in the flag, matching what Clap actually parses.
+        assert_eq!(by_name("base_ref")["flag"], "--base-ref");
+        assert_eq!(by_name("base_ref")["default"], "main");
+        // Positionals have no flag to type.
+        assert_eq!(by_name("targets")["flag"], serde_json::Value::Null);
+        assert_eq!(by_name("targets")["type"], "positional");
+    }
+
+    #[test]
+    fn describe_retypes_config_overrides_rather_than_stringifying_them() {
+        let int_arg = Arg::Int {
+            required: false,
+            default: 1,
+            short: None,
+            long: None,
+            description: None,
+        };
+        assert_eq!(
+            override_as_default(&int_arg, &["2".to_owned()]),
+            serde_json::json!(2)
+        );
+
+        let bool_arg = Arg::Boolean {
+            required: false,
+            default: false,
+            short: None,
+            long: None,
+            description: None,
+        };
+        assert_eq!(
+            override_as_default(&bool_arg, &["true".to_owned()]),
+            serde_json::json!(true)
+        );
+
+        // Genuine list args keep their array shape.
+        let list_arg = Arg::StringList {
+            required: false,
+            default: vec![],
+            short: None,
+            long: None,
+            description: None,
+        };
+        assert_eq!(
+            override_as_default(&list_arg, &["a".to_owned(), "b".to_owned()]),
+            serde_json::json!(["a", "b"])
+        );
     }
 
     #[test]

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -902,12 +902,25 @@ fn describe_arg(scope: Scope<'_>, name: &str, arg: &Arg) -> serde_json::Value {
         // Filtered out by `is_cli_exposed` before reaching here.
         Arg::Custom { description, .. } => ("custom", json!(null), json!(null), description, &None),
     };
+    // `Arg::is_required` reports false for positionals — they carry cardinality
+    // instead of a `required` flag — so a `minimum = 1` positional would read as
+    // optional. Derive requiredness from the cardinality and report the bounds,
+    // or a caller cannot tell `aspect run` (exactly one target) from a task that
+    // takes none.
+    let (required, minimum, maximum) = match arg {
+        Arg::Positional {
+            minimum, maximum, ..
+        } => (*minimum >= 1, json!(minimum), json!(maximum)),
+        _ => (arg.is_required(), json!(null), json!(null)),
+    };
     json!({
         "name": name,
         "type": kind,
         "flag": flag,
         "short": short.as_ref().map(|s| format!("-{s}")),
-        "required": arg.is_required(),
+        "required": required,
+        "minimum": minimum,
+        "maximum": maximum,
         "default": default,
         "allowed_values": values,
         "description": description,
@@ -924,9 +937,18 @@ fn override_as_default(arg: &Arg, over: &[String]) -> serde_json::Value {
     use serde_json::json;
 
     match arg {
-        Arg::StringList { .. } => json!(over),
+        // Positional values are genuinely strings (target patterns), so they
+        // stay as they came.
+        Arg::StringList { .. } | Arg::Positional { .. } => json!(over),
         Arg::BooleanList { .. } => json!(over.iter().map(|v| v == "true").collect::<Vec<_>>()),
-        Arg::IntList { .. } | Arg::UIntList { .. } | Arg::Positional { .. } => json!(over),
+        Arg::IntList { .. } | Arg::UIntList { .. } => json!(
+            over.iter()
+                .map(|v| v
+                    .parse::<i64>()
+                    .map(|n| json!(n))
+                    .unwrap_or_else(|_| json!(v)))
+                .collect::<Vec<_>>()
+        ),
         _ => match over.first() {
             None => json!(null),
             Some(first) => match arg {
@@ -995,10 +1017,24 @@ fn describe_json(
         .iter()
         .filter_map(|feat| {
             let block = feature_block(*feat)?;
+            // `feature_block` bakes scalar overrides into its schema but skips
+            // list-valued ones, so re-apply them here for the same reason task
+            // args do it: a caller must see the default execution will use, not
+            // one it can never observe.
+            let overrides = stringify_overrides(feat.overrides());
             let flags: Vec<serde_json::Value> = block
                 .args
                 .iter()
-                .map(|(arg_name, arg)| describe_arg(Scope::Feature(&block.prefix), arg_name, arg))
+                .map(|(arg_name, arg)| {
+                    let mut described = describe_arg(Scope::Feature(&block.prefix), arg_name, arg);
+                    if let Some(over) = overrides.get(arg_name)
+                        && let Some(obj) = described.as_object_mut()
+                    {
+                        obj.insert("default".into(), override_as_default(arg, over));
+                        obj.insert("default_from_config".into(), json!(true));
+                    }
+                    described
+                })
                 .collect();
             Some(json!({
                 "name": feat.name(),
@@ -1806,6 +1842,53 @@ mod tests {
         // Positionals have no flag to type.
         assert_eq!(by_name("targets")["flag"], serde_json::Value::Null);
         assert_eq!(by_name("targets")["type"], "positional");
+        // A flag arg carries no cardinality.
+        assert_eq!(by_name("base_ref")["minimum"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn describe_reports_positional_cardinality_and_derives_requiredness() {
+        let mut args: SmallMap<String, Arg> = SmallMap::new();
+        // `Arg::is_required` returns false for every positional, so a required
+        // one is only distinguishable via its cardinality.
+        args.insert(
+            "target".to_owned(),
+            Arg::Positional {
+                minimum: 1,
+                maximum: 1,
+                default: None,
+                description: None,
+            },
+        );
+        args.insert(
+            "extras".to_owned(),
+            Arg::Positional {
+                minimum: 0,
+                maximum: 8,
+                default: None,
+                description: None,
+            },
+        );
+        let task = stub_task("run", &[], args);
+        let tasks: Vec<&dyn TaskLike> = vec![&task];
+        let doc = describe_json("1.2.3", &tasks, &[], Path::new("/repo"), &[]);
+        let by_name = |n: &str| {
+            doc["tasks"][0]["args"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|a| a["name"] == n)
+                .unwrap()
+                .clone()
+        };
+
+        assert_eq!(by_name("target")["required"], true);
+        assert_eq!(by_name("target")["minimum"], 1);
+        assert_eq!(by_name("target")["maximum"], 1);
+
+        assert_eq!(by_name("extras")["required"], false);
+        assert_eq!(by_name("extras")["minimum"], 0);
+        assert_eq!(by_name("extras")["maximum"], 8);
     }
 
     #[test]
@@ -1845,6 +1928,31 @@ mod tests {
         assert_eq!(
             override_as_default(&list_arg, &["a".to_owned(), "b".to_owned()]),
             serde_json::json!(["a", "b"])
+        );
+
+        // …and numeric lists are re-typed elementwise, not left as strings.
+        let int_list = Arg::IntList {
+            required: false,
+            default: vec![],
+            short: None,
+            long: None,
+            description: None,
+        };
+        assert_eq!(
+            override_as_default(&int_list, &["1".to_owned(), "2".to_owned()]),
+            serde_json::json!([1, 2])
+        );
+
+        // Positional values are target patterns — genuinely strings.
+        let positional = Arg::Positional {
+            minimum: 0,
+            maximum: 8,
+            default: None,
+            description: None,
+        };
+        assert_eq!(
+            override_as_default(&positional, &["//...".to_owned()]),
+            serde_json::json!(["//..."])
         );
     }
 

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -235,6 +235,9 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                     cmd_for_help.print_help()?;
                     return Ok(ExitCode::SUCCESS);
                 }
+                Some("describe") => {
+                    return Ok(cmd.print_describe(&cli_version));
+                }
                 Some("feature") => {
                     let name = matches
                         .subcommand_matches("feature")

--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::env::var;
 use std::fs;
 use std::fs::File;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
@@ -84,8 +84,8 @@ const ASPECT_LAUNCHER_METHOD_HTTP: &str = "http";
 const ASPECT_LAUNCHER_METHOD_GITHUB: &str = "github";
 const ASPECT_LAUNCHER_METHOD_LOCAL: &str = "local";
 
-/// Minimum interval between download-progress prints when running on CI.
-const CI_DOWNLOAD_PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+/// Minimum interval between download-progress prints when stderr is not a terminal.
+const DOWNLOAD_PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 async fn _download_into_cache(
     client: &Client,
@@ -120,9 +120,11 @@ async fn _download_into_cache(
 
     let mut downloaded: u64 = 0;
 
-    // On CI, terminals don't process `\r` line resets so per-chunk progress
-    // is spammy. Throttle update on its own line.
+    // `\r` line resets only redraw in place on a terminal. Anywhere else — a CI
+    // log, a pipe, an AI agent capturing stderr — every chunk accumulates instead,
+    // so fall back to a throttled line-per-update.
     let is_ci = var("CI").map(|v| !v.is_empty()).unwrap_or(false);
+    let redraw_in_place = io::stderr().is_terminal() && !is_ci;
     let download_start = std::time::Instant::now();
     let mut last_progress = download_start;
 
@@ -140,9 +142,9 @@ async fn _download_into_cache(
 
         downloaded += chunk_size;
 
-        if !is_ci || last_progress.elapsed() >= CI_DOWNLOAD_PROGRESS_INTERVAL {
-            let line_start = if is_ci { "" } else { "\r" };
-            let line_end = if is_ci { "\n" } else { "" };
+        if redraw_in_place || last_progress.elapsed() >= DOWNLOAD_PROGRESS_INTERVAL {
+            let line_start = if redraw_in_place { "\r" } else { "" };
+            let line_end = if redraw_in_place { "" } else { "\n" };
             if let Some(total) = total_size {
                 let percent = ((downloaded as f64 / total as f64) * 100.0) as u64;
                 eprint!(
@@ -171,12 +173,12 @@ async fn _download_into_cache(
     } else {
         format!("{}ms", elapsed.as_millis())
     };
-    if is_ci {
-        eprintln!("downloaded {size_str} in {time_str}");
-    } else {
+    if redraw_in_place {
         // \r overwrites the in-progress KB line; \x1b[K clears any stale tail
         // when the summary is shorter than the last progress print.
         eprintln!("\rdownloaded {size_str} in {time_str}\x1b[K");
+    } else {
+        eprintln!("downloaded {size_str} in {time_str}");
     }
 
     // A 0-byte (or truncated) body would `exec` into an ENOEXEC "Exec format

--- a/crates/axl-runtime/src/banner.rs
+++ b/crates/axl-runtime/src/banner.rs
@@ -28,12 +28,26 @@ const DOCS_URL: &str = "https://aspect.build/docs/cli";
 ///
 /// No trailing newline — callers place it within their own layout.
 pub fn line(version: &str) -> String {
+    line_colored(version, true)
+}
+
+/// [`line`], with the grey wrapper applied only when `color` is set.
+///
+/// Call sites that print the banner themselves (rather than handing it to clap,
+/// which strips escapes off a non-terminal) pass the result of
+/// [`crate::color::stdout_supports_color`] so a piped run stays plain text.
+pub fn line_colored(version: &str, color: bool) -> String {
     let debug = if is_debug_build() {
         " (debug build)"
     } else {
         ""
     };
-    format!("{GREY}Aspect CLI v{version}{debug} — {DOCS_URL}{RESET}")
+    let body = format!("Aspect CLI v{version}{debug} — {DOCS_URL}");
+    if color {
+        format!("{GREY}{body}{RESET}")
+    } else {
+        body
+    }
 }
 
 /// [`line`] resolving the version from workspace crate metadata. For call
@@ -83,6 +97,14 @@ mod tests {
             format!("{GREY}Aspect CLI v9.9.9{debug} — {DOCS_URL}{RESET}")
         );
         assert!(s.starts_with(GREY) && s.ends_with(RESET));
+    }
+
+    #[test]
+    fn line_colored_drops_the_grey_wrapper_when_uncolored() {
+        let plain = line_colored("9.9.9", false);
+        assert!(!plain.contains('\x1b'), "no escapes when uncolored");
+        assert!(plain.starts_with("Aspect CLI v9.9.9"));
+        assert_eq!(line_colored("9.9.9", true), line("9.9.9"));
     }
 
     #[test]

--- a/crates/axl-runtime/src/color.rs
+++ b/crates/axl-runtime/src/color.rs
@@ -1,0 +1,39 @@
+//! Whether hand-rendered output may carry ANSI color.
+//!
+//! Clap strips the escapes baked into our `--help` templates when it renders to
+//! a non-terminal, so help output is already safe. The surfaces that print their
+//! own layout (`aspect feature`, and anything else assembling SGR sequences by
+//! hand) have no such protection and would otherwise emit raw escapes into a
+//! pipe — a log file, a `| grep`, or an AI agent capturing stdout.
+
+use std::io::IsTerminal;
+
+/// Whether stdout may carry ANSI color.
+///
+/// True only on an interactive stdout, and never when `NO_COLOR` is set
+/// (<https://no-color.org>).
+pub fn stdout_supports_color() -> bool {
+    supports_color_from(
+        std::io::stdout().is_terminal(),
+        std::env::var_os("NO_COLOR").is_some(),
+    )
+}
+
+/// Pure core of [`stdout_supports_color`], parameterized over its inputs so the
+/// gating is testable without a real TTY or process env.
+fn supports_color_from(is_tty: bool, no_color_set: bool) -> bool {
+    is_tty && !no_color_set
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color_only_on_a_tty_without_no_color() {
+        assert!(supports_color_from(true, false));
+        assert!(!supports_color_from(false, false));
+        assert!(!supports_color_from(true, true));
+        assert!(!supports_color_from(false, true));
+    }
+}

--- a/crates/axl-runtime/src/lib.rs
+++ b/crates/axl-runtime/src/lib.rs
@@ -7,6 +7,7 @@ extern crate self as axl_runtime;
 pub mod banner;
 pub mod builtins;
 pub mod ci;
+pub mod color;
 pub mod diag;
 pub mod docs;
 pub mod engine;


### PR DESCRIPTION
AI coding agents struggle to drive this CLI, and the reflexive explanation — "AWS CLI and gcloud are in the training data and we aren't" — is only half true. Model knowledge of those tools' flags is substantially stale; what actually makes them work in an agent loop is the recovery loop: cheap structured help, machine-readable output on read commands, and errors that name the next command. More decisively, **Aspect's surface is per-repo** — `aspect <task>` means whatever this repo's `.aspect/*.axl` defines, and customer tasks have by definition never been in any training set. So "get into the weights" is both unreachable and not the bottleneck. This makes the surface answerable at runtime instead.

**Launcher progress.** The download progress renderer chose its line format from the `CI` env var. Anything non-TTY and non-CI — a pipe, a log file, an agent capturing stderr — took the interactive `\r` path, and since a pipe does not process `\r`, every chunk accumulated rather than redrawing in place. That branch was also unthrottled; the 30s interval only applied when `is_ci` was set. A cold `aspect --help` with stderr piped produced 57,178 bytes across 2 lines; it now produces 107. Interactive and CI behavior are unchanged by construction: `redraw_in_place` is `is_terminal() && !is_ci`, so a TTY takes the branch `!is_ci` used to take and CI takes the branch `is_ci` used to take. Only the non-TTY non-CI population moves, onto the throttled path.

**Task summaries.** `build`, `format`, `gazelle`, `lint` and `test` had no `summary`, so `aspect --help` rendered the `"<name> task defined in @aspect//<file>.axl"` fallback for five of nine tasks. Their per-flag help is already detailed, which left the tree descriptive one level down and empty at the top — the level a reader uses to choose a task at all.

**`aspect describe`.** The resolved surface as JSON: every reachable task with a copy-pasteable `command` string, group path, summary, defining module, and every flag with type, default, allowed values and description, plus the feature flags accepted everywhere. Flag strings are produced by `long_flag`, the same helper that builds the real Clap arg, so what is described and what parses cannot drift. `config.axl` overrides are reported as the effective default — re-typed rather than stringified, so an int override reads `2` and not `["2"]` — flagged with `default_from_config`, so a reader sees what will actually happen in this repo rather than the schema value it can never observe. It defaults to JSON because requiring a flag to be known up front defeats the purpose.

**`aspect auth status --output=json`.** The other half: why a thing is broken. `{account, deployments, default_deployment}`, each entry carrying `logged_in`, `status`, `identity`, its endpoints and, most usefully, the `login_command` that re-authenticates it — so a caller that finds an expired token gets the exact remedy without parsing `●`/`○` glyphs out of prose. stdout is clean JSON; the task header stays on stderr. Text output is unchanged.

`--output` is the convention for both. `aspect cache diff` already shipped `--format`, so it gains `--output` as the documented spelling and keeps `--format` working as a deprecated alias that warns.

**Color.** Clap strips the escapes baked into our help templates when rendering off a terminal, but hand-rendered output has no such protection, so `aspect feature` emitted raw SGR sequences into a pipe. Adds `color::stdout_supports_color()` (TTY, and `NO_COLOR` honored) following the pure-core pattern `banner.rs` already uses, plus `banner::line_colored`.

Tracked in ENG-1975, which also carries the follow-ups deliberately left out here: distinct exit codes (breaking — needs a decision on additive-only codes first), generated `AGENTS.md` and an `aspect mcp` adapter over the describe data, task-group summaries (blocked on a new AXL declaration surface — groups are synthesized in Rust from namespace structure with no metadata slot), and an eval harness to keep this measurable.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

```
- New `aspect describe` prints the resolved task, flag and feature surface as JSON — every task with a runnable command string, its flags, types, defaults and allowed values — so scripts and AI agents can discover a repo's Aspect surface in one call.
- New `aspect auth status --output=json` reports login state, endpoints and the exact `login_command` that re-authenticates each entry.
- `aspect cache diff` gains `--output` as the documented spelling of `--format`. `--format` still works and now warns.
- `aspect build`, `format`, `gazelle`, `lint` and `test` now describe themselves in `aspect --help` instead of showing a placeholder.
- The launcher no longer floods non-terminal consumers with download progress: a piped cold download dropped from ~57KB of output to ~107 bytes.
- `aspect feature` no longer emits ANSI escape codes when its output is piped, and honors `NO_COLOR`.
```

### Test plan

- Covered by existing test cases (910 AXL cases via `aspect tests axl`; launcher suite)
- New test cases added:
  - `describe_emits_runnable_commands_and_real_flag_strings` (`crates/aspect-cli/src/cmd.rs`) — command string joins the group path, `_`→`-` flag conversion matches what Clap parses, positionals carry no flag.
  - `describe_retypes_config_overrides_rather_than_stringifying_them` — int/bool overrides come back as JSON numbers/bools; genuine list args keep their array shape.
  - `line_colored_drops_the_grey_wrapper_when_uncolored` (`crates/axl-runtime/src/banner.rs`).
  - `color_only_on_a_tty_without_no_color` (`crates/axl-runtime/src/color.rs`).
- Manual testing:
  1. Cold download with stderr piped, before vs after — `ASPECT_LAUNCHER_CACHE=$(mktemp -d) aspect --help 2>err >/dev/null; wc -c err` → 57,178 bytes on the released launcher, 107 on this branch.
  2. `aspect describe | python3 -c 'import json,sys; json.load(sys.stdin)'` parses; reports 74 tasks and 12 features in this repo. Verified `--run_count` (a task that overrides its flag name) is reported exactly as it parses.
  3. `aspect auth status --output=json 2>/dev/null` is valid JSON on stdout with the task header on stderr; `aspect auth status` text output is unchanged.
  4. `aspect feature | cat -v` shows no escape sequences; on a TTY the listing is still bold/colored.
