### PR TITLE
feat(cli): warn when a task declares no summary, and document every built-in

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3824,6 +3824,7 @@ def test_gitlab_token_cache(ctx: TaskContext, tc: int, temp_dir: str) -> int:
 
 axl = task(
     group = ["tests"],
+    summary = "Run the AXL unit test suite defined in .aspect/axl.axl.",
     implementation = impl,
     args = {},
     # tips.TRAITS must be in the trait list because several tested

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -51,6 +51,7 @@ def _user_task_impl(ctx: TaskContext) -> int:
 
 _user_task = task(
     kind = "user-task-added-by-config",
+    summary = "Test fixture: a user task added from config.axl rather than its own file.",
     group = ["user"],
     implementation = _user_task_impl,
     args = {},

--- a/.aspect/user-task.axl
+++ b/.aspect/user-task.axl
@@ -17,6 +17,7 @@ def _impl(ctx: TaskContext) -> int:
 
 user_task = task(
     group = ["user", "nested"],
+    summary = "Test fixture: a nested user task exercising config-supplied arg defaults.",
     implementation = _impl,
     args = {
         "message": args.custom(str, default = "hello world", description = "The message string to print on each iteration"),

--- a/.aspect/user/user-task-manual.axl
+++ b/.aspect/user/user-task-manual.axl
@@ -4,6 +4,7 @@ def _impl(ctx: TaskContext) -> int:
 
 user_task_manual = task(
     kind = "user-task-man",
+    summary = "Test fixture: a user task registered manually rather than by directory scan.",
     group = ["user"],
     implementation = _impl,
     args = {},

--- a/crates/aspect-cli/src/builtins/aspect/auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth_test.axl
@@ -81,6 +81,7 @@ def _test_impl(ctx):
     return 0
 
 auth_tests = task(
+    summary = "Run the auth AXL unit tests.",
     kind = "test-auth",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/bazel/build_events_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazel/build_events_test.axl
@@ -290,6 +290,7 @@ def _test_impl(ctx):
     return 0
 
 bes_sinks_tests = task(
+    summary = "Run the bes sinks AXL unit tests.",
     kind = "test-bes-sinks",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/github.axl
@@ -59,6 +59,7 @@ def _token_impl(ctx: TaskContext) -> int:
 
 token = task(
     group = ["github"],
+    summary = "Mint a short-lived GitHub App token for a repository and print it to stdout.",
     implementation = _token_impl,
     args = {
         "repo": args.positional(

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -212,6 +212,7 @@ def _test_impl(ctx):
     return 0
 
 bk_annotation_snapshot_tests = task(
+    summary = "Run the bk annotation snapshots AXL unit tests.",
     kind = "test-bk-annotation-snapshots",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -2456,6 +2456,7 @@ def _delivery_partial(data, total):
     return data
 
 pr_comment_snapshot_tests = task(
+    summary = "Run the pr comment snapshots AXL unit tests.",
     kind = "test-pr-comment-snapshots",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/helpers_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/helpers_test.axl
@@ -37,6 +37,7 @@ def _test_impl(ctx):
     return 0
 
 helpers_facade_tests = task(
+    summary = "Run the helpers AXL unit tests.",
     kind = "test-helpers",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth_test.axl
@@ -170,6 +170,7 @@ def _test_impl(ctx):
     return 0
 
 aspect_endpoint_auth_tests = task(
+    summary = "Run the aspect endpoint auth AXL unit tests.",
     kind = "test-aspect-endpoint-auth",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
@@ -418,6 +418,7 @@ def _test_impl(ctx):
     return 0
 
 bazel_flags_tests = task(
+    summary = "Run the bazel flags AXL unit tests.",
     kind = "test-bazel-flags",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
@@ -629,6 +629,7 @@ def _test_impl(ctx):
     return 0
 
 template_snapshot_tests = task(
+    summary = "Run the template snapshots AXL unit tests.",
     kind = "test-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,
@@ -1420,6 +1421,7 @@ def _unit_test_impl(ctx):
     return 0
 
 bazel_results_unit_tests = task(
+    summary = "Run the bazel results AXL unit tests.",
     kind = "test-bazel-results",
     group = ["dev"],
     implementation = _unit_test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_runner_test.axl
@@ -94,6 +94,7 @@ def _test_impl(ctx):
     return 0
 
 bazel_runner_tests = task(
+    summary = "Run the bazel runner AXL unit tests.",
     kind = "test-bazel-runner",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazelrc_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazelrc_test.axl
@@ -202,6 +202,7 @@ def _test_impl(ctx):
     return 0
 
 bazelrc_tests = task(
+    summary = "Run the bazelrc AXL unit tests.",
     kind = "test-bazelrc",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/ci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/ci_test.axl
@@ -215,6 +215,7 @@ def _test_impl(ctx):
     return 0
 
 ci_tests = task(
+    summary = "Run the ci AXL unit tests.",
     kind = "test-ci",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/circleci_test.axl
@@ -319,6 +319,7 @@ def _test_impl(ctx):
     return 0
 
 circleci_tests = task(
+    summary = "Run the circleci AXL unit tests.",
     kind = "test-circleci",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results_test.axl
@@ -404,6 +404,7 @@ def _check_long_subject_title_is_capped(ctx):
         fail("title unexpectedly long (%d chars): %r" % (len(title), title))
 
 delivery_template_snapshot_tests = task(
+    summary = "Run the delivery template snapshots AXL unit tests.",
     kind = "test-delivery-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,
@@ -596,6 +597,7 @@ def _unit_test_impl(ctx):
     return 0
 
 delivery_results_unit_tests = task(
+    summary = "Run the delivery results AXL unit tests.",
     kind = "test-delivery-results",
     group = ["dev"],
     implementation = _unit_test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/deployment_flags_test.axl
@@ -401,6 +401,7 @@ def _test_impl(ctx):
     return 0
 
 deployment_flags_tests = task(
+    summary = "Run the deployment flags AXL unit tests.",
     kind = "test-deployment-flags",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/format_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/format_results_test.axl
@@ -317,6 +317,7 @@ def _check_failed_actions_invoke_snippet_macro(ctx):
         fail("failed action label missing — Bazel-targets block did not render: %r" % out["text"][:600])
 
 format_template_snapshot_tests = task(
+    summary = "Run the format template snapshots AXL unit tests.",
     kind = "test-format-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/format_spawn_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/format_spawn_test.axl
@@ -71,6 +71,7 @@ def _test_impl(ctx):
     return 0
 
 format_spawn_tests = task(
+    summary = "Run the format spawn AXL unit tests.",
     kind = "test-format-spawn",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results_test.axl
@@ -332,6 +332,7 @@ def _check_failed_actions_invoke_snippet_macro(ctx):
         fail("failed action label missing — Bazel-targets block did not render: %r" % out["text"][:600])
 
 gazelle_template_snapshot_tests = task(
+    summary = "Run the gazelle template snapshots AXL unit tests.",
     kind = "test-gazelle-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github_detect_test.axl
@@ -1238,6 +1238,7 @@ def _test_resolve_merge_base_integration(ctx):
     ctx.std.fs.remove_dir_all(repo)
 
 github_detect_tests = task(
+    summary = "Run the github detect AXL unit tests.",
     kind = "test-github-detect",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_detect_test.axl
@@ -231,6 +231,7 @@ def _test_impl(ctx):
     return 0
 
 gitlab_detect_tests = task(
+    summary = "Run the gitlab detect AXL unit tests.",
     kind = "test-gitlab-detect",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_features_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_features_test.axl
@@ -90,6 +90,7 @@ def _test_impl(ctx):
     return 0
 
 gitlab_features_tests = task(
+    summary = "Run the gitlab features AXL unit tests.",
     kind = "test-gitlab-features",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_lint_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_lint_comments_test.axl
@@ -137,6 +137,7 @@ def _test_impl(ctx):
     return 0
 
 gitlab_lint_comments_tests = task(
+    summary = "Run the gitlab lint comments AXL unit tests.",
     kind = "test-gitlab-lint-comments",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_test.axl
@@ -306,6 +306,7 @@ def _test_impl(ctx):
     return 0
 
 gitlab_client_tests = task(
+    summary = "Run the gitlab client AXL unit tests.",
     kind = "test-gitlab-client",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/health_check_ready_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/health_check_ready_test.axl
@@ -279,6 +279,7 @@ def _test_impl(ctx):
     return 0
 
 health_check_ready_tests = task(
+    summary = "Run the health check ready AXL unit tests.",
     kind = "test-health-check-ready",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/init_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/init_test.axl
@@ -176,6 +176,7 @@ def _test_impl(ctx):
     return 0
 
 init_tests = task(
+    summary = "Run the init AXL unit tests.",
     kind = "test-init",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle_test.axl
@@ -66,6 +66,7 @@ def _test_impl(ctx):
     return 0
 
 lifecycle_tests = task(
+    summary = "Run the lifecycle AXL unit tests.",
     kind = "test-lifecycle",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_comments_test.axl
@@ -155,6 +155,7 @@ def _test_impl(ctx):
     return 0
 
 lint_comments_tests = task(
+    summary = "Run the lint comments AXL unit tests.",
     kind = "test-lint-comments",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results_test.axl
@@ -781,6 +781,7 @@ def _check_fix_renders_before_reproduce(ctx):
         fail("Fix block must render before Reproduce (fix@%d, repro@%d)" % (fix_at, repro_at))
 
 lint_template_snapshot_tests = task(
+    summary = "Run the lint template snapshots AXL unit tests.",
     kind = "test-lint-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,
@@ -856,6 +857,7 @@ def _test_lint_annotation_plan(ctx):
     return 0
 
 lint_annotation_plan_tests = task(
+    summary = "Run the lint annotation plan AXL unit tests.",
     kind = "test-lint-annotation-plan",
     group = ["dev"],
     implementation = _test_lint_annotation_plan,
@@ -930,6 +932,7 @@ def _test_linter_rows(ctx):
     return 0
 
 linter_rows_tests = task(
+    summary = "Run the lint linter rows AXL unit tests.",
     kind = "test-lint-linter-rows",
     group = ["dev"],
     implementation = _test_linter_rows,
@@ -986,6 +989,7 @@ def _test_detect_lint_tool(ctx):
     return 0
 
 detect_lint_tool_tests = task(
+    summary = "Run the lint detect tool AXL unit tests.",
     kind = "test-lint-detect-tool",
     group = ["dev"],
     implementation = _test_detect_lint_tool,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/path_normalize_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/path_normalize_test.axl
@@ -140,6 +140,7 @@ def _test_impl(ctx):
     return 0
 
 path_normalize_tests = task(
+    summary = "Run the path normalize AXL unit tests.",
     kind = "test-path-normalize",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/rate_limit_test.axl
@@ -1551,6 +1551,7 @@ def _test_impl(ctx):
     return 0
 
 rate_limit_tests = task(
+    summary = "Run the rate limit AXL unit tests.",
     kind = "test-rate-limit",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/remote_executor_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/remote_executor_test.axl
@@ -48,6 +48,7 @@ def _test_impl(ctx):
     return 0
 
 remote_executor_tests = task(
+    summary = "Run the remote executor AXL unit tests.",
     kind = "test-remote-executor",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/repro_commands_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/repro_commands_test.axl
@@ -1283,6 +1283,7 @@ def _test_impl(ctx):
     return 0
 
 repro_commands_tests = task(
+    summary = "Run the repro commands AXL unit tests.",
     kind = "test-repro-commands",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/runnable_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/runnable_test.axl
@@ -945,6 +945,7 @@ def _test_impl(ctx):
     return 0
 
 runnable_tests = task(
+    summary = "Run the runnable AXL unit tests.",
     kind = "test-runnable",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/runner_job_history_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/runner_job_history_test.axl
@@ -340,6 +340,7 @@ def _test_impl(ctx):
     return 0
 
 runner_job_history_tests = task(
+    summary = "Run the runner job history AXL unit tests.",
     kind = "test-runner-job-history",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery_test.axl
@@ -192,6 +192,7 @@ def _test_impl(ctx):
     return 0
 
 sandbox_recovery_tests = task(
+    summary = "Run the sandbox recovery AXL unit tests.",
     kind = "test-sandbox-recovery",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/tar_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/tar_test.axl
@@ -45,6 +45,7 @@ def _test_impl(ctx):
     return 0
 
 tar_tests = task(
+    summary = "Run the tar AXL unit tests.",
     kind = "test-tar",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/tips_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/tips_test.axl
@@ -737,6 +737,7 @@ def _test_impl(ctx):
 tips_tests = task(
     kind = "test-tips",
     group = ["dev"],
+    summary = "Run the tips AXL unit tests.",
     implementation = _test_impl,
     args = {},
     traits = tips.TRAITS,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results_test.axl
@@ -196,6 +196,7 @@ def _check_failed_actions_invoke_snippet_macro(ctx):
         fail("failed action label missing — Bazel-targets block did not render: %r" % out["text"][:600])
 
 warming_template_snapshot_tests = task(
+    summary = "Run the warming template snapshots AXL unit tests.",
     kind = "test-warming-template-snapshots",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/wrapper_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/wrapper_test.axl
@@ -166,6 +166,7 @@ def _test_impl(ctx):
     return 0
 
 wrapper_tests = task(
+    summary = "Run the wrapper AXL unit tests.",
     kind = "test-wrapper",
     group = ["dev"],
     implementation = _test_impl,

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -1881,32 +1881,26 @@ mod tests {
     }
 
     /// The runtime warning skips `@aspect//` tasks, so enforce the rule here.
+    ///
+    /// Reads the `include_dir!` embed, not the filesystem, so it works under
+    /// Bazel's sandbox where the cargo layout isn't on disk.
     #[test]
     fn every_builtin_task_declares_a_summary() {
-        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/builtins/aspect");
-        let mut offenders = Vec::new();
+        use include_dir::{Dir, include_dir};
+        static ASPECT_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src/builtins/aspect");
 
-        let mut stack = vec![root.clone()];
-        while let Some(dir) = stack.pop() {
-            for entry in std::fs::read_dir(&dir).expect("readable builtin dir") {
-                let path = entry.expect("readable entry").path();
-                if path.is_dir() {
-                    stack.push(path);
-                    continue;
-                }
-                if path.extension().is_none_or(|e| e != "axl") {
-                    continue;
-                }
-                let text = std::fs::read_to_string(&path).expect("readable .axl");
-                // `<var> = task(` at column 0, keywords at one indent.
-                for (idx, _) in text.match_indices(" = task(\n") {
-                    let body = &text[idx..];
-                    let end = body.find("\n)").unwrap_or(body.len());
-                    if !body[..end].contains("\n    summary = ") {
-                        let line = text[..idx].lines().count() + 1;
-                        let rel = path.strip_prefix(&root).unwrap_or(&path);
-                        offenders.push(format!("{}:{}", rel.display(), line));
-                    }
+        let mut offenders = Vec::new();
+        for f in ASPECT_DIR.find("**/*.axl").unwrap() {
+            let Some(text) = f.as_file().and_then(|file| file.contents_utf8()) else {
+                continue;
+            };
+            // `<var> = task(` at column 0, keywords at one indent.
+            for (idx, _) in text.match_indices(" = task(\n") {
+                let body = &text[idx..];
+                let end = body.find("\n)").unwrap_or(body.len());
+                if !body[..end].contains("\n    summary = ") {
+                    let line = text[..idx].lines().count() + 1;
+                    offenders.push(format!("{}:{}", f.path().display(), line));
                 }
             }
         }

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -1153,8 +1153,6 @@ fn task_command(
         kind, label,
     );
     let about = if task.summary().is_empty() {
-        // Warn beside the fallback rather than at the call site, so the
-        // diagnostic and the text it quotes cannot drift apart.
         if needs_summary_warning(task.summary(), label) {
             warn_missing_summary(&kind, label);
         }
@@ -1361,19 +1359,7 @@ fn group_section(group_names: &[String]) -> String {
 
 // ── Misc helpers ───────────────────────────────────────────────────────────
 
-/// Warn once for a task declared without a `summary`.
-///
-/// A task with no summary renders as `"<kind> task defined in <file>"` in
-/// `aspect --help` — the level at which a reader chooses a task at all, so an
-/// undocumented task is effectively invisible. This is a deprecation warning:
-/// `summary` is slated to become required.
-///
-/// Scoped to tasks defined in this repo, which [`defined_in_label`] reports as
-/// a bare relative path (a module's tasks come back as `@mod//…`). Warning
-/// about a third-party module's task would be pure noise — the reader seeing it
-/// cannot fix it. Built-in `@aspect//` tasks are held to the rule by
-/// `every_builtin_task_declares_a_summary` instead, so a regression there fails
-/// our CI rather than printing in a customer's terminal.
+/// Warn that a task has no `summary`, which will become required.
 fn warn_missing_summary(kind: &str, defined_in: &str) {
     diag::warn(&format!(
         "task {kind:?} in {defined_in} has no summary, so it shows as \
@@ -1382,12 +1368,8 @@ fn warn_missing_summary(kind: &str, defined_in: &str) {
     ));
 }
 
-/// Pure core of the [`warn_missing_summary`] gate, parameterized over its
-/// inputs so the rule is testable without capturing stderr.
-///
-/// Only first-party tasks qualify: [`defined_in_label`] reports a module's
-/// tasks as `@mod//…`, and warning about a third-party module's task would be
-/// noise the reader cannot act on.
+/// Undocumented, and defined in this repo rather than a module (`@mod//…`) —
+/// a module's task is not the reader's to fix.
 fn needs_summary_warning(summary: &str, defined_in: &str) -> bool {
     summary.is_empty() && !defined_in.starts_with('@')
 }
@@ -1532,9 +1514,7 @@ mod tests {
         }
     }
 
-    /// Carries a non-empty summary so building the CLI surface stays quiet —
-    /// an empty one trips the deprecation warning and floods test output.
-    /// `needs_summary_warning` covers that rule directly instead.
+    /// Summary is non-empty so `Cmd::build` doesn't warn in every test.
     fn stub_task(name: &str, group: &[&str], args: SmallMap<String, Arg>) -> StubTask {
         StubTask {
             name: name.to_owned(),
@@ -1889,28 +1869,18 @@ mod tests {
 
     #[test]
     fn summary_warning_fires_only_for_undocumented_first_party_tasks() {
-        // The case worth warning about: our own task, no summary.
         assert!(needs_summary_warning("", ".aspect/deploy.axl"));
 
-        // A documented task never warns, wherever it came from.
         assert!(!needs_summary_warning(
             "Deploy the app.",
             ".aspect/deploy.axl"
         ));
         assert!(!needs_summary_warning("Build it.", "@aspect//build.axl"));
-
-        // A module's undocumented task is not the reader's to fix, so warning
-        // about it would be pure noise.
         assert!(!needs_summary_warning("", "@aspect//build.axl"));
         assert!(!needs_summary_warning("", "@some_third_party//task.axl"));
     }
 
-    /// `warn_missing_summary` deliberately stays quiet for `@mod//` tasks, so
-    /// nothing at runtime holds our own built-ins to the rule. This does: it
-    /// scans the built-in source tree for a `task(` call with no `summary`.
-    ///
-    /// Kept as a source scan rather than an evaluation of the task tree because
-    /// it must fail in CI on the file a contributor just wrote, and name it.
+    /// The runtime warning skips `@aspect//` tasks, so enforce the rule here.
     #[test]
     fn every_builtin_task_declares_a_summary() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/builtins/aspect");
@@ -1928,8 +1898,7 @@ mod tests {
                     continue;
                 }
                 let text = std::fs::read_to_string(&path).expect("readable .axl");
-                // Task calls are declared at column 0 as `<var> = task(`; the
-                // body's keywords sit at one indent level.
+                // `<var> = task(` at column 0, keywords at one indent.
                 for (idx, _) in text.match_indices(" = task(\n") {
                     let body = &text[idx..];
                     let end = body.find("\n)").unwrap_or(body.len());
@@ -1944,9 +1913,7 @@ mod tests {
 
         assert!(
             offenders.is_empty(),
-            "every built-in task must declare a summary — it is what `aspect --help` \
-             shows, and a reader (or an AI agent) picks a task from that line. \
-             Add `summary = \"…\"` at:\n  {}",
+            "built-in tasks must declare a summary; add `summary = \"…\"` at:\n  {}",
             offenders.join("\n  ")
         );
     }

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -104,6 +104,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
         let mut tree = Tree::default();
         for (idx, task) in self.tasks.iter().enumerate() {
             let label = defined_in_label(task.path(), self.aspect_root, self.modules);
+            warn_missing_summary(*task, &label);
             let task_cmd = task_command(idx, *task, &label, &feature_blocks, &cli_header);
             tree.insert(*task, &label, task_cmd)?;
         }
@@ -1356,6 +1357,31 @@ fn group_section(group_names: &[String]) -> String {
 
 // ── Misc helpers ───────────────────────────────────────────────────────────
 
+/// Warn once for a task declared without a `summary`.
+///
+/// A task with no summary renders as `"<kind> task defined in <file>"` in
+/// `aspect --help` — the level at which a reader chooses a task at all, so an
+/// undocumented task is effectively invisible. This is a deprecation warning:
+/// `summary` is slated to become required.
+///
+/// Scoped to tasks defined in this repo, which [`defined_in_label`] reports as
+/// a bare relative path (a module's tasks come back as `@mod//…`). Warning
+/// about a third-party module's task would be pure noise — the reader seeing it
+/// cannot fix it. Built-in `@aspect//` tasks are held to the rule by
+/// `every_builtin_task_declares_a_summary` instead, so a regression there fails
+/// our CI rather than printing in a customer's terminal.
+fn warn_missing_summary(task: &dyn TaskLike<'_>, defined_in: &str) {
+    if !task.summary().is_empty() || defined_in.starts_with('@') {
+        return;
+    }
+    let kind = task.kind();
+    diag::warn(&format!(
+        "task {kind:?} in {defined_in} has no summary, so it shows as \
+         \"{kind} task defined in {defined_in}\" in `aspect --help`. \
+         Add summary = \"…\" to task(...) — this becomes an error in a future release."
+    ));
+}
+
 fn defined_in_label(path: &Path, aspect_root: &Path, modules: &[Mod]) -> String {
     for r#mod in modules {
         if r#mod.is_root() || !path.starts_with(&r#mod.root) {
@@ -1844,6 +1870,52 @@ mod tests {
         assert_eq!(by_name("targets")["type"], "positional");
         // A flag arg carries no cardinality.
         assert_eq!(by_name("base_ref")["minimum"], serde_json::Value::Null);
+    }
+
+    /// `warn_missing_summary` deliberately stays quiet for `@mod//` tasks, so
+    /// nothing at runtime holds our own built-ins to the rule. This does: it
+    /// scans the built-in source tree for a `task(` call with no `summary`.
+    ///
+    /// Kept as a source scan rather than an evaluation of the task tree because
+    /// it must fail in CI on the file a contributor just wrote, and name it.
+    #[test]
+    fn every_builtin_task_declares_a_summary() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/builtins/aspect");
+        let mut offenders = Vec::new();
+
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("readable builtin dir") {
+                let path = entry.expect("readable entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().is_none_or(|e| e != "axl") {
+                    continue;
+                }
+                let text = std::fs::read_to_string(&path).expect("readable .axl");
+                // Task calls are declared at column 0 as `<var> = task(`; the
+                // body's keywords sit at one indent level.
+                for (idx, _) in text.match_indices(" = task(\n") {
+                    let body = &text[idx..];
+                    let end = body.find("\n)").unwrap_or(body.len());
+                    if !body[..end].contains("\n    summary = ") {
+                        let line = text[..idx].lines().count() + 1;
+                        let rel = path.strip_prefix(&root).unwrap_or(&path);
+                        offenders.push(format!("{}:{}", rel.display(), line));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "every built-in task must declare a summary — it is what `aspect --help` \
+             shows, and a reader (or an AI agent) picks a task from that line. \
+             Add `summary = \"…\"` at:\n  {}",
+            offenders.join("\n  ")
+        );
     }
 
     #[test]

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -104,7 +104,6 @@ impl<'a, 'v> Cmd<'a, 'v> {
         let mut tree = Tree::default();
         for (idx, task) in self.tasks.iter().enumerate() {
             let label = defined_in_label(task.path(), self.aspect_root, self.modules);
-            warn_missing_summary(*task, &label);
             let task_cmd = task_command(idx, *task, &label, &feature_blocks, &cli_header);
             tree.insert(*task, &label, task_cmd)?;
         }
@@ -1154,6 +1153,11 @@ fn task_command(
         kind, label,
     );
     let about = if task.summary().is_empty() {
+        // Warn beside the fallback rather than at the call site, so the
+        // diagnostic and the text it quotes cannot drift apart.
+        if needs_summary_warning(task.summary(), label) {
+            warn_missing_summary(&kind, label);
+        }
         context_line.clone()
     } else {
         task.summary().clone()
@@ -1370,16 +1374,22 @@ fn group_section(group_names: &[String]) -> String {
 /// cannot fix it. Built-in `@aspect//` tasks are held to the rule by
 /// `every_builtin_task_declares_a_summary` instead, so a regression there fails
 /// our CI rather than printing in a customer's terminal.
-fn warn_missing_summary(task: &dyn TaskLike<'_>, defined_in: &str) {
-    if !task.summary().is_empty() || defined_in.starts_with('@') {
-        return;
-    }
-    let kind = task.kind();
+fn warn_missing_summary(kind: &str, defined_in: &str) {
     diag::warn(&format!(
         "task {kind:?} in {defined_in} has no summary, so it shows as \
          \"{kind} task defined in {defined_in}\" in `aspect --help`. \
          Add summary = \"…\" to task(...) — this becomes an error in a future release."
     ));
+}
+
+/// Pure core of the [`warn_missing_summary`] gate, parameterized over its
+/// inputs so the rule is testable without capturing stderr.
+///
+/// Only first-party tasks qualify: [`defined_in_label`] reports a module's
+/// tasks as `@mod//…`, and warning about a third-party module's task would be
+/// noise the reader cannot act on.
+fn needs_summary_warning(summary: &str, defined_in: &str) -> bool {
+    summary.is_empty() && !defined_in.starts_with('@')
 }
 
 fn defined_in_label(path: &Path, aspect_root: &Path, modules: &[Mod]) -> String {
@@ -1483,6 +1493,7 @@ mod tests {
         group: Vec<String>,
         args: SmallMap<String, Arg>,
         path: PathBuf,
+        summary: String,
     }
 
     impl<'v> TaskLike<'v> for StubTask {
@@ -1490,7 +1501,7 @@ mod tests {
             &self.args
         }
         fn summary(&self) -> &String {
-            empty_string()
+            &self.summary
         }
         fn description(&self) -> &String {
             empty_string()
@@ -1521,12 +1532,16 @@ mod tests {
         }
     }
 
+    /// Carries a non-empty summary so building the CLI surface stays quiet —
+    /// an empty one trips the deprecation warning and floods test output.
+    /// `needs_summary_warning` covers that rule directly instead.
     fn stub_task(name: &str, group: &[&str], args: SmallMap<String, Arg>) -> StubTask {
         StubTask {
             name: name.to_owned(),
             group: group.iter().map(|s| s.to_string()).collect(),
             args,
             path: PathBuf::from("/repo/tasks/test.axl"),
+            summary: format!("Stub {name} task."),
         }
     }
 
@@ -1870,6 +1885,24 @@ mod tests {
         assert_eq!(by_name("targets")["type"], "positional");
         // A flag arg carries no cardinality.
         assert_eq!(by_name("base_ref")["minimum"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn summary_warning_fires_only_for_undocumented_first_party_tasks() {
+        // The case worth warning about: our own task, no summary.
+        assert!(needs_summary_warning("", ".aspect/deploy.axl"));
+
+        // A documented task never warns, wherever it came from.
+        assert!(!needs_summary_warning(
+            "Deploy the app.",
+            ".aspect/deploy.axl"
+        ));
+        assert!(!needs_summary_warning("Build it.", "@aspect//build.axl"));
+
+        // A module's undocumented task is not the reader's to fix, so warning
+        // about it would be pure noise.
+        assert!(!needs_summary_warning("", "@aspect//build.axl"));
+        assert!(!needs_summary_warning("", "@some_third_party//task.axl"));
     }
 
     /// `warn_missing_summary` deliberately stays quiet for `@mod//` tasks, so


### PR DESCRIPTION
Follow-up to #1377. A task declared without a `summary` renders as `"<kind> task defined in <file>"` in `aspect --help` — the level at which a reader chooses a task at all — so an undocumented task is effectively invisible. #1377 fixed the five built-ins that showed that placeholder; this makes the rule stick.

`summary` is slated to become a required argument to `task()`. Making it required today would be a hard break: any customer task lacking one would fail to *load*, so the CLI would refuse to start in that repo, with no migration window. This is the deprecation warning ahead of that, plus the cleanup that makes the warning credible.

**Warning.** `Cmd::build` now warns per task lacking a summary, naming the kind and the defining file:

```
WARNING: task "deploy" in .aspect/deploy.axl has no summary, so it shows as
"deploy task defined in .aspect/deploy.axl" in `aspect --help`. Add
summary = "…" to task(...) — this becomes an error in a future release.
```

It is scoped to tasks defined in the repo being run. A module's tasks come back from `defined_in_label` as `@mod//…`, and warning about a third-party module's task would be noise the reader cannot act on. That scoping is also why the check lives in `Cmd::build` rather than in the `task()` builtin — `task()` knows the defining path but not the module list, so it cannot tell a first-party task from a dependency's.

**Built-ins.** Filling every gap first is what keeps the warning credible; one that fires 43 times per invocation just teaches people to ignore warnings. Before this change 51 of 74 tasks had no summary. `aspect github token` gained a real one, the 42 internal `aspect dev test-*` tasks gained generated ones derived from their kind ("Run the tips AXL unit tests."), and this repo's own four root tasks are documented, so a local `aspect` run is now silent.

**Guard.** Because the runtime warning deliberately stays quiet for `@aspect//` tasks, nothing at runtime holds our own built-ins to the rule. `every_builtin_task_declares_a_summary` does, scanning the built-in source tree so a regression fails CI and names the `file:line` a contributor just wrote rather than surfacing in a customer's terminal.

Tracked in ENG-1975.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

```
- `aspect` now warns when a task in your repo is declared without a `summary`, naming the task and the file. A task without one shows as "<kind> task defined in <file>" in `aspect --help`. `summary` will become required in a future release — adding it now is forward-compatible.
- Every built-in task now has a summary, including `aspect github token` and the internal `aspect dev test-*` tasks.
```

### Test plan

- Covered by existing test cases (910 AXL cases via `aspect tests axl`; the `aspect-cli` unit suite)
- New test cases added:
  - `every_builtin_task_declares_a_summary` — scans the built-in source tree for a `task(` call with no `summary`, failing with the offending `file:line`.
- Manual testing:
  1. `aspect --help` in a repo with an undocumented task emits one warning per task, on stderr, naming the kind and file. Verified against this repo's four root tasks before documenting them.
  2. Tasks from `@dev//` and `@demo//` modules do **not** warn, confirming the first-party scoping.
  3. After documenting the four root tasks, `aspect --help 2>&1 >/dev/null | grep -c WARNING` returns 0.
  4. The guard was verified to fail, not just pass: removing a single `summary` makes it report `private/lib/tips_test.axl:738`. It caught a real regression during this change, when a `git checkout` reverted one of the insertions.
