### PR TITLE
chore: bump pinned CLI version to 2026.32.4

### DIFF
--- a/.aspect/version.axl
+++ b/.aspect/version.axl
@@ -1,5 +1,5 @@
 version(
-    "2026.31.17",
+    "2026.32.4",
     sources = [
         # Cargo build
         local("target/debug/aspect-cli"),


### PR DESCRIPTION
`.aspect/axl.axl` loads `@aspect//bazel/build_metadata.axl`, which #1367 added on 2026-08-04. Builtins are embedded into the binary at compile time, so the pinned 2026.31.17 (released 2026-08-01) does not have that path and every `aspect` command in this repo fails to evaluate:

```
error: path "bazel/build_metadata.axl" does not exist in module `aspect`.
  --> .aspect/axl.axl:5:1
```

Bumps the pin to 2026.32.4, which contains it.

Note this does not unblock a checkout that already has a stale local binary — `version.axl` lists `local(...)` sources ahead of `github(...)`, so a `bazel-bin/crates/aspect-cli/aspect-cli` from before 08-04 still wins. Those need a rebuild or a delete.

ENG-1978, which also notes a possible CI guard so a stale pin fails a PR instead of developer machines.

---

### Changes are visible to end-users: no

### Test plan

- Copied `.aspect/` + `MODULE.aspect` to a scratch dir with no local CLI sources, so the launcher resolves the pin:
  - `2026.32.4` — `aspect --help` loads the full tree, reports `Aspect CLI v2026.32.4`.
  - `2026.31.17` — same tree, reproduces the `build_metadata.axl` error exactly.
