### PR TITLE
feat(cli): make status-surface templates customizable and scopable per task kind

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -6,7 +6,7 @@ load("@aspect//feature/circleci_test_results.axl", "CircleCITestResults")
 load("@aspect//feature/github_status_checks.axl", "GithubStatusChecks")
 load("@aspect//format.axl", "format")
 load("@aspect//helpers.axl", "aspect_web_ui_url", "detect_build_url", "detect_ci_host", "render_bes_url")
-load("@aspect//private/feature/buildkite_annotations_test.axl", "bk_annotation_snapshot_tests")
+load("@aspect//private/feature/buildkite_annotations_test.axl", "bk_annotation_snapshot_tests", "bk_annotation_template_tests")
 load("@aspect//private/feature/github_status_comments_test.axl", "pr_comment_snapshot_tests")
 load("@aspect//private/helpers_test.axl", "helpers_facade_tests")
 load("@aspect//private/lib/aspect_endpoint_auth_test.axl", "aspect_endpoint_auth_tests")
@@ -409,6 +409,11 @@ def config(ctx: ConfigContext):
     # Buildkite annotations: snapshots the annotate body per kind × status.
     # Run with: aspect dev test-bk-annotation-snapshots
     ctx.tasks.add(bk_annotation_snapshot_tests)
+
+    # Template customization: `args.templates` overrides + the per-kind
+    # SUMMARY_TEMPLATE / DETAILS_TEMPLATE exports configs patch.
+    # Run with: aspect dev test-bk-annotation-templates
+    ctx.tasks.add(bk_annotation_template_tests)
 
     # GitHub PR comment: aggregate-status body across kinds/statuses/links/phases.
     # Run with: aspect dev test-pr-comment-snapshots

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -19,6 +19,25 @@ Usage in `.aspect/config.axl`:
         ctx.features[BuildkiteAnnotations].args.enabled = True
         # Open the build + test phase log sections by default (else collapsed).
         ctx.features[BuildkiteAnnotations].args.expand_phases = ["build", "test"]
+
+## Templates and metadata
+
+Rendering goes through the shared `check_dispatch.RENDERERS` table, so
+`templates` ("summary" / "details" Jinja2 overrides) and `metadata_keys`
+configure exactly as they do for `GithubStatusChecks` and
+`GitlabCommitStatuses`. Each per-kind renderer module exports its
+`SUMMARY_TEMPLATE` / `DETAILS_TEMPLATE` so a config can patch the built-in
+rather than re-author it:
+
+    ctx.features[BuildkiteAnnotations].args.templates = {
+        "summary": my_patched_summary_template,
+    }
+    ctx.features[BuildkiteAnnotations].args.metadata_keys = ["DEPLOY_ENV"]
+
+One `templates` dict serves every task kind this feature renders. The
+summary template is identical across kinds, so a summary override applies
+cleanly; details templates are kind-specific, so overriding "details"
+replaces it for all kinds alike.
 """
 
 load("../private/lib/bazel_results.axl", "format_run_date", "html_escape", "now_ms", "render_bes_url", "resolve_aspect_url")
@@ -204,6 +223,9 @@ def _write_annotation(ctx, style, body, context_id):
 def _buildkite_annotations(ctx: FeatureContext):
     lifecycle = ctx.traits[TaskLifecycleTrait]
 
+    templates = ctx.args.templates or {}
+    metadata_keys = list(ctx.args.metadata_keys or [])
+
     mode = ctx.args.mode
     is_bk = bool(ctx.std.env.var("BUILDKITE"))
 
@@ -331,8 +353,8 @@ def _buildkite_annotations(ctx: FeatureContext):
             status,
             make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_BUILDKITE_ANNOTATIONS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             _make_links(data),
-            None,
-            None,
+            templates,
+            metadata_keys,
             snippet_options = _snippet_opts,
             max_snippets = _max_snippets,
         )
@@ -378,6 +400,25 @@ BuildkiteAnnotations = feature(
                           "only the last collapsed section when none is explicitly expanded, so expanding " +
                           "an earlier phase suppresses that auto-expansion of the closing timing-summary " +
                           "section. Empty (default) leaves each phase's own `Phase.expanded`.",
+        ),
+        "templates": args.custom(
+            dict,
+            default = {},
+            description = "Map of template overrides for the rendered annotation body. " +
+                          "Keys: \"summary\", \"details\". Each value is a Jinja2 template " +
+                          "string. Empty dict (default) uses the feature's built-in templates. " +
+                          "The renderer's title, summary and details are concatenated into one " +
+                          "Markdown annotation, hard-capped at Buildkite's 1 MiB limit.",
+        ),
+        "metadata_keys": args.string_list(
+            default = [],
+            long = "buildkite-annotations:metadata-key",
+            description = "Additional BES build_metadata keys to surface in the annotation summary, " +
+                          "beyond the standard keys already rendered in the invocation rows " +
+                          "(BRANCH_NAME, COMMIT_SHA, TAG, COMMIT_MESSAGE, COMMIT_AUTHOR, …). Use " +
+                          "[\"*\"] to show ALL metadata keys from the BES stream. Users inject " +
+                          "custom keys via --bes_metadata=MY_KEY=value or --build_metadata=MY_KEY=value " +
+                          "on their Bazel invocation.",
         ),
     },
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -23,21 +23,21 @@ Usage in `.aspect/config.axl`:
 ## Templates and metadata
 
 Rendering goes through the shared `check_dispatch.RENDERERS` table, so
-`templates` ("summary" / "details" Jinja2 overrides) and `metadata_keys`
-configure exactly as they do for `GithubStatusChecks` and
-`GitlabCommitStatuses`. Each per-kind renderer module exports its
-`SUMMARY_TEMPLATE` / `DETAILS_TEMPLATE` so a config can patch the built-in
-rather than re-author it:
+`templates` and `metadata_keys` configure exactly as they do for
+`GithubStatusChecks` and `GitlabCommitStatuses`. Each per-kind renderer
+module exports its `SUMMARY_TEMPLATE` / `DETAILS_TEMPLATE` so a config can
+patch the built-in rather than re-author it.
+
+Flat "summary"/"details" keys apply to every task kind; a per-task-kind
+block ("build", "lint", …) overlays them for that kind alone, so a config
+can set a shared default and still special-case one task (see
+`check_dispatch.resolve_templates`):
 
     ctx.features[BuildkiteAnnotations].args.templates = {
-        "summary": my_patched_summary_template,
+        "summary": my_shared_summary_template,
+        "lint": {"details": my_lint_details_template},
     }
     ctx.features[BuildkiteAnnotations].args.metadata_keys = ["DEPLOY_ENV"]
-
-One `templates` dict serves every task kind this feature renders. The
-summary template is identical across kinds, so a summary override applies
-cleanly; details templates are kind-specific, so overriding "details"
-replaces it for all kinds alike.
 """
 
 load("../private/lib/bazel_results.axl", "format_run_date", "html_escape", "now_ms", "render_bes_url", "resolve_aspect_url")
@@ -47,6 +47,7 @@ load(
     "apply_artifact_links",
     "make_render_ctx",
     "renderer_for_kind",
+    "resolve_templates",
     "should_emit_update",
     "snippet_budget_for",
 )
@@ -353,7 +354,7 @@ def _buildkite_annotations(ctx: FeatureContext):
             status,
             make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_BUILDKITE_ANNOTATIONS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             _make_links(data),
-            templates,
+            resolve_templates(templates, ctx.task.kind),
             metadata_keys,
             snippet_options = _snippet_opts,
             max_snippets = _max_snippets,
@@ -405,10 +406,11 @@ BuildkiteAnnotations = feature(
             dict,
             default = {},
             description = "Map of template overrides for the rendered annotation body. " +
-                          "Keys: \"summary\", \"details\". Each value is a Jinja2 template " +
-                          "string. Empty dict (default) uses the feature's built-in templates. " +
-                          "The renderer's title, summary and details are concatenated into one " +
-                          "Markdown annotation, hard-capped at Buildkite's 1 MiB limit.",
+                          "Flat keys \"summary\" / \"details\" (Jinja2 strings) apply to every " +
+                          "task kind; a per-task-kind block (\"build\", \"test\", \"lint\", " +
+                          "\"format\", \"gazelle\", \"delivery\", \"warming\") overlays them for " +
+                          "that kind alone, e.g. {\"summary\": ..., \"lint\": {\"details\": ...}}. " +
+                          "Empty dict (default) uses the feature's built-in templates. The renderer's title, summary and details are concatenated into one Markdown annotation, hard-capped at Buildkite's 1 MiB limit.",
         ),
         "metadata_keys": args.string_list(
             default = [],

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -8,11 +8,14 @@ delivery_results → delivery). The per-kind dispatch table lives in
 `lib/check_dispatch.axl`, kept in lockstep with `BuildkiteAnnotations`;
 new task kinds plug in there.
 
-Templates and metadata_keys are feature args:
+Templates and metadata_keys are feature args. `templates` takes flat
+"summary"/"details" keys applying to every task kind, and/or per-task-kind
+blocks that overlay them (see `check_dispatch.resolve_templates`):
 
     def config(ctx: ConfigContext):
         ctx.features[GithubStatusChecks].args.templates = {
-            "summary": "my custom {{ status_label }} template",
+            "summary": my_shared_summary_template,
+            "lint": {"details": my_lint_details_template},
         }
         ctx.features[GithubStatusChecks].args.metadata_keys = ["DEPLOY_ENV", "WORKSPACE"]
         # Or ["*"] to show everything.
@@ -33,6 +36,7 @@ load(
     "kind_for_task",
     "make_render_ctx",
     "renderer_for_kind",
+    "resolve_templates",
     "should_emit_update",
     "snippet_budget_for",
 )
@@ -211,7 +215,7 @@ def _github_status_checks(ctx: FeatureContext):
             "running",
             make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITHUB_STATUS_CHECKS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             dict(_ci_links_base),
-            templates,
+            resolve_templates(templates, ctx.task.kind),
             metadata_keys,
         )
 
@@ -511,7 +515,7 @@ def _github_status_checks(ctx: FeatureContext):
             status,
             make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITHUB_STATUS_CHECKS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             _make_links(data),
-            templates,
+            resolve_templates(templates, ctx.task.kind),
             metadata_keys,
             snippet_options = _snippet_opts,
             max_snippets = _max_snippets,
@@ -587,8 +591,11 @@ GithubStatusChecks = feature(
             dict,
             default = {},
             description = "Map of template overrides for the rendered check-run output. " +
-                          "Keys: \"summary\", \"details\". Each value is a Jinja2 template " +
-                          "string. Empty dict (default) uses the feature's built-in templates.",
+                          "Flat keys \"summary\" / \"details\" (Jinja2 strings) apply to every " +
+                          "task kind; a per-task-kind block (\"build\", \"test\", \"lint\", " +
+                          "\"format\", \"gazelle\", \"delivery\", \"warming\") overlays them for " +
+                          "that kind alone, e.g. {\"summary\": ..., \"lint\": {\"details\": ...}}. " +
+                          "Empty dict (default) uses the feature's built-in templates.",
         ),
         "metadata_keys": args.string_list(
             default = [],

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -594,7 +594,8 @@ GithubStatusChecks = feature(
             default = [],
             long = "github-status-checks:metadata-key",
             description = "Additional BES build_metadata keys to surface in the check run summary, " +
-                          "beyond the built-in set (BRANCH, COMMIT_SHA, TAG, COMMIT_MESSAGE). Use " +
+                          "beyond the standard keys already rendered in the invocation rows " +
+                          "(BRANCH_NAME, COMMIT_SHA, TAG, COMMIT_MESSAGE, COMMIT_AUTHOR, …). Use " +
                           "[\"*\"] to show ALL metadata keys from the BES stream. Users inject " +
                           "custom keys via --bes_metadata=MY_KEY=value or --build_metadata=MY_KEY=value " +
                           "on their Bazel invocation.",

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -45,11 +45,14 @@ future feature that wants merge-blocking semantics.
 
 Rendering goes through the shared `check_dispatch.RENDERERS` table —
 templates and `metadata_keys` configure exactly as they do for
-`GithubStatusChecks`:
+`GithubStatusChecks`. Flat "summary"/"details" keys apply to every task
+kind; a per-task-kind block overlays them for that kind alone (see
+`check_dispatch.resolve_templates`):
 
     def config(ctx: ConfigContext):
         ctx.features[GitlabCommitStatuses].args.templates = {
-            "summary": "my custom {{ status_label }} template",
+            "summary": my_shared_summary_template,
+            "lint": {"details": my_lint_details_template},
         }
         ctx.features[GitlabCommitStatuses].args.metadata_keys = ["DEPLOY_ENV"]
 
@@ -71,6 +74,7 @@ load(
     "kind_for_task",
     "make_render_ctx",
     "renderer_for_kind",
+    "resolve_templates",
     "should_emit_update",
 )
 load("../private/lib/ci.axl", "detect_ci_host", "resolve_build_url")
@@ -301,7 +305,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             "running",
             make_render_ctx(_state, last_updated_at = format_run_date(ctx, now_ms(ctx))),
             initial_links,
-            templates,
+            resolve_templates(templates, ctx.task.kind),
             metadata_keys,
         )
         _post_status(ctx, "pending", initial_output, initial_links)
@@ -375,7 +379,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             status,
             make_render_ctx(_state, last_updated_at = format_run_date(ctx, now_ms(ctx))),
             links,
-            templates,
+            resolve_templates(templates, ctx.task.kind),
             metadata_keys,
         )
 
@@ -433,11 +437,11 @@ GitlabCommitStatuses = feature(
             dict,
             default = {},
             description = "Map of template overrides for the rendered status output. " +
-                          "Keys: \"summary\", \"details\". Each value is a Jinja2 template " +
-                          "string. Empty dict (default) uses the feature's built-in templates. " +
-                          "Note: only the rendered `title` lands on the commit status (in " +
-                          "`description`, truncated to 255 chars) — the full body is rendered " +
-                          "into the GitlabStatusComments rolling note.",
+                          "Flat keys \"summary\" / \"details\" (Jinja2 strings) apply to every " +
+                          "task kind; a per-task-kind block (\"build\", \"test\", \"lint\", " +
+                          "\"format\", \"gazelle\", \"delivery\", \"warming\") overlays them for " +
+                          "that kind alone, e.g. {\"summary\": ..., \"lint\": {\"details\": ...}}. " +
+                          "Empty dict (default) uses the feature's built-in templates. Note: only the rendered `title` lands on the commit status (in `description`, truncated to 255 chars) \u2014 the full body is rendered into the GitlabStatusComments rolling note.",
         ),
         "metadata_keys": args.string_list(
             default = [],

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -50,7 +50,14 @@ load(
     BAZEL_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
     bazel_render_check_output = "render_check_output",
 )
-load("../lib/check_dispatch.axl", "make_render_ctx")
+load(
+    "../lib/check_dispatch.axl",
+    "TEMPLATE_SCOPE_KEYS",
+    "kind_for_task",
+    "make_render_ctx",
+    "renderer_for_kind",
+    "resolve_templates",
+)
 load(
     "../lib/delivery_results.axl",
     DELIVERY_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
@@ -217,9 +224,13 @@ def _test_impl(ctx):
 
         # Show first 2500 chars of the formatted body — enough to see the
         # title/summary and the first chunk of the body without flooding.
+        # The exact length is deliberately not printed: the summary carries a
+        # live `ctx.task.elapsed_ms` reading, so it shifts by a character
+        # whenever the run crosses a digit boundary (99ms -> 100ms) and would
+        # make this snapshot flap between runs.
         print(body[:2500])
         if len(body) > 2500:
-            print("... [truncated, full length: %d chars]" % len(body))
+            print("... [truncated]")
         print("")
 
     print(sep)
@@ -335,8 +346,45 @@ def _test_templates_impl(ctx: TaskContext) -> int:
     )
     _contains("broken summary degrades to fallback", broken_out.get("summary"), "unavailable")
 
+    _assert_resolve_templates()
+
     print("All template-customization assertions passed for %d kinds." % len(_KIND_TEMPLATES))
     return 0
+
+def _assert_resolve_templates():
+    """`resolve_templates` narrows a feature's `args.templates` to the flat
+    dict the renderers take, honoring per-task-kind scoping."""
+    _eq("empty stays None", resolve_templates({}, "build"), None)
+    _eq("None stays None", resolve_templates(None, "build"), None)
+
+    # Flat keys are the pre-scoping shape and must keep applying to every kind.
+    flat = {"summary": "S", "details": "D"}
+    for kind in ["build", "test", "lint", "format", "gazelle", "delivery", "warming"]:
+        _eq("flat applies to %s" % kind, resolve_templates(flat, kind), {"summary": "S", "details": "D"})
+
+    # A scoped block applies to its own kind and is invisible to others.
+    scoped = {"lint": {"details": "LINT"}}
+    _eq("scoped hits its kind", resolve_templates(scoped, "lint"), {"details": "LINT"})
+    _eq("scoped misses other kinds", resolve_templates(scoped, "build"), None)
+
+    # Scoped overlays flat: shared default, one kind special-cased.
+    both = {"summary": "S", "details": "D", "lint": {"details": "LINT"}}
+    _eq("overlay replaces details", resolve_templates(both, "lint"), {"summary": "S", "details": "LINT"})
+    _eq("overlay leaves others flat", resolve_templates(both, "build"), {"summary": "S", "details": "D"})
+
+    # build and test are separable even though both render via bazel_results.
+    split = {"build": {"summary": "B"}, "test": {"summary": "T"}}
+    _eq("build scope", resolve_templates(split, "build"), {"summary": "B"})
+    _eq("test scope", resolve_templates(split, "test"), {"summary": "T"})
+
+    # An unknown task kind sees only the flat keys — no crash, no scoped block.
+    _eq("unknown kind falls back to flat", resolve_templates(both, "mystery"), {"summary": "S", "details": "D"})
+
+    # Every scope key must name a task kind that actually has a renderer,
+    # else a config could scope an override that never fires.
+    for kind in TEMPLATE_SCOPE_KEYS:
+        if renderer_for_kind(kind_for_task(kind)) == None:
+            fail("scope key %r has no renderer" % kind)
 
 bk_annotation_template_tests = task(
     summary = "Run the bk annotation template customization AXL unit tests.",

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -1,18 +1,21 @@
-"""Snapshot tests for `feature/buildkite_annotations.axl`.
+"""Tests for `feature/buildkite_annotations.axl`.
 
-Run with:
-  aspect dev test-bk-annotation-snapshots
+Two suites, both dry-run — we never invoke `buildkite-agent annotate`, and
+instead drive the per-kind renderers plus the feature's `format_body` /
+`severity_for_status` helpers directly.
 
-Dry-run style — we don't actually invoke `buildkite-agent annotate`. Instead,
-we call the per-kind renderers + the feature's `format_body` / `severity_for_status`
-helpers directly and print what *would* be sent to BK for each scenario.
-
-Coverage:
+`aspect dev test-bk-annotation-snapshots` prints what *would* be sent to BK
+for each scenario, so a rendering regression shows up as a visible diff:
   - Each task kind (bazel_results, lint_results, delivery_results,
     format_results, gazelle_results, warming_results)
   - Each terminal status (passed, failed)
   - Style selection edge cases: soft-lint passing with warnings, delivery
     all-skipped, delivery all-failed, soft-format passing with files.
+
+`aspect dev test-bk-annotation-templates` asserts the customization contract
+`args.templates` exposes: overrides reach the rendered body, "summary" and
+"details" are independent, every renderer module exports the templates a
+config patches, and a broken template degrades to the fallback body.
 """
 
 load("@aspect//feature/buildkite_annotations.axl", "format_body")
@@ -43,28 +46,40 @@ load(
 )
 load(
     "../lib/bazel_results.axl",
+    BAZEL_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
+    BAZEL_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
     bazel_render_check_output = "render_check_output",
 )
 load("../lib/check_dispatch.axl", "make_render_ctx")
 load(
     "../lib/delivery_results.axl",
+    DELIVERY_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
+    DELIVERY_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
     delivery_render_check_output = "render_check_output",
 )
 load(
     "../lib/format_results.axl",
+    FORMAT_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
+    FORMAT_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
     format_render_check_output = "render_check_output",
 )
 load(
     "../lib/gazelle_results.axl",
+    GAZELLE_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
+    GAZELLE_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
     gazelle_render_check_output = "render_check_output",
 )
 load(
     "../lib/lint_results.axl",
+    LINT_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
+    LINT_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
     lint_render_check_output = "render_check_output",
 )
 load("../lib/result_text.axl", "severity_for_status")
 load(
     "../lib/warming_results.axl",
+    WARMING_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
+    WARMING_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
     warming_init_data = "init_data",
     warming_render_check_output = "render_check_output",
 )
@@ -216,5 +231,117 @@ bk_annotation_snapshot_tests = task(
     kind = "test-bk-annotation-snapshots",
     group = ["dev"],
     implementation = _test_impl,
+    args = {},
+)
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _contains(label, haystack, needle):
+    if needle not in haystack:
+        fail("%s: %r not found in %r" % (label, needle, haystack[:400]))
+
+def _not_contains(label, haystack, needle):
+    if needle in haystack:
+        fail("%s: %r unexpectedly present in %r" % (label, needle, haystack[:400]))
+
+# renderer kind -> its exported (SUMMARY_TEMPLATE, DETAILS_TEMPLATE). Importing
+# these at all is half the assertion: a config can only patch a built-in the
+# module actually exports.
+_KIND_TEMPLATES = {
+    "bazel_results": (BAZEL_SUMMARY_TEMPLATE, BAZEL_DETAILS_TEMPLATE),
+    "lint_results": (LINT_SUMMARY_TEMPLATE, LINT_DETAILS_TEMPLATE),
+    "format_results": (FORMAT_SUMMARY_TEMPLATE, FORMAT_DETAILS_TEMPLATE),
+    "gazelle_results": (GAZELLE_SUMMARY_TEMPLATE, GAZELLE_DETAILS_TEMPLATE),
+    "delivery_results": (DELIVERY_SUMMARY_TEMPLATE, DELIVERY_DETAILS_TEMPLATE),
+    "warming_results": (WARMING_SUMMARY_TEMPLATE, WARMING_DETAILS_TEMPLATE),
+}
+
+def _test_templates_impl(ctx: TaskContext) -> int:
+    """`args.templates` overrides reach the rendered annotation body, and each
+    renderer's built-in templates are importable so configs can patch them.
+
+    Guards the customization contract documented in the feature docstring:
+    the summary template is shared across kinds (so one override applies
+    everywhere), and every kind re-exports it for patching.
+    """
+    data = _make_build_passed()
+    rc = _render_ctx("//...", "build")
+
+    default_out = bazel_render_check_output(ctx, data, "passed", rc, _bk_links(), None, None)
+    default_body = format_body(default_out, "bazel_results", "passed", final = True)
+    _contains("default summary line", default_body, ":speech_balloon: **Last update:**")
+
+    # The patch-the-default pattern from the feature docstring: anchor on the
+    # built-in's last-update line and swap it for a Buildkite-native one.
+    anchor = ":speech_balloon: **Last update:** `{{ last_update }}`{% endif %}"
+    _contains("anchor present in exported template", BAZEL_SUMMARY_TEMPLATE, anchor)
+    patched = BAZEL_SUMMARY_TEMPLATE.replace(
+        anchor,
+        ":buildkite: **Status:** `{{ last_update }}`{% endif %}",
+    )
+
+    custom_out = bazel_render_check_output(ctx, data, "passed", rc, _bk_links(), {"summary": patched}, None)
+    custom_body = format_body(custom_out, "bazel_results", "passed", final = True)
+    _contains("custom summary line rendered", custom_body, ":buildkite: **Status:**")
+    _not_contains("default summary line replaced", custom_body, ":speech_balloon: **Last update:**")
+
+    # An override of one key must leave the other's output untouched. The
+    # summary is asserted by substring, not equality — it embeds a live
+    # elapsed-time reading that ticks between renders.
+    _eq("details untouched by summary override", custom_out.get("text"), default_out.get("text"))
+
+    details_out = bazel_render_check_output(
+        ctx,
+        data,
+        "passed",
+        rc,
+        _bk_links(),
+        {"details": "CUSTOM DETAILS BODY"},
+        None,
+    )
+    _eq("details override applied", details_out.get("text"), "CUSTOM DETAILS BODY")
+    _contains(
+        "summary untouched by details override",
+        details_out.get("summary"),
+        ":speech_balloon: **Last update:** `build task complete`",
+    )
+
+    # The summary being byte-identical across kinds is what lets one
+    # `templates` override serve every task kind a feature renders.
+    for kind, (summary_tmpl, details_tmpl) in _KIND_TEMPLATES.items():
+        if not summary_tmpl:
+            fail("%s: SUMMARY_TEMPLATE is empty" % kind)
+        if not details_tmpl:
+            fail("%s: DETAILS_TEMPLATE is empty" % kind)
+        _eq("%s summary matches bazel_results" % kind, summary_tmpl, BAZEL_SUMMARY_TEMPLATE)
+        _contains("%s summary carries the patch anchor" % kind, summary_tmpl, anchor)
+
+    # Details templates are kind-specific — a shared details body would mean
+    # the per-kind renderers had collapsed into one.
+    if LINT_DETAILS_TEMPLATE == BAZEL_DETAILS_TEMPLATE:
+        fail("lint and bazel details templates should differ")
+
+    # A broken template degrades to the fallback body instead of aborting.
+    broken_out = bazel_render_check_output(
+        ctx,
+        data,
+        "passed",
+        rc,
+        _bk_links(),
+        {"summary": "{% if unclosed %}"},
+        None,
+    )
+    _contains("broken summary degrades to fallback", broken_out.get("summary"), "unavailable")
+
+    print("All template-customization assertions passed for %d kinds." % len(_KIND_TEMPLATES))
+    return 0
+
+bk_annotation_template_tests = task(
+    summary = "Run the bk annotation template customization AXL unit tests.",
+    kind = "test-bk-annotation-templates",
+    group = ["dev"],
+    implementation = _test_templates_impl,
     args = {},
 )

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
@@ -121,6 +121,41 @@ def kind_for_task(task_kind):
     """
     return _TASK_KIND_DEFAULTS.get(task_kind, "bazel_results")
 
+# Task-kind keys a `templates` dict may nest an override under, as opposed to
+# the flat "summary"/"details" keys that address every kind at once.
+TEMPLATE_SCOPE_KEYS = sorted(_TASK_KIND_DEFAULTS.keys())
+
+def resolve_templates(templates, task_kind):
+    """Narrow a feature's `args.templates` to the flat {"summary", "details"}
+    dict the per-kind renderers accept.
+
+    Two shapes are supported, and they compose:
+
+      {"summary": ...}                     — applies to every task kind
+      {"lint": {"summary": ...}}           — applies to `lint` tasks only
+
+    A per-kind block overlays the flat keys, so a config can set a shared
+    default and override one kind without restating the rest. `task_kind` is
+    the task's own kind ("build", "lint", …), not the renderer kind, since
+    that is how tasks are addressed everywhere else in config (`ctx.tasks[…]`);
+    it also keeps `build` and `test` separable even though both render through
+    `bazel_results`.
+
+    Returns None when nothing applies, matching what the renderers treat as
+    "use the built-ins".
+    """
+    if not templates:
+        return None
+
+    flat = {k: v for k, v in templates.items() if k not in TEMPLATE_SCOPE_KEYS}
+    scoped = templates.get(task_kind) or {}
+    if type(scoped) != "dict":
+        fail("templates[%r] must be a dict of template overrides, got %r" % (task_kind, scoped))
+
+    resolved = dict(flat)
+    resolved.update(scoped)
+    return resolved or None
+
 # Per-surface inline-snippet budgets (max snippets shown + per-snippet line cap).
 # Status checks / BK annotations are glanceable and bump the surface size caps
 # (GitHub 65 KB, BK 1 MiB), so they stay tight; the PR summary comment is the

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/delivery_results.axl
@@ -14,7 +14,7 @@ load(
     "FIX_COMMANDS_BLOCK",
     "REPRO_COMMANDS_BLOCK",
     "SHARED_DETAILS_BODY_TEMPLATE",
-    "TIPS_BLOCK",
+    "SUMMARY_TEMPLATE",
     "active_phase_data",
     "build_details_data",
     "build_summary_data",
@@ -269,14 +269,7 @@ def _plural(count, singular, plural = None):
 
 # ─── Templates ────────────────────────────────────────────────────────────────
 
-_SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
-{% for item in row %}{{ item.icon }} {{ item.value }}{% if not loop.last %} · {% endif %}{% endfor %}{% if not loop.last %}  {% endif %}
-{%- endfor %}{% endif %}
-{% if config_items %}
-:gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
-
-_DETAILS_TEMPLATE = """{% if total == 0 %}### 🚀 No deliveries
+DETAILS_TEMPLATE = """{% if total == 0 %}### 🚀 No deliveries
 
 _No targets selected for delivery._{% else %}### 🚀 Delivery results
 
@@ -512,8 +505,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_data = dict(shared_data)
     details_data.update(_build_details_data(data, render_ctx, status))
 
-    summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
-    details_tmpl = t.get("details") or _DETAILS_TEMPLATE
+    summary_tmpl = t.get("summary") or SUMMARY_TEMPLATE
+    details_tmpl = t.get("details") or DETAILS_TEMPLATE
 
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "delivery")
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/format_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/format_results.axl
@@ -19,7 +19,7 @@ load(
     "FIX_COMMANDS_BLOCK",
     "REPRO_COMMANDS_BLOCK",
     "SHARED_DETAILS_BODY_TEMPLATE",
-    "TIPS_BLOCK",
+    "SUMMARY_TEMPLATE",
     "active_phase_data",
     "build_details_data",
     "build_summary_data",
@@ -164,14 +164,7 @@ def conclusion(status, data):
 
 # ─── Templates ────────────────────────────────────────────────────────────────
 
-_SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
-{% for item in row %}{{ item.icon }} {{ item.value }}{% if not loop.last %} · {% endif %}{% endfor %}{% if not loop.last %}  {% endif %}
-{%- endfor %}{% endif %}
-{% if config_items %}
-:gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
-
-_DETAILS_TEMPLATE = """{% if is_running %}
+DETAILS_TEMPLATE = """{% if is_running %}
 > 🔄 Format task in progress...
 
 {% elif formatter_error %}
@@ -358,8 +351,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_data = dict(shared_data)
     details_data.update(_build_details_data(data, status))
 
-    summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
-    details_tmpl = t.get("details") or _DETAILS_TEMPLATE
+    summary_tmpl = t.get("summary") or SUMMARY_TEMPLATE
+    details_tmpl = t.get("details") or DETAILS_TEMPLATE
 
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "format")
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gazelle_results.axl
@@ -18,7 +18,7 @@ load(
     "FIX_COMMANDS_BLOCK",
     "REPRO_COMMANDS_BLOCK",
     "SHARED_DETAILS_BODY_TEMPLATE",
-    "TIPS_BLOCK",
+    "SUMMARY_TEMPLATE",
     "active_phase_data",
     "build_details_data",
     "build_summary_data",
@@ -234,14 +234,7 @@ def conclusion(status, data):
 
 # ─── Templates ────────────────────────────────────────────────────────────────
 
-_SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
-{% for item in row %}{{ item.icon }} {{ item.value }}{% if not loop.last %} · {% endif %}{% endfor %}{% if not loop.last %}  {% endif %}
-{%- endfor %}{% endif %}
-{% if config_items %}
-:gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
-
-_DETAILS_TEMPLATE = """{% if is_running %}
+DETAILS_TEMPLATE = """{% if is_running %}
 > 🔄 Gazelle task in progress...
 
 {% elif gazelle_error %}
@@ -414,8 +407,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_data = dict(shared_data)
     details_data.update(_build_details_data(data, status))
 
-    summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
-    details_tmpl = t.get("details") or _DETAILS_TEMPLATE
+    summary_tmpl = t.get("summary") or SUMMARY_TEMPLATE
+    details_tmpl = t.get("details") or DETAILS_TEMPLATE
 
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "gazelle")
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lint_results.axl
@@ -18,7 +18,7 @@ load(
     "RENDER_META_STANDARD_KEYS",
     "REPRO_COMMANDS_BLOCK",
     "SHARED_DETAILS_BODY_TEMPLATE",
-    "TIPS_BLOCK",
+    "SUMMARY_TEMPLATE",
     "active_phase_data",
     "build_details_data",
     "build_summary_data",
@@ -213,16 +213,7 @@ def _findings_phrase(errs, warns, infos):
         return "0 findings"
     return ", ".join(parts)
 
-# Summary template reuses bazel_results' SUMMARY_TEMPLATE layout: `detail_rows`
-# (from build_invocation_rows) renders the icon/line grid.
-_SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
-{% for item in row %}{{ item.icon }} {{ item.value }}{% if not loop.last %} · {% endif %}{% endfor %}{% if not loop.last %}  {% endif %}
-{%- endfor %}{% endif %}
-{% if config_items %}
-:gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
-
-_DETAILS_TEMPLATE = """{% if lint_no_diagnostics_failure %}
+DETAILS_TEMPLATE = """{% if lint_no_diagnostics_failure %}
 > ⚠️ Lint task was aborted: {{ lint_no_diagnostics_failure }}
 
 {% endif %}
@@ -832,8 +823,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_data = dict(shared_data)
     details_data.update(_build_details_data(data, render_ctx, status, links = links))
 
-    summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
-    details_tmpl = t.get("details") or _DETAILS_TEMPLATE
+    summary_tmpl = t.get("summary") or SUMMARY_TEMPLATE
+    details_tmpl = t.get("details") or DETAILS_TEMPLATE
 
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "lint")
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/warming_results.axl
@@ -23,7 +23,7 @@ load(
     "./bazel_results.axl",
     "REPRO_COMMANDS_BLOCK",
     "SHARED_DETAILS_BODY_TEMPLATE",
-    "TIPS_BLOCK",
+    "SUMMARY_TEMPLATE",
     "active_phase_data",
     "build_details_data",
     "build_summary_data",
@@ -106,14 +106,7 @@ def conclusion(status, data):
         return "Caches populated"
     return ""
 
-_SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
-{% for item in row %}{{ item.icon }} {{ item.value }}{% if not loop.last %} · {% endif %}{% endfor %}{% if not loop.last %}  {% endif %}
-{%- endfor %}{% endif %}
-{% if config_items %}
-:gear: {% for item in config_items %}**{{ item.key }}:** `{{ item.value }}`{% if not loop.last %} · {% endif %}{% endfor %}{% if last_update %}  {% endif %}{% endif %}{% if last_update %}
-:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
-
-_DETAILS_TEMPLATE = """{% if is_running %}
+DETAILS_TEMPLATE = """{% if is_running %}
 > 🔄 Warming task in progress...
 
 {% elif is_aborted %}
@@ -183,8 +176,8 @@ def render_check_output(ctx, data, status, render_ctx, links, templates = None, 
     details_data = dict(shared_data)
     details_data.update(_build_details_data(data, status))
 
-    summary_tmpl = t.get("summary") or _SUMMARY_TEMPLATE
-    details_tmpl = t.get("details") or _DETAILS_TEMPLATE
+    summary_tmpl = t.get("summary") or SUMMARY_TEMPLATE
+    details_tmpl = t.get("details") or DETAILS_TEMPLATE
 
     (summary_text, _summary_ok) = render_summary_or_fallback(ctx, summary_tmpl, summary_data, surface = "warming")
     (details_text, _rendered_ok) = render_details_or_fallback(ctx, details_tmpl, details_data, surface = "warming")


### PR DESCRIPTION
Status surfaces render through a shared table of per-task-kind renderers, and each renderer accepts `summary` / `details` Jinja2 overrides. Two gaps made that surface hard to actually use.

`BuildkiteAnnotations` never plumbed the overrides through — it hardcoded `None` at its render call, so its annotation body could not be customized at all. It now takes `templates` and `metadata_keys` like `GithubStatusChecks` and `GitlabCommitStatuses`.

Customizing a surface usually means patching one line of a built-in template rather than re-authoring it, which requires importing the default. Only `bazel_results` exported its templates; the other five used `_SUMMARY_TEMPLATE` / `_DETAILS_TEMPLATE`, and the leading underscore is a hard runtime block (`Cannot import private symbol`). Dropping it on lint, format, gazelle, delivery and warming lets a config patch any kind. Those five summary templates turned out to be byte-identical copies of the bazel one, so they now import it instead of redeclaring it.

Finally, one `templates` dict applied to every task kind at once, so a lint-specific `details` override also replaced the build and test bodies. Overrides can now be scoped:

```python
ctx.features[GithubStatusChecks].args.templates = {
    "summary": my_shared_summary_template,      # every task kind
    "lint": {"details": my_lint_details_template},  # lint only
}
```

A per-kind block overlays the flat keys rather than replacing them. Keys are task kinds (`build`, `lint`, …) rather than renderer kinds, matching how tasks are addressed elsewhere in config and keeping `build` and `test` separable though both render via `bazel_results`. Resolution lives in `check_dispatch.resolve_templates`; the renderers still take a flat dict.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Buildkite annotations are now customizable via `BuildkiteAnnotations.args.templates` and `.args.metadata_keys`, matching `GithubStatusChecks` and `GitlabCommitStatuses`.

Every per-kind renderer module now exports its `SUMMARY_TEMPLATE` and `DETAILS_TEMPLATE`, so a config can patch a built-in template instead of re-authoring it.

Template overrides on `GithubStatusChecks`, `GitlabCommitStatuses` and `BuildkiteAnnotations` can be scoped to a single task kind, e.g. `{"lint": {"details": ...}}`. Flat `summary`/`details` keys still apply to every kind.

The `metadata_keys` help text no longer names a `BRANCH` metadata key, which does not exist — the key is `BRANCH_NAME`.

### Test plan

- New test cases added — `aspect dev test-bk-annotation-templates` asserts that overrides reach the rendered body, that `summary` and `details` are independent, that every renderer module exports the templates a config patches, that per-kind scoping resolves and overlays correctly (including flat-only backward compatibility), and that a broken template degrades to the fallback body rather than aborting the task.
- Covered by existing test cases — 43 AXL suites and 74 cargo tests pass. The BK annotation snapshot renders byte-identically to a pre-change baseline, confirming the template consolidation is behavior-preserving.
- Verified the new suite catches regressions by mutation testing: re-privatizing `lint_results.DETAILS_TEMPLATE` fails it.

Also drops the byte count from the BK snapshot output. It was derived from a live `ctx.task.elapsed_ms` reading and flapped by one character whenever a run crossed a digit boundary (`99ms` -> `100ms`), making the snapshot non-deterministic. Pre-existing and unrelated to the rest of this change.
