### PR TITLE
feat(cli): status_surface_update hook to suppress, restyle, or rewrite CI status writes

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -22,6 +22,7 @@ load("@aspect//private/lib/format_results_test.axl", "format_template_snapshot_t
 load("@aspect//private/lib/format_spawn_test.axl", "format_spawn_tests")
 load("@aspect//private/lib/gazelle_results_test.axl", "gazelle_template_snapshot_tests")
 load("@aspect//private/lib/github_detect_test.axl", "github_detect_tests")
+load("@aspect//private/lib/github_features_test.axl", "github_features_tests")
 load("@aspect//private/lib/gitlab_detect_test.axl", "gitlab_detect_tests")
 load("@aspect//private/lib/gitlab_features_test.axl", "gitlab_features_tests")
 load("@aspect//private/lib/gitlab_lint_comments_test.axl", "gitlab_lint_comments_tests")
@@ -272,6 +273,10 @@ def config(ctx: ConfigContext):
     # GitLab features unit: state mapping + description truncation + marker shape.
     # Run with: aspect dev test-gitlab-features
     ctx.tasks.add(gitlab_features_tests)
+
+    # GitHub features unit: check-run conclusion mapping.
+    # Run with: aspect dev test-github-features
+    ctx.tasks.add(github_features_tests)
 
     # GitHub event detection smoke: PR/merge_group/push shapes for detect_changed_files.
     # Run with: aspect dev test-github-detect

--- a/crates/aspect-cli/src/builtins/aspect/BUILD.bazel
+++ b/crates/aspect-cli/src/builtins/aspect/BUILD.bazel
@@ -1,0 +1,1 @@
+genrule(name = "hello", outs = ["hello.txt"], cmd = "echo hi > $@")

--- a/crates/aspect-cli/src/builtins/aspect/BUILD.bazel
+++ b/crates/aspect-cli/src/builtins/aspect/BUILD.bazel
@@ -1,1 +1,0 @@
-genrule(name = "hello", outs = ["hello.txt"], cmd = "echo hi > $@")

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -175,7 +175,8 @@ def _format_body(out, kind, status, task_label = "", final = False):
     (https://forum.buildkite.community/t/3820). Terminal renders keep the
     `<details>` form so users can collapse what they're done with.
 
-    Hard-cap at 1 MiB; BK rejects larger annotations.
+    Size is not capped here — `_write_annotation` truncates at the send
+    boundary, after any `status_surface_decision` rewrite.
     """
     title = out.get("title", "") or ""
     summary = out.get("summary", "") or ""
@@ -216,13 +217,7 @@ def _format_body(out, kind, status, task_label = "", final = False):
         parts.append('<div class="border-top my3"></div>')
     if text:
         parts.append(text.strip())
-    body = "\n\n".join(parts)
-
-    if len(body) > _ANNOTATION_SIZE_LIMIT:
-        # Trim from the tail — the body (`text`) is where trim cascades live,
-        # and the summary/title are the most useful parts to preserve.
-        body = body[:_ANNOTATION_SIZE_LIMIT - 64] + "\n\n_… annotation truncated (1 MiB limit)._"
-    return body
+    return "\n\n".join(parts)
 
 def _task_label(task_name):
     """`:aspect: task <code>task-name</code>` — the leading pill that
@@ -247,7 +242,14 @@ def _write_annotation(ctx, style, body, context_id):
     `--context <id>` makes the call idempotent — re-running with the same
     context replaces the previous annotation rather than creating a new one.
     Body is passed on stdin to sidestep argv length limits.
+
+    Bodies past BK's 1 MiB hard limit are tail-truncated here, at the send
+    boundary, so a `status_surface_decision` rewrite can't push past it —
+    the head (title/summary) is the useful part to keep.
     """
+    if len(body) > _ANNOTATION_SIZE_LIMIT:
+        body = body[:_ANNOTATION_SIZE_LIMIT - 64] + "\n\n_… annotation truncated (1 MiB limit)._"
+
     _LOG.trace("invoking buildkite-agent annotate --style %s --context %s --scope=job (body=%d bytes)" %
                (style, context_id, len(body)))
 
@@ -291,9 +293,8 @@ def _remove_annotation(ctx, context_id):
     the removal targets exactly the annotation this task created.
 
     A failure is logged at trace, not warn: BK errors when the annotation
-    isn't there, which is the expected outcome whenever nothing was posted
-    (the task never streamed an update, or a prior cycle already removed it).
-    Nothing downstream depends on the removal succeeding.
+    isn't there, which is expected whenever the hook removed before the first
+    write went out. Nothing downstream depends on the removal succeeding.
     """
     _LOG.trace("invoking buildkite-agent annotation remove --context %s --scope=job" % context_id)
 
@@ -407,10 +408,8 @@ def _buildkite_annotations(ctx: FeatureContext):
         status = update.status
         final = update.final
 
-        # A removal is terminal for this task's annotation: re-posting after
-        # retracting it would resurrect what the hook just asked to hide, and
-        # re-deciding would re-render a body only to throw it away again. Bail
-        # before any work — the hook already had its say.
+        # A removal latches: re-posting would resurrect what the hook asked to
+        # hide, so bail before any further rendering or hook consults.
         if _state.get("_removed"):
             return
 
@@ -458,12 +457,8 @@ def _buildkite_annotations(ctx: FeatureContext):
             max_snippets = _max_snippets,
         )
 
-        # Ask the config what to do with this write. Consulted after rendering
-        # so the hook can rewrite `body`; a `remove` verdict therefore discards
-        # a body we already paid for, which is the accepted trade for letting
-        # hooks edit content. Still cheaper than the alternative a config has
-        # today — a `task_update` hook can't do this at all, since those run
-        # after the feature has already posted (see the module docstring).
+        # Consulted after rendering so hooks can rewrite the body; a `remove`
+        # verdict discards the render, the cost of giving hooks that access.
         decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
             surface = StatusSurface("buildkite_annotation"),
             status = status,
@@ -480,7 +475,7 @@ def _buildkite_annotations(ctx: FeatureContext):
             return
 
         body = decision.body
-        style = decision.style or severity_for_status(status)
+        style = decision.style
         if final:
             _LOG.trace("completing %s (style=%s len=%d)" %
                        (context_id, style, len(body)))

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -19,17 +19,42 @@ Usage in `.aspect/config.axl`:
         ctx.features[BuildkiteAnnotations].args.enabled = True
         # Open the build + test phase log sections by default (else collapsed).
         ctx.features[BuildkiteAnnotations].args.expand_phases = ["build", "test"]
-        # Keep the Annotations tab to tasks that need attention.
-        ctx.features[BuildkiteAnnotations].args.remove_on = ["passed"]
 
-## Removing an annotation on success
+## Suppressing or restyling an annotation
 
-`remove_on` names the terminal statuses whose annotation is retracted rather
-than finalized. This has to live in the feature: `task_update` handlers run in
+`TaskLifecycleTrait.status_surface_decision` is consulted immediately before
+every write and returns a verdict — publish (optionally restyled) or remove.
+To drop the annotation for tasks that finished clean, so the Annotations tab
+only lists what needs attention:
+
+    load(
+        "@aspect//traits.axl",
+        "SURFACE_PUBLISH",
+        "SURFACE_REMOVE",
+        "StatusSurfaceInfo",
+        "TaskLifecycleTrait",
+    )
+
+    def _drop_when_passed(ctx: TaskContext, info: StatusSurfaceInfo):
+        if info.final and info.status == "passed":
+            return SURFACE_REMOVE
+        return SURFACE_PUBLISH
+
+    def config(ctx):
+        ctx.traits[TaskLifecycleTrait].status_surface_decision.append(_drop_when_passed)
+
+A `remove` verdict *replaces* the write rather than following it, so the
+annotation never flickers into view and the body is never rendered just to be
+discarded. Anything this task already published is retracted.
+
+This can't be done from a `task_update` hook: those handlers run in
 registration order and features register before a config's own hooks, so a
 config hook that shells out to `annotation remove` is immediately followed by
-this feature re-posting the terminal annotation. Doing it here replaces the
-terminal write instead of racing it.
+this feature re-posting the terminal annotation.
+
+Hooks see live updates too, not just the terminal one, so a hook that ignores
+`info.final` retracts mid-run as well. Scope by `info.surface` when several
+status surfaces are enabled.
 
 ## Templates and metadata
 
@@ -64,7 +89,16 @@ load(
 )
 load("../private/lib/ci.axl", "resolve_build_url")
 load("../private/lib/environment.axl", "feature_logger", "workflows_results_url")
-load("../private/lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate", "publish_expanded_phases")
+load(
+    "../private/lib/lifecycle.axl",
+    "StatusSurface",
+    "StatusSurfaceAction",
+    "StatusSurfaceInfo",
+    "TaskLifecycleTrait",
+    "TaskUpdate",
+    "apply_status_surface_hooks",
+    "publish_expanded_phases",
+)
 load("../private/lib/rate_limit.axl", "usage_footer")
 load("../private/lib/result_text.axl", "severity_for_status")
 load("../private/lib/tips.axl", "SURFACE_BUILDKITE_ANNOTATIONS", "collect_tips_sorted")
@@ -75,25 +109,11 @@ def format_body(out, kind, status, task_label = "", final = False):
     """Public test hook; see `_format_body` for behavior."""
     return _format_body(out, kind, status, task_label = task_label, final = final)
 
-def should_remove(remove_on, status, final):
-    """Whether this update should retract the annotation instead of writing it.
-
-    Only the terminal emit retracts: live updates keep posting so a running
-    task stays visible, and a mid-run status isn't the task's outcome.
-    `remove_on` is the configured status set (see the `remove_on` arg).
-    """
-    return bool(final) and status in remove_on
-
 # ─── Body formatting ──────────────────────────────────────────────────────────
 
 _LOG = feature_logger("Buildkite annotations")
 
 _ANNOTATION_SIZE_LIMIT = 1024 * 1024  # 1 MiB, Buildkite's hard limit per annotation
-
-# Statuses a task can end on (the `final` emit) — the values `remove_on`
-# accepts. `running` / `failing` are live-only, so naming them would never
-# match. Mirrors `lifecycle.Status` minus those two.
-_TERMINAL_STATUSES = ["passed", "warning", "failed", "aborted"]
 
 def _unwrap_details_for_streaming(text):
     """Drop `<details>` collapsibility from a rendered body so the
@@ -317,16 +337,6 @@ def _buildkite_annotations(ctx: FeatureContext):
     min_update_interval_ms = max(1, ctx.args.min_update_interval_seconds) * 1000
     _state = {}
 
-    # Terminal statuses whose annotation is retracted instead of finalized.
-    # Validated here rather than left to silently never match: a status that
-    # can't be terminal (or a typo) would otherwise look configured and do
-    # nothing. Read into a set so the hook body stays a membership test.
-    for s in (ctx.args.remove_on or []):
-        if s not in _TERMINAL_STATUSES:
-            fail("buildkite-annotations:remove-on got %r; expected one of %s" %
-                 (s, ", ".join(_TERMINAL_STATUSES)))
-    _state["_remove_on"] = {s: True for s in (ctx.args.remove_on or [])}
-
     def _make_links(data):
         # The annotation IS on the BK job page, so we only need enough for
         # the rendered summary's CI link.
@@ -408,13 +418,22 @@ def _buildkite_annotations(ctx: FeatureContext):
         elif not should_emit_update(_state, now_ms(ctx), min_update_interval_ms, final):
             return
 
-        # Retract instead of posting the terminal state, when this task's
-        # outcome isn't one the config wants kept. Replaces the terminal write
-        # rather than following it: posting first and deleting after would leave
-        # the annotation briefly visible and burn two agent calls. Checked
-        # before rendering, since the body would only be discarded.
-        if should_remove(_state["_remove_on"], status, final):
-            _LOG.trace("removing %s on terminal status=%s" % (context_id, status))
+        # Ask the config what to do with this annotation before building it.
+        # A `remove` verdict replaces the write rather than following it, so
+        # the annotation never flickers into view and the body is never
+        # rendered just to be discarded — which is also why this can't be done
+        # from a `task_update` hook: those run after the feature has already
+        # posted (see the module docstring).
+        decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
+            surface = StatusSurface("buildkite_annotation"),
+            status = status,
+            final = final,
+            style = severity_for_status(status),
+            task_kind = ctx.task.kind,
+            task_name = ctx.task.name,
+        ))
+        if decision.action == StatusSurfaceAction("remove"):
+            _LOG.trace("hook removed %s (status=%s final=%s)" % (context_id, status, final))
             _remove_annotation(ctx, context_id)
             return
 
@@ -431,7 +450,7 @@ def _buildkite_annotations(ctx: FeatureContext):
             max_snippets = _max_snippets,
         )
         body = _format_body(out, update.kind, status, task_label = _state.get("_task_label", ""), final = final)
-        style = severity_for_status(status)
+        style = decision.style or severity_for_status(status)
         if final:
             _LOG.trace("completing %s (style=%s len=%d)" %
                        (context_id, style, len(body)))
@@ -452,19 +471,6 @@ BuildkiteAnnotations = feature(
             default = "ci-only",
             values = ["ci-only", "local-only", "always"],
             description = "When to create Buildkite annotations: ci-only (default), local-only, or always.",
-        ),
-        "remove_on": args.string_list(
-            default = [],
-            long = "buildkite-annotations:remove-on",
-            description = "Terminal task statuses whose annotation is removed instead of finalized — " +
-                          "one or more of passed, warning, failed, aborted. " +
-                          "e.g. [\"passed\"] to keep the Annotations tab to tasks that need attention " +
-                          "(repeat the flag to name several: --buildkite-annotations:remove-on=passed " +
-                          "--buildkite-annotations:remove-on=warning). The removal replaces the terminal " +
-                          "post rather than following it, so the annotation never flickers into view, and " +
-                          "any annotation from this task's live updates is retracted. Live updates still " +
-                          "post while the task runs — a long task stays visible until it finishes. Empty " +
-                          "(default) keeps every annotation.",
         ),
         "min_update_interval_seconds": args.int(
             default = 5,

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -22,7 +22,7 @@ Usage in `.aspect/config.axl`:
 
 ## Suppressing, restyling or rewriting an annotation
 
-`TaskLifecycleTrait.status_surface_decision` is consulted before every write
+`TaskLifecycleTrait.status_surface_update` is consulted before every write
 and returns a verdict — publish (optionally with a rewritten body or style), or
 remove. To drop the annotation for tasks that finished clean, so the
 Annotations tab only lists what needs attention:
@@ -31,28 +31,28 @@ Annotations tab only lists what needs attention:
         "@aspect//traits.axl",
         "SURFACE_PUBLISH",
         "SURFACE_REMOVE",
-        "StatusSurfaceInfo",
+        "StatusSurfaceUpdate",
         "TaskLifecycleTrait",
     )
 
-    def _drop_when_passed(ctx: TaskContext, info: StatusSurfaceInfo):
+    def _drop_when_passed(ctx: TaskContext, info: StatusSurfaceUpdate):
         if info.final and info.status == "passed":
             return SURFACE_REMOVE
         return SURFACE_PUBLISH
 
     def config(ctx):
-        ctx.traits[TaskLifecycleTrait].status_surface_decision.append(_drop_when_passed)
+        ctx.traits[TaskLifecycleTrait].status_surface_update.append(_drop_when_passed)
 
 A `remove` verdict *replaces* the write rather than following it, so the
 annotation never flickers into view. Anything this task already published is
 retracted.
 
-`info.body` carries the fully rendered annotation, so a hook can post-process
+`update.body` carries the fully rendered annotation, so a hook can post-process
 it and publish the result:
 
     load("@aspect//traits.axl", "surface_replace")
 
-    def _add_runbook(ctx: TaskContext, info: StatusSurfaceInfo):
+    def _add_runbook(ctx: TaskContext, info: StatusSurfaceUpdate):
         if info.status in ("failed", "failing"):
             return surface_replace(info.body + "\n\nRunbook: https://wiki/ci")
         return SURFACE_PUBLISH
@@ -68,12 +68,12 @@ config hook that shells out to `annotation remove` is immediately followed by
 this feature re-posting the terminal annotation.
 
 Hooks see live updates too, not just the terminal one, so a hook that ignores
-`info.final` retracts mid-run as well — and a removal is final: the feature
+`update.final` retracts mid-run as well — and a removal is final: the feature
 stops rendering and stops consulting hooks for the rest of that task rather
 than re-posting what the hook asked to hide.
 
 `GithubStatusChecks` and `GitlabCommitStatuses` consult the same hook, so a
-restyle or rewrite can span all three; scope with `info.surface`. `remove` is
+restyle or rewrite can span all three; scope with `update.surface`. `remove` is
 Buildkite-only — the others can't retract what they've posted, so a removal
 there is downgraded to a publish and logged. See `StatusSurface`.
 
@@ -116,7 +116,7 @@ load(
     "TaskLifecycleTrait",
     "TaskUpdate",
     "publish_expanded_phases",
-    "resolve_surface_write",
+    "resolve_surface_update",
 )
 load("../private/lib/rate_limit.axl", "usage_footer")
 load("../private/lib/result_text.axl", "severity_for_status")
@@ -175,7 +175,7 @@ def _format_body(out, kind, status, task_label = "", final = False):
     `<details>` form so users can collapse what they're done with.
 
     Size is not capped here — `_write_annotation` truncates at the send
-    boundary, after any `status_surface_decision` rewrite.
+    boundary, after any `status_surface_update` rewrite.
     """
     title = out.get("title", "") or ""
     summary = out.get("summary", "") or ""
@@ -243,7 +243,7 @@ def _write_annotation(ctx, style, body, context_id):
     Body is passed on stdin to sidestep argv length limits.
 
     Bodies past BK's 1 MiB hard limit are tail-truncated here, at the send
-    boundary, so a `status_surface_decision` rewrite can't push past it —
+    boundary, so a `status_surface_update` rewrite can't push past it —
     the head (title/summary) is the useful part to keep.
     """
     if len(body) > _ANNOTATION_SIZE_LIMIT:
@@ -458,7 +458,7 @@ def _buildkite_annotations(ctx: FeatureContext):
 
         # Consulted after rendering so hooks can rewrite the body; a `remove`
         # verdict discards the render, the cost of giving hooks that access.
-        decision = resolve_surface_write(
+        decision = resolve_surface_update(
             ctx,
             lifecycle,
             "buildkite_annotation",

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -68,7 +68,9 @@ config hook that shells out to `annotation remove` is immediately followed by
 this feature re-posting the terminal annotation.
 
 Hooks see live updates too, not just the terminal one, so a hook that ignores
-`info.final` retracts mid-run as well.
+`info.final` retracts mid-run as well — and a removal is final: the feature
+stops rendering and stops consulting hooks for the rest of that task rather
+than re-posting what the hook asked to hide.
 
 The Buildkite annotation is the only surface that consults this hook. A
 `remove` needs a surface a single task can retract on its own, and the other
@@ -405,6 +407,13 @@ def _buildkite_annotations(ctx: FeatureContext):
         status = update.status
         final = update.final
 
+        # A removal is terminal for this task's annotation: re-posting after
+        # retracting it would resurrect what the hook just asked to hide, and
+        # re-deciding would re-render a body only to throw it away again. Bail
+        # before any work — the hook already had its say.
+        if _state.get("_removed"):
+            return
+
         # Keep the most recent phase label on bare refreshes (empty
         # progress styles). BK renders the narrative `body` form.
         progress_text = update.progress.body
@@ -467,6 +476,7 @@ def _buildkite_annotations(ctx: FeatureContext):
         if decision.action == StatusSurfaceAction("remove"):
             _LOG.trace("hook removed %s (status=%s final=%s)" % (context_id, status, final))
             _remove_annotation(ctx, context_id)
+            _state["_removed"] = True
             return
 
         body = decision.body

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -112,13 +112,11 @@ load("../private/lib/ci.axl", "resolve_build_url")
 load("../private/lib/environment.axl", "feature_logger", "workflows_results_url")
 load(
     "../private/lib/lifecycle.axl",
-    "StatusSurface",
     "StatusSurfaceAction",
-    "StatusSurfaceInfo",
     "TaskLifecycleTrait",
     "TaskUpdate",
-    "apply_status_surface_hooks",
     "publish_expanded_phases",
+    "resolve_surface_write",
 )
 load("../private/lib/rate_limit.axl", "usage_footer")
 load("../private/lib/result_text.axl", "severity_for_status")
@@ -460,15 +458,15 @@ def _buildkite_annotations(ctx: FeatureContext):
 
         # Consulted after rendering so hooks can rewrite the body; a `remove`
         # verdict discards the render, the cost of giving hooks that access.
-        decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
-            surface = StatusSurface("buildkite_annotation").value,
-            status = status,
-            final = final,
-            style = severity_for_status(status),
-            body = _format_body(out, update.kind, status, task_label = _state.get("_task_label", ""), final = final),
-            task_kind = ctx.task.kind,
-            task_name = ctx.task.name,
-        ))
+        decision = resolve_surface_write(
+            ctx,
+            lifecycle,
+            "buildkite_annotation",
+            status,
+            final,
+            severity_for_status(status),
+            _format_body(out, update.kind, status, task_label = _state.get("_task_label", ""), final = final),
+        )
         if decision.action == StatusSurfaceAction("remove"):
             _LOG.trace("hook removed %s (status=%s final=%s)" % (context_id, status, final))
             _remove_annotation(ctx, context_id)

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -72,9 +72,10 @@ Hooks see live updates too, not just the terminal one, so a hook that ignores
 stops rendering and stops consulting hooks for the rest of that task rather
 than re-posting what the hook asked to hide.
 
-The Buildkite annotation is the only surface that consults this hook. A
-`remove` needs a surface a single task can retract on its own, and the other
-status surfaces don't qualify — see `StatusSurface`.
+`GithubStatusChecks` and `GitlabCommitStatuses` consult the same hook, so a
+restyle or rewrite can span all three; scope with `info.surface`. `remove` is
+Buildkite-only — the others can't retract what they've posted, so a removal
+there is downgraded to a publish and logged. See `StatusSurface`.
 
 ## Templates and metadata
 
@@ -460,7 +461,7 @@ def _buildkite_annotations(ctx: FeatureContext):
         # Consulted after rendering so hooks can rewrite the body; a `remove`
         # verdict discards the render, the cost of giving hooks that access.
         decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
-            surface = StatusSurface("buildkite_annotation"),
+            surface = StatusSurface("buildkite_annotation").value,
             status = status,
             final = final,
             style = severity_for_status(status),

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -19,6 +19,17 @@ Usage in `.aspect/config.axl`:
         ctx.features[BuildkiteAnnotations].args.enabled = True
         # Open the build + test phase log sections by default (else collapsed).
         ctx.features[BuildkiteAnnotations].args.expand_phases = ["build", "test"]
+        # Keep the Annotations tab to tasks that need attention.
+        ctx.features[BuildkiteAnnotations].args.remove_on = ["passed"]
+
+## Removing an annotation on success
+
+`remove_on` names the terminal statuses whose annotation is retracted rather
+than finalized. This has to live in the feature: `task_update` handlers run in
+registration order and features register before a config's own hooks, so a
+config hook that shells out to `annotation remove` is immediately followed by
+this feature re-posting the terminal annotation. Doing it here replaces the
+terminal write instead of racing it.
 
 ## Templates and metadata
 
@@ -64,11 +75,25 @@ def format_body(out, kind, status, task_label = "", final = False):
     """Public test hook; see `_format_body` for behavior."""
     return _format_body(out, kind, status, task_label = task_label, final = final)
 
+def should_remove(remove_on, status, final):
+    """Whether this update should retract the annotation instead of writing it.
+
+    Only the terminal emit retracts: live updates keep posting so a running
+    task stays visible, and a mid-run status isn't the task's outcome.
+    `remove_on` is the configured status set (see the `remove_on` arg).
+    """
+    return bool(final) and status in remove_on
+
 # ─── Body formatting ──────────────────────────────────────────────────────────
 
 _LOG = feature_logger("Buildkite annotations")
 
 _ANNOTATION_SIZE_LIMIT = 1024 * 1024  # 1 MiB, Buildkite's hard limit per annotation
+
+# Statuses a task can end on (the `final` emit) — the values `remove_on`
+# accepts. `running` / `failing` are live-only, so naming them would never
+# match. Mirrors `lifecycle.Status` minus those two.
+_TERMINAL_STATUSES = ["passed", "warning", "failed", "aborted"]
 
 def _unwrap_details_for_streaming(text):
     """Drop `<details>` collapsibility from a rendered body so the
@@ -219,6 +244,32 @@ def _write_annotation(ctx, style, body, context_id):
     _LOG.trace("annotation ok (ctx=%s wrote=%d/%d bytes)" %
                (context_id, written, len(body)))
 
+def _remove_annotation(ctx, context_id):
+    """Invoke `buildkite-agent annotation remove` for this task's annotation.
+
+    Same `--context` / `--scope=job` pair `_write_annotation` posts under, so
+    the removal targets exactly the annotation this task created.
+
+    A failure is logged at trace, not warn: BK errors when the annotation
+    isn't there, which is the expected outcome whenever nothing was posted
+    (the task never streamed an update, or a prior cycle already removed it).
+    Nothing downstream depends on the removal succeeding.
+    """
+    _LOG.trace("invoking buildkite-agent annotation remove --context %s --scope=job" % context_id)
+
+    out = ctx.std.process.command("buildkite-agent") \
+        .args(["annotation", "remove", "--context", context_id, "--scope=job"]) \
+        .stdout("piped") \
+        .stderr("piped") \
+        .spawn() \
+        .wait_with_output()
+
+    if not out.status.success:
+        _LOG.trace("annotation remove failed (ctx=%s code=%s stderr=%r) — already absent?" %
+                   (context_id, str(out.status.code), (out.stderr or "").strip()))
+        return
+    _LOG.trace("annotation removed (ctx=%s)" % context_id)
+
 # ─── Feature implementation ───────────────────────────────────────────────────
 
 def _buildkite_annotations(ctx: FeatureContext):
@@ -265,6 +316,16 @@ def _buildkite_annotations(ctx: FeatureContext):
     # than it can finish — clamp to 1s floor.
     min_update_interval_ms = max(1, ctx.args.min_update_interval_seconds) * 1000
     _state = {}
+
+    # Terminal statuses whose annotation is retracted instead of finalized.
+    # Validated here rather than left to silently never match: a status that
+    # can't be terminal (or a typo) would otherwise look configured and do
+    # nothing. Read into a set so the hook body stays a membership test.
+    for s in (ctx.args.remove_on or []):
+        if s not in _TERMINAL_STATUSES:
+            fail("buildkite-annotations:remove-on got %r; expected one of %s" %
+                 (s, ", ".join(_TERMINAL_STATUSES)))
+    _state["_remove_on"] = {s: True for s in (ctx.args.remove_on or [])}
 
     def _make_links(data):
         # The annotation IS on the BK job page, so we only need enough for
@@ -347,6 +408,16 @@ def _buildkite_annotations(ctx: FeatureContext):
         elif not should_emit_update(_state, now_ms(ctx), min_update_interval_ms, final):
             return
 
+        # Retract instead of posting the terminal state, when this task's
+        # outcome isn't one the config wants kept. Replaces the terminal write
+        # rather than following it: posting first and deleting after would leave
+        # the annotation briefly visible and burn two agent calls. Checked
+        # before rendering, since the body would only be discarded.
+        if should_remove(_state["_remove_on"], status, final):
+            _LOG.trace("removing %s on terminal status=%s" % (context_id, status))
+            _remove_annotation(ctx, context_id)
+            return
+
         _snippet_opts, _max_snippets = snippet_budget_for(SURFACE_BUILDKITE)
         out = renderer.render(
             ctx,
@@ -381,6 +452,19 @@ BuildkiteAnnotations = feature(
             default = "ci-only",
             values = ["ci-only", "local-only", "always"],
             description = "When to create Buildkite annotations: ci-only (default), local-only, or always.",
+        ),
+        "remove_on": args.string_list(
+            default = [],
+            long = "buildkite-annotations:remove-on",
+            description = "Terminal task statuses whose annotation is removed instead of finalized — " +
+                          "one or more of passed, warning, failed, aborted. " +
+                          "e.g. [\"passed\"] to keep the Annotations tab to tasks that need attention " +
+                          "(repeat the flag to name several: --buildkite-annotations:remove-on=passed " +
+                          "--buildkite-annotations:remove-on=warning). The removal replaces the terminal " +
+                          "post rather than following it, so the annotation never flickers into view, and " +
+                          "any annotation from this task's live updates is retracted. Live updates still " +
+                          "post while the task runs — a long task stays visible until it finishes. Empty " +
+                          "(default) keeps every annotation.",
         ),
         "min_update_interval_seconds": args.int(
             default = 5,

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -20,12 +20,12 @@ Usage in `.aspect/config.axl`:
         # Open the build + test phase log sections by default (else collapsed).
         ctx.features[BuildkiteAnnotations].args.expand_phases = ["build", "test"]
 
-## Suppressing or restyling an annotation
+## Suppressing, restyling or rewriting an annotation
 
-`TaskLifecycleTrait.status_surface_decision` is consulted immediately before
-every write and returns a verdict — publish (optionally restyled) or remove.
-To drop the annotation for tasks that finished clean, so the Annotations tab
-only lists what needs attention:
+`TaskLifecycleTrait.status_surface_decision` is consulted before every write
+and returns a verdict — publish (optionally with a rewritten body or style), or
+remove. To drop the annotation for tasks that finished clean, so the
+Annotations tab only lists what needs attention:
 
     load(
         "@aspect//traits.axl",
@@ -44,8 +44,23 @@ only lists what needs attention:
         ctx.traits[TaskLifecycleTrait].status_surface_decision.append(_drop_when_passed)
 
 A `remove` verdict *replaces* the write rather than following it, so the
-annotation never flickers into view and the body is never rendered just to be
-discarded. Anything this task already published is retracted.
+annotation never flickers into view. Anything this task already published is
+retracted.
+
+`info.body` carries the fully rendered annotation, so a hook can post-process
+it and publish the result:
+
+    load("@aspect//traits.axl", "surface_replace")
+
+    def _add_runbook(ctx: TaskContext, info: StatusSurfaceInfo):
+        if info.status in ("failed", "failing"):
+            return surface_replace(info.body + "\n\nRunbook: https://wiki/ci")
+        return SURFACE_PUBLISH
+
+For authoring a body wholesale, prefer the `templates` arg below — it renders
+from structured data rather than string-editing finished markup, so a layout
+change can't silently break it. Reach for `surface_replace` when the edit
+depends on what the body turned out to be.
 
 This can't be done from a `task_update` hook: those handlers run in
 registration order and features register before a config's own hooks, so a
@@ -53,8 +68,11 @@ config hook that shells out to `annotation remove` is immediately followed by
 this feature re-posting the terminal annotation.
 
 Hooks see live updates too, not just the terminal one, so a hook that ignores
-`info.final` retracts mid-run as well. Scope by `info.surface` when several
-status surfaces are enabled.
+`info.final` retracts mid-run as well.
+
+The Buildkite annotation is the only surface that consults this hook. A
+`remove` needs a surface a single task can retract on its own, and the other
+status surfaces don't qualify — see `StatusSurface`.
 
 ## Templates and metadata
 
@@ -418,25 +436,6 @@ def _buildkite_annotations(ctx: FeatureContext):
         elif not should_emit_update(_state, now_ms(ctx), min_update_interval_ms, final):
             return
 
-        # Ask the config what to do with this annotation before building it.
-        # A `remove` verdict replaces the write rather than following it, so
-        # the annotation never flickers into view and the body is never
-        # rendered just to be discarded — which is also why this can't be done
-        # from a `task_update` hook: those run after the feature has already
-        # posted (see the module docstring).
-        decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
-            surface = StatusSurface("buildkite_annotation"),
-            status = status,
-            final = final,
-            style = severity_for_status(status),
-            task_kind = ctx.task.kind,
-            task_name = ctx.task.name,
-        ))
-        if decision.action == StatusSurfaceAction("remove"):
-            _LOG.trace("hook removed %s (status=%s final=%s)" % (context_id, status, final))
-            _remove_annotation(ctx, context_id)
-            return
-
         _snippet_opts, _max_snippets = snippet_budget_for(SURFACE_BUILDKITE)
         out = renderer.render(
             ctx,
@@ -449,7 +448,28 @@ def _buildkite_annotations(ctx: FeatureContext):
             snippet_options = _snippet_opts,
             max_snippets = _max_snippets,
         )
-        body = _format_body(out, update.kind, status, task_label = _state.get("_task_label", ""), final = final)
+
+        # Ask the config what to do with this write. Consulted after rendering
+        # so the hook can rewrite `body`; a `remove` verdict therefore discards
+        # a body we already paid for, which is the accepted trade for letting
+        # hooks edit content. Still cheaper than the alternative a config has
+        # today — a `task_update` hook can't do this at all, since those run
+        # after the feature has already posted (see the module docstring).
+        decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
+            surface = StatusSurface("buildkite_annotation"),
+            status = status,
+            final = final,
+            style = severity_for_status(status),
+            body = _format_body(out, update.kind, status, task_label = _state.get("_task_label", ""), final = final),
+            task_kind = ctx.task.kind,
+            task_name = ctx.task.name,
+        ))
+        if decision.action == StatusSurfaceAction("remove"):
+            _LOG.trace("hook removed %s (status=%s final=%s)" % (context_id, status, final))
+            _remove_annotation(ctx, context_id)
+            return
+
+        body = decision.body
         style = decision.style or severity_for_status(status)
         if final:
             _LOG.trace("completing %s (style=%s len=%d)" %

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -71,12 +71,9 @@ load("../private/lib/environment.axl", "feature_logger", "workflows_results_url"
 load("../private/lib/github.axl", "detect_commit_sha", "detect_github_repo", "github")
 load(
     "../private/lib/lifecycle.axl",
-    "StatusSurface",
-    "StatusSurfaceAction",
-    "StatusSurfaceInfo",
     "TaskLifecycleTrait",
     "TaskUpdate",
-    "apply_status_surface_hooks",
+    "resolve_surface_write",
 )
 load(
     "../private/lib/lint_results.axl",
@@ -126,6 +123,28 @@ def _detect_triggered_by(env):
         return env.var("CIRCLE_USERNAME") or "CircleCI"
     if env.var("GITLAB_CI"):
         return env.var("GITLAB_USER_LOGIN") or "GitLab CI"
+    return ""
+
+def _conclusion_for(status, final):
+    """Map Aspect `(status, final)` to a GitHub check-run conclusion, or "" when
+    this update lands none (a mid-run PATCH that only refreshes output).
+
+      `failing`                  → `failure` (early red, before build.wait)
+      final `failed` / `aborted` → `failure`
+      final `warning`            → `neutral` (ran with non-fatal findings)
+      final `passed`             → `success` (may flip back from an early
+                                   `failure`; GitHub allows it for retries)
+    """
+    if status == "failing":
+        return "failure"
+    if not final:
+        return ""
+    if status == "failed" or status == "aborted":
+        return "failure"
+    if status == "warning":
+        return "neutral"
+    if status == "passed":
+        return "success"
     return ""
 
 def _collect_ci_links(ctx, results_base_url):
@@ -199,30 +218,27 @@ def _github_status_checks(ctx: FeatureContext):
         return links
 
     def _decide(ctx, status, final, output, conclusion):
-        """Run this write past `status_surface_decision`, returning
-        `(output, conclusion, publish)`.
+        """Run this write past `status_surface_decision`, returning the
+        `(output, conclusion)` to send.
 
-        The check run's `text` is the hook-visible body; `style` is the
-        conclusion this write would land ("" when it lands none). A `remove` is
-        downgraded to a publish by `apply_status_surface_hooks` — check runs
-        can't be deleted — so `publish` is always True today; it's threaded so
-        the caller reads the verdict rather than assuming it.
+        The check run's details `text` is the hook-visible body. `remove` is
+        unreachable here — `resolve_surface_write` downgrades it for surfaces
+        that can't retract — so only style/body come back.
         """
-        decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
-            surface = StatusSurface("github_check").value,
-            status = status,
-            final = final,
-            style = conclusion,
-            body = (output or {}).get("text", "") or "",
-            task_kind = ctx.task.kind,
-            task_name = ctx.task.name,
-        ))
-        if decision.action == StatusSurfaceAction("remove"):
-            return (output, conclusion, False)
-        if output != None and decision.body != (output.get("text", "") or ""):
+        text = (output or {}).get("text", "") or ""
+        decision = resolve_surface_write(
+            ctx,
+            lifecycle,
+            "github_check",
+            status,
+            final,
+            conclusion,
+            text,
+        )
+        if output != None and decision.body != text:
             output = dict(output)
             output["text"] = decision.body
-        return (output, decision.style, True)
+        return (output, decision.style)
 
     def _create_check_run(ctx):
         """Authenticate and create the check run with initial output.
@@ -298,15 +314,7 @@ def _github_status_checks(ctx: FeatureContext):
         html_url = result.get("html_url") or ""
         checkrun.set_url(ctx, html_url)
 
-        (initial_patch_output, _initial_style, initial_publish) = _decide(
-            ctx,
-            "running",
-            False,
-            initial_output,
-            "",
-        )
-        if not initial_publish:
-            return
+        (initial_patch_output, _) = _decide(ctx, "running", False, initial_output, "")
 
         # Point details_url at the check-run page; otherwise GitHub
         # auto-fills it with the App's useless homepage URL.
@@ -371,38 +379,16 @@ def _github_status_checks(ctx: FeatureContext):
         if now_ms(ctx) - last >= _HEARTBEAT_INTERVAL_MS:
             _register_check(ctx, final = False)
 
-    def _push_status(ctx, status, final, output = None, conclusion_override = ""):
-        """Send a check-run update for `(status, final)`. Idempotent re:
-        conclusion via `_state["_gh_conclusion"]`. Map:
+    def _push_status(ctx, status, final, desired, output = None):
+        """Send a check-run update, concluding the run when `desired` is a
+        conclusion (see `_conclusion_for`) and PATCHing output only when it's "".
 
-          - `failing` → early-complete `failure` (red ❌ before build.wait).
-          - live `running`/`warning` → PATCH output only, no conclusion.
-          - terminal `passed` → `success` (may flip back from an early
-            `failing`; GitHub's PATCH allows this for retry recovery).
-          - terminal `warning` → `neutral` (ran with non-fatal findings).
-          - terminal `failed`/`aborted` → `failure`.
+        Idempotent re: conclusion via `_state["_gh_conclusion"]`.
         """
         token = _state.get("_github_token")
         check_run_id = _state.get("_check_run_id")
         if not token or not check_run_id:
             return
-
-        # (status, final) → conclusion map. None = no conclusion change.
-        desired = None
-        if status == "failing":
-            desired = "failure"  # early-fail
-        elif final:
-            if status == "failed" or status == "aborted":
-                desired = "failure"
-            elif status == "warning":
-                desired = "neutral"
-            elif status == "passed":
-                desired = "success"
-
-        # A `status_surface_decision` restyle replaces the conclusion, but only
-        # on writes that land one — see `StatusSurfaceInfo.style`.
-        if desired and conclusion_override:
-            desired = conclusion_override
 
         current = _state.get("_gh_conclusion")
         if desired and desired != current:
@@ -538,18 +524,9 @@ def _github_status_checks(ctx: FeatureContext):
 
         # Bypass throttle on conclusion-flipping updates and on the first
         # caller-priority update (e.g. the first BES event).
-        desired_conclusion = None
-        if status == "failing":
-            desired_conclusion = "failure"
-        elif final:
-            if status == "failed" or status == "aborted":
-                desired_conclusion = "failure"
-            elif status == "warning":
-                desired_conclusion = "neutral"
-            elif status == "passed":
-                desired_conclusion = "success"
+        desired_conclusion = _conclusion_for(status, final)
         is_conclusion_transition = (
-            desired_conclusion != None and
+            desired_conclusion != "" and
             desired_conclusion != _state.get("_gh_conclusion")
         )
 
@@ -630,20 +607,19 @@ def _github_status_checks(ctx: FeatureContext):
                     _LOG.info(ctx.std, "Capping lint annotations at %d (of %d eligible)" %
                                        (len(annotations), total_eligible))
 
-        (output, conclusion_override, publish) = _decide(
-            ctx,
-            status,
-            final,
-            output,
-            desired_conclusion or "",
-        )
-        if not publish:
-            return
-        _push_status(ctx, status, final, output = output, conclusion_override = conclusion_override)
+        (output, conclusion) = _decide(ctx, status, final, output, desired_conclusion)
+        _push_status(ctx, status, final, conclusion, output = output)
         if final and extra_batches:
             _send_extra_annotation_batches(ctx, token, check_run_id, output, extra_batches)
 
     lifecycle.task_update.append(_task_update)
+
+# Public test hooks, mirroring `GitlabCommitStatuses` — let the unit suite
+# exercise pure logic without standing up the whole feature machinery.
+
+def conclusion_for(status, final):
+    """Public test hook; see `_conclusion_for`."""
+    return _conclusion_for(status, final)
 
 GithubStatusChecks = feature(
     summary = "Report live task status as GitHub check runs.",

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -10,28 +10,28 @@ new task kinds plug in there.
 
 ## Restyling or rewriting the check run
 
-`TaskLifecycleTrait.status_surface_decision` is consulted before every write and
+`TaskLifecycleTrait.status_surface_update` is consulted before every write and
 returns a verdict — publish, or publish with a different style or body. Here
-`info.body` is the check run's details text and `info.style` is the conclusion
+`update.body` is the check run's details text and `update.style` is the conclusion
 this write would land (`""` when it lands none, e.g. a mid-run PATCH). A
 restyle overrides the conclusion, which decides whether the check blocks a PR:
 
-    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceInfo", "TaskLifecycleTrait", "surface_restyle")
+    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceUpdate", "TaskLifecycleTrait", "surface_restyle")
 
     # Report lint findings without blocking the PR.
-    def _lint_never_blocks(ctx: TaskContext, info: StatusSurfaceInfo):
+    def _lint_never_blocks(ctx: TaskContext, info: StatusSurfaceUpdate):
         if info.task_kind == "lint" and info.style == "failure":
             return surface_restyle("neutral")
         return SURFACE_PUBLISH
 
     def config(ctx):
-        ctx.traits[TaskLifecycleTrait].status_surface_decision.append(_lint_never_blocks)
+        ctx.traits[TaskLifecycleTrait].status_surface_update.append(_lint_never_blocks)
 
 `remove` isn't supported — GitHub can't delete a check run — so a removal is
 downgraded to a publish and logged. Only `BuildkiteAnnotations` honors it.
 
-Hooks see every surface that consults them, so scope with `info.surface` when
-more than one is enabled. See `StatusSurfaceInfo` for the full field set.
+Hooks see every surface that consults them, so scope with `update.surface` when
+more than one is enabled. See `StatusSurfaceUpdate` for the full field set.
 
 Templates and metadata_keys are feature args. `templates` takes flat
 "summary"/"details" keys applying to every task kind, and/or per-task-kind
@@ -73,7 +73,7 @@ load(
     "../private/lib/lifecycle.axl",
     "TaskLifecycleTrait",
     "TaskUpdate",
-    "resolve_surface_write",
+    "resolve_surface_update",
 )
 load(
     "../private/lib/lint_results.axl",
@@ -218,15 +218,15 @@ def _github_status_checks(ctx: FeatureContext):
         return links
 
     def _decide(ctx, status, final, output, conclusion):
-        """Run this write past `status_surface_decision`, returning the
+        """Run this write past `status_surface_update`, returning the
         `(output, conclusion)` to send.
 
         The check run's details `text` is the hook-visible body. `remove` is
-        unreachable here — `resolve_surface_write` downgrades it for surfaces
+        unreachable here — `resolve_surface_update` downgrades it for surfaces
         that can't retract — so only style/body come back.
         """
         text = (output or {}).get("text", "") or ""
-        decision = resolve_surface_write(
+        decision = resolve_surface_update(
             ctx,
             lifecycle,
             "github_check",

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -8,6 +8,31 @@ delivery_results → delivery). The per-kind dispatch table lives in
 `lib/check_dispatch.axl`, kept in lockstep with `BuildkiteAnnotations`;
 new task kinds plug in there.
 
+## Restyling or rewriting the check run
+
+`TaskLifecycleTrait.status_surface_decision` is consulted before every write and
+returns a verdict — publish, or publish with a different style or body. Here
+`info.body` is the check run's details text and `info.style` is the conclusion
+this write would land (`""` when it lands none, e.g. a mid-run PATCH). A
+restyle overrides the conclusion, which decides whether the check blocks a PR:
+
+    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceInfo", "TaskLifecycleTrait", "surface_restyle")
+
+    # Report lint findings without blocking the PR.
+    def _lint_never_blocks(ctx: TaskContext, info: StatusSurfaceInfo):
+        if info.task_kind == "lint" and info.style == "failure":
+            return surface_restyle("neutral")
+        return SURFACE_PUBLISH
+
+    def config(ctx):
+        ctx.traits[TaskLifecycleTrait].status_surface_decision.append(_lint_never_blocks)
+
+`remove` isn't supported — GitHub can't delete a check run — so a removal is
+downgraded to a publish and logged. Only `BuildkiteAnnotations` honors it.
+
+Hooks see every surface that consults them, so scope with `info.surface` when
+more than one is enabled. See `StatusSurfaceInfo` for the full field set.
+
 Templates and metadata_keys are feature args. `templates` takes flat
 "summary"/"details" keys applying to every task kind, and/or per-task-kind
 blocks that overlay them (see `check_dispatch.resolve_templates`):
@@ -44,7 +69,15 @@ load("../private/lib/checkrun.axl", "checkrun")
 load("../private/lib/ci.axl", "detect_ci_host", "resolve_build_url")
 load("../private/lib/environment.axl", "feature_logger", "workflows_results_url")
 load("../private/lib/github.axl", "detect_commit_sha", "detect_github_repo", "github")
-load("../private/lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
+load(
+    "../private/lib/lifecycle.axl",
+    "StatusSurface",
+    "StatusSurfaceAction",
+    "StatusSurfaceInfo",
+    "TaskLifecycleTrait",
+    "TaskUpdate",
+    "apply_status_surface_hooks",
+)
 load(
     "../private/lib/lint_results.axl",
     "lint_annotation_plan",
@@ -165,6 +198,32 @@ def _github_status_checks(ctx: FeatureContext):
         apply_artifact_links(ctx, links)
         return links
 
+    def _decide(ctx, status, final, output, conclusion):
+        """Run this write past `status_surface_decision`, returning
+        `(output, conclusion, publish)`.
+
+        The check run's `text` is the hook-visible body; `style` is the
+        conclusion this write would land ("" when it lands none). A `remove` is
+        downgraded to a publish by `apply_status_surface_hooks` — check runs
+        can't be deleted — so `publish` is always True today; it's threaded so
+        the caller reads the verdict rather than assuming it.
+        """
+        decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
+            surface = StatusSurface("github_check").value,
+            status = status,
+            final = final,
+            style = conclusion,
+            body = (output or {}).get("text", "") or "",
+            task_kind = ctx.task.kind,
+            task_name = ctx.task.name,
+        ))
+        if decision.action == StatusSurfaceAction("remove"):
+            return (output, conclusion, False)
+        if output != None and decision.body != (output.get("text", "") or ""):
+            output = dict(output)
+            output["text"] = decision.body
+        return (output, decision.style, True)
+
     def _create_check_run(ctx):
         """Authenticate and create the check run with initial output.
 
@@ -239,6 +298,16 @@ def _github_status_checks(ctx: FeatureContext):
         html_url = result.get("html_url") or ""
         checkrun.set_url(ctx, html_url)
 
+        (initial_patch_output, _initial_style, initial_publish) = _decide(
+            ctx,
+            "running",
+            False,
+            initial_output,
+            "",
+        )
+        if not initial_publish:
+            return
+
         # Point details_url at the check-run page; otherwise GitHub
         # auto-fills it with the App's useless homepage URL.
         github.status_checks.update(
@@ -247,7 +316,7 @@ def _github_status_checks(ctx: FeatureContext):
             owner,
             repo,
             _state["_check_run_id"],
-            output = initial_output,
+            output = initial_patch_output,
             details_url = html_url or None,
         )
 
@@ -302,7 +371,7 @@ def _github_status_checks(ctx: FeatureContext):
         if now_ms(ctx) - last >= _HEARTBEAT_INTERVAL_MS:
             _register_check(ctx, final = False)
 
-    def _push_status(ctx, status, final, output = None):
+    def _push_status(ctx, status, final, output = None, conclusion_override = ""):
         """Send a check-run update for `(status, final)`. Idempotent re:
         conclusion via `_state["_gh_conclusion"]`. Map:
 
@@ -329,6 +398,11 @@ def _github_status_checks(ctx: FeatureContext):
                 desired = "neutral"
             elif status == "passed":
                 desired = "success"
+
+        # A `status_surface_decision` restyle replaces the conclusion, but only
+        # on writes that land one — see `StatusSurfaceInfo.style`.
+        if desired and conclusion_override:
+            desired = conclusion_override
 
         current = _state.get("_gh_conclusion")
         if desired and desired != current:
@@ -556,7 +630,16 @@ def _github_status_checks(ctx: FeatureContext):
                     _LOG.info(ctx.std, "Capping lint annotations at %d (of %d eligible)" %
                                        (len(annotations), total_eligible))
 
-        _push_status(ctx, status, final, output = output)
+        (output, conclusion_override, publish) = _decide(
+            ctx,
+            status,
+            final,
+            output,
+            desired_conclusion or "",
+        )
+        if not publish:
+            return
+        _push_status(ctx, status, final, output = output, conclusion_override = conclusion_override)
         if final and extra_batches:
             _send_extra_annotation_batches(ctx, token, check_run_id, output, extra_batches)
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -43,25 +43,25 @@ future feature that wants merge-blocking semantics.
 
 ## Restyling or rewriting the commit status
 
-`TaskLifecycleTrait.status_surface_decision` is consulted before every write and
+`TaskLifecycleTrait.status_surface_update` is consulted before every write and
 returns a verdict — publish, or publish with a different style or body. A commit
-status carries no body, only the one-line description, so that is `info.body`
-(re-truncated to 255 chars after a rewrite); `info.style` is the state this
+status carries no body, only the one-line description, so that is `update.body`
+(re-truncated to 255 chars after a rewrite); `update.style` is the state this
 write would post, from the table above:
 
-    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceInfo", "TaskLifecycleTrait", "surface_replace")
+    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceUpdate", "TaskLifecycleTrait", "surface_replace")
 
-    def _prefix_team(ctx: TaskContext, info: StatusSurfaceInfo):
+    def _prefix_team(ctx: TaskContext, info: StatusSurfaceUpdate):
         return surface_replace("[platform] " + info.body)
 
     def config(ctx):
-        ctx.traits[TaskLifecycleTrait].status_surface_decision.append(_prefix_team)
+        ctx.traits[TaskLifecycleTrait].status_surface_update.append(_prefix_team)
 
 `remove` isn't supported — commit statuses are post-only — so a removal is
 downgraded to a publish and logged. Only `BuildkiteAnnotations` honors it.
 
-Hooks see every surface that consults them, so scope with `info.surface` when
-more than one is enabled. See `StatusSurfaceInfo` for the full field set.
+Hooks see every surface that consults them, so scope with `update.surface` when
+more than one is enabled. See `StatusSurfaceUpdate` for the full field set.
 
 ## Templates and metadata
 
@@ -108,7 +108,7 @@ load(
     "../private/lib/lifecycle.axl",
     "TaskLifecycleTrait",
     "TaskUpdate",
-    "resolve_surface_write",
+    "resolve_surface_update",
 )
 load(
     "../private/lib/rate_limit.axl",
@@ -246,18 +246,18 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         )
 
     def _decide(ctx, status, final, state, output):
-        """Run this write past `status_surface_decision`, returning the
+        """Run this write past `status_surface_update`, returning the
         `(state, description)` to post.
 
         A commit status carries no body, only the 255-char description, so that
         one line is what a hook sees and can rewrite (re-truncated after). A
-        `remove` is unreachable here — `resolve_surface_write` downgrades it for
+        `remove` is unreachable here — `resolve_surface_update` downgrades it for
         surfaces that can't retract.
         """
         description = _truncate_description(
             (output or {}).get("title", "") or (output or {}).get("summary", ""),
         )
-        decision = resolve_surface_write(
+        decision = resolve_surface_update(
             ctx,
             lifecycle,
             "gitlab_commit_status",
@@ -443,7 +443,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         if desired_state == None:
             return
 
-        # Dedup on the state we'd actually POST, so a `status_surface_decision`
+        # Dedup on the state we'd actually POST, so a `status_surface_update`
         # restyle is compared against what it last posted rather than against
         # the state it overrode.
         (post_state, description) = _decide(ctx, status, final, desired_state, output)

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -106,12 +106,9 @@ load("../private/lib/gitlab_detect.axl", "detect_gitlab_mr")
 load("../private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
 load(
     "../private/lib/lifecycle.axl",
-    "StatusSurface",
-    "StatusSurfaceAction",
-    "StatusSurfaceInfo",
     "TaskLifecycleTrait",
     "TaskUpdate",
-    "apply_status_surface_hooks",
+    "resolve_surface_write",
 )
 load(
     "../private/lib/rate_limit.axl",
@@ -248,32 +245,28 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             (links.get("aspect_url") or "")
         )
 
-    def _decide(ctx, status, final, state, output, links):
-        """Run this write past `status_surface_decision`, returning
-        `(state, description, publish)`.
+    def _decide(ctx, status, final, state, output):
+        """Run this write past `status_surface_decision`, returning the
+        `(state, description)` to post.
 
-        GitLab carries no body — only a 255-char `description` — so that one
-        line is what a hook sees and can rewrite. `style` is the commit-status
-        state this write would post. A `remove` is downgraded to a publish by
-        `apply_status_surface_hooks` (commit statuses are post-only), so
-        `publish` is always True today; it's threaded so the caller reads the
-        verdict rather than assuming it.
+        A commit status carries no body, only the 255-char description, so that
+        one line is what a hook sees and can rewrite (re-truncated after). A
+        `remove` is unreachable here — `resolve_surface_write` downgrades it for
+        surfaces that can't retract.
         """
         description = _truncate_description(
             (output or {}).get("title", "") or (output or {}).get("summary", ""),
         )
-        decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
-            surface = StatusSurface("gitlab_commit_status").value,
-            status = status,
-            final = final,
-            style = state,
-            body = description,
-            task_kind = ctx.task.kind,
-            task_name = ctx.task.name,
-        ))
-        if decision.action == StatusSurfaceAction("remove"):
-            return (state, description, False)
-        return (decision.style, _truncate_description(decision.body), True)
+        decision = resolve_surface_write(
+            ctx,
+            lifecycle,
+            "gitlab_commit_status",
+            status,
+            final,
+            state,
+            description,
+        )
+        return (decision.style, _truncate_description(decision.body))
 
     def _post_status(ctx, state, description, links):
         token = _state.get("_gitlab_token")
@@ -364,16 +357,8 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             resolve_templates(templates, ctx.task.kind),
             metadata_keys,
         )
-        (initial_state, initial_desc, initial_publish) = _decide(
-            ctx,
-            "running",
-            False,
-            "pending",
-            initial_output,
-            initial_links,
-        )
-        if initial_publish:
-            _post_status(ctx, initial_state, initial_desc, initial_links)
+        (initial_state, initial_desc) = _decide(ctx, "running", False, "pending", initial_output)
+        _post_status(ctx, initial_state, initial_desc, initial_links)
 
     def _task_update(ctx, update):
         # Latch the subject (raw) before init/render: setup_phase sets
@@ -461,16 +446,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         # Dedup on the state we'd actually POST, so a `status_surface_decision`
         # restyle is compared against what it last posted rather than against
         # the state it overrode.
-        (post_state, description, publish) = _decide(
-            ctx,
-            status,
-            final,
-            desired_state,
-            output,
-            links,
-        )
-        if not publish:
-            return
+        (post_state, description) = _decide(ctx, status, final, desired_state, output)
         if post_state == _state.get("_last_state"):
             return
         _post_status(ctx, post_state, description, links)

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -41,6 +41,28 @@ future feature that wants merge-blocking semantics.
 `skipped` is the GitLab-blessed mapping for "ran with non-fatal findings"
 — see `lib/gitlab.axl::_commit_status_skipped`. Renders without a red ✗.
 
+## Restyling or rewriting the commit status
+
+`TaskLifecycleTrait.status_surface_decision` is consulted before every write and
+returns a verdict — publish, or publish with a different style or body. A commit
+status carries no body, only the one-line description, so that is `info.body`
+(re-truncated to 255 chars after a rewrite); `info.style` is the state this
+write would post, from the table above:
+
+    load("@aspect//traits.axl", "SURFACE_PUBLISH", "StatusSurfaceInfo", "TaskLifecycleTrait", "surface_replace")
+
+    def _prefix_team(ctx: TaskContext, info: StatusSurfaceInfo):
+        return surface_replace("[platform] " + info.body)
+
+    def config(ctx):
+        ctx.traits[TaskLifecycleTrait].status_surface_decision.append(_prefix_team)
+
+`remove` isn't supported — commit statuses are post-only — so a removal is
+downgraded to a publish and logged. Only `BuildkiteAnnotations` honors it.
+
+Hooks see every surface that consults them, so scope with `info.surface` when
+more than one is enabled. See `StatusSurfaceInfo` for the full field set.
+
 ## Templates and metadata
 
 Rendering goes through the shared `check_dispatch.RENDERERS` table —
@@ -82,7 +104,15 @@ load("../private/lib/environment.axl", "feature_logger", "workflows_results_url"
 load("../private/lib/gitlab.axl", "gitlab")
 load("../private/lib/gitlab_detect.axl", "detect_gitlab_mr")
 load("../private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
-load("../private/lib/lifecycle.axl", "TaskLifecycleTrait", "TaskUpdate")
+load(
+    "../private/lib/lifecycle.axl",
+    "StatusSurface",
+    "StatusSurfaceAction",
+    "StatusSurfaceInfo",
+    "TaskLifecycleTrait",
+    "TaskUpdate",
+    "apply_status_surface_hooks",
+)
 load(
     "../private/lib/rate_limit.axl",
     "BUCKET_APP",
@@ -218,7 +248,34 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             (links.get("aspect_url") or "")
         )
 
-    def _post_status(ctx, state, output, links):
+    def _decide(ctx, status, final, state, output, links):
+        """Run this write past `status_surface_decision`, returning
+        `(state, description, publish)`.
+
+        GitLab carries no body — only a 255-char `description` — so that one
+        line is what a hook sees and can rewrite. `style` is the commit-status
+        state this write would post. A `remove` is downgraded to a publish by
+        `apply_status_surface_hooks` (commit statuses are post-only), so
+        `publish` is always True today; it's threaded so the caller reads the
+        verdict rather than assuming it.
+        """
+        description = _truncate_description(
+            (output or {}).get("title", "") or (output or {}).get("summary", ""),
+        )
+        decision = apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
+            surface = StatusSurface("gitlab_commit_status").value,
+            status = status,
+            final = final,
+            style = state,
+            body = description,
+            task_kind = ctx.task.kind,
+            task_name = ctx.task.name,
+        ))
+        if decision.action == StatusSurfaceAction("remove"):
+            return (state, description, False)
+        return (decision.style, _truncate_description(decision.body), True)
+
+    def _post_status(ctx, state, description, links):
         token = _state.get("_gitlab_token")
         if not token:
             return
@@ -227,7 +284,6 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         # the same (name, sha, ref) triple POSTs. We still track our
         # last-posted state so live-refresh callers can decide whether
         # to re-POST.
-        description = _truncate_description((output or {}).get("title", "") or (output or {}).get("summary", ""))
         target_url = _resolve_target_url(links)
         result = gitlab.commit_status.post(
             ctx,
@@ -308,7 +364,16 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             resolve_templates(templates, ctx.task.kind),
             metadata_keys,
         )
-        _post_status(ctx, "pending", initial_output, initial_links)
+        (initial_state, initial_desc, initial_publish) = _decide(
+            ctx,
+            "running",
+            False,
+            "pending",
+            initial_output,
+            initial_links,
+        )
+        if initial_publish:
+            _post_status(ctx, initial_state, initial_desc, initial_links)
 
     def _task_update(ctx, update):
         # Latch the subject (raw) before init/render: setup_phase sets
@@ -392,10 +457,23 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
         # GitlabStatusComments feature.
         if desired_state == None:
             return
-        if desired_state == _state.get("_last_state"):
-            return
 
-        _post_status(ctx, desired_state, output, links)
+        # Dedup on the state we'd actually POST, so a `status_surface_decision`
+        # restyle is compared against what it last posted rather than against
+        # the state it overrode.
+        (post_state, description, publish) = _decide(
+            ctx,
+            status,
+            final,
+            desired_state,
+            output,
+            links,
+        )
+        if not publish:
+            return
+        if post_state == _state.get("_last_state"):
+            return
+        _post_status(ctx, post_state, description, links)
 
     lifecycle.task_update.append(_task_update)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -380,21 +380,11 @@ def _surface_info(status, final, style = "info", body = "RENDERED"):
         task_name = "build-test",
     )
 
-def _removed_after(verdicts):
-    """Replay `verdicts` through the same latch rule the feature applies
-    (`_state["_removed"]` set on remove, checked before any later work) and
-    report whether the surface ended up latched off."""
-    removed = False
-    for v in verdicts:
-        if removed:
-            continue
-        if v.action == StatusSurfaceAction("remove"):
-            removed = True
-    return removed
-
 def _assert_status_surface_hooks(ctx):
-    """`status_surface_decision` hooks decide publish / remove / restyle, chain
-    in order, and default to publishing."""
+    """`status_surface_decision` hooks decide publish / remove / restyle /
+    rewrite; they chain in order and resolve to exactly what the caller
+    writes. (The remove-latch — a removed surface never re-posts — lives in
+    feature state, covered by the stub-agent e2e runs, not here.)"""
 
     def _drop_passed(ctx, info):
         if info.final and info.status == "passed":
@@ -438,9 +428,11 @@ def _assert_status_surface_hooks(ctx):
     chained = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _observe_style]), _surface_info("passed", True))
     _eq("style threads through the chain", chained.style, "warning+seen")
 
-    # A publish always carries the body to write, even when no hook touched it,
-    # so the caller never has to re-resolve it.
-    _eq("body defaults to the rendered one", apply_status_surface_hooks(ctx, _fake_lifecycle([]), _surface_info("passed", True)).body, "RENDERED")
+    # A publish is returned resolved — style and body always set, falling back
+    # to the incoming values — so the caller writes it without re-resolving.
+    untouched = apply_status_surface_hooks(ctx, _fake_lifecycle([]), _surface_info("passed", True))
+    _eq("body defaults to the rendered one", untouched.body, "RENDERED")
+    _eq("style defaults to the resolved severity", untouched.style, "info")
     _eq("untouched body passes through", apply_status_surface_hooks(ctx, one, _surface_info("failed", True)).body, "RENDERED")
 
     # Rewriting the content is the point of handing hooks `info.body`.
@@ -455,11 +447,15 @@ def _assert_status_surface_hooks(ctx):
     composed = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook, _append_runbook]), _surface_info("failed", True))
     _eq("body edits compose", composed.body, "RENDERED +RUNBOOK +RUNBOOK")
 
-    # `remove` is terminal for the surface: the feature latches it and stops
-    # rendering, so a later update can't resurrect the artifact. Asserted on the
-    # feature's latch rather than the chain, which is stateless by design.
-    _eq("remove latches", _removed_after([SURFACE_REMOVE, SURFACE_PUBLISH]), True)
-    _eq("publish does not latch", _removed_after([SURFACE_PUBLISH, SURFACE_PUBLISH]), False)
+    # An edit earlier in the chain survives a later plain publish: the resolved
+    # verdict carries the threaded style/body, not just the last return value.
+    def _plain(ctx, info):
+        return SURFACE_PUBLISH
+
+    kept = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _plain]), _surface_info("passed", True))
+    _eq("restyle survives a later plain publish", kept.style, "warning")
+    kept_body = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook, _plain]), _surface_info("failed", True))
+    _eq("rewrite survives a later plain publish", kept_body.body, "RENDERED +RUNBOOK")
 
     # A rewrite can restyle at the same time.
     def _replace_and_restyle(ctx, info):
@@ -468,7 +464,6 @@ def _assert_status_surface_hooks(ctx):
     both = apply_status_surface_hooks(ctx, _fake_lifecycle([_replace_and_restyle]), _surface_info("passed", True))
     _eq("replace can restyle", both.style, "error")
     _eq("replace sets body", both.body, "NEW")
-
 
 def _assert_title_overrides(ctx, data, rc):
     """A "title" override replaces the annotation title, renders with the

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -427,12 +427,15 @@ def _assert_status_surface_hooks(ctx):
         StatusSurfaceAction("remove"),
     )
 
-    # A restyle threads into the next handler's info, so the last writer wins.
-    def _observe_style(ctx, info):
-        return surface_restyle(info.style + "+seen")
+    # A restyle threads into the next handler's info, so a handler reacting to
+    # its predecessor sees the edit and the last writer wins.
+    def _escalate_warning(ctx, info):
+        if info.style == "warning":
+            return surface_restyle("error")
+        return SURFACE_PUBLISH
 
-    chained = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _observe_style]), _surface_info("passed", True))
-    _eq("style threads through the chain", chained.style, "warning+seen")
+    chained = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _escalate_warning]), _surface_info("passed", True))
+    _eq("style threads through the chain", chained.style, "error")
 
     # A publish is returned resolved — style and body always set, falling back
     # to the incoming values — so the caller writes it without re-resolving.
@@ -471,16 +474,54 @@ def _assert_status_surface_hooks(ctx):
     _eq("replace can restyle", both.style, "error")
     _eq("replace sets body", both.body, "NEW")
 
-    # Restyle and rewrite work on every surface that consults the hook — a hook
-    # written once spans all of them.
-    for surface in ["buildkite_annotation", "github_check", "gitlab_commit_status"]:
+    # Rewrite works on every surface that consults the hook, and a restyle is
+    # honored when it answers in that surface's own vocabulary.
+    for (surface, style) in [
+        ("buildkite_annotation", "error"),
+        ("github_check", "neutral"),
+        ("gitlab_commit_status", "canceled"),
+    ]:
+        def _replace_for_surface(ctx, info):
+            return surface_replace("NEW", style = style)
+
         resolved = apply_status_surface_hooks(
             ctx,
-            _fake_lifecycle([_replace_and_restyle]),
+            _fake_lifecycle([_replace_for_surface]),
             _surface_info("passed", True, surface = surface),
         )
         _eq("%s honors replace" % surface, resolved.body, "NEW")
-        _eq("%s honors restyle" % surface, resolved.style, "error")
+        _eq("%s honors restyle" % surface, resolved.style, style)
+
+    # A style from another surface's vocabulary is refused, so an unscoped hook
+    # can't corrupt the surfaces it wasn't written for — Buildkite's "warning"
+    # matches no GitHub conclusion, and GitHub's client would conclude `failure`.
+    for (surface, incoming, foreign) in [
+        ("github_check", "success", "warning"),
+        ("gitlab_commit_status", "success", "neutral"),
+        ("buildkite_annotation", "info", "canceled"),
+    ]:
+        def _foreign_restyle(ctx, info):
+            return surface_restyle(foreign)
+
+        refused = apply_status_surface_hooks(
+            ctx,
+            _fake_lifecycle([_foreign_restyle]),
+            _surface_info("passed", True, style = incoming, surface = surface),
+        )
+        _eq("%s refuses a foreign style" % surface, refused.style, incoming)
+        _eq("%s still publishes" % surface, refused.action, StatusSurfaceAction("publish"))
+
+    # A refused style doesn't discard a body rewrite in the same verdict.
+    def _foreign_style_with_body(ctx, info):
+        return surface_replace("KEPT", style = "warning")
+
+    mixed = apply_status_surface_hooks(
+        ctx,
+        _fake_lifecycle([_foreign_style_with_body]),
+        _surface_info("passed", True, style = "success", surface = "github_check"),
+    )
+    _eq("refused style keeps the body rewrite", mixed.body, "KEPT")
+    _eq("refused style keeps the incoming style", mixed.style, "success")
 
     # `info.surface` is a plain string, so a hook scopes itself with a literal
     # (as it does for `info.status`) rather than needing the enum.

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -587,16 +587,37 @@ def _assert_status_surface_hooks(ctx):
         _eq("%s keeps its body when downgraded" % surface, downgraded.body, "RENDERED")
         _eq("%s keeps its style when downgraded" % surface, downgraded.style, "info")
 
-    # A downgrade stops the chain where the remove was returned, so a later
-    # handler can't quietly restyle a write the config tried to suppress.
+    # A refused verdict is skipped, not chain-ending: one unscoped or buggy
+    # handler must not silence the handlers after it. Each of the three refusal
+    # kinds is followed here by a handler whose valid edit has to survive.
+    def _neutral(ctx, update):
+        return surface_restyle("neutral")
+
+    def _foreign_for_gh(ctx, update):
+        return surface_restyle("warning")  # a Buildkite style; refused here
+
+    for (label, first) in [
+        ("unsupported remove", _drop_passed),
+        ("None return", _forgot_to_return),
+        ("foreign style", _foreign_for_gh),
+    ]:
+        survived = apply_status_surface_hooks(
+            ctx,
+            _fake_lifecycle([first, _neutral]),
+            _surface_update("passed", True, surface = "github_check"),
+        )
+        _eq("later handler runs after a refused %s" % label, survived.style, "neutral")
+
+    # The supported case still short-circuits: once Buildkite's annotation is
+    # actually being retracted there is nothing left for a later hook to edit.
     _eq(
-        "downgrade halts the chain",
+        "honored remove ends the chain",
         apply_status_surface_hooks(
             ctx,
-            _fake_lifecycle([_drop_passed, _warn]),
-            _surface_update("passed", True, surface = "github_check"),
-        ).style,
-        "info",
+            _fake_lifecycle([_drop_passed, _neutral]),
+            _surface_update("passed", True),
+        ).action,
+        StatusSurfaceAction("remove"),
     )
 
 def _assert_title_overrides(ctx, data, rc):

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -18,7 +18,7 @@ for each scenario, so a rendering regression shows up as a visible diff:
 config patches, and a broken template degrades to the fallback body.
 """
 
-load("@aspect//feature/buildkite_annotations.axl", "format_body", "should_remove")
+load("@aspect//feature/buildkite_annotations.axl", "format_body")
 
 # Shared fixture factories — also consumed by github_status_comments_test.axl.
 load(
@@ -81,6 +81,16 @@ load(
     LINT_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
     LINT_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
     lint_render_check_output = "render_check_output",
+)
+load(
+    "../lib/lifecycle.axl",
+    "SURFACE_PUBLISH",
+    "SURFACE_REMOVE",
+    "StatusSurface",
+    "StatusSurfaceAction",
+    "StatusSurfaceInfo",
+    "apply_status_surface_hooks",
+    "surface_restyle",
 )
 load("../lib/result_text.axl", "severity_for_status")
 load(
@@ -348,38 +358,72 @@ def _test_templates_impl(ctx: TaskContext) -> int:
 
     _assert_title_overrides(ctx, data, rc)
     _assert_resolve_templates()
-    _assert_should_remove()
+    _assert_status_surface_hooks(ctx)
 
     print("All template-customization assertions passed for %d kinds." % len(_KIND_TEMPLATES))
     return 0
 
-_TERMINAL_STATUSES_UNDER_TEST = ["passed", "warning", "failed", "aborted"]
+def _fake_lifecycle(handlers):
+    """Minimal stand-in for the lifecycle trait — `apply_status_surface_hooks`
+    reads only `.status_surface_decision`."""
+    return struct(status_surface_decision = handlers)
 
-def _assert_should_remove():
-    """`remove_on` retracts only on the terminal emit, and only for the
-    statuses it names."""
-    passed_only = {"passed": True}
+def _surface_info(status, final, style = "info"):
+    return StatusSurfaceInfo(
+        surface = StatusSurface("buildkite_annotation"),
+        status = status,
+        final = final,
+        style = style,
+        task_kind = "build",
+        task_name = "build-test",
+    )
 
-    # The whole point: a green task's annotation is retracted at the end.
-    _eq("terminal passed retracts", should_remove(passed_only, "passed", True), True)
+def _assert_status_surface_hooks(ctx):
+    """`status_surface_decision` hooks decide publish / remove / restyle, chain
+    in order, and default to publishing."""
 
-    # Live updates keep posting, so a long-running task stays visible while it
-    # runs — only its outcome decides whether the annotation survives.
-    _eq("live passed keeps posting", should_remove(passed_only, "passed", False), False)
+    def _drop_passed(ctx, info):
+        if info.final and info.status == "passed":
+            return SURFACE_REMOVE
+        return SURFACE_PUBLISH
 
-    # A status the config didn't name is always kept, terminal or not.
-    for st in ["failed", "warning", "aborted", "running", "failing"]:
-        _eq("terminal %s kept" % st, should_remove(passed_only, st, True), False)
+    # No handlers → publish unchanged.
+    _eq("no handlers publishes", apply_status_surface_hooks(ctx, _fake_lifecycle([]), _surface_info("passed", True)).action, StatusSurfaceAction("publish"))
 
-    # Empty config (the default) never retracts anything.
-    for st in _TERMINAL_STATUSES_UNDER_TEST:
-        _eq("default keeps %s" % st, should_remove({}, st, True), False)
+    one = _fake_lifecycle([_drop_passed])
 
-    # Several statuses can be named at once.
-    both = {"passed": True, "warning": True}
-    _eq("multi passed", should_remove(both, "passed", True), True)
-    _eq("multi warning", should_remove(both, "warning", True), True)
-    _eq("multi failed kept", should_remove(both, "failed", True), False)
+    # The customer's case: a green task's annotation is retracted at the end.
+    _eq("terminal passed removes", apply_status_surface_hooks(ctx, one, _surface_info("passed", True)).action, StatusSurfaceAction("remove"))
+
+    # Live updates keep posting, so a long task stays visible while it runs.
+    _eq("live passed publishes", apply_status_surface_hooks(ctx, one, _surface_info("passed", False)).action, StatusSurfaceAction("publish"))
+
+    # Statuses the hook doesn't name are always kept.
+    for st in ["failed", "warning", "aborted"]:
+        _eq("terminal %s publishes" % st, apply_status_surface_hooks(ctx, one, _surface_info(st, True)).action, StatusSurfaceAction("publish"))
+
+    # A restyle publishes with the overridden style.
+    def _warn(ctx, info):
+        return surface_restyle("warning")
+
+    restyled = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn]), _surface_info("passed", True))
+    _eq("restyle publishes", restyled.action, StatusSurfaceAction("publish"))
+    _eq("restyle sets style", restyled.style, "warning")
+
+    # `remove` short-circuits, so a later handler can't resurrect the write.
+    _eq(
+        "remove short-circuits",
+        apply_status_surface_hooks(ctx, _fake_lifecycle([_drop_passed, _warn]), _surface_info("passed", True)).action,
+        StatusSurfaceAction("remove"),
+    )
+
+    # A restyle threads into the next handler's info, so the last writer wins.
+    def _observe_style(ctx, info):
+        return surface_restyle(info.style + "+seen")
+
+    chained = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _observe_style]), _surface_info("passed", True))
+    _eq("style threads through the chain", chained.style, "warning+seen")
+
 
 def _assert_title_overrides(ctx, data, rc):
     """A "title" override replaces the annotation title, renders with the

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -90,6 +90,7 @@ load(
     "StatusSurfaceAction",
     "StatusSurfaceInfo",
     "apply_status_surface_hooks",
+    "surface_replace",
     "surface_restyle",
 )
 load("../lib/result_text.axl", "severity_for_status")
@@ -368,12 +369,13 @@ def _fake_lifecycle(handlers):
     reads only `.status_surface_decision`."""
     return struct(status_surface_decision = handlers)
 
-def _surface_info(status, final, style = "info"):
+def _surface_info(status, final, style = "info", body = "RENDERED"):
     return StatusSurfaceInfo(
         surface = StatusSurface("buildkite_annotation"),
         status = status,
         final = final,
         style = style,
+        body = body,
         task_kind = "build",
         task_name = "build-test",
     )
@@ -423,6 +425,31 @@ def _assert_status_surface_hooks(ctx):
 
     chained = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _observe_style]), _surface_info("passed", True))
     _eq("style threads through the chain", chained.style, "warning+seen")
+
+    # A publish always carries the body to write, even when no hook touched it,
+    # so the caller never has to re-resolve it.
+    _eq("body defaults to the rendered one", apply_status_surface_hooks(ctx, _fake_lifecycle([]), _surface_info("passed", True)).body, "RENDERED")
+    _eq("untouched body passes through", apply_status_surface_hooks(ctx, one, _surface_info("failed", True)).body, "RENDERED")
+
+    # Rewriting the content is the point of handing hooks `info.body`.
+    def _append_runbook(ctx, info):
+        return surface_replace(info.body + " +RUNBOOK")
+
+    replaced = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook]), _surface_info("failed", True))
+    _eq("replace publishes", replaced.action, StatusSurfaceAction("publish"))
+    _eq("replace rewrites body", replaced.body, "RENDERED +RUNBOOK")
+
+    # Each handler sees its predecessor's edit, so rewrites compose.
+    composed = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook, _append_runbook]), _surface_info("failed", True))
+    _eq("body edits compose", composed.body, "RENDERED +RUNBOOK +RUNBOOK")
+
+    # A rewrite can restyle at the same time.
+    def _replace_and_restyle(ctx, info):
+        return surface_replace("NEW", style = "error")
+
+    both = apply_status_surface_hooks(ctx, _fake_lifecycle([_replace_and_restyle]), _surface_info("passed", True))
+    _eq("replace can restyle", both.style, "error")
+    _eq("replace sets body", both.body, "NEW")
 
 
 def _assert_title_overrides(ctx, data, rc):

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -12,10 +12,15 @@ for each scenario, so a rendering regression shows up as a visible diff:
   - Style selection edge cases: soft-lint passing with warnings, delivery
     all-skipped, delivery all-failed, soft-format passing with files.
 
-`aspect dev test-bk-annotation-templates` asserts the customization contract
-`args.templates` exposes: overrides reach the rendered body, "summary" and
-"details" are independent, every renderer module exports the templates a
-config patches, and a broken template degrades to the fallback body.
+`aspect dev test-bk-annotation-templates` asserts the two customization
+contracts a config writes against:
+  - `args.templates` — overrides reach the rendered body, "title"/"summary"/
+    "details" are independent, per-task-kind blocks overlay the flat keys,
+    every renderer module exports the templates a config patches, and a broken
+    template degrades to a fallback.
+  - `TaskLifecycleTrait.status_surface_decision` — verdicts resolve, chain, and
+    compose across surfaces, and a `remove` no surface can honor downgrades to
+    a publish.
 """
 
 load("@aspect//feature/buildkite_annotations.axl", "format_body")
@@ -369,9 +374,9 @@ def _fake_lifecycle(handlers):
     reads only `.status_surface_decision`."""
     return struct(status_surface_decision = handlers)
 
-def _surface_info(status, final, style = "info", body = "RENDERED"):
+def _surface_info(status, final, style = "info", body = "RENDERED", surface = "buildkite_annotation"):
     return StatusSurfaceInfo(
-        surface = StatusSurface("buildkite_annotation"),
+        surface = StatusSurface(surface).value,
         status = status,
         final = final,
         style = style,
@@ -464,6 +469,61 @@ def _assert_status_surface_hooks(ctx):
     both = apply_status_surface_hooks(ctx, _fake_lifecycle([_replace_and_restyle]), _surface_info("passed", True))
     _eq("replace can restyle", both.style, "error")
     _eq("replace sets body", both.body, "NEW")
+
+    # Restyle and rewrite work on every surface that consults the hook — a hook
+    # written once spans all of them.
+    for surface in ["buildkite_annotation", "github_check", "gitlab_commit_status"]:
+        resolved = apply_status_surface_hooks(
+            ctx,
+            _fake_lifecycle([_replace_and_restyle]),
+            _surface_info("passed", True, surface = surface),
+        )
+        _eq("%s honors replace" % surface, resolved.body, "NEW")
+        _eq("%s honors restyle" % surface, resolved.style, "error")
+
+    # `info.surface` is a plain string, so a hook scopes itself with a literal
+    # (as it does for `info.status`) rather than needing the enum.
+    def _bk_only(ctx, info):
+        if info.surface == "buildkite_annotation":
+            return surface_restyle("error")
+        return SURFACE_PUBLISH
+
+    scoped = _fake_lifecycle([_bk_only])
+    _eq(
+        "literal surface comparison matches",
+        apply_status_surface_hooks(ctx, scoped, _surface_info("passed", True)).style,
+        "error",
+    )
+    _eq(
+        "literal surface comparison skips others",
+        apply_status_surface_hooks(ctx, scoped, _surface_info("passed", True, surface = "github_check")).style,
+        "info",
+    )
+
+    # `remove` is Buildkite-only: the surfaces that can't retract downgrade to a
+    # publish rather than dropping the write or silently ignoring the verdict.
+    _eq(
+        "buildkite honors remove",
+        apply_status_surface_hooks(ctx, one, _surface_info("passed", True)).action,
+        StatusSurfaceAction("remove"),
+    )
+    for surface in ["github_check", "gitlab_commit_status"]:
+        downgraded = apply_status_surface_hooks(ctx, one, _surface_info("passed", True, surface = surface))
+        _eq("%s downgrades remove" % surface, downgraded.action, StatusSurfaceAction("publish"))
+        _eq("%s keeps its body when downgraded" % surface, downgraded.body, "RENDERED")
+        _eq("%s keeps its style when downgraded" % surface, downgraded.style, "info")
+
+    # A downgrade stops the chain where the remove was returned, so a later
+    # handler can't quietly restyle a write the config tried to suppress.
+    _eq(
+        "downgrade halts the chain",
+        apply_status_surface_hooks(
+            ctx,
+            _fake_lifecycle([_drop_passed, _warn]),
+            _surface_info("passed", True, surface = "github_check"),
+        ).style,
+        "info",
+    )
 
 def _assert_title_overrides(ctx, data, rc):
     """A "title" override replaces the annotation title, renders with the

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -18,7 +18,7 @@ for each scenario, so a rendering regression shows up as a visible diff:
 config patches, and a broken template degrades to the fallback body.
 """
 
-load("@aspect//feature/buildkite_annotations.axl", "format_body")
+load("@aspect//feature/buildkite_annotations.axl", "format_body", "should_remove")
 
 # Shared fixture factories — also consumed by github_status_comments_test.axl.
 load(
@@ -348,9 +348,38 @@ def _test_templates_impl(ctx: TaskContext) -> int:
 
     _assert_title_overrides(ctx, data, rc)
     _assert_resolve_templates()
+    _assert_should_remove()
 
     print("All template-customization assertions passed for %d kinds." % len(_KIND_TEMPLATES))
     return 0
+
+_TERMINAL_STATUSES_UNDER_TEST = ["passed", "warning", "failed", "aborted"]
+
+def _assert_should_remove():
+    """`remove_on` retracts only on the terminal emit, and only for the
+    statuses it names."""
+    passed_only = {"passed": True}
+
+    # The whole point: a green task's annotation is retracted at the end.
+    _eq("terminal passed retracts", should_remove(passed_only, "passed", True), True)
+
+    # Live updates keep posting, so a long-running task stays visible while it
+    # runs — only its outcome decides whether the annotation survives.
+    _eq("live passed keeps posting", should_remove(passed_only, "passed", False), False)
+
+    # A status the config didn't name is always kept, terminal or not.
+    for st in ["failed", "warning", "aborted", "running", "failing"]:
+        _eq("terminal %s kept" % st, should_remove(passed_only, st, True), False)
+
+    # Empty config (the default) never retracts anything.
+    for st in _TERMINAL_STATUSES_UNDER_TEST:
+        _eq("default keeps %s" % st, should_remove({}, st, True), False)
+
+    # Several statuses can be named at once.
+    both = {"passed": True, "warning": True}
+    _eq("multi passed", should_remove(both, "passed", True), True)
+    _eq("multi warning", should_remove(both, "warning", True), True)
+    _eq("multi failed kept", should_remove(both, "failed", True), False)
 
 def _assert_title_overrides(ctx, data, rc):
     """A "title" override replaces the annotation title, renders with the

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -18,7 +18,7 @@ contracts a config writes against:
     "details" are independent, per-task-kind blocks overlay the flat keys,
     every renderer module exports the templates a config patches, and a broken
     template degrades to a fallback.
-  - `TaskLifecycleTrait.status_surface_decision` — verdicts resolve, chain, and
+  - `TaskLifecycleTrait.status_surface_update` — verdicts resolve, chain, and
     compose across surfaces, and a `remove` no surface can honor downgrades to
     a publish.
 """
@@ -87,9 +87,9 @@ load(
     "SURFACE_REMOVE",
     "StatusSurface",
     "StatusSurfaceAction",
-    "StatusSurfaceInfo",
+    "StatusSurfaceUpdate",
     "apply_status_surface_hooks",
-    "resolve_surface_write",
+    "resolve_surface_update",
     "surface_replace",
     "surface_restyle",
 )
@@ -372,11 +372,11 @@ def _test_templates_impl(ctx: TaskContext) -> int:
 
 def _fake_lifecycle(handlers):
     """Minimal stand-in for the lifecycle trait — `apply_status_surface_hooks`
-    reads only `.status_surface_decision`."""
-    return struct(status_surface_decision = handlers)
+    reads only `.status_surface_update`."""
+    return struct(status_surface_update = handlers)
 
-def _surface_info(status, final, style = "info", body = "RENDERED", surface = "buildkite_annotation"):
-    return StatusSurfaceInfo(
+def _surface_update(status, final, style = "info", body = "RENDERED", surface = "buildkite_annotation"):
+    return StatusSurfaceUpdate(
         surface = StatusSurface(surface).value,
         status = status,
         final = final,
@@ -387,7 +387,7 @@ def _surface_info(status, final, style = "info", body = "RENDERED", surface = "b
     )
 
 def _assert_status_surface_hooks(ctx):
-    """`status_surface_decision` hooks decide publish / remove / restyle /
+    """`status_surface_update` hooks decide publish / remove / restyle /
     rewrite; they chain in order and resolve to exactly what the caller
     writes. (The remove-latch — a removed surface never re-posts — lives in
     feature state, covered by the stub-agent e2e runs, not here.)"""
@@ -398,32 +398,32 @@ def _assert_status_surface_hooks(ctx):
         return SURFACE_PUBLISH
 
     # No handlers → publish unchanged.
-    _eq("no handlers publishes", apply_status_surface_hooks(ctx, _fake_lifecycle([]), _surface_info("passed", True)).action, StatusSurfaceAction("publish"))
+    _eq("no handlers publishes", apply_status_surface_hooks(ctx, _fake_lifecycle([]), _surface_update("passed", True)).action, StatusSurfaceAction("publish"))
 
     one = _fake_lifecycle([_drop_passed])
 
     # The customer's case: a green task's annotation is retracted at the end.
-    _eq("terminal passed removes", apply_status_surface_hooks(ctx, one, _surface_info("passed", True)).action, StatusSurfaceAction("remove"))
+    _eq("terminal passed removes", apply_status_surface_hooks(ctx, one, _surface_update("passed", True)).action, StatusSurfaceAction("remove"))
 
     # Live updates keep posting, so a long task stays visible while it runs.
-    _eq("live passed publishes", apply_status_surface_hooks(ctx, one, _surface_info("passed", False)).action, StatusSurfaceAction("publish"))
+    _eq("live passed publishes", apply_status_surface_hooks(ctx, one, _surface_update("passed", False)).action, StatusSurfaceAction("publish"))
 
     # Statuses the hook doesn't name are always kept.
     for st in ["failed", "warning", "aborted"]:
-        _eq("terminal %s publishes" % st, apply_status_surface_hooks(ctx, one, _surface_info(st, True)).action, StatusSurfaceAction("publish"))
+        _eq("terminal %s publishes" % st, apply_status_surface_hooks(ctx, one, _surface_update(st, True)).action, StatusSurfaceAction("publish"))
 
     # A restyle publishes with the overridden style.
     def _warn(ctx, info):
         return surface_restyle("warning")
 
-    restyled = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn]), _surface_info("passed", True))
+    restyled = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn]), _surface_update("passed", True))
     _eq("restyle publishes", restyled.action, StatusSurfaceAction("publish"))
     _eq("restyle sets style", restyled.style, "warning")
 
     # `remove` short-circuits, so a later handler can't resurrect the write.
     _eq(
         "remove short-circuits",
-        apply_status_surface_hooks(ctx, _fake_lifecycle([_drop_passed, _warn]), _surface_info("passed", True)).action,
+        apply_status_surface_hooks(ctx, _fake_lifecycle([_drop_passed, _warn]), _surface_update("passed", True)).action,
         StatusSurfaceAction("remove"),
     )
 
@@ -434,26 +434,26 @@ def _assert_status_surface_hooks(ctx):
             return surface_restyle("error")
         return SURFACE_PUBLISH
 
-    chained = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _escalate_warning]), _surface_info("passed", True))
+    chained = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _escalate_warning]), _surface_update("passed", True))
     _eq("style threads through the chain", chained.style, "error")
 
     # A publish is returned resolved — style and body always set, falling back
     # to the incoming values — so the caller writes it without re-resolving.
-    untouched = apply_status_surface_hooks(ctx, _fake_lifecycle([]), _surface_info("passed", True))
+    untouched = apply_status_surface_hooks(ctx, _fake_lifecycle([]), _surface_update("passed", True))
     _eq("body defaults to the rendered one", untouched.body, "RENDERED")
     _eq("style defaults to the resolved severity", untouched.style, "info")
-    _eq("untouched body passes through", apply_status_surface_hooks(ctx, one, _surface_info("failed", True)).body, "RENDERED")
+    _eq("untouched body passes through", apply_status_surface_hooks(ctx, one, _surface_update("failed", True)).body, "RENDERED")
 
-    # Rewriting the content is the point of handing hooks `info.body`.
+    # Rewriting the content is the point of handing hooks `update.body`.
     def _append_runbook(ctx, info):
         return surface_replace(info.body + " +RUNBOOK")
 
-    replaced = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook]), _surface_info("failed", True))
+    replaced = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook]), _surface_update("failed", True))
     _eq("replace publishes", replaced.action, StatusSurfaceAction("publish"))
     _eq("replace rewrites body", replaced.body, "RENDERED +RUNBOOK")
 
     # Each handler sees its predecessor's edit, so rewrites compose.
-    composed = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook, _append_runbook]), _surface_info("failed", True))
+    composed = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook, _append_runbook]), _surface_update("failed", True))
     _eq("body edits compose", composed.body, "RENDERED +RUNBOOK +RUNBOOK")
 
     # An edit earlier in the chain survives a later plain publish: the resolved
@@ -461,16 +461,16 @@ def _assert_status_surface_hooks(ctx):
     def _plain(ctx, info):
         return SURFACE_PUBLISH
 
-    kept = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _plain]), _surface_info("passed", True))
+    kept = apply_status_surface_hooks(ctx, _fake_lifecycle([_warn, _plain]), _surface_update("passed", True))
     _eq("restyle survives a later plain publish", kept.style, "warning")
-    kept_body = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook, _plain]), _surface_info("failed", True))
+    kept_body = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook, _plain]), _surface_update("failed", True))
     _eq("rewrite survives a later plain publish", kept_body.body, "RENDERED +RUNBOOK")
 
     # A rewrite can restyle at the same time.
     def _replace_and_restyle(ctx, info):
         return surface_replace("NEW", style = "error")
 
-    both = apply_status_surface_hooks(ctx, _fake_lifecycle([_replace_and_restyle]), _surface_info("passed", True))
+    both = apply_status_surface_hooks(ctx, _fake_lifecycle([_replace_and_restyle]), _surface_update("passed", True))
     _eq("replace can restyle", both.style, "error")
     _eq("replace sets body", both.body, "NEW")
 
@@ -487,7 +487,7 @@ def _assert_status_surface_hooks(ctx):
         resolved = apply_status_surface_hooks(
             ctx,
             _fake_lifecycle([_replace_for_surface]),
-            _surface_info("passed", True, surface = surface),
+            _surface_update("passed", True, surface = surface),
         )
         _eq("%s honors replace" % surface, resolved.body, "NEW")
         _eq("%s honors restyle" % surface, resolved.style, style)
@@ -506,7 +506,7 @@ def _assert_status_surface_hooks(ctx):
         refused = apply_status_surface_hooks(
             ctx,
             _fake_lifecycle([_foreign_restyle]),
-            _surface_info("passed", True, style = incoming, surface = surface),
+            _surface_update("passed", True, style = incoming, surface = surface),
         )
         _eq("%s refuses a foreign style" % surface, refused.style, incoming)
         _eq("%s still publishes" % surface, refused.action, StatusSurfaceAction("publish"))
@@ -518,12 +518,23 @@ def _assert_status_surface_hooks(ctx):
     mixed = apply_status_surface_hooks(
         ctx,
         _fake_lifecycle([_foreign_style_with_body]),
-        _surface_info("passed", True, style = "success", surface = "github_check"),
+        _surface_update("passed", True, style = "success", surface = "github_check"),
     )
     _eq("refused style keeps the body rewrite", mixed.body, "KEPT")
     _eq("refused style keeps the incoming style", mixed.style, "success")
 
-    # `info.surface` is a plain string, so a hook scopes itself with a literal
+    # A handler that forgets to return — the `task_update` shape, which this
+    # hook's name parallels — degrades to publish-unchanged rather than failing
+    # the task, since the build itself is fine.
+    def _forgot_to_return(ctx, update):
+        pass
+
+    none_ret = apply_status_surface_hooks(ctx, _fake_lifecycle([_forgot_to_return]), _surface_update("passed", True))
+    _eq("None degrades to publish", none_ret.action, StatusSurfaceAction("publish"))
+    _eq("None keeps the body", none_ret.body, "RENDERED")
+    _eq("None keeps the style", none_ret.style, "info")
+
+    # `update.surface` is a plain string, so a hook scopes itself with a literal
     # (as it does for `info.status`) rather than needing the enum.
     def _bk_only(ctx, info):
         if info.surface == "buildkite_annotation":
@@ -533,21 +544,21 @@ def _assert_status_surface_hooks(ctx):
     scoped = _fake_lifecycle([_bk_only])
     _eq(
         "literal surface comparison matches",
-        apply_status_surface_hooks(ctx, scoped, _surface_info("passed", True)).style,
+        apply_status_surface_hooks(ctx, scoped, _surface_update("passed", True)).style,
         "error",
     )
     _eq(
         "literal surface comparison skips others",
-        apply_status_surface_hooks(ctx, scoped, _surface_info("passed", True, surface = "github_check")).style,
+        apply_status_surface_hooks(ctx, scoped, _surface_update("passed", True, surface = "github_check")).style,
         "info",
     )
 
-    # `resolve_surface_write` is what surfaces actually call: it builds the info
+    # `resolve_surface_update` is what surfaces actually call: it builds the info
     # record, validating the surface name, and reads task identity off `ctx`.
     def _echo_identity(ctx, info):
         return surface_replace("%s|%s|%s" % (info.surface, info.task_kind, info.task_name))
 
-    wrapped = resolve_surface_write(
+    wrapped = resolve_surface_update(
         ctx,
         _fake_lifecycle([_echo_identity]),
         "buildkite_annotation",
@@ -567,11 +578,11 @@ def _assert_status_surface_hooks(ctx):
     # publish rather than dropping the write or silently ignoring the verdict.
     _eq(
         "buildkite honors remove",
-        apply_status_surface_hooks(ctx, one, _surface_info("passed", True)).action,
+        apply_status_surface_hooks(ctx, one, _surface_update("passed", True)).action,
         StatusSurfaceAction("remove"),
     )
     for surface in ["github_check", "gitlab_commit_status"]:
-        downgraded = apply_status_surface_hooks(ctx, one, _surface_info("passed", True, surface = surface))
+        downgraded = apply_status_surface_hooks(ctx, one, _surface_update("passed", True, surface = surface))
         _eq("%s downgrades remove" % surface, downgraded.action, StatusSurfaceAction("publish"))
         _eq("%s keeps its body when downgraded" % surface, downgraded.body, "RENDERED")
         _eq("%s keeps its style when downgraded" % surface, downgraded.style, "info")
@@ -583,7 +594,7 @@ def _assert_status_surface_hooks(ctx):
         apply_status_surface_hooks(
             ctx,
             _fake_lifecycle([_drop_passed, _warn]),
-            _surface_info("passed", True, surface = "github_check"),
+            _surface_update("passed", True, surface = "github_check"),
         ).style,
         "info",
     )

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -82,12 +82,6 @@ load(
     gazelle_render_check_output = "render_check_output",
 )
 load(
-    "../lib/lint_results.axl",
-    LINT_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
-    LINT_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
-    lint_render_check_output = "render_check_output",
-)
-load(
     "../lib/lifecycle.axl",
     "SURFACE_PUBLISH",
     "SURFACE_REMOVE",
@@ -95,8 +89,15 @@ load(
     "StatusSurfaceAction",
     "StatusSurfaceInfo",
     "apply_status_surface_hooks",
+    "resolve_surface_write",
     "surface_replace",
     "surface_restyle",
+)
+load(
+    "../lib/lint_results.axl",
+    LINT_DETAILS_TEMPLATE = "DETAILS_TEMPLATE",
+    LINT_SUMMARY_TEMPLATE = "SUMMARY_TEMPLATE",
+    lint_render_check_output = "render_check_output",
 )
 load("../lib/result_text.axl", "severity_for_status")
 load(
@@ -499,6 +500,27 @@ def _assert_status_surface_hooks(ctx):
         apply_status_surface_hooks(ctx, scoped, _surface_info("passed", True, surface = "github_check")).style,
         "info",
     )
+
+    # `resolve_surface_write` is what surfaces actually call: it builds the info
+    # record, validating the surface name, and reads task identity off `ctx`.
+    def _echo_identity(ctx, info):
+        return surface_replace("%s|%s|%s" % (info.surface, info.task_kind, info.task_name))
+
+    wrapped = resolve_surface_write(
+        ctx,
+        _fake_lifecycle([_echo_identity]),
+        "buildkite_annotation",
+        "passed",
+        True,
+        "success",
+        "RENDERED",
+    )
+    _eq(
+        "wrapper passes surface + task identity through",
+        wrapped.body,
+        "buildkite_annotation|%s|%s" % (ctx.task.kind, ctx.task.name),
+    )
+    _eq("wrapper resolves style when untouched", wrapped.style, "success")
 
     # `remove` is Buildkite-only: the surfaces that can't retract downgrade to a
     # publish rather than dropping the write or silently ignoring the verdict.

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -380,6 +380,18 @@ def _surface_info(status, final, style = "info", body = "RENDERED"):
         task_name = "build-test",
     )
 
+def _removed_after(verdicts):
+    """Replay `verdicts` through the same latch rule the feature applies
+    (`_state["_removed"]` set on remove, checked before any later work) and
+    report whether the surface ended up latched off."""
+    removed = False
+    for v in verdicts:
+        if removed:
+            continue
+        if v.action == StatusSurfaceAction("remove"):
+            removed = True
+    return removed
+
 def _assert_status_surface_hooks(ctx):
     """`status_surface_decision` hooks decide publish / remove / restyle, chain
     in order, and default to publishing."""
@@ -442,6 +454,12 @@ def _assert_status_surface_hooks(ctx):
     # Each handler sees its predecessor's edit, so rewrites compose.
     composed = apply_status_surface_hooks(ctx, _fake_lifecycle([_append_runbook, _append_runbook]), _surface_info("failed", True))
     _eq("body edits compose", composed.body, "RENDERED +RUNBOOK +RUNBOOK")
+
+    # `remove` is terminal for the surface: the feature latches it and stops
+    # rendering, so a later update can't resurrect the artifact. Asserted on the
+    # feature's latch rather than the chain, which is stateless by design.
+    _eq("remove latches", _removed_after([SURFACE_REMOVE, SURFACE_PUBLISH]), True)
+    _eq("publish does not latch", _removed_after([SURFACE_PUBLISH, SURFACE_PUBLISH]), False)
 
     # A rewrite can restyle at the same time.
     def _replace_and_restyle(ctx, info):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github_features_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github_features_test.axl
@@ -1,0 +1,55 @@
+"""Unit tests for pure `GithubStatusChecks` logic.
+
+Sibling of `gitlab_features_test.axl`: exercises the mapping functions the
+feature exposes as public test hooks, without standing up auth, the check-runs
+API, or the render pipeline.
+
+  * `conclusion_for(status, final)` — Aspect task status → GitHub check-run
+    conclusion, or "" when the update lands none.
+
+Run with:
+  aspect dev test-github-features
+"""
+
+load("@aspect//feature/github_status_checks.axl", "conclusion_for")
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _test_impl(ctx):
+    # Early-fail concludes `failure` before the terminal update, so a broken
+    # build turns the check red without waiting for build.wait().
+    _eq("live failing", conclusion_for("failing", False), "failure")
+    _eq("terminal failing", conclusion_for("failing", True), "failure")
+
+    # Live updates otherwise land no conclusion — they only PATCH output, so the
+    # check stays in progress.
+    for status in ["running", "warning", "passed", "failed", "aborted"]:
+        _eq("live %s lands none" % status, conclusion_for(status, False), "")
+
+    _eq("terminal passed", conclusion_for("passed", True), "success")
+    _eq("terminal failed", conclusion_for("failed", True), "failure")
+    _eq("terminal aborted", conclusion_for("aborted", True), "failure")
+
+    # `neutral`, not `failure`: a task that ran with non-fatal findings
+    # shouldn't block a PR.
+    _eq("terminal warning", conclusion_for("warning", True), "neutral")
+
+    # `running` can't be terminal, but the map must still answer rather than
+    # crash if a producer emits it.
+    _eq("terminal running lands none", conclusion_for("running", True), "")
+
+    # Unknown statuses degrade to "no conclusion" instead of concluding wrongly.
+    _eq("unknown status", conclusion_for("bogus", True), "")
+
+    print("github features test: OK")
+    return 0
+
+github_features_tests = task(
+    summary = "Run the github features AXL unit tests.",
+    kind = "test-github-features",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -364,6 +364,10 @@ def apply_status_surface_hooks(ctx, lifecycle, update: StatusSurfaceUpdate) -> S
     A handler returning None (the `task_update` shape) is reported and treated
     as publish-unchanged, so a config bug degrades rather than failing the task.
 
+    Refused verdicts — a None, an unsupported `remove`, a foreign style — are
+    skipped rather than ending the chain, so one unscoped or buggy handler can't
+    silence the handlers after it.
+
     Verdicts a surface can't honor are refused rather than forwarded, so one
     unscoped hook can't corrupt the other surfaces it also sees: a `remove`
     becomes a publish where the artifact can't be retracted
@@ -382,15 +386,21 @@ def apply_status_surface_hooks(ctx, lifecycle, update: StatusSurfaceUpdate) -> S
         # Likeliest hook bug, and likelier still because the name parallels
         # `task_update`, whose handlers return nothing. Degrade rather than fail
         # the task: the build itself is fine, only the reporting hook is wrong.
+        # One broken handler doesn't silence the rest, so skip just this verdict.
         if decision == None:
             _refuse(ctx, update, "returned None — return SURFACE_PUBLISH to leave the write unchanged (unlike task_update, these handlers must return a verdict)")
-            break
+            continue
 
         if decision.action == StatusSurfaceAction("remove"):
+            # A removal the surface CAN honor ends the chain — there's nothing
+            # left to edit. One it can't is merely inapplicable here, so it's
+            # skipped like any other refused verdict and later handlers (often
+            # scoped to this surface) still get their say.
             if _SURFACE_CAN_REMOVE.get(update.surface):
                 return decision
             _refuse(ctx, update, "asked to remove the %s artifact, which that surface can't retract — publishing instead" % update.surface)
-            break
+            continue
+
         update = _threaded(ctx, update, decision)
     return StatusSurfaceDecision(
         action = StatusSurfaceAction("publish"),

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -245,7 +245,7 @@ _SURFACE_STYLES = {
 # surface can't be added to one without the other — an unlisted surface would
 # otherwise silently refuse every restyle.
 #
-# Surfaces validate their own name through this enum; `StatusSurfaceInfo.surface`
+# Surfaces validate their own name through this enum; `StatusSurfaceUpdate.surface`
 # stays `str` so hooks compare with plain literals (as `TaskUpdate.status` does).
 #
 # The aggregate PR/MR summary comments deliberately don't consult the hook: a
@@ -254,7 +254,7 @@ _SURFACE_STYLES = {
 # surfaces customize through their `templates` arg ("body").
 StatusSurface = enum(*sorted(_SURFACE_STYLES.keys()))
 
-# Verdict from a `status_surface_decision` hook. `publish` writes (optionally
+# Verdict from a `status_surface_update` hook. `publish` writes (optionally
 # with a rewritten `body` or `style`); `remove` suppresses the write and
 # retracts anything already published for this task on that surface.
 #
@@ -265,9 +265,9 @@ StatusSurface = enum(*sorted(_SURFACE_STYLES.keys()))
 # it — restyle it instead.
 StatusSurfaceAction = enum("publish", "remove")
 
-# Passed to each `status_surface_decision` hook alongside `ctx` — what the
+# Passed to each `status_surface_update` hook alongside `ctx` — what the
 # surface knows at the instant it's about to write.
-StatusSurfaceInfo = record(
+StatusSurfaceUpdate = record(
     surface = field(str),
     # Lifecycle status ("passed", "failing", …) and whether this is the
     # terminal emit. A hook that ignores `final` also fires mid-run.
@@ -308,58 +308,61 @@ SURFACE_REMOVE = StatusSurfaceDecision(action = StatusSurfaceAction("remove"))
 
 def surface_restyle(style: str) -> StatusSurfaceDecision:
     """Publish, overriding the styling. Values are per-surface — see
-    `StatusSurfaceInfo.style`."""
+    `StatusSurfaceUpdate.style`."""
     return StatusSurfaceDecision(action = StatusSurfaceAction("publish"), style = style)
 
 def surface_replace(body: str, style: str | None = None) -> StatusSurfaceDecision:
     """Publish `body` in place of what the surface rendered, optionally
-    restyling too. Build it from `info.body` to post-process, or pass a fresh
+    restyling too. Build it from `update.body` to post-process, or pass a fresh
     string to author it outright."""
     return StatusSurfaceDecision(action = StatusSurfaceAction("publish"), style = style, body = body)
 
 _LOG = feature_logger("Status surface")
 
-def _refuse(ctx, info: StatusSurfaceInfo, msg: str):
+def _refuse(ctx, update: StatusSurfaceUpdate, msg: str):
     """Report a verdict this surface can't honor. Warn on the terminal emit so
     an unscoped hook is noticed once per task, not once per update."""
-    full = ("status_surface_decision %s. Scope the hook with `info.surface`." % msg)
-    if info.final:
+    full = ("status_surface_update %s. Scope the hook with `update.surface`." % msg)
+    if update.final:
         _LOG.warn(ctx.std, full)
     else:
         _LOG.trace(full)
 
-def _threaded(ctx, info: StatusSurfaceInfo, decision: StatusSurfaceDecision) -> StatusSurfaceInfo:
-    """`info` with the decision's style/body applied, for the next handler.
+def _threaded(ctx, update: StatusSurfaceUpdate, decision: StatusSurfaceDecision) -> StatusSurfaceUpdate:
+    """`update` with the decision's style/body applied, for the next handler.
 
     Unset fields keep the incoming value. A style outside this surface's
     vocabulary (`_SURFACE_STYLES`) is refused, so a hook written for another
     surface leaves this one's styling intact rather than corrupting it.
     """
-    style = info.style
-    if decision.style and decision.style != info.style:
-        if decision.style in (_SURFACE_STYLES.get(info.surface) or []):
+    style = update.style
+    if decision.style and decision.style != update.style:
+        if decision.style in (_SURFACE_STYLES.get(update.surface) or []):
             style = decision.style
         else:
-            _refuse(ctx, info, "returned style %r, which %s can't express — keeping %r" %
-                               (decision.style, info.surface, info.style))
-    return StatusSurfaceInfo(
-        surface = info.surface,
-        status = info.status,
-        final = info.final,
+            _refuse(ctx, update, "returned style %r, which %s can't express — keeping %r" %
+                                 (decision.style, update.surface, update.style))
+    return StatusSurfaceUpdate(
+        surface = update.surface,
+        status = update.status,
+        final = update.final,
         style = style,
-        body = decision.body if decision.body != None else info.body,
-        task_kind = info.task_kind,
-        task_name = info.task_name,
+        body = decision.body if decision.body != None else update.body,
+        task_kind = update.task_kind,
+        task_name = update.task_name,
     )
 
-def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> StatusSurfaceDecision:
-    """Run `info` through every `status_surface_decision` hook.
+def apply_status_surface_hooks(ctx, lifecycle, update: StatusSurfaceUpdate) -> StatusSurfaceDecision:
+    """Run `update` through every `status_surface_update` hook.
 
     Handlers chain in order and the first `remove` short-circuits — there is
     nothing left to edit once the write is being suppressed. A `publish`
     carrying a rewritten `body` and/or `style` is threaded into the next
-    handler's `info`, so each handler sees its predecessor's edits and a later
+    handler's `update`, so each handler sees its predecessor's edits and a later
     plain publish keeps them.
+
+    A handler returning None (the `task_update` shape) is reported and treated
+    as publish-unchanged, so a config bug degrades rather than failing the task.
 
     Verdicts a surface can't honor are refused rather than forwarded, so one
     unscoped hook can't corrupt the other surfaces it also sees: a `remove`
@@ -373,29 +376,37 @@ def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> Statu
     are always set (the incoming values when no hook rewrote them), so the
     caller writes exactly what the chain settled on.
     """
-    for handler in lifecycle.status_surface_decision:
-        decision = handler(ctx, info)
-        if decision.action == StatusSurfaceAction("remove"):
-            if _SURFACE_CAN_REMOVE.get(info.surface):
-                return decision
-            _refuse(ctx, info, "asked to remove the %s artifact, which that surface can't retract — publishing instead" % info.surface)
+    for handler in lifecycle.status_surface_update:
+        decision = handler(ctx, update)
+
+        # Likeliest hook bug, and likelier still because the name parallels
+        # `task_update`, whose handlers return nothing. Degrade rather than fail
+        # the task: the build itself is fine, only the reporting hook is wrong.
+        if decision == None:
+            _refuse(ctx, update, "returned None — return SURFACE_PUBLISH to leave the write unchanged (unlike task_update, these handlers must return a verdict)")
             break
-        info = _threaded(ctx, info, decision)
+
+        if decision.action == StatusSurfaceAction("remove"):
+            if _SURFACE_CAN_REMOVE.get(update.surface):
+                return decision
+            _refuse(ctx, update, "asked to remove the %s artifact, which that surface can't retract — publishing instead" % update.surface)
+            break
+        update = _threaded(ctx, update, decision)
     return StatusSurfaceDecision(
         action = StatusSurfaceAction("publish"),
-        style = info.style,
-        body = info.body,
+        style = update.style,
+        body = update.body,
     )
 
-def resolve_surface_write(ctx, lifecycle, surface, status, final, style, body) -> StatusSurfaceDecision:
-    """`apply_status_surface_hooks` with the `StatusSurfaceInfo` built for you.
+def resolve_surface_update(ctx, lifecycle, surface, status, final, style, body) -> StatusSurfaceDecision:
+    """`apply_status_surface_hooks` with the `StatusSurfaceUpdate` built for you.
 
     What a surface calls at its write site. `surface` is validated against
     `StatusSurface` here, and task identity is read off `ctx`, so a surface
     passes only what it alone knows: its `status`/`final`, plus the `style` and
     `body` it was about to write in its own vocabulary.
     """
-    return apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
+    return apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceUpdate(
         surface = StatusSurface(surface).value,
         status = status,
         final = final,
@@ -424,20 +435,27 @@ TaskLifecycleTrait = trait(
     # See `apply_repro_fix_hooks`.
     repro_fix_suggestion = attr(list[typing.Callable[[TaskContext, ReproFixInfo], ReproFixSuggestion]], default = []),
 
-    # `(ctx: TaskContext, info: StatusSurfaceInfo) -> StatusSurfaceDecision`,
+    # `(ctx: TaskContext, update: StatusSurfaceUpdate) -> StatusSurfaceDecision`,
     # consulted by a status surface immediately before it writes, so a config
     # can suppress the write, restyle it, or rewrite its rendered body
-    # (`info.body`).
+    # (`update.body`).
+    #
+    # Note the contract differs from `task_update` above despite the parallel
+    # name: `task_update` handlers observe and return nothing, while these
+    # RETURN a verdict that decides what the surface actually writes. A handler
+    # that falls off the end returns None, which is reported and treated as
+    # publish-unchanged — return `SURFACE_PUBLISH` explicitly to leave a write
+    # alone.
+    #
+    # `task_update` also can't do this job: handlers run in registration order
+    # and features register first, so a config hook always runs *after* the
+    # surface has posted.
     #
     # Lives on the lifecycle trait (not the surface's own) because a feature
     # can't contribute a trait — `feature()` takes no `traits` — and tasks must
     # not reference features. Every task already declares this trait, so a hook
     # here is reachable from `.aspect/config.axl` with no task changes.
-    #
-    # A `task_update` handler can't do this job: handlers run in registration
-    # order and features register first, so a config hook always runs *after*
-    # the surface has posted. See `StatusSurfaceDecision`.
-    status_surface_decision = attr(list[typing.Callable[[TaskContext, StatusSurfaceInfo], StatusSurfaceDecision]], default = []),
+    status_surface_update = attr(list[typing.Callable[[TaskContext, StatusSurfaceUpdate], StatusSurfaceDecision]], default = []),
 )
 
 # Lives next to `task_update()` so every surface emit routes through

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -223,12 +223,29 @@ def repro_fix_replace(command: str | None = None, description: str | None = None
 
 # Which status surface is about to write. Lets one hook scope itself to a
 # single surface when several are enabled.
-StatusSurface = enum("buildkite_annotation", "github_check", "gitlab_commit_status")
+#
+# Only surfaces whose API can retract a published artifact are listed, because
+# `remove` is the reason this hook exists:
+#
+#   buildkite_annotation  — `buildkite-agent annotation remove`
+#   github_pr_comment     — DELETE issue comment
+#   gitlab_mr_note        — DELETE note
+#
+# Deliberately absent: GitHub check runs (the REST API has no DELETE — a check
+# run can only be updated once created) and GitLab commit statuses (post-only).
+# Those surfaces can't honor `remove` at all, so letting a hook ask for it
+# would only produce a verdict they'd have to ignore.
+StatusSurface = enum("buildkite_annotation", "github_pr_comment", "gitlab_mr_note")
 
 # Verdict from a `status_surface_decision` hook. `publish` writes as normal;
 # `remove` suppresses the write and retracts anything already published for
 # this task on that surface. `style` (publish only) overrides the surface's
 # severity styling.
+#
+# There is no "replace the content" verdict: the hook runs before the body is
+# rendered (so a `remove` doesn't pay for a render it discards), which means
+# there is no content to hand it. Content is customized through the surface's
+# `templates` arg instead — see `check_dispatch.resolve_templates`.
 StatusSurfaceAction = enum("publish", "remove")
 
 # Passed to each `status_surface_decision` hook alongside `ctx` — what the
@@ -305,7 +322,8 @@ TaskLifecycleTrait = trait(
 
     # `(ctx: TaskContext, info: StatusSurfaceInfo) -> StatusSurfaceDecision`,
     # consulted by a status surface immediately before it writes, so a config
-    # can suppress or restyle the write itself.
+    # can suppress or restyle the write itself. It does not carry the rendered
+    # content — use the surface's `templates` arg for that.
     #
     # Lives on the lifecycle trait (not the surface's own) because a feature
     # can't contribute a trait — `feature()` takes no `traits` — and tasks must

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -244,6 +244,12 @@ StatusSurface = enum("buildkite_annotation")
 # Verdict from a `status_surface_decision` hook. `publish` writes (optionally
 # with a rewritten `body` or `style`); `remove` suppresses the write and
 # retracts anything already published for this task on that surface.
+#
+# `remove` is terminal for the task's artifact on that surface: once retracted,
+# the surface stops rendering and stops consulting hooks for the rest of the
+# task. Re-posting would resurrect what the hook asked to hide, and re-deciding
+# would render bodies only to discard them. A hook that wants the artifact back
+# later shouldn't remove it — restyle it instead.
 StatusSurfaceAction = enum("publish", "remove")
 
 # Passed to each `status_surface_decision` hook alongside `ctx` — what the

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -239,6 +239,18 @@ StatusSurface = enum("buildkite_annotation", "github_check", "gitlab_commit_stat
 # created) and GitLab commit statuses are post-only.
 _SURFACE_CAN_REMOVE = {"buildkite_annotation": True}
 
+# Styles each surface can express, i.e. what a `surface_restyle` may answer.
+# Anything else is refused and the surface's own style stands, because these
+# vocabularies don't overlap: Buildkite's "warning" reaching a check run matches
+# no conclusion (GitHub's client would conclude `failure`, turning a green check
+# red), and GitHub's "neutral" reaching GitLab is rejected by the API for the
+# rest of the task. An unscoped hook meant for one surface can't corrupt another.
+_SURFACE_STYLES = {
+    "buildkite_annotation": ["success", "info", "warning", "error"],
+    "github_check": ["success", "neutral", "failure"],
+    "gitlab_commit_status": ["pending", "running", "success", "failed", "canceled", "skipped"],
+}
+
 # Verdict from a `status_surface_decision` hook. `publish` writes (optionally
 # with a rewritten `body` or `style`); `remove` suppresses the write and
 # retracts anything already published for this task on that surface.
@@ -304,14 +316,34 @@ def surface_replace(body: str, style: str | None = None) -> StatusSurfaceDecisio
 
 _LOG = feature_logger("Status surface")
 
-def _threaded(info: StatusSurfaceInfo, decision: StatusSurfaceDecision) -> StatusSurfaceInfo:
+def _refuse(ctx, info: StatusSurfaceInfo, msg: str):
+    """Report a verdict this surface can't honor. Warn on the terminal emit so
+    an unscoped hook is noticed once per task, not once per update."""
+    full = ("status_surface_decision %s. Scope the hook with `info.surface`." % msg)
+    if info.final:
+        _LOG.warn(ctx.std, full)
+    else:
+        _LOG.trace(full)
+
+def _threaded(ctx, info: StatusSurfaceInfo, decision: StatusSurfaceDecision) -> StatusSurfaceInfo:
     """`info` with the decision's style/body applied, for the next handler.
-    Unset fields keep the incoming value."""
+
+    Unset fields keep the incoming value. A style outside this surface's
+    vocabulary (`_SURFACE_STYLES`) is refused, so a hook written for another
+    surface leaves this one's styling intact rather than corrupting it.
+    """
+    style = info.style
+    if decision.style and decision.style != info.style:
+        if decision.style in (_SURFACE_STYLES.get(info.surface) or []):
+            style = decision.style
+        else:
+            _refuse(ctx, info, "returned style %r, which %s can't express — keeping %r" %
+                               (decision.style, info.surface, info.style))
     return StatusSurfaceInfo(
         surface = info.surface,
         status = info.status,
         final = info.final,
-        style = decision.style or info.style,
+        style = style,
         body = decision.body if decision.body != None else info.body,
         task_kind = info.task_kind,
         task_name = info.task_name,
@@ -326,11 +358,13 @@ def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> Statu
     handler's `info`, so each handler sees its predecessor's edits and a later
     plain publish keeps them.
 
-    A `remove` the surface can't honor (see `_SURFACE_CAN_REMOVE`) is downgraded
-    to a publish so a hook written for Buildkite doesn't silently break the
-    other surfaces it also sees. The downgrade is logged — at warn on the
-    terminal emit, so it's noticed once per task rather than per update. Callers
-    on those surfaces therefore never see a `remove` and needn't handle one.
+    Verdicts a surface can't honor are refused rather than forwarded, so one
+    unscoped hook can't corrupt the other surfaces it also sees: a `remove`
+    becomes a publish where the artifact can't be retracted
+    (`_SURFACE_CAN_REMOVE`), and a style outside the surface's vocabulary
+    (`_SURFACE_STYLES`) leaves the incoming style standing. Both are reported by
+    `_refuse`. Callers therefore never see a `remove` on a surface that can't
+    retract, nor a style it can't express.
 
     Returns a resolved verdict: on `publish` the decision's `style` and `body`
     are always set (the incoming values when no hook rewrote them), so the
@@ -341,15 +375,9 @@ def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> Statu
         if decision.action == StatusSurfaceAction("remove"):
             if _SURFACE_CAN_REMOVE.get(info.surface):
                 return decision
-            msg = ("status_surface_decision asked to remove the %s artifact, which that " +
-                   "surface can't retract — publishing instead. Scope the hook with " +
-                   "`info.surface` to silence this.") % info.surface
-            if info.final:
-                _LOG.warn(ctx.std, msg)
-            else:
-                _LOG.trace(msg)
+            _refuse(ctx, info, "asked to remove the %s artifact, which that surface can't retract — publishing instead" % info.surface)
             break
-        info = _threaded(info, decision)
+        info = _threaded(ctx, info, decision)
     return StatusSurfaceDecision(
         action = StatusSurfaceAction("publish"),
         style = info.style,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -234,13 +234,9 @@ def repro_fix_replace(command: str | None = None, description: str | None = None
 # Those surfaces customize through their `templates` arg ("body").
 StatusSurface = enum("buildkite_annotation", "github_check", "gitlab_commit_status")
 
-_LOG = feature_logger("Status surface")
-
 # Surfaces whose artifact a single task can retract on its own — the only ones
-# a `remove` verdict is honored for. GitHub check runs have no DELETE (a check
-# run is update-only once created) and GitLab commit statuses are post-only, so
-# neither can honor a removal; refusing it loudly beats a verdict the surface
-# silently ignores.
+# honoring a `remove`. GitHub check runs have no DELETE (update-only once
+# created) and GitLab commit statuses are post-only.
 _SURFACE_CAN_REMOVE = {"buildkite_annotation": True}
 
 # Verdict from a `status_surface_decision` hook. `publish` writes (optionally
@@ -274,14 +270,9 @@ StatusSurfaceInfo = record(
     # The rendered content this write would publish, in the surface's own unit:
     # the whole annotation body (buildkite_annotation), the check run's details
     # text (github_check), the one-line description (gitlab_commit_status).
-    # Hooks get it after rendering precisely so they can post-process it;
-    # `surface_replace` builds a verdict carrying an edited copy.
-    #
-    # For wholesale authoring, prefer the surface's `templates` arg — it renders
-    # from structured data instead of string-editing finished markup, so it
-    # can't be broken by a layout change. This is the escape hatch for the cases
-    # templates can't reach (appending to whatever the body turned out to be,
-    # redacting a pattern across every kind, …).
+    # Hooks see it post-render so they can edit it — `surface_replace` carries
+    # the edited copy. Authoring a body wholesale is better done with the
+    # surface's `templates` arg, which renders from structured data.
     body = field(str),
     # Task identity, so one hook can scope itself per task.
     task_kind = field(str),
@@ -301,8 +292,8 @@ SURFACE_PUBLISH = StatusSurfaceDecision(action = StatusSurfaceAction("publish"))
 SURFACE_REMOVE = StatusSurfaceDecision(action = StatusSurfaceAction("remove"))
 
 def surface_restyle(style: str) -> StatusSurfaceDecision:
-    """Publish, overriding the surface's severity styling. Values are
-    surface-specific — Buildkite takes `success|info|warning|error`."""
+    """Publish, overriding the styling. Values are per-surface — see
+    `StatusSurfaceInfo.style`."""
     return StatusSurfaceDecision(action = StatusSurfaceAction("publish"), style = style)
 
 def surface_replace(body: str, style: str | None = None) -> StatusSurfaceDecision:
@@ -310,6 +301,21 @@ def surface_replace(body: str, style: str | None = None) -> StatusSurfaceDecisio
     restyling too. Build it from `info.body` to post-process, or pass a fresh
     string to author it outright."""
     return StatusSurfaceDecision(action = StatusSurfaceAction("publish"), style = style, body = body)
+
+_LOG = feature_logger("Status surface")
+
+def _threaded(info: StatusSurfaceInfo, decision: StatusSurfaceDecision) -> StatusSurfaceInfo:
+    """`info` with the decision's style/body applied, for the next handler.
+    Unset fields keep the incoming value."""
+    return StatusSurfaceInfo(
+        surface = info.surface,
+        status = info.status,
+        final = info.final,
+        style = decision.style or info.style,
+        body = decision.body if decision.body != None else info.body,
+        task_kind = info.task_kind,
+        task_name = info.task_name,
+    )
 
 def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> StatusSurfaceDecision:
     """Run `info` through every `status_surface_decision` hook.
@@ -323,7 +329,8 @@ def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> Statu
     A `remove` the surface can't honor (see `_SURFACE_CAN_REMOVE`) is downgraded
     to a publish so a hook written for Buildkite doesn't silently break the
     other surfaces it also sees. The downgrade is logged — at warn on the
-    terminal emit, so it's noticed once per task rather than per update.
+    terminal emit, so it's noticed once per task rather than per update. Callers
+    on those surfaces therefore never see a `remove` and needn't handle one.
 
     Returns a resolved verdict: on `publish` the decision's `style` and `body`
     are always set (the incoming values when no hook rewrote them), so the
@@ -342,21 +349,30 @@ def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> Statu
             else:
                 _LOG.trace(msg)
             break
-        if decision.style or decision.body != None:
-            info = StatusSurfaceInfo(
-                surface = info.surface,
-                status = info.status,
-                final = info.final,
-                style = decision.style or info.style,
-                body = decision.body if decision.body != None else info.body,
-                task_kind = info.task_kind,
-                task_name = info.task_name,
-            )
+        info = _threaded(info, decision)
     return StatusSurfaceDecision(
         action = StatusSurfaceAction("publish"),
         style = info.style,
         body = info.body,
     )
+
+def resolve_surface_write(ctx, lifecycle, surface, status, final, style, body) -> StatusSurfaceDecision:
+    """`apply_status_surface_hooks` with the `StatusSurfaceInfo` built for you.
+
+    What a surface calls at its write site. `surface` is validated against
+    `StatusSurface` here, and task identity is read off `ctx`, so a surface
+    passes only what it alone knows: its `status`/`final`, plus the `style` and
+    `body` it was about to write in its own vocabulary.
+    """
+    return apply_status_surface_hooks(ctx, lifecycle, StatusSurfaceInfo(
+        surface = StatusSurface(surface).value,
+        status = status,
+        final = final,
+        style = style,
+        body = body,
+        task_kind = ctx.task.kind,
+        task_name = ctx.task.name,
+    ))
 
 # Lifecycle hooks any task can fire, so features like GithubStatusChecks
 # observe progress without coupling to Bazel-specific hooks.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -221,6 +221,69 @@ def repro_fix_replace(command: str | None = None, description: str | None = None
         description = description,
     )
 
+# Which status surface is about to write. Lets one hook scope itself to a
+# single surface when several are enabled.
+StatusSurface = enum("buildkite_annotation", "github_check", "gitlab_commit_status")
+
+# Verdict from a `status_surface_decision` hook. `publish` writes as normal;
+# `remove` suppresses the write and retracts anything already published for
+# this task on that surface. `style` (publish only) overrides the surface's
+# severity styling.
+StatusSurfaceAction = enum("publish", "remove")
+
+# Passed to each `status_surface_decision` hook alongside `ctx` — what the
+# surface knows at the instant it's about to write.
+StatusSurfaceInfo = record(
+    surface = field(StatusSurface),
+    # Lifecycle status ("passed", "failing", …) and whether this is the
+    # terminal emit. A hook that ignores `final` also fires mid-run.
+    status = field(str),
+    final = field(bool),
+    # Severity styling the surface resolved for `status`.
+    style = field(str),
+    # Task identity, so one hook can scope itself per task.
+    task_kind = field(str),
+    task_name = field(str),
+)
+
+StatusSurfaceDecision = record(
+    action = field(StatusSurfaceAction),
+    style = field(str | None, default = None),
+)
+
+# Shared singletons for the no-argument verdicts.
+SURFACE_PUBLISH = StatusSurfaceDecision(action = StatusSurfaceAction("publish"))
+SURFACE_REMOVE = StatusSurfaceDecision(action = StatusSurfaceAction("remove"))
+
+def surface_restyle(style: str) -> StatusSurfaceDecision:
+    """Publish, overriding the surface's severity styling. Values are
+    surface-specific — Buildkite takes `success|info|warning|error`."""
+    return StatusSurfaceDecision(action = StatusSurfaceAction("publish"), style = style)
+
+def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> StatusSurfaceDecision:
+    """Run `info` through every `status_surface_decision` hook.
+
+    Handlers chain in order; the first `remove` short-circuits, since there is
+    nothing left to restyle once the write is being suppressed. A `publish`
+    carrying a `style` is threaded into the next handler's `info`, so the last
+    writer wins. No handlers → `SURFACE_PUBLISH`.
+    """
+    decision = SURFACE_PUBLISH
+    for handler in lifecycle.status_surface_decision:
+        decision = handler(ctx, info)
+        if decision.action == StatusSurfaceAction("remove"):
+            return decision
+        if decision.style:
+            info = StatusSurfaceInfo(
+                surface = info.surface,
+                status = info.status,
+                final = info.final,
+                style = decision.style,
+                task_kind = info.task_kind,
+                task_name = info.task_name,
+            )
+    return decision
+
 # Lifecycle hooks any task can fire, so features like GithubStatusChecks
 # observe progress without coupling to Bazel-specific hooks.
 TaskLifecycleTrait = trait(
@@ -239,6 +302,20 @@ TaskLifecycleTrait = trait(
     # makes it idempotent. Handlers chain in order; `reject` short-circuits.
     # See `apply_repro_fix_hooks`.
     repro_fix_suggestion = attr(list[typing.Callable[[TaskContext, ReproFixInfo], ReproFixSuggestion]], default = []),
+
+    # `(ctx: TaskContext, info: StatusSurfaceInfo) -> StatusSurfaceDecision`,
+    # consulted by a status surface immediately before it writes, so a config
+    # can suppress or restyle the write itself.
+    #
+    # Lives on the lifecycle trait (not the surface's own) because a feature
+    # can't contribute a trait — `feature()` takes no `traits` — and tasks must
+    # not reference features. Every task already declares this trait, so a hook
+    # here is reachable from `.aspect/config.axl` with no task changes.
+    #
+    # A `task_update` handler can't do this job: handlers run in registration
+    # order and features register first, so a config hook always runs *after*
+    # the surface has posted. See `StatusSurfaceDecision`.
+    status_surface_decision = attr(list[typing.Callable[[TaskContext, StatusSurfaceInfo], StatusSurfaceDecision]], default = []),
 )
 
 # Lives next to `task_update()` so every surface emit routes through

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -29,7 +29,7 @@ Status surfaces flip to the verdict via the task's own terminal
 
 load("./ansi.axl", "ansi")
 load("./bazel_flags.axl", "setup_bazel_command")
-load("./environment.axl", "color_enabled", "detect_ci")
+load("./environment.axl", "color_enabled", "detect_ci", "feature_logger")
 load("./health_check.axl", "run_health_checks")
 load("./runner_job_history.axl", "append_runner_job_history")
 
@@ -221,50 +221,61 @@ def repro_fix_replace(command: str | None = None, description: str | None = None
         description = description,
     )
 
-# Which status surface is about to write. Lets one hook scope itself to a
-# single surface once more than one consults this.
+# Which status surface is consulting the hook. Every per-task surface consults
+# it, so one hook can restyle or rewrite across all of them and scope itself by
+# `info.surface` or task identity.
 #
-# Only the Buildkite annotation, because `remove` is the reason the hook exists
-# and it's the only surface a single task can retract on its own:
+# Surfaces validate their own name through this enum; `StatusSurfaceInfo.surface`
+# stays `str` so hooks compare with plain literals (as `TaskUpdate.status` does).
 #
-#   - GitHub check runs / GitLab commit statuses have no delete at all (a check
-#     run can only be updated once created; commit statuses are post-only).
-#   - The PR comment and MR note *have* a delete endpoint, but they're a shared
-#     aggregate: every sibling job contributes its task's status to one comment
-#     and a server elects a poster each cycle. One task retracting it would
-#     erase every other task's status — including failures from other jobs —
-#     and the next elected poster would recreate it, flapping. The existing
-#     `delete_comment` call is for collapsing duplicate comments, never for
-#     retracting the live one.
-#
-# An enum (not a bare string) so adding a surface is a deliberate act that has
-# to answer "can one task retract this on its own?".
-StatusSurface = enum("buildkite_annotation")
+# The aggregate PR/MR summary comments deliberately do not consult it: a
+# comment write merges every sibling task's status (a server elects one poster
+# per cycle), so the per-task `status` / `final` fields can't describe it.
+# Those surfaces customize through their `templates` arg ("body").
+StatusSurface = enum("buildkite_annotation", "github_check", "gitlab_commit_status")
+
+_LOG = feature_logger("Status surface")
+
+# Surfaces whose artifact a single task can retract on its own — the only ones
+# a `remove` verdict is honored for. GitHub check runs have no DELETE (a check
+# run is update-only once created) and GitLab commit statuses are post-only, so
+# neither can honor a removal; refusing it loudly beats a verdict the surface
+# silently ignores.
+_SURFACE_CAN_REMOVE = {"buildkite_annotation": True}
 
 # Verdict from a `status_surface_decision` hook. `publish` writes (optionally
 # with a rewritten `body` or `style`); `remove` suppresses the write and
 # retracts anything already published for this task on that surface.
 #
-# `remove` is terminal for the task's artifact on that surface: once retracted,
-# the surface stops rendering and stops consulting hooks for the rest of the
-# task. Re-posting would resurrect what the hook asked to hide, and re-deciding
-# would render bodies only to discard them. A hook that wants the artifact back
-# later shouldn't remove it — restyle it instead.
+# `remove` is honored only where the surface can retract (see
+# `_SURFACE_CAN_REMOVE`) and is terminal for the task's artifact there: once
+# retracted, the surface stops rendering and stops consulting hooks for the
+# rest of the task. A hook that wants the artifact back later shouldn't remove
+# it — restyle it instead.
 StatusSurfaceAction = enum("publish", "remove")
 
 # Passed to each `status_surface_decision` hook alongside `ctx` — what the
 # surface knows at the instant it's about to write.
 StatusSurfaceInfo = record(
-    surface = field(StatusSurface),
+    surface = field(str),
     # Lifecycle status ("passed", "failing", …) and whether this is the
     # terminal emit. A hook that ignores `final` also fires mid-run.
     status = field(str),
     final = field(bool),
-    # Severity styling the surface resolved for `status`.
+    # The styling this write would carry, in the surface's own vocabulary — a
+    # restyle must answer in the same one:
+    #   buildkite_annotation   annotation style: success|info|warning|error
+    #   github_check           conclusion: success|neutral|failure, or "" when
+    #                          this write lands no conclusion (mid-run PATCH; a
+    #                          restyle is a no-op there)
+    #   gitlab_commit_status   state: pending|running|success|failed|canceled|
+    #                          skipped
     style = field(str),
-    # The fully rendered content this write would publish. Hooks get it after
-    # rendering precisely so they can post-process it; `surface_replace` builds
-    # a verdict carrying an edited copy.
+    # The rendered content this write would publish, in the surface's own unit:
+    # the whole annotation body (buildkite_annotation), the check run's details
+    # text (github_check), the one-line description (gitlab_commit_status).
+    # Hooks get it after rendering precisely so they can post-process it;
+    # `surface_replace` builds a verdict carrying an edited copy.
     #
     # For wholesale authoring, prefer the surface's `templates` arg — it renders
     # from structured data instead of string-editing finished markup, so it
@@ -309,6 +320,11 @@ def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> Statu
     handler's `info`, so each handler sees its predecessor's edits and a later
     plain publish keeps them.
 
+    A `remove` the surface can't honor (see `_SURFACE_CAN_REMOVE`) is downgraded
+    to a publish so a hook written for Buildkite doesn't silently break the
+    other surfaces it also sees. The downgrade is logged — at warn on the
+    terminal emit, so it's noticed once per task rather than per update.
+
     Returns a resolved verdict: on `publish` the decision's `style` and `body`
     are always set (the incoming values when no hook rewrote them), so the
     caller writes exactly what the chain settled on.
@@ -316,7 +332,16 @@ def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> Statu
     for handler in lifecycle.status_surface_decision:
         decision = handler(ctx, info)
         if decision.action == StatusSurfaceAction("remove"):
-            return decision
+            if _SURFACE_CAN_REMOVE.get(info.surface):
+                return decision
+            msg = ("status_surface_decision asked to remove the %s artifact, which that " +
+                   "surface can't retract — publishing instead. Scope the hook with " +
+                   "`info.surface` to silence this.") % info.surface
+            if info.final:
+                _LOG.warn(ctx.std, msg)
+            else:
+                _LOG.trace(msg)
+            break
         if decision.style or decision.body != None:
             info = StatusSurfaceInfo(
                 surface = info.surface,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -221,35 +221,38 @@ def repro_fix_replace(command: str | None = None, description: str | None = None
         description = description,
     )
 
-# Which status surface is consulting the hook. Every per-task surface consults
-# it, so one hook can restyle or rewrite across all of them and scope itself by
-# `info.surface` or task identity.
-#
-# Surfaces validate their own name through this enum; `StatusSurfaceInfo.surface`
-# stays `str` so hooks compare with plain literals (as `TaskUpdate.status` does).
-#
-# The aggregate PR/MR summary comments deliberately do not consult it: a
-# comment write merges every sibling task's status (a server elects one poster
-# per cycle), so the per-task `status` / `final` fields can't describe it.
-# Those surfaces customize through their `templates` arg ("body").
-StatusSurface = enum("buildkite_annotation", "github_check", "gitlab_commit_status")
-
 # Surfaces whose artifact a single task can retract on its own — the only ones
 # honoring a `remove`. GitHub check runs have no DELETE (update-only once
 # created) and GitLab commit statuses are post-only.
 _SURFACE_CAN_REMOVE = {"buildkite_annotation": True}
 
-# Styles each surface can express, i.e. what a `surface_restyle` may answer.
-# Anything else is refused and the surface's own style stands, because these
-# vocabularies don't overlap: Buildkite's "warning" reaching a check run matches
-# no conclusion (GitHub's client would conclude `failure`, turning a green check
-# red), and GitHub's "neutral" reaching GitLab is rejected by the API for the
-# rest of the task. An unscoped hook meant for one surface can't corrupt another.
+# Every per-task status surface, and the styles each one can express — the
+# values a `surface_restyle` may answer with for that surface.
+#
+# A style outside its surface's list is refused and the surface's own style
+# stands, because the vocabularies don't overlap and forwarding blindly is
+# destructive: Buildkite's "warning" reaching a check run matches no conclusion
+# (GitHub's client would then conclude `failure`, turning a green check red),
+# and GitHub's "neutral" reaching GitLab is rejected by the API for the rest of
+# the task. So an unscoped hook can't corrupt the surfaces it wasn't written for.
 _SURFACE_STYLES = {
     "buildkite_annotation": ["success", "info", "warning", "error"],
     "github_check": ["success", "neutral", "failure"],
     "gitlab_commit_status": ["pending", "running", "success", "failed", "canceled", "skipped"],
 }
+
+# Which surface is consulting the hook. Derived from `_SURFACE_STYLES` so a new
+# surface can't be added to one without the other — an unlisted surface would
+# otherwise silently refuse every restyle.
+#
+# Surfaces validate their own name through this enum; `StatusSurfaceInfo.surface`
+# stays `str` so hooks compare with plain literals (as `TaskUpdate.status` does).
+#
+# The aggregate PR/MR summary comments deliberately don't consult the hook: a
+# comment write merges every sibling task's status (a server elects one poster
+# per cycle), so the per-task `status` / `final` fields can't describe it. Those
+# surfaces customize through their `templates` arg ("body").
+StatusSurface = enum(*sorted(_SURFACE_STYLES.keys()))
 
 # Verdict from a `status_surface_decision` hook. `publish` writes (optionally
 # with a rewritten `body` or `style`); `remove` suppresses the write and

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -279,10 +279,9 @@ StatusSurfaceInfo = record(
 
 StatusSurfaceDecision = record(
     action = field(StatusSurfaceAction),
+    # `publish` only; None keeps the incoming value. `apply_status_surface_hooks`
+    # resolves both before returning, so surface code reads concrete values.
     style = field(str | None, default = None),
-    # None on a `remove`, and on a `publish` that didn't rewrite anything —
-    # `apply_status_surface_hooks` resolves it to the incoming body before
-    # returning, so callers can always read `decision.body` on a publish.
     body = field(str | None, default = None),
 )
 
@@ -307,14 +306,13 @@ def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> Statu
     Handlers chain in order and the first `remove` short-circuits — there is
     nothing left to edit once the write is being suppressed. A `publish`
     carrying a rewritten `body` and/or `style` is threaded into the next
-    handler's `info`, so each handler sees its predecessor's edits and the last
-    writer wins.
+    handler's `info`, so each handler sees its predecessor's edits and a later
+    plain publish keeps them.
 
-    On a `publish` the returned decision always carries a `body` (falling back
-    to the incoming one), so callers don't have to re-resolve it. No handlers →
-    publish the body unchanged.
+    Returns a resolved verdict: on `publish` the decision's `style` and `body`
+    are always set (the incoming values when no hook rewrote them), so the
+    caller writes exactly what the chain settled on.
     """
-    decision = StatusSurfaceDecision(action = StatusSurfaceAction("publish"), body = info.body)
     for handler in lifecycle.status_surface_decision:
         decision = handler(ctx, info)
         if decision.action == StatusSurfaceAction("remove"):
@@ -329,15 +327,11 @@ def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> Statu
                 task_kind = info.task_kind,
                 task_name = info.task_name,
             )
-
-    # Normalize so a publish always carries the body that should be written.
-    if decision.action == StatusSurfaceAction("publish") and decision.body == None:
-        return StatusSurfaceDecision(
-            action = decision.action,
-            style = decision.style,
-            body = info.body,
-        )
-    return decision
+    return StatusSurfaceDecision(
+        action = StatusSurfaceAction("publish"),
+        style = info.style,
+        body = info.body,
+    )
 
 # Lifecycle hooks any task can fire, so features like GithubStatusChecks
 # observe progress without coupling to Bazel-specific hooks.
@@ -360,8 +354,8 @@ TaskLifecycleTrait = trait(
 
     # `(ctx: TaskContext, info: StatusSurfaceInfo) -> StatusSurfaceDecision`,
     # consulted by a status surface immediately before it writes, so a config
-    # can suppress or restyle the write itself. It does not carry the rendered
-    # content — use the surface's `templates` arg for that.
+    # can suppress the write, restyle it, or rewrite its rendered body
+    # (`info.body`).
     #
     # Lives on the lifecycle trait (not the surface's own) because a feature
     # can't contribute a trait — `feature()` takes no `traits` — and tasks must

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -222,30 +222,28 @@ def repro_fix_replace(command: str | None = None, description: str | None = None
     )
 
 # Which status surface is about to write. Lets one hook scope itself to a
-# single surface when several are enabled.
+# single surface once more than one consults this.
 #
-# Only surfaces whose API can retract a published artifact are listed, because
-# `remove` is the reason this hook exists:
+# Only the Buildkite annotation, because `remove` is the reason the hook exists
+# and it's the only surface a single task can retract on its own:
 #
-#   buildkite_annotation  — `buildkite-agent annotation remove`
-#   github_pr_comment     — DELETE issue comment
-#   gitlab_mr_note        — DELETE note
+#   - GitHub check runs / GitLab commit statuses have no delete at all (a check
+#     run can only be updated once created; commit statuses are post-only).
+#   - The PR comment and MR note *have* a delete endpoint, but they're a shared
+#     aggregate: every sibling job contributes its task's status to one comment
+#     and a server elects a poster each cycle. One task retracting it would
+#     erase every other task's status — including failures from other jobs —
+#     and the next elected poster would recreate it, flapping. The existing
+#     `delete_comment` call is for collapsing duplicate comments, never for
+#     retracting the live one.
 #
-# Deliberately absent: GitHub check runs (the REST API has no DELETE — a check
-# run can only be updated once created) and GitLab commit statuses (post-only).
-# Those surfaces can't honor `remove` at all, so letting a hook ask for it
-# would only produce a verdict they'd have to ignore.
-StatusSurface = enum("buildkite_annotation", "github_pr_comment", "gitlab_mr_note")
+# An enum (not a bare string) so adding a surface is a deliberate act that has
+# to answer "can one task retract this on its own?".
+StatusSurface = enum("buildkite_annotation")
 
-# Verdict from a `status_surface_decision` hook. `publish` writes as normal;
-# `remove` suppresses the write and retracts anything already published for
-# this task on that surface. `style` (publish only) overrides the surface's
-# severity styling.
-#
-# There is no "replace the content" verdict: the hook runs before the body is
-# rendered (so a `remove` doesn't pay for a render it discards), which means
-# there is no content to hand it. Content is customized through the surface's
-# `templates` arg instead — see `check_dispatch.resolve_templates`.
+# Verdict from a `status_surface_decision` hook. `publish` writes (optionally
+# with a rewritten `body` or `style`); `remove` suppresses the write and
+# retracts anything already published for this task on that surface.
 StatusSurfaceAction = enum("publish", "remove")
 
 # Passed to each `status_surface_decision` hook alongside `ctx` — what the
@@ -258,6 +256,16 @@ StatusSurfaceInfo = record(
     final = field(bool),
     # Severity styling the surface resolved for `status`.
     style = field(str),
+    # The fully rendered content this write would publish. Hooks get it after
+    # rendering precisely so they can post-process it; `surface_replace` builds
+    # a verdict carrying an edited copy.
+    #
+    # For wholesale authoring, prefer the surface's `templates` arg — it renders
+    # from structured data instead of string-editing finished markup, so it
+    # can't be broken by a layout change. This is the escape hatch for the cases
+    # templates can't reach (appending to whatever the body turned out to be,
+    # redacting a pattern across every kind, …).
+    body = field(str),
     # Task identity, so one hook can scope itself per task.
     task_kind = field(str),
     task_name = field(str),
@@ -266,6 +274,10 @@ StatusSurfaceInfo = record(
 StatusSurfaceDecision = record(
     action = field(StatusSurfaceAction),
     style = field(str | None, default = None),
+    # None on a `remove`, and on a `publish` that didn't rewrite anything —
+    # `apply_status_surface_hooks` resolves it to the incoming body before
+    # returning, so callers can always read `decision.body` on a publish.
+    body = field(str | None, default = None),
 )
 
 # Shared singletons for the no-argument verdicts.
@@ -277,28 +289,48 @@ def surface_restyle(style: str) -> StatusSurfaceDecision:
     surface-specific — Buildkite takes `success|info|warning|error`."""
     return StatusSurfaceDecision(action = StatusSurfaceAction("publish"), style = style)
 
+def surface_replace(body: str, style: str | None = None) -> StatusSurfaceDecision:
+    """Publish `body` in place of what the surface rendered, optionally
+    restyling too. Build it from `info.body` to post-process, or pass a fresh
+    string to author it outright."""
+    return StatusSurfaceDecision(action = StatusSurfaceAction("publish"), style = style, body = body)
+
 def apply_status_surface_hooks(ctx, lifecycle, info: StatusSurfaceInfo) -> StatusSurfaceDecision:
     """Run `info` through every `status_surface_decision` hook.
 
-    Handlers chain in order; the first `remove` short-circuits, since there is
-    nothing left to restyle once the write is being suppressed. A `publish`
-    carrying a `style` is threaded into the next handler's `info`, so the last
-    writer wins. No handlers → `SURFACE_PUBLISH`.
+    Handlers chain in order and the first `remove` short-circuits — there is
+    nothing left to edit once the write is being suppressed. A `publish`
+    carrying a rewritten `body` and/or `style` is threaded into the next
+    handler's `info`, so each handler sees its predecessor's edits and the last
+    writer wins.
+
+    On a `publish` the returned decision always carries a `body` (falling back
+    to the incoming one), so callers don't have to re-resolve it. No handlers →
+    publish the body unchanged.
     """
-    decision = SURFACE_PUBLISH
+    decision = StatusSurfaceDecision(action = StatusSurfaceAction("publish"), body = info.body)
     for handler in lifecycle.status_surface_decision:
         decision = handler(ctx, info)
         if decision.action == StatusSurfaceAction("remove"):
             return decision
-        if decision.style:
+        if decision.style or decision.body != None:
             info = StatusSurfaceInfo(
                 surface = info.surface,
                 status = info.status,
                 final = info.final,
-                style = decision.style,
+                style = decision.style or info.style,
+                body = decision.body if decision.body != None else info.body,
                 task_kind = info.task_kind,
                 task_name = info.task_name,
             )
+
+    # Normalize so a publish always carries the body that should be written.
+    if decision.action == StatusSurfaceAction("publish") and decision.body == None:
+        return StatusSurfaceDecision(
+            action = decision.action,
+            style = decision.style,
+            body = info.body,
+        )
     return decision
 
 # Lifecycle hooks any task can fire, so features like GithubStatusChecks

--- a/crates/aspect-cli/src/builtins/aspect/traits.axl
+++ b/crates/aspect-cli/src/builtins/aspect/traits.axl
@@ -21,6 +21,8 @@ files can load the full trait set with a single import:
          "StatusSurface",
          "StatusSurfaceDecision",
          "StatusSurfaceInfo",
+         "surface_replace",
+         "surface_restyle",
          "TaskUpdate",
          "repro_fix_replace")
 
@@ -58,6 +60,7 @@ load(
     _TaskLifecycleTrait = "TaskLifecycleTrait",
     _TaskUpdate = "TaskUpdate",
     _repro_fix_replace = "repro_fix_replace",
+    _surface_replace = "surface_replace",
     _surface_restyle = "surface_restyle",
 )
 
@@ -81,4 +84,5 @@ StatusSurfaceInfo = _StatusSurfaceInfo
 TaskLifecycleTrait = _TaskLifecycleTrait
 TaskUpdate = _TaskUpdate
 repro_fix_replace = _repro_fix_replace
+surface_replace = _surface_replace
 surface_restyle = _surface_restyle

--- a/crates/aspect-cli/src/builtins/aspect/traits.axl
+++ b/crates/aspect-cli/src/builtins/aspect/traits.axl
@@ -16,6 +16,11 @@ files can load the full trait set with a single import:
          "ReproFixCommandKind",
          "ReproFixInfo",
          "ReproFixSuggestion",
+         "SURFACE_PUBLISH",
+         "SURFACE_REMOVE",
+         "StatusSurface",
+         "StatusSurfaceDecision",
+         "StatusSurfaceInfo",
          "TaskUpdate",
          "repro_fix_replace")
 
@@ -44,9 +49,16 @@ load(
     _ReproFixCommandKind = "ReproFixCommandKind",
     _ReproFixInfo = "ReproFixInfo",
     _ReproFixSuggestion = "ReproFixSuggestion",
+    _SURFACE_PUBLISH = "SURFACE_PUBLISH",
+    _SURFACE_REMOVE = "SURFACE_REMOVE",
+    _StatusSurface = "StatusSurface",
+    _StatusSurfaceAction = "StatusSurfaceAction",
+    _StatusSurfaceDecision = "StatusSurfaceDecision",
+    _StatusSurfaceInfo = "StatusSurfaceInfo",
     _TaskLifecycleTrait = "TaskLifecycleTrait",
     _TaskUpdate = "TaskUpdate",
     _repro_fix_replace = "repro_fix_replace",
+    _surface_restyle = "surface_restyle",
 )
 
 BazelTrait = _BazelTrait
@@ -60,6 +72,13 @@ ReproFixCommand = _ReproFixCommand
 ReproFixCommandKind = _ReproFixCommandKind
 ReproFixInfo = _ReproFixInfo
 ReproFixSuggestion = _ReproFixSuggestion
+SURFACE_PUBLISH = _SURFACE_PUBLISH
+SURFACE_REMOVE = _SURFACE_REMOVE
+StatusSurface = _StatusSurface
+StatusSurfaceAction = _StatusSurfaceAction
+StatusSurfaceDecision = _StatusSurfaceDecision
+StatusSurfaceInfo = _StatusSurfaceInfo
 TaskLifecycleTrait = _TaskLifecycleTrait
 TaskUpdate = _TaskUpdate
 repro_fix_replace = _repro_fix_replace
+surface_restyle = _surface_restyle

--- a/crates/aspect-cli/src/builtins/aspect/traits.axl
+++ b/crates/aspect-cli/src/builtins/aspect/traits.axl
@@ -19,6 +19,7 @@ files can load the full trait set with a single import:
          "SURFACE_PUBLISH",
          "SURFACE_REMOVE",
          "StatusSurface",
+         "StatusSurfaceAction",
          "StatusSurfaceDecision",
          "StatusSurfaceInfo",
          "surface_replace",

--- a/crates/aspect-cli/src/builtins/aspect/traits.axl
+++ b/crates/aspect-cli/src/builtins/aspect/traits.axl
@@ -21,7 +21,7 @@ files can load the full trait set with a single import:
          "StatusSurface",
          "StatusSurfaceAction",
          "StatusSurfaceDecision",
-         "StatusSurfaceInfo",
+         "StatusSurfaceUpdate",
          "surface_replace",
          "surface_restyle",
          "TaskUpdate",
@@ -57,7 +57,7 @@ load(
     _StatusSurface = "StatusSurface",
     _StatusSurfaceAction = "StatusSurfaceAction",
     _StatusSurfaceDecision = "StatusSurfaceDecision",
-    _StatusSurfaceInfo = "StatusSurfaceInfo",
+    _StatusSurfaceUpdate = "StatusSurfaceUpdate",
     _TaskLifecycleTrait = "TaskLifecycleTrait",
     _TaskUpdate = "TaskUpdate",
     _repro_fix_replace = "repro_fix_replace",
@@ -81,7 +81,7 @@ SURFACE_REMOVE = _SURFACE_REMOVE
 StatusSurface = _StatusSurface
 StatusSurfaceAction = _StatusSurfaceAction
 StatusSurfaceDecision = _StatusSurfaceDecision
-StatusSurfaceInfo = _StatusSurfaceInfo
+StatusSurfaceUpdate = _StatusSurfaceUpdate
 TaskLifecycleTrait = _TaskLifecycleTrait
 TaskUpdate = _TaskUpdate
 repro_fix_replace = _repro_fix_replace


### PR DESCRIPTION
Adds `TaskLifecycleTrait.status_surface_update`: a hook consulted immediately before a status surface writes, returning a verdict — publish, publish with a different style or body, or remove. `BuildkiteAnnotations`, `GithubStatusChecks`, and `GitlabCommitStatuses` all consult it.

The motivating ask was to suppress a task's Buildkite annotation when it passes, so the Annotations tab only lists what needs attention. That isn't reachable from config otherwise: `task_update` handlers run in registration order and features register before config hooks, so a hook that shells out to `annotation remove` is immediately followed by the feature re-posting the terminal annotation.

```python
load("@aspect//traits.axl", "SURFACE_PUBLISH", "SURFACE_REMOVE", "StatusSurfaceUpdate", "TaskLifecycleTrait")

def _drop_when_passed(ctx: TaskContext, update: StatusSurfaceUpdate):
    if update.surface == "buildkite_annotation" and update.final and update.status == "passed":
        return SURFACE_REMOVE
    return SURFACE_PUBLISH

def config(ctx: ConfigContext):
    ctx.traits[TaskLifecycleTrait].status_surface_update.append(_drop_when_passed)
```

## Verdicts

Same shape as the existing `repro_fix_suggestion` / `tip_suggestion` hooks — singletons plus helpers for the argument-taking cases:

- `SURFACE_PUBLISH` — write as rendered.
- `surface_restyle(style)` — override the styling.
- `surface_replace(body, style=None)` — publish an edited or new body. `update.body` carries the rendered content, so hooks can post-process it.
- `SURFACE_REMOVE` — suppress the write and retract anything the task already posted. **Replaces** the write rather than following it, so nothing flickers into view. Terminal: the surface then stops rendering and stops consulting hooks for the rest of the task, so a hook wanting the artifact back later should restyle instead.

Styles and bodies thread through the chain — each handler sees its predecessor's result, and a later plain publish keeps earlier edits. Hooks fire on live updates too, so check `update.final` to act only on the outcome. `info` also carries `surface`, `status`, `style`, `body`, `task_kind`, and `task_name` for scoping.

## Per-surface semantics

`update.style` and `update.body` are in each surface's own vocabulary, and a restyle must answer in the same one:

| Surface | `style` | `body` | `remove` |
|---|---|---|---|
| `buildkite_annotation` | annotation style (`success`/`info`/`warning`/`error`) | the whole annotation body | ✅ |
| `github_check` | conclusion (`success`/`neutral`/`failure`), `""` when the write lands none | the check run's details text | ❌ |
| `gitlab_commit_status` | commit-status state (`pending`/`running`/…) | the 255-char description — the only text it carries | ❌ |

Restyling a check run overrides its conclusion, which decides whether it blocks a PR — e.g. `surface_restyle("neutral")` to report lint findings without gating merges.

Verdicts a surface can't honor are refused rather than forwarded, so one unscoped hook can't corrupt the other surfaces it also sees:

- **`remove`** needs a surface a single task can retract on its own. Check runs have no DELETE (update-only once created) and commit statuses are post-only, so a removal there becomes a publish.
- **A restyle** outside the surface's vocabulary leaves the incoming style standing. The vocabularies don't overlap, and forwarding blindly is destructive: Buildkite's `warning` matches no GitHub conclusion and would conclude `failure`, turning a green check red.

Both refusals warn on the terminal emit, so an unscoped hook is noticed once per task. Scope with `update.surface` to avoid them.

The aggregate PR/MR summary comments deliberately don't consult the hook: a comment write merges every sibling task's status with a server electing one poster per cycle, so the per-task `status`/`final` fields can't describe it, and one task retracting it would erase every other task's status. Those surfaces customize through their `templates` arg.

## Notes for reviewers

- Named to parallel `task_update`, but the contract differs: `task_update` handlers observe and return nothing, while these return a verdict that decides what gets written. A handler that falls off the end is reported and treated as publish-unchanged rather than raising from inside the chain.
- The hook lives on `TaskLifecycleTrait` — which every task already declares — because features can't contribute traits (`feature()` takes no `traits`) and tasks must not reference features. It's reachable from `.aspect/config.axl` with no task changes.
- `StatusSurfaceUpdate.surface` is a plain `str` validated through the `StatusSurface` enum at the write site, matching `TaskUpdate.status`, so hooks scope with a literal.
- Surfaces call `resolve_surface_update`, which builds the info record and validates the surface name; `apply_status_surface_hooks` holds the chain logic and the per-surface capability tables (`_SURFACE_CAN_REMOVE`, `_SURFACE_STYLES`).
- Buildkite bodies are tail-truncated at the send boundary, so a hook rewrite can't exceed the 1 MiB hard limit.
- Extracts `GithubStatusChecks._conclusion_for` (mirroring `GitlabCommitStatuses._state_for`), which the throttle and the PATCH had each computed independently.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`TaskLifecycleTrait.status_surface_update` lets `.aspect/config.axl` decide what happens to a status-surface write before it happens — publish it, restyle it, rewrite its rendered body, or (Buildkite annotations only) remove it. Returning `SURFACE_REMOVE` on a task's terminal update drops its annotation and retracts anything already posted, keeping the Annotations tab to tasks that need attention; `surface_replace` post-processes the rendered content. Consulted by `BuildkiteAnnotations`, `GithubStatusChecks`, and `GitlabCommitStatuses`.

### Test plan

- New test cases in `aspect dev test-bk-annotation-templates` covering the hook chain: no handlers publishes a resolved style+body; terminal-passed removes while live-passed and other statuses publish; `remove` short-circuits later handlers; restyles and rewrites thread through the chain, compose, and survive a later plain publish; a rewrite can restyle simultaneously; restyle and rewrite are honored on all three surfaces; `remove` downgrades to publish (preserving style and body) on the two that can't retract, halting the chain; each surface refuses a style borrowed from another's vocabulary while still publishing, and a refused style doesn't discard an accompanying body rewrite; `update.surface` compares against a plain literal; and `resolve_surface_write` passes surface + task identity through.
- New `aspect dev test-github-features` suite covering `conclusion_for` across live/terminal statuses, including `warning` → `neutral` and unknown statuses landing no conclusion.
- Each new behavior verified caught by mutation testing.
- End-to-end against a real task with a stub `buildkite-agent` recording every invocation and body: drop-when-passed yields 4 live `annotate` calls then `annotation remove` as the final call (no terminal post); a failing task keeps all 5 `annotate` calls; a mid-run remove issues exactly one `annotation remove` with no further renders; a surface-scoped hook restyles all 4 live writes, appends its text to each, and removes at terminal; with no hooks, styles are unchanged (4× `info`, 1× `success`).
- 44 AXL suites and 74 cargo tests pass; `bazel test -- //... -//exclude/...` passes; the 24 annotation-snapshot titles render byte-identically to main.
- GHSC and GitLab wiring is covered by unit tests and review only — exercising those surfaces end-to-end needs live GitHub/GitLab credentials.
- Confirmed against Buildkite's CLI reference that `annotation remove` takes the same `--context` / `--scope` pair the feature annotates under, and against GitHub's REST docs that check runs expose no DELETE.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle hooks for customizing task status updates across Buildkite, GitHub, and GitLab.
  * Status updates can now be restyled, rewritten, suppressed, or removed where supported.
  * Added shared status-surface configuration and customization helpers.
  * Improved Buildkite annotation handling, including safe truncation and removal support.

* **Bug Fixes**
  * Unsupported status removals now fall back to publishing an updated status.

* **Tests**
  * Added coverage for status customization, conclusion mapping, validation, fallback behavior, and handler chaining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->