### PR TITLE
fix(ci): drop legacy-CLI-only flags from build-task steps

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -271,7 +271,7 @@ jobs:
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task
-        run: bazel --aspect:disable_plugins --aspect:lock_version build --task:name build-gha
+        run: bazel build --task:name build-gha
   build-debug-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]
@@ -283,7 +283,7 @@ jobs:
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Build Task (ASPECT_DEBUG=1)
-        run: ASPECT_DEBUG=1 bazel --aspect:disable_plugins --aspect:lock_version build --task:name build-gha-debug
+        run: ASPECT_DEBUG=1 bazel build --task:name build-gha-debug
   test-task:
     runs-on: [self-hosted, aspect-workflows, aspect-default]
     needs: [pre-build]


### PR DESCRIPTION
## Problem

Every open PR started failing CI this morning on the build-task and build-debug-task jobs. The error is:

```
error: unexpected argument '--aspect:disable_plugins' found
```

## Root cause

A search of the source code shows that the two flags, --aspect:disable_plugins and --aspect:lock_version, are not supported by the Rust aspect-cli. The root clap command in `crates/aspect-cli/src/cmd.rs` has no such global arguments, and clap rejects unrecognized ones outright.

These flags belonged to the old, pre-Rust legacy CLI. It looks like PR #1205  hardcoded them into these two CI steps back in June as a temporary measure. Its own commit message says they exist "to be removed once workflows runners no longer ship with legacy cli."

The equivalent behavior already exists inside the CLI itself. The `is_legacy_cli` probe in `workflows.axl `detects the old CLI at runtime and applies these same flags to the underlying bazel subprocess only when needed. The hardcoded CI flags seem to be a stale duplicate of that logic, and they are what broke once the runner fleet stopped shipping the legacy CLI.

## Fix

Remove --aspect:disable_plugins and --aspect:lock_version from the two build-task steps in .github/workflows/ci-workflows.yaml. Nothing else changes.

.aspect/bootstrap.sh is left untouched. It is already gated behind ASPECT_WORKFLOWS_RUNNER_NO_LEGACY_CLI and is not implicated in this failure.

## Verification

The diff is limited to the two flag removals. Once CI runs, the build-task and build-debug-task jobs should go green.