### PR TITLE
chore: setup --downloader_config and mirror musl.libc.org

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,13 @@ common:linux --host_platform=//bazel/platforms:linux_host_platform
 common --@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=False
 common --@toolchains_llvm_bootstrapped//config:experimental_stub_libgcc_s=True
 
+# Rewrite flaky download hosts to mirrors (musl.libc.org times out from CI,
+# stalling the musl_libc repository fetch until the job timeout kills it).
+# See bazel/downloader.cfg for the rules; pinned integrity checksums keep
+# mirrors honest. Complements --module_mirrors (bazel/defaults.bazelrc),
+# which only covers BCR module sources, not extension-fetched archives.
+common --downloader_config=bazel/downloader.cfg
+
 common:release --stamp
 common:release --workspace_status_command "${PWD}/bazel/workspace_status.sh"
 common:release --compilation_mode=opt

--- a/bazel/downloader.cfg
+++ b/bazel/downloader.cfg
@@ -1,0 +1,10 @@
+# Bazel downloader rewrite rules (--experimental_downloader_config).
+#
+# musl.libc.org is a single small origin with no CDN and frequently times out
+# from CI runners, stalling the toolchains_llvm_bootstrapped musl_libc fetch
+# until the job is killed. Try a mirror first, then the upstream origin.
+# The repository pins an integrity checksum, so a mirror cannot substitute
+# different bytes.
+rewrite musl\.libc\.org/releases/(.+) sources.buildroot.net/musl/$1
+rewrite musl\.libc\.org/releases/(.+) sources.voidlinux.org/musl-1.2.5/$1
+rewrite musl\.libc\.org/releases/(.+) musl.libc.org/releases/$1


### PR DESCRIPTION
A robot tells me this specific download has been a frequent source of CI failures recently.

BCR entries have been mirrored with `--module_mirrors="https://bcr.cloudflaremirrors.com"` since `bazelrc-preset.bzl` 1.9.2 added that snippet. But that doesn't cover every other downloads bazel does.

Example errors:
https://gitlab.com/aspect-build/aspect-cli/-/jobs/15839255112
> java.io.IOException: Error downloading [https://musl.libc.org/releases/musl-1.2.5.tar.gz] to /mnt/ephemeral/output/aspect-cli/aspect-cli/external/toolchains_llvm_bootstrapped++musl+musl_libc/temp313838676835598877/musl-1.2.5.tar.gz: Connect timed out

https://gitlab.com/aspect-build/aspect-cli/-/jobs/15844474173
> java.io.IOException: Error downloading [https://musl.libc.org/releases/musl-1.2.5.tar.gz] to /mnt/ephemeral/output/aspect-cli/aspect-cli/external/toolchains_llvm_bootstrapped++musl+musl_libc/temp910020944593838320/musl-1.2.5.tar.gz: Connect timed out

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
