### PR TITLE
fix(circleci): percent-encode S3 object keys before signing

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/private/lib/artifacts.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/artifacts.axl
@@ -393,7 +393,14 @@ def _upload_group_per_file(ctx, provider, group, entries, name):
         else:
             for err in result["errors"]:
                 _print_upload_error(ctx, dest, err)
-            break
+
+            # A permanent rejection (this file, every time) is counted as
+            # handled: retrying it on each later snapshot would warn again and
+            # again, and stopping here would strand every file behind it. A
+            # transient failure keeps its slot so the next snapshot retries it.
+            if not result.get("permanent", False):
+                break
+            group["last_count"] += 1
 
     return any_success
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/circleci.axl
@@ -319,11 +319,16 @@ def s3_failure_is_retryable(http_code: str, body: str) -> bool:
     4xx is only when its `<Code>` names a rotation, skew, or throttle (see
     `_RETRYABLE_S3_ERROR_CODES`).
 
+    A 2xx counts as retryable too, because reaching here with one means curl
+    exited nonzero *after* S3 answered — the response transfer was cut short
+    (`curl: (18) Partial file`, or a reset mid-body). That's the network, not
+    something about the request that a retry would hit again.
+
     Public (not `_`-prefixed) so `circleci_test.axl` can load it.
     """
     if not http_code or http_code == "000":
         return True
-    if http_code.startswith("5") or http_code in ("408", "429"):
+    if http_code.startswith("2") or http_code.startswith("5") or http_code in ("408", "429"):
         return True
     return s3_extract_error_code(body) in _RETRYABLE_S3_ERROR_CODES
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/circleci.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/circleci.axl
@@ -11,6 +11,11 @@ credentials:
 Neither is pre-signed by the runner; the client signs both — see `_s3_put`
 and `_s3_put_object`.
 
+Because we sign with curl's `--aws-sigv4`, which signs the URL path exactly
+as written, every object key goes through `aws_uri_encode` first — otherwise
+a key holding anything outside `A-Za-z0-9-_.~/` is canonicalized differently
+by S3 and the PUT fails with `403 SignatureDoesNotMatch`.
+
 Credential lifetime: the runner mints the temporary S3 (STS) credentials
 returned by `/api/v2/output/credentials` with a short TTL (≈10 min) and
 hands back those same job-scoped credentials on every call. A task that
@@ -28,6 +33,7 @@ fails (see `session_cache_get` / `session_cache_clear`). A standalone
 call (`cache = None`) keeps the original fetch-per-call behavior.
 """
 
+load("@std//base64.axl", "base64")
 load("@std//time.axl", "time")
 load("./environment.axl", "warn")
 
@@ -231,9 +237,95 @@ def _header_args(headers):
         args = args + ["-H", k + ": " + v]
     return args
 
+_UNRESERVED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
+_B64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+_HEX_DIGITS = "0123456789ABCDEF"
+
+def _utf8_bytes(s: str) -> list[int]:
+    """The UTF-8 bytes of `s`, as ints.
+
+    AXL exposes no codepoint or byte primitive and `elems()` yields whole
+    characters, so base64 — which encodes the UTF-8 bytes — is the only route
+    to the byte values `aws_uri_encode` has to percent-encode one by one.
+    """
+    acc = 0
+    bits = 0
+    out = []
+    for c in base64.encode(s).elems():
+        if c == "=":
+            break
+        acc = (acc << 6) | _B64_ALPHABET.find(c)
+        bits += 6
+        if bits >= 8:
+            bits -= 8
+            out.append((acc >> bits) & 0xFF)
+    return out
+
+def aws_uri_encode(key: str) -> str:
+    """Percent-encode an S3 object key the way SigV4 canonicalization does.
+
+    AWS `UriEncode` escapes every byte outside `A-Za-z0-9-_.~`, leaving `/`
+    as a path separator. S3 verifies a signature against that canonical form,
+    while curl's `--aws-sigv4` signs — and sends — the URL path verbatim. So a
+    key carrying anything else (`@`, `(`, `)`, `{`, a space, any non-ASCII
+    byte) is signed as one string and canonicalized by S3 as another, and the
+    PUT fails with `403 SignatureDoesNotMatch`. Encoding here makes the two
+    agree: S3 decodes the path back to the intended key, re-encodes it, and
+    lands on exactly what we signed.
+
+    `%` is escaped to `%25` like any other byte, so a filename that already
+    contains a percent sequence (Cucumber writes screenshot names as
+    `%7BSMOKE%7D…`) is stored under its literal name instead of being silently
+    decoded into `{SMOKE}`.
+
+    Public (not `_`-prefixed) so `circleci_test.axl` can load it.
+    """
+    out = ""
+    for c in key.elems():
+        if c == "/" or c in _UNRESERVED:
+            out += c
+        else:
+            for b in _utf8_bytes(c):
+                out += "%" + _HEX_DIGITS[b // 16] + _HEX_DIGITS[b % 16]
+    return out
+
 def _s3_object_url(bucket, region, key):
-    """Virtual-hosted S3 URL for `key` in `bucket`/`region`."""
-    return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key
+    """Virtual-hosted S3 URL for `key` in `bucket`/`region`.
+
+    The key is `aws_uri_encode`d so the signed path survives S3's canonical
+    form — see `aws_uri_encode`.
+    """
+    return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + aws_uri_encode(key)
+
+# S3 conditions worth another attempt: the job-scoped credentials rotated or
+# the clock drifted, or S3 itself asked us to come back. Anything else 4xx
+# (`SignatureDoesNotMatch`, `AccessDenied`, a malformed key) fails the same
+# way on every attempt, so retrying only multiplies the log noise.
+_RETRYABLE_S3_ERROR_CODES = [
+    "ExpiredToken",
+    "ExpiredTokenException",
+    "TokenRefreshRequired",
+    "RequestTimeTooSkewed",
+    "RequestTimeout",
+    "InternalError",
+    "ServiceUnavailable",
+    "SlowDown",
+]
+
+def s3_failure_is_retryable(http_code: str, body: str) -> bool:
+    """Whether a failed S3 PUT is worth re-attempting with fresh credentials.
+
+    Transport failures (`http_code == "000"`) and 5xx/408/429 always are; a
+    4xx is only when its `<Code>` names a rotation, skew, or throttle (see
+    `_RETRYABLE_S3_ERROR_CODES`).
+
+    Public (not `_`-prefixed) so `circleci_test.axl` can load it.
+    """
+    if not http_code or http_code == "000":
+        return True
+    if http_code.startswith("5") or http_code in ("408", "429"):
+        return True
+    return s3_extract_error_code(body) in _RETRYABLE_S3_ERROR_CODES
 
 def s3_sigv4_put_args(region, aws_creds, path, headers = None):
     """curl args for a sigv4-signed PUT using the job-scoped STS credentials.
@@ -328,8 +420,9 @@ def _run_s3_put(ctx, curl_args, url):
 def _s3_put(ctx, session, path, name):
     """Register the artifact with the runner and PUT it to S3.
 
-    Returns `(success, detail, download_url)`. `detail` is a human-readable
-    failure reason on `success == False`. Uses the credentials in
+    Returns `(success, detail, download_url, retryable)`. `detail` is a
+    human-readable failure reason on `success == False`, and `retryable` says
+    whether another attempt could plausibly succeed. Uses the credentials in
     `session`; callers re-fetch the session between attempts.
     """
     token = session["token"]
@@ -344,7 +437,7 @@ def _s3_put(ctx, session, path, name):
         "artifactType": "application/octet-stream",
     })
     if not artifact_resp:
-        return (False, "failed to register artifact with runner API", "")
+        return (False, "failed to register artifact with runner API", "", True)
     prefix = artifact_resp["prefix"]
     tags = artifact_resp.get("key", {}).get("tags", {})
 
@@ -360,17 +453,22 @@ def _s3_put(ctx, session, path, name):
         s3_url,
     )
     if not ok:
-        return (False, s3_upload_error_detail(http_code, curl_err, body), "")
+        return (
+            False,
+            s3_upload_error_detail(http_code, curl_err, body),
+            "",
+            s3_failure_is_retryable(http_code, body),
+        )
 
     # Stable public CircleCI artifact URL so callers can link to individual
     # files. CIRCLE_WORKFLOW_JOB_ID is always set by the runner; fall back to
     # the signed S3 URL if it's ever absent.
     job_id = ctx.std.env.var("CIRCLE_WORKFLOW_JOB_ID") or ""
     if job_id:
-        download_url = "https://output.circle-artifacts.com/output/job/" + job_id + "/artifacts/0/" + name
+        download_url = "https://output.circle-artifacts.com/output/job/" + job_id + "/artifacts/0/" + aws_uri_encode(name)
     else:
         download_url = s3_url
-    return (True, "", download_url)
+    return (True, "", download_url, False)
 
 def _upload_artifact(ctx, path, name, cache = None):
     """Upload a file to CircleCI via the runner API and S3.
@@ -384,11 +482,17 @@ def _upload_artifact(ctx, path, name, cache = None):
     omit it (`cache = None`) for a one-off, un-cached upload. Retries up to
     `_UPLOAD_MAX_ATTEMPTS` with exponential backoff; the returned `errors`
     carry the real HTTP status / S3 error code from the last attempt.
+
+    A failure S3 will reject identically every time (`SignatureDoesNotMatch`,
+    `AccessDenied` — see `s3_failure_is_retryable`) stops after the first
+    attempt and comes back with `permanent = True`, so the caller can drop
+    this file and move on instead of re-attempting it for the rest of the run.
     """
     if not ctx.std.fs.exists(path):
-        return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["file not found: " + path]}
+        return {"success": False, "artifact_ref": None, "download_url": "", "errors": ["file not found: " + path], "permanent": True}
 
     last_detail = "unknown error"
+    permanent = False
     backoff_ms = _UPLOAD_BACKOFF_BASE_MS
     for attempt in range(_UPLOAD_MAX_ATTEMPTS):
         session = session_cache_get(cache)
@@ -401,10 +505,15 @@ def _upload_artifact(ctx, path, name, cache = None):
             last_detail = session["error"]
             session_cache_clear(cache)
         else:
-            ok, detail, download_url = _s3_put(ctx, session, path, name)
+            ok, detail, download_url, retryable = _s3_put(ctx, session, path, name)
             if ok:
-                return {"success": True, "artifact_ref": name, "download_url": download_url, "errors": []}
+                return {"success": True, "artifact_ref": name, "download_url": download_url, "errors": [], "permanent": False}
             last_detail = detail
+            if not retryable:
+                # The credentials are fine — this file is what S3 objects to.
+                # Keep the session for the next file and stop here.
+                permanent = True
+                break
 
             # The cached creds may have expired — drop them so the next
             # attempt (and the next file) re-mints rather than reusing a
@@ -415,7 +524,7 @@ def _upload_artifact(ctx, path, name, cache = None):
             time.sleep(backoff_ms)
             backoff_ms = backoff_ms * 2
 
-    return {"success": False, "artifact_ref": None, "download_url": "", "errors": [last_detail]}
+    return {"success": False, "artifact_ref": None, "download_url": "", "errors": [last_detail], "permanent": permanent}
 
 def _delete_artifact(ctx, name):
     """CircleCI has no artifact deletion API — no-op."""
@@ -450,7 +559,9 @@ def test_results_object_url(bucket: str, region: str, location: str) -> str:
     """Resolve a test-result Key.location to a PUT URL.
 
     The Key returns a relative S3 object key; join it with the config
-    bucket/region. An already-absolute (http/https) location passes through.
+    bucket/region (and `aws_uri_encode` it, as with any other key). An
+    already-absolute (http/https) location passes through untouched — it
+    carries its own encoding, and may carry its own signature.
     """
     if location.startswith("http://") or location.startswith("https://"):
         return location

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/circleci_test.axl
@@ -196,6 +196,13 @@ def _test_retryable_transport_error(_ctx):
     if not s3_failure_is_retryable("000", ""):
         fail("transport failure must be retryable")
 
+def _test_retryable_interrupted_after_2xx(_ctx):
+    """`_run_s3_put` fails a PUT whose curl exit is nonzero even when S3
+    answered 2xx — an interrupted response transfer (`curl: (18) Partial
+    file`). The upload never completed, and the next attempt can still work."""
+    if not s3_failure_is_retryable("200", ""):
+        fail("a 2xx with a nonzero curl exit must be retryable")
+
 def _test_retryable_server_error(_ctx):
     if not s3_failure_is_retryable("503", ""):
         fail("5xx must be retryable")
@@ -423,6 +430,7 @@ _UNIT_TESTS = [
     _test_not_retryable_signature_mismatch,
     _test_not_retryable_access_denied,
     _test_retryable_transport_error,
+    _test_retryable_interrupted_after_2xx,
     _test_retryable_server_error,
     _test_retryable_throttled,
     _test_not_retryable_unknown_4xx,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/circleci_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/circleci_test.axl
@@ -6,7 +6,7 @@ S3 error parsing, the session cache, test-result URL resolution, the
 sigv4 PUT arg builder, trace redaction, and JUnit skipped-marking.
 """
 
-load("./circleci.axl", "mark_testcases_skipped", "redact_curl_trace", "s3_extract_error_code", "s3_extract_error_message", "s3_sigv4_put_args", "s3_upload_error_detail", "session_cache_clear", "session_cache_get", "session_cache_put", "test_results_object_url")
+load("./circleci.axl", "aws_uri_encode", "mark_testcases_skipped", "redact_curl_trace", "s3_extract_error_code", "s3_extract_error_message", "s3_failure_is_retryable", "s3_sigv4_put_args", "s3_upload_error_detail", "session_cache_clear", "session_cache_get", "session_cache_put", "test_results_object_url")
 
 def _eq(label, got, want):
     if got != want:
@@ -118,6 +118,98 @@ def _test_cache_clear_empty_noop(_ctx):
     session_cache_clear(cache)
     _eq("clear on empty cache stays a miss", session_cache_get(cache), None)
 
+# aws_uri_encode — percent-encode an object key to match S3's canonical form
+
+def _test_uri_encode_unreserved_untouched(_ctx):
+    """`A-Za-z0-9-_.~` and the `/` separator are left exactly as they are."""
+    key = "test/shard_1/test.outputs/a-b_c.d~e/F9.log"
+    _eq("unreserved key unchanged", aws_uri_encode(key), key)
+
+def _test_uri_encode_at_sign(_ctx):
+    """The reported case: Bazel's `@failures.txt` undeclared output. `@` is a
+    sub-delim, so S3 canonicalizes it to `%40` while curl signs it raw."""
+    _eq(
+        "@ encoded",
+        aws_uri_encode("test/shard_4/test.outputs/@failures.txt"),
+        "test/shard_4/test.outputs/%40failures.txt",
+    )
+
+def _test_uri_encode_parens_and_brackets(_ctx):
+    """Cucumber screenshot names carry the scenario name: parens, brackets,
+    braces, and spaces all need escaping."""
+    _eq(
+        "parens/brackets/space encoded",
+        aws_uri_encode("[WFD] (date condition) GEQ.png"),
+        "%5BWFD%5D%20%28date%20condition%29%20GEQ.png",
+    )
+
+def _test_uri_encode_percent_is_escaped(_ctx):
+    """A literal percent sequence in the filename is escaped, not passed
+    through — otherwise S3 decodes `%7BSMOKE%7D` and stores `{SMOKE}`."""
+    _eq(
+        "% escaped to %25",
+        aws_uri_encode("1787166988273_%7BSMOKE%7D.png"),
+        "1787166988273_%257BSMOKE%257D.png",
+    )
+
+def _test_uri_encode_non_ascii_is_per_utf8_byte(_ctx):
+    """Non-ASCII is escaped byte by byte, as `UriEncode` specifies: `é` is
+    two UTF-8 bytes, `☃` three."""
+    _eq("2-byte codepoint", aws_uri_encode("café.log"), "caf%C3%A9.log")
+    _eq("3-byte codepoint", aws_uri_encode("☃.png"), "%E2%98%83.png")
+
+def _test_uri_encode_empty(_ctx):
+    _eq("empty key stays empty", aws_uri_encode(""), "")
+
+def _test_uri_encode_is_not_idempotent(_ctx):
+    """Encoding twice is *not* a no-op — the caller must encode exactly once,
+    which is why `_s3_object_url` owns the only call."""
+    _eq("double-encoding escapes the escape", aws_uri_encode(aws_uri_encode("@a")), "%2540a")
+
+# s3_failure_is_retryable — is another attempt with fresh creds worth it?
+
+def _test_retryable_expired_token(_ctx):
+    """The rotation case the retry loop exists for."""
+    body = "<Error><Code>ExpiredToken</Code></Error>"
+    if not s3_failure_is_retryable("400", body):
+        fail("ExpiredToken must be retryable")
+
+def _test_retryable_clock_skew(_ctx):
+    body = "<Error><Code>RequestTimeTooSkewed</Code></Error>"
+    if not s3_failure_is_retryable("403", body):
+        fail("RequestTimeTooSkewed must be retryable")
+
+def _test_not_retryable_signature_mismatch(_ctx):
+    """A key S3 rejects is rejected identically every time — retrying it just
+    re-mints credentials and multiplies the warning."""
+    body = "<Error><Code>SignatureDoesNotMatch</Code></Error>"
+    if s3_failure_is_retryable("403", body):
+        fail("SignatureDoesNotMatch must not be retryable")
+
+def _test_not_retryable_access_denied(_ctx):
+    body = "<Error><Code>AccessDenied</Code></Error>"
+    if s3_failure_is_retryable("403", body):
+        fail("AccessDenied must not be retryable")
+
+def _test_retryable_transport_error(_ctx):
+    """No HTTP response at all → the network, not the request."""
+    if not s3_failure_is_retryable("000", ""):
+        fail("transport failure must be retryable")
+
+def _test_retryable_server_error(_ctx):
+    if not s3_failure_is_retryable("503", ""):
+        fail("5xx must be retryable")
+
+def _test_retryable_throttled(_ctx):
+    if not s3_failure_is_retryable("429", ""):
+        fail("429 must be retryable")
+
+def _test_not_retryable_unknown_4xx(_ctx):
+    """An unrecognized 4xx defaults to permanent — a request S3 refuses to
+    accept won't start working on attempt three."""
+    if s3_failure_is_retryable("400", "<Error><Code>InvalidTag</Code></Error>"):
+        fail("unknown 4xx must not be retryable")
+
 # test_results_object_url — resolve a test-result Key.location to a PUT URL
 
 def _test_object_url_relative_key(_ctx):
@@ -126,6 +218,15 @@ def _test_object_url_relative_key(_ctx):
         "relative key → virtual-hosted S3 URL",
         test_results_object_url("circleci-tasks-prod", "us-east-1", "storage/test-raw/a/b/0/0.tar.gz"),
         "https://circleci-tasks-prod.s3.us-east-1.amazonaws.com/storage/test-raw/a/b/0/0.tar.gz",
+    )
+
+def _test_object_url_encodes_the_key(_ctx):
+    """A relative key is percent-encoded on the way into the URL, so what we
+    sign matches what S3 canonicalizes."""
+    _eq(
+        "key encoded in the URL",
+        test_results_object_url("bkt", "us-east-1", "storage/test-raw/@a (1).tar.gz"),
+        "https://bkt.s3.us-east-1.amazonaws.com/storage/test-raw/%40a%20%281%29.tar.gz",
     )
 
 def _test_object_url_absolute_https_passthrough(_ctx):
@@ -310,6 +411,22 @@ _UNIT_TESTS = [
     _test_cache_put_none_cache_noop,
     _test_cache_clear,
     _test_cache_clear_empty_noop,
+    _test_uri_encode_unreserved_untouched,
+    _test_uri_encode_at_sign,
+    _test_uri_encode_parens_and_brackets,
+    _test_uri_encode_percent_is_escaped,
+    _test_uri_encode_non_ascii_is_per_utf8_byte,
+    _test_uri_encode_empty,
+    _test_uri_encode_is_not_idempotent,
+    _test_retryable_expired_token,
+    _test_retryable_clock_skew,
+    _test_not_retryable_signature_mismatch,
+    _test_not_retryable_access_denied,
+    _test_retryable_transport_error,
+    _test_retryable_server_error,
+    _test_retryable_throttled,
+    _test_not_retryable_unknown_4xx,
+    _test_object_url_encodes_the_key,
 ]
 
 def _test_impl(ctx):


### PR DESCRIPTION
## Problem

Reported by a customer on CircleCI ([Slack](https://aspect-build.slack.com/archives/C09RXH0FGAU/p1787168131513089)), on every build in their branch:

```
WARNING: Artifact upload failed for test/cucumber-e2e/testlogs/.../shard_2/test.outputs/1787166988273_%7BSMOKE%7D%20%5BWFD-Condition%20Designer%5D%20(date%20condition)%20GEQ%20....png: S3 upload HTTP 403 (SignatureDoesNotMatch): The request signature we calculated does not match the signature you provided.
WARNING: Artifact upload failed for .../shard_4/test.outputs/@failures.txt: S3 upload HTTP 403 (SignatureDoesNotMatch): ...
```

(The S3 in the message is CircleCI's own artifact storage behind its runner output service — worth stating, because the customer reasonably read it as us shipping their artifacts into an AWS account they don't own. Their runners are on GCP; nothing here is cross-cloud.)

Two files failed, `test.log` and `test.xml` in the same groups succeeded with the same credentials, and it reproduced on every build — so not the credential expiry the retry loop was built for.

## Root cause

The two failing names are the tell: one contains `@`, the other `(` and `)`.

SigV4 requires `CanonicalURI` to be the AWS-`UriEncode`d path — every byte outside `A-Za-z0-9-_.~` escaped, `/` kept — and S3 verifies against that form. curl's `--aws-sigv4` signs the URL path **verbatim**. `_s3_object_url` handed it the raw key, so any key holding a sub-delim was signed as one string and canonicalized by S3 as another.

Verified against curl 8.7.1 by capturing the signed request and recomputing the signature over each candidate canonical path:

```
sent      : /dir/@failures.txt
  MATCH   raw path as sent        -> /dir/@failures.txt
  differs UriEncode(decoded key)  -> /dir/%40failures.txt
```

Cucumber failure screenshots are the perfect trigger — the scenario name becomes the filename, parens and brackets included.

Two things amplified it in `_upload_group_per_file`: a failed upload `break`s without advancing `last_count`, so one unencodable filename **stranded every later file in its group** for the rest of the build and was re-attempted on every BEP snapshot flush, burning all 3 credential re-mints each time. That's the ~19 identical warnings for a single `@failures.txt` in the customer's log.

## Fix

`aws_uri_encode` applies AWS `UriEncode` to the key inside `_s3_object_url`, so both upload flows (artifacts and test results) sign and send the same string S3 canonicalizes to. Re-running the capture with encoded paths, curl's signature now matches S3's canonical form for both real filenames and for non-ASCII keys.

AXL has no codepoint or byte primitive and `elems()` yields whole characters, so `_utf8_bytes` reaches the bytes through their base64 encoding — `UriEncode` is defined per byte, and a non-ASCII character needs all of its UTF-8 bytes escaped individually.

`%` is escaped like any other byte, which also fixes a quieter bug: `%7BSMOKE%7D` used to be sent raw and *decoded by S3*, storing the object as `{SMOKE}` rather than under the filename on disk.

`s3_failure_is_retryable` splits transient from permanent: transport errors, 5xx, 408/429, and the rotation/skew/throttle `<Code>`s stay retryable; every other 4xx is permanent. A permanent failure returns `permanent = True` without re-minting credentials, and `_upload_group_per_file` counts that file as handled — so it warns once and the rest of the group still uploads, instead of one bad name blocking the group and re-warning per snapshot.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes — nothing to update; these are `private/lib` helpers with no generated reference page, and no docs describe artifact-name constraints.
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

CircleCI artifact uploads no longer fail with `403 SignatureDoesNotMatch` when a filename contains characters outside `A-Za-z0-9-_.~` — spaces, `@`, parens, brackets, braces, or non-ASCII. Test outputs like Cucumber failure screenshots and Bazel's `@failures.txt` now upload, and a filename that already contains a percent sequence is stored under its literal name instead of being decoded. A file S3 rejects outright is also no longer retried on every build-event snapshot, so it can't block the other artifacts in its group or repeat its warning.

### Test plan

- New test cases added — `aspect dev test-circleci` (52 tests, was 33) covers `aws_uri_encode` on the reported `@failures.txt` and Cucumber names, `/` preservation, `%` → `%25`, 2- and 3-byte UTF-8 codepoints, the empty key, non-idempotency, key encoding through `test_results_object_url`, and every branch of `s3_failure_is_retryable`.
- Covered by existing test cases — the absolute-URL passthrough and sigv4-arg suites are unchanged; `bazel test //crates/...` passes (12/12).
- Signature verification outside the test suite: spawned a local listener, ran the real curl invocation from `s3_sigv4_put_args`, and recomputed SigV4 over each candidate canonical path. Before the fix the raw path matched curl and S3's canonical form did not; after encoding, both agree for `@failures.txt`, the full Cucumber screenshot name, and `café.log`.
- Cross-checked the AXL encoder against an independent reference implementation on the two real customer filenames plus a key holding every ASCII special and multi-byte characters — byte-identical output.
- Review feedback addressed in d22002f5: the retry classifier read a failure carrying a 2xx as permanent. `_run_s3_put` fails a PUT whose curl exit is nonzero even when S3 answered, and an interrupted response body does exactly that — reproduced with a server that promises `Content-Length: 100`, sends 10 bytes and hangs up: curl exits 18 while `-w %{http_code}` prints `200`. Any 2xx reaching the classifier is now retryable, covered by a new test.
- Not verified against live CircleCI infrastructure: the runner socket, output API, and a real S3 PUT need a CircleCI job. The customer's build is the confirming test.

