### PR TITLE
Improve per-day deduplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,11 @@ dependencies = [
 name = "aspect-telemetry"
 version = "0.0.0-dev"
 dependencies = [
+ "chrono",
  "reqwest",
  "serde_json",
  "sha1",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/aspect-telemetry/BUILD.bazel
+++ b/crates/aspect-telemetry/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("//bazel/rust:defs.bzl", "rust_library")
+load("//bazel/rust:defs.bzl", "rust_library", "rust_test")
 
 cargo_build_script(
     name = "build_rs",
@@ -17,8 +17,17 @@ rust_library(
     ],
     deps = [
         ":build_rs",
+        "@crates//:chrono",
         "@crates//:reqwest",
         "@crates//:serde_json",
         "@crates//:sha1",
+    ],
+)
+
+rust_test(
+    name = "test",
+    crate = ":aspect-telemetry",
+    deps = [
+        "@crates//:tempfile",
     ],
 )

--- a/crates/aspect-telemetry/Cargo.toml
+++ b/crates/aspect-telemetry/Cargo.toml
@@ -10,6 +10,10 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 reqwest = { version = "0.12.22", default-features = false, features = ["http2", "charset", "system-proxy", "rustls-tls", "stream"] }
 serde_json = "1.0"
 sha1 = "0.10"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/aspect-telemetry/src/lib.rs
+++ b/crates/aspect-telemetry/src/lib.rs
@@ -1,9 +1,28 @@
+//! Usage telemetry for the Aspect CLI and launcher.
+//!
+//! Builds the report posted to Aspect's ingest endpoint and sends it on a
+//! best-effort, fire-and-forget basis. `DO_NOT_TRACK` disables sending
+//! entirely.
+//!
+//! Reports share an aggregation table with the Bazel rulesets'
+//! (https://github.com/aspect-build/tools_telemetry), which is why field names
+//! mirror that module's vocabulary (`os`, `arch`, `ci`, `runner`, `counter`,
+//! `id_day`) and why `id_day` must be derived exactly as the module derives it
+//! — two implementations that disagree count the same repository twice. Fields
+//! specific to this crate name their subject (`cli_version`), since the table
+//! also carries Bazel and module versions. When adding fields, prefer reusing
+//! the module's names over inventing new ones; Bazel-specific fields are
+//! intentionally omitted because the module already covers those.
+
+use chrono::Utc;
 use reqwest::header::HeaderName;
 use reqwest::redirect::Policy;
 use reqwest::{self, Method, StatusCode};
 use serde_json::{Value, json};
 use sha1::{Digest, Sha1};
-use std::env::var;
+use std::env::{current_dir, var};
+use std::fs::read_to_string;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 // The Bazel arch and os per @platforms and //bazel/platforms
@@ -70,7 +89,7 @@ pub fn do_not_track() -> bool {
 
 /// Salted SHA-1 of `data`, mirroring `tools_telemetry`'s `hash` helper. Honors
 /// the `ASPECT_TOOLS_TELEMETRY_SALT` env var so a single salt covers both
-/// sources.
+/// sources, and so a repository that sets one is hashed identically by each.
 fn salted_hash(data: &str) -> String {
     let mut hasher = Sha1::new();
     if let Ok(salt) = var("ASPECT_TOOLS_TELEMETRY_SALT") {
@@ -85,6 +104,104 @@ fn salted_hash(data: &str) -> String {
         let _ = write!(out, "{b:02x}");
     }
     out
+}
+
+/// Candidate documentation filenames, in `tools_telemetry`'s search order:
+/// directory, then basename, then extension. The order decides which file wins
+/// when a repository has several, so it has to match the module's exactly.
+const REPO_ID_DIRS: &[&str] = &["", "doc", "docs", "Doc", "Docs"];
+const REPO_ID_BASES: &[&str] = &["README", "readme", "Readme", "index"];
+const REPO_ID_EXTS: &[&str] = &[
+    "",
+    ".adoc",
+    ".asc",
+    ".asciidoc",
+    ".markdown",
+    ".md",
+    ".mdown",
+    ".mkdk",
+    ".org",
+    ".rdoc",
+    ".rst",
+    ".textile",
+    ".txt",
+    ".wiki",
+];
+
+/// Markers of a project root. For bzlmod repositories this lands on the same
+/// directory the module's `repository_ctx.workspace_root` does; the Aspect
+/// project markers (mirroring the CLI's own root detection) and the
+/// WORKSPACE-era markers extend coverage to repositories the module never
+/// runs in, where any consistent root serves deduplication equally well.
+const ROOT_MARKERS: &[&str] = &[
+    // Aspect project roots: MODULE.aspect per axl-runtime's AXL_MODULE_FILE,
+    // plus the version pin the CLI itself anchors on.
+    "MODULE.aspect",
+    ".aspect/version.axl",
+    // Bazel workspace roots.
+    "MODULE.bazel",
+    "MODULE.bazel.lock",
+    "REPO.bazel",
+    "WORKSPACE",
+    "WORKSPACE.bazel",
+];
+
+/// Nearest ancestor of `start` holding a project-root marker.
+///
+/// Walked here rather than taken from a caller so this crate stays a leaf
+/// dependency of the CLI and the launcher.
+fn workspace_root_from(start: &Path) -> Option<PathBuf> {
+    let mut dir = start.to_path_buf();
+    loop {
+        if ROOT_MARKERS.iter().any(|m| dir.join(m).exists()) {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+fn workspace_root() -> Option<PathBuf> {
+    workspace_root_from(&current_dir().ok()?)
+}
+
+/// Stable per-repository value, never reported on its own.
+///
+/// Hashes the first four lines of the repository's documentation, falling back
+/// to `MODULE.bazel`, exactly as `tools_telemetry` does — the two have to agree
+/// or the same repository counts twice.
+fn repo_id(root: &Path) -> Option<String> {
+    let mut chosen = None;
+    'search: for dir in REPO_ID_DIRS {
+        for base in REPO_ID_BASES {
+            for ext in REPO_ID_EXTS {
+                let candidate = root.join(dir).join(format!("{base}{ext}"));
+                if candidate.is_file() {
+                    chosen = Some(candidate);
+                    break 'search;
+                }
+            }
+        }
+    }
+    let path = chosen.unwrap_or_else(|| root.join("MODULE.bazel"));
+    let content = read_to_string(path).ok()?;
+    let head: Vec<&str> = content.split('\n').take(4).collect();
+    Some(salted_hash(&head.join("\n")))
+}
+
+/// Day-scoped repository value: reports from one repository group together
+/// within a UTC day and cannot be linked across days.
+fn id_day_for(root: &Path, date: &str) -> Option<String> {
+    let id = repo_id(root)?;
+    Some(salted_hash(&format!("{id};{date}")))
+}
+
+fn id_day() -> Option<String> {
+    id_day_for(
+        &workspace_root()?,
+        &Utc::now().format("%Y-%m-%d").to_string(),
+    )
 }
 
 /// Returns the first env var from `vars` that is set and non-empty.
@@ -144,53 +261,12 @@ fn build_counter() -> Option<String> {
     ])
 }
 
-/// Organization slug from CI env, mirroring `tools_telemetry`'s `_repo_org`.
-fn repo_org() -> Option<String> {
-    first_env(&[
-        "BUILDKITE_ORGANIZATION_SLUG",
-        "GITHUB_REPOSITORY_OWNER",
-        "CI_PROJECT_NAMESPACE",
-        "CIRCLE_PROJECT_USERNAME",
-        "DRONE_REPO_NAMESPACE",
-        "CI_REPO_OWNER",
-        "TRAVIS_REPO_SLUG",
-    ])
-}
-
-/// Salted hash of the user, mirroring `tools_telemetry`'s `_repo_user`. Without
-/// a stable repo `id` to salt with, we fall back to the configured telemetry
-/// salt only.
-fn repo_user() -> Option<String> {
-    let raw = first_env(&[
-        "BUILDKITE_BUILD_AUTHOR_EMAIL",
-        "GITHUB_ACTOR",
-        "GITLAB_USER_EMAIL",
-        "CIRCLE_USERNAME",
-        "DRONE_COMMIT_AUTHOR",
-        "DRONE_COMMIT_AUTHOR_EMAIL",
-        "CI_COMMIT_AUTHOR",
-        "CI_COMMIT_AUTHOR_EMAIL",
-        "LOGNAME",
-        "USER",
-    ])?;
-    Some(salted_hash(&raw))
-}
-
-fn shell() -> Option<String> {
-    first_env(&["SHELL"])
-}
-
-/// Build the JSON body posted to the ingest endpoint.
-///
-/// Breadcrumb: keys here intentionally mirror `tools_telemetry`'s key vocabulary
-/// (`os`, `arch`, `ci`, `runner`, `counter`, `org`, `user`, `shell`) so that a
-/// single aggregator can group both sources. When adding new fields, prefer
-/// reusing names from https://github.com/aspect-build/tools_telemetry rather
-/// than inventing new ones. Bazel-specific fields are intentionally omitted —
-/// `tools_telemetry` already covers those.
+/// Build the JSON body posted to the ingest endpoint. Field names follow the
+/// crate-level contract above; optional fields are omitted rather than sent
+/// empty.
 fn build_payload() -> Value {
     let mut payload = json!({
-        "version": cargo_pkg_version(),
+        "cli_version": cargo_pkg_version(),
         "os": BZLOS,
         "arch": BZLARCH,
         "ci": is_ci(),
@@ -202,14 +278,8 @@ fn build_payload() -> Value {
     if let Some(v) = build_counter() {
         obj.insert("counter".into(), Value::String(v));
     }
-    if let Some(v) = repo_org() {
-        obj.insert("org".into(), Value::String(v));
-    }
-    if let Some(v) = repo_user() {
-        obj.insert("user".into(), Value::String(v));
-    }
-    if let Some(v) = shell() {
-        obj.insert("shell".into(), Value::String(v));
+    if let Some(v) = id_day() {
+        obj.insert("id_day".into(), Value::String(v));
     }
     json!({ "aspect-cli": payload })
 }
@@ -245,18 +315,101 @@ mod tests {
             .get("aspect-cli")
             .and_then(Value::as_object)
             .expect("aspect-cli envelope");
-        for k in ["version", "os", "arch", "ci"] {
+        for k in ["cli_version", "os", "arch", "ci"] {
             assert!(inner.contains_key(k), "missing key: {k}");
         }
         assert!(inner.get("ci").unwrap().is_boolean());
     }
 
+    /// The search order decides which file is hashed, and it has to match the
+    /// Bazel module's or the same repository resolves to two different values.
+    #[test]
+    fn repo_id_prefers_the_module_search_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::create_dir_all(dir.join("docs")).unwrap();
+        std::fs::write(dir.join("MODULE.bazel"), "module(name = \"x\")\n").unwrap();
+        std::fs::write(dir.join("docs/README.md"), "docs one\n").unwrap();
+
+        // docs/README.md beats the MODULE.bazel fallback.
+        let with_docs = repo_id(dir).unwrap();
+        std::fs::write(dir.join("README.md"), "root one\n").unwrap();
+        // A root README outranks docs/, so the value must change.
+        let with_root = repo_id(dir).unwrap();
+        assert_ne!(with_docs, with_root);
+
+        // Only the first four lines participate.
+        std::fs::write(dir.join("README.md"), "root one\n\n\n\nfifth\n").unwrap();
+        let four = repo_id(dir).unwrap();
+        std::fs::write(dir.join("README.md"), "root one\n\n\n\ndifferent\n").unwrap();
+        assert_eq!(four, repo_id(dir).unwrap());
+    }
+
+    /// Known-answer vectors, independently computed with Python's hashlib from
+    /// the derivation both implementations share: repo_id is sha1 of the first
+    /// four lines, id_day is sha1 of "repo_id;YYYY-MM-DD". If either value
+    /// drifts, this implementation has diverged from tools_telemetry and the
+    /// same repository will count twice in the aggregates. No-salt path only;
+    /// a set salt skips, as in salted_hash_is_stable_and_hex.
+    #[test]
+    fn id_day_matches_the_shared_derivation() {
+        if std::env::var("ASPECT_TOOLS_TELEMETRY_SALT").is_ok() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(
+            dir.join("README.md"),
+            "# Fixture repo\n\nUsed by the id_day known-answer test.\nLine four.\nLine five is not hashed.\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            repo_id(dir).unwrap(),
+            "a66894ba5f70368a295eb44fec1ff3b272efabd4"
+        );
+        assert_eq!(
+            id_day_for(dir, "2026-01-02").unwrap(),
+            "0c96cba5e7efaea4f3a2ea0054a7a6a451229536"
+        );
+    }
+
+    #[test]
+    fn workspace_root_is_the_nearest_marked_ancestor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("repo");
+        let nested = root.join("a/b");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(root.join("MODULE.bazel"), "").unwrap();
+
+        assert_eq!(workspace_root_from(&nested).unwrap(), root);
+        // A nearer marker wins over the outer one.
+        std::fs::write(root.join("a/WORKSPACE"), "").unwrap();
+        assert_eq!(workspace_root_from(&nested).unwrap(), root.join("a"));
+    }
+
+    /// Aspect projects without any Bazel workspace still resolve a root, so
+    /// the CLI reports an id_day for them too.
+    #[test]
+    fn aspect_project_markers_resolve_a_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("proj");
+        let nested = root.join("src/deep");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir_all(root.join(".aspect")).unwrap();
+        std::fs::write(root.join(".aspect/version.axl"), "").unwrap();
+        assert_eq!(workspace_root_from(&nested).unwrap(), root);
+
+        let module_root = root.join("src");
+        std::fs::write(module_root.join("MODULE.aspect"), "").unwrap();
+        assert_eq!(workspace_root_from(&nested).unwrap(), module_root);
+    }
+
+    /// Covers the no-salt path only: mutating env vars in tests is racy under
+    /// the multi-threaded test runner, so a set salt skips the assertions
+    /// instead of being unset.
     #[test]
     fn salted_hash_is_stable_and_hex() {
-        // Test the no-salt path; setting env vars in tests is racy so we don't.
-        // SAFETY: ensure the salt is unset for this assertion path.
-        // SAFETY: setting/removing env vars in tests is technically unsafe in
-        // multithreaded contexts; we only read it here.
         if std::env::var("ASPECT_TOOLS_TELEMETRY_SALT").is_ok() {
             return;
         }


### PR DESCRIPTION
Replaces the identity-adjacent telemetry fields with the same day-scoped deduplication ID the rulesets report, and names the version field for its subject.

- **`id_day`**: hashes the on-device repository ID together with the UTC date, so reports from one repository deduplicate and count uniquely within a day while remaining unlinkable across days from the reported data. The on-device repository ID never leaves the machine. The derivation must agree with `tools_telemetry`'s or the same repository counts twice, so it is pinned two ways: a known-answer test with independently computed vectors, and coverage of the documentation-file search order it hinges on. The server does not store the replaced fields either: reports from older versions have them discarded at ingestion.
- **`version` becomes `cli_version`**: reports share a table with the Bazel rulesets', which carry Bazel and module versions of their own, so an unqualified `version` says nothing about its subject.
- **Adds a `rust_test` target**: this crate had unit tests that no Bazel target ran; all five now run, including the new search-order coverage.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added under the new `//crates/aspect-telemetry:test` target: known-answer vectors for `repo_id` and `id_day` (computed independently with Python's hashlib, so divergence from `tools_telemetry` fails CI), the documentation-file search order (a root README outranks `docs/`, only the first four lines participate), and workspace-root resolution (nearest marked ancestor wins). Seven tests total, including the crate's pre-existing ones, which had no Bazel target running them.
- `bazel build //crates/aspect-telemetry:aspect-telemetry` and `bazel test //crates/aspect-telemetry:test` pass.
