### PR TITLE
fix(bes): release the BEP reader when Bazel never opens the pipe

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -142,6 +142,12 @@ steps:
       $$LAUNCHER build --task-id not-a-uuid //... && echo "ERROR: --task-id should reject non-UUID" && exit 1 || true
       echo "--- :aspect: invalid task-key"
       $$LAUNCHER build --task:name "bad key!" //... && echo "ERROR: --task:name should reject invalid chars" && exit 1 || true
+      # A flag Bazel rejects has to come back as Bazel's error. This is the
+      # shape that used to hang: Bazel exits without opening the build-event
+      # pipe, and the reader waited on it forever. `timeout` bounds a
+      # regression to a clear failure instead of the whole job budget.
+      echo "--- :aspect: flag rejected by Bazel"
+      timeout 180 $$LAUNCHER build --bazel-flag=--definitely_not_a_flag //... 2>&1 | grep -q "Unrecognized option" || { echo "ERROR: a Bazel-rejected flag must fail, not hang"; exit 1; }
       echo "--- :aspect: aspect dev test-template-snapshots"
       $$LAUNCHER dev test-template-snapshots
       echo "--- :aspect: aspect dev test-lint-template-snapshots"

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -575,6 +575,13 @@ jobs:
           "$LAUNCHER" build --task-id not-a-uuid //... && echo "ERROR: --task-id should reject non-UUID" && exit 1 || true
           echo "--- invalid task-key"
           "$LAUNCHER" build --task:name "bad key!" //... && echo "ERROR: --task:name should reject invalid chars" && exit 1 || true
+          # A flag Bazel rejects has to come back as Bazel's error. This is the
+          # shape that used to hang: Bazel exits without opening the build-event
+          # pipe, and the reader waited on it forever. `timeout` bounds a
+          # regression to a clear failure instead of the whole job budget.
+          echo "--- flag rejected by Bazel"
+          timeout 180 "$LAUNCHER" build --bazel-flag=--definitely_not_a_flag //... 2>&1 | grep -q "Unrecognized option" \
+            || { echo "ERROR: a Bazel-rejected flag must fail, not hang"; exit 1; }
           echo "--- aspect dev test-template-snapshots"
           "$LAUNCHER" dev test-template-snapshots
           echo "--- aspect dev test-lint-template-snapshots"

--- a/crates/aspect-cli/src/builtins/aspect/bazel/invocation_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazel/invocation_test.axl
@@ -144,9 +144,9 @@ def _test_lookup_is_command_scoped(_):
 
 
 def _test_rejected_command_line_does_not_hang(ctx: TaskContext) -> None:
-    """A flag Bazel rejects: it exits without ever opening the build-event
-    pipe, and the invocation has to surface that exit rather than wait on a
-    writer that can never arrive.
+    """Regression for aspect-build/aspect-cli#1400: a flag Bazel rejects makes
+    it exit without ever opening the build-event pipe, and the invocation has
+    to surface that exit rather than wait on a writer that can never arrive.
 
     Requires `build_events`, since that is what puts a pipe there to wait on.
     A regression stalls this task until the CI job's own timeout — loud

--- a/crates/aspect-cli/src/builtins/aspect/bazel/invocation_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazel/invocation_test.axl
@@ -12,6 +12,10 @@ default reaches Bazel — get that wrong and a caller-forwarded
 `--target_pattern_file` collides with an invented pattern, which Bazel
 rejects outright.
 
+Every section but the last is pure logic. The last one spawns a real Bazel,
+because the thing it guards — an invocation that Bazel rejects outright —
+only exists once there is a real process to reject it.
+
 Run with:
   aspect dev test-bazel-invocation
 """
@@ -138,6 +142,31 @@ def _test_lookup_is_command_scoped(_):
     rc = _fake_rc({"build": {"--target_pattern_file": "/tmp/p"}})
     _eq("test unaffected", target_patterns(False, ["..."], "", rc, "test"), ["..."])
 
+
+def _test_rejected_command_line_does_not_hang(ctx: TaskContext) -> None:
+    """A flag Bazel rejects: it exits without ever opening the build-event
+    pipe, and the invocation has to surface that exit rather than wait on a
+    writer that can never arrive.
+
+    Requires `build_events`, since that is what puts a pipe there to wait on.
+    A regression stalls this task until the CI job's own timeout — loud
+    enough to spot, which is the point of running it here against a real
+    Bazel rather than a fake."""
+    events = bazel.build_events.iterator()
+    build = ctx.bazel.build(
+        "//crates/galvanize:galvanize",
+        build_events = [events],
+        flags = ["--definitely_not_a_flag"],
+        stderr = None,
+    )
+    seen = 0
+    for _ in events:
+        seen += 1
+    status = build.wait()
+    if status.success:
+        fail("expected Bazel to reject --definitely_not_a_flag")
+    _eq("rejected command line yields no events", seen, 0)
+
 def _test_impl(ctx: TaskContext) -> int:
     _test_attempt_dispatch_empty_is_noop(ctx)
     _test_build_end_dispatch_empty_is_noop(ctx)
@@ -149,7 +178,11 @@ def _test_impl(ctx: TaskContext) -> int:
     _test_explicit_patterns_always_reach_bazel(ctx)
     _test_aspect_own_flag_suppresses_the_default(ctx)
     _test_lookup_is_command_scoped(ctx)
-    print("invocation_test.axl: OK (10 sections)")
+
+    # Spawns a real Bazel; keep it last so a stall cannot mask the pure
+    # sections above.
+    _test_rejected_command_line_does_not_hang(ctx)
+    print("invocation_test.axl: OK (11 sections)")
     return 0
 
 invocation_tests = task(

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -1202,6 +1202,50 @@ Test = task(implementation = _impl)
         assert_eq!(exit, Some(0));
     }
 
+    /// A mistyped flag reaches Bazel, which rejects the command line and
+    /// exits without ever opening the BEP file. The build must report that
+    /// exit code instead of waiting forever on a writer that cannot come.
+    #[test]
+    fn a_rejected_command_line_does_not_hang_the_bes_reader() {
+        use std::time::Duration;
+        // Generous: the timeout is here to catch a hang, not to bound a
+        // healthy run, which finishes in well under a second.
+        let result = crate::test::with_timeout(Duration::from_secs(60), || {
+            crate::test::eval(
+                r#"
+def _impl(ctx):
+    iter = bazel.build_events.iterator()
+    build = ctx.bazel.build(
+        flags = ["--scenario=rejects_command_line"],
+        build_events = [iter],
+        stderr = None,
+    )
+    events = 0
+    for _ in iter:
+        events += 1
+    status = build.wait()
+    if status.success: return 1
+    if status.code != 2: return 2
+    if events != 0: return 3
+    return 0
+
+Test = task(implementation = _impl)
+"#,
+            )
+            .with_fake_bazel()
+            .run_task(0)
+        });
+
+        match result {
+            None => panic!("timed out: a rejected command line hung the BES reader"),
+            Some(exit) => assert_eq!(
+                exit.expect("run_task"),
+                Some(0),
+                "expected an empty stream and bazel's exit code 2"
+            ),
+        }
+    }
+
     /// Regression for aspect-build/aspect-cli#1060: REMOTE_CACHE_EVICTED
     /// without a follow-up retry must not hang the BES reader.
     #[test]

--- a/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
@@ -4,9 +4,9 @@ use std::fs::File;
 use std::io::BufWriter;
 use std::io::ErrorKind;
 use std::io::Write;
-use std::{env, io};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::{env, io};
 use std::{
     io::Read,
     path::PathBuf,
@@ -33,12 +33,46 @@ pub enum BuildEventStreamError {
 /// enough to be invisible next to a build, long enough not to spin.
 const WRITER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 
-/// How many times the watchdog offers to release an open that has not parked
-/// yet, before concluding it never will. At [`WRITER_POLL_INTERVAL`] apiece
-/// this spans about two seconds — far longer than the gap between spawning
-/// this thread and its `open`, and it only ever elapses when that `open` never
-/// happened at all.
+/// How many times [`spawn_open_watchdog`] offers to release an open that has
+/// not parked yet, before concluding it never will. At
+/// [`WRITER_POLL_INTERVAL`] apiece this spans about two seconds, far longer
+/// than the microseconds between spawning the watchdog and the open it guards.
 const WRITER_RELEASE_OFFERS: u32 = 200;
+
+/// Release a reader parked in `Pipe::open` on `path` once `writer_pid` — the
+/// invocation expected to write there — is gone.
+///
+/// Bazel can reject a command line and exit without ever opening the BEP file,
+/// leaving its daemon behind to look like a writer still on its way, and a
+/// FIFO's blocking open would then park for the life of the process. Guessing
+/// wrong is cheap: a FIFO ends only once every writer has closed, so a poke
+/// landing beside a writer bazel did open is invisible to the reader.
+///
+/// The returned flag retires the watchdog; the caller sets it once its own
+/// open has returned, so a reader that got its writer honestly is left alone.
+fn spawn_open_watchdog(path: PathBuf, writer_pid: u32) -> Arc<AtomicBool> {
+    let opened = Arc::new(AtomicBool::new(false));
+    let flag = Arc::clone(&opened);
+    thread::spawn(move || {
+        let mut offers = 0;
+        while !flag.load(Ordering::Relaxed) {
+            // `poke_writer` only lands while a reader is actually parked, which
+            // may still be moments away when the invocation is already over —
+            // so keep offering rather than giving up on the first miss.
+            if !galvanize::is_pid_alive(writer_pid) {
+                if let Ok(true) = galvanize::Pipe::poke_writer(&path) {
+                    return;
+                }
+                offers += 1;
+                if offers >= WRITER_RELEASE_OFFERS {
+                    return;
+                }
+            }
+            thread::sleep(WRITER_POLL_INTERVAL);
+        }
+    });
+    opened
+}
 
 #[derive(Debug)]
 pub struct BuildEventStream {
@@ -67,10 +101,10 @@ impl BuildEventStream {
     /// `writer_pid` is the per-invocation pid whose death means no more bytes
     /// are coming — for real bazel the spawned client process
     /// (`Command::spawn().id()`). It answers both "will a writer ever arrive?"
-    /// (the watchdog below, which releases the initial open) and "is another
-    /// attempt coming?" (the `BrokenPipe` branch in the read loop). Neither
-    /// question can be put to `server_pid`, since the daemon outlives the
-    /// invocation and so always looks like a writer still on its way.
+    /// (see [`spawn_open_watchdog`]) and "is another attempt coming?" (the
+    /// `BrokenPipe` branch in the read loop). Neither question can be put to
+    /// `server_pid`, since the daemon outlives the invocation and so always
+    /// looks like a writer still on its way.
     ///
     /// Each `(path, signal)` pair gets raw FIFO bytes mirrored to `path`;
     /// `signal.complete(result)` fires after flush, unblocking the file
@@ -103,10 +137,9 @@ impl BuildEventStream {
                 Ok(MultiWriter { writers })
             };
 
-            // Close a stream that has ended: no more events are coming, so
-            // subscribers are cut loose and the file sinks are flushed and
-            // signalled. Whether the build itself succeeded is the caller's
-            // business, read off bazel's exit code.
+            // End the stream: cut subscribers loose, flush and signal the
+            // file sinks. Says nothing about whether the build succeeded —
+            // that is the caller's to read off bazel's exit code.
             let finish = |raw_out: &mut MultiWriter<BufWriter<File>>| {
                 broadcaster.close();
                 match raw_out.flush() {
@@ -130,48 +163,11 @@ impl BuildEventStream {
             };
             // mkfifo is idempotent (tolerates EEXIST), so this works whether
             // the caller pre-created the FIFO via `reserve_path` (production)
-            // or not (unit tests). It has to happen before the watchdog, which
-            // has nothing to poke until the inode exists.
+            // or not (unit tests). Before the watchdog, which has nothing to
+            // poke until the inode exists.
             galvanize::Pipe::mkfifo(&path)?;
 
-            // Bazel can reject the command line and exit without ever opening
-            // the BEP file, leaving its daemon behind to look like a writer
-            // still on its way — and `Pipe::open` would then park for the life
-            // of the process. This watchdog releases it once the invocation is
-            // over. Guessing wrong is cheap: a poke alongside a writer bazel
-            // did open is invisible, since a FIFO ends only when every writer
-            // has closed.
-            let opened = Arc::new(AtomicBool::new(false));
-            {
-                let path = path.clone();
-                let opened = Arc::clone(&opened);
-                thread::spawn(move || {
-                    let mut offers = 0;
-                    loop {
-                        if opened.load(Ordering::Relaxed) {
-                            return;
-                        }
-                        if !galvanize::is_pid_alive(writer_pid) {
-                            match galvanize::Pipe::poke_writer(&path) {
-                                // Released, or the FIFO is gone and there is
-                                // nothing left to release.
-                                Ok(true) | Err(_) => return,
-                                // Nobody parked on it yet: the open is still on
-                                // its way. Keep offering briefly — a reader that
-                                // has not arrived by now never will.
-                                Ok(false) => {
-                                    offers += 1;
-                                    if offers >= WRITER_RELEASE_OFFERS {
-                                        return;
-                                    }
-                                }
-                            }
-                        }
-                        thread::sleep(WRITER_POLL_INTERVAL);
-                    }
-                });
-            }
-
+            let opened = spawn_open_watchdog(path.clone(), writer_pid);
             let mut reader =
                 galvanize::Pipe::open(path, galvanize::RetryPolicy::IfOpenForPid(server_pid))?;
             opened.store(true, Ordering::Relaxed);
@@ -444,6 +440,33 @@ mod tests {
     // No writer ever arrives: Bazel exited before opening the BEP file
     // -------------------------------------------------------------------------
 
+    /// The watchdog usually starts while the invocation is still alive, but
+    /// nothing guarantees it: an invocation already over when the watchdog
+    /// starts means the first poke arrives before there is any reader to
+    /// release. Poking is only effective against a parked reader, so the
+    /// watchdog has to keep offering — one attempt would strand this reader.
+    #[test]
+    fn the_watchdog_waits_for_a_reader_that_has_not_parked_yet() {
+        let released = crate::test::with_timeout(Duration::from_secs(10), || {
+            let path = temp_fifo_path();
+            galvanize::Pipe::mkfifo(&path).expect("mkfifo");
+
+            // Dead from the outset, so the watchdog starts poking immediately —
+            // well before the open below exists to be released.
+            let opened = spawn_open_watchdog(path.clone(), dead_pid());
+            std::thread::sleep(Duration::from_millis(100));
+
+            let reader = galvanize::Pipe::open(path, galvanize::RetryPolicy::Never);
+            opened.store(true, Ordering::Relaxed);
+            reader.is_ok()
+        });
+        assert_eq!(
+            released,
+            Some(true),
+            "the watchdog must keep offering until the reader is there to release"
+        );
+    }
+
     /// Bazel can exit before it ever opens the BEP file — an unrecognized flag,
     /// a bad startup option — leaving a live daemon that still looks like a
     /// writer on its way. The stream has to end, empty, rather than wait on a
@@ -469,10 +492,10 @@ mod tests {
         );
     }
 
-    /// The other edge of the same wait: this thread starts the moment bazel is
-    /// spawned, but bazel does not open the BEP file until its JVM is up
-    /// seconds later, and that gap must not be mistaken for an invocation that
-    /// will never write. Every event of a real build rides on the difference.
+    /// The other edge: the reader starts the moment bazel is spawned, but bazel
+    /// does not open the BEP file until its JVM is up seconds later. That gap
+    /// must not be taken for an invocation that will never write, or every
+    /// event of a real build is lost.
     #[test]
     fn a_writer_that_opens_late_still_delivers_its_events() {
         let path = temp_fifo_path();

--- a/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
@@ -5,6 +5,8 @@ use std::io::BufWriter;
 use std::io::ErrorKind;
 use std::io::Write;
 use std::{env, io};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     io::Read,
     path::PathBuf,
@@ -26,10 +28,17 @@ pub enum BuildEventStreamError {
     ProstEncode(#[from] prost::EncodeError),
 }
 
-/// How often the reader re-checks for a writer on the FIFO — both while
-/// waiting for the first one and in the gap between retry attempts. Short
+/// How often to re-check for a writer on the FIFO — while the watchdog waits
+/// for the invocation to end, and in the gap between retry attempts. Short
 /// enough to be invisible next to a build, long enough not to spin.
 const WRITER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+
+/// How many times the watchdog offers to release an open that has not parked
+/// yet, before concluding it never will. At [`WRITER_POLL_INTERVAL`] apiece
+/// this spans about two seconds — far longer than the gap between spawning
+/// this thread and its `open`, and it only ever elapses when that `open` never
+/// happened at all.
+const WRITER_RELEASE_OFFERS: u32 = 200;
 
 #[derive(Debug)]
 pub struct BuildEventStream {
@@ -57,11 +66,11 @@ impl BuildEventStream {
     ///
     /// `writer_pid` is the per-invocation pid whose death means no more bytes
     /// are coming — for real bazel the spawned client process
-    /// (`Command::spawn().id()`). It bounds both waits this thread can get
-    /// stuck in: for the first writer to open the FIFO at all, and for a retry
-    /// attempt to reopen it after a `BrokenPipe`. Neither can be answered by
-    /// `server_pid`, since the daemon outlives the invocation and so always
-    /// looks like a writer still on its way.
+    /// (`Command::spawn().id()`). It answers both "will a writer ever arrive?"
+    /// (the watchdog below, which releases the initial open) and "is another
+    /// attempt coming?" (the `BrokenPipe` branch in the read loop). Neither
+    /// question can be put to `server_pid`, since the daemon outlives the
+    /// invocation and so always looks like a writer still on its way.
     ///
     /// Each `(path, signal)` pair gets raw FIFO bytes mirrored to `path`;
     /// `signal.complete(result)` fires after flush, unblocking the file
@@ -121,28 +130,51 @@ impl BuildEventStream {
             };
             // mkfifo is idempotent (tolerates EEXIST), so this works whether
             // the caller pre-created the FIFO via `reserve_path` (production)
-            // or not (unit tests).
+            // or not (unit tests). It has to happen before the watchdog, which
+            // has nothing to poke until the inode exists.
             galvanize::Pipe::mkfifo(&path)?;
-            let reader = galvanize::Pipe::open_waiting_for_writer(
-                path,
-                galvanize::RetryPolicy::IfOpenForPid(server_pid),
-                WRITER_POLL_INTERVAL,
-                || galvanize::is_pid_alive(writer_pid),
-            );
-            let mut reader = match reader {
-                Ok(reader) => reader,
-                // Bazel rejected the command line, or otherwise died before
-                // opening the BEP file: the invocation is over and emitted
-                // nothing.
-                Err(e) if e.kind() == ErrorKind::BrokenPipe => {
-                    return finish(&mut raw_out);
-                }
-                Err(e) => {
-                    signal_all(Err(format!("failed to open the BES pipe: {e}")));
-                    broadcaster.close();
-                    return Err(BuildEventStreamError::IO(e));
-                }
-            };
+
+            // Bazel can reject the command line and exit without ever opening
+            // the BEP file, leaving its daemon behind to look like a writer
+            // still on its way — and `Pipe::open` would then park for the life
+            // of the process. This watchdog releases it once the invocation is
+            // over. Guessing wrong is cheap: a poke alongside a writer bazel
+            // did open is invisible, since a FIFO ends only when every writer
+            // has closed.
+            let opened = Arc::new(AtomicBool::new(false));
+            {
+                let path = path.clone();
+                let opened = Arc::clone(&opened);
+                thread::spawn(move || {
+                    let mut offers = 0;
+                    loop {
+                        if opened.load(Ordering::Relaxed) {
+                            return;
+                        }
+                        if !galvanize::is_pid_alive(writer_pid) {
+                            match galvanize::Pipe::poke_writer(&path) {
+                                // Released, or the FIFO is gone and there is
+                                // nothing left to release.
+                                Ok(true) | Err(_) => return,
+                                // Nobody parked on it yet: the open is still on
+                                // its way. Keep offering briefly — a reader that
+                                // has not arrived by now never will.
+                                Ok(false) => {
+                                    offers += 1;
+                                    if offers >= WRITER_RELEASE_OFFERS {
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                        thread::sleep(WRITER_POLL_INTERVAL);
+                    }
+                });
+            }
+
+            let mut reader =
+                galvanize::Pipe::open(path, galvanize::RetryPolicy::IfOpenForPid(server_pid))?;
+            opened.store(true, Ordering::Relaxed);
 
             let mut buf: Vec<u8> = Vec::with_capacity(1024 * 5);
             // Initial size for reading a varint

--- a/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
@@ -465,7 +465,11 @@ mod tests {
         let _ = holder.kill();
 
         let events: Vec<_> = std::iter::from_fn(|| sub.recv().ok()).collect();
-        assert_eq!(events.len(), 1, "a late writer's events must not be dropped");
+        assert_eq!(
+            events.len(),
+            1,
+            "a late writer's events must not be dropped"
+        );
         assert!(events[0].last_message);
     }
 

--- a/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
@@ -26,6 +26,11 @@ pub enum BuildEventStreamError {
     ProstEncode(#[from] prost::EncodeError),
 }
 
+/// How often the reader re-checks for a writer on the FIFO — both while
+/// waiting for the first one and in the gap between retry attempts. Short
+/// enough to be invisible next to a build, long enough not to spin.
+const WRITER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+
 #[derive(Debug)]
 pub struct BuildEventStream {
     /// Thread handle, stored in Option so we can take() it to join without consuming self.
@@ -50,11 +55,14 @@ impl BuildEventStream {
     /// (it's the pid that *holds the FIFO write end open during an
     /// attempt*; for real bazel that's the server/daemon pid).
     ///
-    /// `writer_pid` is the per-invocation pid whose death signals
-    /// "no more retries coming" — for real bazel that's the spawned
-    /// client process (`Command::spawn().id()`). The BES thread checks
-    /// it in the `expecting_retry` BrokenPipe branch; a live writer
-    /// means an inter-attempt gap, a dead writer means end-of-build.
+    /// `writer_pid` is the per-invocation pid whose death means no more bytes
+    /// are coming — for real bazel the spawned client process
+    /// (`Command::spawn().id()`). It bounds both waits this thread can get
+    /// stuck in: for the first writer to open the FIFO at all, and for a retry
+    /// attempt to reopen it after a `BrokenPipe`. Neither can be answered by
+    /// `server_pid`, since the daemon outlives the invocation and so always
+    /// looks like a writer still on its way.
+    ///
     /// Each `(path, signal)` pair gets raw FIFO bytes mirrored to `path`;
     /// `signal.complete(result)` fires after flush, unblocking the file
     /// sink handle's `wait()`.
@@ -86,6 +94,24 @@ impl BuildEventStream {
                 Ok(MultiWriter { writers })
             };
 
+            // Close a stream that has ended: no more events are coming, so
+            // subscribers are cut loose and the file sinks are flushed and
+            // signalled. Whether the build itself succeeded is the caller's
+            // business, read off bazel's exit code.
+            let finish = |raw_out: &mut MultiWriter<BufWriter<File>>| {
+                broadcaster.close();
+                match raw_out.flush() {
+                    Ok(()) => {
+                        signal_all(Ok(()));
+                        Ok(())
+                    }
+                    Err(e) => {
+                        signal_all(Err(format!("flush failed: {e}")));
+                        Err(BuildEventStreamError::IO(e))
+                    }
+                }
+            };
+
             let mut raw_out = match open_file_sinks(&raw_file_sink_paths) {
                 Ok(w) => w,
                 Err(e) => {
@@ -93,11 +119,30 @@ impl BuildEventStream {
                     return Err(BuildEventStreamError::IO(e));
                 }
             };
-            // mkfifo is idempotent (`Pipe::new` tolerates EEXIST), so this
-            // works whether the caller pre-created the FIFO via
-            // `reserve_path` (production) or not (unit tests).
-            let mut reader =
-                galvanize::Pipe::new(path, galvanize::RetryPolicy::IfOpenForPid(server_pid))?;
+            // mkfifo is idempotent (tolerates EEXIST), so this works whether
+            // the caller pre-created the FIFO via `reserve_path` (production)
+            // or not (unit tests).
+            galvanize::Pipe::mkfifo(&path)?;
+            let reader = galvanize::Pipe::open_waiting_for_writer(
+                path,
+                galvanize::RetryPolicy::IfOpenForPid(server_pid),
+                WRITER_POLL_INTERVAL,
+                || galvanize::is_pid_alive(writer_pid),
+            );
+            let mut reader = match reader {
+                Ok(reader) => reader,
+                // Bazel rejected the command line, or otherwise died before
+                // opening the BEP file: the invocation is over and emitted
+                // nothing.
+                Err(e) if e.kind() == ErrorKind::BrokenPipe => {
+                    return finish(&mut raw_out);
+                }
+                Err(e) => {
+                    signal_all(Err(format!("failed to open the BES pipe: {e}")));
+                    broadcaster.close();
+                    return Err(BuildEventStreamError::IO(e));
+                }
+            };
 
             let mut buf: Vec<u8> = Vec::with_capacity(1024 * 5);
             // Initial size for reading a varint
@@ -201,15 +246,7 @@ impl BuildEventStream {
                         broadcaster.send(event);
 
                         if last_message && !expecting_retry {
-                            broadcaster.close();
-                            match raw_out.flush() {
-                                Ok(()) => signal_all(Ok(())),
-                                Err(e) => {
-                                    signal_all(Err(format!("flush failed: {e}")));
-                                    return Err(BuildEventStreamError::IO(e));
-                                }
-                            }
-                            return Ok(());
+                            return finish(&mut raw_out);
                         }
                     }
                     Err(BuildEventStreamError::IO(err)) if err.kind() == ErrorKind::BrokenPipe => {
@@ -221,31 +258,15 @@ impl BuildEventStream {
                             // gone, no retry is coming — close gracefully
                             // instead of spinning.
                             //
-                            // We check `writer_pid` (the bazel client process
-                            // the runtime spawned), not the server/daemon pid
-                            // passed to galvanize. A bazel daemon stays alive
-                            // across invocations and would always look alive
-                            // here; only the per-invocation client pid dies
-                            // when the build is truly done.
-                            //
-                            // We use pid liveness, not `is_path_open_for_pid`,
-                            // because Bazel closes the BEP file at the end of
-                            // each attempt and reopens it for the next one
-                            // (FileTransport.SequentialWriter.close() runs on
-                            // every attempt). During that gap the writer pid
-                            // is alive but the FIFO has no writer; mistaking
-                            // that for "no retry coming" would drop attempt 2
-                            // events.
+                            // Pid liveness rather than `is_path_open_for_pid`:
+                            // Bazel closes the BEP file at the end of every
+                            // attempt and reopens it for the next
+                            // (FileTransport.SequentialWriter.close()), so
+                            // during that gap the writer is alive with no
+                            // writer attached to the FIFO. Reading that as "no
+                            // retry coming" would drop attempt 2's events.
                             if !galvanize::is_pid_alive(writer_pid) {
-                                broadcaster.close();
-                                match raw_out.flush() {
-                                    Ok(()) => signal_all(Ok(())),
-                                    Err(e) => {
-                                        signal_all(Err(format!("flush failed: {e}")));
-                                        return Err(BuildEventStreamError::IO(e));
-                                    }
-                                }
-                                return Ok(());
+                                return finish(&mut raw_out);
                             }
                             // Writer is alive; Bazel is between attempts.
                             // With no writer attached, read() on the FIFO
@@ -253,18 +274,10 @@ impl BuildEventStream {
                             // backoff creates a hot CPU spin until the next
                             // writer opens the pipe. Sleep briefly to yield
                             // the CPU between polls.
-                            std::thread::sleep(std::time::Duration::from_millis(10));
+                            std::thread::sleep(WRITER_POLL_INTERVAL);
                             continue;
                         }
-                        broadcaster.close();
-                        match raw_out.flush() {
-                            Ok(()) => signal_all(Ok(())),
-                            Err(e) => {
-                                signal_all(Err(format!("flush failed: {e}")));
-                                return Err(BuildEventStreamError::IO(e));
-                            }
-                        }
-                        return Ok(());
+                        return finish(&mut raw_out);
                     }
                     Err(err) => {
                         signal_all(Err(format!("BES read error: {err}")));
@@ -355,10 +368,9 @@ mod tests {
         std::env::temp_dir().join(format!("test-bes-{}.fifo", uuid::Uuid::new_v4()))
     }
 
-    /// Poll until the FIFO inode appears at `path`. The BES thread mkfifos
-    /// the path lazily (via `Pipe::new` inside `BuildEventStream::spawn`),
-    /// so test main threads that open the writer side need to wait for the
-    /// inode to exist before calling `OpenOptions::open`.
+    /// Poll until the FIFO inode appears at `path`. The BES thread mkfifos the
+    /// path lazily inside `BuildEventStream::spawn`, so test threads that open
+    /// the writer side have to wait for the inode before `OpenOptions::open`.
     fn wait_for_fifo(path: &PathBuf) {
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         while !path.exists() {
@@ -383,6 +395,78 @@ mod tests {
             .stderr(std::process::Stdio::null())
             .spawn()
             .expect("failed to spawn sleep")
+    }
+
+    /// A pid that is certainly gone: spawn the shortest-lived process there is
+    /// and reap it, so `is_pid_alive` sees a free pid rather than a zombie.
+    fn dead_pid() -> u32 {
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("failed to spawn true");
+        let pid = child.id();
+        child.wait().expect("failed to reap true");
+        pid
+    }
+
+    // -------------------------------------------------------------------------
+    // No writer ever arrives: Bazel exited before opening the BEP file
+    // -------------------------------------------------------------------------
+
+    /// Bazel can exit before it ever opens the BEP file — an unrecognized flag,
+    /// a bad startup option — leaving a live daemon that still looks like a
+    /// writer on its way. The stream has to end, empty, rather than wait on a
+    /// writer that cannot arrive; the caller reports bazel's exit code.
+    #[test]
+    fn a_writer_that_never_opens_ends_the_stream() {
+        let outcome = crate::test::with_timeout(Duration::from_secs(10), || {
+            let path = temp_fifo_path();
+            // Server alive (daemons outlive the invocation), invocation gone.
+            let mut holder = spawn_pid_holder();
+            let mut stream =
+                BuildEventStream::spawn(path, holder.id(), dead_pid(), vec![]).unwrap();
+            let sub = stream.subscribe();
+            let joined = stream.join().is_ok();
+            let events: Vec<_> = std::iter::from_fn(|| sub.recv().ok()).collect();
+            let _ = holder.kill();
+            (joined, events.len())
+        });
+        assert_eq!(
+            outcome,
+            Some((true, 0)),
+            "the stream must end promptly and empty, not wait for a writer that cannot come"
+        );
+    }
+
+    /// The other edge of the same wait: this thread starts the moment bazel is
+    /// spawned, but bazel does not open the BEP file until its JVM is up
+    /// seconds later, and that gap must not be mistaken for an invocation that
+    /// will never write. Every event of a real build rides on the difference.
+    #[test]
+    fn a_writer_that_opens_late_still_delivers_its_events() {
+        let path = temp_fifo_path();
+        let mut holder = spawn_pid_holder();
+        let pid = holder.id();
+
+        let mut stream = BuildEventStream::spawn(path.clone(), pid, pid, vec![]).unwrap();
+        let sub = stream.subscribe();
+        wait_for_fifo(&path);
+
+        let path_w = path.clone();
+        let writer = std::thread::spawn(move || {
+            // Many poll intervals' worth of "no writer", so the reader cannot
+            // pass this test by racing to its first read.
+            std::thread::sleep(Duration::from_millis(300));
+            let mut f = OpenOptions::new().write(true).open(&path_w).unwrap();
+            f.write_all(&encode_event(&make_event(true))).unwrap();
+        });
+
+        writer.join().unwrap();
+        stream.join().unwrap();
+        let _ = holder.kill();
+
+        let events: Vec<_> = std::iter::from_fn(|| sub.recv().ok()).collect();
+        assert_eq!(events.len(), 1, "a late writer's events must not be dropped");
+        assert!(events[0].last_message);
     }
 
     // -------------------------------------------------------------------------

--- a/crates/basil/src/main.rs
+++ b/crates/basil/src/main.rs
@@ -237,6 +237,16 @@ fn scenario(name: &str) -> Scenario {
             exit: ExitBehavior::Code(2),
         },
 
+        // Bazel rejecting the command line: it exits nonzero having never
+        // opened the BEP file, so no attempts at all. The read side waits on
+        // a writer that cannot come, which is what `spawn_open_watchdog`
+        // exists to break out of.
+        "rejects_command_line" => Scenario {
+            open_delay: Duration::ZERO,
+            attempts: vec![],
+            exit: ExitBehavior::Code(2),
+        },
+
         // Like `success`, but basil is killed by SIGKILL after the event
         // sequence is flushed. The parent's `ExitStatus::code()` is
         // `None`, which exercises the signal-kill path in `wait()`'s

--- a/crates/galvanize/BUILD.bazel
+++ b/crates/galvanize/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel/rust:defs.bzl", "rust_library")
+load("//bazel/rust:defs.bzl", "rust_library", "rust_test")
 
 config_setting(
     name = "macos",
@@ -23,4 +23,9 @@ rust_library(
         ":macos": ["@crates//:proc_pidinfo"],
         ":linux": ["@crates//:procfs"],
     }),
+)
+
+rust_test(
+    name = "galvanize_test",
+    crate = ":galvanize",
 )

--- a/crates/galvanize/src/lib.rs
+++ b/crates/galvanize/src/lib.rs
@@ -145,12 +145,12 @@ impl Pipe {
     /// that leaves the `open` parked in the kernel with no read for
     /// [`RetryPolicy`] to govern, and nothing short of a signal to call it off.
     ///
-    /// Nothing here teaches the reader anything new. Its `open` returns, and
-    /// what the first read then finds is whatever the FIFO already implies: no
-    /// writer attached and no data, so end-of-stream — a plain `Ok(0)` under
-    /// [`RetryPolicy::Never`], surfaced as `BrokenPipe` by
-    /// [`RetryPolicy::IfOpenForPid`] once it confirms the pid is not holding
-    /// the path open either.
+    /// Nothing here teaches the reader anything new: its `open` returns and the
+    /// first read reports whatever the FIFO already implies. Ordinarily that is
+    /// end-of-stream, since this poke wrote nothing and closed — `read` gives
+    /// `Ok(0)` under [`RetryPolicy::Never`], which [`RetryPolicy::IfOpenForPid`]
+    /// turns into `BrokenPipe` once it confirms the pid is not holding the path
+    /// open either. It is `Ok(n)` instead when the real writer got there first.
     ///
     /// Returns whether a reader was actually waiting. `O_NONBLOCK` keeps this
     /// from becoming the mirror image of the problem it solves: with no reader

--- a/crates/galvanize/src/lib.rs
+++ b/crates/galvanize/src/lib.rs
@@ -387,12 +387,11 @@ mod tests {
     fn gives_up_when_no_writer_ever_opens() {
         let path = fifo();
         let started = Instant::now();
-        let err = match Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
-            false
-        }) {
-            Ok(_) => panic!("must not hand back a pipe no writer will ever use"),
-            Err(e) => e,
-        };
+        let err =
+            match Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || false) {
+                Ok(_) => panic!("must not hand back a pipe no writer will ever use"),
+                Err(e) => e,
+            };
 
         assert_eq!(err.kind(), ErrorKind::BrokenPipe);
         assert!(
@@ -445,18 +444,19 @@ mod tests {
         // loop's next read, which is what makes that read return data rather
         // than EAGAIN. Doing it from another thread would race that ordering.
         let mut wrote = false;
-        let mut pipe = Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
-            if !wrote {
-                wrote = true;
-                let mut w = OpenOptions::new()
-                    .write(true)
-                    .open(&path_w)
-                    .expect("open write end");
-                w.write_all(b"hello world").expect("write");
-            }
-            true
-        })
-        .expect("data queued on the FIFO must end the wait");
+        let mut pipe =
+            Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
+                if !wrote {
+                    wrote = true;
+                    let mut w = OpenOptions::new()
+                        .write(true)
+                        .open(&path_w)
+                        .expect("open write end");
+                    w.write_all(b"hello world").expect("write");
+                }
+                true
+            })
+            .expect("data queued on the FIFO must end the wait");
 
         // Read in small chunks: the hand-over buffer has to survive being
         // drained across several reads, not just one big one.
@@ -483,18 +483,19 @@ mod tests {
         // guard call, and the guard says "gone" every time. So the bytes can
         // only come back via the read taken after the writer is known gone.
         let mut wrote = false;
-        let mut pipe = Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
-            if !wrote {
-                wrote = true;
-                let mut w = OpenOptions::new()
-                    .write(true)
-                    .open(&path_w)
-                    .expect("open write end");
-                w.write_all(b"late").expect("write");
-            }
-            false
-        })
-        .expect("bytes written before the last read must be delivered");
+        let mut pipe =
+            Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
+                if !wrote {
+                    wrote = true;
+                    let mut w = OpenOptions::new()
+                        .write(true)
+                        .open(&path_w)
+                        .expect("open write end");
+                    w.write_all(b"late").expect("write");
+                }
+                false
+            })
+            .expect("bytes written before the last read must be delivered");
 
         let mut got = [0u8; 4];
         pipe.read_exact(&mut got).expect("read");

--- a/crates/galvanize/src/lib.rs
+++ b/crates/galvanize/src/lib.rs
@@ -325,8 +325,15 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(5));
         }
-        assert!(poked, "a reader was parked in open; the poke should have found it");
-        assert_eq!(reader.join().expect("reader thread"), 0, "the released reader must see end-of-stream");
+        assert!(
+            poked,
+            "a reader was parked in open; the poke should have found it"
+        );
+        assert_eq!(
+            reader.join().expect("reader thread"),
+            0,
+            "the released reader must see end-of-stream"
+        );
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/galvanize/src/lib.rs
+++ b/crates/galvanize/src/lib.rs
@@ -140,20 +140,26 @@ impl Pipe {
 
     /// Release a reader parked in [`Pipe::open`] by briefly becoming the writer
     /// it is waiting for: open the write end and close it without writing.
-    /// The reader's open returns and its first read reports end-of-stream.
     ///
     /// For callers whose real writer may die before it ever opens the FIFO:
     /// that leaves the `open` parked in the kernel with no read for
     /// [`RetryPolicy`] to govern, and nothing short of a signal to call it off.
+    ///
+    /// Nothing here teaches the reader anything new. Its `open` returns, and
+    /// what the first read then finds is whatever the FIFO already implies: no
+    /// writer attached and no data, so end-of-stream — a plain `Ok(0)` under
+    /// [`RetryPolicy::Never`], surfaced as `BrokenPipe` by
+    /// [`RetryPolicy::IfOpenForPid`] once it confirms the pid is not holding
+    /// the path open either.
     ///
     /// Returns whether a reader was actually waiting. `O_NONBLOCK` keeps this
     /// from becoming the mirror image of the problem it solves: with no reader
     /// on the other side the open fails `ENXIO` rather than parking, reported
     /// here as `Ok(false)`.
     ///
-    /// Harmless to call when the real writer did arrive: a FIFO reports
-    /// end-of-stream only once *every* writer has closed, so a poke alongside
-    /// a live writer is invisible to the reader.
+    /// Harmless if the real writer turns out to have arrived after all — a
+    /// FIFO ends only once *every* writer has closed, so a poke alongside a
+    /// live writer is invisible and reading proceeds as normal.
     pub fn poke_writer(path: &Path) -> io::Result<bool> {
         use std::os::unix::fs::OpenOptionsExt;
 

--- a/crates/galvanize/src/lib.rs
+++ b/crates/galvanize/src/lib.rs
@@ -108,10 +108,30 @@ fn is_path_open_for_pid(path: &Path, pid: u32) -> io::Result<bool> {
     Ok(false)
 }
 
+/// Drop `O_NONBLOCK` from an open descriptor, so reads block again.
+fn clear_nonblocking(file: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let fd = file.as_raw_fd();
+    // SAFETY: `fd` is owned by `file` and stays open for this call; F_GETFL and
+    // F_SETFL only read and rewrite this descriptor's status flags.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags == -1 || libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_NONBLOCK) == -1 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
 pub struct Pipe {
     path: PathBuf,
     inner: File,
     policy: RetryPolicy,
+    /// Bytes already read off the FIFO while waiting for a writer to show up
+    /// (see [`Pipe::open_waiting_for_writer`]), handed to the next `read`
+    /// before the fd is touched again. Empty for every other constructor.
+    pending: Vec<u8>,
 }
 
 pub enum RetryPolicy {
@@ -149,6 +169,88 @@ impl Pipe {
             inner,
             policy,
             path,
+            pending: Vec::new(),
+        })
+    }
+
+    /// Open the read end of an existing FIFO without committing to a writer
+    /// ever arriving. Returns `ErrorKind::BrokenPipe` once `should_wait`
+    /// reports the writer is no longer coming.
+    ///
+    /// [`Pipe::open`] cannot do this: a blocking `open(O_RDONLY)` on a FIFO
+    /// parks in the kernel until a writer opens the other end, and nothing
+    /// short of a signal calls it off — so a writer that dies *before* opening
+    /// strands the caller for good, with no read for [`RetryPolicy`] to
+    /// govern. `O_NONBLOCK` makes the open return at once; this then polls
+    /// every `poll_interval`, asking `should_wait` whether to keep waiting.
+    ///
+    /// Readiness is decided by a read rather than by `poll` flags, whose
+    /// meaning for an unconnected FIFO varies by platform. The read results
+    /// POSIX does pin down are easy to read backwards:
+    ///
+    /// * `Ok(0)` — *nobody* has the FIFO open for writing. Ambiguous between
+    ///   "the writer has not gotten to it yet" and "the writer is finished",
+    ///   so it is a waiting state rather than an answer. Mistaking it for a
+    ///   writer sighting hands back a pipe whose first read reports the stream
+    ///   already over, losing everything the writer had yet to send.
+    /// * `EAGAIN` — a writer *is* attached, with nothing written yet. Proof it
+    ///   arrived, so the wait ends here.
+    /// * `Ok(n)` — data, which this read has consumed; the bytes are held in
+    ///   `pending` for the first [`Read::read`] call.
+    ///
+    /// Once a writer has been seen the descriptor goes back to blocking, so
+    /// streaming reads cost exactly what [`Pipe::open`]'s do.
+    pub fn open_waiting_for_writer(
+        path: PathBuf,
+        policy: RetryPolicy,
+        poll_interval: std::time::Duration,
+        mut should_wait: impl FnMut() -> bool,
+    ) -> io::Result<Self> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        /// Enough to hold whatever a writer managed to send before this thread
+        /// got to its first read; the rest stays in the FIFO for later reads.
+        const FIRST_READ_CAPACITY: usize = 4096;
+
+        let inner = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&path)?;
+
+        let mut pending = vec![0u8; FIRST_READ_CAPACITY];
+        let mut buffered = 0;
+        // Whether `should_wait` has already gone false. Reading once more
+        // after it does is what keeps a writer that filled the FIFO and exited
+        // between two polls from being treated as one that never wrote.
+        let mut writer_gone = false;
+        loop {
+            match (&inner).read(&mut pending) {
+                Ok(n) if n > 0 => {
+                    buffered = n;
+                    break;
+                }
+                Err(e) if e.kind() == ErrorKind::WouldBlock => break,
+                Ok(_) => {}
+                Err(e) => return Err(e),
+            }
+            if writer_gone {
+                return Err(io::Error::new(
+                    ErrorKind::BrokenPipe,
+                    "no writer opened the pipe",
+                ));
+            }
+            writer_gone = !should_wait();
+            std::thread::sleep(poll_interval);
+        }
+        pending.truncate(buffered);
+
+        clear_nonblocking(&inner)?;
+        let path = path.canonicalize()?;
+        Ok(Self {
+            inner,
+            policy,
+            path,
+            pending,
         })
     }
 
@@ -161,6 +263,12 @@ impl Pipe {
     }
 
     fn read_with_policy(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if !self.pending.is_empty() {
+            let n = buf.len().min(self.pending.len());
+            buf[..n].copy_from_slice(&self.pending[..n]);
+            self.pending.drain(..n);
+            return Ok(n);
+        }
         match self.policy {
             RetryPolicy::Never => self.inner.read(buf).map_err(|err| err.into()),
             RetryPolicy::IfOpenForPid(pid) => loop {
@@ -247,5 +355,150 @@ impl Read for StreamingFile {
             }
             other => other,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::{Duration, Instant};
+
+    const POLL: Duration = Duration::from_millis(5);
+
+    /// A FIFO of our own, created and owned by the calling test.
+    fn fifo() -> PathBuf {
+        static NEXT: AtomicU32 = AtomicU32::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "galvanize-test-{}-{}.fifo",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        Pipe::mkfifo(&path).expect("mkfifo");
+        path
+    }
+
+    /// Nothing ever opens the write end, and the caller stops waiting: the open
+    /// has to fail rather than park in the kernel the way `open` would.
+    #[test]
+    fn gives_up_when_no_writer_ever_opens() {
+        let path = fifo();
+        let started = Instant::now();
+        let err = match Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
+            false
+        }) {
+            Ok(_) => panic!("must not hand back a pipe no writer will ever use"),
+            Err(e) => e,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::BrokenPipe);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "gave up after {:?}; it should take a couple of polls",
+            started.elapsed()
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A writer that has attached without sending anything yet is still a
+    /// writer, and `EAGAIN` is the only proof of one — so the wait ends there,
+    /// whatever the guard says.
+    ///
+    /// The writer opens from another thread because `open(O_WRONLY)` on a FIFO
+    /// blocks until a reader arrives: opening it up front would deadlock
+    /// against the very open under test.
+    #[test]
+    fn ends_the_wait_when_a_writer_attaches_without_writing() {
+        let path = fifo();
+        let path_w = path.clone();
+        let writer = std::thread::spawn(move || {
+            OpenOptions::new()
+                .write(true)
+                .open(&path_w)
+                .expect("open write end")
+        });
+
+        // Bounded rather than `|| true`, so a regression fails the test
+        // instead of hanging it.
+        let mut polls = 0;
+        let pipe = Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
+            polls += 1;
+            polls < 200
+        });
+        assert!(pipe.is_ok(), "an attached writer must end the wait");
+
+        drop(writer.join().expect("writer thread"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// The wait spends a read to learn where it stands, so whatever that read
+    /// swallowed has to reach the caller's first `read`.
+    #[test]
+    fn hands_over_bytes_it_read_while_waiting() {
+        let path = fifo();
+        let path_w = path.clone();
+
+        // Writing from inside the guard puts the bytes in the FIFO before the
+        // loop's next read, which is what makes that read return data rather
+        // than EAGAIN. Doing it from another thread would race that ordering.
+        let mut wrote = false;
+        let mut pipe = Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
+            if !wrote {
+                wrote = true;
+                let mut w = OpenOptions::new()
+                    .write(true)
+                    .open(&path_w)
+                    .expect("open write end");
+                w.write_all(b"hello world").expect("write");
+            }
+            true
+        })
+        .expect("data queued on the FIFO must end the wait");
+
+        // Read in small chunks: the hand-over buffer has to survive being
+        // drained across several reads, not just one big one.
+        let mut got = Vec::new();
+        let mut chunk = [0u8; 4];
+        loop {
+            match pipe.read(&mut chunk).expect("read") {
+                0 => break,
+                n => got.extend_from_slice(&chunk[..n]),
+            }
+        }
+        assert_eq!(got, b"hello world");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A writer can fill the FIFO and exit between two polls. Its bytes are
+    /// still in the pipe, so noticing it left must not throw them away.
+    #[test]
+    fn delivers_bytes_from_a_writer_that_left_between_polls() {
+        let path = fifo();
+        let path_w = path.clone();
+
+        // The whole writer lifetime — attach, write, leave — happens inside one
+        // guard call, and the guard says "gone" every time. So the bytes can
+        // only come back via the read taken after the writer is known gone.
+        let mut wrote = false;
+        let mut pipe = Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
+            if !wrote {
+                wrote = true;
+                let mut w = OpenOptions::new()
+                    .write(true)
+                    .open(&path_w)
+                    .expect("open write end");
+                w.write_all(b"late").expect("write");
+            }
+            false
+        })
+        .expect("bytes written before the last read must be delivered");
+
+        let mut got = [0u8; 4];
+        pipe.read_exact(&mut got).expect("read");
+        assert_eq!(&got, b"late");
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/galvanize/src/lib.rs
+++ b/crates/galvanize/src/lib.rs
@@ -108,30 +108,10 @@ fn is_path_open_for_pid(path: &Path, pid: u32) -> io::Result<bool> {
     Ok(false)
 }
 
-/// Drop `O_NONBLOCK` from an open descriptor, so reads block again.
-fn clear_nonblocking(file: &File) -> io::Result<()> {
-    use std::os::fd::AsRawFd;
-
-    let fd = file.as_raw_fd();
-    // SAFETY: `fd` is owned by `file` and stays open for this call; F_GETFL and
-    // F_SETFL only read and rewrite this descriptor's status flags.
-    unsafe {
-        let flags = libc::fcntl(fd, libc::F_GETFL);
-        if flags == -1 || libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_NONBLOCK) == -1 {
-            return Err(io::Error::last_os_error());
-        }
-    }
-    Ok(())
-}
-
 pub struct Pipe {
     path: PathBuf,
     inner: File,
     policy: RetryPolicy,
-    /// Bytes already read off the FIFO while waiting for a writer to show up
-    /// (see [`Pipe::open_waiting_for_writer`]), handed to the next `read`
-    /// before the fd is touched again. Empty for every other constructor.
-    pending: Vec<u8>,
 }
 
 pub enum RetryPolicy {
@@ -158,10 +138,43 @@ impl Pipe {
         }
     }
 
+    /// Release a reader parked in [`Pipe::open`] by briefly becoming the writer
+    /// it is waiting for: open the write end and close it without writing.
+    /// The reader's open returns and its first read reports end-of-stream.
+    ///
+    /// For callers whose real writer may die before it ever opens the FIFO:
+    /// that leaves the `open` parked in the kernel with no read for
+    /// [`RetryPolicy`] to govern, and nothing short of a signal to call it off.
+    ///
+    /// Returns whether a reader was actually waiting. `O_NONBLOCK` keeps this
+    /// from becoming the mirror image of the problem it solves: with no reader
+    /// on the other side the open fails `ENXIO` rather than parking, reported
+    /// here as `Ok(false)`.
+    ///
+    /// Harmless to call when the real writer did arrive: a FIFO reports
+    /// end-of-stream only once *every* writer has closed, so a poke alongside
+    /// a live writer is invisible to the reader.
+    pub fn poke_writer(path: &Path) -> io::Result<bool> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(path)
+        {
+            Ok(_) => Ok(true),
+            Err(e) if e.raw_os_error() == Some(libc::ENXIO) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Open the read end of an existing FIFO at `path`. Blocks until a
     /// writer connects (POSIX FIFO semantics) unless one already has.
     /// Pair with `mkfifo` when the caller needs to control ordering
     /// between FIFO creation and writer spawn.
+    ///
+    /// A writer that never arrives parks this forever; see
+    /// [`Pipe::poke_writer`] for the way out.
     pub fn open(path: PathBuf, policy: RetryPolicy) -> io::Result<Self> {
         let inner = File::open(&path)?;
         let path = path.canonicalize()?;
@@ -169,88 +182,6 @@ impl Pipe {
             inner,
             policy,
             path,
-            pending: Vec::new(),
-        })
-    }
-
-    /// Open the read end of an existing FIFO without committing to a writer
-    /// ever arriving. Returns `ErrorKind::BrokenPipe` once `should_wait`
-    /// reports the writer is no longer coming.
-    ///
-    /// [`Pipe::open`] cannot do this: a blocking `open(O_RDONLY)` on a FIFO
-    /// parks in the kernel until a writer opens the other end, and nothing
-    /// short of a signal calls it off — so a writer that dies *before* opening
-    /// strands the caller for good, with no read for [`RetryPolicy`] to
-    /// govern. `O_NONBLOCK` makes the open return at once; this then polls
-    /// every `poll_interval`, asking `should_wait` whether to keep waiting.
-    ///
-    /// Readiness is decided by a read rather than by `poll` flags, whose
-    /// meaning for an unconnected FIFO varies by platform. The read results
-    /// POSIX does pin down are easy to read backwards:
-    ///
-    /// * `Ok(0)` — *nobody* has the FIFO open for writing. Ambiguous between
-    ///   "the writer has not gotten to it yet" and "the writer is finished",
-    ///   so it is a waiting state rather than an answer. Mistaking it for a
-    ///   writer sighting hands back a pipe whose first read reports the stream
-    ///   already over, losing everything the writer had yet to send.
-    /// * `EAGAIN` — a writer *is* attached, with nothing written yet. Proof it
-    ///   arrived, so the wait ends here.
-    /// * `Ok(n)` — data, which this read has consumed; the bytes are held in
-    ///   `pending` for the first [`Read::read`] call.
-    ///
-    /// Once a writer has been seen the descriptor goes back to blocking, so
-    /// streaming reads cost exactly what [`Pipe::open`]'s do.
-    pub fn open_waiting_for_writer(
-        path: PathBuf,
-        policy: RetryPolicy,
-        poll_interval: std::time::Duration,
-        mut should_wait: impl FnMut() -> bool,
-    ) -> io::Result<Self> {
-        use std::os::unix::fs::OpenOptionsExt;
-
-        /// Enough to hold whatever a writer managed to send before this thread
-        /// got to its first read; the rest stays in the FIFO for later reads.
-        const FIRST_READ_CAPACITY: usize = 4096;
-
-        let inner = std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_NONBLOCK)
-            .open(&path)?;
-
-        let mut pending = vec![0u8; FIRST_READ_CAPACITY];
-        let mut buffered = 0;
-        // Whether `should_wait` has already gone false. Reading once more
-        // after it does is what keeps a writer that filled the FIFO and exited
-        // between two polls from being treated as one that never wrote.
-        let mut writer_gone = false;
-        loop {
-            match (&inner).read(&mut pending) {
-                Ok(n) if n > 0 => {
-                    buffered = n;
-                    break;
-                }
-                Err(e) if e.kind() == ErrorKind::WouldBlock => break,
-                Ok(_) => {}
-                Err(e) => return Err(e),
-            }
-            if writer_gone {
-                return Err(io::Error::new(
-                    ErrorKind::BrokenPipe,
-                    "no writer opened the pipe",
-                ));
-            }
-            writer_gone = !should_wait();
-            std::thread::sleep(poll_interval);
-        }
-        pending.truncate(buffered);
-
-        clear_nonblocking(&inner)?;
-        let path = path.canonicalize()?;
-        Ok(Self {
-            inner,
-            policy,
-            path,
-            pending,
         })
     }
 
@@ -263,12 +194,6 @@ impl Pipe {
     }
 
     fn read_with_policy(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if !self.pending.is_empty() {
-            let n = buf.len().min(self.pending.len());
-            buf[..n].copy_from_slice(&self.pending[..n]);
-            self.pending.drain(..n);
-            return Ok(n);
-        }
         match self.policy {
             RetryPolicy::Never => self.inner.read(buf).map_err(|err| err.into()),
             RetryPolicy::IfOpenForPid(pid) => loop {
@@ -362,12 +287,8 @@ impl Read for StreamingFile {
 mod tests {
     use super::*;
 
-    use std::fs::OpenOptions;
-    use std::io::Write;
     use std::sync::atomic::{AtomicU32, Ordering};
-    use std::time::{Duration, Instant};
-
-    const POLL: Duration = Duration::from_millis(5);
+    use std::time::Duration;
 
     /// A FIFO of our own, created and owned by the calling test.
     fn fifo() -> PathBuf {
@@ -381,125 +302,95 @@ mod tests {
         path
     }
 
-    /// Nothing ever opens the write end, and the caller stops waiting: the open
-    /// has to fail rather than park in the kernel the way `open` would.
+    /// The reason `poke_writer` exists: a reader parked in `open` with no writer
+    /// coming has to be able to get out, and what it sees on the way out is an
+    /// ended stream.
     #[test]
-    fn gives_up_when_no_writer_ever_opens() {
+    fn poking_releases_a_parked_reader() {
         let path = fifo();
-        let started = Instant::now();
-        let err =
-            match Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || false) {
-                Ok(_) => panic!("must not hand back a pipe no writer will ever use"),
-                Err(e) => e,
-            };
+        let path_r = path.clone();
+        let reader = std::thread::spawn(move || {
+            let mut pipe = Pipe::open(path_r, RetryPolicy::Never).expect("open read end");
+            let mut buf = [0u8; 8];
+            pipe.read(&mut buf).expect("read")
+        });
 
-        assert_eq!(err.kind(), ErrorKind::BrokenPipe);
+        // Poll rather than sleep-once: the poke only works while the reader is
+        // parked, and `Ok(false)` says it wasn't there yet.
+        let mut poked = false;
+        for _ in 0..200 {
+            if Pipe::poke_writer(&path).expect("poke") {
+                poked = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(poked, "a reader was parked in open; the poke should have found it");
+        assert_eq!(reader.join().expect("reader thread"), 0, "the released reader must see end-of-stream");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// With nobody parked the poke must report that and return, not park in the
+    /// kernel itself waiting for a reader.
+    #[test]
+    fn poking_an_unattended_fifo_reports_no_reader() {
+        let path = fifo();
         assert!(
-            started.elapsed() < Duration::from_secs(5),
-            "gave up after {:?}; it should take a couple of polls",
-            started.elapsed()
+            !Pipe::poke_writer(&path).expect("poke must not fail"),
+            "no reader is waiting on this FIFO"
         );
         let _ = std::fs::remove_file(&path);
     }
 
-    /// A writer that has attached without sending anything yet is still a
-    /// writer, and `EAGAIN` is the only proof of one — so the wait ends there,
-    /// whatever the guard says.
-    ///
-    /// The writer opens from another thread because `open(O_WRONLY)` on a FIFO
-    /// blocks until a reader arrives: opening it up front would deadlock
-    /// against the very open under test.
+    /// A poke is allowed to lose the race and land while the real writer holds
+    /// the FIFO open. The reader must not see that as the end of anything.
     #[test]
-    fn ends_the_wait_when_a_writer_attaches_without_writing() {
+    fn poking_alongside_a_live_writer_does_not_end_the_stream() {
         let path = fifo();
-        let path_w = path.clone();
-        let writer = std::thread::spawn(move || {
-            OpenOptions::new()
-                .write(true)
-                .open(&path_w)
-                .expect("open write end")
-        });
-
-        // Bounded rather than `|| true`, so a regression fails the test
-        // instead of hanging it.
-        let mut polls = 0;
-        let pipe = Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
-            polls += 1;
-            polls < 200
-        });
-        assert!(pipe.is_ok(), "an attached writer must end the wait");
-
-        drop(writer.join().expect("writer thread"));
-        let _ = std::fs::remove_file(&path);
-    }
-
-    /// The wait spends a read to learn where it stands, so whatever that read
-    /// swallowed has to reach the caller's first `read`.
-    #[test]
-    fn hands_over_bytes_it_read_while_waiting() {
-        let path = fifo();
-        let path_w = path.clone();
-
-        // Writing from inside the guard puts the bytes in the FIFO before the
-        // loop's next read, which is what makes that read return data rather
-        // than EAGAIN. Doing it from another thread would race that ordering.
-        let mut wrote = false;
-        let mut pipe =
-            Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
-                if !wrote {
-                    wrote = true;
-                    let mut w = OpenOptions::new()
-                        .write(true)
-                        .open(&path_w)
-                        .expect("open write end");
-                    w.write_all(b"hello world").expect("write");
+        let path_r = path.clone();
+        let reader = std::thread::spawn(move || {
+            let mut pipe = Pipe::open(path_r, RetryPolicy::Never).expect("open read end");
+            let mut got = Vec::new();
+            let mut buf = [0u8; 4];
+            loop {
+                match pipe.read(&mut buf).expect("read") {
+                    0 => break,
+                    n => got.extend_from_slice(&buf[..n]),
                 }
-                true
-            })
-            .expect("data queued on the FIFO must end the wait");
-
-        // Read in small chunks: the hand-over buffer has to survive being
-        // drained across several reads, not just one big one.
-        let mut got = Vec::new();
-        let mut chunk = [0u8; 4];
-        loop {
-            match pipe.read(&mut chunk).expect("read") {
-                0 => break,
-                n => got.extend_from_slice(&chunk[..n]),
             }
-        }
-        assert_eq!(got, b"hello world");
-        let _ = std::fs::remove_file(&path);
-    }
+            got
+        });
 
-    /// A writer can fill the FIFO and exit between two polls. Its bytes are
-    /// still in the pipe, so noticing it left must not throw them away.
-    #[test]
-    fn delivers_bytes_from_a_writer_that_left_between_polls() {
-        let path = fifo();
-        let path_w = path.clone();
-
-        // The whole writer lifetime — attach, write, leave — happens inside one
-        // guard call, and the guard says "gone" every time. So the bytes can
-        // only come back via the read taken after the writer is known gone.
-        let mut wrote = false;
-        let mut pipe =
-            Pipe::open_waiting_for_writer(path.clone(), RetryPolicy::Never, POLL, || {
-                if !wrote {
-                    wrote = true;
-                    let mut w = OpenOptions::new()
-                        .write(true)
-                        .open(&path_w)
-                        .expect("open write end");
-                    w.write_all(b"late").expect("write");
+        let mut w = {
+            use std::io::Write;
+            let mut w = None;
+            for _ in 0..200 {
+                match std::fs::OpenOptions::new().write(true).open(&path) {
+                    Ok(f) => {
+                        w = Some(f);
+                        break;
+                    }
+                    Err(_) => std::thread::sleep(Duration::from_millis(5)),
                 }
-                false
-            })
-            .expect("bytes written before the last read must be delivered");
+            }
+            let mut f = w.expect("open write end");
+            f.write_all(b"before").expect("write");
+            f
+        };
 
-        let mut got = [0u8; 4];
-        pipe.read_exact(&mut got).expect("read");
-        assert_eq!(&got, b"late");
+        // Poke while the real writer is still attached, then keep writing.
+        let _ = Pipe::poke_writer(&path).expect("poke");
+        {
+            use std::io::Write;
+            w.write_all(b"after").expect("write after the poke");
+        }
+        drop(w);
+
+        assert_eq!(
+            reader.join().expect("reader thread"),
+            b"beforeafter".to_vec(),
+            "a poke beside a live writer must not truncate the stream"
+        );
         let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
`aspect build` could print Bazel's error and then hang forever, until the user hit Ctrl-C or CI killed the job — one run took a self-hosted runner to its 15-minute timeout and ended in `Terminate orphan process: pid (17665) (aspect-cli)`.

Tasks that stream build events read them over a FIFO the CLI creates itself: `mkfifo`, hand the path to Bazel as `--build_event_binary_file`, open the read end. A FIFO's blocking `open(O_RDONLY)` parks in the kernel until a writer opens the other end, with nothing short of a signal to call it off — and Bazel exits before opening that file whenever it rejects the command line (an unrecognized flag, a bad startup option). Its *server* stays alive, so the reader saw what looked like a writer still on its way and waited for the life of the process, while `block_on` waited on the reader. `RetryPolicy` governs only `read()`, so the `writer_pid` liveness check the reader already does for `BrokenPipe` never got a chance to run.

The open stays exactly as it was; a watchdog beside it does the releasing. `spawn_open_watchdog` polls `is_pid_alive(writer_pid)` — the Bazel client, the same pid and the same reasoning as the `BrokenPipe` branch that handles retry gaps, since the daemon outlives the invocation and can never answer the question. Once the invocation is over it opens the FIFO's **write** end and closes it, which releases the parked open. The reader sets a flag when its own open returns, retiring the watchdog so a reader that got its writer honestly is left alone.

Nothing in the reader learns anything new. Once released, its first read reports what the FIFO already implied: `Ok(0)`, which the existing `RetryPolicy::IfOpenForPid` turns into `BrokenPipe` after confirming the server is not holding the path open either — and that lands in the `BrokenPipe` arm the read loop already had, ending the stream empty and leaving the caller to report Bazel's exit code. Not a line of that path is new, which is the point: the release routes into behaviour the reader already had rather than adding a decision to the streaming path.

The failure mode is the point. A FIFO reports end-of-stream only once *every* writer has closed, so a poke landing beside a writer Bazel did open is invisible to the reader — guessing wrong costs nothing. `poke_writer` uses `O_NONBLOCK` so it cannot become the mirror image of the problem it solves: with no reader parked it returns `ENXIO` (`Ok(false)`) instead of parking itself. Since a poke only lands against an already-parked reader, the watchdog keeps offering under a bounded number of attempts rather than giving up on the first miss.

**Scope**: only invocations that ask for build events, since only those get a `--build_event_binary_file` FIFO (`build.rs`, gated on `build_events`) — `ctx.bazel.build` with events, so `aspect build`, `test`, `run` and the other build-backed tasks. `ctx.bazel.query` / `info` / `version` never create the FIFO and were never affected.

The galvanize diff is purely additive — `poke_writer`, docs and tests, with every read path byte-identical to `main`. Separately, the stream-termination epilogue (close subscribers, flush, signal the file sinks) had accumulated four copies, and is now one `finish` closure.

Found while working on #1396, which makes this far easier to reach: once unrecognized flags are forwarded to Bazel, any mistyped flag lands here. The bug is independent of that change — `--bazel-flag=--bogus` gets you the same hang today — so it goes first.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no — no documented behavior changes, this is a hang fix
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- Fixed `aspect build`, `aspect test` and `aspect run` hanging instead of exiting when Bazel rejects the command line (an unrecognized flag, a bad startup option). Tasks that stream build events waited on a build-event pipe Bazel had already died without opening; they now report Bazel's error and exit code.

### Test plan

- New test cases added:
  - `galvanize` gets its first test suite, and a `rust_test` target so it runs under Bazel too: a poke releases a parked reader and it sees end-of-stream; a poke at an unattended FIFO reports no reader rather than parking; a poke landing beside a live writer does not truncate the stream.
  - `a_writer_that_never_opens_ends_the_stream` — live server pid, dead invocation pid, no writer; the stream must end promptly and empty, under a 10s `with_timeout` so a regression fails instead of hanging CI.
  - `a_writer_that_opens_late_still_delivers_its_events` — the opposite edge: a writer that opens 300ms in, long after the reader parked, must still have its events delivered.
  - `the_watchdog_waits_for_a_reader_that_has_not_parked_yet` — an invocation already dead when the watchdog starts, so its first poke precedes the reader; the reader must still be released.
  - `a_rejected_command_line_does_not_hang_the_bes_reader` — the user-facing case, end to end through `ctx.bazel.build`: a new `basil` scenario that never opens the BEP file and exits 2, asserting the build surfaces that exit code with an empty event stream.
  - `invocation_test.axl` — the same case in AXL against a **real** Bazel (`aspect dev test-bazel-invocation`): build with a flag Bazel rejects, assert the invocation surfaces the failure with no events.
  - `axl-smoke` — and at the CLI level in CI, modelled on the invocation that surfaced this on #1396: `aspect build --bazel-flag=--definitely_not_a_flag //...` must come back as Bazel's `Unrecognized option`, under a `timeout` so a regression is a bounded failure rather than the whole job budget.

  Each of the three was confirmed to fail for the right reason — with the fix reverted, the Rust test trips its 60s timeout and the AXL suite hangs.
- Covered by existing test cases — the BES stream suite (complete stream, `BrokenPipe`, retry reconnect, file sinks) covers the reader and the `finish` consolidation. `cargo test --workspace`: 681 passed, 0 failed.
- Manual testing, with a fake bazel that answers `info` and then fails the build without opening the FIFO:
  ```
  # before: printed the error, then hung until killed
  # after:
  ERROR: --bogus_flag :: Unrecognized option: --bogus_flag
  → ❌ Failed build task (exit code 2) in 27ms · Failed to build
  ```
  Same result with and without `--bes-backend`, so no BES backend is needed to hit it. Also verified real `bazel` builds and the `basil` fake still stream their events.

  And against a real Bazel with a live server, which is the shape users hit — `aspect build --bazel-flag=--definitely_not_a_flag //crates/galvanize:galvanize` hangs past 60s on `main` and exits in 1.9s with code 2 here.
- The `poke` semantics this rests on were checked against both kernels, macOS and Linux: opening the write end `O_NONBLOCK` while a reader is parked succeeds and releases it; with nobody parked it returns `ENXIO` immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
