### PR TITLE
style: apply rustfmt to the BES tracing sink

### DIFF
--- a/crates/axl-runtime/src/engine/bazel/sink/tracing.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/tracing.rs
@@ -164,8 +164,8 @@ impl Tracing {
                         // exit code — 0 for a spawn that merely executed), this
                         // span carries the real BlazeTestStatus and sets the OTel
                         // span status to error when the test failed.
-                        let status =
-                            TestStatus::try_from(summary.overall_status).unwrap_or(TestStatus::NoStatus);
+                        let status = TestStatus::try_from(summary.overall_status)
+                            .unwrap_or(TestStatus::NoStatus);
                         #[allow(deprecated)]
                         let start_time = timestamp_secs_or_now(
                             summary.first_start_time.as_ref(),
@@ -197,7 +197,8 @@ impl Tracing {
                         // final target verdict; these are the individual attempts
                         // (a failing attempt that later passes is visible here as
                         // an error span while the summary reports FLAKY).
-                        let status = TestStatus::try_from(result.status).unwrap_or(TestStatus::NoStatus);
+                        let status =
+                            TestStatus::try_from(result.status).unwrap_or(TestStatus::NoStatus);
                         #[allow(deprecated)]
                         let start_time = timestamp_secs_or_now(
                             result.test_attempt_start.as_ref(),
@@ -253,7 +254,11 @@ mod tests {
             TestStatus::RemoteFailure,
             TestStatus::ToolHaltedBeforeTesting,
         ] {
-            assert_eq!(test_status_code(s), "error", "{s:?} should be an error span");
+            assert_eq!(
+                test_status_code(s),
+                "error",
+                "{s:?} should be an error span"
+            );
         }
     }
 
@@ -271,13 +276,19 @@ mod tests {
 
     #[test]
     fn timestamp_prefers_modern_field() {
-        let ts = Timestamp { seconds: 42, nanos: 0 };
+        let ts = Timestamp {
+            seconds: 42,
+            nanos: 0,
+        };
         assert_eq!(timestamp_secs_or_now(Some(&ts), 999_000), 42);
     }
 
     #[test]
     fn timestamp_falls_back_to_legacy_millis() {
-        assert_eq!(timestamp_secs_or_now(None, 1_723_000_000_000), 1_723_000_000);
+        assert_eq!(
+            timestamp_secs_or_now(None, 1_723_000_000_000),
+            1_723_000_000
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes the `format-gha` / `format-gha-debug` / `format-format-repeat-task` failures on [#1369](https://github.com/aspect-build/aspect-cli/pull/1369). The format task reported exactly one unformatted file, `crates/axl-runtime/src/engine/bazel/sink/tracing.rs`:

- both `TestStatus::try_from(...).unwrap_or(...)` bindings wrapped on the wrong side of the call
- the multi-argument `assert_eq!`s in the new tests exceeded the line width
- the `Timestamp { seconds: 42, nanos: 0 }` literal needed expanding

Produced by running `cargo fmt --all`; `cargo fmt --all -- --check` is now clean across the workspace.

Based on `claude/axl-cli-otel-test-spans-52xxpx` so the diff is only the formatting change. Merging it into that branch turns #1369's format checks green.

### Changes are visible to end-users: no

Whitespace and line wrapping only — no behavior change.

### Test plan

- `cargo fmt --all -- --check` passes with no diff
- `cargo test -p axl-runtime --lib engine::bazel::sink::tracing` — 6 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_016oNr9XDzApMo9qx2V4A7hK)_