### PR TITLE
fix(workflows): don't signal runner unhealthy mid-job on sandbox poisoning

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -11,11 +11,7 @@ load(
     "sanitize_filename",
 )
 load("../private/lib/health_check.axl", "HealthCheckTrait", "agent_health_check")
-load(
-    "../private/lib/sandbox_recovery.axl",
-    "make_attempt_end_hook",
-    "make_final_status_hook",
-)
+load("../private/lib/sandbox_recovery.axl", "sandbox_recovery")
 
 def _workflows_impl(ctx: FeatureContext):
     environment = get_workflows_environment(ctx.std)
@@ -54,12 +50,17 @@ def _workflows_impl(ctx: FeatureContext):
         hc_trait.health_check.append(lambda ctx: agent_health_check(ctx, environment))
 
         # Detect + repair stranded sandbox state (bazelbuild/bazel#23880) after
-        # every bazel attempt, and signal the runner unhealthy when the final
-        # exit is server-internal-error class. See `lib/sandbox_recovery.axl`
-        # for the full rationale; on-runner only because `signal_instance_unhealthy`
-        # is meaningless off-runner.
-        bazel_trait.bazel_attempt_end.append(make_attempt_end_hook(environment))
-        bazel_trait.build_end.append(make_final_status_hook(environment))
+        # every bazel attempt, stop retrying onto a sandbox we could not clean,
+        # and signal the runner unhealthy at build_end. See
+        # `lib/sandbox_recovery.axl` for the full rationale; on-runner only
+        # because `signal_instance_unhealthy` is meaningless off-runner.
+        # The three hooks share one recovery state, so they come from a single
+        # `.new()` — registering them independently would drop the verdict that
+        # links them.
+        recovery = sandbox_recovery.new(environment)
+        bazel_trait.bazel_attempt_end.append(recovery.attempt_end)
+        bazel_trait.build_retry = recovery.build_retry
+        bazel_trait.build_end.append(recovery.build_end)
 
         # Flags to optimize build & test
         (startup_flags, build_flags) = get_bazelrc_flags(

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -51,13 +51,14 @@ def _workflows_impl(ctx: FeatureContext):
 
         # Detect + repair stranded sandbox state (bazelbuild/bazel#23880) after
         # every bazel attempt, stop retrying onto a sandbox we could not clean,
-        # and signal the runner unhealthy at build_end. See
-        # `lib/sandbox_recovery.axl` for the full rationale; on-runner only
-        # because `signal_instance_unhealthy` is meaningless off-runner.
-        # The three hooks share one recovery state, so they come from a single
-        # `.new()` — registering them independently would drop the verdict that
-        # links them.
-        recovery = sandbox_recovery.new(environment)
+        # and mark the runner unhealthy once the task ends. See
+        # `lib/sandbox_recovery.axl`; on-runner only because
+        # `signal_instance_unhealthy` is meaningless off-runner.
+        #
+        # The hooks share one recovery state, so they come from a single
+        # `.new()`. `build_retry` is a single-valued attr, so the current
+        # predicate is passed in and delegated to rather than dropped.
+        recovery = sandbox_recovery.new(environment, retry_predicate = bazel_trait.build_retry)
         bazel_trait.bazel_attempt_end.append(recovery.attempt_end)
         bazel_trait.build_retry = recovery.build_retry
         bazel_trait.build_end.append(recovery.build_end)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery.axl
@@ -1,8 +1,9 @@
 """Runner-side mitigations for Bazel server states that poison a
 Workflows runner for subsequent jobs.
 
-Two failure modes, addressed by two trait hooks the Workflows feature
-registers when `environment.runner != None`:
+Two failure modes, coordinated by `sandbox_recovery.new(environment)`,
+whose three hooks the Workflows feature registers when
+`environment.runner != None`.
 
 1. **Stranded sandbox subtree** (bazelbuild/bazel#23880). When a Bazel
    8.x server hits an `IOException` during sandbox setup (typically
@@ -16,9 +17,8 @@ registers when `environment.runner != None`:
    `ctx.bazel.recover_poisoned_sandbox()` (lists entries under
    `<output_base>/sandbox/` against Bazel's
    `SANDBOX_BASE_PERSISTENT_DIRS` whitelist) and `rm -rf` the offending
-   entries. If repair fails (`still_poisoned`), we signal the instance
-   unhealthy immediately. Wired as `bazel_attempt_end` so retries get
-   a clean sandbox to try again on.
+   entries. Wired as `bazel_attempt_end` so a *repaired* sandbox gives
+   the next retry a clean state to try again on.
 
 2. **Persistent server-internal failure across all retries**. When
    the FINAL attempt exits with `BLAZE_INTERNAL_ERROR (37)` or
@@ -33,16 +33,35 @@ registers when `environment.runner != None`:
    hit server-internal trouble" without tracking per-attempt history.
    Wired as `build_end` so it fires once per task.
 
+**Never signal unhealthy mid-job.** `signal_instance_unhealthy` is not
+a drain request: on AWS it flips the instance to `Unhealthy` with
+`--no-should-respect-grace-period`, and on GCP it calls
+`instance-groups managed delete-instances` outright. Either way the
+ASG/MIG reclaims the box within a couple of minutes, killing whatever
+is still running on it. Signalling from a *non-final* attempt therefore
+races the retry we just started: the runner is torn out mid-retry, the
+agent takes a cancellation signal, and the job dies with SIGTERM/143
+instead of reporting the real Bazel exit code.
+
+So `still_poisoned` does NOT signal from the attempt hook. It records
+the verdict, and `build_retry` then declines to retry — a sandbox we
+could not clean poisons every subsequent invocation on this output
+base, so the retry is guaranteed to fail anyway. The task ends on its
+real exit code and the deferred signal fires from `build_end`, once
+the job has its verdict and is winding down. The runner still leaves
+the pool before it can take the next job.
+
 Critical: a sequence like 37 → repair → real-build-failure (exit 1)
 does NOT signal unhealthy. The retry loop breaks on the non-retryable
-exit; the final code is 1 (build failure), not retryable; the build_end
-hook returns early. The runner is healthy enough to produce a verdict.
+exit; the final code is 1 (build failure), not retryable; nothing
+recorded a poisoning verdict; the build_end hook returns early. The
+runner is healthy enough to produce a verdict.
 """
 
 load("@aspect//bazel.axl", "default_retry")
 load("./ansi.axl", "ansi")
 
-def _signal_unhealthy(ctx, environment):
+def _signal_unhealthy(ctx, environment) -> None:
     """Best-effort invoke the Workflows agent's `signal_instance_unhealthy`
     binary. No-op when the binary isn't present (e.g. older agent versions
     that pre-date the script). Caller is responsible for surfacing the
@@ -52,26 +71,33 @@ def _signal_unhealthy(ctx, environment):
     if ctx.std.fs.exists(signal_bin):
         ctx.std.process.command(signal_bin).spawn().wait()
 
-def make_attempt_end_hook(environment):
-    """Build a `bazel_attempt_end` hook closed over the resolved
-    Workflows runner environment.
+def _new(environment):
+    """Build the three coordinated hooks for one task's bazel run.
 
-    The hook calls `ctx.bazel.recover_poisoned_sandbox()` and branches
-    on its outcome:
+    Holds the one bit of cross-hook state (§7): whether some attempt
+    left behind sandbox poisoning we could not clean. That verdict is
+    set by `attempt_end`, read by `build_retry` to stop retrying, and
+    read again by `build_end` to decide whether to signal unhealthy.
 
-      - `clean`: no-op (the common case).
-      - `repaired`: print a warning so CI logs show the recovery; the
-        retry (or the next job on this runner) can then proceed.
-      - `still_poisoned` (rm -rf failed for at least one entry): print a
-        warning and signal the instance unhealthy. Further bazel commands
-        on this runner will keep crashing the same way, so we accept the
-        current task's failure and ensure the next job lands on a fresh
-        instance.
-
-    Ignores `exit_code` — the recovery decision is purely on-disk.
+    Returns a struct of `attempt_end(ctx, exit_code)`,
+    `build_retry(code)` and `build_end(ctx, exit_code)`.
     """
 
-    def _hook(ctx, _exit_code):
+    # Single-key dict rather than a record: Starlark records are frozen,
+    # and this genuinely needs to be mutated across hook invocations.
+    state = {"still_poisoned": False}
+
+    def _attempt_end(ctx, _exit_code) -> None:
+        """Detect + repair stranded sandbox state after each attempt.
+
+        `clean` is the common case and is silent. `repaired` prints a
+        warning and lets the retry proceed on the cleaned state.
+        `still_poisoned` records the verdict so `build_retry` stops the
+        loop and `build_end` signals — deliberately NOT signalling here,
+        which would kill the job mid-flight.
+
+        Ignores `exit_code` — the recovery decision is purely on-disk.
+        """
         result = ctx.bazel.recover_poisoned_sandbox()
         if result.outcome == "clean":
             return
@@ -85,30 +111,45 @@ def make_attempt_end_hook(environment):
             )
             return
 
+        state["still_poisoned"] = True
         remaining = ", ".join(result.remaining) if result.remaining else "(unknown)"
         print(
             ansi.style("WARNING", ansi.RED) + ": bazel#23880-style sandbox poisoning " +
             "detected and could not be cleaned (entries that survived " +
-            "removal: " + remaining + "). Marking this runner unhealthy " +
-            "so the next job lands on a fresh instance.",
+            "removal: " + remaining + "). Not retrying — every further " +
+            "Bazel invocation on this output base would crash the same " +
+            "way. This runner will be marked unhealthy once the job " +
+            "finishes, so the next job lands on a fresh instance.",
         )
-        _signal_unhealthy(ctx, environment)
 
-    return _hook
+    def _build_retry(code: int) -> bool:
+        """`build_retry` predicate: `default_retry`, but never once we've
+        seen an uncleanable sandbox. Retrying onto poisoning we failed to
+        remove just burns minutes to reach the same crash."""
+        if state["still_poisoned"]:
+            return False
+        return default_retry(code)
 
-def make_final_status_hook(environment):
-    """Build a `build_end` hook that marks the runner unhealthy when
-    the FINAL Bazel exit code is server-internal-error class.
+    def _build_end(ctx, exit_code) -> None:
+        """Signal the runner unhealthy when the sandbox stayed poisoned,
+        or when the FINAL exit code is server-internal-error class.
 
-    The retry loop only continues on `default_retry`-matching codes, so
-    a final exit that is itself retryable-class implies every prior
-    attempt was also retryable-class — the server is persistently sick.
-    A final non-retryable code (success, build failure, test failure,
-    user error, …) means the server produced a verdict, so the runner
-    is fine; we no-op.
-    """
+        The retry loop only continues on `default_retry`-matching codes,
+        so a final exit that is itself retryable-class implies every
+        prior attempt was too — the server is persistently sick. A final
+        non-retryable code (success, build failure, test failure, user
+        error, …) with no poisoning verdict means the server produced a
+        verdict, so the runner is fine; we no-op.
+        """
+        if state["still_poisoned"]:
+            print(
+                ansi.style("WARNING", ansi.RED) + ": marking this runner unhealthy " +
+                "(sandbox poisoning could not be cleaned) so the next job " +
+                "lands on a fresh instance.",
+            )
+            _signal_unhealthy(ctx, environment)
+            return
 
-    def _hook(ctx, exit_code):
         if not default_retry(exit_code):
             return
         print(
@@ -119,4 +160,12 @@ def make_final_status_hook(environment):
         )
         _signal_unhealthy(ctx, environment)
 
-    return _hook
+    return struct(
+        attempt_end = _attempt_end,
+        build_retry = _build_retry,
+        build_end = _build_end,
+    )
+
+sandbox_recovery = namespace(
+    new = _new,
+)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery.axl
@@ -2,7 +2,7 @@
 Workflows runner for subsequent jobs.
 
 Two failure modes, coordinated by `sandbox_recovery.new(environment)`,
-whose three hooks the Workflows feature registers when
+whose hooks the Workflows feature registers when
 `environment.runner != None`.
 
 1. **Stranded sandbox subtree** (bazelbuild/bazel#23880). When a Bazel
@@ -13,49 +13,50 @@ whose three hooks the Workflows feature registers when
    `<output_base>/sandbox/<strategy>/` is left behind on disk. Every
    subsequent `bazel build/test` against the same output_base crashes
    in `checkSandboxBaseTopOnlyContainsPersistentDirs`. Fixed upstream
-   by abe8d6090 (Bazel 9.0+). We detect via
+   by abe8d6090 (Bazel 9.0+). Detected via
    `ctx.bazel.recover_poisoned_sandbox()` (lists entries under
    `<output_base>/sandbox/` against Bazel's
-   `SANDBOX_BASE_PERSISTENT_DIRS` whitelist) and `rm -rf` the offending
-   entries. Wired as `bazel_attempt_end` so a *repaired* sandbox gives
-   the next retry a clean state to try again on.
+   `SANDBOX_BASE_PERSISTENT_DIRS` whitelist), which `rm -rf`s the
+   offending entries. Wired as `bazel_attempt_end` so a *repaired*
+   sandbox gives the next retry a clean state to try again on.
 
 2. **Persistent server-internal failure across all retries**. When
    the FINAL attempt exits with `BLAZE_INTERNAL_ERROR (37)` or
    `LOCAL_ENVIRONMENTAL_ERROR (36)`, the Bazel server is persistently
    sick (could be #23880 the disk-scan missed, JVM OOM, native crash,
-   corrupt lock file, etc.). The `bazel.build(ctx)` retry loop only
-   continues retrying on these two codes — `bazel_trait.build_retry`
-   keys off `default_retry`. So a final exit code that is itself
-   retryable-class means *every* prior attempt was also retryable-class
-   (otherwise the loop would have broken on a non-retryable exit). The
-   final code alone is therefore sufficient to detect "all attempts
-   hit server-internal trouble" without tracking per-attempt history.
-   Wired as `build_end` so it fires once per task.
+   corrupt lock file, etc.). The retry loop only continues on codes
+   the retry predicate accepts, so a final exit that is itself
+   retryable-class implies every prior attempt was too. The final code
+   alone therefore detects "all attempts hit server-internal trouble"
+   without tracking per-attempt history. Wired as `build_end`.
 
-**Never signal unhealthy mid-job.** `signal_instance_unhealthy` is not
-a drain request: on AWS it flips the instance to `Unhealthy` with
-`--no-should-respect-grace-period`, and on GCP it calls
-`instance-groups managed delete-instances` outright. Either way the
-ASG/MIG reclaims the box within a couple of minutes, killing whatever
-is still running on it. Signalling from a *non-final* attempt therefore
-races the retry we just started: the runner is torn out mid-retry, the
-agent takes a cancellation signal, and the job dies with SIGTERM/143
-instead of reporting the real Bazel exit code.
+**Never signal unhealthy while the task is still running.**
+`signal_instance_unhealthy` is not a drain request: on AWS it flips the
+instance to `Unhealthy` with `--no-should-respect-grace-period`, and on
+GCP it calls `instance-groups managed delete-instances` outright. Either
+way the ASG/MIG reclaims the box within a couple of minutes, killing
+whatever is still running on it. Signalling mid-task therefore races the
+work still in flight: the runner is torn out, the agent takes a
+cancellation signal, and the job dies with SIGTERM/143 instead of
+reporting its real exit code.
 
-So `still_poisoned` does NOT signal from the attempt hook. It records
-the verdict, and `build_retry` then declines to retry — a sandbox we
-could not clean poisons every subsequent invocation on this output
-base, so the retry is guaranteed to fail anyway. The task ends on its
-real exit code and the deferred signal fires from `build_end`, once
-the job has its verdict and is winding down. The runner still leaves
-the pool before it can take the next job.
+`build_end` is NOT job completion — it is per-*build*. `delivery.axl`
+fires it after phases 1/2 and then keeps working for minutes (phase 3
+plus the deliverable subprocesses), and phase 3 deliberately fires only
+`bazel_attempt_end`. So both signal paths register a `ctx.defer`
+instead, which runs after the task impl returns (even on a fatal
+Starlark error) and is the only true end-of-task seam. Defers are
+registered at most once per task; `_signal_pending` is the latch.
+
+The poisoning verdict additionally suppresses retries: a sandbox we
+could not clean poisons every subsequent invocation on the same output
+base, so the retry is guaranteed to reach the same crash.
 
 Critical: a sequence like 37 → repair → real-build-failure (exit 1)
 does NOT signal unhealthy. The retry loop breaks on the non-retryable
-exit; the final code is 1 (build failure), not retryable; nothing
-recorded a poisoning verdict; the build_end hook returns early. The
-runner is healthy enough to produce a verdict.
+exit, the repair cleared the sandbox so no poisoning verdict was
+recorded, and exit 1 is not server-internal-error class. The runner is
+healthy enough to produce a verdict.
 """
 
 load("@aspect//bazel.axl", "default_retry")
@@ -64,37 +65,53 @@ load("./ansi.axl", "ansi")
 def _signal_unhealthy(ctx, environment) -> None:
     """Best-effort invoke the Workflows agent's `signal_instance_unhealthy`
     binary. No-op when the binary isn't present (e.g. older agent versions
-    that pre-date the script). Caller is responsible for surfacing the
-    *reason* in a warning before calling — this helper only does the
-    side-effect."""
+    that pre-date the script)."""
     signal_bin = environment.runner.bin_dir + "/signal_instance_unhealthy"
     if ctx.std.fs.exists(signal_bin):
         ctx.std.process.command(signal_bin).spawn().wait()
 
-def _new(environment):
-    """Build the three coordinated hooks for one task's bazel run.
+def _new(environment, retry_predicate = default_retry):
+    """Build the coordinated sandbox-recovery hooks for one task.
 
-    Holds the one bit of cross-hook state (§7): whether some attempt
-    left behind sandbox poisoning we could not clean. That verdict is
-    set by `attempt_end`, read by `build_retry` to stop retrying, and
-    read again by `build_end` to decide whether to signal unhealthy.
+    Holds the cross-hook state (§7): whether an attempt left behind
+    sandbox poisoning we could not clean, and whether the deferred
+    unhealthy signal has already been registered.
+
+    Args:
+        environment:     resolved Workflows runner environment; only
+                         `.runner.bin_dir` is read.
+        retry_predicate: the task's existing `BazelTrait.build_retry`,
+                         which `build_retry` delegates to whenever no
+                         poisoning has been recorded. Defaults to
+                         `default_retry`.
 
     Returns a struct of `attempt_end(ctx, exit_code)`,
     `build_retry(code)` and `build_end(ctx, exit_code)`.
     """
 
-    # Single-key dict rather than a record: Starlark records are frozen,
-    # and this genuinely needs to be mutated across hook invocations.
-    state = {"still_poisoned": False}
+    # Mutable across hook invocations, so a dict rather than a record.
+    state = {"still_poisoned": False, "signal_pending": False}
+
+    def _defer_signal(ctx, reason: str) -> None:
+        """Register the unhealthy signal to fire once the task is over.
+        Idempotent: one task reclaims its runner at most once, however
+        many attempts or builds report trouble."""
+        if state["signal_pending"]:
+            return
+        state["signal_pending"] = True
+        print(
+            ansi.style("WARNING", ansi.RED) + ": " + reason + " Marking this " +
+            "runner unhealthy once the job finishes, so the next job lands " +
+            "on a fresh instance.",
+        )
+        ctx.defer(lambda: _signal_unhealthy(ctx, environment))
 
     def _attempt_end(ctx, _exit_code) -> None:
         """Detect + repair stranded sandbox state after each attempt.
 
-        `clean` is the common case and is silent. `repaired` prints a
-        warning and lets the retry proceed on the cleaned state.
-        `still_poisoned` records the verdict so `build_retry` stops the
-        loop and `build_end` signals — deliberately NOT signalling here,
-        which would kill the job mid-flight.
+        `clean` is silent (the common case). `repaired` warns and lets the
+        retry proceed on the cleaned state. `still_poisoned` records the
+        verdict, which stops further retries, and defers the signal.
 
         Ignores `exit_code` — the recovery decision is purely on-disk.
         """
@@ -113,52 +130,40 @@ def _new(environment):
 
         state["still_poisoned"] = True
         remaining = ", ".join(result.remaining) if result.remaining else "(unknown)"
-        print(
-            ansi.style("WARNING", ansi.RED) + ": bazel#23880-style sandbox poisoning " +
-            "detected and could not be cleaned (entries that survived " +
-            "removal: " + remaining + "). Not retrying — every further " +
-            "Bazel invocation on this output base would crash the same " +
-            "way. This runner will be marked unhealthy once the job " +
-            "finishes, so the next job lands on a fresh instance.",
+        _defer_signal(
+            ctx,
+            "bazel#23880-style sandbox poisoning detected and could not be " +
+            "cleaned (entries that survived removal: " + remaining + "). Not " +
+            "retrying — every further Bazel invocation on this output base " +
+            "would crash the same way.",
         )
 
     def _build_retry(code: int) -> bool:
-        """`build_retry` predicate: `default_retry`, but never once we've
-        seen an uncleanable sandbox. Retrying onto poisoning we failed to
-        remove just burns minutes to reach the same crash."""
+        """Delegate to the task's retry predicate, except once an
+        uncleanable sandbox is recorded — retrying onto poisoning we
+        failed to remove just burns minutes to reach the same crash."""
         if state["still_poisoned"]:
             return False
-        return default_retry(code)
+        return retry_predicate(code)
 
     def _build_end(ctx, exit_code) -> None:
-        """Signal the runner unhealthy when the sandbox stayed poisoned,
-        or when the FINAL exit code is server-internal-error class.
+        """Defer the unhealthy signal when a build's final exit code is
+        server-internal-error class.
 
-        The retry loop only continues on `default_retry`-matching codes,
-        so a final exit that is itself retryable-class implies every
-        prior attempt was too — the server is persistently sick. A final
-        non-retryable code (success, build failure, test failure, user
-        error, …) with no poisoning verdict means the server produced a
-        verdict, so the runner is fine; we no-op.
+        Classification is `default_retry`, not `retry_predicate`: a task
+        that declines to retry 37 has not thereby made its runner healthy.
+        A non-retryable code (success, build failure, test failure, user
+        error, …) means the server produced a verdict, so the runner is
+        fine. Fires per *build*, so a multi-build task (delivery) may call
+        this more than once; `_defer_signal` is idempotent.
         """
-        if state["still_poisoned"]:
-            print(
-                ansi.style("WARNING", ansi.RED) + ": marking this runner unhealthy " +
-                "(sandbox poisoning could not be cleaned) so the next job " +
-                "lands on a fresh instance.",
-            )
-            _signal_unhealthy(ctx, environment)
-            return
-
         if not default_retry(exit_code):
             return
-        print(
-            ansi.style("WARNING", ansi.RED) + ": Bazel exited " + str(exit_code) +
-            " after all retries (server-internal-error class). Marking " +
-            "this runner unhealthy so the next job lands on a fresh " +
-            "instance.",
+        _defer_signal(
+            ctx,
+            "Bazel exited " + str(exit_code) + " after all retries " +
+            "(server-internal-error class).",
         )
-        _signal_unhealthy(ctx, environment)
 
     return struct(
         attempt_end = _attempt_end,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery_test.axl
@@ -1,9 +1,11 @@
 """Tests for `lib/sandbox_recovery.axl`.
 
 Exercises the per-attempt hook (detect + repair, record the verdict on
-`still_poisoned`), the retry predicate (stop retrying onto a sandbox we
-could not clean) and the build-end hook (signal unhealthy, deferred to
-the end of the job).
+`still_poisoned`), the retry predicate (delegate to the task's predicate,
+but stop retrying onto a sandbox we could not clean) and the build-end
+hook (server-internal-error class). Both signal paths register a
+`ctx.defer` rather than signalling inline, so the tests assert on what
+was deferred and then run the defers.
 
 Run with:
   aspect dev test-sandbox-recovery
@@ -14,8 +16,6 @@ load("./sandbox_recovery.axl", "sandbox_recovery")
 def _eq(label, got, want):
     if got != want:
         fail("%s: got %r, want %r" % (label, got, want))
-
-# ── fakes ─────────────────────────────────────────────────────────────────
 
 def _fake_recovery_result(outcome, removed = [], remaining = []):
     """Stand-in for `bazel.SandboxRecoveryResult`. The hooks read
@@ -32,17 +32,20 @@ def _fake_environment(signal_bin_exists = True):
     )
 
 def _fake_ctx(environment, recovery):
-    """Build a fake TaskContext wired up so the hook's `ctx.bazel.recover_poisoned_sandbox()`,
-    `ctx.std.fs.exists()`, and `ctx.std.process.command().spawn().wait()`
-    calls are observable via the returned `recorder` dict.
+    """Build a fake TaskContext so the hooks' `recover_poisoned_sandbox()`,
+    `ctx.defer()`, `ctx.std.fs.exists()` and
+    `ctx.std.process.command().spawn().wait()` calls are observable via the
+    returned `recorder` dict.
 
-    `recovery` is the `RecoveryResult`-shaped stand-in to return from
-    `recover_poisoned_sandbox`."""
-    recorder = {"spawned": []}
+    `recorder["deferred"]` collects the callables passed to `ctx.defer`;
+    `recorder["spawned"]` stays empty until `_run_defers` invokes them,
+    which is what lets a test distinguish "signal deferred" from "signal
+    fired mid-task". `recovery` is the `RecoveryResult`-shaped stand-in
+    to return from `recover_poisoned_sandbox`."""
+    recorder = {"spawned": [], "deferred": []}
 
     def _spawn():
-        # `.spawn().wait()` chain — both no-op; recording happens on
-        # `command()` because that's where the binary path is visible.
+        # Recording happens on `command()` — that's where the path is visible.
         return struct(wait = lambda: None)
 
     def _command(path):
@@ -50,14 +53,13 @@ def _fake_ctx(environment, recovery):
         return struct(spawn = _spawn)
 
     def _exists(path):
-        # The hook checks the signal binary's existence before invoking
-        # it. Mirror the environment's flag.
         if path == environment.runner.bin_dir + "/signal_instance_unhealthy":
             return environment._signal_bin_exists
         return False
 
     ctx = struct(
         bazel = struct(recover_poisoned_sandbox = lambda: recovery),
+        defer = lambda fn: recorder["deferred"].append(fn),
         std = struct(
             fs = struct(exists = _exists),
             process = struct(command = _command),
@@ -65,39 +67,44 @@ def _fake_ctx(environment, recovery):
     )
     return ctx, recorder
 
-# ── attempt-end hook ──────────────────────────────────────────────────────
+def _run_defers(recorder):
+    """Invoke everything registered via `ctx.defer`, mimicking the runtime
+    running defers after the task impl returns."""
+    for fn in recorder["deferred"]:
+        fn()
+
+_SIGNAL_BIN = "/etc/aspect/workflows/bin/signal_instance_unhealthy"
 
 def _test_attempt_hook_clean_is_quiet(_):
-    """Clean outcome: hook must NOT signal unhealthy. This is the
-    overwhelming-majority case (no poisoning on disk)."""
+    """Clean outcome: no signal, no defer. This is the overwhelming-majority
+    case (no poisoning on disk)."""
     env = _fake_environment()
     rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
     rec.attempt_end(ctx, 0)
-    _eq("clean → no signal", recorder["spawned"], [])
+    _eq("clean → no defer", recorder["deferred"], [])
     _eq("clean → retry policy unchanged", rec.build_retry(37), True)
 
 def _test_attempt_hook_repaired_does_not_signal(_):
-    """Repaired outcome: rm -rf succeeded. Print a warning (not asserted
-    here) but do NOT signal — the retry can succeed on the cleaned state."""
+    """Repaired outcome: rm -rf succeeded. Warn (not asserted here) but do
+    not signal — the retry can succeed on the cleaned state."""
     env = _fake_environment()
     rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(
         env,
         _fake_recovery_result("repaired", removed = ["linux-sandbox"]),
     )
-    rec.attempt_end(ctx, 37)  # retryable code; hook ignores it on repair path
-    _eq("repaired → no signal", recorder["spawned"], [])
+    rec.attempt_end(ctx, 37)
+    _eq("repaired → no defer", recorder["deferred"], [])
     _eq("repaired → still retryable", rec.build_retry(37), True)
 
-def _test_attempt_hook_still_poisoned_does_not_signal_midjob(_):
-    """REGRESSION: still_poisoned must NOT signal from the attempt hook.
+def _test_still_poisoned_does_not_signal_during_task(_):
+    """REGRESSION: still_poisoned must not signal while the task runs.
 
     `signal_instance_unhealthy` is a hard reclaim (AWS: set-instance-health
     Unhealthy with no grace period; GCP: delete-instances), so signalling
-    between attempts tears the runner out from under the retry that the
-    loop is about to start. The job then dies on SIGTERM/143 instead of
-    reporting its real Bazel exit code."""
+    mid-task tears the runner out from under work still in flight and the
+    job dies on SIGTERM/143 instead of reporting its real exit code."""
     env = _fake_environment()
     rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(
@@ -105,12 +112,13 @@ def _test_attempt_hook_still_poisoned_does_not_signal_midjob(_):
         _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
     )
     rec.attempt_end(ctx, 37)
-    _eq("still_poisoned → no mid-job signal", recorder["spawned"], [])
+    _eq("still_poisoned → nothing spawned yet", recorder["spawned"], [])
+    _eq("still_poisoned → signal deferred", len(recorder["deferred"]), 1)
 
 def _test_still_poisoned_stops_retrying(_):
-    """REGRESSION: an uncleanable sandbox poisons every later invocation
-    on the same output base, so the retry cannot succeed. `build_retry`
-    must decline even for a normally-retryable code."""
+    """REGRESSION: an uncleanable sandbox poisons every later invocation on
+    the same output base, so the retry cannot succeed. `build_retry` must
+    decline even a normally-retryable code."""
     env = _fake_environment()
     rec = sandbox_recovery.new(env)
     ctx, _recorder = _fake_ctx(
@@ -122,10 +130,10 @@ def _test_still_poisoned_stops_retrying(_):
     _eq("after poisoning → 37 not retryable", rec.build_retry(37), False)
     _eq("after poisoning → 36 not retryable", rec.build_retry(36), False)
 
-def _test_still_poisoned_signals_at_build_end(_):
-    """The signal is deferred, not dropped: once the job has its verdict,
-    build_end marks the runner unhealthy so the next job lands fresh.
-    Exit 1 here proves the poisoning verdict drives it, not the code."""
+def _test_still_poisoned_signals_after_task(_):
+    """The signal is deferred, not dropped: running the defers marks the
+    runner unhealthy so the next job lands fresh. Never calling build_end
+    mirrors delivery's phase 3, which fires only `bazel_attempt_end`."""
     env = _fake_environment()
     rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(
@@ -133,18 +141,12 @@ def _test_still_poisoned_signals_at_build_end(_):
         _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
     )
     rec.attempt_end(ctx, 37)
-    _eq("no signal before build_end", recorder["spawned"], [])
-    rec.build_end(ctx, 1)
-    _eq(
-        "still_poisoned → signal at build_end",
-        recorder["spawned"],
-        ["/etc/aspect/workflows/bin/signal_instance_unhealthy"],
-    )
+    _run_defers(recorder)
+    _eq("still_poisoned → signal on defer", recorder["spawned"], [_SIGNAL_BIN])
 
 def _test_still_poisoned_noops_when_binary_absent(_):
-    """When the signal binary doesn't exist (older agent), the deferred
-    signal must skip the invocation rather than fail. The warning print
-    still happens — the agent's just missing the script."""
+    """Missing signal binary (older agent) → the deferred signal skips the
+    invocation rather than failing."""
     env = _fake_environment(signal_bin_exists = False)
     rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(
@@ -152,12 +154,48 @@ def _test_still_poisoned_noops_when_binary_absent(_):
         _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
     )
     rec.attempt_end(ctx, 37)
-    rec.build_end(ctx, 1)
+    _run_defers(recorder)
     _eq("absent binary → no spawn", recorder["spawned"], [])
 
-# ── final-status hook ─────────────────────────────────────────────────────
+def _test_repeated_poisoning_defers_signal_once(_):
+    """Poisoning seen on several attempts (and then a retryable build_end)
+    must still register exactly one defer — one job, one reclaim."""
+    env = _fake_environment()
+    rec = sandbox_recovery.new(env)
+    ctx, recorder = _fake_ctx(
+        env,
+        _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
+    )
+    rec.attempt_end(ctx, 37)
+    rec.attempt_end(ctx, 37)
+    rec.build_end(ctx, 37)
+    _eq("repeat poisoning → one defer", len(recorder["deferred"]), 1)
+    _run_defers(recorder)
+    _eq("repeat poisoning → one signal", recorder["spawned"], [_SIGNAL_BIN])
 
-def _test_final_hook_signals_on_blaze_internal_error(_):
+def _test_build_retry_delegates_to_task_predicate(_):
+    """REGRESSION: `build_retry` is a single-valued attr, so the feature
+    must delegate to the predicate already on the trait instead of
+    silently reinstating `default_retry`."""
+    env = _fake_environment()
+    rec = sandbox_recovery.new(env, retry_predicate = lambda code: code == 42)
+    _eq("delegates: 42 retryable", rec.build_retry(42), True)
+    _eq("delegates: 37 not retryable", rec.build_retry(37), False)
+
+def _test_build_retry_delegation_yields_to_poisoning(_):
+    """Even a permissive task predicate must not retry onto an uncleanable
+    sandbox."""
+    env = _fake_environment()
+    rec = sandbox_recovery.new(env, retry_predicate = lambda _code: True)
+    ctx, _recorder = _fake_ctx(
+        env,
+        _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
+    )
+    _eq("permissive predicate retries", rec.build_retry(1), True)
+    rec.attempt_end(ctx, 37)
+    _eq("poisoning overrides predicate", rec.build_retry(1), False)
+
+def _test_build_end_signals_on_blaze_internal_error(_):
     """Final exit 37 → server persistently sick → signal unhealthy.
 
     Per `default_retry`, 37 (BLAZE_INTERNAL_ERROR) is the canonical
@@ -166,37 +204,44 @@ def _test_final_hook_signals_on_blaze_internal_error(_):
     rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
     rec.build_end(ctx, 37)
-    _eq(
-        "final 37 → signal invoked",
-        recorder["spawned"],
-        ["/etc/aspect/workflows/bin/signal_instance_unhealthy"],
-    )
+    _eq("final 37 → nothing spawned yet", recorder["spawned"], [])
+    _run_defers(recorder)
+    _eq("final 37 → signal on defer", recorder["spawned"], [_SIGNAL_BIN])
 
-def _test_final_hook_signals_on_local_environmental_error(_):
+def _test_build_end_signals_on_local_environmental_error(_):
     """Final exit 36 → same policy as 37 (server-internal-error class)."""
     env = _fake_environment()
     rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
     rec.build_end(ctx, 36)
-    _eq(
-        "final 36 → signal invoked",
-        recorder["spawned"],
-        ["/etc/aspect/workflows/bin/signal_instance_unhealthy"],
-    )
+    _run_defers(recorder)
+    _eq("final 36 → signal on defer", recorder["spawned"], [_SIGNAL_BIN])
 
-def _test_final_hook_quiet_on_success(_):
+def _test_build_end_classification_ignores_task_predicate(_):
+    """The server-sick classification is `default_retry`, deliberately not
+    the task's predicate: a task that declines to retry 37 has not made its
+    runner healthy."""
+    env = _fake_environment()
+    rec = sandbox_recovery.new(env, retry_predicate = lambda _code: False)
+    ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
+    rec.build_end(ctx, 37)
+    _run_defers(recorder)
+    _eq("final 37 → signal regardless of predicate", recorder["spawned"], [_SIGNAL_BIN])
+
+def _test_build_end_quiet_on_success(_):
     """Final exit 0 → success → no signal."""
     env = _fake_environment()
     rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
     rec.build_end(ctx, 0)
+    _run_defers(recorder)
     _eq("final 0 → no signal", recorder["spawned"], [])
 
-def _test_final_hook_quiet_on_real_failure(_):
-    """Final exit 1 (build failure) → server produced a verdict →
-    runner is fine → no signal. This is the critical contract: a
-    successful retry-after-repair that ends in a normal build failure
-    must NOT mark the runner unhealthy.
+def _test_build_end_quiet_on_real_failure(_):
+    """Final exit 1 (build failure) → server produced a verdict → runner is
+    fine → no signal. This is the critical contract: a successful
+    retry-after-repair ending in a normal build failure must NOT mark the
+    runner unhealthy.
 
     Standard non-retryable codes: 1 (build), 2 (cmdline), 3 (tests),
     4 (no tests), 6 (run), 7 (analysis), 8 (interrupted)."""
@@ -205,31 +250,37 @@ def _test_final_hook_quiet_on_real_failure(_):
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
     for code in [1, 2, 3, 4, 6, 7, 8]:
         recorder["spawned"] = []
+        recorder["deferred"] = []
         rec.build_end(ctx, code)
+        _run_defers(recorder)
         _eq("final %d → no signal" % code, recorder["spawned"], [])
 
-def _test_final_hook_noops_when_binary_absent(_):
-    """Missing signal binary → no spawn (same defensiveness as the
-    attempt-end hook)."""
+def _test_build_end_noops_when_binary_absent(_):
+    """Missing signal binary → no spawn."""
     env = _fake_environment(signal_bin_exists = False)
     rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
     rec.build_end(ctx, 37)
+    _run_defers(recorder)
     _eq("absent binary → no spawn", recorder["spawned"], [])
 
 def _test_impl(ctx):
     _test_attempt_hook_clean_is_quiet(ctx)
     _test_attempt_hook_repaired_does_not_signal(ctx)
-    _test_attempt_hook_still_poisoned_does_not_signal_midjob(ctx)
+    _test_still_poisoned_does_not_signal_during_task(ctx)
     _test_still_poisoned_stops_retrying(ctx)
-    _test_still_poisoned_signals_at_build_end(ctx)
+    _test_still_poisoned_signals_after_task(ctx)
     _test_still_poisoned_noops_when_binary_absent(ctx)
-    _test_final_hook_signals_on_blaze_internal_error(ctx)
-    _test_final_hook_signals_on_local_environmental_error(ctx)
-    _test_final_hook_quiet_on_success(ctx)
-    _test_final_hook_quiet_on_real_failure(ctx)
-    _test_final_hook_noops_when_binary_absent(ctx)
-    print("sandbox_recovery_test.axl: OK (11 sections)")
+    _test_repeated_poisoning_defers_signal_once(ctx)
+    _test_build_retry_delegates_to_task_predicate(ctx)
+    _test_build_retry_delegation_yields_to_poisoning(ctx)
+    _test_build_end_signals_on_blaze_internal_error(ctx)
+    _test_build_end_signals_on_local_environmental_error(ctx)
+    _test_build_end_classification_ignores_task_predicate(ctx)
+    _test_build_end_quiet_on_success(ctx)
+    _test_build_end_quiet_on_real_failure(ctx)
+    _test_build_end_noops_when_binary_absent(ctx)
+    print("sandbox_recovery_test.axl: OK (15 sections)")
     return 0
 
 sandbox_recovery_tests = task(

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/sandbox_recovery_test.axl
@@ -1,14 +1,15 @@
 """Tests for `lib/sandbox_recovery.axl`.
 
-Exercises the per-attempt hook (detect + repair, escalate on
-`still_poisoned`) and the final-status hook (signal on server-internal
-final exit code).
+Exercises the per-attempt hook (detect + repair, record the verdict on
+`still_poisoned`), the retry predicate (stop retrying onto a sandbox we
+could not clean) and the build-end hook (signal unhealthy, deferred to
+the end of the job).
 
 Run with:
   aspect dev test-sandbox-recovery
 """
 
-load("./sandbox_recovery.axl", "make_attempt_end_hook", "make_final_status_hook")
+load("./sandbox_recovery.axl", "sandbox_recovery")
 
 def _eq(label, got, want):
     if got != want:
@@ -70,50 +71,88 @@ def _test_attempt_hook_clean_is_quiet(_):
     """Clean outcome: hook must NOT signal unhealthy. This is the
     overwhelming-majority case (no poisoning on disk)."""
     env = _fake_environment()
-    hook = make_attempt_end_hook(env)
+    rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
-    hook(ctx, 0)
+    rec.attempt_end(ctx, 0)
     _eq("clean → no signal", recorder["spawned"], [])
+    _eq("clean → retry policy unchanged", rec.build_retry(37), True)
 
 def _test_attempt_hook_repaired_does_not_signal(_):
     """Repaired outcome: rm -rf succeeded. Print a warning (not asserted
     here) but do NOT signal — the retry can succeed on the cleaned state."""
     env = _fake_environment()
-    hook = make_attempt_end_hook(env)
+    rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(
         env,
         _fake_recovery_result("repaired", removed = ["linux-sandbox"]),
     )
-    hook(ctx, 37)  # retryable code; hook ignores it on repair path
+    rec.attempt_end(ctx, 37)  # retryable code; hook ignores it on repair path
     _eq("repaired → no signal", recorder["spawned"], [])
+    _eq("repaired → still retryable", rec.build_retry(37), True)
 
-def _test_attempt_hook_still_poisoned_signals(_):
-    """still_poisoned: rm -rf failed. Hook must signal unhealthy via
-    the agent binary so the next job lands on a fresh runner."""
+def _test_attempt_hook_still_poisoned_does_not_signal_midjob(_):
+    """REGRESSION: still_poisoned must NOT signal from the attempt hook.
+
+    `signal_instance_unhealthy` is a hard reclaim (AWS: set-instance-health
+    Unhealthy with no grace period; GCP: delete-instances), so signalling
+    between attempts tears the runner out from under the retry that the
+    loop is about to start. The job then dies on SIGTERM/143 instead of
+    reporting its real Bazel exit code."""
     env = _fake_environment()
-    hook = make_attempt_end_hook(env)
+    rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(
         env,
         _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
     )
-    hook(ctx, 37)
+    rec.attempt_end(ctx, 37)
+    _eq("still_poisoned → no mid-job signal", recorder["spawned"], [])
+
+def _test_still_poisoned_stops_retrying(_):
+    """REGRESSION: an uncleanable sandbox poisons every later invocation
+    on the same output base, so the retry cannot succeed. `build_retry`
+    must decline even for a normally-retryable code."""
+    env = _fake_environment()
+    rec = sandbox_recovery.new(env)
+    ctx, _recorder = _fake_ctx(
+        env,
+        _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
+    )
+    _eq("before poisoning → 37 retryable", rec.build_retry(37), True)
+    rec.attempt_end(ctx, 37)
+    _eq("after poisoning → 37 not retryable", rec.build_retry(37), False)
+    _eq("after poisoning → 36 not retryable", rec.build_retry(36), False)
+
+def _test_still_poisoned_signals_at_build_end(_):
+    """The signal is deferred, not dropped: once the job has its verdict,
+    build_end marks the runner unhealthy so the next job lands fresh.
+    Exit 1 here proves the poisoning verdict drives it, not the code."""
+    env = _fake_environment()
+    rec = sandbox_recovery.new(env)
+    ctx, recorder = _fake_ctx(
+        env,
+        _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
+    )
+    rec.attempt_end(ctx, 37)
+    _eq("no signal before build_end", recorder["spawned"], [])
+    rec.build_end(ctx, 1)
     _eq(
-        "still_poisoned → signal invoked",
+        "still_poisoned → signal at build_end",
         recorder["spawned"],
         ["/etc/aspect/workflows/bin/signal_instance_unhealthy"],
     )
 
-def _test_attempt_hook_still_poisoned_noops_when_binary_absent(_):
-    """When the signal binary doesn't exist (older agent), the hook must
-    skip the invocation rather than fail. The warning print still
-    happens — the agent's just missing the script."""
+def _test_still_poisoned_noops_when_binary_absent(_):
+    """When the signal binary doesn't exist (older agent), the deferred
+    signal must skip the invocation rather than fail. The warning print
+    still happens — the agent's just missing the script."""
     env = _fake_environment(signal_bin_exists = False)
-    hook = make_attempt_end_hook(env)
+    rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(
         env,
         _fake_recovery_result("still_poisoned", remaining = ["linux-sandbox"]),
     )
-    hook(ctx, 37)
+    rec.attempt_end(ctx, 37)
+    rec.build_end(ctx, 1)
     _eq("absent binary → no spawn", recorder["spawned"], [])
 
 # ── final-status hook ─────────────────────────────────────────────────────
@@ -124,9 +163,9 @@ def _test_final_hook_signals_on_blaze_internal_error(_):
     Per `default_retry`, 37 (BLAZE_INTERNAL_ERROR) is the canonical
     retryable-class code; a final exit of 37 means all retries hit it."""
     env = _fake_environment()
-    hook = make_final_status_hook(env)
+    rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
-    hook(ctx, 37)
+    rec.build_end(ctx, 37)
     _eq(
         "final 37 → signal invoked",
         recorder["spawned"],
@@ -136,9 +175,9 @@ def _test_final_hook_signals_on_blaze_internal_error(_):
 def _test_final_hook_signals_on_local_environmental_error(_):
     """Final exit 36 → same policy as 37 (server-internal-error class)."""
     env = _fake_environment()
-    hook = make_final_status_hook(env)
+    rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
-    hook(ctx, 36)
+    rec.build_end(ctx, 36)
     _eq(
         "final 36 → signal invoked",
         recorder["spawned"],
@@ -148,9 +187,9 @@ def _test_final_hook_signals_on_local_environmental_error(_):
 def _test_final_hook_quiet_on_success(_):
     """Final exit 0 → success → no signal."""
     env = _fake_environment()
-    hook = make_final_status_hook(env)
+    rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
-    hook(ctx, 0)
+    rec.build_end(ctx, 0)
     _eq("final 0 → no signal", recorder["spawned"], [])
 
 def _test_final_hook_quiet_on_real_failure(_):
@@ -162,33 +201,35 @@ def _test_final_hook_quiet_on_real_failure(_):
     Standard non-retryable codes: 1 (build), 2 (cmdline), 3 (tests),
     4 (no tests), 6 (run), 7 (analysis), 8 (interrupted)."""
     env = _fake_environment()
-    hook = make_final_status_hook(env)
+    rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
     for code in [1, 2, 3, 4, 6, 7, 8]:
         recorder["spawned"] = []
-        hook(ctx, code)
+        rec.build_end(ctx, code)
         _eq("final %d → no signal" % code, recorder["spawned"], [])
 
 def _test_final_hook_noops_when_binary_absent(_):
     """Missing signal binary → no spawn (same defensiveness as the
     attempt-end hook)."""
     env = _fake_environment(signal_bin_exists = False)
-    hook = make_final_status_hook(env)
+    rec = sandbox_recovery.new(env)
     ctx, recorder = _fake_ctx(env, _fake_recovery_result("clean"))
-    hook(ctx, 37)
+    rec.build_end(ctx, 37)
     _eq("absent binary → no spawn", recorder["spawned"], [])
 
 def _test_impl(ctx):
     _test_attempt_hook_clean_is_quiet(ctx)
     _test_attempt_hook_repaired_does_not_signal(ctx)
-    _test_attempt_hook_still_poisoned_signals(ctx)
-    _test_attempt_hook_still_poisoned_noops_when_binary_absent(ctx)
+    _test_attempt_hook_still_poisoned_does_not_signal_midjob(ctx)
+    _test_still_poisoned_stops_retrying(ctx)
+    _test_still_poisoned_signals_at_build_end(ctx)
+    _test_still_poisoned_noops_when_binary_absent(ctx)
     _test_final_hook_signals_on_blaze_internal_error(ctx)
     _test_final_hook_signals_on_local_environmental_error(ctx)
     _test_final_hook_quiet_on_success(ctx)
     _test_final_hook_quiet_on_real_failure(ctx)
     _test_final_hook_noops_when_binary_absent(ctx)
-    print("sandbox_recovery_test.axl: OK (9 sections)")
+    print("sandbox_recovery_test.axl: OK (11 sections)")
     return 0
 
 sandbox_recovery_tests = task(


### PR DESCRIPTION
A customer's Buildkite job died with `status 143` a couple of minutes after a Bazel server crash (`Socket closed`), instead of reporting the real Bazel exit code.

The `still_poisoned` branch of the bazel#23880 sandbox recovery hook called `signal_instance_unhealthy` inline, from `bazel_attempt_end`. That signal is a hard reclaim, not a drain request: on AWS it flips the instance `Unhealthy` with `--no-should-respect-grace-period`, on GCP it calls `instance-groups managed delete-instances`. Meanwhile the retry loop, which knows nothing about the hook's side effect, started the next attempt. The ASG/MIG reclaimed the box out from under the running job, the agent took a cancellation signal, and the job exited 143.

That retry was doomed regardless: we mark the runner unhealthy precisely *because* the sandbox could not be cleaned, and every subsequent Bazel invocation against the same output base crashes the same way.

## What changed

The hooks now share one `sandbox_recovery.new(environment, retry_predicate)` state holder:

- **`attempt_end`** records the poisoning verdict instead of signalling.
- **`build_retry`** declines to retry once that verdict is set, delegating to the task's existing predicate otherwise.
- **`build_end`** handles the separate "final exit is server-internal-error class" policy.

Both signal paths register a **`ctx.defer`** rather than signalling inline. `build_end` is a per-*build* seam, not per-task — `delivery.axl` fires it after phases 1/2 and then keeps working for minutes (phase 3 plus the deliverable subprocesses), and phase 3 fires only `bazel_attempt_end`. `ctx.defer` runs after the task impl returns, even on a fatal Starlark error, so it is the only seam that reliably means "the job is over". A `signal_pending` latch keeps it to one reclaim per task however many attempts or builds report trouble.

`build_retry` is a single-valued attr, so the previous predicate is passed into `.new()` and delegated to rather than overwritten — otherwise enabling this feature would silently reinstate `default_retry` over any predicate a custom task or another feature installed. The server-sick classification in `build_end` deliberately stays on `default_retry`: a task that declines to retry 37 has not thereby made its runner healthy.

Net effect: the job ends on its real exit code, and the runner still leaves the pool before it can pick up the next job.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: n/a (internal runner behavior; no docsite surface)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Fixed a bug where an unrecoverable Bazel sandbox-poisoning state (bazelbuild/bazel#23880) marked the Workflows runner unhealthy *during* a job, causing the CI agent to be cancelled mid-job and the job to fail with exit code 143 instead of the actual Bazel exit code. The runner is now marked unhealthy after the task completes, and the doomed retry is skipped.

### Test plan

- Covered by existing test cases
- New test cases added

`aspect dev test-sandbox-recovery` — 15 sections, covering:

- poisoning defers the signal instead of firing it mid-task, and the deferred signal still fires
- `build_retry` stops retrying once poisoning is recorded, including over a permissive task predicate
- `build_retry` delegates to the task's predicate when no poisoning is recorded
- repeated poisoning across attempts and builds registers exactly one defer
- `build_end` classification ignores the task predicate and uses `default_retry`
- the pre-existing contracts: `clean`/`repaired` stay quiet, final 36/37 signal, final 0/1/2/3/4/6/7/8 do not, and a missing signal binary is a no-op

Each new regression test was confirmed to fail against the pre-fix behavior. The full AXL suite (~45 `dev test-*` tasks) and the Rust `sandbox_recovery` unit tests pass.

Not reproduced end-to-end on a live runner — the diagnosis is from the customer's log plus the `signal_instance_unhealthy` implementation in silo (`lib.sh:1548-1565`). The ~2 min gap between the unhealthy signal and the cancellation matches ASG reaction latency plus the deliberate `sleep 10` for CloudWatch flushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
