### PR TITLE
fix(auth): open the login URL on Linux and Windows, not just macOS

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -14,6 +14,7 @@ load("@aspect//private/lib/aspect_endpoint_auth_test.axl", "aspect_endpoint_auth
 load("@aspect//private/lib/bazel_flags_test.axl", "bazel_flags_tests")
 load("@aspect//private/lib/bazel_results_test.axl", "bazel_results_unit_tests", "template_snapshot_tests")
 load("@aspect//private/lib/bazelrc_test.axl", "bazelrc_tests")
+load("@aspect//private/lib/browser_test.axl", "browser_tests")
 load("@aspect//private/lib/ci_test.axl", "ci_tests")
 load("@aspect//private/lib/circleci_test.axl", "circleci_tests")
 load("@aspect//private/lib/delivery_results_test.axl", "delivery_results_unit_tests", "delivery_template_snapshot_tests")
@@ -387,6 +388,10 @@ def config(ctx: ConfigContext):
     # auth.axl: status/configure detail string builders.
     # Run with: aspect dev test-auth
     ctx.tasks.add(auth_tests)
+
+    # browser.axl: per-OS URL-opener candidates, $BROWSER, headless gate.
+    # Run with: aspect dev test-browser
+    ctx.tasks.add(browser_tests)
 
     # delivery_results template snapshots.
     # Run with: aspect dev test-delivery-template-snapshots

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -1,4 +1,5 @@
 load("./private/lib/aspect_endpoint_auth.axl", "login_hint")
+load("./private/lib/browser.axl", "browser")
 load("./private/lib/deployment_flags.axl", "REMOTE_DEFAULT_CAPS", "capability_labels", "join_and")
 load("./private/lib/environment.axl", "error", "info", "warn")
 load("./private/lib/prompt.axl", "prompt_choice")
@@ -7,12 +8,11 @@ def _run_browser_login(ctx: TaskContext, deployment: str):
     """Open the deployment's authorize URL in a browser and wait for the callback,
     returning the minted credentials. Prints the URL if a browser can't be opened."""
     session = ctx.aspect.auth.login(deployment = deployment)
-    result = ctx.std.process.command("open").arg(session.url).spawn().wait()
-    if not result.success:
+    if browser.open_url(ctx, session.url):
+        print("Browser opened. Waiting for authentication...")
+    else:
         print("Open this URL to log in:")
         print("  " + session.url)
-    else:
-        print("Browser opened. Waiting for authentication...")
     return session.wait()
 
 # Width of the label column in a deployment's detail block so values align. Must

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/browser.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/browser.axl
@@ -1,0 +1,92 @@
+"""Opening a URL in the user's browser.
+
+`open` exists only on macOS, so spawning it on Linux is a hard AXL error
+(`No such file or directory`) rather than a failed exit status — hence the
+per-OS candidate list, the `$PATH` check before every spawn, and the
+headless gate that keeps a text-mode browser from taking over the terminal.
+Callers fall back to printing the URL when `open_url` returns False.
+"""
+
+# Debian's `sensible-browser`/`x-www-browser` come last; `www-browser` is
+# deliberately absent, being a text browser that would seize the terminal.
+_LINUX_OPENERS = [
+    ["xdg-open"],
+    ["wslview"],
+    ["gio", "open"],
+    ["sensible-browser"],
+    ["x-www-browser"],
+]
+
+# A graphical session, or WSL (whose `wslview` hands off to the Windows host).
+_LINUX_DISPLAY_VARS = ["DISPLAY", "WAYLAND_DISPLAY", "WSL_DISTRO_NAME"]
+
+_ENV_VARS = ["BROWSER"] + _LINUX_DISPLAY_VARS
+
+# Extensions `_resolve` appends on Windows, where "cmd" on $PATH is "cmd.exe".
+_WINDOWS_EXTS = ["", ".exe", ".cmd", ".bat"]
+
+def _browser_var_commands(spec: str, url: str) -> list:
+    """The argv lists named by a `$BROWSER` value: colon-separated commands,
+    each substituting `%s` with the URL or taking it as a trailing argument."""
+    commands = []
+    for entry in spec.split(":"):
+        argv = entry.split()
+        if not argv:
+            continue
+        if "%s" in argv:
+            commands.append([url if a == "%s" else a for a in argv])
+        else:
+            commands.append(argv + [url])
+    return commands
+
+def _open_commands(os_name: str, env: dict, url: str) -> list:
+    """Candidate argv lists for opening `url`, most preferred first.
+
+    `$BROWSER` wins everywhere. Empty for a Linux host with no graphical
+    session and no `$BROWSER` — there is nothing there to open a page with.
+    """
+    commands = _browser_var_commands(env.get("BROWSER") or "", url)
+    if os_name == "macos":
+        commands.append(["open", url])
+    elif os_name == "windows":
+        # `start`'s first quoted argument is the window title, not the URL.
+        commands.append(["cmd", "/c", "start", "", url])
+    elif any([env.get(v) for v in _LINUX_DISPLAY_VARS]):
+        commands.extend([argv + [url] for argv in _LINUX_OPENERS])
+    return commands
+
+def _resolve(ctx: TaskContext, program: str) -> str | None:
+    """`program` resolved against `$PATH`, or None when it isn't there.
+
+    Checked up front because spawning a missing binary aborts the task."""
+    if "/" in program or "\\" in program:
+        return program if ctx.std.fs.exists(program) else None
+    windows = ctx.std.env.os() == "windows"
+    exts = _WINDOWS_EXTS if windows else [""]
+    for entry in (ctx.std.env.var("PATH") or "").split(";" if windows else ":"):
+        if not entry:
+            continue
+        for ext in exts:
+            candidate = entry + "/" + program + ext
+            if ctx.std.fs.exists(candidate):
+                return candidate
+    return None
+
+def _open_url(ctx: TaskContext, url: str) -> bool:
+    """Open `url` in the user's browser, returning whether one was launched."""
+    env = {v: ctx.std.env.var(v) or "" for v in _ENV_VARS}
+    for argv in _open_commands(ctx.std.env.os(), env, url):
+        program = _resolve(ctx, argv[0])
+        if not program:
+            continue
+        cmd = ctx.std.process.command(program).stdout("null").stderr("null")
+        for arg in argv[1:]:
+            cmd = cmd.arg(arg)
+        if cmd.spawn().wait().success:
+            return True
+    return False
+
+browser = namespace(
+    open_url = _open_url,
+    testonly_open_commands = _open_commands,
+)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/browser_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/browser_test.axl
@@ -1,0 +1,86 @@
+"""Unit tests for `browser.axl`'s candidate-command builder — the per-OS opener
+choice, `$BROWSER` precedence and `%s` substitution, and the headless-Linux
+gate. The `$PATH` resolution and the spawn itself need a host, and are not
+covered here.
+
+Run with:
+  aspect dev test-browser
+"""
+
+load("./browser.axl", "browser")
+
+_URL = "https://auth.aspect.build/oauth/authorize?client_id=abc"
+
+def _eq(label, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (label, got, want))
+
+def _commands(os_name, **env):
+    return browser.testonly_open_commands(os_name, env, _URL)
+
+def _test_macos(_):
+    _eq("macos", _commands("macos"), [["open", _URL]])
+
+def _test_windows(_):
+    _eq("windows", _commands("windows"), [["cmd", "/c", "start", "", _URL]])
+
+def _test_linux_graphical(_):
+    got = _commands("linux", DISPLAY = ":0")
+    _eq("first opener", got[0], ["xdg-open", _URL])
+    _eq("gio takes a subcommand", got[2], ["gio", "open", _URL])
+    if ["www-browser", _URL] in got:
+        fail("www-browser is a text browser and must not be a candidate")
+
+def _test_linux_wayland_and_wsl(_):
+    _eq("wayland", _commands("linux", WAYLAND_DISPLAY = "wayland-0"), _commands("linux", DISPLAY = ":0"))
+    _eq("wsl", _commands("linux", WSL_DISTRO_NAME = "Ubuntu"), _commands("linux", DISPLAY = ":0"))
+
+def _test_linux_headless(_):
+    _eq("no display", _commands("linux"), [])
+    _eq("empty display", _commands("linux", DISPLAY = ""), [])
+
+def _test_browser_var(_):
+    _eq(
+        "appended url",
+        _commands("linux", BROWSER = "firefox", DISPLAY = ":0")[0],
+        ["firefox", _URL],
+    )
+    _eq(
+        "%s substitution",
+        _commands("macos", BROWSER = "chromium --new-window %s")[0],
+        ["chromium", "--new-window", _URL],
+    )
+    _eq(
+        "colon-separated list",
+        _commands("linux", BROWSER = "firefox:epiphany")[:2],
+        [["firefox", _URL], ["epiphany", _URL]],
+    )
+    _eq("empty entries ignored", _commands("linux", BROWSER = ":: :"), [])
+
+def _test_other_unix(_):
+    _eq("freebsd is treated as linux", _commands("freebsd", DISPLAY = ":0"), _commands("linux", DISPLAY = ":0"))
+    _eq("headless freebsd", _commands("freebsd"), [])
+
+_UNIT_TESTS = [
+    _test_browser_var,
+    _test_linux_graphical,
+    _test_linux_headless,
+    _test_linux_wayland_and_wsl,
+    _test_macos,
+    _test_other_unix,
+    _test_windows,
+]
+
+def _test_impl(ctx):
+    for t in _UNIT_TESTS:
+        t(ctx)
+    print("browser.axl: OK (%d tests)" % len(_UNIT_TESTS))
+    return 0
+
+browser_tests = task(
+    summary = "Run the browser-opener AXL unit tests.",
+    kind = "test-browser",
+    group = ["dev"],
+    implementation = _test_impl,
+    args = {},
+)


### PR DESCRIPTION
## Problem

On Linux, `aspect auth login` dies instead of logging you in:

```
error: failed to spawn command open "https://auth.aspect.build/oauth/authorize?...":
       No such file or directory (os error 2)
  --> aspect/auth.axl:10:14
```

`_run_browser_login` spawned `open`, which exists only on macOS. Two things go wrong on every other platform:

1. There is no `open`, so no browser is launched.
2. The failure is a spawn error, not a non-zero exit status — a hard AXL error that aborts the task. The existing `if not result.success:` fallback that prints the URL could therefore never run, and the local callback listener died with the task, so there was no way to finish the flow by hand either.

## Fix

New `private/lib/browser.axl` exposing `browser.open_url(ctx, url) -> bool`:

- **Per-OS openers** — macOS `open`; Windows `cmd /c start "" <url>`; Linux and other Unix `xdg-open`, `wslview`, `gio open`, `sensible-browser`, `x-www-browser`, tried in order.
- **`$BROWSER` first, everywhere**, colon-separated and with `%s` substitution, per the POSIX convention.
- **Every candidate is resolved against `$PATH` before spawning it**, because a missing binary aborts the task rather than returning a failed status. This is what makes the fallback reachable.
- **Headless gate** — on Linux with no `$DISPLAY`, `$WAYLAND_DISPLAY` or `$WSL_DISTRO_NAME` there are no candidates at all, so an SSH session prints the URL rather than letting `xdg-open` hand the terminal to a text-mode browser. `www-browser` is deliberately absent from the list for the same reason.
- Opener stdout/stderr go to `null` so `gio`/`xdg-open` chatter doesn't land in the middle of the login prompt.

`auth.axl` now calls it and keeps the same two messages — "Browser opened. Waiting for authentication..." on success, the pasteable URL otherwise.

Note that a headless host still needs `ssh -L 19556:localhost:19556` for the callback to reach the listener; `--with-token` / `--with-api-token` remain the browser-free paths.

## Test plan

- `aspect dev test-browser` (new, 7 cases) — per-OS candidate lists, `$BROWSER` precedence and `%s`, colon-separated lists, empty entries, the headless gate, and that `www-browser` never appears.
- `aspect dev test-auth` — 4 cases, unchanged.
- `aspect-cli tests axl` — 910 cases pass.
- Manually verified the impure path on macOS (`$PATH` resolution → spawn → exit status) with a temporary assertion against `BROWSER=true`, since the unit tests cover only the pure candidate builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)