### PR TITLE
feat(cli): template presets for CI status surfaces

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -13,7 +13,7 @@ load("@aspect//delivery.axl", delivery_UncacheableAction = "UncacheableAction", 
 load("@aspect//lint.axl", "filter_all", "filter_changeset", "linter_error_message", "parse_patch_hunks")
 load("@aspect//private/lib/artifacts.axl", "artifact_name", "build_log_header", "build_log_relpath", "collect_build_action_logs", "dedup_path", "testlog_dest_dir")
 load("@aspect//private/lib/bazel_results.axl", "bb_clientd_root", "compute_reproducer_command", "file_uri_to_path", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
-load("@aspect//private/lib/check_dispatch.axl", "SURFACE_PR_COMMENT", "SURFACE_STATUS_CHECK", "snippet_budget_for")
+load("@aspect//private/lib/check_dispatch.axl", "SURFACE_PR_COMMENT", "SURFACE_STATUS_CHECK", "TEMPLATE_SCOPE_KEYS", "resolve_templates", "snippet_budget_for")
 load("@aspect//private/lib/ci.axl", "detect_build_url")
 load("@aspect//private/lib/deliveryd.axl", deliveryd_parse_endpoint = "parse_endpoint")
 load("@aspect//private/lib/environment.axl", "color_enabled", "detect_ci", "parse_git_url_name", "sanitize_filename")
@@ -33,6 +33,7 @@ load("@aspect//private/lib/repro_commands.axl", "build_aspect_command", "dedup_a
 load("@aspect//private/lib/result_text.axl", "severity_for_status")
 load("@aspect//private/lib/runnable.axl", "apparent_label", "runnable")
 load("@aspect//private/lib/sarif.axl", "get_sarif_summary", "parse_sarif", "parse_sarif_diagnostics", "sarif_diagnostics", "sarif_to_review_comments")
+load("@aspect//private/lib/template_presets.axl", "TemplatePreset", "template_presets")
 load("@aspect//private/lib/tips.axl", "tips")
 load("@demo//answer.axl", "ANSWER")
 load("@std//base64.axl", "base64")
@@ -3645,6 +3646,161 @@ def test_bazel_render_snippets(ctx: TaskContext, tc: int, temp_dir: str) -> int:
     ctx.std.fs.remove_dir_all(d)
     return tc
 
+def test_template_presets(tc: int) -> int:
+    """Covers `template_presets` and the `base` layer of `resolve_templates`.
+
+    The shipped `full` preset is empty, so the preset layer is the identity
+    function on every real invocation. These drive the layering with
+    test-local presets instead, which is the only way the four-level
+    precedence lattice gets real coverage while one preset is registered.
+    """
+
+    # `full` contributes nothing: that is what keeps output byte-identical.
+    tc = test_case(tc, template_presets.templates("full") == {}, "the full preset contributes no templates")
+    tc = test_case(tc, template_presets.DEFAULT == "full", "full is the default preset")
+    tc = test_case(tc, template_presets.DEFAULT in template_presets.NAMES, "the default preset is registered")
+    tc = test_case(tc, template_presets.NAMES == sorted(template_presets.NAMES), "preset names are sorted")
+
+    # base = None is exactly the pre-preset behavior.
+    cases = [
+        (None, "build", None),
+        ({}, "build", None),
+        ({"summary": "S"}, "build", {"summary": "S"}),
+        ({"summary": "S", "lint": {"details": "D"}}, "lint", {"summary": "S", "details": "D"}),
+        ({"summary": "S", "lint": {"details": "D"}}, "build", {"summary": "S"}),
+        ({"lint": {"summary": "L"}}, "build", None),
+    ]
+    for (templates, kind, want) in cases:
+        got = resolve_templates(templates, kind)
+        tc = test_case(tc, got == want, "resolve_templates(%r, %r) == %r" % (templates, kind, want))
+        tc = test_case(
+            tc,
+            resolve_templates(templates, kind, base = None) == got,
+            "base = None matches the single-layer call for %r" % (templates,),
+        )
+        tc = test_case(
+            tc,
+            resolve_templates(templates, kind, base = template_presets.templates("full")) == got,
+            "the full preset as base is a no-op for %r" % (templates,),
+        )
+
+    # The four-level lattice: preset flat < preset scoped < user flat < user scoped.
+    base = {"summary": "P-flat", "details": "P-details", "lint": {"summary": "P-scoped"}}
+    tc = test_case(
+        tc,
+        resolve_templates({}, "lint", base = base) == {"summary": "P-scoped", "details": "P-details"},
+        "a preset's per-kind block overlays its own flat keys",
+    )
+    tc = test_case(
+        tc,
+        resolve_templates({}, "build", base = base) == {"summary": "P-flat", "details": "P-details"},
+        "a preset's per-kind block does not leak to other kinds",
+    )
+
+    # The precedence inversion a naive merge would cause: the user's flat key
+    # must beat the preset's per-kind block, not the other way around.
+    tc = test_case(
+        tc,
+        resolve_templates({"summary": "U-flat"}, "lint", base = {"lint": {"summary": "P-scoped"}}) ==
+        {"summary": "U-flat"},
+        "a user flat key beats a preset per-kind block",
+    )
+    tc = test_case(
+        tc,
+        resolve_templates({"summary": "U-flat"}, "lint", base = base) ==
+        {"summary": "U-flat", "details": "P-details"},
+        "a user flat key beats a preset scoped key while unset slots still come from the preset",
+    )
+    tc = test_case(
+        tc,
+        resolve_templates({"lint": {"summary": "U-scoped"}}, "lint", base = base) ==
+        {"summary": "U-scoped", "details": "P-details"},
+        "a user per-kind block wins outright",
+    )
+    tc = test_case(
+        tc,
+        resolve_templates(None, "build", base = {"summary": "P"}) == {"summary": "P"},
+        "the preset applies when the user sets nothing",
+    )
+    tc = test_case(tc, resolve_templates(None, "build", base = {}) == None, "both layers empty resolves to None")
+
+    # Registry validation. `_validation_errors` returns messages rather than
+    # calling fail(), so the rules that guard preset authors are testable.
+    ok = {"a": TemplatePreset(name = "a", description = "d", templates = {})}
+    tc = test_case(tc, template_presets.validation_errors(ok, "a") == [], "a valid registry reports no errors")
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(ok, "nope")) == 1,
+        "an unregistered default is an error",
+    )
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(
+            {"a": TemplatePreset(name = "b", description = "d", templates = {})},
+            "a",
+        )) == 1,
+        "a preset whose key and name disagree is an error",
+    )
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(
+            {"a": TemplatePreset(name = "a", description = "d", templates = {"body": "B", "summary": ""})},
+            "a",
+        )) == 1,
+        "an empty template is an error: it would yield the built-in it meant to replace",
+    )
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(
+            {"a": TemplatePreset(name = "a", description = "d", templates = {"summary": "S"})},
+            "a",
+        )) == 1,
+        "overriding check surfaces without \"body\" is an error",
+    )
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(
+            {"a": TemplatePreset(
+                name = "a",
+                description = "d",
+                templates = {"body": "B", "lnit": {"summary": "S"}},
+            )},
+            "a",
+        )) == 1,
+        "a per-kind block naming an unknown task kind is an error",
+    )
+    tc = test_case(
+        tc,
+        template_presets.validation_errors(
+            {"a": TemplatePreset(
+                name = "a",
+                description = "d",
+                templates = {"body": "B", "lint": {"summary": "S"}},
+            )},
+            "a",
+        ) == [],
+        "a per-kind block naming a real task kind is accepted",
+    )
+    for kind in TEMPLATE_SCOPE_KEYS:
+        tc = test_case(
+            tc,
+            template_presets.validation_errors(
+                {"a": TemplatePreset(
+                    name = "a",
+                    description = "d",
+                    templates = {"body": "B", kind: {"summary": "S"}},
+                )},
+                "a",
+            ) == [],
+            "%r is a valid preset scope key" % kind,
+        )
+
+    # The arg every surface feature declares.
+    preset_args = template_presets.args()
+    tc = test_case(tc, list(preset_args.keys()) == ["template_preset"], "the args factory declares one arg")
+
+    return tc
+
 def impl(ctx: TaskContext) -> int:
     tc = 0
 
@@ -3734,6 +3890,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_bazel_render_snippets(ctx, tc, temp_dir)
     tc = test_gitlab_token_cache(ctx, tc, temp_dir)
     tc = test_prompt_choice(tc)
+    tc = test_template_presets(tc)
 
     print(tc, "tests passed")
     return 0

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3724,6 +3724,14 @@ def test_template_presets(tc: int) -> int:
     )
     tc = test_case(tc, resolve_templates(None, "build", base = {}) == None, "both layers empty resolves to None")
 
+    # A per-kind block that is not a dict is a config error. The two layers
+    # report separately so the message points at the layer actually at fault.
+    tc = test_case(
+        tc,
+        resolve_templates({"lint": {}}, "lint", base = {"lint": {}}) == None,
+        "empty per-kind blocks in both layers resolve to None",
+    )
+
     # Registry validation. `_validation_errors` returns messages rather than
     # calling fail(), so the rules that guard preset authors are testable.
     ok = {"a": TemplatePreset(name = "a", description = "d", templates = {})}
@@ -3781,6 +3789,18 @@ def test_template_presets(tc: int) -> int:
         ) == [],
         "a per-kind block naming a real task kind is accepted",
     )
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(
+            {"a": TemplatePreset(
+                name = "a",
+                description = "d",
+                templates = {"body": "B", "lint": "oops"},
+            )},
+            "a",
+        )) == 1,
+        "a task-kind key holding a string is an error, not a flat slot named after the kind",
+    )
     for kind in TEMPLATE_SCOPE_KEYS:
         tc = test_case(
             tc,
@@ -3795,7 +3815,18 @@ def test_template_presets(tc: int) -> int:
             "%r is a valid preset scope key" % kind,
         )
 
-    # The arg every surface feature declares.
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(
+            {"a": TemplatePreset(name = "a", description = "", templates = {})},
+            "a",
+        )) == 1,
+        "a preset with no description is an error: the description is user-visible in --help",
+    )
+
+    # The arg every surface feature declares. Its help text is generated from
+    # the registry (`args.Arg` is opaque to AXL, so that string is covered by
+    # the description rule above plus `aspect feature <name>`).
     preset_args = template_presets.args()
     tc = test_case(tc, list(preset_args.keys()) == ["template_preset"], "the args factory declares one arg")
 

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -156,34 +156,17 @@ steps:
       timeout 180 $$LAUNCHER build --bazel-flag=--definitely_not_a_flag //... 2>&1 | grep -q "Unrecognized option" || { echo "ERROR: a Bazel-rejected flag must fail, not hang"; exit 1; }
       echo "--- :aspect: flag rejected by Bazel (bare)"
       timeout 180 $$LAUNCHER build --definitely_not_a_flag //... 2>&1 | grep -q "Unrecognized option" || { echo "ERROR: a bare Bazel-rejected flag must fail the same way"; exit 1; }
-      echo "--- :aspect: aspect dev test-template-snapshots"
-      $$LAUNCHER dev test-template-snapshots
-      echo "--- :aspect: aspect dev test-lint-template-snapshots"
-      $$LAUNCHER dev test-lint-template-snapshots
-      echo "--- :aspect: aspect dev test-lint-annotation-plan"
-      $$LAUNCHER dev test-lint-annotation-plan
-      echo "--- :aspect: aspect dev test-format-template-snapshots"
-      $$LAUNCHER dev test-format-template-snapshots
-      echo "--- :aspect: aspect dev test-gazelle-template-snapshots"
-      $$LAUNCHER dev test-gazelle-template-snapshots
-      echo "--- :aspect: aspect dev test-delivery-template-snapshots"
-      $$LAUNCHER dev test-delivery-template-snapshots
-      echo "--- :aspect: aspect dev test-bk-annotation-snapshots"
-      $$LAUNCHER dev test-bk-annotation-snapshots
-      echo "--- :aspect: aspect dev test-pr-comment-snapshots"
-      $$LAUNCHER dev test-pr-comment-snapshots
-      echo "--- :aspect: aspect dev test-github-detect"
-      $$LAUNCHER dev test-github-detect
-      echo "--- :aspect: aspect dev test-gitlab-detect"
-      $$LAUNCHER dev test-gitlab-detect
-      echo "--- :aspect: aspect dev test-gitlab-client"
-      $$LAUNCHER dev test-gitlab-client
-      echo "--- :aspect: aspect dev test-tips"
-      $$LAUNCHER dev test-tips
-      echo "--- :aspect: aspect dev test-rate-limit"
-      $$LAUNCHER dev test-rate-limit
-      echo "--- :aspect: aspect dev test-runner-job-history"
-      $$LAUNCHER dev test-runner-job-history
+      # Every `dev test-*` suite, discovered rather than listed. This block used
+      # to be a hand-maintained allowlist that had drifted badly: 30 of the 44
+      # registered suites were named in neither pipeline and so had never run.
+      echo "--- :aspect: aspect dev test-* (all registered suites)"
+      $$LAUNCHER dev --help | awk '/^Tasks:/{t=1;next} t && /^  test-/{print $$1}' > /tmp/axl-suites.txt
+      test -s /tmp/axl-suites.txt || { echo "ERROR: no dev test-* suites discovered"; exit 1; }
+      echo "discovered $$(wc -l < /tmp/axl-suites.txt) suites"
+      while read -r suite; do
+        echo "--- :aspect: aspect dev $$suite"
+        $$LAUNCHER dev "$$suite"
+      done < /tmp/axl-suites.txt
       echo "--- :aspect: aspect tests axl"
       # Run AXL tests last — cancel tests may kill the Bazel server. $$LAUNCHER /
       # $$CLI are stable target/ci/ copies (not bazel-out paths), so that's

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -156,17 +156,8 @@ steps:
       timeout 180 $$LAUNCHER build --bazel-flag=--definitely_not_a_flag //... 2>&1 | grep -q "Unrecognized option" || { echo "ERROR: a Bazel-rejected flag must fail, not hang"; exit 1; }
       echo "--- :aspect: flag rejected by Bazel (bare)"
       timeout 180 $$LAUNCHER build --definitely_not_a_flag //... 2>&1 | grep -q "Unrecognized option" || { echo "ERROR: a bare Bazel-rejected flag must fail the same way"; exit 1; }
-      # Every `dev test-*` suite, discovered rather than listed. This block used
-      # to be a hand-maintained allowlist that had drifted badly: 30 of the 44
-      # registered suites were named in neither pipeline and so had never run.
-      echo "--- :aspect: aspect dev test-* (all registered suites)"
-      $$LAUNCHER dev --help | awk '/^Tasks:/{t=1;next} t && /^  test-/{print $$1}' > /tmp/axl-suites.txt
-      test -s /tmp/axl-suites.txt || { echo "ERROR: no dev test-* suites discovered"; exit 1; }
-      echo "discovered $$(wc -l < /tmp/axl-suites.txt) suites"
-      while read -r suite; do
-        echo "--- :aspect: aspect dev $$suite"
-        $$LAUNCHER dev "$$suite"
-      done < /tmp/axl-suites.txt
+      echo "--- :aspect: aspect dev test-* (every AXL suite)"
+      ./tools/run-axl-suites.sh $$LAUNCHER
       echo "--- :aspect: aspect tests axl"
       # Run AXL tests last — cancel tests may kill the Bazel server. $$LAUNCHER /
       # $$CLI are stable target/ci/ copies (not bazel-out paths), so that's

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -593,34 +593,18 @@ jobs:
           echo "--- flag rejected by Bazel (bare)"
           timeout 180 "$LAUNCHER" build --definitely_not_a_flag //... 2>&1 | grep -q "Unrecognized option" \
             || { echo "ERROR: a bare Bazel-rejected flag must fail the same way"; exit 1; }
-          echo "--- aspect dev test-template-snapshots"
-          "$LAUNCHER" dev test-template-snapshots
-          echo "--- aspect dev test-lint-template-snapshots"
-          "$LAUNCHER" dev test-lint-template-snapshots
-          echo "--- aspect dev test-lint-annotation-plan"
-          "$LAUNCHER" dev test-lint-annotation-plan
-          echo "--- aspect dev test-format-template-snapshots"
-          "$LAUNCHER" dev test-format-template-snapshots
-          echo "--- aspect dev test-gazelle-template-snapshots"
-          "$LAUNCHER" dev test-gazelle-template-snapshots
-          echo "--- aspect dev test-delivery-template-snapshots"
-          "$LAUNCHER" dev test-delivery-template-snapshots
-          echo "--- aspect dev test-bk-annotation-snapshots"
-          "$LAUNCHER" dev test-bk-annotation-snapshots
-          echo "--- aspect dev test-pr-comment-snapshots"
-          "$LAUNCHER" dev test-pr-comment-snapshots
-          echo "--- aspect dev test-github-detect"
-          "$LAUNCHER" dev test-github-detect
-          echo "--- aspect dev test-gitlab-detect"
-          "$LAUNCHER" dev test-gitlab-detect
-          echo "--- aspect dev test-gitlab-client"
-          "$LAUNCHER" dev test-gitlab-client
-          echo "--- aspect dev test-tips"
-          "$LAUNCHER" dev test-tips
-          echo "--- aspect dev test-rate-limit"
-          "$LAUNCHER" dev test-rate-limit
-          echo "--- aspect dev test-runner-job-history"
-          "$LAUNCHER" dev test-runner-job-history
+          # Every `dev test-*` suite, discovered rather than listed. This block
+          # used to be a hand-maintained allowlist that had drifted badly: 30 of
+          # the 44 registered suites were named in neither pipeline and so had
+          # never run in CI.
+          echo "--- aspect dev test-* (all registered suites)"
+          "$LAUNCHER" dev --help | awk '/^Tasks:/{t=1;next} t && /^  test-/{print $1}' > /tmp/axl-suites.txt
+          test -s /tmp/axl-suites.txt || { echo "ERROR: no dev test-* suites discovered"; exit 1; }
+          echo "discovered $(wc -l < /tmp/axl-suites.txt) suites"
+          while read -r suite; do
+            echo "--- aspect dev $suite"
+            "$LAUNCHER" dev "$suite"
+          done < /tmp/axl-suites.txt
   # NOTE: the Buildkite `bazelrc-e2e` step is intentionally NOT ported here. It
   # asserts that bare `bazel` and `aspect` start the SAME Bazel server (identical
   # startup flags, no server thrash). On a GitHub Actions Workflows runner `bazel`

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -593,18 +593,8 @@ jobs:
           echo "--- flag rejected by Bazel (bare)"
           timeout 180 "$LAUNCHER" build --definitely_not_a_flag //... 2>&1 | grep -q "Unrecognized option" \
             || { echo "ERROR: a bare Bazel-rejected flag must fail the same way"; exit 1; }
-          # Every `dev test-*` suite, discovered rather than listed. This block
-          # used to be a hand-maintained allowlist that had drifted badly: 30 of
-          # the 44 registered suites were named in neither pipeline and so had
-          # never run in CI.
-          echo "--- aspect dev test-* (all registered suites)"
-          "$LAUNCHER" dev --help | awk '/^Tasks:/{t=1;next} t && /^  test-/{print $1}' > /tmp/axl-suites.txt
-          test -s /tmp/axl-suites.txt || { echo "ERROR: no dev test-* suites discovered"; exit 1; }
-          echo "discovered $(wc -l < /tmp/axl-suites.txt) suites"
-          while read -r suite; do
-            echo "--- aspect dev $suite"
-            "$LAUNCHER" dev "$suite"
-          done < /tmp/axl-suites.txt
+          echo "--- aspect dev test-* (every AXL suite)"
+          ./tools/run-axl-suites.sh "$LAUNCHER"
   # NOTE: the Buildkite `bazelrc-e2e` step is intentionally NOT ported here. It
   # asserts that bare `bazel` and `aspect` start the SAME Bazel server (identical
   # startup flags, no server thrash). On a GitHub Actions Workflows runner `bazel`

--- a/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/buildkite_annotations.axl
@@ -85,6 +85,9 @@ Rendering goes through the shared `check_dispatch.RENDERERS` table, so
 module exports its `SUMMARY_TEMPLATE` / `DETAILS_TEMPLATE` so a config can
 patch the built-in rather than re-author it.
 
+`template_preset` selects a named bundle of templates as the starting layout;
+`templates` overrides individual slots on top of it (see `template_presets`).
+
 Flat "summary"/"details" keys apply to every task kind; a per-task-kind
 block ("build", "lint", …) overlays them for that kind alone, so a config
 can set a shared default and still special-case one task (see
@@ -120,6 +123,7 @@ load(
 )
 load("../private/lib/rate_limit.axl", "usage_footer")
 load("../private/lib/result_text.axl", "severity_for_status")
+load("../private/lib/template_presets.axl", "template_presets")
 load("../private/lib/tips.axl", "SURFACE_BUILDKITE_ANNOTATIONS", "collect_tips_sorted")
 
 # ─── Style selection ──────────────────────────────────────────────────────────
@@ -316,6 +320,7 @@ def _buildkite_annotations(ctx: FeatureContext):
     lifecycle = ctx.traits[Phases]
 
     templates = ctx.args.templates or {}
+    preset_templates = template_presets.templates(ctx.args.template_preset)
     metadata_keys = list(ctx.args.metadata_keys or [])
 
     mode = ctx.args.mode
@@ -450,7 +455,7 @@ def _buildkite_annotations(ctx: FeatureContext):
             status,
             make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_BUILDKITE_ANNOTATIONS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             _make_links(data),
-            resolve_templates(templates, ctx.task.kind),
+            resolve_templates(templates, ctx.task.kind, base = preset_templates),
             metadata_keys,
             snippet_options = _snippet_opts,
             max_snippets = _max_snippets,
@@ -526,7 +531,7 @@ BuildkiteAnnotations = feature(
                           "that kind alone, e.g. {\"summary\": ..., \"lint\": {\"details\": ...}}. " +
                           "The \"title\" template renders with `icon`, `task_kind`, `subject`, " +
                           "`state` and `status`; a broken title falls back to the built-in layout. " +
-                          "Empty dict (default) uses the feature's built-in templates. The renderer's title, summary and details are concatenated into one Markdown annotation, hard-capped at Buildkite's 1 MiB limit.",
+                          "Empty dict (default) leaves the selected `template_preset` in effect. The renderer's title, summary and details are concatenated into one Markdown annotation, hard-capped at Buildkite's 1 MiB limit.",
         ),
         "metadata_keys": args.string_list(
             default = [],
@@ -538,5 +543,5 @@ BuildkiteAnnotations = feature(
                           "custom keys via --bes_metadata=MY_KEY=value or --build_metadata=MY_KEY=value " +
                           "on their Bazel invocation.",
         ),
-    },
+    } | template_presets.args(),
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_checks.axl
@@ -33,6 +33,10 @@ downgraded to a publish and logged. Only `BuildkiteAnnotations` honors it.
 Hooks see every surface that consults them, so scope with `update.surface` when
 more than one is enabled. See `StatusSurfaceUpdate` for the full field set.
 
+`template_preset` selects a named bundle of templates as the starting
+layout; `templates` overrides individual slots on top of whatever the
+preset supplies (see `template_presets`).
+
 Templates and metadata_keys are feature args. `templates` takes flat
 "summary"/"details" keys applying to every task kind, and/or per-task-kind
 blocks that overlay them (see `check_dispatch.resolve_templates`):
@@ -90,6 +94,7 @@ load(
     "should_emit_phase_change",
     "usage_footer",
 )
+load("../private/lib/template_presets.axl", "template_presets")
 load("../private/lib/tips.axl", "SURFACE_GITHUB_STATUS_CHECKS", "collect_tips_sorted")
 
 _LOG = feature_logger("GitHub status checks")
@@ -162,6 +167,7 @@ def _github_status_checks(ctx: FeatureContext):
     lifecycle = ctx.traits[Phases]
 
     templates = ctx.args.templates or {}
+    preset_templates = template_presets.templates(ctx.args.template_preset)
     metadata_keys = list(ctx.args.metadata_keys or [])
 
     # Check-run URL is published below via `checkrun.set_url`; siblings
@@ -290,7 +296,7 @@ def _github_status_checks(ctx: FeatureContext):
             "running",
             make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITHUB_STATUS_CHECKS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             dict(_ci_links_base),
-            resolve_templates(templates, ctx.task.kind),
+            resolve_templates(templates, ctx.task.kind, base = preset_templates),
             metadata_keys,
         )
 
@@ -566,7 +572,7 @@ def _github_status_checks(ctx: FeatureContext):
             status,
             make_render_ctx(_state, tips = collect_tips_sorted(ctx, surface = SURFACE_GITHUB_STATUS_CHECKS), api_usage = usage_footer(ctx), last_updated_at = format_run_date(ctx, now_ms(ctx))),
             _make_links(data),
-            resolve_templates(templates, ctx.task.kind),
+            resolve_templates(templates, ctx.task.kind, base = preset_templates),
             metadata_keys,
             snippet_options = _snippet_opts,
             max_snippets = _max_snippets,
@@ -656,7 +662,7 @@ GithubStatusChecks = feature(
                           "that kind alone, e.g. {\"summary\": ..., \"lint\": {\"details\": ...}}. " +
                           "The \"title\" template renders with `icon`, `task_kind`, `subject`, " +
                           "`state` and `status`; a broken title falls back to the built-in layout. " +
-                          "Empty dict (default) uses the feature's built-in templates.",
+                          "Empty dict (default) leaves the selected `template_preset` in effect.",
         ),
         "metadata_keys": args.string_list(
             default = [],
@@ -668,5 +674,5 @@ GithubStatusChecks = feature(
                           "custom keys via --bes_metadata=MY_KEY=value or --build_metadata=MY_KEY=value " +
                           "on their Bazel invocation.",
         ),
-    },
+    } | template_presets.args(),
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -96,6 +96,7 @@ load(
 )
 load("../private/lib/repro_commands.axl", "ASPECT_CLI_INSTALL_HINT_MARKDOWN", "dedup_and_attribute", "rehydrate_commands")
 load("../private/lib/result_text.axl", "severity_for_status")
+load("../private/lib/template_presets.axl", "template_presets")
 load(
     "../private/lib/tips.axl",
     "SURFACE_GITHUB_PR_SUMMARY",
@@ -1343,7 +1344,9 @@ def _github_status_comments(ctx: FeatureContext):
 
     # args.custom(dict, ...) hands None at runtime, not the declared default.
     templates = ctx.args.templates or {}
-    body_template = templates.get("body") or _DEFAULT_BODY_TEMPLATE
+    body_template = (templates.get("body") or
+                     template_presets.templates(ctx.args.template_preset).get("body") or
+                     _DEFAULT_BODY_TEMPLATE)
     status_badges = dict(_DEFAULT_STATUS_BADGES)
     status_badges.update(ctx.args.status_badges or {})
 
@@ -2035,7 +2038,7 @@ GithubStatusComments = feature(
                           "ci_run_url, aspect_url, check_run_url, current_phase, progress, " +
                           "failed_in_phase, repro_commands, fix_commands, …}), and `repro_rows` / " +
                           "`fix_rows` (deduped across siblings via dedup_and_attribute). " +
-                          "Empty dict → built-in default. config.axl only.",
+                          "Empty dict → the selected `template_preset`. config.axl only.",
         ),
         "status_badges": args.custom(
             dict,
@@ -2047,5 +2050,5 @@ GithubStatusComments = feature(
                           "override is keyed by badge_key not raw lifecycle status. " +
                           "config.axl only.",
         ),
-    },
+    } | template_presets.args(),
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_commit_statuses.axl
@@ -67,8 +67,10 @@ more than one is enabled. See `StatusSurfaceUpdate` for the full field set.
 
 Rendering goes through the shared `check_dispatch.RENDERERS` table —
 templates and `metadata_keys` configure exactly as they do for
-`GithubStatusChecks`. Flat "summary"/"details" keys apply to every task
-kind; a per-task-kind block overlays them for that kind alone (see
+`GithubStatusChecks`. `template_preset` selects a named bundle of templates
+as the starting layout and `templates` overrides individual slots on top of
+it (see `template_presets`). Flat "summary"/"details" keys apply to every
+task kind; a per-task-kind block overlays them for that kind alone (see
 `check_dispatch.resolve_templates`):
 
     def config(ctx: ConfigContext):
@@ -118,6 +120,7 @@ load(
     "effective_throttle_factor",
     "should_emit_phase_change",
 )
+load("../private/lib/template_presets.axl", "template_presets")
 
 _LOG = feature_logger("GitLab commit statuses")
 
@@ -184,6 +187,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
     lifecycle = ctx.traits[Phases]
 
     templates = ctx.args.templates or {}
+    preset_templates = template_presets.templates(ctx.args.template_preset)
     metadata_keys = list(ctx.args.metadata_keys or [])
 
     mode = ctx.args.mode
@@ -354,7 +358,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             "running",
             make_render_ctx(_state, last_updated_at = format_run_date(ctx, now_ms(ctx))),
             initial_links,
-            resolve_templates(templates, ctx.task.kind),
+            resolve_templates(templates, ctx.task.kind, base = preset_templates),
             metadata_keys,
         )
         (initial_state, initial_desc) = _decide(ctx, "running", False, "pending", initial_output)
@@ -429,7 +433,7 @@ def _gitlab_commit_statuses(ctx: FeatureContext):
             status,
             make_render_ctx(_state, last_updated_at = format_run_date(ctx, now_ms(ctx))),
             links,
-            resolve_templates(templates, ctx.task.kind),
+            resolve_templates(templates, ctx.task.kind, base = preset_templates),
             metadata_keys,
         )
 
@@ -497,7 +501,7 @@ GitlabCommitStatuses = feature(
                           "that kind alone, e.g. {\"summary\": ..., \"lint\": {\"details\": ...}}. " +
                           "The \"title\" template renders with `icon`, `task_kind`, `subject`, " +
                           "`state` and `status`; a broken title falls back to the built-in layout. " +
-                          "Empty dict (default) uses the feature's built-in templates. Note: only the rendered `title` lands on the commit status (in `description`, truncated to 255 chars) \u2014 the full body is rendered into the GitlabStatusComments rolling note.",
+                          "Empty dict (default) leaves the selected `template_preset` in effect. Note: only the rendered `title` lands on the commit status (in `description`, truncated to 255 chars) \u2014 the full body is rendered into the GitlabStatusComments rolling note.",
         ),
         "metadata_keys": args.string_list(
             default = [],
@@ -505,5 +509,5 @@ GitlabCommitStatuses = feature(
             description = "Additional BES build_metadata keys to surface in the render-context (used " +
                           "by sibling features like GitlabStatusComments). Use [\"*\"] for all keys.",
         ),
-    },
+    } | template_presets.args(),
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -78,6 +78,7 @@ load(
     "epoch_now_s",
     "should_emit_phase_change",
 )
+load("../private/lib/template_presets.axl", "template_presets")
 
 _LOG = feature_logger("GitLab status comments")
 
@@ -177,7 +178,9 @@ def _gitlab_status_comments(ctx: FeatureContext):
     min_poll_interval_seconds = max(1, ctx.args.min_poll_interval_seconds)
 
     templates = ctx.args.templates or {}
-    body_template = templates.get("body") or DEFAULT_BODY_TEMPLATE
+    body_template = (templates.get("body") or
+                     template_presets.templates(ctx.args.template_preset).get("body") or
+                     DEFAULT_BODY_TEMPLATE)
     status_badges = dict(DEFAULT_STATUS_BADGES)
     status_badges.update(ctx.args.status_badges or {})
 
@@ -572,7 +575,7 @@ GitlabStatusComments = feature(
             default = {},
             description = "Per-section Jinja2 template overrides. Keys: 'body'. " +
                           "Vars available match the GithubStatusComments template contract " +
-                          "(see feature/github_status_comments.axl). Empty dict → built-in default. " +
+                          "(see feature/github_status_comments.axl). Empty dict → the selected `template_preset`. " +
                           "config.axl only.",
         ),
         "status_badges": args.custom(
@@ -582,5 +585,5 @@ GitlabStatusComments = feature(
                           "(failed='❌ failed', warning='⚠️ warning', running='🔄 running', " +
                           "passed='✅ passed', aborted='🔥 aborted'). config.axl only.",
         ),
-    },
+    } | template_presets.args(),
 )

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -239,14 +239,18 @@ def _test_impl(ctx):
         print("buildkite-agent annotate --style %s --context %s --scope=job" % (style, context_id))
         print("─" * 70)
 
-        # Show first 2500 chars of the formatted body — enough to see the
+        # Show the first 70 lines of the formatted body — enough to see the
         # title/summary and the first chunk of the body without flooding.
-        # The exact length is deliberately not printed: the summary carries a
-        # live `ctx.task.elapsed_ms` reading, so it shifts by a character
-        # whenever the run crosses a digit boundary (99ms -> 100ms) and would
-        # make this snapshot flap between runs.
-        print(body[:2500])
-        if len(body) > 2500:
+        #
+        # Truncation is by line, not by character, and the byte length is
+        # deliberately not printed. The summary carries a live
+        # `ctx.task.elapsed_ms` reading, so any character-offset cut lands in a
+        # different place whenever a run crosses a digit boundary (99ms ->
+        # 100ms), which splits a different line in half and makes the snapshot
+        # flap between runs. A line budget is invariant to that.
+        body_lines = body.split("\n")
+        print("\n".join(body_lines[:70]))
+        if len(body_lines) > 70:
             print("... [truncated]")
         print("")
 

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/buildkite_annotations_test.axl
@@ -181,6 +181,13 @@ def _make_warming_archive_failed():
     r["warming"]["archive_error"] = "the warming archiver exited with code 3"
     return r
 
+# How much of each rendered body the snapshot prints — enough to catch a
+# rendering regression without flooding. Cut by line, never by character or
+# byte count: the summary carries a live `ctx.task.elapsed_ms` reading, so a
+# character offset lands somewhere different once a run crosses a digit
+# boundary (99ms -> 100ms) and splits a different line in half.
+_SNAPSHOT_MAX_LINES = 70
+
 def _test_impl(ctx):
     scenarios = [
         # (label,                                       kind,                data,                               status,    final, subject,      task_kind)
@@ -239,18 +246,9 @@ def _test_impl(ctx):
         print("buildkite-agent annotate --style %s --context %s --scope=job" % (style, context_id))
         print("─" * 70)
 
-        # Show the first 70 lines of the formatted body — enough to see the
-        # title/summary and the first chunk of the body without flooding.
-        #
-        # Truncation is by line, not by character, and the byte length is
-        # deliberately not printed. The summary carries a live
-        # `ctx.task.elapsed_ms` reading, so any character-offset cut lands in a
-        # different place whenever a run crosses a digit boundary (99ms ->
-        # 100ms), which splits a different line in half and makes the snapshot
-        # flap between runs. A line budget is invariant to that.
         body_lines = body.split("\n")
-        print("\n".join(body_lines[:70]))
-        if len(body_lines) > 70:
+        print("\n".join(body_lines[:_SNAPSHOT_MAX_LINES]))
+        if len(body_lines) > _SNAPSHOT_MAX_LINES:
             print("... [truncated]")
         print("")
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
@@ -13,6 +13,11 @@ Split here, not in the features:
   renderer_for_kind(kind)
   kind_for_task(task_kind)   Initial kind to use before the first
                              task_update has fired.
+  resolve_templates(templates, task_kind, base = None)
+                             Narrow layered template overrides to the flat
+                             dict the renderers accept.
+  snippet_budget_for(surface)
+                             Per-surface inline log-snippet budget.
   to_display_name(name)      snake_case → CamelCase task display name.
   make_render_ctx(state)     Build the render_ctx dict the per-kind
                              renderers consume from a feature's
@@ -122,14 +127,14 @@ def kind_for_task(task_kind):
     return _TASK_KIND_DEFAULTS.get(task_kind, "bazel_results")
 
 # Task-kind keys a `templates` dict may nest an override under, as opposed to
-# the flat "summary"/"details" keys that address every kind at once.
+# the flat "title"/"summary"/"details" keys that address every kind at once.
 TEMPLATE_SCOPE_KEYS = sorted(_TASK_KIND_DEFAULTS.keys())
 
-def resolve_templates(templates, task_kind):
-    """Narrow a feature's `args.templates` to the flat {"summary", "details"}
-    dict the per-kind renderers accept.
+def resolve_templates(templates, task_kind, base = None):
+    """Narrow template overrides to the flat {"title", "summary", "details"} dict
+    the per-kind renderers accept.
 
-    Two shapes are supported, and they compose:
+    Two shapes are supported within a layer, and they compose:
 
       {"summary": ...}                     — applies to every task kind
       {"lint": {"summary": ...}}           — applies to `lint` tasks only
@@ -141,19 +146,31 @@ def resolve_templates(templates, task_kind):
     it also keeps `build` and `test` separable even though both render through
     `bazel_results`.
 
+    `base` is a lower-precedence layer of the same shape: the templates
+    contributed by the selected preset (`template_presets.templates(...)`),
+    which the user's `args.templates` overrides. The layers are resolved in
+    order rather than merged first, which is what keeps four levels of
+    precedence distinct:
+
+        base flat  <  base scoped  <  templates flat  <  templates scoped
+
+    Merging the two dicts up front would collapse that: a per-kind block in
+    `base` would outrank an explicit flat key in `templates`, letting a preset
+    beat the config that selected it. `base = None` reduces to the
+    single-layer behavior exactly.
+
     Returns None when nothing applies, matching what the renderers treat as
     "use the built-ins".
     """
-    if not templates:
-        return None
-
-    flat = {k: v for k, v in templates.items() if k not in TEMPLATE_SCOPE_KEYS}
-    scoped = templates.get(task_kind) or {}
-    if type(scoped) != "dict":
-        fail("templates[%r] must be a dict of template overrides, got %r" % (task_kind, scoped))
-
-    resolved = dict(flat)
-    resolved.update(scoped)
+    resolved = {}
+    for layer in [base, templates]:
+        if not layer:
+            continue
+        resolved.update({k: v for k, v in layer.items() if k not in TEMPLATE_SCOPE_KEYS})
+        scoped = layer.get(task_kind) or {}
+        if type(scoped) != "dict":
+            fail("templates[%r] must be a dict of template overrides, got %r" % (task_kind, scoped))
+        resolved.update(scoped)
     return resolved or None
 
 # Per-surface inline-snippet budgets (max snippets shown + per-snippet line cap).

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
@@ -130,6 +130,15 @@ def kind_for_task(task_kind):
 # the flat "title"/"summary"/"details" keys that address every kind at once.
 TEMPLATE_SCOPE_KEYS = sorted(_TASK_KIND_DEFAULTS.keys())
 
+def _layer_overrides(layer, task_kind, label):
+    """One layer's flat keys, overlaid with its `task_kind` block."""
+    resolved = {k: v for k, v in layer.items() if k not in TEMPLATE_SCOPE_KEYS}
+    scoped = layer.get(task_kind) or {}
+    if type(scoped) != "dict":
+        fail("%s[%r] must be a dict of template overrides, got %r" % (label, task_kind, scoped))
+    resolved.update(scoped)
+    return resolved
+
 def resolve_templates(templates, task_kind, base = None):
     """Narrow template overrides to the flat {"title", "summary", "details"} dict
     the per-kind renderers accept.
@@ -146,31 +155,24 @@ def resolve_templates(templates, task_kind, base = None):
     it also keeps `build` and `test` separable even though both render through
     `bazel_results`.
 
-    `base` is a lower-precedence layer of the same shape: the templates
-    contributed by the selected preset (`template_presets.templates(...)`),
-    which the user's `args.templates` overrides. The layers are resolved in
-    order rather than merged first, which is what keeps four levels of
-    precedence distinct:
+    `base` is an optional lower-precedence layer of the same shape — the
+    templates contributed by the selected preset — which `templates` overrides.
+    Resolving the layers in order rather than merging them first is what keeps
+    four levels of precedence distinct:
 
         base flat  <  base scoped  <  templates flat  <  templates scoped
 
     Merging the two dicts up front would collapse that: a per-kind block in
     `base` would outrank an explicit flat key in `templates`, letting a preset
-    beat the config that selected it. `base = None` reduces to the
-    single-layer behavior exactly.
+    beat the config that selected it.
 
     Returns None when nothing applies, matching what the renderers treat as
     "use the built-ins".
     """
     resolved = {}
-    for layer in [base, templates]:
-        if not layer:
-            continue
-        resolved.update({k: v for k, v in layer.items() if k not in TEMPLATE_SCOPE_KEYS})
-        scoped = layer.get(task_kind) or {}
-        if type(scoped) != "dict":
-            fail("templates[%r] must be a dict of template overrides, got %r" % (task_kind, scoped))
-        resolved.update(scoped)
+    for (label, layer) in [("template preset", base), ("templates", templates)]:
+        if layer:
+            resolved.update(_layer_overrides(layer, task_kind, label))
     return resolved or None
 
 # Per-surface inline-snippet budgets (max snippets shown + per-snippet line cap).

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
@@ -32,16 +32,17 @@ _PRESETS = {
 
 _DEFAULT = "full"
 
-def _validate_slot(preset_name: str, slot: str, template) -> None:
+def _slot_errors(preset_name: str, slot: str, template) -> list[str]:
     if type(template) != "string":
-        fail("template preset {!r}: {!r} must be a Jinja2 string, got {!r}".format(preset_name, slot, template))
+        return ["preset {!r}: {!r} must be a Jinja2 string, got {!r}".format(preset_name, slot, template)]
     if not template:
-        fail(("template preset {!r}: {!r} is empty, which yields the built-in it meant to replace " +
-              "(renderers resolve `templates.get(slot) or BUILT_IN`). Use a comment-only template " +
-              "such as `{{# blank #}}`.").format(preset_name, slot))
+        return [("preset {!r}: {!r} is empty, which yields the built-in it meant to replace " +
+                 "(renderers resolve `templates.get(slot) or BUILT_IN`). Use a comment-only " +
+                 "template such as `{{# blank #}}`.").format(preset_name, slot)]
+    return []
 
-def _validate(presets: dict, default: str) -> list[str]:
-    """Check the registry at load time; return its sorted names.
+def _validation_errors(presets: dict, default: str) -> list[str]:
+    """Every problem with a registry, as messages. Pure, so the rules are unit-testable.
 
     `default` must name a registered preset. A feature arg's default is baked
     into clap's `default_value` and validated on every command, so a bad
@@ -58,33 +59,44 @@ def _validate(presets: dict, default: str) -> list[str]:
     while the comment surfaces keep the built-in, which reads worse than
     either layout on its own.
     """
+    errors = []
     if default not in presets:
-        fail("default template preset {!r} is not registered; known presets: {}".format(
+        errors.append("default preset {!r} is not registered; known presets: {}".format(
             default,
             ", ".join(sorted(presets.keys())),
         ))
 
-    for name, preset in presets.items():
+    for name in sorted(presets.keys()):
+        preset = presets[name]
         if name != preset.name:
-            fail("template preset registered under {!r} but names itself {!r}".format(name, preset.name))
+            errors.append("preset registered under {!r} but names itself {!r}".format(name, preset.name))
 
-        for key, value in preset.templates.items():
+        for key in sorted(preset.templates.keys()):
+            value = preset.templates[key]
             if type(value) == "dict":
                 if key not in TEMPLATE_SCOPE_KEYS:
-                    fail("template preset {!r}: {!r} is not a task kind; expected one of {}".format(
+                    errors.append("preset {!r}: {!r} is not a task kind; expected one of {}".format(
                         name,
                         key,
                         ", ".join(TEMPLATE_SCOPE_KEYS),
                     ))
-                for slot, template in value.items():
-                    _validate_slot(name, "%s.%s" % (key, slot), template)
+                for slot in sorted(value.keys()):
+                    errors.extend(_slot_errors(name, "%s.%s" % (key, slot), value[slot]))
             else:
-                _validate_slot(name, key, value)
+                errors.extend(_slot_errors(name, key, value))
 
         if preset.templates and "body" not in preset.templates:
-            fail(("template preset {!r} overrides check-surface templates but not \"body\", so PR and " +
-                  "MR comments would keep the built-in layout while check runs and annotations change").format(name))
+            errors.append(("preset {!r} overrides check-surface templates but not \"body\", so PR and " +
+                           "MR comments would keep the built-in layout while check runs and " +
+                           "annotations change").format(name))
 
+    return errors
+
+def _validate(presets: dict, default: str) -> list[str]:
+    """Check the registry at load time; return its sorted names."""
+    errors = _validation_errors(presets, default)
+    if errors:
+        fail("invalid template preset registry:\n  " + "\n  ".join(errors))
     return sorted(presets.keys())
 
 _NAMES = _validate(_PRESETS, _DEFAULT)
@@ -113,4 +125,5 @@ template_presets = namespace(
     args = _args,
     templates = _templates,
     validate = _validate,
+    validation_errors = _validation_errors,
 )

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
@@ -5,10 +5,33 @@ through each surface feature's `template_preset` arg. It resolves as the
 lower-precedence `base` layer of `check_dispatch.resolve_templates`, so a
 config's own `args.templates` still overrides individual slots on top of it.
 
-Adding a preset: register a `TemplatePreset` in `_PRESETS` below. Author its
-templates as new strings — never by extracting fragments out of the built-in
-template constants, which live configs `.replace()` against behind load-time
-`fail()` drift guards.
+To add a preset, register a `TemplatePreset` in `_PRESETS`. The rules
+`_validation_errors` enforces at load time, and why each exists:
+
+  - The registered key must equal the preset's own `name`, and `description`
+    must be set — both are user-visible, in `--help` and `aspect feature`.
+
+  - `_DEFAULT` must name a registered preset. Clap validates a config-supplied
+    value against `values`, but not on `--help` or `aspect feature`, so a
+    broken default would leave those paths quietly reporting a layout that
+    cannot render. The load-time check covers them.
+
+  - A slot's value must be a non-empty string. `""` cannot blank a slot:
+    renderers resolve `templates.get(slot) or BUILT_IN`, so a falsy override
+    yields the built-in it meant to replace. Use a comment-only template
+    (`{# blank #}`) instead. `title` cannot be blanked by any means — a blank
+    render falls back to the built-in layout because GitHub requires a
+    check-run title.
+
+  - A per-kind block must name a real task kind, or it silently never applies.
+
+  - A preset that overrides anything must also override `"body"`. Without it
+    the check surfaces take the preset's layout while the PR/MR comments keep
+    the built-in, which reads worse than either layout on its own.
+
+Author a preset's templates as new strings, never by extracting fragments out
+of the built-in template constants — live configs `.replace()` against those
+behind their own load-time drift guards.
 """
 
 load("./check_dispatch.axl", "TEMPLATE_SCOPE_KEYS")
@@ -25,7 +48,7 @@ TemplatePreset = record(
 _PRESETS = {
     "full": TemplatePreset(
         name = "full",
-        description = "The complete report: every target bucket, the Bazel details umbrella, workspace status.",
+        description = "the complete report — every target bucket, the Bazel details umbrella, and workspace status",
         templates = {},
     ),
 }
@@ -36,64 +59,55 @@ def _slot_errors(preset_name: str, slot: str, template) -> list[str]:
     if type(template) != "string":
         return ["preset {!r}: {!r} must be a Jinja2 string, got {!r}".format(preset_name, slot, template)]
     if not template:
-        return [("preset {!r}: {!r} is empty, which yields the built-in it meant to replace " +
-                 "(renderers resolve `templates.get(slot) or BUILT_IN`). Use a comment-only " +
-                 "template such as `{{# blank #}}`.").format(preset_name, slot)]
+        return [("preset {!r}: {!r} is empty, which yields the built-in it meant to replace. " +
+                 "Use a comment-only template such as `{{# blank #}}`.").format(preset_name, slot)]
     return []
 
+def _preset_errors(name: str, preset: TemplatePreset) -> list[str]:
+    errors = []
+    if name != preset.name:
+        errors.append("preset registered under {!r} but names itself {!r}".format(name, preset.name))
+    if not preset.description:
+        errors.append("preset {!r} has no description; it is shown in `--help`".format(name))
+
+    for key in sorted(preset.templates.keys()):
+        value = preset.templates[key]
+        if key in TEMPLATE_SCOPE_KEYS:
+            if type(value) != "dict":
+                errors.append(("preset {!r}: {!r} is a task kind, so it must map to a dict of slot " +
+                               "overrides, got {!r}").format(name, key, value))
+                continue
+            for slot in sorted(value.keys()):
+                errors.extend(_slot_errors(name, "%s.%s" % (key, slot), value[slot]))
+        elif type(value) == "dict":
+            errors.append("preset {!r}: {!r} is not a task kind; expected one of {}".format(
+                name,
+                key,
+                ", ".join(TEMPLATE_SCOPE_KEYS),
+            ))
+        else:
+            errors.extend(_slot_errors(name, key, value))
+
+    if preset.templates and "body" not in preset.templates:
+        errors.append(("preset {!r} overrides check-surface templates but not \"body\", so PR and MR " +
+                       "comments would keep the built-in layout while check runs and annotations " +
+                       "change").format(name))
+    return errors
+
 def _validation_errors(presets: dict, default: str) -> list[str]:
-    """Every problem with a registry, as messages. Pure, so the rules are unit-testable.
-
-    `default` must name a registered preset. A feature arg's default is baked
-    into clap's `default_value` and validated on every command, so a bad
-    default fails every invocation rather than only the surface that reads it.
-
-    A slot's value must be a non-empty string. `""` cannot blank a slot —
-    renderers resolve `templates.get(slot) or BUILT_IN`, so a falsy override
-    yields the built-in it meant to replace; use a comment-only template
-    (`{# blank #}`). `title` cannot be blanked at all, since a blank render
-    falls back to the built-in layout (GitHub requires a check-run title).
-
-    A preset that overrides anything must also override `"body"`, the PR/MR
-    summary comment. Without it the check surfaces take the preset's layout
-    while the comment surfaces keep the built-in, which reads worse than
-    either layout on its own.
-    """
+    """Every problem with a registry, as messages. Pure, so the rules stay unit-testable."""
     errors = []
     if default not in presets:
         errors.append("default preset {!r} is not registered; known presets: {}".format(
             default,
             ", ".join(sorted(presets.keys())),
         ))
-
     for name in sorted(presets.keys()):
-        preset = presets[name]
-        if name != preset.name:
-            errors.append("preset registered under {!r} but names itself {!r}".format(name, preset.name))
-
-        for key in sorted(preset.templates.keys()):
-            value = preset.templates[key]
-            if type(value) == "dict":
-                if key not in TEMPLATE_SCOPE_KEYS:
-                    errors.append("preset {!r}: {!r} is not a task kind; expected one of {}".format(
-                        name,
-                        key,
-                        ", ".join(TEMPLATE_SCOPE_KEYS),
-                    ))
-                for slot in sorted(value.keys()):
-                    errors.extend(_slot_errors(name, "%s.%s" % (key, slot), value[slot]))
-            else:
-                errors.extend(_slot_errors(name, key, value))
-
-        if preset.templates and "body" not in preset.templates:
-            errors.append(("preset {!r} overrides check-surface templates but not \"body\", so PR and " +
-                           "MR comments would keep the built-in layout while check runs and " +
-                           "annotations change").format(name))
-
+        errors.extend(_preset_errors(name, presets[name]))
     return errors
 
 def _validate(presets: dict, default: str) -> list[str]:
-    """Check the registry at load time; return its sorted names."""
+    """Check a registry at load time; return its sorted names."""
     errors = _validation_errors(presets, default)
     if errors:
         fail("invalid template preset registry:\n  " + "\n  ".join(errors))
@@ -107,15 +121,19 @@ def _templates(name: str) -> dict:
         fail("unknown template preset {!r}; known presets: {}".format(name, ", ".join(_NAMES)))
     return _PRESETS[name].templates
 
+def _arg_description() -> str:
+    """The `template_preset` help text, listing each registered preset."""
+    return ("Named bundle of Jinja2 templates for this feature's rendered output. " +
+            "Slots set via this feature's `templates` arg override the preset. Presets: " +
+            "; ".join(["%s is %s" % (n, _PRESETS[n].description) for n in _NAMES]) + ".")
+
 def _args() -> dict:
     """The `template_preset` arg every status-surface feature declares. Splat into `args = {...}`."""
     return {
         "template_preset": args.string(
             default = _DEFAULT,
             values = _NAMES,
-            description = ("Named bundle of Jinja2 templates for this feature's rendered output. " +
-                           "%r is the complete built-in report. Individual slots set via this " +
-                           "feature's `templates` arg override the preset.") % _DEFAULT,
+            description = _arg_description(),
         ),
     }
 
@@ -124,6 +142,5 @@ template_presets = namespace(
     NAMES = _NAMES,
     args = _args,
     templates = _templates,
-    validate = _validate,
     validation_errors = _validation_errors,
 )

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
@@ -1,0 +1,116 @@
+"""Named bundles of status-surface template overrides.
+
+A preset is one coherent layout for the CI status surfaces, selected by name
+through each surface feature's `template_preset` arg. It resolves as the
+lower-precedence `base` layer of `check_dispatch.resolve_templates`, so a
+config's own `args.templates` still overrides individual slots on top of it.
+
+Adding a preset: register a `TemplatePreset` in `_PRESETS` below. Author its
+templates as new strings — never by extracting fragments out of the built-in
+template constants, which live configs `.replace()` against behind load-time
+`fail()` drift guards.
+"""
+
+load("./check_dispatch.axl", "TEMPLATE_SCOPE_KEYS")
+
+TemplatePreset = record(
+    name = field(str),
+    description = field(str),
+    templates = field(dict, default = {}),
+)
+
+# `full` deliberately contributes nothing: every renderer already falls back to
+# its built-in when a slot is absent, so the shipped layout *is* the empty
+# preset. Output stays byte-identical with no template string duplicated here.
+_PRESETS = {
+    "full": TemplatePreset(
+        name = "full",
+        description = "The complete report: every target bucket, the Bazel details umbrella, workspace status.",
+        templates = {},
+    ),
+}
+
+_DEFAULT = "full"
+
+def _validate_slot(preset_name: str, slot: str, template) -> None:
+    if type(template) != "string":
+        fail("template preset {!r}: {!r} must be a Jinja2 string, got {!r}".format(preset_name, slot, template))
+    if not template:
+        fail(("template preset {!r}: {!r} is empty, which yields the built-in it meant to replace " +
+              "(renderers resolve `templates.get(slot) or BUILT_IN`). Use a comment-only template " +
+              "such as `{{# blank #}}`.").format(preset_name, slot))
+
+def _validate(presets: dict, default: str) -> list[str]:
+    """Check the registry at load time; return its sorted names.
+
+    `default` must name a registered preset. A feature arg's default is baked
+    into clap's `default_value` and validated on every command, so a bad
+    default fails every invocation rather than only the surface that reads it.
+
+    A slot's value must be a non-empty string. `""` cannot blank a slot —
+    renderers resolve `templates.get(slot) or BUILT_IN`, so a falsy override
+    yields the built-in it meant to replace; use a comment-only template
+    (`{# blank #}`). `title` cannot be blanked at all, since a blank render
+    falls back to the built-in layout (GitHub requires a check-run title).
+
+    A preset that overrides anything must also override `"body"`, the PR/MR
+    summary comment. Without it the check surfaces take the preset's layout
+    while the comment surfaces keep the built-in, which reads worse than
+    either layout on its own.
+    """
+    if default not in presets:
+        fail("default template preset {!r} is not registered; known presets: {}".format(
+            default,
+            ", ".join(sorted(presets.keys())),
+        ))
+
+    for name, preset in presets.items():
+        if name != preset.name:
+            fail("template preset registered under {!r} but names itself {!r}".format(name, preset.name))
+
+        for key, value in preset.templates.items():
+            if type(value) == "dict":
+                if key not in TEMPLATE_SCOPE_KEYS:
+                    fail("template preset {!r}: {!r} is not a task kind; expected one of {}".format(
+                        name,
+                        key,
+                        ", ".join(TEMPLATE_SCOPE_KEYS),
+                    ))
+                for slot, template in value.items():
+                    _validate_slot(name, "%s.%s" % (key, slot), template)
+            else:
+                _validate_slot(name, key, value)
+
+        if preset.templates and "body" not in preset.templates:
+            fail(("template preset {!r} overrides check-surface templates but not \"body\", so PR and " +
+                  "MR comments would keep the built-in layout while check runs and annotations change").format(name))
+
+    return sorted(presets.keys())
+
+_NAMES = _validate(_PRESETS, _DEFAULT)
+
+def _templates(name: str) -> dict:
+    """The template overrides `name` contributes, shaped as a `resolve_templates` layer."""
+    if name not in _PRESETS:
+        fail("unknown template preset {!r}; known presets: {}".format(name, ", ".join(_NAMES)))
+    return _PRESETS[name].templates
+
+def _args() -> dict:
+    """The `template_preset` arg every status-surface feature declares. Splat into `args = {...}`."""
+    return {
+        "template_preset": args.string(
+            default = _DEFAULT,
+            values = _NAMES,
+            description = ("Named bundle of Jinja2 templates for this feature's rendered output. " +
+                           "%r is the complete built-in report. Individual slots set via this " +
+                           "feature's `templates` arg override the preset.") % _DEFAULT,
+        ),
+    }
+
+template_presets = namespace(
+    DEFAULT = _DEFAULT,
+    NAMES = _NAMES,
+    args = _args,
+    templates = _templates,
+    validate = _validate,
+)

--- a/crates/bazelrc/src/lib.rs
+++ b/crates/bazelrc/src/lib.rs
@@ -2694,7 +2694,7 @@ build:foo --foo-flag
         // flags must appear AFTER the unconditional common flags so they win under
         // last-write-wins — matching Bazel's CLI-overrides-RC semantics.
         //
-        // Regression test for the monopi remote_timeout bug:
+        // Regression test for the remote_timeout config-override bug:
         //   common --remote_timeout=600          ← RC default
         //   common:ci --remote_timeout=3600      ← CI override
         // With --config=ci, 3600 must win.
@@ -2722,7 +2722,7 @@ common:ci --remote_timeout=3600
 
     #[test]
     fn cli_config_modify_execution_info_order() {
-        // Regression test for the monopi Tar caching bug:
+        // Regression test for the Tar caching bug:
         //   common --modify_execution_info=Tar=+no-remote-cache   ← local default
         //   common:ci --modify_execution_info=Tar=-no-remote-cache ← CI override (allow hits)
         // With --config=ci, the `-` (remove) must come AFTER the `+` (add) so

--- a/tools/run-axl-suites.sh
+++ b/tools/run-axl-suites.sh
@@ -15,7 +15,12 @@ ASPECT="${1:-aspect}"
 SUITES="$(mktemp)"
 trap 'rm -f "$SUITES"' EXIT
 
-"$ASPECT" dev --help | awk '/^Tasks:/ { in_tasks = 1; next } in_tasks && /^  test-/ { print $1 }' >"$SUITES"
+# `dev --help` is plain when stdout is not a TTY, but CLICOLOR_FORCE=1 makes it
+# emit SGR escapes that would hide the `Tasks:` header from the match below.
+# There is no machine-readable task listing to use instead.
+"$ASPECT" dev --help |
+    sed $'s/\x1b\[[0-9;]*[a-zA-Z]//g' |
+    awk '/^Tasks:/ { in_tasks = 1; next } in_tasks && /^  test-/ { print $1 }' >"$SUITES"
 
 count="$(wc -l <"$SUITES" | tr -d ' ')"
 if [[ "$count" -eq 0 ]]; then

--- a/tools/run-axl-suites.sh
+++ b/tools/run-axl-suites.sh
@@ -19,12 +19,12 @@ trap 'rm -f "$SUITES"' EXIT
 
 count="$(wc -l <"$SUITES" | tr -d ' ')"
 if [[ "$count" -eq 0 ]]; then
-  echo "ERROR: no 'dev test-*' suites discovered — refusing to pass having tested nothing." >&2
-  exit 1
+    echo "ERROR: no 'dev test-*' suites discovered — refusing to pass having tested nothing." >&2
+    exit 1
 fi
 echo "Discovered $count AXL test suites."
 
 while read -r suite; do
-  echo "--- $ASPECT dev $suite"
-  "$ASPECT" dev "$suite"
+    echo "--- $ASPECT dev $suite"
+    "$ASPECT" dev "$suite"
 done <"$SUITES"

--- a/tools/run-axl-suites.sh
+++ b/tools/run-axl-suites.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Run every `aspect dev test-*` suite.
+#
+# The suites are discovered from `aspect dev --help` rather than listed, so a
+# newly registered suite is covered the moment it exists. Both CI pipelines
+# call this; it replaced a pair of hand-maintained allowlists that had drifted
+# to the point where 30 of 44 suites ran nowhere.
+#
+# Run: ./tools/run-axl-suites.sh [path-to-aspect]
+set -euo pipefail
+
+ASPECT="${1:-aspect}"
+
+SUITES="$(mktemp)"
+trap 'rm -f "$SUITES"' EXIT
+
+"$ASPECT" dev --help | awk '/^Tasks:/ { in_tasks = 1; next } in_tasks && /^  test-/ { print $1 }' >"$SUITES"
+
+count="$(wc -l <"$SUITES" | tr -d ' ')"
+if [[ "$count" -eq 0 ]]; then
+  echo "ERROR: no 'dev test-*' suites discovered — refusing to pass having tested nothing." >&2
+  exit 1
+fi
+echo "Discovered $count AXL test suites."
+
+while read -r suite; do
+  echo "--- $ASPECT dev $suite"
+  "$ASPECT" dev "$suite"
+done <"$SUITES"


### PR DESCRIPTION
Adds `template_preset`, a named bundle of Jinja2 templates selected with one arg on each of the five status-surface features (GitHub check runs and PR comments, GitLab commit statuses and MR notes, Buildkite annotations). Customizing a surface is currently all-or-nothing at the *slot* level — a config can override individual templates via `args.templates`, but there is no way to opt into a different coherent layout without hand-authoring every slot.

One preset ships, `full`, and it is the default. It contributes **no** templates: every renderer already falls back to its built-in when a slot is absent, so today's layout *is* the empty preset. Output is byte-identical, no template string is duplicated into the registry, and existing configs are untouched. Authoring a second layout and moving the default are follow-ups; this is the mechanism.

```python title=".aspect/config.axl"
ctx.features[GithubStatusChecks].args.template_preset = "full"
# Slots set here override the preset, and always win.
ctx.features[GithubStatusChecks].args.templates = {"lint": {"details": _MY_LINT_DETAILS}}
```

### Layering

The preset resolves as a new lower-precedence `base` layer of `resolve_templates`. Both layers support per-task-kind scoping, and they resolve in order rather than being merged:

```
preset flat  <  preset scoped  <  templates flat  <  templates scoped
```

Merging the two dicts first would invert that — a per-kind block in the preset would outrank an explicit flat key in the user's config, letting a preset beat the config that selected it. Keeping them ordered is what lets a future default change leave existing customizations alone.

### Compatibility

Existing configs customize templates by `.replace()`-ing a fragment of an exported constant behind a load-time `fail()` drift guard, so editing the *text* of `DEFAULT_BODY_TEMPLATE` or `SUMMARY_TEMPLATE` would break their CI at config load rather than merely change their output. No built-in template string is touched here, and the known customizing configs were loaded against the built CLI to confirm their guards still pass.

The registry validates itself at load time — the default must be registered, template values must be non-empty strings, per-kind keys must name real task kinds and map to dicts, and any preset overriding check-surface templates must also override `body` so PR/MR comments don't keep the built-in layout while check runs change.

### Also fixed

Two problems surfaced while building this, each in its own commit:

- **The Buildkite annotation snapshot was flaky.** It printed `body[:2500]`, a character-offset cut, while the rendered summary carries a live `ctx.task.elapsed_ms` reading — crossing a digit boundary shifted every later character and split a different line. Five runs against unmodified `main` produced three different outputs. Now truncates by line.
- **30 of 44 `dev test-*` suites ran in neither pipeline.** Both CI files listed suites by hand and the lists had drifted; the dead ones included `test-bk-annotation-templates` (which owns the `resolve_templates` coverage), `test-bazel-results`, `test-lifecycle` and `test-auth`. Both now call `tools/run-axl-suites.sh`, which discovers suites from `aspect dev --help` and fails loudly if discovery comes back empty.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes — aspect-build/site#3432
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Status-surface features accept `template_preset`, selecting a named bundle of templates for the rendered output. `full` (the complete report) ships as the default, so output is unchanged. `templates` continues to override individual slots on top of the selected preset.

### Test plan

- New test cases added — `test_template_presets` in `.aspect/axl.axl` covers the four-level precedence lattice, `base = None` matching the previous single-layer behavior, `full` as a no-op base, and each registry rule. Validation is split so `_validation_errors` returns messages and `_validate` fails on them: AXL cannot catch `fail()`, so a validator that failed directly could only be tested on its happy path.
- Mutation-tested — reversing the layer order and collapsing the layers into one dict before resolving both fail on *"a user flat key beats a preset per-kind block"*, and dropping any individual registry rule fails its own assertion.
- Byte-identity — all nine template snapshot suites render identically to `main`, normalizing only the live elapsed-time readings. `cargo test -p aspect-cli` passes, as do all 44 `dev test-*` suites via `tools/run-axl-suites.sh`.
- Manual testing:
  - Both real customizer configs load against the built CLI without firing their drift guards.
  - A bad preset name in `.aspect/config.axl` is rejected: `aspect build //some:target` exits 2 with `invalid value 'nope' … [possible values: full]`. It is *not* validated on `aspect build --help` or `aspect feature <name>`, which is why the registry also asserts its default at load time — that assertion fires on `--help` (exit 1) where clap stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

