### PR TITLE
feat(cli): reformat the PR and MR summary comment as one line per task

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -10,7 +10,6 @@ load(
     "version_tuple",
 )
 load("@aspect//delivery.axl", delivery_UncacheableAction = "UncacheableAction", delivery_collect_blocking_culprits = "collect_blocking_culprits", delivery_count_unexplained_unresolved = "count_unexplained_unresolved", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
-load("@aspect//feature/github_status_comments.axl", "shorten_result_text")
 load("@aspect//lint.axl", "filter_all", "filter_changeset", "linter_error_message", "parse_patch_hunks")
 load("@aspect//private/lib/artifacts.axl", "artifact_name", "build_log_header", "build_log_relpath", "collect_build_action_logs", "dedup_path", "testlog_dest_dir")
 load("@aspect//private/lib/bazel_results.axl", "bb_clientd_root", "compute_reproducer_command", "file_uri_to_path", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
@@ -3833,30 +3832,6 @@ def test_template_presets(tc: int) -> int:
 
     return tc
 
-def test_shorten_result_text(tc: int) -> int:
-    """The status-comment row drops what its own task label already says: the
-    `Bazel <command>` narration, and a `failed in <phase>` prefix ahead of a
-    segment that already reports the failure."""
-    cases = [
-        ("Spawning bazel build...", "Spawning"),
-        ("Spawning bazel test...", "Spawning"),
-        ("Bazel test running... (12 of 58 tests run)", "running... (12 of 58 tests run)"),
-        ("Bazel build complete", "complete"),
-        ("Bazel build failing", "failing"),
-        ("failed in test · failed", "failed"),
-        ("failed in build · Bazel build failed (3 actions failed)", "failed (3 actions failed)"),
-        # No bazel narration to strip; producers own these verbatim.
-        ("Lint failed (2 errors)", "Lint failed (2 errors)"),
-        ("aborted (timeout)", "aborted (timeout)"),
-        ("", ""),
-        # The phase prefix survives when what follows is not a failure report.
-        ("failed in build · flaky", "failed in build · flaky"),
-    ]
-    for (raw, want) in cases:
-        got = shorten_result_text(raw)
-        tc = test_case(tc, got == want, "shorten_result_text(%r) == %r (got %r)" % (raw, want, got))
-    return tc
-
 def impl(ctx: TaskContext) -> int:
     tc = 0
 
@@ -3947,7 +3922,6 @@ def impl(ctx: TaskContext) -> int:
     tc = test_gitlab_token_cache(ctx, tc, temp_dir)
     tc = test_prompt_choice(tc)
     tc = test_template_presets(tc)
-    tc = test_shorten_result_text(tc)
 
     print(tc, "tests passed")
     return 0

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -10,6 +10,7 @@ load(
     "version_tuple",
 )
 load("@aspect//delivery.axl", delivery_UncacheableAction = "UncacheableAction", delivery_collect_blocking_culprits = "collect_blocking_culprits", delivery_count_unexplained_unresolved = "count_unexplained_unresolved", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
+load("@aspect//feature/github_status_comments.axl", "shorten_result_text")
 load("@aspect//lint.axl", "filter_all", "filter_changeset", "linter_error_message", "parse_patch_hunks")
 load("@aspect//private/lib/artifacts.axl", "artifact_name", "build_log_header", "build_log_relpath", "collect_build_action_logs", "dedup_path", "testlog_dest_dir")
 load("@aspect//private/lib/bazel_results.axl", "bb_clientd_root", "compute_reproducer_command", "file_uri_to_path", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
@@ -3832,6 +3833,30 @@ def test_template_presets(tc: int) -> int:
 
     return tc
 
+def test_shorten_result_text(tc: int) -> int:
+    """The status-comment row drops what its own task label already says: the
+    `Bazel <command>` narration, and a `failed in <phase>` prefix ahead of a
+    segment that already reports the failure."""
+    cases = [
+        ("Spawning bazel build...", "Spawning"),
+        ("Spawning bazel test...", "Spawning"),
+        ("Bazel test running... (12 of 58 tests run)", "running... (12 of 58 tests run)"),
+        ("Bazel build complete", "complete"),
+        ("Bazel build failing", "failing"),
+        ("failed in test · failed", "failed"),
+        ("failed in build · Bazel build failed (3 actions failed)", "failed (3 actions failed)"),
+        # No bazel narration to strip; producers own these verbatim.
+        ("Lint failed (2 errors)", "Lint failed (2 errors)"),
+        ("aborted (timeout)", "aborted (timeout)"),
+        ("", ""),
+        # The phase prefix survives when what follows is not a failure report.
+        ("failed in build · flaky", "failed in build · flaky"),
+    ]
+    for (raw, want) in cases:
+        got = shorten_result_text(raw)
+        tc = test_case(tc, got == want, "shorten_result_text(%r) == %r (got %r)" % (raw, want, got))
+    return tc
+
 def impl(ctx: TaskContext) -> int:
     tc = 0
 
@@ -3922,6 +3947,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_gitlab_token_cache(ctx, tc, temp_dir)
     tc = test_prompt_choice(tc)
     tc = test_template_presets(tc)
+    tc = test_shorten_result_text(tc)
 
     print(tc, "tests passed")
     return 0

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -118,11 +118,10 @@ GITHUB_STATUS_COMMENT_ROLES = ["prs.write"]
 
 _MARKER_FMT = "<!-- aspect-ci-status:pr-%d -->"
 
-# Fallback CI-host link label/icon for entries serialized without host metadata
+# Fallback CI-host link label for entries serialized without host metadata
 # (older entries, or hosts not in the registry). New entries carry the detected
-# host's `ci_host_label` / `ci_host_icon` from `detect_ci_host`.
+# host's `ci_host_label` from `detect_ci_host`.
 _DEFAULT_CI_HOST_LABEL = "GitHub Actions"
-_DEFAULT_CI_HOST_ICON = "🐙"
 
 # Cross-workflow state block embedded in the rendered comment.
 #
@@ -188,20 +187,19 @@ _DEFAULT_BODY_TEMPLATE = """{{ marker }}
 {% endif %}{% if not entries -%}
 _No tasks have reported yet._
 {% else -%}
-{% macro section(label, icon, items) -%}
-{% if items %}
-## {{ icon }} {{ items|length }} {{ label }} task{{ "s" if items|length != 1 else "" }}
+{% macro task_icon(entry) -%}
+{%- if entry._badge_key == "passed" -%}✅
+{%- elif entry._badge_key == "failed" -%}❌
+{%- elif entry._badge_key == "warning" -%}⚠️
+{%- elif entry._badge_key == "aborted" -%}🔥
+{%- else -%}🔄
+{%- endif -%}
+{%- endmacro -%}
+## Task Results
 
-{% for e in items -%}
-- {{ status_badges[e._badge_key] }} {{ e.name or e.kind }}{% if e.name and e.name != e.kind %} [{{ e.kind }}]{% endif %}{% if e._elapsed_text %} · {{ e._elapsed_text }}{% endif %}{% if e._links_text %} · {{ e._links_text }}{% endif %}{% if e._result_text %}<br>💬 {{ e._result_text }}{% endif %}
+{% for e in entries -%}
+- {{ task_icon(e) }} **{{ e.name or e.kind }}**{% if e.name and e.name != e.kind %} [{{ e.kind }}]{% endif %} · {{ e._result_text or status_badges[e._badge_key] }}{% if e._elapsed_text %} · {{ e._elapsed_text }}{% endif %}{% if e._links_text %} · {{ e._links_text }}{% endif %}
 {% endfor -%}
-{% endif -%}
-{% endmacro -%}
-{{ section("in progress", "🔄", sections.running) -}}
-{{ section("failed",      "❌", sections.failed) -}}
-{{ section("failing",     "❌", sections.failing) -}}
-{{ section("flagged",     "⚠️", sections.flagged) -}}
-{{ section("successful",  "✅", sections.successful) -}}
 {% macro snippet_block(s) %}
 ❌ {{ s.kind or (s.bucket if s.bucket != "timeout" else "test") }} `{{ s.label }}` {{ s.verb }}:
 {{ s.fence }}text
@@ -299,6 +297,9 @@ def _badge_key_for(entry):
 
 # ─── Cell formatters ──────────────────────────────────────────────────────────
 
+# Long CI host labels abbreviated for the row; anything absent is used as-is.
+_SHORT_CI_HOST_LABELS = {"GitHub Actions": "GHA"}
+
 def _links_cell_text(entry):
     """Build the row's link line; each link is `<icon> <label>`, omitted
     when its URL is unset (see `_publish` for URL sourcing):
@@ -317,20 +318,19 @@ def _links_cell_text(entry):
     parts = []
 
     if entry.get("aspect_url"):
-        parts.append("✨ [Aspect](%s)" % entry["aspect_url"])
+        parts.append("[Aspect](%s)" % entry["aspect_url"])
 
     # Independent of the Aspect link — both render when set.
     bes_url = entry.get("bes_url", "")
     if bes_url and bes_url != entry.get("aspect_url", ""):
-        parts.append("🔗 [BES](%s)" % bes_url)
+        parts.append("[BES](%s)" % bes_url)
 
     if entry.get("ci_run_url"):
-        icon = entry.get("ci_host_icon") or _DEFAULT_CI_HOST_ICON
         label = entry.get("ci_host_label") or _DEFAULT_CI_HOST_LABEL
-        parts.append("%s [%s](%s)" % (icon, label, entry["ci_run_url"]))
+        parts.append("[%s](%s)" % (_SHORT_CI_HOST_LABELS.get(label, label), entry["ci_run_url"]))
 
     if entry.get("check_run_url"):
-        parts.append("☑️ [Check](%s)" % entry["check_run_url"])
+        parts.append("[Check](%s)" % entry["check_run_url"])
 
     return " · ".join(parts)
 
@@ -339,7 +339,7 @@ def _elapsed_text(entry):
     ms = entry.get("elapsed_ms", 0) or 0
     if ms <= 0:
         return ""
-    return "⏱ " + format_duration_ms(ms)
+    return format_duration_ms(ms)
 
 def _result_cell_text(entry):
     """Compose the row's result text from the producer's `progress.body`.
@@ -385,6 +385,37 @@ def _result_cell_text(entry):
 
 # ─── Pre-render decoration + rollup ───────────────────────────────────────────
 
+def _shorten_phase_segment(segment):
+    """Drop the `Bazel <command>` narration from one ` · `-separated segment."""
+    if segment.startswith("Spawning bazel "):
+        return "Spawning"
+    if segment.startswith("Bazel "):
+        rest = segment[len("Bazel "):].split(" ", 1)
+        return rest[1] if len(rest) == 2 else rest[0]
+    return segment
+
+def shorten_result_text(text):
+    """Drop what a row already says through its own task label and icon.
+
+    Producers narrate the live phase in full — "Spawning bazel build...",
+    "Bazel test running... (12 of 58 tests run)" — which reads well as a
+    check-run summary but is redundant beside the task name. Each segment is
+    shortened, then a leading `failed in <phase>` is dropped when the segment
+    after it already reports the failure:
+
+      Spawning bazel build...                      -> Spawning
+      Bazel test running... (12 of 58 tests run)   -> running... (12 of 58 tests run)
+      failed in test · failed                      -> failed
+      failed in build · Bazel build failed (3)     -> failed (3)
+
+    Detail the producer appended always survives. Public so the AXL suite can
+    exercise the rules directly.
+    """
+    segments = [_shorten_phase_segment(s) for s in text.split(" · ")]
+    if len(segments) > 1 and segments[0].startswith("failed in ") and segments[1].startswith("failed"):
+        segments = segments[1:]
+    return " · ".join(segments)
+
 def _prepare_for_render(entries):
     """Decorate entries for the template, sorted by (job, name, key) so
     positions stay stable across PATCHes. `_severity` is a pure status
@@ -394,7 +425,7 @@ def _prepare_for_render(entries):
         e["_badge_key"] = _badge_key_for(e)
         e["_links_text"] = _links_cell_text(e)
         e["_elapsed_text"] = _elapsed_text(e)
-        e["_result_text"] = _result_cell_text(e)
+        e["_result_text"] = shorten_result_text(_result_cell_text(e))
     return sorted(entries, key = lambda e: (
         e.get("job", ""),
         e.get("kind", ""),

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -182,23 +182,15 @@ _DEFAULT_STATUS_BADGES = {
 # changed in AXL.
 _DEFAULT_BODY_TEMPLATE = """{{ marker }}
 
-## ✨ Aspect Workflows Tasks
+## Aspect Workflows Tasks
 {% if started_at %}📅 {{ started_at }}<br>
 {% endif %}{% if not entries -%}
 _No tasks have reported yet._
 {% else -%}
-{% macro task_icon(entry) -%}
-{%- if entry._badge_key == "passed" -%}✅
-{%- elif entry._badge_key == "failed" -%}❌
-{%- elif entry._badge_key == "warning" -%}⚠️
-{%- elif entry._badge_key == "aborted" -%}🔥
-{%- else -%}🔄
-{%- endif -%}
-{%- endmacro -%}
 ## Task Results
 
 {% for e in entries -%}
-- {{ task_icon(e) }} **{{ e.name or e.kind }}**{% if e.name and e.name != e.kind %} [{{ e.kind }}]{% endif %} · {{ e._result_text or status_badges[e._badge_key] }}{% if e._elapsed_text %} · {{ e._elapsed_text }}{% endif %}{% if e._links_text %} · {{ e._links_text }}{% endif %}
+- {{ status_badges[e._badge_key] }} **{{ e.name or e.kind }}**{% if e.name and e.name != e.kind %} [{{ e.kind }}]{% endif %}{% if e._result_text %} · {{ e._result_text }}{% endif %}{% if e._elapsed_text %} · {{ e._elapsed_text }}{% endif %}{% if e._links_text %} · {{ e._links_text }}{% endif %}
 {% endfor -%}
 {% macro snippet_block(s) %}
 ❌ {{ s.kind or (s.bucket if s.bucket != "timeout" else "test") }} `{{ s.label }}` {{ s.verb }}:

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -289,9 +289,6 @@ def _badge_key_for(entry):
 
 # ─── Cell formatters ──────────────────────────────────────────────────────────
 
-# Long CI host labels abbreviated for the row; anything absent is used as-is.
-_SHORT_CI_HOST_LABELS = {"GitHub Actions": "GHA"}
-
 def _links_cell_text(entry):
     """Build the row's link line; each link is `<icon> <label>`, omitted
     when its URL is unset (see `_publish` for URL sourcing):
@@ -319,7 +316,7 @@ def _links_cell_text(entry):
 
     if entry.get("ci_run_url"):
         label = entry.get("ci_host_label") or _DEFAULT_CI_HOST_LABEL
-        parts.append("[%s](%s)" % (_SHORT_CI_HOST_LABELS.get(label, label), entry["ci_run_url"]))
+        parts.append("[%s](%s)" % (label, entry["ci_run_url"]))
 
     if entry.get("check_run_url"):
         parts.append("[Check](%s)" % entry["check_run_url"])
@@ -377,37 +374,6 @@ def _result_cell_text(entry):
 
 # ─── Pre-render decoration + rollup ───────────────────────────────────────────
 
-def _shorten_phase_segment(segment):
-    """Drop the `Bazel <command>` narration from one ` · `-separated segment."""
-    if segment.startswith("Spawning bazel "):
-        return "Spawning"
-    if segment.startswith("Bazel "):
-        rest = segment[len("Bazel "):].split(" ", 1)
-        return rest[1] if len(rest) == 2 else rest[0]
-    return segment
-
-def shorten_result_text(text):
-    """Drop what a row already says through its own task label and icon.
-
-    Producers narrate the live phase in full — "Spawning bazel build...",
-    "Bazel test running... (12 of 58 tests run)" — which reads well as a
-    check-run summary but is redundant beside the task name. Each segment is
-    shortened, then a leading `failed in <phase>` is dropped when the segment
-    after it already reports the failure:
-
-      Spawning bazel build...                      -> Spawning
-      Bazel test running... (12 of 58 tests run)   -> running... (12 of 58 tests run)
-      failed in test · failed                      -> failed
-      failed in build · Bazel build failed (3)     -> failed (3)
-
-    Detail the producer appended always survives. Public so the AXL suite can
-    exercise the rules directly.
-    """
-    segments = [_shorten_phase_segment(s) for s in text.split(" · ")]
-    if len(segments) > 1 and segments[0].startswith("failed in ") and segments[1].startswith("failed"):
-        segments = segments[1:]
-    return " · ".join(segments)
-
 def _prepare_for_render(entries):
     """Decorate entries for the template, sorted by (job, name, key) so
     positions stay stable across PATCHes. `_severity` is a pure status
@@ -417,7 +383,7 @@ def _prepare_for_render(entries):
         e["_badge_key"] = _badge_key_for(e)
         e["_links_text"] = _links_cell_text(e)
         e["_elapsed_text"] = _elapsed_text(e)
-        e["_result_text"] = shorten_result_text(_result_cell_text(e))
+        e["_result_text"] = _result_cell_text(e)
     return sorted(entries, key = lambda e: (
         e.get("job", ""),
         e.get("kind", ""),

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -1564,6 +1564,7 @@ def _check_row_renders_name_and_kind(ctx):
         DEFAULT_STATUS_BADGES,
         bucket_entries(prepared),
     )
+    _eq("row — the badge map drives the row icon", "✅ **lint**" in body, True)
     _eq("row — name != kind renders '<name> [<kind>]'", "**delivery-gha-debug** [delivery]" in body, True)
     _eq("row — name == kind omits the bracket", "**lint** [lint]" in body, False)
     _eq("row — name == kind still renders the name", "✅ **lint** ·" in body, True)

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -1479,9 +1479,9 @@ def _check_rerun_renders_each_task_once(ctx):
         sections,
         state = new,
     )
-    _eq("rerun render — 'cpu-test [test]' appears once", body.count("cpu-test [test]"), 1)
-    _eq("rerun render — 'lint' row appears once", body.count("✅ lint"), 1)
-    _eq("rerun render — two task rows total", body.count("<br>💬"), 2)
+    _eq("rerun render — 'cpu-test [test]' appears once", body.count("**cpu-test** [test]"), 1)
+    _eq("rerun render — 'lint' row appears once", body.count("✅ **lint**"), 1)
+    _eq("rerun render — two task rows total", body.count("\n- "), 2)
 
 def _check_render_body_emits_state_block(ctx):
     """When `state` is set, the rendered body carries an HTML-comment
@@ -1564,14 +1564,14 @@ def _check_row_renders_name_and_kind(ctx):
         DEFAULT_STATUS_BADGES,
         bucket_entries(prepared),
     )
-    _eq("row — name != kind renders '<name> [<kind>]'", "delivery-gha-debug [delivery]" in body, True)
-    _eq("row — name == kind omits the bracket", "lint [lint]" in body, False)
-    _eq("row — name == kind still renders the name", "✅ lint ·" in body, True)
+    _eq("row — name != kind renders '<name> [<kind>]'", "**delivery-gha-debug** [delivery]" in body, True)
+    _eq("row — name == kind omits the bracket", "**lint** [lint]" in body, False)
+    _eq("row — name == kind still renders the name", "✅ **lint** ·" in body, True)
 
 def _check_ci_host_link_label(ctx):
-    """The CI build/job link is labelled + iconed for the host that produced
-    the entry (carried as `ci_host_label` / `ci_host_icon`), and falls back to
-    GitHub Actions for entries serialized without host metadata."""
+    """The CI build/job link is labelled for the host that produced the entry
+    (carried as `ci_host_label`), abbreviated where the full name is long, and
+    falls back to GitHub Actions for entries serialized without host metadata."""
     bk_url = "https://buildkite.com/acme/repo/builds/1#job"
     gha_url = "https://github.com/acme/repo/actions/runs/1"
     entries = [
@@ -1604,9 +1604,9 @@ def _check_ci_host_link_label(ctx):
         DEFAULT_STATUS_BADGES,
         bucket_entries(prepared),
     )
-    _eq("ci-host — Buildkite label + icon", ("🏗 [Buildkite](%s)" % bk_url) in body, True)
-    _eq("ci-host — no GitHub Actions mislabel for the BK url", ("[GitHub Actions](%s)" % bk_url) in body, False)
-    _eq("ci-host — missing metadata falls back to GitHub Actions", ("🐙 [GitHub Actions](%s)" % gha_url) in body, True)
+    _eq("ci-host — Buildkite label", ("[Buildkite](%s)" % bk_url) in body, True)
+    _eq("ci-host — no GitHub Actions mislabel for the BK url", ("[GHA](%s)" % bk_url) in body, False)
+    _eq("ci-host — missing metadata falls back to GitHub Actions, abbreviated", ("[GHA](%s)" % gha_url) in body, True)
 
 def _check_repro_dedup_consecutive_headings(ctx):
     """Two fix commands from the same task collapse to one heading.

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -1571,8 +1571,8 @@ def _check_row_renders_name_and_kind(ctx):
 
 def _check_ci_host_link_label(ctx):
     """The CI build/job link is labelled for the host that produced the entry
-    (carried as `ci_host_label`), abbreviated where the full name is long, and
-    falls back to GitHub Actions for entries serialized without host metadata."""
+    (carried as `ci_host_label`), and falls back to GitHub Actions for entries
+    serialized without host metadata."""
     bk_url = "https://buildkite.com/acme/repo/builds/1#job"
     gha_url = "https://github.com/acme/repo/actions/runs/1"
     entries = [
@@ -1606,8 +1606,8 @@ def _check_ci_host_link_label(ctx):
         bucket_entries(prepared),
     )
     _eq("ci-host — Buildkite label", ("[Buildkite](%s)" % bk_url) in body, True)
-    _eq("ci-host — no GitHub Actions mislabel for the BK url", ("[GHA](%s)" % bk_url) in body, False)
-    _eq("ci-host — missing metadata falls back to GitHub Actions, abbreviated", ("[GHA](%s)" % gha_url) in body, True)
+    _eq("ci-host — no GitHub Actions mislabel for the BK url", ("[GitHub Actions](%s)" % bk_url) in body, False)
+    _eq("ci-host — missing metadata falls back to GitHub Actions", ("[GitHub Actions](%s)" % gha_url) in body, True)
 
 def _check_repro_dedup_consecutive_headings(ctx):
     """Two fix commands from the same task collapse to one heading.


### PR DESCRIPTION
The PR/MR summary comment grouped tasks under a heading per status — up to five headings ("3 in progress tasks", "1 failed task", …) — and each row spilled its result text onto a second line via `<br>💬`. Reading a run meant reassembling it from the buckets, and a clean run spent five lines on structure before saying anything.

One line per task, in run order:

```markdown
## Aspect Workflows Tasks
📅 Fri May 10 07:16:05 UTC 2024<br>
## Task Results

- ❌ **build-task** [build] · Bazel build failed · 42s · [Aspect](…) · [GitHub Actions](…) · [Check](…)
- ✅ **lint-task** [lint] · Lint complete (clean) · 24s · [Aspect](…) · [GitHub Actions](…) · [Check](…)
- 🔄 **test-task** [test] · Bazel test running... (13/60 tests run) · 1m 18s · [Aspect](…)
```

Every per-task detail survives: name, kind, status, elapsed and each link, with the result text exactly as its producer composed it. What goes is the grouping — the status moves from a bucket heading to the row's own icon, and with it the per-status counts those headings carried (`rollup` still exposes them to custom templates). The result text no longer needs a second line, and the link and clock glyphs go since each label already says what it is.

The row icon comes from `status_badges`, so overriding that map works exactly as documented.

Applies to `GithubStatusComments` and `GitlabStatusComments`, which share this body template. The check-run, commit-status and Buildkite annotation surfaces are untouched.

Also drops the sparkle from the `## Aspect Workflows Tasks` heading.

### Known follow-up

Rows still repeat themselves — `[build] · Bazel build complete (1 built)`, `[format] · Format complete (clean)` — because the producers narrate a phase in a form written for the check-run summary, where no task label sits beside it. Fixing that belongs at the source (a task supplying a short status alongside the long one), not in a filter that pattern-matches the long text after the fact. Tracked separately.

### Breaking for configs that patch `DEFAULT_BODY_TEMPLATE`

The task-sections block those configs anchor `.replace()` on no longer exists, so their load-time drift guard fires and the CLI fails at config load until they update — which is exactly what that guard is for. A config that had already adopted this layout can now drop its override.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: the docsite guide documents the grouped layout and needs rewriting; that PR follows this one
- Breaking change (forces users to change their own code or config): yes — only for configs that patch `DEFAULT_BODY_TEMPLATE`; see above
- Suggested release notes appear below: yes

#### Suggested release notes

- The PR and MR summary comment now renders one line per task in run order instead of grouping tasks under a heading per status. Every per-task detail is still shown; the per-status counts from the old headings are not. Configs that patch `DEFAULT_BODY_TEMPLATE` will need updating — their drift guard will fire at config load.

### Test plan

- Covered by existing test cases — the PR-comment snapshot suite renders all 20 scenarios through the new template; assertions that pinned the old row shape were updated to the new one.
- New test case added — the row icon comes from the `status_badges` map, mutation-tested by hardcoding an icon back in.
- `cargo test -p aspect-cli`, all 44 `dev test-*` suites, `aspect tests axl` (957) and repo-wide `aspect format` all pass.
- Manual testing: read the rendered output for every snapshot scenario, including the failed / aborted / failed-in-phase / mixed-link cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
