### PR TITLE
fix(cli): don't abort when stdout or stderr is closed early

### DIFF
--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -15,7 +15,7 @@
 //!
 //! Everything else in this module is private.
 
-use axl_runtime::{errln, outln};
+use axl_runtime::{errln, out, outln};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
@@ -335,7 +335,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
 
         match name {
             None => {
-                print!(
+                out!(
                     "{}",
                     render_feature_list(version, &blocks, color::stdout_supports_color())
                 );

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -15,6 +15,7 @@
 //!
 //! Everything else in this module is private.
 
+use axl_runtime::{errln, outln};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
@@ -304,7 +305,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
                 match select_task(&full, name) {
                     Some(t) => t,
                     None => {
-                        eprintln!(
+                        errln!(
                             "error: no task {name:?}. Run `aspect describe` for the list of commands."
                         );
                         return ExitCode::FAILURE;
@@ -314,11 +315,11 @@ impl<'a, 'v> Cmd<'a, 'v> {
         };
         match serde_json::to_string_pretty(&doc) {
             Ok(s) => {
-                println!("{s}");
+                outln!("{s}");
                 ExitCode::SUCCESS
             }
             Err(e) => {
-                eprintln!("error: failed to serialize the CLI surface: {e}");
+                errln!("error: failed to serialize the CLI surface: {e}");
                 ExitCode::FAILURE
             }
         }
@@ -349,7 +350,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
                 }
                 None => {
                     let valid: Vec<String> = blocks.iter().map(|(f, _)| f.name()).collect();
-                    eprintln!(
+                    errln!(
                         "\x1b[1;31merror:\x1b[0m unknown feature {name:?}. Valid features: {}",
                         valid.join(", ")
                     );

--- a/crates/aspect-cli/src/credential_helper.rs
+++ b/crates/aspect-cli/src/credential_helper.rs
@@ -19,7 +19,6 @@
 
 use anyhow::Context;
 use axl_runtime::engine::{profile_for_uri, resolve_access_token};
-use axl_runtime::outln;
 
 /// The credential-helper command, as the spec passes it (`argv[1]`). Also the
 /// reserved top-level command name the CLI guards in `cmd`.
@@ -62,7 +61,7 @@ pub fn run() -> anyhow::Result<()> {
     // passes (a global `--credential_helper=aspect` never sends a token to a
     // third-party host) and Bazel falls back to whatever it would otherwise use.
     let Some(deployment) = resolved.deployment else {
-        outln!("{}", no_credential_response());
+        write_response(&no_credential_response())?;
         return Ok(());
     };
 
@@ -84,8 +83,22 @@ pub fn run() -> anyhow::Result<()> {
             )
         })?;
 
-    outln!("{}", bearer_response(&token));
-    Ok(())
+    write_response(&bearer_response(&token))
+}
+
+/// Write the helper's JSON response to stdout.
+///
+/// Unlike console output, this is the protocol payload Bazel parses, so a
+/// failed write is a failed request: propagate it rather than exiting 0 on a
+/// response Bazel never received. (This is why `outln!` is wrong here — see
+/// `axl_runtime::out`.)
+fn write_response(response: &serde_json::Value) -> anyhow::Result<()> {
+    use std::io::Write as _;
+    let mut stdout = std::io::stdout().lock();
+    writeln!(stdout, "{response}").context("writing the credential-helper response to stdout")?;
+    stdout
+        .flush()
+        .context("flushing the credential-helper response to stdout")
 }
 
 /// The empty response Bazel reads as "no credential from this helper", so it

--- a/crates/aspect-cli/src/credential_helper.rs
+++ b/crates/aspect-cli/src/credential_helper.rs
@@ -19,6 +19,7 @@
 
 use anyhow::Context;
 use axl_runtime::engine::{profile_for_uri, resolve_access_token};
+use axl_runtime::outln;
 
 /// The credential-helper command, as the spec passes it (`argv[1]`). Also the
 /// reserved top-level command name the CLI guards in `cmd`.
@@ -61,7 +62,7 @@ pub fn run() -> anyhow::Result<()> {
     // passes (a global `--credential_helper=aspect` never sends a token to a
     // third-party host) and Bazel falls back to whatever it would otherwise use.
     let Some(deployment) = resolved.deployment else {
-        println!("{}", no_credential_response());
+        outln!("{}", no_credential_response());
         return Ok(());
     };
 
@@ -83,7 +84,7 @@ pub fn run() -> anyhow::Result<()> {
             )
         })?;
 
-    println!("{}", bearer_response(&token));
+    outln!("{}", bearer_response(&token));
     Ok(())
 }
 

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -56,6 +56,7 @@ fn install_allocator_error_handler() {
     unsafe { libmimalloc_sys::mi_register_error(Some(on_error), std::ptr::null_mut()) };
 }
 
+use axl_runtime::{errln, outln};
 use std::path::Path;
 use std::process::ExitCode;
 use std::time::Duration;
@@ -235,7 +236,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
 
             match matches.subcommand_name() {
                 Some("version") => {
-                    println!("{}", cargo_pkg_display_version());
+                    outln!("{}", cargo_pkg_display_version());
                     return Ok(ExitCode::SUCCESS);
                 }
                 Some("help") => {
@@ -291,7 +292,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                 for spec in &mut exporters {
                     if let ExporterSpec::File(file) = spec {
                         if file.destination == FileDestination::Stdout {
-                            eprintln!(
+                            errln!(
                                 "warning: a stdout telemetry exporter is configured, but `aspect \
                                  mcp` owns stdout for the MCP protocol — redirecting it to stderr."
                             );
@@ -343,7 +344,7 @@ fn main() -> ExitCode {
         return match credential_helper::run() {
             Ok(()) => ExitCode::SUCCESS,
             Err(err) => {
-                eprintln!("error: {err:?}");
+                errln!("error: {err:?}");
                 ExitCode::FAILURE
             }
         };
@@ -352,7 +353,7 @@ fn main() -> ExitCode {
     match run() {
         Ok(code) => code,
         Err(err) => {
-            eprintln!("error: {err:?}");
+            errln!("error: {err:?}");
             ExitCode::FAILURE
         }
     }
@@ -519,7 +520,7 @@ async fn run_shutdown_sequence(signal_name: &str, exit_code: i32) {
         }
     }
 
-    eprintln!("aspect-cli: received {signal_name}, cancelling bazel subprocesses…");
+    errln!("aspect-cli: received {signal_name}, cancelling bazel subprocesses…");
 
     // Two graceful SIGINTs; the CI/off-CI split below decides what follows.
     // See `install_shutdown_handler` for the full rationale.
@@ -530,7 +531,7 @@ async fn run_shutdown_sequence(signal_name: &str, exit_code: i32) {
     if on_recognized_ci() {
         // Stop short of KillServerProcess and SIGKILL — let bazel finish its
         // own cleanup so a cancellation can't strand a poisoned sandbox.
-        eprintln!("aspect-cli: on CI, leaving bazel to wind down; exiting with code {exit_code}");
+        errln!("aspect-cli: on CI, leaving bazel to wind down; exiting with code {exit_code}");
         std::process::exit(exit_code);
     }
 
@@ -542,10 +543,10 @@ async fn run_shutdown_sequence(signal_name: &str, exit_code: i32) {
 
     let killed = bazel_live::force_kill_all_remaining();
     if killed > 0 {
-        eprintln!("aspect-cli: SIGKILL'd {killed} bazel subprocess(es) that didn't exit");
+        errln!("aspect-cli: SIGKILL'd {killed} bazel subprocess(es) that didn't exit");
         tokio::time::sleep(POST_KILL_GRACE).await;
     }
 
-    eprintln!("aspect-cli: exiting with code {exit_code}");
+    errln!("aspect-cli: exiting with code {exit_code}");
     std::process::exit(exit_code);
 }

--- a/crates/aspect-cli/src/trace.rs
+++ b/crates/aspect-cli/src/trace.rs
@@ -17,6 +17,7 @@
 use axl_runtime::engine::telemetry::{
     ExporterSpec, FileDestination, FileSpec, OtlpProtocol, OtlpSpec,
 };
+use axl_runtime::errln;
 use opentelemetry::{KeyValue, global, trace::TracerProvider as _};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig, WithTonicConfig};
@@ -747,7 +748,7 @@ impl Drop for OtelGuard {
             .unwrap_or(false);
         let timeout = shutdown_timeout();
         if any_otel && debug {
-            eprintln!(
+            errln!(
                 "telemetry: flushing exporters (per-provider timeout {}ms; \
                  set ASPECT_TELEMETRY_SHUTDOWN_TIMEOUT_MS to override)",
                 timeout.as_millis()
@@ -774,18 +775,18 @@ impl Drop for OtelGuard {
             let elapsed_ms = start.elapsed().as_millis();
             if errors.is_empty() {
                 if debug {
-                    eprintln!("telemetry: flush complete in {}ms", elapsed_ms);
+                    errln!("telemetry: flush complete in {}ms", elapsed_ms);
                 }
             } else {
                 // Always surface errors — visibility gap, not a build failure.
-                eprintln!(
+                errln!(
                     "telemetry: flush completed with errors after {}ms — \
                      some records may have been dropped (this does not affect \
                      the task exit code)",
                     elapsed_ms
                 );
                 for err in errors {
-                    eprintln!("  {}", err);
+                    errln!("  {}", err);
                 }
             }
         }

--- a/crates/aspect-cli/tests/broken_pipe.rs
+++ b/crates/aspect-cli/tests/broken_pipe.rs
@@ -1,0 +1,40 @@
+//! A closed stdout must not abort the CLI.
+//!
+//! `println!` / `eprintln!` panic when their write fails, and a reader that
+//! stops early — `aspect build … | head`, or a CI assertion piping into
+//! `grep -q` — closes the pipe as soon as it has what it wants. The panic
+//! (exit 101) aborts the process mid-task, so nothing runs the task's terminal
+//! update and its GitHub check run is stranded "running" until the API sweeper
+//! finalizes it as DISCONNECTED. See `axl_runtime::out`.
+//!
+//! Closing the read end before the child writes anything makes the first write
+//! fail deterministically, rather than depending on the buffering race that
+//! decides whether a real pipeline trips it.
+
+use std::process::{Command, Stdio};
+
+/// Rust's exit code for a panic.
+const PANIC_EXIT: i32 = 101;
+
+#[test]
+fn closed_stdout_does_not_panic() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_aspect-cli"))
+        // `describe` serializes the whole CLI surface through our own stdout
+        // path (`cmd.rs`), unlike `--help`, which clap writes and error-checks
+        // itself.
+        .arg("describe")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn aspect-cli");
+
+    // Close our read end before the child writes, so its writes get EPIPE.
+    drop(child.stdout.take().expect("piped stdout"));
+
+    let status = child.wait().expect("wait for aspect-cli");
+    assert_ne!(
+        status.code(),
+        Some(PANIC_EXIT),
+        "writing to a closed stdout panicked instead of exiting cleanly"
+    );
+}

--- a/crates/aspect-cli/tests/broken_pipe.rs
+++ b/crates/aspect-cli/tests/broken_pipe.rs
@@ -11,6 +11,7 @@
 //! fail deterministically, rather than depending on the buffering race that
 //! decides whether a real pipeline trips it.
 
+use std::io::Write;
 use std::process::{Command, Stdio};
 
 /// Rust's exit code for a panic.
@@ -36,5 +37,55 @@ fn closed_stdout_does_not_panic() {
         status.code(),
         Some(PANIC_EXIT),
         "writing to a closed stdout panicked instead of exiting cleanly"
+    );
+}
+
+/// `aspect feature` renders its list through `print!`, which the newline-less
+/// `out!` covers; a partial migration would leave this path panicking.
+#[test]
+fn closed_stdout_does_not_panic_listing_features() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_aspect-cli"))
+        .arg("feature")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn aspect-cli");
+    drop(child.stdout.take().expect("piped stdout"));
+
+    let status = child.wait().expect("wait for aspect-cli");
+    assert_ne!(
+        status.code(),
+        Some(PANIC_EXIT),
+        "`feature` panicked writing to a closed stdout"
+    );
+}
+
+/// The credential helper's stdout is a protocol payload, not console output:
+/// Bazel parses it. A failed write means Bazel got no response, so the helper
+/// must report failure rather than exit 0 on output nobody received — the one
+/// place `out!`/`outln!` would be the wrong tool.
+#[test]
+fn credential_helper_reports_a_failed_response_write() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_aspect-cli"))
+        .arg("get")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn aspect-cli get");
+
+    // Close the read end first, so the helper's response write cannot land.
+    drop(child.stdout.take().expect("piped stdout"));
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(br#"{"uri":"https://example.com"}"#)
+        .expect("write the helper request");
+
+    let status = child.wait().expect("wait for aspect-cli get");
+    assert!(
+        !status.success(),
+        "credential helper reported success for a response Bazel never received"
     );
 }

--- a/crates/axl-runtime/src/diag.rs
+++ b/crates/axl-runtime/src/diag.rs
@@ -18,6 +18,7 @@
 //!     predicate reads the ambient environment directly (via [`crate::ci`] and
 //!     `IsTerminal`) instead of `std.io.stdout.is_tty`.
 
+use crate::errln;
 use std::io::IsTerminal;
 
 use crate::ci::on_recognized_ci;
@@ -80,7 +81,7 @@ fn colorize() -> bool {
 
 /// Print one severity-prefixed line to stderr, colorized per [`colorize`].
 fn emit(sev: Severity, msg: &str) {
-    eprintln!("{}", format_line(sev, colorize(), msg));
+    errln!("{}", format_line(sev, colorize(), msg));
 }
 
 /// Print a cyan `INFO:` line for a notable runtime branch.

--- a/crates/axl-runtime/src/engine/aspect/mcp.rs
+++ b/crates/axl-runtime/src/engine/aspect/mcp.rs
@@ -16,6 +16,7 @@
 //! version-gating message instead. An agent then relays an actionable answer
 //! rather than the session dying on a transport error.
 
+use crate::errln;
 use std::sync::Arc;
 
 use allocative::Allocative;
@@ -739,7 +740,7 @@ fn serve_blocking(deployment_name: Option<&str>) -> anyhow::Result<i32> {
         match http.get(&probe_url).send().await {
             Ok(r) if r.status().is_success() => true,
             Ok(r) => {
-                eprintln!(
+                errln!(
                     "warning: {probe_url} answered HTTP {} — serving anyway; tools will explain \
                      what the deployment is missing and re-check on every call.",
                     r.status()
@@ -747,7 +748,7 @@ fn serve_blocking(deployment_name: Option<&str>) -> anyhow::Result<i32> {
                 false
             }
             Err(e) => {
-                eprintln!(
+                errln!(
                     "warning: could not probe {probe_url} ({e}) — serving anyway; tools will \
                      re-check on every call."
                 );
@@ -764,7 +765,7 @@ fn serve_blocking(deployment_name: Option<&str>) -> anyhow::Result<i32> {
         http,
     };
 
-    eprintln!(
+    errln!(
         "aspect mcp: serving build results for deployment '{}' ({origin}) over stdio",
         deployment.name
     );

--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -1,3 +1,4 @@
+use crate::errln;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::io;
@@ -699,10 +700,10 @@ pub(super) fn announce_spawn(
 ) {
     let (grey, reset) = grey_style();
     if announce.version {
-        eprintln!("{grey}INFO: {}{reset}", version_line(version));
+        errln!("{grey}INFO: {}{reset}", version_line(version));
     }
     if announce.command {
-        eprintln!("{grey}INFO: Spawning: {}{reset}", render_command(cmd));
+        errln!("{grey}INFO: Spawning: {}{reset}", render_command(cmd));
     }
 }
 
@@ -963,7 +964,7 @@ impl Build {
         let sink_invocation_id: Option<String> = if !grpc_sinks.is_empty() {
             let invocation_id = uuid::Uuid::new_v4().to_string();
             if debug {
-                eprintln!(
+                errln!(
                     "BES sinks: spawning {} gRPC sink(s) sink_invocation_id={}",
                     grpc_sinks.len(),
                     invocation_id
@@ -981,7 +982,7 @@ impl Build {
                     .unwrap_or_else(|_| "<unset>".to_string());
                 let bes_results = std::env::var("ASPECT_WORKFLOWS_BES_RESULTS_URL")
                     .unwrap_or_else(|_| "<unset>".to_string());
-                eprintln!(
+                errln!(
                     "BES sinks: 0 gRPC sinks configured (skipping spawn). \
                      ASPECT_WORKFLOWS_BES_BACKEND={bes_backend} \
                      ASPECT_WORKFLOWS_BES_RESULTS_URL={bes_results}"

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -1,3 +1,4 @@
+use crate::errln;
 use std::{
     collections::HashMap,
     sync::OnceLock,
@@ -97,7 +98,7 @@ fn dbg(endpoint: &str, invocation_id: &str, msg: &str) {
         return;
     }
     let short = invocation_id.get(..8).unwrap_or(invocation_id);
-    eprintln!("BES sink {endpoint} [{short}]: {msg}");
+    errln!("BES sink {endpoint} [{short}]: {msg}");
 }
 
 /// Emit a user-facing `WARNING:` for this sink, prefixed `BES sink <endpoint>:`

--- a/crates/axl-runtime/src/engine/bazel/stream/broadcaster.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/broadcaster.rs
@@ -178,6 +178,7 @@
 //! - Dead subscribers are cleaned up lazily on the next `send()`
 //! - The `close()` method immediately frees all sender resources
 
+use crate::outln;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, Weak};
 
@@ -294,7 +295,7 @@ impl<T> std::ops::Deref for Subscriber<T> {
 /// // Subscribe and consume
 /// let sub = broadcaster.subscribe();
 /// for event in std::iter::from_fn(|| sub.recv().ok()) {
-///     println!("Received: {}", event);
+///     outln!("Received: {}", event);
 /// }
 /// ```
 #[derive(Debug)]

--- a/crates/axl-runtime/src/engine/std/fs.rs
+++ b/crates/axl-runtime/src/engine/std/fs.rs
@@ -1,3 +1,4 @@
+use crate::outln;
 use allocative::Allocative;
 use derive_more::Display;
 use starlark::environment::Methods;
@@ -399,7 +400,7 @@ pub(crate) fn filesystem_methods(registry: &mut MethodsBuilder) {
         #[allow(unused)] this: values::Value<'v>,
         #[starlark(require = pos)] path: values::StringValue,
     ) -> anyhow::Result<bool> {
-        println!(
+        outln!(
             r#"Deprecated: is_file is deprecated and will be removed in a future version of AXL.
             Use `fs.metadata().is_file` instead."#
         );

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -1,3 +1,4 @@
+use crate::errln;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
@@ -413,16 +414,16 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         let label = task_label(task.group(), &task.kind(), task_name, task_name_meaningful);
         // Identity banner above the task header — see `crate::banner`.
         if banner::show_runtime_banner() {
-            eprintln!("{}\n", banner::line_from_pkg());
+            errln!("{}\n", banner::line_from_pkg());
         }
         if std::env::var_os("BUILDKITE").is_some() {
             // The BK section header replaces the `→` line on BK (avoids
             // duplicating the same text in the BK log viewer).
-            eprintln!("--- :aspect: {}Running{} {}", verb_seq, reset, label);
+            errln!("--- :aspect: {}Running{} {}", verb_seq, reset, label);
         } else {
             // 🎬 (clapper board) pairs with the closing ✅ / ⚠️ / ❌ as
             // the task's bookend.
-            eprintln!("→ 🎬 {}Running{} {}", verb_seq, reset, label);
+            errln!("→ 🎬 {}Running{} {}", verb_seq, reset, label);
         }
         Ok(())
     }
@@ -674,10 +675,10 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
             // keep `---` and let the auto-expand handle the summary.
             let unclean = failed || flagged;
             if unclean {
-                eprintln!("^^^ +++");
+                errln!("^^^ +++");
             }
             let bookend_marker = if unclean { "+++" } else { "---" };
-            eprintln!(
+            errln!(
                 "{} {} {}{}{} · {}{}{}{}{}",
                 bookend_marker,
                 verdict.bk_shortcode,
@@ -691,8 +692,8 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
                 breakdown,
             );
         } else {
-            eprintln!();
-            eprintln!(
+            errln!();
+            errln!(
                 "→ {} {}{}{} {}{}{}{}{}",
                 verdict.glyph,
                 verdict.color,

--- a/crates/axl-runtime/src/lib.rs
+++ b/crates/axl-runtime/src/lib.rs
@@ -13,6 +13,7 @@ pub mod docs;
 pub mod engine;
 pub mod eval;
 pub mod module;
+pub mod out;
 pub mod trace;
 
 /// Bazel subprocess live-tracking. Re-exported so `aspect-cli`'s

--- a/crates/axl-runtime/src/module/disk_store.rs
+++ b/crates/axl-runtime/src/module/disk_store.rs
@@ -1,3 +1,4 @@
+use crate::errln;
 use std::{io, os::unix::ffi::OsStrExt, path::PathBuf, str::FromStr};
 
 use anyhow::anyhow;
@@ -349,7 +350,7 @@ impl DiskStore {
                                     }
                                     Err(err) => {
                                         if dep.urls.len() > 1 && i != dep.urls.len() - 1 {
-                                            eprintln!("failed to fetch `{url}`: {err}");
+                                            errln!("failed to fetch `{url}`: {err}");
                                         }
                                         last_err = Some(err);
                                         if i == dep.urls.len() - 1 {

--- a/crates/axl-runtime/src/out.rs
+++ b/crates/axl-runtime/src/out.rs
@@ -10,6 +10,10 @@
 //! These macros discard the write error instead. Output past the close is lost
 //! either way — nobody is reading it — but the process finishes its work,
 //! reports its real result, and exits with its real code.
+//!
+//! For human-facing console output only. Anything a *program* consumes — a
+//! credential-helper response, a machine-readable dump — must propagate the
+//! failure rather than report success on output nobody received.
 
 /// `println!` that ignores a failed write (notably a closed pipe).
 #[macro_export]
@@ -21,6 +25,15 @@ macro_rules! outln {
     ($($arg:tt)*) => {{
         use std::io::Write as _;
         let _ = writeln!(std::io::stdout(), $($arg)*);
+    }};
+}
+
+/// `print!` that ignores a failed write (notably a closed pipe).
+#[macro_export]
+macro_rules! out {
+    ($($arg:tt)*) => {{
+        use std::io::Write as _;
+        let _ = write!(std::io::stdout(), $($arg)*);
     }};
 }
 

--- a/crates/axl-runtime/src/out.rs
+++ b/crates/axl-runtime/src/out.rs
@@ -1,0 +1,38 @@
+//! Console writes that survive a closed pipe.
+//!
+//! `println!` / `eprintln!` panic when the write fails, and a closed reader is
+//! the common case: `aspect build … | head`, or a CI assertion piping into
+//! `grep -q`, closes the pipe as soon as it has what it wants. The panic aborts
+//! the process mid-task, so nothing runs the task's terminal update and its
+//! GitHub check run is left "running" until the API sweeper finalizes it as
+//! DISCONNECTED.
+//!
+//! These macros discard the write error instead. Output past the close is lost
+//! either way — nobody is reading it — but the process finishes its work,
+//! reports its real result, and exits with its real code.
+
+/// `println!` that ignores a failed write (notably a closed pipe).
+#[macro_export]
+macro_rules! outln {
+    () => {{
+        use std::io::Write as _;
+        let _ = writeln!(std::io::stdout());
+    }};
+    ($($arg:tt)*) => {{
+        use std::io::Write as _;
+        let _ = writeln!(std::io::stdout(), $($arg)*);
+    }};
+}
+
+/// `eprintln!` that ignores a failed write (notably a closed pipe).
+#[macro_export]
+macro_rules! errln {
+    () => {{
+        use std::io::Write as _;
+        let _ = writeln!(std::io::stderr());
+    }};
+    ($($arg:tt)*) => {{
+        use std::io::Write as _;
+        let _ = writeln!(std::io::stderr(), $($arg)*);
+    }};
+}


### PR DESCRIPTION
When a pipeline's reader exits before the writer is done — `aspect build … | head`, or `… 2>&1 | grep -q "…"` as our own CI assertions do — the reader's end of the pipe closes. The CLI's next write then fails with `EPIPE`, and because `println!` and `eprintln!` **panic** on a failed write, the process aborts with exit 101 instead of its real exit code.

The wrong exit code is the smaller half of the damage. The panic aborts the process *mid-task*, so nothing runs the task's terminal update and its GitHub check run is stranded `running` until the API sweeper finalizes it as `🚫 DISCONNECTED`. That is where the four DISCONNECTED checks on every aspect-cli PR came from — #1406 stopped those four smoke assertions from posting check runs at all; this fixes the reason they were orphaned in the first place.

### Why `| cat` is fine and `| grep -q` is not

Measured against `main`, all on `aspect build --definitely_not_a_flag //...`:

| pipeline | rc | why |
|---|---|---|
| `2>&1 \| cat` | 2 | `cat` reads to EOF — never closes early |
| `2>&1 \| grep -q "Unrecognized option"` | **101** | `grep -q` exits *at the match*, closing the pipe while the CLI is still writing |
| `2>&1 \| head -1` | **101** | same class — takes what it needs and leaves |
| `2>&1 \| (sleep 2; cat)` | 2 | reader is slow but *stays* |
| `2>/dev/null \| head -1` | 2 | this command writes to stderr, so with stderr out of the pipe nothing hits the closed end |

It is not `cat` versus `grep`, and it is not buffering or reader speed — the slow-reader row rules both out. What matters is **whether the reader closes the pipe before the writer is done**. `grep -q` and `head -N` are "I have what I need" tools that exit early by design. Here the matched text comes from bazel early in the output and the CLI keeps writing its own failure summary afterwards, so those later writes land on a pipe with no reader.

### This is a standing Rust complaint, and the usual fix is the wrong one for us

Rust's standard library installs `SIGPIPE` as *ignored* at startup, deliberately: it wants a failed write to surface as an `io::Error` that library code can handle, rather than a signal that kills the process. But `println!` then panics on that error instead of propagating it. The net effect is that a Rust program writing more than a bufferful, piped into `head`, panics — where the equivalent C program dies quietly on the signal. Every Rust CLI meets this eventually.

There are two standard remedies:

1. **Restore `SIGPIPE` to its default at startup.** The process then dies on the signal like any other Unix tool, exiting 141. This is what most CLIs do, and it is a one-line change.
2. **Handle the write error.** The process keeps running with its output discarded.

**We take the second, and the difference matters here.** Restoring `SIGPIPE` to default would kill the process on the signal — which strands the check run in exactly the same way the panic does. It would fix the exit code and leave the real problem in place. Handling the error is what lets the task finish, post its terminal update, and exit with its true status.

So this deliberately does *not* take the one-line fix. Please don't simplify it back to `SIGPIPE`/`SIG_DFL` — that reintroduces the orphaned check runs.

### The change

Adds `outln!` / `errln!` in `axl_runtime::out` — `writeln!` with the result discarded — and converts the console writes to them. Output past the close is lost either way, since nobody is reading it, but the process finishes its work and reports its real result.

Deliberately unchanged: a task killed by an uncatchable signal still strands its check run. That is what the sweeper is for, and the CLI's force-exit on SIGINT/SIGTERM (`main.rs:393-440`) is load-bearing — it exists because the AXL drain loop runs on `spawn_blocking`, where a hung feature handler could otherwise keep the process alive past cancellation.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: n/a — no documented behavior changes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Piping Aspect CLI output into a reader that exits early (`| head`, `| grep -q`) no longer aborts the CLI with exit 101. The command now completes and exits with its real status, and its GitHub check run is no longer left showing as running.

### Test plan

- New test case added — `tests/broken_pipe.rs` closes the child's stdout before it writes, so the first write fails deterministically rather than depending on the buffering race a real pipeline hits.
- Mutation-tested — reverting `cmd.rs` to `println!`/`eprintln!` fails the test. Worth noting the first version of this test used `--help` and passed *under mutation*: clap writes its own help and error-checks it, so that path never exercised the fix. It now uses `describe`, which serializes through our own stdout path.
- Measured end to end on the exact CI shape: 10/10 runs exit 101 before the change, 10/10 exit 2 after.
- `cargo test -p aspect-cli`, `cargo test -p axl-runtime`, `aspect tests axl` (957) and `cargo fmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
