### PR TITLE
feat(cli): warn when a terminal comment post is withheld

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -10,6 +10,7 @@ load(
     "version_tuple",
 )
 load("@aspect//delivery.axl", delivery_UncacheableAction = "UncacheableAction", delivery_collect_blocking_culprits = "collect_blocking_culprits", delivery_count_unexplained_unresolved = "count_unexplained_unresolved", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
+load("@aspect//feature/github_status_comments.axl", "denied_terminal_post_warning")
 load("@aspect//lint.axl", "filter_all", "filter_changeset", "linter_error_message", "parse_patch_hunks")
 load("@aspect//private/lib/artifacts.axl", "artifact_name", "build_log_header", "build_log_relpath", "collect_build_action_logs", "dedup_path", "testlog_dest_dir")
 load("@aspect//private/lib/bazel_results.axl", "bb_clientd_root", "compute_reproducer_command", "file_uri_to_path", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
@@ -3832,6 +3833,20 @@ def test_template_presets(tc: int) -> int:
 
     return tc
 
+def test_denied_terminal_post_warning(tc: int) -> int:
+    """A terminal publish the server declines to post leaves the task's entry
+    frozen mid-run, which is otherwise invisible. The warning names the grant
+    holder when the server reports one, and stays sensible when it does not."""
+    with_holder = denied_terminal_post_warning("lint-gha", "123456")
+    tc = test_case(tc, "lint-gha" in with_holder, "the warning names the task")
+    tc = test_case(tc, "post grant held by run 123456" in with_holder, "the warning names the grant holder")
+
+    without = denied_terminal_post_warning("lint-gha", "")
+    tc = test_case(tc, "lint-gha" in without, "the warning names the task with no holder reported")
+    tc = test_case(tc, "post grant held by" not in without, "no dangling holder clause when the server reports none")
+    tc = test_case(tc, without.endswith("posts later"), "the message ends cleanly with no holder")
+    return tc
+
 def impl(ctx: TaskContext) -> int:
     tc = 0
 
@@ -3922,6 +3937,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_gitlab_token_cache(ctx, tc, temp_dir)
     tc = test_prompt_choice(tc)
     tc = test_template_presets(tc)
+    tc = test_denied_terminal_post_warning(tc)
 
     print(tc, "tests passed")
     return 0

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3841,6 +3841,25 @@ def test_denied_terminal_post_warning(tc: int) -> int:
     tc = test_case(tc, "lint-gha" in with_holder, "the warning names the task")
     tc = test_case(tc, "post grant held by run 123456" in with_holder, "the warning names the grant holder")
 
+    # The formatter is only useful if the field survives the response wrapper,
+    # which rebuilds the body rather than passing it through.
+    piped = github.contribute_result({
+        "state": {"entries": []},
+        "should_post": False,
+        "comment_id": "c1",
+        "post_grant_run": "987654",
+    })
+    tc = test_case(tc, piped.get("post_grant_run") == "987654", "the contribute wrapper preserves post_grant_run")
+    tc = test_case(
+        tc,
+        "post grant held by run 987654" in denied_terminal_post_warning("t", piped.get("post_grant_run", "")),
+        "a server-reported holder reaches the warning end to end",
+    )
+
+    # Older servers omit the field entirely.
+    older = github.contribute_result({"state": {}, "should_post": False, "comment_id": ""})
+    tc = test_case(tc, older.get("post_grant_run") == "", "an omitted post_grant_run reads as empty, not missing")
+
     without = denied_terminal_post_warning("lint-gha", "")
     tc = test_case(tc, "lint-gha" in without, "the warning names the task with no holder reported")
     tc = test_case(tc, "post grant held by" not in without, "no dangling holder clause when the server reports none")

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -330,6 +330,20 @@ def _elapsed_text(entry):
         return ""
     return format_duration_ms(ms)
 
+def denied_terminal_post_warning(task_name, post_grant_run):
+    """Warn that a task's terminal status was contributed but not posted.
+
+    A terminal publish is the job's last word — there is no later emit from
+    this task. If the server withholds the post and no other job posts
+    afterwards, the entry stays frozen at whatever the previous post captured,
+    reporting a finished task as still running for as long as the comment
+    lives. That failure is otherwise invisible, so it gets a log line naming
+    the grant holder when the server reports one (older servers do not).
+    """
+    held = " (post grant held by run %s)" % post_grant_run if post_grant_run else ""
+    return ("Terminal status for %s was contributed but the server withheld the comment post; " +
+            "it will only appear if another job posts later%s") % (task_name, held)
+
 def _result_cell_text(entry):
     """Compose the row's result text from the producer's `progress.body`.
 
@@ -1646,6 +1660,12 @@ def _github_status_comments(ctx: FeatureContext):
         _state["_shown_fixes"] = sel["shown_fixes"]
 
         if not result.get("should_post"):
+            # Mid-run denials are routine throttling; a terminal one is not.
+            if final:
+                _LOG.warn(ctx.std, denied_terminal_post_warning(
+                    ctx.task.name,
+                    result.get("post_grant_run", ""),
+                ))
             return
 
         # Resolve the comment id before posting so we PATCH the existing comment

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -472,6 +472,21 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
 
 # Status-comment coordination (Aspect API)
 
+def contribute_result(parsed):
+    """Narrow a 2xx `contribute` body to the fields callers read.
+
+    Every field a caller needs must be listed here — the response is rebuilt,
+    not passed through, so anything omitted silently reads as absent no matter
+    what the server sent. `post_grant_run` is optional: older servers omit it.
+    """
+    return {
+        "success": True,
+        "state": parsed.get("state") or {},
+        "should_post": bool(parsed.get("should_post", False)),
+        "comment_id": parsed.get("comment_id", "") or "",
+        "post_grant_run": parsed.get("post_grant_run", "") or "",
+    }
+
 def _status_comment_contribute(ctx, request, profile = None):
     """Contribute this job's task status for a PR to the Aspect API and get
     back the merged set of all jobs' contributions + a posting directive.
@@ -514,12 +529,7 @@ def _status_comment_contribute(ctx, request, profile = None):
         if type(parsed) != "dict" or "state" not in parsed:
             snippet = (resp.body or "")[:200].replace("\n", " ")
             return {"success": False, "error": "unusable 2xx body: %s" % snippet, "status": resp.status}
-        return {
-            "success": True,
-            "state": parsed.get("state") or {},
-            "should_post": bool(parsed.get("should_post", False)),
-            "comment_id": parsed.get("comment_id", "") or "",
-        }
+        return contribute_result(parsed)
 
     return {"success": False, "error": resp.body or "", "status": resp.status}
 
@@ -2346,6 +2356,7 @@ github = struct(
     with_job_link_role = with_job_link_role,
     authenticate = _authenticate,
     status_comment_contribute = _status_comment_contribute,
+    contribute_result = contribute_result,
     status_check_register = _status_check_register,
     preferred_token_pair = _preferred_token_pair,
     missing_credentials_reason = _missing_credentials_reason,


### PR DESCRIPTION
A terminal publish is a task's last word. If the server declines to grant the post and no other job posts afterwards, that task's entry stays frozen at whatever the previous post captured — reporting a **finished task as still running**, for as long as the comment lives.

Today that happens with no trace.

### The change

Warn when a **terminal** publish is contributed but not granted a post, naming the grant holder when the server reports one:

```
WARNING: Terminal status for run-axl-smoke was contributed but the server withheld the
comment post; it will only appear if another job posts later (post grant held by run 123456)
```

`post_grant_run` comes from aspect-build/silo#11996; against a server that does not send it the clause is omitted and the rest of the message still stands, so this does not depend on deploy ordering.

Mid-run denials are routine throttling and stay quiet — only the terminal one is a lasting problem.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: n/a — a warning, no documented behavior change
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- When the Aspect API withholds a PR/MR comment post for a task's final status update, the CLI now warns instead of failing silently — previously the task could be left showing as running in the comment with nothing explaining why.

### Test plan

- New test cases added — `test_denied_terminal_post_warning` in `.aspect/axl.axl` covers the message with and without a reported grant holder, including that no dangling "post grant held by" clause is emitted when the server sends none.
- Mutation-tested — dropping the holder clause, and emitting it unconditionally, each fail their assertion.
- `aspect tests axl` (962) and all 44 `dev test-*` suites pass; repo-wide `buildifier` clean.
