### PR TITLE
fix(cli): emit a terminal task update from `aspect run`

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -4,7 +4,7 @@ load("@aspect//bazel/build_events.axl", "announce_bes_sinks", "bes_args", "bes_s
 load("@aspect//bazel.axl", "BazelTrait", "dispatch_bazel_attempt_end", "dispatch_bazel_build_end", bzl = "bazel")
 load("@std//time.axl", "sleep_iter")
 load("./private/lib/artifacts.axl", "artifacts")
-load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "init_data", "process_event")
+load("./private/lib/bazel_results.axl", "BES_DRAIN_TICK_MS", "conclusion", "init_data", "process_event")
 load("./private/lib/environment.axl", "error")
 load("./private/lib/health_check.axl", "HealthCheckTrait")
 load("./private/lib/lifecycle.axl", "phases")
@@ -43,6 +43,24 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     data["bes_streamed_by_bazel"] = bes_streamed_by_bazel(ctx, rc)
     events = bazel.build_events.iterator()
     build_events = [events] + bes_sinks
+
+    def _conclude(status, code, text):
+        """Emit the terminal `task_update` and return the task's conclusion.
+
+        Every exit path goes through here. Without a terminal update the status
+        surfaces keep whatever "running" state they last saw — a finished run
+        shows as still in progress for as long as the PR comment lives, because
+        nothing ever supersedes it.
+        """
+        ph.dispatch(phases.Update(
+            kind = "bazel_results",
+            status = status,
+            final = True,
+            conclusion = text,
+            data = data,
+            progress = phases.ProgressStyles(body = text),
+        ))
+        return TaskConclusion(exit_code = code, text = text, flagged = False)
 
     for hook in bazel_trait.build_start:
         hook(ctx)
@@ -90,12 +108,12 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     dispatch_bazel_build_end(ctx, bazel_trait, build_status.code)
 
     if not build_status.success:
-        return build_status.code
+        return _conclude("failed", build_status.code, conclusion("failed", data))
 
     entrypoint = r.determine_entrypoint(target)
     if entrypoint == None:
         error(ctx.std, "Failed to determine the run entrypoint for %s." % target)
-        return 1
+        return _conclude("failed", 1, "Could not determine the run entrypoint for %s" % target)
 
     ph.update(
         "running",
@@ -106,7 +124,10 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         phase = phases.Phase(name = "run", description = "Run target", emoji = "🚀"),
     )
 
-    return r.spawn(entrypoint, forward_args, cwd = spawn_cwd).wait().code
+    code = r.spawn(entrypoint, forward_args, cwd = spawn_cwd).wait().code
+    if code == 0:
+        return _conclude("passed", code, "Ran %s" % target)
+    return _conclude("failed", code, "%s exited %d" % (target, code))
 
 run = task(
     summary = "Build a target with bazel and run the resulting binary.",


### PR DESCRIPTION
`aspect run` emitted two `"running"` updates and then returned the spawn's exit code — never a terminal one. Nothing supersedes the last `"running"` state, so every status surface keeps it forever.

That is why these two rows have sat in the aspect-cli PR comment on **every PR for months**, for tasks that pass in seconds:

```
🔄 run-axl-smoke   [run] · Building //examples/deliverable:py_deliverable... · 5.6s
🔄 run-axl-smoke-2 [run] · Building //examples/deliverable:sh_deliverable...  · 4.7s
```

The stuck text is the tell: it is verbatim the task's **first** update. The second (`Running …`) is a non-final, non-initial event and gets throttled, so the surface never advanced past the first one it saw.

Confirmed long-standing — the same two entries are frozen in the comment state of #1400, #1402, #1404, #1405 and #1408.

### The change

All three exit paths now close out through one `_conclude` helper:

| path | status | text |
|---|---|---|
| build failed | `failed` | the shared bazel bookend, so it renders as `aspect build` would |
| no resolvable entrypoint | `failed` | names the target |
| binary ran | from its exit code | the run's verdict, not the build's |

That last row matters: `run`'s outcome is the spawned binary's exit code, so a target that builds cleanly and then exits non-zero must not report as passed.

Visible locally as the conclusion text the bookend previously lacked:

```
before: → ✅ Passed run task in 984ms
after:  → ✅ Passed run task in 744ms · Ran //examples/deliverable:py_deliverable
```

### Scope

This fixes the two `run-axl-smoke` rows. The two `build-axl-smoke` rows in the same comment are **not** explained by this — `aspect build` does conclude (`→ ❌ Failed build task (exit code 2) · Failed to build`), and the diagnostic added in #1408 did not fire for them either, which rules out the server withholding the post. They remain open.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: n/a
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- `aspect run` now reports a terminal status. Previously it left its GitHub check run and PR/MR comment entry showing as still running after the task finished.

### Test plan

- Manual testing: the success path prints the new conclusion text and exits 0; the build-failure path exits 1 and renders the standard bazel failure bookend. Compared against `main` on the same target to confirm the bookend text is new.
- `aspect tests axl` (965) and all 44 `dev test-*` suites pass; `buildifier` clean.
- Not exercised end to end: a target that builds and then exits non-zero. `_conclude` passes `code` straight into `TaskConclusion(exit_code = code)`, but I did not find a fixture that fails at runtime, so that path is by inspection only.
- The real check is CI on this PR — the two `run-axl-smoke` rows in its own summary comment should reach a terminal state instead of freezing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
