### PR TITLE
fix(cli): don't report a failed `aspect run` as a failed build

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -10,7 +10,7 @@ load(
     "version_tuple",
 )
 load("@aspect//delivery.axl", delivery_UncacheableAction = "UncacheableAction", delivery_collect_blocking_culprits = "collect_blocking_culprits", delivery_count_unexplained_unresolved = "count_unexplained_unresolved", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
-load("@aspect//feature/github_status_comments.axl", "denied_terminal_post_warning")
+load("@aspect//feature/github_status_comments.axl", "denied_terminal_post_warning", "dropped_terminal_contribute_warning")
 load("@aspect//lint.axl", "filter_all", "filter_changeset", "linter_error_message", "parse_patch_hunks")
 load("@aspect//private/lib/artifacts.axl", "artifact_name", "build_log_header", "build_log_relpath", "collect_build_action_logs", "dedup_path", "testlog_dest_dir")
 load("@aspect//private/lib/bazel_results.axl", "bb_clientd_root", "compute_reproducer_command", "file_uri_to_path", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
@@ -3859,6 +3859,16 @@ def test_denied_terminal_post_warning(tc: int) -> int:
     # Older servers omit the field entirely.
     older = github.contribute_result({"state": {}, "should_post": False, "comment_id": ""})
     tc = test_case(tc, older.get("post_grant_run") == "", "an omitted post_grant_run reads as empty, not missing")
+
+    # The other silent path: a terminal contribution that never reached the API.
+    dropped = dropped_terminal_contribute_warning("build-gha", "503 upstream")
+    tc = test_case(tc, "build-gha" in dropped, "the dropped-contribute warning names the task")
+    tc = test_case(tc, "503 upstream" in dropped, "the dropped-contribute warning carries the error")
+    tc = test_case(
+        tc,
+        "unknown" in dropped_terminal_contribute_warning("build-gha", ""),
+        "an empty error still reads sensibly",
+    )
 
     without = denied_terminal_post_warning("lint-gha", "")
     tc = test_case(tc, "lint-gha" in without, "the warning names the task with no holder reported")

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -330,6 +330,18 @@ def _elapsed_text(entry):
         return ""
     return format_duration_ms(ms)
 
+def dropped_terminal_contribute_warning(task_name, error):
+    """Warn that a task's terminal contribution never reached the API.
+
+    Mid-run this is unremarkable — the next tick retries. On the terminal
+    update there is no next tick, so if the comment-state fallback cannot post
+    either, the task's entry keeps whatever a previous post captured and
+    reports a finished task as still running. Traced rather than warned, that
+    failure is invisible in a normal CI log.
+    """
+    return ("Terminal status for %s could not be contributed to the status-comment API (%s); " +
+            "falling back to coordinating through the comment itself") % (task_name, error or "unknown")
+
 def denied_terminal_post_warning(task_name, post_grant_run):
     """Warn that a task's terminal status was contributed but not posted.
 
@@ -1635,7 +1647,17 @@ def _github_status_comments(ctx: FeatureContext):
             # API unreachable / errored — fall back to coordinating through the
             # comment's own state block (read → merge our entry → render →
             # post), so a single job still renders a correct comment.
-            _LOG.trace("status-comment API unavailable (%s); using comment-state fallback" % result.get("error", ""))
+            # Mid-run this is unremarkable — the next tick retries. On the
+            # terminal update there is no next tick: if the fallback below
+            # cannot post, the task's last state is whatever a previous post
+            # captured, so the failure is worth naming rather than tracing.
+            if final:
+                _LOG.warn(ctx.std, dropped_terminal_contribute_warning(
+                    ctx.task.name,
+                    result.get("error", ""),
+                ))
+            else:
+                _LOG.trace("status-comment API unavailable (%s); using comment-state fallback" % result.get("error", ""))
             _publish_via_comment_state(ctx, token, own_entry, now_epoch, final)
             return
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -2000,6 +2000,14 @@ def compute_invocation_state(data, status):
         for bucket in _FAILURE_BUCKETS:
             if counts.get(bucket, 0) > 0:
                 return _BUCKET_INVOCATION_LABELS[bucket]
+
+        # `aspect run` builds a target and then executes it. When the build
+        # succeeded and the program exited non-zero there is no failure bucket,
+        # and the fallback below would report a build failure for a build that
+        # worked. Only `run` sets this.
+        run_exit = (data.get("run") or {}).get("exit_code", 0)
+        if run_exit:
+            return "Run failed (exit %d)" % run_exit
         return _BUCKET_INVOCATION_LABELS[_BUCKET_FAILED_TO_BUILD]
 
     for group in _BUCKET_PRIORITY_GROUPS:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results_test.axl
@@ -735,6 +735,33 @@ def _test_failed_status_without_failure_bucket(ctx):
         "Failed to build",
     )
 
+def _test_run_exit_is_not_a_build_failure(ctx):
+    """`aspect run` builds a target and then executes it. A program that exits
+    non-zero after a clean build leaves no failure bucket, so without the run
+    marker the state falls through to "Failed to build" — reporting a build
+    failure for a build that worked."""
+    data = _make_unaffected_targets_built()
+    data["run"] = {"exit_code": 42}
+    _eq(
+        "compute_invocation_state — non-zero run exit is a run failure",
+        compute_invocation_state(data, "failed"),
+        "Run failed (exit 42)",
+    )
+    _eq(
+        "conclusion — non-zero run exit is a run failure",
+        conclusion("failed", data),
+        "Run failed (exit 42)",
+    )
+
+    # A clean run must not be mistaken for one.
+    zero = _make_unaffected_targets_built()
+    zero["run"] = {"exit_code": 0}
+    _eq(
+        "compute_invocation_state — run exit 0 keeps the build verdict",
+        compute_invocation_state(zero, "failed"),
+        "Failed to build",
+    )
+
 def _test_failed_status_with_explicit_action_failure(ctx):
     _eq(
         "compute_invocation_state — failed with failed_action",
@@ -1420,6 +1447,7 @@ _UNIT_TESTS = [
     _test_build_started_preserves_bazel_streamed,
     _test_render_bes_url,
     _test_failed_status_without_failure_bucket,
+    _test_run_exit_is_not_a_build_failure,
     _test_failed_status_with_explicit_action_failure,
     _test_passed_status_returns_successful_build,
     _test_aborted_short_circuits,

--- a/crates/aspect-cli/src/builtins/aspect/run.axl
+++ b/crates/aspect-cli/src/builtins/aspect/run.axl
@@ -127,6 +127,11 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     code = r.spawn(entrypoint, forward_args, cwd = spawn_cwd).wait().code
     if code == 0:
         return _conclude("passed", code, "Ran %s" % target)
+
+    # The build succeeded and the program failed. Record that so the renderer
+    # reports a run failure rather than falling back to "Failed to build",
+    # which is what a failed status with no failure buckets otherwise means.
+    data["run"] = {"exit_code": code}
     return _conclude("failed", code, "%s exited %d" % (target, code))
 
 run = task(


### PR DESCRIPTION
Two follow-ups on the status-surface work, both cases where a terminal update is dispatched but then misreported or lost.

### A failed `aspect run` reported as a failed build

Addresses the review comment on #1409, which landed before it was resolved.

`run` concludes with `kind = "bazel_results"`, and `compute_invocation_state` maps a failed status with **no failure buckets** to `"Failed to build"`. A target that builds cleanly and then exits non-zero has no failure bucket, so every surface claimed the build failed when it had succeeded and only the program failed:

```
❌ run-foo [run] · Failed to build        ← the build was fine; the binary exited 3
```

`run` now records the runtime exit code and the renderer reports it as what it is:

```
❌ run-foo [run] · Run failed (exit 3)
```

A run that exits 0 is untouched, and a genuine build failure still reads `"Failed to build"` — both are asserted.

### A dropped terminal contribution logged at trace level

The second silent path out of `_publish`. A contribution that never reaches the status-comment API was traced, which is invisible in a normal CI log:

```python
_LOG.trace("status-comment API unavailable (%s); using comment-state fallback" % …)
```

Mid-run that is unremarkable — the next tick retries. On the **terminal** update there is no next tick: if the comment-state fallback cannot post either, the entry keeps whatever a previous post captured and reports a finished task as still running for as long as the comment lives. It warns now, naming the task and the error, and mirrors `denied_terminal_post_warning` from #1408 so both ways a terminal publish can vanish are visible.

This matters for the `build-axl-smoke` rows still stuck in the PR comment: `aspect build` *does* dispatch its terminal update (the piped form exits 2, which comes from `TaskConclusion`), so the loss is inside `_publish` — and until now both remaining exits there said nothing. With #1410 capturing the output, the next run should name which one.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: n/a
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- A target run by `aspect run` that builds successfully and then exits non-zero is now reported as a run failure rather than a build failure.
- The CLI warns when a task's final status cannot be contributed to the status-comment API, instead of failing silently.

### Test plan

- New test cases added — `_test_run_exit_is_not_a_build_failure` in the `bazel-results` suite covers a non-zero run exit, and that exit 0 and a genuine build failure are unaffected; the AXL suite covers the new warning's text with and without an error string.
- Mutation-tested — reverting the renderer branch fails the bazel-results assertion.
- `aspect tests axl` (968), all 44 `dev test-*` suites, and `buildifier` pass. `aspect run` re-checked end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
