### PR TITLE
ci: stop the smoke checks from posting PR-comment rows

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -562,10 +562,16 @@ jobs:
           )
           # These four smoke checks assert CLI behavior, not status reporting, so
           # the job's own status is the signal — same reasoning as the delivery
-          # digest jobs.
+          # digest jobs. Reporting anything is actively misleading here: two of
+          # them pass Bazel a flag it must reject, so the PR comment carried two
+          # red rows for a passing PR.
+          no_status=(
+            --github-status-checks:enabled=false
+            --github-status-comments:enabled=false
+          )
           echo "--- aspect run smoke (//examples/deliverable)"
-          "$LAUNCHER" run --github-status-checks:enabled=false //examples/deliverable:py_deliverable
-          "$LAUNCHER" run --github-status-checks:enabled=false //examples/deliverable:sh_deliverable -- forwarded-arg
+          "$LAUNCHER" run "${no_status[@]}" //examples/deliverable:py_deliverable
+          "$LAUNCHER" run "${no_status[@]}" //examples/deliverable:sh_deliverable -- forwarded-arg
           echo "--- aspect help"
           "$LAUNCHER" help
           echo "--- aspect-launcher --version"
@@ -603,7 +609,7 @@ jobs:
           assert_rejects_flag() {
             local label="$1"; shift
             local out code
-            out="$(timeout 180 "$LAUNCHER" build --github-status-checks:enabled=false "$@" //... 2>&1)" && code=0 || code=$?
+            out="$(timeout 180 "$LAUNCHER" build "${no_status[@]}" "$@" //... 2>&1)" && code=0 || code=$?
             echo "$out"
             if [ "$code" -eq 124 ]; then
               echo "ERROR: $label hung until the 180s timeout instead of failing"; exit 1


### PR DESCRIPTION
#1406 stopped the `axl-smoke` invocations creating check runs. They still contributed a row each to the PR summary comment, and two of them pass Bazel a flag it must reject — so a passing PR carried two red rows:

```
❌ build-axl-smoke   [build] · failed in build · Bazel build failed · 1m
❌ build-axl-smoke-2 [build] · failed in build · Bazel build failed · 1m 6s
```

Those are the assertions *succeeding* — the task is supposed to fail — but nothing about that belongs in a summary of the run, and a red row on a green PR is exactly the kind of thing people learn to ignore.

Adds `--github-status-comments:enabled=false` alongside the existing checks flag, on the same reasoning: these four assert CLI behavior, not status reporting, and the job's own status is the signal.

The flag pair is now a `no_status` array rather than a third copy-paste of the literals.

Only the smoke assertions are affected. `axl-smoke-gha-bootstrap` still reports normally — it is a real build of the launcher and belongs in the comment.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing: confirmed both features expose `:enabled`, that the two flags are accepted together on `aspect run` and `aspect build`, and that the flag-rejection assertion still matches with them applied (`code=2`, `Unrecognized option` found).
- Verified the `no_status` array is in scope inside `assert_rejects_flag`, which is defined later in the same step.
- CI on this PR is the real test — its own summary comment should show neither `build-axl-smoke` row nor the two `run-axl-smoke` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
