### PR TITLE
fix(cli): let a template preset cover a subset of the status surfaces

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3778,6 +3778,46 @@ def test_template_presets(tc: int) -> int:
         ) == [],
         "a preset covering only the comment surfaces is valid",
     )
+
+    # A subset is fine; a slot no renderer reads is not. Without this a typo
+    # leaves the preset selectable and silently inert.
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(
+            {"a": TemplatePreset(name = "a", description = "d", templates = {"summray": "S"})},
+            "a",
+        )) == 1,
+        "a misspelled top-level slot is an error",
+    )
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(
+            {"a": TemplatePreset(name = "a", description = "d", templates = {"lint": {"body": "B"}})},
+            "a",
+        )) == 1,
+        "\"body\" inside a per-kind block is an error — a comment covers every task",
+    )
+    tc = test_case(
+        tc,
+        len(template_presets.validation_errors(
+            {"a": TemplatePreset(name = "a", description = "d", templates = {"lint": {"summray": "S"}})},
+            "a",
+        )) == 1,
+        "a misspelled slot inside a per-kind block is an error",
+    )
+    for slot in ("title", "summary", "details"):
+        tc = test_case(
+            tc,
+            template_presets.validation_errors(
+                {"a": TemplatePreset(
+                    name = "a",
+                    description = "d",
+                    templates = {slot: "S", "lint": {slot: "S"}},
+                )},
+                "a",
+            ) == [],
+            "%r is a valid slot flat and per-kind" % slot,
+        )
     tc = test_case(
         tc,
         len(template_presets.validation_errors(

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -3758,13 +3758,25 @@ def test_template_presets(tc: int) -> int:
         )) == 1,
         "an empty template is an error: it would yield the built-in it meant to replace",
     )
+
+    # A preset may target a subset of the surfaces: `template_preset` is a
+    # per-feature arg, so a check-surfaces-only preset is a normal thing to
+    # write, and a comment feature selecting it just keeps the built-in body.
     tc = test_case(
         tc,
-        len(template_presets.validation_errors(
+        template_presets.validation_errors(
             {"a": TemplatePreset(name = "a", description = "d", templates = {"summary": "S"})},
             "a",
-        )) == 1,
-        "overriding check surfaces without \"body\" is an error",
+        ) == [],
+        "a preset covering only the check surfaces is valid",
+    )
+    tc = test_case(
+        tc,
+        template_presets.validation_errors(
+            {"a": TemplatePreset(name = "a", description = "d", templates = {"body": "B"})},
+            "a",
+        ) == [],
+        "a preset covering only the comment surfaces is valid",
     )
     tc = test_case(
         tc,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/check_dispatch.axl
@@ -127,8 +127,18 @@ def kind_for_task(task_kind):
     return _TASK_KIND_DEFAULTS.get(task_kind, "bazel_results")
 
 # Task-kind keys a `templates` dict may nest an override under, as opposed to
-# the flat "title"/"summary"/"details" keys that address every kind at once.
+# the flat slot keys that address every kind at once.
 TEMPLATE_SCOPE_KEYS = sorted(_TASK_KIND_DEFAULTS.keys())
+
+# Slots the per-kind renderers consume. Valid as a flat key or inside a
+# per-kind block; anything else in a `templates` dict is inert.
+RENDERER_TEMPLATE_SLOTS = ["details", "summary", "title"]
+
+# The PR/MR summary comment's only slot, owned by the comment features. Listed
+# here so preset validation can see the whole slot vocabulary in one place — a
+# lib cannot import a feature. Never scopeable per task kind: one comment
+# aggregates every sibling task, so there is no single kind to scope it to.
+COMMENT_TEMPLATE_SLOT = "body"
 
 def _layer_overrides(layer, task_kind, label):
     """One layer's flat keys, overlaid with its `task_kind` block."""

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
@@ -25,9 +25,12 @@ To add a preset, register a `TemplatePreset` in `_PRESETS`. The rules
 
   - A per-kind block must name a real task kind, or it silently never applies.
 
-  - A preset that overrides anything must also override `"body"`. Without it
-    the check surfaces take the preset's layout while the PR/MR comments keep
-    the built-in, which reads worse than either layout on its own.
+A preset may cover any subset of the surfaces. `template_preset` is a
+per-feature arg, so a config selects presets surface by surface — a preset that
+only defines check-surface slots is a normal thing to write, and applying it to
+a comment feature simply leaves `body` on the built-in. Slots a preset does not
+define always fall through, which is the same rule that makes the empty `full`
+preset render exactly today's output.
 
 Author a preset's templates as new strings, never by extracting fragments out
 of the built-in template constants — live configs `.replace()` against those
@@ -88,10 +91,6 @@ def _preset_errors(name: str, preset: TemplatePreset) -> list[str]:
         else:
             errors.extend(_slot_errors(name, key, value))
 
-    if preset.templates and "body" not in preset.templates:
-        errors.append(("preset {!r} overrides check-surface templates but not \"body\", so PR and MR " +
-                       "comments would keep the built-in layout while check runs and annotations " +
-                       "change").format(name))
     return errors
 
 def _validation_errors(presets: dict, default: str) -> list[str]:

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/template_presets.axl
@@ -23,7 +23,9 @@ To add a preset, register a `TemplatePreset` in `_PRESETS`. The rules
     render falls back to the built-in layout because GitHub requires a
     check-run title.
 
-  - A per-kind block must name a real task kind, or it silently never applies.
+  - A per-kind block must name a real task kind, and every slot must be one a
+    renderer actually consumes. A misspelled slot is inert: it would leave the
+    preset selectable while changing nothing.
 
 A preset may cover any subset of the surfaces. `template_preset` is a
 per-feature arg, so a config selects presets surface by surface — a preset that
@@ -37,7 +39,7 @@ of the built-in template constants — live configs `.replace()` against those
 behind their own load-time drift guards.
 """
 
-load("./check_dispatch.axl", "TEMPLATE_SCOPE_KEYS")
+load("./check_dispatch.axl", "COMMENT_TEMPLATE_SLOT", "RENDERER_TEMPLATE_SLOTS", "TEMPLATE_SCOPE_KEYS")
 
 TemplatePreset = record(
     name = field(str),
@@ -66,6 +68,49 @@ def _slot_errors(preset_name: str, slot: str, template) -> list[str]:
                  "Use a comment-only template such as `{{# blank #}}`.").format(preset_name, slot)]
     return []
 
+# Every slot a preset may set at the top level: the renderer slots plus the
+# comment body.
+_TOP_LEVEL_SLOTS = RENDERER_TEMPLATE_SLOTS + [COMMENT_TEMPLATE_SLOT]
+
+def _scope_block_errors(preset_name: str, kind: str, block) -> list[str]:
+    """Errors in one per-kind block, `{"lint": {"summary": ...}}`.
+
+    `body` is deliberately not a valid slot here: one comment aggregates every
+    sibling task, so there is no single kind to scope it to.
+    """
+    if type(block) != "dict":
+        return [("preset {!r}: {!r} is a task kind, so it must map to a dict of slot overrides, " +
+                 "got {!r}").format(preset_name, kind, block)]
+
+    errors = []
+    for slot in sorted(block.keys()):
+        if slot not in RENDERER_TEMPLATE_SLOTS:
+            errors.append("preset {!r}: {!r} is not a slot of the {!r} block; expected one of {}".format(
+                preset_name,
+                slot,
+                kind,
+                ", ".join(RENDERER_TEMPLATE_SLOTS),
+            ))
+            continue
+        errors.extend(_slot_errors(preset_name, "%s.%s" % (kind, slot), block[slot]))
+    return errors
+
+def _top_level_errors(preset_name: str, key: str, value) -> list[str]:
+    """Errors for a top-level entry that is not a per-kind block."""
+    if type(value) == "dict":
+        return ["preset {!r}: {!r} is not a task kind; expected one of {}".format(
+            preset_name,
+            key,
+            ", ".join(TEMPLATE_SCOPE_KEYS),
+        )]
+    if key not in _TOP_LEVEL_SLOTS:
+        return ["preset {!r}: {!r} is not a template slot; expected one of {}".format(
+            preset_name,
+            key,
+            ", ".join(_TOP_LEVEL_SLOTS),
+        )]
+    return _slot_errors(preset_name, key, value)
+
 def _preset_errors(name: str, preset: TemplatePreset) -> list[str]:
     errors = []
     if name != preset.name:
@@ -76,21 +121,9 @@ def _preset_errors(name: str, preset: TemplatePreset) -> list[str]:
     for key in sorted(preset.templates.keys()):
         value = preset.templates[key]
         if key in TEMPLATE_SCOPE_KEYS:
-            if type(value) != "dict":
-                errors.append(("preset {!r}: {!r} is a task kind, so it must map to a dict of slot " +
-                               "overrides, got {!r}").format(name, key, value))
-                continue
-            for slot in sorted(value.keys()):
-                errors.extend(_slot_errors(name, "%s.%s" % (key, slot), value[slot]))
-        elif type(value) == "dict":
-            errors.append("preset {!r}: {!r} is not a task kind; expected one of {}".format(
-                name,
-                key,
-                ", ".join(TEMPLATE_SCOPE_KEYS),
-            ))
+            errors.extend(_scope_block_errors(name, key, value))
         else:
-            errors.extend(_slot_errors(name, key, value))
-
+            errors.extend(_top_level_errors(name, key, value))
     return errors
 
 def _validation_errors(presets: dict, default: str) -> list[str]:


### PR DESCRIPTION
A template preset may now cover a subset of the status surfaces, and its slot names are validated.

### The subset rule

The registry rejected any preset that set a template without also setting `"body"` — a guard from #1404 meant to stop a preset changing check runs while leaving PR/MR comments on the built-in layout.

It was the wrong rule. `template_preset` is a *per-feature* arg, so a config selects presets surface by surface:

```python
ctx.features[GithubStatusChecks].args.template_preset = "compact"
ctx.features[GithubStatusComments].args.template_preset = "full"
```

A preset covering only the check surfaces is therefore a normal thing to write, and the guard made it impossible to register one without inventing a comment body for it. Which surfaces a preset reaches is the config's decision at selection time — the registry cannot know which features will select it.

Slots a preset does not define fall through to the built-in, the same mechanism that makes the empty `full` preset render today's output byte-for-byte.

### What this means for selecting presets

`template_preset` is a per-feature arg, so presets are chosen surface by surface:

```python title=".aspect/config.axl"
ctx.features[GithubStatusChecks].args.template_preset = "compact"
ctx.features[BuildkiteAnnotations].args.template_preset = "compact"
ctx.features[GithubStatusComments].args.template_preset = "full"
```

or per invocation:

```bash
aspect build //... --github-status-checks:template-preset=compact
```

That much already worked. What changes is which presets can exist to be selected.

**Before**, any preset defining a template had to define `body` as well, so every preset necessarily restyled the PR/MR comment. A preset that only restyles check runs could not be registered at all.

**Now** a preset may cover whichever surfaces it is about. Selecting one on a surface it does not cover leaves that surface on the built-in:

| Preset defines | `GithubStatusChecks` | `GithubStatusComments` |
|---|---|---|
| `summary`, `details` | preset's layout | built-in |
| `body` | built-in | preset's layout |
| both | preset's layout | preset's layout |

So a preset is free to be surface-specific, and `args.templates` still overrides individual slots on top of whatever it supplies.

### Slot names

Removing that guard left nothing checking slot *names*, so a preset made only of typos would validate clean, appear in `--help` as selectable, and silently render the built-ins. Every slot is now checked against what the renderers actually read:

| Position | Valid slots |
|---|---|
| Top level | `title`, `summary`, `details`, `body` |
| Inside a per-kind block | `title`, `summary`, `details` |

`body` is rejected inside a per-kind block: one comment aggregates every sibling task, so there is no single kind to scope it to.

That vocabulary had no canonical home — the names were string literals spread across the renderers. It now sits beside `TEMPLATE_SCOPE_KEYS` in `check_dispatch`, which already owns the flat-versus-scoped contract.

---

### Changes are visible to end-users: no

Presets are not in a release yet (`v2026.35.9` predates #1404), so no shipped behavior changes. This corrects the constraints before anyone writes a preset against them.

### Test plan

- New test cases — check-surfaces-only and comment-surfaces-only presets are valid; a misspelled slot is rejected at the top level and inside a per-kind block; `body` inside a per-kind block is rejected; each of `title`/`summary`/`details` is accepted both flat and per-kind.
- Mutation-tested — removing either slot check fails its assertions.
- `aspect tests axl` (975) and all 44 `dev test-*` suites pass; template snapshot output is byte-identical to `main`; repo-wide `buildifier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

