### PR TITLE
feat(cli): short status text for surfaces that name the task

### DIFF
--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -26,7 +26,7 @@ load(
 )
 load("@aspect//private/lib/github.axl", "detect_commit_sha", "github")
 load("@aspect//private/lib/gitlab_token_cache.axl", "gitlab_token_cache")
-load("@aspect//private/lib/lifecycle.axl", "ReproFixCommand")
+load("@aspect//private/lib/lifecycle.axl", "ReproFixCommand", "phases")
 load("@aspect//private/lib/log_snippet.axl", "SnippetOptions", "code_fence_for", "extract_junit_failure", "extract_snippet")
 load("@aspect//private/lib/path_glob.axl", "match_any", "match_path")
 load("@aspect//private/lib/prompt.axl", "prompt_choice")
@@ -3928,6 +3928,30 @@ def test_denied_terminal_post_warning(tc: int) -> int:
     tc = test_case(tc, without.endswith("posts later"), "the message ends cleanly with no holder")
     return tc
 
+def test_terminal_progress(tc: int) -> int:
+    """`ProgressStyles.short` drops the leading noun for surfaces that print
+    the task label beside the text — a PR-comment row reads
+    `**lint-gha** [lint] · complete (clean)`, not `… · Lint complete (clean)`.
+    Both forms come from one composer so they cannot describe different
+    outcomes."""
+    p = phases.terminal_progress("Lint", "complete", "clean")
+    tc = test_case(tc, p.body == "Lint complete (clean)", "body keeps the noun")
+    tc = test_case(tc, p.short == "complete (clean)", "short drops the noun")
+
+    bare = phases.terminal_progress("Gazelle", "aborted")
+    tc = test_case(tc, bare.body == "Gazelle aborted", "body with no detail")
+    tc = test_case(tc, bare.short == "aborted", "short with no detail")
+
+    # The detail is the part worth keeping; it must survive into both.
+    detailed = phases.terminal_progress("Bazel test", "complete", "28/28 passed · 27 cached")
+    tc = test_case(tc, "28/28 passed · 27 cached" in detailed.body, "body keeps the detail")
+    tc = test_case(tc, "28/28 passed · 27 cached" in detailed.short, "short keeps the detail")
+    tc = test_case(tc, not detailed.short.startswith("Bazel"), "short has no command lead")
+
+    # Unset is the documented fallback: surfaces read `body`.
+    tc = test_case(tc, phases.ProgressStyles(body = "x").short == "", "short defaults to empty")
+    return tc
+
 def impl(ctx: TaskContext) -> int:
     tc = 0
 
@@ -4018,6 +4042,7 @@ def impl(ctx: TaskContext) -> int:
     tc = test_gitlab_token_cache(ctx, tc, temp_dir)
     tc = test_prompt_choice(tc)
     tc = test_template_presets(tc)
+    tc = test_terminal_progress(tc)
     tc = test_denied_terminal_post_warning(tc)
 
     print(tc, "tests passed")

--- a/.aspect/axl.axl
+++ b/.aspect/axl.axl
@@ -10,7 +10,7 @@ load(
     "version_tuple",
 )
 load("@aspect//delivery.axl", delivery_UncacheableAction = "UncacheableAction", delivery_collect_blocking_culprits = "collect_blocking_culprits", delivery_count_unexplained_unresolved = "count_unexplained_unresolved", delivery_fmt_elapsed = "fmt_elapsed", delivery_should_surface_phase2_stderr = "should_surface_phase2_stderr", delivery_should_upload_grpc_log = "should_upload_grpc_log")
-load("@aspect//feature/github_status_comments.axl", "denied_terminal_post_warning", "dropped_terminal_contribute_warning")
+load("@aspect//feature/github_status_comments.axl", "denied_terminal_post_warning", "dropped_terminal_contribute_warning", "result_cell_text", "results_subset")
 load("@aspect//lint.axl", "filter_all", "filter_changeset", "linter_error_message", "parse_patch_hunks")
 load("@aspect//private/lib/artifacts.axl", "artifact_name", "build_log_header", "build_log_relpath", "collect_build_action_logs", "dedup_path", "testlog_dest_dir")
 load("@aspect//private/lib/bazel_results.axl", "bb_clientd_root", "compute_reproducer_command", "file_uri_to_path", "init_data", "render_check_output", "resolve_aspect_url", "summary_title")
@@ -3952,6 +3952,89 @@ def test_terminal_progress(tc: int) -> int:
     tc = test_case(tc, phases.ProgressStyles(body = "x").short == "", "short defaults to empty")
     return tc
 
+def test_result_cell_text(tc: int) -> int:
+    """The comment row prefers `short`, but a failure in a phase that is not the
+    task's own kind still says which phase — the short text names the outcome,
+    not where it happened."""
+
+    def entry(**kw):
+        base = {"status": "failed", "kind": "gazelle", "progress": {"body": "B", "short": "failed (3 out of date)"}}
+        base.update(kw)
+        return base
+
+    tc = test_case(
+        tc,
+        result_cell_text(entry(failed_in_phase = "diff")) == "failed in diff · failed (3 out of date)",
+        "a phase unlike the task kind is kept",
+    )
+    tc = test_case(
+        tc,
+        result_cell_text(entry(failed_in_phase = "gazelle")) == "failed (3 out of date)",
+        "a phase equal to the task kind is dropped — the row already prints it",
+    )
+    tc = test_case(
+        tc,
+        result_cell_text(entry(failed_in_phase = "")) == "failed (3 out of date)",
+        "no phase recorded leaves the short text alone",
+    )
+    tc = test_case(
+        tc,
+        result_cell_text(entry(status = "passed", failed_in_phase = "diff")) == "failed (3 out of date)",
+        "a non-failed status never gets a phase prefix",
+    )
+
+    # Without `short`, the long-form composition is unchanged.
+    tc = test_case(
+        tc,
+        result_cell_text({
+            "status": "failed",
+            "kind": "gazelle",
+            "failed_in_phase": "diff",
+            "progress": {"body": "Gazelle failed (3 out of date)"},
+        }) ==
+        "failed in diff · Gazelle failed (3 out of date)",
+        "the long form still composes the phase prefix",
+    )
+    return tc
+
+def test_results_subset_carries_progress(tc: int) -> int:
+    """`results_subset` is how both the GitHub and GitLab comment features turn
+    an update into an entry. It must carry the whole `ProgressStyles` through —
+    the GitLab path passed `None` here for its entire life, so MR rows rendered
+    no producer text at all."""
+    styles = phases.terminal_progress("Lint", "complete", "clean")
+    subset = results_subset(
+        {},
+        1000,
+        aspect_url = "",
+        bes_url = "",
+        check_run_url = "",
+        current_phase = "",
+        current_phase_elapsed_ms = 0,
+        progress_styles = styles,
+        failed_in_phase = "",
+        start_time_ms = 0,
+    )
+    pg = subset.get("progress") or {}
+    tc = test_case(tc, pg.get("body") == "Lint complete (clean)", "the long form survives into the entry")
+    tc = test_case(tc, pg.get("short") == "complete (clean)", "the short form survives into the entry")
+
+    # `None` is legitimate for callers with no styles yet; it must not crash.
+    empty = results_subset(
+        {},
+        0,
+        aspect_url = "",
+        bes_url = "",
+        check_run_url = "",
+        current_phase = "",
+        current_phase_elapsed_ms = 0,
+        progress_styles = None,
+        failed_in_phase = "",
+        start_time_ms = 0,
+    )
+    tc = test_case(tc, (empty.get("progress") or {}).get("short") == "", "no styles yields an empty short")
+    return tc
+
 def impl(ctx: TaskContext) -> int:
     tc = 0
 
@@ -4043,6 +4126,8 @@ def impl(ctx: TaskContext) -> int:
     tc = test_prompt_choice(tc)
     tc = test_template_presets(tc)
     tc = test_terminal_progress(tc)
+    tc = test_result_cell_text(tc)
+    tc = test_results_subset_carries_progress(tc)
     tc = test_denied_terminal_post_warning(tc)
 
     print(tc, "tests passed")

--- a/crates/aspect-cli/src/builtins/aspect/delivery.axl
+++ b/crates/aspect-cli/src/builtins/aspect/delivery.axl
@@ -898,17 +898,18 @@ def _compact_text(status, data):
             if total > 0:
                 return "%d/%d delivered" % (done, total)
             return "%d delivered" % done
-    return ""
+    return phases.ProgressStyles()
 
-def _body_text(status, data):
-    """Narrative-form `progress.body` for the PR-comment 💬 line."""
+def _progress(status, data):
+    """Terminal `ProgressStyles` — long form for standalone surfaces, short
+    form for rows that already name the task."""
     compact = _compact_text(status, data)
     if status == "passed" or status == "warning":
-        return "Delivery complete" + ((" (" + compact + ")") if compact else "")
+        return phases.terminal_progress("Delivery", "complete", compact)
     if status == "failed":
-        return "Delivery failed" + ((" (" + compact + ")") if compact else "")
+        return phases.terminal_progress("Delivery", "failed", compact)
     if status == "aborted":
-        return "Delivery aborted"
+        return phases.terminal_progress("Delivery", "aborted")
     return ""
 
 def _fire_target_hook(data, delivery_trait, run_tracker, label):
@@ -1008,9 +1009,7 @@ def _emit_final(ph, exit_code):
         final = True,
         conclusion = bookend,
         data = data,
-        progress = phases.ProgressStyles(
-            body = _body_text(final_status, data),
-        ),
+        progress = _progress(final_status, data),
     ))
     print_repro_and_fix(ctx.std, data, final_status)
 

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -357,7 +357,11 @@ def denied_terminal_post_warning(task_name, post_grant_run):
             "it will only appear if another job posts later%s") % (task_name, held)
 
 def _result_cell_text(entry):
-    """Compose the row's result text from the producer's `progress.body`.
+    """Compose the row's result text.
+
+    A producer may supply `progress.short` for surfaces that name the task
+    beside the text; it is used verbatim. Otherwise the text is composed from
+    `progress.body`.
 
     Layout per status:
       aborted                       — `aborted (reason)?`
@@ -374,6 +378,14 @@ def _result_cell_text(entry):
             text = text + " (%s)" % entry["abort_reason"]
         return text
     pg = entry.get("progress", {}) or {}
+
+    # A producer that supplies `short` has written the row's whole text: it
+    # already knows the outcome and the phase, so composing a `failed in …`
+    # prefix around it would put back the duplication it exists to remove.
+    short = pg.get("short", "")
+    if short:
+        return short
+
     body = pg.get("body", "")
 
     parts = []
@@ -617,12 +629,13 @@ def _ci_identity(env, marker):
 
 def _progress_dict(progress_styles):
     """Serialize a ProgressStyles record to a dict surviving the contribution
-    JSON round-trip (entry["progress"]["body"/"stream"])."""
+    JSON round-trip (entry["progress"]["body"/"stream"/"short"])."""
     if progress_styles == None:
-        return {"body": "", "stream": ""}
+        return {"body": "", "stream": "", "short": ""}
     return {
         "body": progress_styles.body or "",
         "stream": progress_styles.stream or "",
+        "short": progress_styles.short or "",
     }
 
 def _results_subset(

--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -356,12 +356,29 @@ def denied_terminal_post_warning(task_name, post_grant_run):
     return ("Terminal status for %s was contributed but the server withheld the comment post; " +
             "it will only appear if another job posts later%s") % (task_name, held)
 
+def _with_failed_phase(entry, text):
+    """Prefix `failed in <phase>` when the phase adds something.
+
+    A producer's short text names the outcome but not where it happened, and
+    the phase is often a step of its own — gazelle's `diff`, lint's `filter`.
+    Dropped only when the phase is the task's own kind, which the row already
+    prints beside the text. The long-form path below keeps the prefix
+    unconditionally: its surfaces render the text on its own, with no task
+    label next to it to make the phase redundant.
+    """
+    if entry.get("status", "") != "failed":
+        return text
+    phase = entry.get("failed_in_phase", "")
+    if not phase or phase == entry.get("kind", ""):
+        return text
+    return "failed in %s · %s" % (phase, text)
+
 def _result_cell_text(entry):
     """Compose the row's result text.
 
     A producer may supply `progress.short` for surfaces that name the task
-    beside the text; it is used verbatim. Otherwise the text is composed from
-    `progress.body`.
+    beside the text; it is used as-is apart from the failed-phase prefix (see
+    `_with_failed_phase`). Otherwise the text is composed from `progress.body`.
 
     Layout per status:
       aborted                       — `aborted (reason)?`
@@ -379,12 +396,9 @@ def _result_cell_text(entry):
         return text
     pg = entry.get("progress", {}) or {}
 
-    # A producer that supplies `short` has written the row's whole text: it
-    # already knows the outcome and the phase, so composing a `failed in …`
-    # prefix around it would put back the duplication it exists to remove.
     short = pg.get("short", "")
     if short:
-        return short
+        return _with_failed_phase(entry, short)
 
     body = pg.get("body", "")
 
@@ -1931,6 +1945,10 @@ def _github_status_comments(ctx: FeatureContext):
 def prepare_for_render(entries):
     """Public test hook; see `_prepare_for_render`."""
     return _prepare_for_render(entries)
+
+def result_cell_text(entry):
+    """Public test hook; see `_result_cell_text`."""
+    return _result_cell_text(entry)
 
 def rehydrate_entries(entries):
     """Rehydrate API/state-block entries' command lists in place; see

--- a/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/gitlab_status_comments.axl
@@ -479,7 +479,7 @@ def _gitlab_status_comments(ctx: FeatureContext):
             check_run_url = "",
             current_phase = (update.progress.body or _state.get("_current_phase", "")),
             current_phase_elapsed_ms = 0,
-            progress_styles = update.progress.styles if hasattr(update.progress, "styles") else None,
+            progress_styles = update.progress,
             failed_in_phase = _state.get("_failed_in_phase", ""),
             start_time_ms = _state.get("_task_started_at_ms", 0),
         )

--- a/crates/aspect-cli/src/builtins/aspect/format.axl
+++ b/crates/aspect-cli/src/builtins/aspect/format.axl
@@ -112,18 +112,18 @@ def _compact_text(status, data):
         if n > 0:
             return "%d file%s differ%s" % (n, "s" if n != 1 else "", "" if n != 1 else "s")
         return ""
-    return ""
+    return phases.ProgressStyles()
 
-def _body_text(status, data):
+def _progress(status, data):
     """Narrative-form `progress.body` for the PR-comment 💬 line.
     Wraps `_compact_text` with a status-specific verb prefix."""
     compact = _compact_text(status, data)
     if status == "passed" or status == "warning":
-        return "Format complete" + ((" (" + compact + ")") if compact else "")
+        return phases.terminal_progress("Format", "complete", compact)
     if status == "failed":
-        return "Format failed" + ((" (" + compact + ")") if compact else "")
+        return phases.terminal_progress("Format", "failed", compact)
     if status == "aborted":
-        return "Format aborted"
+        return phases.terminal_progress("Format", "aborted")
     return ""
 
 # Above this many files, the producer truncates the positional list and adds a
@@ -273,9 +273,7 @@ def _emit_final(ph, exit_code):
         final = True,
         conclusion = bookend,
         data = data,
-        progress = phases.ProgressStyles(
-            body = _body_text(status, data),
-        ),
+        progress = _progress(status, data),
     ))
     print_repro_and_fix(ctx.std, data, status)
 

--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -136,17 +136,18 @@ def _compact_text(status, data):
         if n > 0:
             return "%d update%s pending" % (n, "s" if n != 1 else "")
         return ""
-    return ""
+    return phases.ProgressStyles()
 
-def _body_text(status, data):
-    """Narrative-form `progress.body` for the PR-comment 💬 line."""
+def _progress(status, data):
+    """Terminal `ProgressStyles` — long form for standalone surfaces, short
+    form for rows that already name the task."""
     compact = _compact_text(status, data)
     if status == "passed" or status == "warning":
-        return "Gazelle complete" + ((" (" + compact + ")") if compact else "")
+        return phases.terminal_progress("Gazelle", "complete", compact)
     if status == "failed":
-        return "Gazelle failed" + ((" (" + compact + ")") if compact else "")
+        return phases.terminal_progress("Gazelle", "failed", compact)
     if status == "aborted":
-        return "Gazelle aborted"
+        return phases.terminal_progress("Gazelle", "aborted")
     return ""
 
 # Above this many dirs, the producer truncates the positional list and adds a
@@ -406,9 +407,7 @@ def _emit_final(ph, exit_code):
         final = True,
         conclusion = bookend,
         data = data,
-        progress = phases.ProgressStyles(
-            body = _body_text(status, data),
-        ),
+        progress = _progress(status, data),
     ))
     print_repro_and_fix(ctx.std, data, status)
 

--- a/crates/aspect-cli/src/builtins/aspect/lint.axl
+++ b/crates/aspect-cli/src/builtins/aspect/lint.axl
@@ -551,7 +551,7 @@ def _compact_text(status, data):
     bits = _sev_bits(e, w, i)
     if bits:
         return " · ".join(bits)
-    return ""
+    return phases.ProgressStyles()
 
 def _sev_bits(e, w, i):
     """Per-severity count bits in display order (error → warning → info), skipping zeros."""
@@ -564,19 +564,19 @@ def _sev_bits(e, w, i):
         bits.append("%d info" % i)
     return bits
 
-def _body_text(status, data):
+def _progress(status, data):
     """Narrative `progress.body` for the PR-comment 💬 line — wraps `_compact_text`
     with a status verb prefix (e.g. `Lint failed · 3 errors`). Terminal emits only.
     """
     compact = _compact_text(status, data)
     if status == "passed":
-        return "Lint complete" + ((" (" + compact + ")") if compact else "")
+        return phases.terminal_progress("Lint", "complete", compact)
     if status == "warning":
-        return "Lint complete" + ((" (" + compact + ")") if compact else "")
+        return phases.terminal_progress("Lint", "complete", compact)
     if status == "failed":
-        return "Lint failed" + ((" (" + compact + ")") if compact else "")
+        return phases.terminal_progress("Lint", "failed", compact)
     if status == "aborted":
-        return "Lint aborted"
+        return phases.terminal_progress("Lint", "aborted")
     return ""
 
 def _read_lint_file(ctx, filepath, timeout_ms = _LINT_FILE_PROBE_TIMEOUT_MS, expected_len = -1):
@@ -1172,9 +1172,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
         final = True,
         conclusion = bookend,
         data = data,
-        progress = phases.ProgressStyles(
-            body = _body_text(final_status, data),
-        ),
+        progress = _progress(final_status, data),
     ))
     print_repro_and_fix(ctx.std, data, final_status)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -72,6 +72,7 @@ load(
 )
 load("../lib/bazel_results.axl", "compute_reproducer_command")
 load("../lib/github.axl", "github")
+load("../lib/lifecycle.axl", "phases")
 load("../lib/repro_commands.axl", "rehydrate_commands")
 load("../lib/tips.axl", "tips")
 
@@ -116,48 +117,53 @@ def _with_commands(data, repro = [], fix = []):
     )
     return out
 
-def _body_for(kind, status, data):
-    """Mirror the producer's `progress.body` narrative form.
+# Live-phase narrative per kind. Bazel's is built from the command name; the
+# rest are fixed phrases their producers emit while running.
+_RUNNING_BODY = {
+    "lint": "Linting...",
+    "format": "Formatting...",
+    "gazelle": "Running gazelle...",
+    "delivery": "Delivering...",
+}
 
-    Running emits ship the live phase narrative (`Bazel test running
-    (12 of 58 tests run)` / `Linting`); terminal emits ship a verb-prefixed
-    summary (`Bazel test complete (58/58 passed)` /
-    `Lint failed (3 errors)`)."""
+# Noun each producer leads its terminal text with.
+_TERMINAL_NOUN = {
+    "lint": "Lint",
+    "format": "Format",
+    "gazelle": "Gazelle",
+    "delivery": "Delivery",
+}
+
+_TERMINAL_VERBS = {
+    "passed": "complete",
+    "warning": "complete",
+    "failing": "failing",
+    "failed": "failed",
+    "aborted": "aborted",
+}
+
+def _progress_for(kind, status, data):
+    """Mirror the `progress` dict a producer ships, as it reaches an entry.
+
+    Terminal emits go through `phases.terminal_progress`, the same composer the
+    producers use, so this cannot drift from them on shape. Live emits carry no
+    `short`: only bazel's names its command, and the rest are already short.
+    """
     compact = _compact_for(kind, status, data)
+    suffix = (" (" + compact + ")") if compact else ""
+    is_bazel = kind == "build" or kind == "test"
 
-    # Live forms.
     if status == "running":
-        if kind == "build" or kind == "test":
-            base = "Bazel " + kind + " running..."
-            return base + (" (" + compact + ")") if compact else base
-        if kind == "lint":
-            return ("Linting... (" + compact + ")") if compact else "Linting..."
-        if kind == "format":
-            return ("Formatting... (" + compact + ")") if compact else "Formatting..."
-        if kind == "gazelle":
-            return ("Running gazelle... (" + compact + ")") if compact else "Running gazelle..."
-        if kind == "delivery":
-            return ("Delivering... (" + compact + ")") if compact else "Delivering..."
-        return ""
+        if is_bazel:
+            styles = phases.terminal_progress("Bazel " + kind, "running..." + suffix)
+            return {"body": styles.body, "stream": "", "short": styles.short}
+        body = _RUNNING_BODY.get(kind, "")
+        return {"body": (body + suffix) if body else "", "stream": "", "short": ""}
 
-    # Terminal / live-non-running forms — verb-prefixed summary.
-    verb_map = {
-        "passed": "complete",
-        "warning": "complete",
-        "failing": "failing",
-        "failed": "failed",
-        "aborted": "aborted",
-    }
-    verb = verb_map.get(status, status)
-    if kind == "build" or kind == "test":
-        return "Bazel " + kind + " " + verb + ((" (" + compact + ")") if compact else "")
-    title = {
-        "lint": "Lint",
-        "format": "Format",
-        "gazelle": "Gazelle",
-        "delivery": "Delivery",
-    }.get(kind, kind)
-    return title + " " + verb + ((" (" + compact + ")") if compact else "")
+    verb = _TERMINAL_VERBS.get(status, status)
+    noun = ("Bazel " + kind) if is_bazel else _TERMINAL_NOUN.get(kind, kind)
+    styles = phases.terminal_progress(noun, verb, compact)
+    return {"body": styles.body, "stream": "", "short": styles.short}
 
 def _compact_for(kind, status, data):
     if kind == "build" or kind == "test":
@@ -354,10 +360,7 @@ def _entry(
     else:
         # Default: mirror what each producer ships — narrative `body`
         # text + empty `stream`.
-        payload["progress"] = {
-            "body": _body_for(kind, status, data),
-            "stream": "",
-        }
+        payload["progress"] = _progress_for(kind, status, data)
     payload["kind"] = task_kind
     payload["name"] = task_name
     payload["job"] = job

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -4740,16 +4740,20 @@ def _live_progress(data, command, status):
                 actions = data["bazel"].get("actions_executed", 0) or 0
                 if actions > 0:
                     running_detail = pluralize(actions, "action") + " executed"
-        head = base + " running..."
-        body = head + (" (" + running_detail + ")") if running_detail else head
+        lead = "running..."
+        detail = running_detail
     else:
-        verb = _TERMINAL_VERB.get(status, status)
-        body = base + " " + verb
-        tail = _compact_text(command, status, data)
-        if tail:
-            body = body + " (" + tail + ")"
+        lead = _TERMINAL_VERB.get(status, status)
+        detail = _compact_text(command, status, data)
 
-    return phases.ProgressStyles(body = body, stream = "")
+    suffix = (" (" + detail + ")") if detail else ""
+    return phases.ProgressStyles(
+        body = base + " " + lead + suffix,
+        stream = "",
+        # Same text without the `Bazel <command>` lead, which a surface that
+        # prints the task label beside it already says.
+        short = lead + suffix,
+    )
 
 # ms since the last live emit before a heartbeat is forced (matches
 # MIN_HEARTBEAT_INTERVAL_MS); measured off the monotonic clock.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -52,7 +52,27 @@ ProgressStyles = record(
     # Live terminal output. ANSI welcome; present-continuous, no
     # trailing "..." since it's a live stream.
     stream = field(str, default = ""),
+
+    # `body` for a surface that already names the task beside it — the PR/MR
+    # comment, whose rows read `**test-gha** [test] · <short>`. Drop what the
+    # label already says ("Bazel test complete (28/28)" -> "complete (28/28)")
+    # and keep the detail. Optional: unset falls back to `body`.
+    short = field(str, default = ""),
 )
+
+def terminal_progress(noun: str, verb: str, detail: str = "") -> ProgressStyles:
+    """`ProgressStyles` for a terminal verdict, in both forms.
+
+    `body` reads `<noun> <verb> (<detail>)` for surfaces that show the text on
+    its own. `short` drops the noun for surfaces that print the task label
+    beside it — the PR/MR comment row, where "Lint complete (clean)" sits next
+    to `**lint-gha** [lint]` and says "lint" twice.
+    """
+    suffix = (" (" + detail + ")") if detail else ""
+    return ProgressStyles(
+        body = noun + " " + verb + suffix,
+        short = verb + suffix,
+    )
 
 # Lifecycle severity bucket:
 #   running — clean in-flight; warning — non-fatal (live or terminal);
@@ -1076,6 +1096,7 @@ phases = namespace(
     bk_phase_section_marker = _bk_phase_section_marker,
     Phase = Phase,
     ProgressStyles = ProgressStyles,
+    terminal_progress = terminal_progress,
     Update = TaskUpdate,
     ReproFixCommand = ReproFixCommand,
 )


### PR DESCRIPTION
A PR/MR comment row prints the task label right beside its result, so the producers' narration says everything twice:

```
✅ **lint-gha** [lint]   · Lint complete (clean)
✅ **test-gha** [test]   · Bazel test complete (28/28 passed · 27 cached)
❌ **build-gha** [build] · failed in build · Bazel build failed (3 actions failed)
```

`ProgressStyles` gains an optional `short` — the same verdict without the noun the row already carries. The comment prefers it; every other surface renders the text on its own and keeps `body` unchanged.

```
✅ **lint-gha** [lint]   · complete (clean)
✅ **test-gha** [test]   · complete (28/28 passed · 27 cached)
❌ **build-gha** [build] · failed (3 actions failed)
```

### How the two forms stay honest

Both come from one composer:

```python
phases.terminal_progress("Lint", "complete", compact)
#  body  -> "Lint complete (clean)"
#  short -> "complete (clean)"
```

The short form is *composed*, not derived by pattern-matching the long one, so the two cannot drift into describing different outcomes and no filter has to track how a producer phrases things. That composer also replaces the same four-line concatenation copied across lint, format, gazelle and delivery.

### The failed phase is preserved

`short` names the outcome but not where it happened, and the phase is often a step of its own. It is kept, and dropped only when it is the task's own kind — the one case the row already shows:

| `failed_in_phase` | Row |
|---|---|
| `diff` (a gazelle task) | `failed in diff · failed (3 out of date)` |
| `gazelle` (a gazelle task) | `failed (3 out of date)` |

The long-form path keeps the prefix unconditionally, since its surfaces have no task label beside the text to make it redundant.

### A GitLab bug this uncovered

`gitlab_status_comments` built its entry with `update.progress.styles if hasattr(update.progress, "styles") else None`. `update.progress` *is* the `ProgressStyles` record and has no `styles` member, so that has always evaluated to `None` — MR rows have been rendering **no producer text at all**, long or short. It now forwards the record.

That survived because the MR comment entry path has no test suite; `gitlab_features_test.axl` covers only the commit-status mapping. A round-trip test over `results_subset`, the entry builder both features share, now asserts the styles reach the entry. A suite for the GitLab feature itself is worth having and is not in this change.

### Scope

`short` is optional and falls back to `body`. It is set for every terminal verdict and for bazel's live text, which names its command; the live phases of lint, format, gazelle and delivery are untouched, since `Linting...` beside `[lint]` is already short.

Not addressed, both visible in the same rows: the `[kind]` bracket is inferable from the task name in most rows, and the CI-host link repeats identically on every row.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no — the guide documents `progress.body` as a template variable, unchanged here
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Rows in the PR and MR summary comment no longer repeat the task kind in their status text — `[lint] · complete (clean)` rather than `[lint] · Lint complete (clean)`. A failure in a phase other than the task's own kind still names the phase. Check runs, commit statuses and Buildkite annotations are unchanged.
- Fixed GitLab MR summary comment rows rendering no status text.

### Test plan

- New test cases — `test_terminal_progress` (both forms, no-detail, detail survives, `short` defaults empty), `test_result_cell_text` (the four phase-prefix cases plus the unchanged long form), and `test_results_subset_carries_progress` (styles reach the entry; `None` stays benign).
- Mutation-tested — making `short` mirror `body`, returning `short` without the phase prefix, and keeping the prefix when it matches the kind each fail their assertions; making the comment ignore `short` reverts 86 rows.
- Byte-identity — the eight check-run, annotation and per-kind snapshot suites are unchanged. Every changed line in the PR-comment snapshot is a task row, confirmed by diffing with row lines filtered out.
- `aspect tests axl` (991), all 44 `dev test-*` suites, `cargo test -p aspect-cli` and `buildifier` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
