### PR TITLE
feat(cli): drop the emoji from PR and MR summary comment headers

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/github_status_comments.axl
@@ -212,18 +212,18 @@ Reproduce with:
 {% endif %}
 {% endmacro -%}
 {% if build_snippets %}
-## 💥 Build Failures
+## Build Failures
 {% for s in build_snippets %}{{ snippet_block(s) }}{% endfor %}
 {% endif -%}
 {% if test_snippets %}
-## ❌ Test Failures
+## Test Failures
 {% for s in test_snippets %}{{ snippet_block(s) }}{% endfor %}
 {% endif -%}
 {% if snippet_overflow_note %}
 {{ snippet_overflow_note }}
 {% endif %}
 {% if tip_rows %}
-## 💡 Tips
+## Tips
 {% for tip in tip_rows %}
 > {{ tip.severity_emoji }} **{{ tip.severity_label|upper }}: {{ tip.title }}**
 >
@@ -235,7 +235,7 @@ Reproduce with:
 
 {% endfor %}{% endif -%}
 {% if fix_rows %}
-## 🛠️ Fix
+## Fix
 {% for r in fix_rows %}{% if r.show_heading %}
 #### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_names %} ({{ r.task_names|join(" · ") }}){% endif %}{% endif %}
 ```
@@ -249,7 +249,7 @@ Reproduce with:
 """ + ASPECT_CLI_INSTALL_HINT_MARKDOWN + """
 {% endif -%}
 {% if repro_rows %}
-## 🔁 Reproduce
+## Reproduce
 {% for r in repro_rows %}{% if r.show_heading %}
 #### {% if r.severity_emoji %}{{ r.severity_emoji }} {% endif %}{% if r.kind %}{{ r.kind }}{% endif %}{% if r.task_names %} ({{ r.task_names|join(" · ") }}){% endif %}{% endif %}
 ```

--- a/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/feature/github_status_comments_test.axl
@@ -836,8 +836,8 @@ def _check_select_snippets(ctx):
         bucket_entries(prepared),
         snippet_rows = sel_rows,
     )
-    _eq("select: render emits Build Failures group", "## 💥 Build Failures" in body, True)
-    _eq("select: render emits Test Failures group", "## ❌ Test Failures" in body, True)
+    _eq("select: render emits Build Failures group", "## Build Failures" in body, True)
+    _eq("select: render emits Test Failures group", "## Test Failures" in body, True)
     _eq(
         "select: build header is kind + label (no inline tasks)",
         "❌ genrule `//pkg:broken` failed to build:" in body,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_results.axl
@@ -2848,8 +2848,9 @@ SUMMARY_TEMPLATE = """{% if detail_rows %}{% for row in detail_rows %}
 :speech_balloon: **Last update:** `{{ last_update }}`{% endif %}""" + TIPS_BLOCK
 
 # Reusable Jinja snippets: iterate producer-authored repro_commands/fix_commands
-# into one fenced code block per entry + optional italic description. Headings
-# use the same emojis (🔁 / 🛠️) as the PR-comment aggregator.
+# into one fenced code block per entry + optional italic description. These
+# render inside a check run or annotation, where the emoji is the only visual
+# break in a wall of text; the PR comment drops it, having its own structure.
 REPRO_COMMANDS_BLOCK = """{%- if repro_commands %}
 ### 🔁 Reproduce
 {% for c in repro_commands %}

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/tips.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/tips.axl
@@ -476,7 +476,7 @@ def tip_to_payload(t):
 
 def decorate_tip(t):
     """Project a stored tip into the render-shape consumed by the surface
-    templates (`TIPS_BLOCK` in `bazel_results.axl`, the `## 💡 Tips` section
+    templates (`TIPS_BLOCK` in `bazel_results.axl`, the `## Tips` section
     in `feature/github_status_comments.axl`) — single source of truth so both
     stay aligned. The PR-comment aggregator adds a `task_names` list for its
     "Surfaced by:" footer."""


### PR DESCRIPTION
The PR/MR summary comment's section headers each carried an emoji. The text reads better without them, and the comment already has plenty of structure — headings, a task list, fenced code blocks.

| Before | After |
|---|---|
| `## 💥 Build Failures` | `## Build Failures` |
| `## ❌ Test Failures` | `## Test Failures` |
| `## 💡 Tips` | `## Tips` |
| `## 🛠️ Fix` | `## Fix` |
| `## 🔁 Reproduce` | `## Reproduce` |

(`## ✨ Aspect Workflows Tasks` lost its emoji in #1405.)

### Scoped to the comment

The check-run and annotation templates keep their `### 🔁 Reproduce` / `### 🛠️ Fix`. Those render inside a wall of build output where the emoji is the only visual break, so the same reasoning does not carry over. A note in `bazel_results.axl` claimed the two sets matched deliberately; it now records why they differ.

Per-row status icons (`✅` / `❌` / `🔄`) are untouched — they carry the verdict, not decoration.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes — one stale reference in `tips.axl`
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

#### Suggested release notes

- Section headers in the PR and MR summary comment no longer carry an emoji. Check runs, commit statuses and Buildkite annotations are unchanged.

### Test plan

- Existing assertions updated — two tests pinned the old `Build Failures` / `Test Failures` headers.
- Byte-identity — diffed against `main` with header lines filtered out: nothing but the headers changed. The eight check-run, annotation and per-kind snapshot suites are unchanged, confirming the shared repro/fix blocks were not touched.
- `aspect tests axl` (991), all 44 `dev test-*` suites and `buildifier` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
