### PR TITLE
feat(launcher): default to the CDN mirror as a fallback source, add debug builds

### DIFF
--- a/crates/aspect-launcher/src/cache.rs
+++ b/crates/aspect-launcher/src/cache.rs
@@ -33,7 +33,7 @@ impl AspectCache {
         Ok(AspectCache::from(aspect_data_dir))
     }
 
-    pub fn tool_path(&self, tool_name: &String, tool_source: &String) -> PathBuf {
+    pub fn tool_path(&self, tool_name: &str, tool_source: &str) -> PathBuf {
         let mut hasher = Sha256::new();
         hasher.update(tool_name.as_bytes());
         hasher.update(tool_source.as_bytes());

--- a/crates/aspect-launcher/src/config.rs
+++ b/crates/aspect-launcher/src/config.rs
@@ -109,10 +109,17 @@ impl ToolSpec for AspectCliConfig {
     }
 }
 
-/// URL template for the Aspect-run CDN mirror of the GitHub releases.
+/// The repository the default sources download from. The CDN mirrors these
+/// releases and no others.
+pub const ASPECT_CLI_ORG: &str = "aspect-build";
+pub const ASPECT_CLI_REPO: &str = "aspect-cli";
+
+/// URL template for the Aspect-run CDN mirror of [`ASPECT_CLI_ORG`]/
+/// [`ASPECT_CLI_REPO`] releases.
 ///
-/// The launcher expands `{artifact}` to the same asset name the `github()`
-/// source would request, so the mirror tracks `debug = True` automatically.
+/// The launcher expands `{artifact}` to the same asset name the default
+/// `github()` source would request, so the mirror tracks `debug = True`
+/// automatically.
 pub const CDN_MIRROR_URL: &str = "https://cdn.aspect.build/github.com/aspect-build/aspect-cli/releases/download/v{version}/{artifact}";
 
 /// The GitHub release, then the Aspect CDN mirror of the same assets, so a
@@ -120,8 +127,8 @@ pub const CDN_MIRROR_URL: &str = "https://cdn.aspect.build/github.com/aspect-bui
 fn default_cli_sources() -> Vec<ToolSource> {
     vec![
         ToolSource::GitHub {
-            org: "aspect-build".into(),
-            repo: "aspect-cli".into(),
+            org: ASPECT_CLI_ORG.into(),
+            repo: ASPECT_CLI_REPO.into(),
             tag: String::new(),
             artifact: String::new(),
         },

--- a/crates/aspect-launcher/src/config.rs
+++ b/crates/aspect-launcher/src/config.rs
@@ -58,7 +58,7 @@ pub struct AspectCliConfig {
     /// by querying the releases API for the latest available release.
     version: Option<String>,
     /// Whether to fetch the `-debug-` build variant instead of the primary
-    /// binary. Set by `debug = True` in `version()`.
+    /// binary.
     debug: bool,
 }
 
@@ -111,12 +111,12 @@ impl ToolSpec for AspectCliConfig {
 
 /// URL template for the Aspect-run CDN mirror of the GitHub releases.
 ///
-/// `{artifact}` is expanded by the launcher to the same asset name the GitHub
-/// source would request, so the mirror follows `debug = True` automatically.
+/// The launcher expands `{artifact}` to the same asset name the `github()`
+/// source would request, so the mirror tracks `debug = True` automatically.
 pub const CDN_MIRROR_URL: &str = "https://cdn.aspect.build/github.com/aspect-build/aspect-cli/releases/download/v{version}/{artifact}";
 
-/// GitHub first, then the Aspect CDN mirror of the same release assets, so a
-/// GitHub outage or rate limit degrades to a slower path instead of a failure.
+/// The GitHub release, then the Aspect CDN mirror of the same assets, so a
+/// GitHub outage or rate limit costs a retry rather than the whole download.
 fn default_cli_sources() -> Vec<ToolSource> {
     vec![
         ToolSource::GitHub {
@@ -154,10 +154,8 @@ fn extract_string_literal(expr: &AstExpr) -> Result<&str> {
     }
 }
 
-/// Extract a boolean from an expression.
-///
-/// Starlark parses `True`/`False` as identifiers rather than literals, so both
-/// spellings are matched here.
+/// Extract a boolean from an expression. Starlark parses `True`/`False` as
+/// identifiers rather than literals, so both are matched as such.
 fn extract_bool_literal(expr: &AstExpr) -> Result<bool> {
     match &expr.node {
         Expr::Identifier(id) if id.ident == "True" => Ok(true),

--- a/crates/aspect-launcher/src/config.rs
+++ b/crates/aspect-launcher/src/config.rs
@@ -57,6 +57,9 @@ pub struct AspectCliConfig {
     /// The pinned version string, or `None` if the version should be resolved
     /// by querying the releases API for the latest available release.
     version: Option<String>,
+    /// Whether to fetch the `-debug-` build variant instead of the primary
+    /// binary. Set by `debug = True` in `version()`.
+    debug: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -84,6 +87,8 @@ pub trait ToolSpec: Debug {
     /// at download time (e.g. by querying the GitHub releases API).
     fn version(&self) -> Option<&str>;
     fn sources(&self) -> &Vec<ToolSource>;
+    /// Whether the config asked for the `-debug-` build variant.
+    fn debug(&self) -> bool;
 }
 
 impl ToolSpec for AspectCliConfig {
@@ -98,21 +103,40 @@ impl ToolSpec for AspectCliConfig {
     fn version(&self) -> Option<&str> {
         self.version.as_deref()
     }
+
+    fn debug(&self) -> bool {
+        self.debug
+    }
 }
 
+/// URL template for the Aspect-run CDN mirror of the GitHub releases.
+///
+/// `{artifact}` is expanded by the launcher to the same asset name the GitHub
+/// source would request, so the mirror follows `debug = True` automatically.
+pub const CDN_MIRROR_URL: &str = "https://cdn.aspect.build/github.com/aspect-build/aspect-cli/releases/download/v{version}/{artifact}";
+
+/// GitHub first, then the Aspect CDN mirror of the same release assets, so a
+/// GitHub outage or rate limit degrades to a slower path instead of a failure.
 fn default_cli_sources() -> Vec<ToolSource> {
-    vec![ToolSource::GitHub {
-        org: "aspect-build".into(),
-        repo: "aspect-cli".into(),
-        tag: String::new(),
-        artifact: String::new(),
-    }]
+    vec![
+        ToolSource::GitHub {
+            org: "aspect-build".into(),
+            repo: "aspect-cli".into(),
+            tag: String::new(),
+            artifact: String::new(),
+        },
+        ToolSource::Http {
+            url: CDN_MIRROR_URL.into(),
+            headers: HashMap::new(),
+        },
+    ]
 }
 
 fn default_aspect_cli_config() -> AspectCliConfig {
     AspectCliConfig {
         sources: default_cli_sources(),
         version: None,
+        debug: false,
     }
 }
 
@@ -127,6 +151,18 @@ fn extract_string_literal(expr: &AstExpr) -> Result<&str> {
     match &expr.node {
         Expr::Literal(AstLiteral::String(s)) => Ok(&s.node),
         _ => Err(miette!("expected string literal")),
+    }
+}
+
+/// Extract a boolean from an expression.
+///
+/// Starlark parses `True`/`False` as identifiers rather than literals, so both
+/// spellings are matched here.
+fn extract_bool_literal(expr: &AstExpr) -> Result<bool> {
+    match &expr.node {
+        Expr::Identifier(id) if id.ident == "True" => Ok(true),
+        Expr::Identifier(id) if id.ident == "False" => Ok(false),
+        _ => Err(miette!("expected True or False")),
     }
 }
 
@@ -284,6 +320,7 @@ fn parse_version_axl(content: &str) -> Result<AspectLauncherConfig> {
 
     let mut version: Option<String> = None;
     let mut sources: Option<Vec<ToolSource>> = None;
+    let mut debug = false;
 
     for arg in &args.args {
         match &arg.node {
@@ -308,6 +345,10 @@ fn parse_version_axl(content: &str) -> Result<AspectLauncherConfig> {
                         return Err(miette!("'sources' must be a list"));
                     }
                 }
+                "debug" => {
+                    debug = extract_bool_literal(expr)
+                        .map_err(|_| miette!("'debug' must be True or False"))?;
+                }
                 other => {
                     return Err(miette!("unknown argument '{}' in version() call", other));
                 }
@@ -322,6 +363,7 @@ fn parse_version_axl(content: &str) -> Result<AspectLauncherConfig> {
         aspect_cli: AspectCliConfig {
             version,
             sources: sources.unwrap_or_else(default_cli_sources),
+            debug,
         },
     })
 }
@@ -518,7 +560,7 @@ version(
     fn test_parse_version_no_sources_uses_default() {
         let content = r#"version("1.0.0")"#;
         let config = parse_version_axl(content).unwrap();
-        assert_eq!(config.aspect_cli.sources().len(), 1);
+        assert_eq!(config.aspect_cli.sources().len(), 2);
         match &config.aspect_cli.sources()[0] {
             ToolSource::GitHub { org, repo, .. } => {
                 assert_eq!(org, "aspect-build");
@@ -526,6 +568,51 @@ version(
             }
             other => panic!("expected default GitHub source, got {:?}", other),
         }
+        match &config.aspect_cli.sources()[1] {
+            ToolSource::Http { url, headers } => {
+                assert_eq!(url, CDN_MIRROR_URL);
+                assert!(headers.is_empty());
+            }
+            other => panic!("expected default CDN mirror source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_version_debug_defaults_to_false() {
+        let config = parse_version_axl(r#"version("1.0.0")"#).unwrap();
+        assert!(!config.aspect_cli.debug());
+    }
+
+    #[test]
+    fn test_parse_version_debug_true() {
+        let config = parse_version_axl(r#"version("1.0.0", debug = True)"#).unwrap();
+        assert!(config.aspect_cli.debug());
+    }
+
+    #[test]
+    fn test_parse_version_debug_false_is_explicit() {
+        let config = parse_version_axl(r#"version("1.0.0", debug = False)"#).unwrap();
+        assert!(!config.aspect_cli.debug());
+    }
+
+    #[test]
+    fn test_parse_version_debug_alongside_sources() {
+        let content = r#"
+version(
+    "1.0.0",
+    debug = True,
+    sources = [github(org = "aspect-build", repo = "aspect-cli")],
+)
+"#;
+        let config = parse_version_axl(content).unwrap();
+        assert!(config.aspect_cli.debug());
+        assert_eq!(config.aspect_cli.sources().len(), 1);
+    }
+
+    #[test]
+    fn test_parse_version_debug_non_bool_errors() {
+        let result = parse_version_axl(r#"version("1.0.0", debug = "yes")"#);
+        assert!(result.is_err(), "debug must reject a non-boolean");
     }
 
     #[test]
@@ -581,7 +668,8 @@ version(
     fn test_default_config() {
         let config = super::default_config();
         assert_eq!(config.aspect_cli.version(), None);
-        assert_eq!(config.aspect_cli.sources().len(), 1);
+        assert!(!config.aspect_cli.debug());
+        assert_eq!(config.aspect_cli.sources().len(), 2);
         assert!(matches!(
             &config.aspect_cli.sources()[0],
             ToolSource::GitHub {
@@ -589,6 +677,12 @@ version(
                 repo,
                 ..
             } if org == "aspect-build" && repo == "aspect-cli"
+        ));
+        // The CDN mirror is the fallback, so a GitHub outage degrades to a
+        // second attempt rather than a hard failure.
+        assert!(matches!(
+            &config.aspect_cli.sources()[1],
+            ToolSource::Http { url, .. } if url == CDN_MIRROR_URL
         ));
     }
 

--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -40,6 +40,14 @@ fn replace_vars(s: &str, version: &str) -> String {
         .replace("{target}", LLVM_TRIPLE)
 }
 
+/// Like [`replace_vars`], plus `{artifact}` for URLs that mirror the GitHub
+/// release assets. `artifact` already carries the `-debug-` infix when the
+/// debug variant was requested, so a mirror URL follows it without needing its
+/// own debug placeholder.
+fn replace_url_vars(s: &str, version: &str, artifact: &str) -> String {
+    replace_vars(s, version).replace("{artifact}", artifact)
+}
+
 fn debug_mode() -> bool {
     match var("ASPECT_DEBUG") {
         Ok(val) => !val.is_empty(),
@@ -51,7 +59,13 @@ fn debug_mode() -> bool {
 ///
 /// Separate from [`debug_mode`] on purpose: `ASPECT_DEBUG` requests verbose logging and
 /// is set routinely, so it must not also swap in a larger, slower binary.
-fn debug_cli_mode() -> bool {
+///
+/// `config_debug` carries `debug = True` from `version()`. The env var remains an
+/// override so a debug binary can be requested without editing a checked-in file.
+fn debug_cli_mode(config_debug: bool) -> bool {
+    if config_debug {
+        return true;
+    }
     match var("ASPECT_DEBUG_CLI") {
         Ok(val) => !val.is_empty(),
         _ => false,
@@ -383,7 +397,8 @@ async fn configure_tool_task(
                 ToolSource::Http { url, headers } => {
                     let fallback_version = cargo_pkg_short_version();
                     let version = tool.version().unwrap_or(&fallback_version);
-                    let url = replace_vars(url, version);
+                    let artifact = default_artifact(&tool.name(), debug_cli_mode(tool.debug()));
+                    let url = replace_url_vars(url, version, &artifact);
                     let req_headers = headermap_from_hashmap(headers.iter());
                     let req = client
                         .request(Method::GET, &url)
@@ -443,7 +458,7 @@ async fn configure_tool_task(
 
                     // Gates the fallback below: only a name we chose has a known primary
                     // counterpart to fall back to.
-                    let chose_debug_variant = artifact.is_empty() && debug_cli_mode();
+                    let chose_debug_variant = artifact.is_empty() && debug_cli_mode(tool.debug());
                     let artifact = if artifact.is_empty() {
                         default_artifact(repo, chose_debug_variant)
                     } else {
@@ -944,6 +959,48 @@ mod tests {
     fn test_replace_vars_no_placeholders() {
         let result = replace_vars("plain-string", "1.0.0");
         assert_eq!(result, "plain-string");
+    }
+
+    #[test]
+    fn test_replace_url_vars_expands_artifact() {
+        assert_eq!(
+            replace_url_vars(
+                "https://cdn/{version}/{artifact}",
+                "1.2.3",
+                "aspect-cli-linux"
+            ),
+            "https://cdn/1.2.3/aspect-cli-linux"
+        );
+    }
+
+    /// The default CDN mirror must resolve to the same asset path the GitHub
+    /// source would request, for both the primary and the debug variant.
+    #[test]
+    fn test_cdn_mirror_url_matches_the_github_asset_path() {
+        use crate::config::CDN_MIRROR_URL;
+
+        let primary = default_artifact("aspect-cli", false);
+        assert_eq!(
+            replace_url_vars(CDN_MIRROR_URL, "2026.35.9", &primary),
+            format!(
+                "https://cdn.aspect.build/github.com/aspect-build/aspect-cli/releases/download/v2026.35.9/{primary}"
+            )
+        );
+
+        let debug = default_artifact("aspect-cli", true);
+        assert!(debug.contains("-debug-"));
+        assert_eq!(
+            replace_url_vars(CDN_MIRROR_URL, "2026.35.9", &debug),
+            format!(
+                "https://cdn.aspect.build/github.com/aspect-build/aspect-cli/releases/download/v2026.35.9/{debug}"
+            )
+        );
+    }
+
+    #[test]
+    fn test_debug_cli_mode_follows_the_config_flag() {
+        // True regardless of the env var, which is only an additional opt-in.
+        assert!(debug_cli_mode(true));
     }
 
     #[test]

--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -130,6 +130,39 @@ impl ArtifactChoice {
     }
 }
 
+/// Whether a `github()` source names the repo the CDN mirrors.
+fn is_aspect_cli_repo(org: &str, repo: &str) -> bool {
+    org == config::ASPECT_CLI_ORG && repo == config::ASPECT_CLI_REPO
+}
+
+/// The Aspect release a preceding `github()` source resolved, so a following
+/// `http()` mirror requests that same release rather than re-deriving it.
+///
+/// An unpinned config resolves its version from the releases API; without this
+/// the mirror would substitute the launcher's own, older version and silently
+/// downgrade the CLI during the outage the mirror exists to cover.
+///
+/// Only recorded for [`ASPECT_CLI_REPO`]: we mirror our own releases and
+/// nothing else, so a custom `github(org/repo)` must not redirect a mirror at
+/// assets the CDN does not carry.
+struct MirroredRelease {
+    /// Version for `{version}`, without the tag's leading `v`.
+    version: String,
+    artifact: String,
+    /// Primary-binary name to retry with, carried from the resolved
+    /// [`ArtifactChoice`] so the mirror falls back the same way.
+    fallback: Option<String>,
+}
+
+impl From<&MirroredRelease> for ArtifactChoice {
+    fn from(m: &MirroredRelease) -> Self {
+        Self {
+            name: m.artifact.clone(),
+            fallback: m.fallback.clone(),
+        }
+    }
+}
+
 /// Direct download URL for a release asset. Also the cache key for the downloaded
 /// binary, so every caller must build it the same way.
 fn release_asset_url(org: &str, repo: &str, tag: &str, artifact: &str) -> String {
@@ -470,13 +503,22 @@ async fn configure_tool_task(
 
         let client = reqwest::Client::new();
 
+        let mut mirrored: Option<MirroredRelease> = None;
+
         for source in tool.sources() {
             match source {
                 ToolSource::Http { url, headers } => {
                     let fallback_version = cargo_pkg_short_version();
-                    let version = tool.version().unwrap_or(&fallback_version);
-                    let choice =
-                        ArtifactChoice::derived(&tool.name(), debug_cli_mode(tool.debug()));
+                    let debug = debug_cli_mode(tool.debug());
+                    // Follow the Aspect release an earlier github() source resolved;
+                    // otherwise derive from the pinned version and this launcher.
+                    let (version, choice) = match &mirrored {
+                        Some(m) => (m.version.as_str(), ArtifactChoice::from(m)),
+                        None => (
+                            tool.version().unwrap_or(&fallback_version),
+                            ArtifactChoice::derived(&tool.name(), debug),
+                        ),
+                    };
                     let mut attempt_url = replace_url_vars(url, version, &choice.name);
                     let mut result =
                         http_fetch(&client, &cache, &tool.name(), &attempt_url, headers).await?;
@@ -699,12 +741,32 @@ async fn configure_tool_task(
                                         ));
                                     }
                                 }
+                                // The API is unreachable, but a cached hint still names
+                                // the last resolved release; let the mirror try it
+                                // rather than fall back to the launcher's version.
+                                if is_aspect_cli_repo(org, repo)
+                                    && let Ok(hint) = fs::read_to_string(&hint_path)
+                                {
+                                    mirrored = Some(MirroredRelease {
+                                        version: hint.trim().trim_start_matches('v').to_owned(),
+                                        artifact: choice.name.clone(),
+                                        fallback: choice.fallback.clone(),
+                                    });
+                                }
                                 errs.push(failure);
                                 continue;
                             }
                         };
+                        // A chosen debug variant also matches a release carrying only
+                        // the primary binary; the download below falls back to it.
+                        let acceptable: Vec<&str> = std::iter::once(artifact.as_str())
+                            .chain(choice.fallback.as_deref())
+                            .collect();
                         let found = releases.into_iter().find(|r| {
-                            !r.prerelease && r.assets.iter().any(|a| a.name == *artifact)
+                            !r.prerelease
+                                && r.assets
+                                    .iter()
+                                    .any(|a| acceptable.contains(&a.name.as_str()))
                         });
                         let resolved = match found {
                             Some(release) => release.tag_name,
@@ -808,6 +870,13 @@ async fn configure_tool_task(
                     }
 
                     if let Some(e) = download_err {
+                        if is_aspect_cli_repo(org, repo) {
+                            mirrored = Some(MirroredRelease {
+                                version: resolved_tag.trim_start_matches('v').to_owned(),
+                                artifact: choice.name.clone(),
+                                fallback: choice.fallback.clone(),
+                            });
+                        }
                         errs.push(SourceFailure::new(direct_url.clone(), e));
                         continue;
                     }
@@ -1049,6 +1118,51 @@ mod tests {
             assert_eq!(choice.name, "custom-1.0.0");
             assert_eq!(choice.debug_fallback("v1.0.0"), None);
         }
+    }
+
+    #[test]
+    fn test_is_aspect_cli_repo_matches_only_the_mirrored_repo() {
+        assert!(is_aspect_cli_repo("aspect-build", "aspect-cli"));
+        assert!(!is_aspect_cli_repo("aspect-build", "my-cli"));
+        assert!(!is_aspect_cli_repo("my-org", "aspect-cli"));
+    }
+
+    /// A mirror follows the resolved release, so an unpinned config that
+    /// resolved a newer tag is not downgraded to the launcher's own version.
+    #[test]
+    fn test_mirrored_release_drives_the_url() {
+        use crate::config::CDN_MIRROR_URL;
+
+        let m = MirroredRelease {
+            version: "2026.35.9".to_owned(),
+            artifact: default_artifact("aspect-cli", false),
+            fallback: None,
+        };
+        let choice = ArtifactChoice::from(&m);
+        assert_eq!(
+            replace_url_vars(CDN_MIRROR_URL, &m.version, &choice.name),
+            format!(
+                "https://cdn.aspect.build/github.com/aspect-build/aspect-cli/releases/download/v2026.35.9/{}",
+                default_artifact("aspect-cli", false)
+            )
+        );
+    }
+
+    /// The debug fallback survives the hand-off, so a mirror recovers from a
+    /// release with no debug asset exactly as the github() source would.
+    #[test]
+    fn test_mirrored_release_carries_the_debug_fallback() {
+        let source = ArtifactChoice::derived("aspect-cli", true);
+        let m = MirroredRelease {
+            version: "2026.31.1".to_owned(),
+            artifact: source.name.clone(),
+            fallback: source.fallback.clone(),
+        };
+        let choice = ArtifactChoice::from(&m);
+        let (primary, _) = choice
+            .debug_fallback("2026.31.1")
+            .expect("fallback carried");
+        assert_eq!(primary, default_artifact("aspect-cli", false));
     }
 
     #[test]
@@ -1393,6 +1507,46 @@ mod tests {
         cache.touch_latest_tag(&hint);
         assert!(cache.latest_tag_is_fresh(&hint, std::time::Duration::from_secs(86400)));
         assert!(dest.exists());
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    /// When the releases API is down, the cached hint names the release the last
+    /// successful run resolved. The mirror must reuse that version rather than
+    /// the launcher's own, which would silently downgrade an unpinned config.
+    #[test]
+    fn test_stale_hint_version_feeds_the_mirror_url() {
+        use crate::config::CDN_MIRROR_URL;
+
+        let tmp = tmp_cache_dir("hint-mirror");
+        let cache = make_cache(&tmp);
+
+        let hint = cache.latest_tag_path(
+            "aspect-cli",
+            "aspect-build",
+            "aspect-cli",
+            "aspect-cli-aarch64-apple-darwin",
+        );
+        std::fs::create_dir_all(hint.parent().unwrap()).unwrap();
+        std::fs::write(&hint, "v2026.35.9").unwrap();
+
+        // The hand-off the http() branch performs: hint tag -> mirrored version.
+        let recorded = std::fs::read_to_string(&hint).unwrap();
+        let choice = ArtifactChoice::derived("aspect-cli", false);
+        let m = MirroredRelease {
+            version: recorded.trim().trim_start_matches('v').to_owned(),
+            artifact: choice.name.clone(),
+            fallback: choice.fallback.clone(),
+        };
+        assert_eq!(m.version, "2026.35.9");
+        assert_ne!(m.version, cargo_pkg_short_version());
+        assert_eq!(
+            replace_url_vars(CDN_MIRROR_URL, &m.version, &ArtifactChoice::from(&m).name),
+            format!(
+                "https://cdn.aspect.build/github.com/aspect-build/aspect-cli/releases/download/v2026.35.9/{}",
+                default_artifact("aspect-cli", false)
+            )
+        );
 
         std::fs::remove_dir_all(&tmp).unwrap();
     }

--- a/crates/aspect-launcher/src/main.rs
+++ b/crates/aspect-launcher/src/main.rs
@@ -40,10 +40,10 @@ fn replace_vars(s: &str, version: &str) -> String {
         .replace("{target}", LLVM_TRIPLE)
 }
 
-/// Like [`replace_vars`], plus `{artifact}` for URLs that mirror the GitHub
-/// release assets. `artifact` already carries the `-debug-` infix when the
-/// debug variant was requested, so a mirror URL follows it without needing its
-/// own debug placeholder.
+/// Like [`replace_vars`], plus `{artifact}` for URLs that mirror the release
+/// assets. `artifact` already carries the `-debug-` infix when the debug
+/// variant was requested, so a mirror URL tracks it with no debug placeholder
+/// of its own.
 fn replace_url_vars(s: &str, version: &str, artifact: &str) -> String {
     replace_vars(s, version).replace("{artifact}", artifact)
 }
@@ -55,21 +55,14 @@ fn debug_mode() -> bool {
     }
 }
 
-/// Whether to fetch the `-debug-` release variant instead of the primary binary.
+/// Whether to fetch the `-debug-` release variant instead of the primary binary,
+/// requested either by `debug = True` in `version()` (`config_debug`) or by the
+/// `ASPECT_DEBUG_CLI` environment variable.
 ///
 /// Separate from [`debug_mode`] on purpose: `ASPECT_DEBUG` requests verbose logging and
 /// is set routinely, so it must not also swap in a larger, slower binary.
-///
-/// `config_debug` carries `debug = True` from `version()`. The env var remains an
-/// override so a debug binary can be requested without editing a checked-in file.
 fn debug_cli_mode(config_debug: bool) -> bool {
-    if config_debug {
-        return true;
-    }
-    match var("ASPECT_DEBUG_CLI") {
-        Ok(val) => !val.is_empty(),
-        _ => false,
-    }
+    config_debug || var("ASPECT_DEBUG_CLI").is_ok_and(|val| !val.is_empty())
 }
 
 /// Default release asset name for a tool, e.g. `aspect-cli-x86_64-unknown-linux-musl`.
@@ -85,6 +78,55 @@ fn default_artifact(repo: &str, debug: bool) -> String {
         format!("{}-debug-{}", repo, LLVM_TRIPLE)
     } else {
         format!("{}-{}", repo, LLVM_TRIPLE)
+    }
+}
+
+/// The release asset a source should request, plus the primary-binary name to
+/// retry with when the debug variant was chosen.
+///
+/// Not every release publishes a `-debug-` asset, and a pinned tag is
+/// downloaded without consulting the asset list, so a missing one surfaces only
+/// as a failed download. [`Self::debug_fallback`] then names the primary binary,
+/// degrading a debug request to a working CLI instead of no CLI. An artifact
+/// named explicitly in config has no known counterpart, so it gets no fallback.
+struct ArtifactChoice {
+    name: String,
+    /// Set only when [`Self::name`] is a debug variant this resolver chose.
+    fallback: Option<String>,
+}
+
+impl ArtifactChoice {
+    /// The asset name this launcher derives for `repo`.
+    fn derived(repo: &str, debug: bool) -> Self {
+        Self {
+            name: default_artifact(repo, debug),
+            fallback: debug.then(|| default_artifact(repo, false)),
+        }
+    }
+
+    /// Resolve the asset name for `repo`, honoring an explicit `configured`
+    /// name (with `{var}` placeholders expanded) over the derived default.
+    fn resolve(repo: &str, configured: &str, version: &str, debug: bool) -> Self {
+        if configured.is_empty() {
+            return Self::derived(repo, debug);
+        }
+        Self {
+            name: replace_vars(configured, version),
+            fallback: None,
+        }
+    }
+
+    /// The primary-binary name to retry with, and the warning to print, after a
+    /// download of a chosen debug variant failed.
+    fn debug_fallback(&self, tag: &str) -> Option<(&str, String)> {
+        let primary = self.fallback.as_deref()?;
+        Some((
+            primary,
+            format!(
+                "{} is unavailable in {tag}; falling back to {primary}",
+                self.name
+            ),
+        ))
     }
 }
 
@@ -258,6 +300,42 @@ async fn download_with_retries(
     Err(last_err.expect("at least one attempt must have run"))
 }
 
+/// Fetch `url` into the launcher cache for `tool_name`, serving an existing
+/// cache entry without a request.
+///
+/// The outer `Result` is a local failure that aborts provisioning entirely (an
+/// unusable cache directory, a malformed request); the inner one is a download
+/// failure the caller can attribute to this URL and recover from by trying
+/// another source.
+async fn http_fetch(
+    client: &Client,
+    cache: &AspectCache,
+    tool_name: &str,
+    url: &str,
+    headers: &HashMap<String, String>,
+) -> Result<Result<PathBuf, Report>> {
+    let dest = cache.tool_path(tool_name, url);
+    if dest.exists() {
+        if debug_mode() {
+            eprintln!("{tool_name} found {url:?} in cache");
+        }
+        return Ok(Ok(dest));
+    }
+    fs::create_dir_all(dest.parent().unwrap()).into_diagnostic()?;
+    if debug_mode() {
+        eprintln!("{tool_name} downloading {url:?} to {dest:?}");
+    }
+    let req = client
+        .request(Method::GET, url)
+        .headers(headermap_from_hashmap(headers.iter()))
+        .build()
+        .into_diagnostic()?;
+    let msg = format!("downloading aspect cli from {url}");
+    Ok(_download_into_cache(client, &dest, req, &msg)
+        .await
+        .map(|()| dest))
+}
+
 /// A failed attempt to obtain a tool from one of its sources.
 struct SourceFailure {
     /// Human-readable identity of the source attempt, e.g. the download URL.
@@ -397,53 +475,41 @@ async fn configure_tool_task(
                 ToolSource::Http { url, headers } => {
                     let fallback_version = cargo_pkg_short_version();
                     let version = tool.version().unwrap_or(&fallback_version);
-                    let artifact = default_artifact(&tool.name(), debug_cli_mode(tool.debug()));
-                    let url = replace_url_vars(url, version, &artifact);
-                    let req_headers = headermap_from_hashmap(headers.iter());
-                    let req = client
-                        .request(Method::GET, &url)
-                        .headers(req_headers)
-                        .build()
-                        .into_diagnostic()?;
-                    let tool_dest_file = cache.tool_path(&tool.name(), &url);
-                    let mut extra_envs = HashMap::new();
-                    extra_envs.insert("ASPECT_LAUNCHER_ASPECT_CLI_URL".to_string(), url.clone());
-                    if tool_dest_file.exists() {
-                        if debug_mode() {
-                            eprintln!(
-                                "{:} source {:?} found in cache {:?}",
-                                tool.name(),
-                                source,
-                                url
-                            );
-                        };
-                        return Ok((
-                            tool_dest_file,
-                            ASPECT_LAUNCHER_METHOD_HTTP.to_string(),
-                            extra_envs,
-                        ));
-                    }
-                    fs::create_dir_all(tool_dest_file.parent().unwrap()).into_diagnostic()?;
-                    if debug_mode() {
-                        eprintln!(
-                            "{:} source {:?} downloading {:?} to {:?}",
-                            tool.name(),
-                            source,
-                            url,
-                            tool_dest_file
-                        );
-                    };
-                    let download_msg = format!("downloading aspect cli from {}", url);
-                    if let Err(e) =
-                        _download_into_cache(&client, &tool_dest_file, req, &download_msg).await
+                    let choice =
+                        ArtifactChoice::derived(&tool.name(), debug_cli_mode(tool.debug()));
+                    let mut attempt_url = replace_url_vars(url, version, &choice.name);
+                    let mut result =
+                        http_fetch(&client, &cache, &tool.name(), &attempt_url, headers).await?;
+
+                    // Skipped when the URL has no {artifact}, since the retry would
+                    // repeat the same request.
+                    if result.is_err()
+                        && let Some((primary, warning)) = choice.debug_fallback(version)
                     {
-                        errs.push(SourceFailure::new(url.clone(), e));
-                        continue;
+                        let primary_url = replace_url_vars(url, version, primary);
+                        if primary_url != attempt_url {
+                            eprintln!("{warning}");
+                            attempt_url = primary_url;
+                            result =
+                                http_fetch(&client, &cache, &tool.name(), &attempt_url, headers)
+                                    .await?;
+                        }
+                    }
+
+                    let tool_dest_file = match result {
+                        Ok(dest) => dest,
+                        Err(e) => {
+                            errs.push(SourceFailure::new(attempt_url, e));
+                            continue;
+                        }
                     };
                     return Ok((
                         tool_dest_file,
                         ASPECT_LAUNCHER_METHOD_HTTP.to_string(),
-                        extra_envs,
+                        HashMap::from([(
+                            "ASPECT_LAUNCHER_ASPECT_CLI_URL".to_string(),
+                            attempt_url,
+                        )]),
                     ));
                 }
                 ToolSource::GitHub {
@@ -456,14 +522,13 @@ async fn configure_tool_task(
                     let pinned_version = tool.version();
                     let version_for_vars = pinned_version.unwrap_or(&fallback_version);
 
-                    // Gates the fallback below: only a name we chose has a known primary
-                    // counterpart to fall back to.
-                    let chose_debug_variant = artifact.is_empty() && debug_cli_mode(tool.debug());
-                    let artifact = if artifact.is_empty() {
-                        default_artifact(repo, chose_debug_variant)
-                    } else {
-                        replace_vars(artifact, version_for_vars)
-                    };
+                    let choice = ArtifactChoice::resolve(
+                        repo,
+                        artifact,
+                        version_for_vars,
+                        debug_cli_mode(tool.debug()),
+                    );
+                    let artifact = choice.name.clone();
 
                     // How long a resolved tag hint is considered fresh before we
                     // re-query the releases API to pick up newer versions.
@@ -714,19 +779,17 @@ async fn configure_tool_task(
                     .await
                     .err();
 
-                    // A pinned tag is resolved without consulting the asset list, so a
-                    // release that predates the `-debug-` variant only fails here. Serve
-                    // the primary binary rather than no CLI at all.
-                    if download_err.is_some() && chose_debug_variant {
-                        let primary = default_artifact(repo, false);
-                        eprintln!(
-                            "{artifact} is unavailable in {resolved_tag}; falling back to {primary}"
-                        );
-                        direct_url = release_asset_url(org, repo, &resolved_tag, &primary);
+                    if let Some((primary, warning)) = download_err
+                        .is_some()
+                        .then(|| choice.debug_fallback(&resolved_tag))
+                        .flatten()
+                    {
+                        eprintln!("{warning}");
+                        direct_url = release_asset_url(org, repo, &resolved_tag, primary);
                         tool_dest_file = cache.tool_path(&tool.name(), &direct_url);
                         extra_envs.insert(
                             "ASPECT_LAUNCHER_ASPECT_CLI_ARTIFACT".to_string(),
-                            primary.clone(),
+                            primary.to_owned(),
                         );
                         download_err = if tool_dest_file.exists() {
                             None
@@ -737,7 +800,7 @@ async fn configure_tool_task(
                                 &client,
                                 &direct_url,
                                 &tool_dest_file,
-                                &download_msg(&primary),
+                                &download_msg(primary),
                             )
                             .await
                             .err()
@@ -962,6 +1025,33 @@ mod tests {
     }
 
     #[test]
+    fn test_artifact_choice_defaults_to_the_primary_binary() {
+        let choice = ArtifactChoice::resolve("aspect-cli", "", "1.0.0", false);
+        assert_eq!(choice.name, default_artifact("aspect-cli", false));
+        assert_eq!(choice.debug_fallback("v1.0.0"), None);
+    }
+
+    #[test]
+    fn test_artifact_choice_debug_falls_back_to_the_primary() {
+        let choice = ArtifactChoice::resolve("aspect-cli", "", "1.0.0", true);
+        assert_eq!(choice.name, default_artifact("aspect-cli", true));
+        let (primary, warning) = choice.debug_fallback("v1.0.0").expect("fallback");
+        assert_eq!(primary, default_artifact("aspect-cli", false));
+        assert!(warning.contains("unavailable in v1.0.0"), "{warning}");
+    }
+
+    /// A configured artifact has no known primary counterpart, so requesting a
+    /// debug build must not invent one.
+    #[test]
+    fn test_artifact_choice_configured_name_wins_and_has_no_fallback() {
+        for debug in [false, true] {
+            let choice = ArtifactChoice::resolve("aspect-cli", "custom-{version}", "1.0.0", debug);
+            assert_eq!(choice.name, "custom-1.0.0");
+            assert_eq!(choice.debug_fallback("v1.0.0"), None);
+        }
+    }
+
+    #[test]
     fn test_replace_url_vars_expands_artifact() {
         assert_eq!(
             replace_url_vars(
@@ -1001,6 +1091,36 @@ mod tests {
     fn test_debug_cli_mode_follows_the_config_flag() {
         // True regardless of the env var, which is only an additional opt-in.
         assert!(debug_cli_mode(true));
+    }
+
+    /// A url= without {artifact} names one fixed asset, so the debug retry would
+    /// repeat the same request; the branch guards on the URL actually changing.
+    #[test]
+    fn test_debug_fallback_url_is_unchanged_without_an_artifact_placeholder() {
+        let choice = ArtifactChoice::derived("aspect-cli", true);
+        let (primary, _) = choice.debug_fallback("v1.0.0").expect("fallback");
+        let url = "https://example.com/aspect-cli-{version}";
+        assert_eq!(
+            replace_url_vars(url, "1.0.0", &choice.name),
+            replace_url_vars(url, "1.0.0", primary)
+        );
+    }
+
+    /// The CDN mirror must reach the primary binary when a release published no
+    /// debug asset, matching the github() source rather than failing outright.
+    #[test]
+    fn test_cdn_mirror_debug_fallback_url_targets_the_primary() {
+        use crate::config::CDN_MIRROR_URL;
+
+        let choice = ArtifactChoice::resolve("aspect-cli", "", "2026.31.1", true);
+        let (primary, _) = choice.debug_fallback("2026.31.1").expect("fallback");
+        assert_eq!(
+            replace_url_vars(CDN_MIRROR_URL, "2026.31.1", primary),
+            format!(
+                "https://cdn.aspect.build/github.com/aspect-build/aspect-cli/releases/download/v2026.31.1/{}",
+                default_artifact("aspect-cli", false)
+            )
+        );
     }
 
     #[test]

--- a/docs/version.md
+++ b/docs/version.md
@@ -10,9 +10,34 @@ Pin a specific version:
 version("2025.46.20")
 ```
 
-The launcher will download this version from the default GitHub release source.
+The launcher downloads this version from the default sources: the GitHub
+release, falling back to Aspect's CDN mirror of the same release assets if
+GitHub is unreachable or rate-limiting. No configuration is needed to get the
+fallback.
 
 If no `.aspect/version.axl` file exists, the launcher downloads the same version as itself.
+
+## Debug Builds
+
+Set `debug = True` to fetch the `-debug-` build variant published alongside each
+release. It is unstripped and built with debug assertions, so a crash report
+resolves to function and `file:line`, at the cost of size and speed. Use it when
+reproducing a crash for a bug report.
+
+```python
+version(
+    "2025.46.20",
+    debug = True,
+)
+```
+
+This applies to the default sources and to any `github()` source that does not
+name an explicit `artifact`. If a pinned release predates the debug variant, the
+launcher warns and falls back to the primary binary rather than failing.
+
+The `ASPECT_DEBUG_CLI` environment variable requests the same thing without
+editing a checked-in file. (It is distinct from `ASPECT_DEBUG`, which only turns
+on verbose launcher logging and never changes which binary is fetched.)
 
 ## Custom Sources
 
@@ -99,5 +124,6 @@ String values in `tag`, `artifact`, and `url` support `{variable}` placeholders 
 | `{os}` | `darwin`, `linux` | Operating system kernel name |
 | `{arch}` | `x86_64`, `aarch64` | CPU instruction set architecture |
 | `{target}` | `aarch64-apple-darwin` | Full platform target triple |
+| `{artifact}` | `aspect-cli-aarch64-apple-darwin` | Release asset name; `url` only. Carries the `-debug-` infix when a debug build is requested, so a mirror URL tracks `debug` automatically |
 
 These are the only supported placeholders. The file is not evaluated as Starlark; it is parsed as Starlark syntax but only string literals and function call structure are extracted.

--- a/docs/version.md
+++ b/docs/version.md
@@ -126,4 +126,10 @@ String values in `tag`, `artifact`, and `url` support `{variable}` placeholders 
 | `{target}` | `aarch64-apple-darwin` | Full platform target triple |
 | `{artifact}` | `aspect-cli-aarch64-apple-darwin` | Release asset name; `url` only. Carries the `-debug-` infix when a debug build is requested, so a mirror URL tracks `debug` automatically |
 
+An `http()` source listed after the default `github(org = "aspect-build", repo =
+"aspect-cli")` mirrors whatever that source resolved, so an unpinned config keeps
+the version it resolved from the releases API instead of falling back to the
+launcher's own. A `github()` source for any other repository does not feed a
+mirror, since the Aspect CDN carries only `aspect-build/aspect-cli` releases.
+
 These are the only supported placeholders. The file is not evaluated as Starlark; it is parsed as Starlark syntax but only string literals and function call structure are extracted.


### PR DESCRIPTION
The launcher's only default source was the GitHub release, so a GitHub outage or rate limit left users with no CLI at all. We already mirror every release on `cdn.aspect.build`, but getting that fallback meant hand-writing a `sources` list — the config we have been handing to affected customers one at a time.

Default sources are now the GitHub release followed by the CDN mirror, so anyone who has not customized `sources` picks up the fallback with the next launcher release. An explicit `sources` list still wins.

`version()` also gains `debug = True`, which fetches the `-debug-` build variant published alongside each release (unstripped, debug assertions) for symbolicated crash reports. That variant was previously reachable only through the `ASPECT_DEBUG_CLI` environment variable, which still works as an override.

### Implementation notes

A new `{artifact}` URL placeholder expands to the same asset name the `github()` source would request, so a mirror URL tracks `debug` without a debug placeholder of its own.

Not every release publishes a `-debug-` asset, and a pinned tag is downloaded without consulting the release asset list, so a missing one surfaces only as a failed download. Both sources share an `ArtifactChoice` resolver that names the asset and the primary binary to fall back to, so they recover identically.

A mirror listed after the default `github()` source reuses the release that source resolved — including the tag hint cached from an earlier run when the releases API is unreachable — so an unpinned config is not silently downgraded to the launcher's own version during an outage. This hand-off is scoped to `aspect-build/aspect-cli`: the CDN mirrors our own releases and nothing else, so a custom `github(org/repo)` records nothing and a mirror after it derives independently.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes — `docs/version.md` covers the default sources, `debug`, `{artifact}`, and the mirroring rules.
- Breaking change (forces users to change their own code or config): no — an explicit `sources` list still takes precedence, and `debug` defaults to `false`.
- Suggested release notes appear below: yes

### Suggested release notes

- The launcher now falls back to Aspect's CDN mirror (`cdn.aspect.build`) when a release cannot be downloaded from GitHub. No configuration needed; an explicit `sources` list still takes precedence.
- `version()` accepts `debug = True` to fetch the `-debug-` build variant of a release, for symbolicated crash reports.

### Test plan

- Covered by existing test cases
- New test cases added — `debug` parsing (default, `True`, `False`, non-boolean error, alongside `sources`), the two-source default, `{artifact}` expansion, `ArtifactChoice` (derived vs. configured names, the debug fallback, the no-placeholder guard), and the mirror hand-off (resolved version drives the URL, the debug fallback survives it, and only `aspect-build/aspect-cli` feeds a mirror). The fallback tests were confirmed to fail with the fix reverted.
- Manual testing, against a scratch workspace with a `MODULE.bazel` and `.aspect/version.axl`:

| `version.axl` | Result |
|---|---|
| `version("2026.35.9")` | primary binary |
| `version("2026.35.9", debug = True)` | `aspect-cli-debug-*`, CLI reports `(debug build)` |
| `debug = True`, CDN as the only source | `aspect-cli-debug-*` from the CDN |
| `debug = True` pinned to `2026.31.1` (no debug asset), CDN only | warns, falls back to the primary |
| `debug = True` pinned to `2026.31.1`, GitHub only | same warning and fallback |
| `github()` pointed at a nonexistent repo, CDN second | GitHub fails, CDN serves the binary |
| unpinned, and unpinned with `debug = True` | resolves the latest release through either source |
| `github(repo = "my-private-cli")` ahead of the default CDN | CDN still requests `aspect-cli-*`, not `my-private-cli-*` |

Also verified the CDN serves both the primary and `-debug-` assets across releases and that its bytes match the GitHub asset.
