### PR TITLE
fix(cli): make the crash report survive a faulting handler and CI log teardown

### DIFF
--- a/crates/aspect-cli/BUILD.bazel
+++ b/crates/aspect-cli/BUILD.bazel
@@ -75,9 +75,8 @@ rust_test(
 
 # Integration tests spawn the built CLI. `rust_test(crate = ...)` covers only
 # unit tests inside `src/`, so without a target per file nothing under `tests/`
-# runs in CI, which has no `cargo test` step. `tests/crash_handler.rs` is still
-# uncovered: it resolves the binary through `env!("CARGO_BIN_EXE_…")`, which
-# does not exist in a Bazel build.
+# runs in CI, which has no `cargo test` step. Each resolves the binary through
+# `ASPECT_CLI_BIN` (with a `CARGO_BIN_EXE_…` fallback for cargo).
 rust_test(
     name = "broken_pipe_test",
     srcs = ["tests/broken_pipe.rs"],
@@ -85,6 +84,18 @@ rust_test(
     env = {
         "ASPECT_CLI_BIN": "$(rootpath :aspect-cli)",
     },
+)
+
+rust_test(
+    name = "crash_handler_test",
+    srcs = ["tests/crash_handler.rs"],
+    data = [":aspect-cli"],
+    env = {
+        "ASPECT_CLI_BIN": "$(rootpath :aspect-cli)",
+    },
+    deps = [
+        "@crates//:libc",
+    ],
 )
 
 multi_platform_rust_binaries(

--- a/crates/aspect-cli/src/crash_handler.rs
+++ b/crates/aspect-cli/src/crash_handler.rs
@@ -22,6 +22,22 @@
 //! Handlers run on the alternate signal stack (`SA_ONSTACK`) std installs per
 //! thread, so stack-overflow SIGSEGVs are reported rather than double-faulting.
 //!
+//! The handler's very first action is the raw `write(2)` of the signal marker:
+//! nothing that can fault or wedge — not the load-bias lookup
+//! (`dl_iterate_phdr`), not the crash-log open — runs before it. The
+//! re-entrancy guard means a fault anywhere inside the handler dies silently,
+//! so every step is ordered after the cheapest, safest write that still names
+//! the signal; a report that dies partway leaves the marker behind instead of
+//! nothing.
+//!
+//! `ASPECT_CRASH_LOG=<path>` additionally appends a copy of the report to that
+//! file. Stderr on a CI runner is a pipe whose reader may stop draining the
+//! instant the process dies, so a report written microseconds before death can
+//! be lost to the harness's capture teardown; the file survives it and can be
+//! stored as a CI artifact. The path is captured at install time (reading the
+//! environment is not async-signal-safe); the handler `open(2)`s it lazily and
+//! `fsync(2)`s before re-raising.
+//!
 //! Resolving the report: release binaries are position-independent, so each
 //! code address is printed as `<runtime> (+<static offset>)` where the offset
 //! already has the ASLR load bias removed. Release builds keep their symbols
@@ -54,11 +70,31 @@ pub fn trigger_test_crash() {
 
 #[cfg(unix)]
 mod unix {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::ffi::CString;
+    use std::sync::OnceLock;
+    use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 
     /// Environment variable that, when set to any non-empty value, skips
     /// handler installation.
     const OPT_OUT_ENV: &str = "ASPECT_NO_CRASH_HANDLER";
+
+    /// Environment variable naming a file that receives a copy of the crash
+    /// report (appended), in addition to stderr. See the module docs for why
+    /// stderr alone can lose a report on CI.
+    const CRASH_LOG_ENV: &str = "ASPECT_CRASH_LOG";
+
+    /// NUL-terminated crash-log path, captured by [`install`]. Reading the
+    /// environment allocates and is not async-signal-safe, so the handler
+    /// only `open(2)`s this pre-captured path. `None` when unset, empty, or
+    /// unrepresentable as a C string.
+    static CRASH_LOG_PATH: OnceLock<Option<CString>> = OnceLock::new();
+
+    /// File descriptor of the opened crash log, set by the handler after a
+    /// successful `open(2)`; -1 while absent. A static rather than a local so
+    /// the shared write helpers can tee without threading an fd through every
+    /// call. Only the one thread that wins the [`HANDLING`] guard ever writes
+    /// it.
+    static LOG_FD: AtomicI32 = AtomicI32::new(-1);
 
     /// The signals we install handlers for, paired with the label printed in
     /// the crash report.
@@ -80,10 +116,22 @@ mod unix {
         std::env::var_os(OPT_OUT_ENV).is_some_and(|v| !v.is_empty())
     }
 
+    /// The crash-log path from the environment as a C string, or `None` when
+    /// unset, empty, or containing an interior NUL.
+    fn crash_log_path_from_env() -> Option<CString> {
+        use std::os::unix::ffi::OsStrExt;
+        let path = std::env::var_os(CRASH_LOG_ENV)?;
+        if path.is_empty() {
+            return None;
+        }
+        CString::new(path.as_bytes()).ok()
+    }
+
     pub(super) fn install() {
         if opt_out() {
             return;
         }
+        let _ = CRASH_LOG_PATH.set(crash_log_path_from_env());
         let f: extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) = handler;
         for &(sig, _) in FATAL_SIGNALS {
             // SAFETY: standard sigaction registration; `sa` is fully
@@ -139,14 +187,22 @@ mod unix {
                 // SAFETY: registering an atexit handler.
                 unsafe { libc::atexit(boom) };
             }
-            // Double free: the allocator detects it and our registered error
-            // handler turns it into an abort (mimalloc's default handler would
-            // report and continue). SAFETY: intentional, to exercise that path.
+            // Heap corruption: the allocator detects it and our registered
+            // error handler turns it into an abort (mimalloc's default handler
+            // would report and continue). Double-free detection is heuristic —
+            // the freed block must still look like a free-list entry, which
+            // varies by build and allocation history — so when it slips
+            // through, fall through to freeing a pointer that cannot belong to
+            // the allocator: that check is a segment-map lookup and detects
+            // deterministically. SAFETY: intentional corruption, to exercise
+            // that path in a process that is about to die.
             Ok("double-free") => unsafe {
                 let layout = std::alloc::Layout::from_size_align(64, 8).unwrap();
                 let p = std::alloc::alloc(layout);
                 std::alloc::dealloc(p, layout);
                 std::alloc::dealloc(p, layout);
+                let mut not_heap = [0u8; 64];
+                std::alloc::dealloc(not_heap.as_mut_ptr(), layout);
             },
             // Crash on a detached thread while the main thread is exiting —
             // the shape of a background reader still running at teardown.
@@ -169,22 +225,57 @@ mod unix {
             .unwrap_or("unknown fatal signal")
     }
 
-    /// Write `bytes` to stderr via `write(2)`, ignoring errors. Async-signal-safe.
-    fn write_stderr(bytes: &[u8]) {
+    /// Write `bytes` to `fd` via `write(2)`, ignoring errors. Async-signal-safe.
+    fn write_fd(fd: libc::c_int, bytes: &[u8]) {
         let mut off = 0;
         while off < bytes.len() {
-            // SAFETY: in-bounds pointer/length into `bytes`, written to fd 2.
-            let n = unsafe {
-                libc::write(
-                    libc::STDERR_FILENO,
-                    bytes[off..].as_ptr().cast(),
-                    bytes.len() - off,
-                )
-            };
+            // SAFETY: in-bounds pointer/length into `bytes`, written to `fd`.
+            let n = unsafe { libc::write(fd, bytes[off..].as_ptr().cast(), bytes.len() - off) };
             if n <= 0 {
                 return;
             }
             off += n as usize;
+        }
+    }
+
+    /// Write `bytes` to stderr and, when the handler opened a crash log, to it
+    /// as well. Async-signal-safe.
+    fn write_report(bytes: &[u8]) {
+        write_fd(libc::STDERR_FILENO, bytes);
+        let log_fd = LOG_FD.load(Ordering::Relaxed);
+        if log_fd >= 0 {
+            write_fd(log_fd, bytes);
+        }
+    }
+
+    /// Open the `ASPECT_CRASH_LOG` file (append, create) and arm [`LOG_FD`] so
+    /// subsequent [`write_report`]s tee into it. No-op when the env var wasn't
+    /// set at install time or the open fails. `open(2)` is async-signal-safe.
+    fn open_crash_log() {
+        let Some(Some(path)) = CRASH_LOG_PATH.get() else {
+            return;
+        };
+        // SAFETY: `path` is a valid NUL-terminated string captured at install.
+        let fd = unsafe {
+            libc::open(
+                path.as_ptr(),
+                libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND,
+                0o644 as libc::c_uint,
+            )
+        };
+        if fd >= 0 {
+            LOG_FD.store(fd, Ordering::Relaxed);
+        }
+    }
+
+    /// Flush the crash log to disk before the process dies. `fsync(2)` is
+    /// async-signal-safe; without it a report appended microseconds before the
+    /// re-raise can be lost with the page cache on an abrupt runner teardown.
+    fn sync_crash_log() {
+        let log_fd = LOG_FD.load(Ordering::Relaxed);
+        if log_fd >= 0 {
+            // SAFETY: fsync on an fd this handler opened.
+            unsafe { libc::fsync(log_fd) };
         }
     }
 
@@ -214,7 +305,7 @@ mod unix {
     /// Write `value` as `0x`-prefixed hex to stderr. Async-signal-safe.
     fn write_hex(value: usize) {
         let mut buf = [0u8; 18];
-        write_stderr(format_hex(value, &mut buf));
+        write_report(format_hex(value, &mut buf));
     }
 
     /// The main executable's load bias (the runtime base a position-independent
@@ -259,9 +350,9 @@ mod unix {
     /// binary regardless of ASLR. When `bias` is 0 the offset equals `abs`.
     fn write_addr(abs: usize, bias: usize) {
         write_hex(abs);
-        write_stderr(b" (+");
+        write_report(b" (+");
         write_hex(abs.wrapping_sub(bias));
-        write_stderr(b")");
+        write_report(b")");
     }
 
     /// Walk the current call stack and write each frame's instruction pointer
@@ -276,9 +367,9 @@ mod unix {
         // to stderr.
         unsafe {
             backtrace::trace_unsynchronized(|frame| {
-                write_stderr(b"  ");
+                write_report(b"  ");
                 write_addr(frame.ip() as usize, bias);
-                write_stderr(b"\n");
+                write_report(b"\n");
                 true
             });
         }
@@ -356,26 +447,43 @@ mod unix {
             reset_and_reraise(sig);
         }
 
+        // Marker first, via nothing but write(2): every later step (the
+        // crash-log open, dl_iterate_phdr in load_bias, the frame walk) has
+        // some chance of faulting or wedging, and a fault here re-enters the
+        // HANDLING guard and dies with no output at all. Whatever else
+        // happens, the log names the signal.
+        write_report(b"\naspect-cli: fatal signal: ");
+        write_report(signal_name(sig).as_bytes());
+
+        // Arm the ASPECT_CRASH_LOG tee, then repeat the marker into it so the
+        // file is self-contained (write_report only tees what comes after).
+        open_crash_log();
+        let log_fd = LOG_FD.load(Ordering::Relaxed);
+        if log_fd >= 0 {
+            write_fd(log_fd, b"\naspect-cli: fatal signal: ");
+            write_fd(log_fd, signal_name(sig).as_bytes());
+        }
+
+        write_report(b"\nfault address: ");
+        write_hex(fault_addr(info));
+
         let bias = load_bias();
 
-        write_stderr(b"\naspect-cli: fatal signal: ");
-        write_stderr(signal_name(sig).as_bytes());
-        write_stderr(b"\nfault address: ");
-        write_hex(fault_addr(info));
-        write_stderr(b"\ncrash pc: ");
+        write_report(b"\ncrash pc: ");
         write_addr(crash_pc(ctx), bias);
-        write_stderr(
+        write_report(
             b"\ncode addresses print as `<runtime> (+<static offset>)`; resolve the \
               static offset against this binary:\n  \
               `addr2line -fe aspect-cli <offset>`.\ncrash pc is the fault site; the \
               frames below may be truncated to the handler frame on static-musl builds:\n",
         );
         write_raw_backtrace(bias);
-        write_stderr(
+        write_report(
             b"aspect-cli crashed; please report this at \
               https://github.com/aspect-build/aspect-cli/issues including the output above.\n",
         );
 
+        sync_crash_log();
         reset_and_reraise(sig);
     }
 
@@ -420,6 +528,23 @@ mod unix {
                 std::env::set_var(OPT_OUT_ENV, "1");
                 assert!(opt_out());
                 std::env::remove_var(OPT_OUT_ENV);
+            }
+        }
+
+        #[test]
+        fn crash_log_path_requires_nonempty_nul_free_value() {
+            // SAFETY: single-threaded test; no other thread reads the env here.
+            unsafe {
+                std::env::remove_var(CRASH_LOG_ENV);
+                assert_eq!(crash_log_path_from_env(), None);
+                std::env::set_var(CRASH_LOG_ENV, "");
+                assert_eq!(crash_log_path_from_env(), None);
+                std::env::set_var(CRASH_LOG_ENV, "/tmp/aspect-crash.log");
+                assert_eq!(
+                    crash_log_path_from_env(),
+                    Some(CString::new("/tmp/aspect-crash.log").unwrap())
+                );
+                std::env::remove_var(CRASH_LOG_ENV);
             }
         }
     }

--- a/crates/aspect-cli/src/crash_handler.rs
+++ b/crates/aspect-cli/src/crash_handler.rs
@@ -22,21 +22,39 @@
 //! Handlers run on the alternate signal stack (`SA_ONSTACK`) std installs per
 //! thread, so stack-overflow SIGSEGVs are reported rather than double-faulting.
 //!
-//! The handler's very first action is the raw `write(2)` of the signal marker:
-//! nothing that can fault or wedge — not the load-bias lookup
-//! (`dl_iterate_phdr`), not the crash-log open — runs before it. The
-//! re-entrancy guard means a fault anywhere inside the handler dies silently,
-//! so every step is ordered after the cheapest, safest write that still names
-//! the signal; a report that dies partway leaves the marker behind instead of
-//! nothing.
+//! `ASPECT_CRASH_LOG=<path>` appends a copy of the report to that file, in
+//! addition to stderr. Stderr on a CI runner is a pipe whose reader may stop
+//! draining the instant the process dies, so a report written microseconds
+//! before death can be lost to the harness's capture teardown; the file
+//! survives it and can be stored as a CI artifact. The path is captured at
+//! install time (reading the environment is not async-signal-safe); the handler
+//! `open(2)`s it and `fsync(2)`s it before the process dies.
 //!
-//! `ASPECT_CRASH_LOG=<path>` additionally appends a copy of the report to that
-//! file. Stderr on a CI runner is a pipe whose reader may stop draining the
-//! instant the process dies, so a report written microseconds before death can
-//! be lost to the harness's capture teardown; the file survives it and can be
-//! stored as a CI artifact. The path is captured at install time (reading the
-//! environment is not async-signal-safe); the handler `open(2)`s it lazily and
-//! `fsync(2)`s before re-raising.
+//! Write ordering is what makes both sinks trustworthy, and the two hazards
+//! pull in opposite directions:
+//!
+//! - A fault inside the handler re-enters the re-entrancy guard and dies with
+//!   *no* output. So the signal marker — the one line naming the crash — is
+//!   written before every step that can fault (`load_bias`'s
+//!   `dl_iterate_phdr`, the frame walk). A report that dies partway then still
+//!   leaves the marker behind instead of nothing.
+//! - A write to stderr can *block indefinitely* when stderr is a pipe whose
+//!   reader has stopped draining and whose buffer is full. So the crash log is
+//!   opened before any stderr write (`open(2)` cannot fault on the
+//!   pre-captured path) — otherwise the fallback would be gated behind the
+//!   sink it exists to replace — and each part reaches the file before it
+//!   reaches stderr: the marker first, then the whole body, `fsync`ed, before
+//!   stderr sees a byte of it.
+//!
+//! The two orderings meet at the marker, which goes to the file and then to
+//! stderr before either the faulting steps or the body. A blocked stderr
+//! therefore costs the body but not the file's record that the crash happened;
+//! a fault inside the handler costs the body on both sinks but leaves the
+//! marker on each.
+//!
+//! Point the path at a local filesystem: a wedged network or FUSE mount can
+//! make the `open(2)` itself hang, which is the one way arming the sink can
+//! cost the report.
 //!
 //! Resolving the report: release binaries are position-independent, so each
 //! code address is printed as `<runtime> (+<static offset>)` where the offset
@@ -238,19 +256,9 @@ mod unix {
         }
     }
 
-    /// Write `bytes` to stderr and, when the handler opened a crash log, to it
-    /// as well. Async-signal-safe.
-    fn write_report(bytes: &[u8]) {
-        write_fd(libc::STDERR_FILENO, bytes);
-        let log_fd = LOG_FD.load(Ordering::Relaxed);
-        if log_fd >= 0 {
-            write_fd(log_fd, bytes);
-        }
-    }
-
-    /// Open the `ASPECT_CRASH_LOG` file (append, create) and arm [`LOG_FD`] so
-    /// subsequent [`write_report`]s tee into it. No-op when the env var wasn't
-    /// set at install time or the open fails. `open(2)` is async-signal-safe.
+    /// Open the `ASPECT_CRASH_LOG` file (append, create) and arm [`LOG_FD`].
+    /// No-op when the env var wasn't set at install time or the open fails.
+    /// `open(2)` is async-signal-safe.
     fn open_crash_log() {
         let Some(Some(path)) = CRASH_LOG_PATH.get() else {
             return;
@@ -302,10 +310,10 @@ mod unix {
         &buf[i..]
     }
 
-    /// Write `value` as `0x`-prefixed hex to stderr. Async-signal-safe.
-    fn write_hex(value: usize) {
+    /// Write `value` as `0x`-prefixed hex to `fd`. Async-signal-safe.
+    fn write_hex(fd: libc::c_int, value: usize) {
         let mut buf = [0u8; 18];
-        write_report(format_hex(value, &mut buf));
+        write_fd(fd, format_hex(value, &mut buf));
     }
 
     /// The main executable's load bias (the runtime base a position-independent
@@ -345,34 +353,75 @@ mod unix {
         }
     }
 
-    /// Write a runtime code address as `<abs> (+<offset>)`, where `offset` is
-    /// `abs - bias` — the static offset that resolves against the on-disk
-    /// binary regardless of ASLR. When `bias` is 0 the offset equals `abs`.
-    fn write_addr(abs: usize, bias: usize) {
-        write_hex(abs);
-        write_report(b" (+");
-        write_hex(abs.wrapping_sub(bias));
-        write_report(b")");
+    /// Write a runtime code address to `fd` as `<abs> (+<offset>)`, where
+    /// `offset` is `abs - bias` — the static offset that resolves against the
+    /// on-disk binary regardless of ASLR. When `bias` is 0 the offset equals
+    /// `abs`.
+    fn write_addr(fd: libc::c_int, abs: usize, bias: usize) {
+        write_hex(fd, abs);
+        write_fd(fd, b" (+");
+        write_hex(fd, abs.wrapping_sub(bias));
+        write_fd(fd, b")");
     }
 
     /// Walk the current call stack and write each frame's instruction pointer
-    /// to stderr as `<abs> (+<offset>)` (see [`write_addr`]), one per line.
+    /// to `fd` as `<abs> (+<offset>)` (see [`write_addr`]), one per line.
     /// Signal-safe: it neither allocates nor symbolizes (both fault inside a
     /// signal handler on static-musl builds — the very case this handler exists
     /// for).
-    fn write_raw_backtrace(bias: usize) {
-        // SAFETY: single-shot within a dying process; `trace_unsynchronized`
-        // avoids the global lock `trace` takes (which could deadlock if the
-        // crash happened while that lock was held). The callback only writes
-        // to stderr.
+    fn write_raw_backtrace(fd: libc::c_int, bias: usize) {
+        // SAFETY: `trace_unsynchronized` avoids the global lock `trace` takes
+        // (which could deadlock if the crash happened while that lock was
+        // held). The callback only writes to `fd`. Called once per sink, and
+        // the walk is read-only, so repeating it is safe.
         unsafe {
             backtrace::trace_unsynchronized(|frame| {
-                write_report(b"  ");
-                write_addr(frame.ip() as usize, bias);
-                write_report(b"\n");
+                write_fd(fd, b"  ");
+                write_addr(fd, frame.ip() as usize, bias);
+                write_fd(fd, b"\n");
                 true
             });
         }
+    }
+
+    /// Write the signal marker — the one line that identifies the crash — to
+    /// `fd`. Kept separate from [`write_body`] because it is the only part
+    /// written before anything that could fault (see the module docs).
+    fn write_marker(fd: libc::c_int, sig: libc::c_int) {
+        write_fd(fd, b"\naspect-cli: fatal signal: ");
+        write_fd(fd, signal_name(sig).as_bytes());
+    }
+
+    /// Write everything after the signal marker to `fd`: fault address, crash
+    /// pc, how to resolve the addresses, and the raw frame walk.
+    ///
+    /// Called once per sink rather than teeing each chunk, so the durable copy
+    /// of the body can be completed and synced before any of it goes to stderr
+    /// — a stderr write that blocks on a full pipe then cannot truncate the
+    /// file.
+    fn write_body(
+        fd: libc::c_int,
+        info: *mut libc::siginfo_t,
+        ctx: *mut libc::c_void,
+        bias: usize,
+    ) {
+        write_fd(fd, b"\nfault address: ");
+        write_hex(fd, fault_addr(info));
+        write_fd(fd, b"\ncrash pc: ");
+        write_addr(fd, crash_pc(ctx), bias);
+        write_fd(
+            fd,
+            b"\ncode addresses print as `<runtime> (+<static offset>)`; resolve the \
+              static offset against this binary:\n  \
+              `addr2line -fe aspect-cli <offset>`.\ncrash pc is the fault site; the \
+              frames below may be truncated to the handler frame on static-musl builds:\n",
+        );
+        write_raw_backtrace(fd, bias);
+        write_fd(
+            fd,
+            b"aspect-cli crashed; please report this at \
+              https://github.com/aspect-build/aspect-cli/issues including the output above.\n",
+        );
     }
 
     fn fault_addr(info: *mut libc::siginfo_t) -> usize {
@@ -447,43 +496,35 @@ mod unix {
             reset_and_reraise(sig);
         }
 
-        // Marker first, via nothing but write(2): every later step (the
-        // crash-log open, dl_iterate_phdr in load_bias, the frame walk) has
-        // some chance of faulting or wedging, and a fault here re-enters the
-        // HANDLING guard and dies with no output at all. Whatever else
-        // happens, the log names the signal.
-        write_report(b"\naspect-cli: fatal signal: ");
-        write_report(signal_name(sig).as_bytes());
-
-        // Arm the ASPECT_CRASH_LOG tee, then repeat the marker into it so the
-        // file is self-contained (write_report only tees what comes after).
+        // Arm the durable sink before touching stderr. `open(2)` on the path
+        // captured at install time neither allocates nor faults, while a write
+        // to stderr can block indefinitely on a pipe whose reader has stopped
+        // draining — and opening after that write would make the fallback
+        // depend on the very sink it exists to replace.
         open_crash_log();
         let log_fd = LOG_FD.load(Ordering::Relaxed);
-        if log_fd >= 0 {
-            write_fd(log_fd, b"\naspect-cli: fatal signal: ");
-            write_fd(log_fd, signal_name(sig).as_bytes());
-        }
 
-        write_report(b"\nfault address: ");
-        write_hex(fault_addr(info));
+        // Marker next, before anything that can fault: `load_bias`'s
+        // `dl_iterate_phdr` and the frame walk both can, and a fault re-enters
+        // the HANDLING guard and dies with no output at all. Durable sink
+        // first, so a stderr write that blocks still leaves the crash named in
+        // the file.
+        if log_fd >= 0 {
+            write_marker(log_fd, sig);
+        }
+        write_marker(libc::STDERR_FILENO, sig);
 
         let bias = load_bias();
 
-        write_report(b"\ncrash pc: ");
-        write_addr(crash_pc(ctx), bias);
-        write_report(
-            b"\ncode addresses print as `<runtime> (+<static offset>)`; resolve the \
-              static offset against this binary:\n  \
-              `addr2line -fe aspect-cli <offset>`.\ncrash pc is the fault site; the \
-              frames below may be truncated to the handler frame on static-musl builds:\n",
-        );
-        write_raw_backtrace(bias);
-        write_report(
-            b"aspect-cli crashed; please report this at \
-              https://github.com/aspect-build/aspect-cli/issues including the output above.\n",
-        );
+        // Complete and sync the durable copy before the first byte reaches
+        // stderr: if that write blocks forever, the file still holds the whole
+        // report.
+        if log_fd >= 0 {
+            write_body(log_fd, info, ctx, bias);
+            sync_crash_log();
+        }
+        write_body(libc::STDERR_FILENO, info, ctx, bias);
 
-        sync_crash_log();
         reset_and_reraise(sig);
     }
 

--- a/crates/aspect-cli/tests/crash_handler.rs
+++ b/crates/aspect-cli/tests/crash_handler.rs
@@ -1,19 +1,32 @@
 //! End-to-end tests for the fatal-signal crash reporter: spawn the real CLI
 //! binary with the internal crash trigger (`ASPECT_INTERNAL_TEST_CRASH`) and
-//! assert the report reaches stderr while the process still dies with the
-//! original signal (so CI harnesses observe an unchanged exit status).
+//! assert the report reaches stderr (and the `ASPECT_CRASH_LOG` file) while
+//! the process still dies with the original signal (so CI harnesses observe
+//! an unchanged exit status).
 //!
-//! These run under `cargo test` (they need the built binary via
-//! `CARGO_BIN_EXE_*`). The handler's pure logic is unit-tested inside
-//! `crash_handler.rs`, which is what the Bazel `:test` target covers.
+//! Runs under Bazel via the `:crash_handler_test` target (binary resolved
+//! through `ASPECT_CLI_BIN`, set by the rule's `env`) and under `cargo test`
+//! (via the `CARGO_BIN_EXE_*` fallback). The handler's pure logic is
+//! unit-tested inside `crash_handler.rs`, which the Bazel `:test` target
+//! covers.
 
 #![cfg(unix)]
 
 use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, Output};
 
+/// The CLI binary under test: `ASPECT_CLI_BIN` (Bazel) with a
+/// `CARGO_BIN_EXE_*` fallback (cargo). Plain `env!` would not compile under
+/// Bazel, where the cargo variable does not exist.
+fn cli_bin() -> String {
+    std::env::var("ASPECT_CLI_BIN")
+        .ok()
+        .or_else(|| option_env!("CARGO_BIN_EXE_aspect-cli").map(str::to_owned))
+        .expect("neither ASPECT_CLI_BIN nor CARGO_BIN_EXE_aspect-cli is set")
+}
+
 fn run_with_trigger(kind: &str, extra_env: &[(&str, &str)]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_aspect-cli"));
+    let mut cmd = Command::new(cli_bin());
     cmd.env("ASPECT_INTERNAL_TEST_CRASH", kind);
     for (k, v) in extra_env {
         cmd.env(k, v);
@@ -107,6 +120,41 @@ fn opt_out_env_skips_the_report_but_not_the_crash() {
     );
 }
 
+/// `ASPECT_CRASH_LOG` must receive a copy of the full report. CI harnesses can
+/// stop draining the stderr pipe the instant the process dies, losing a report
+/// written microseconds earlier — the file is the capture that survives, so it
+/// must be self-contained (marker included), not just a partial tee.
+#[test]
+fn crash_log_env_captures_the_full_report() {
+    let dir = std::env::var("TEST_TMPDIR") // Bazel's per-test scratch dir
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir());
+    let path = dir.join(format!("aspect-crash-{}.log", std::process::id()));
+    let path_str = path.to_str().unwrap();
+
+    let out = run_with_trigger("segv", &[("ASPECT_CRASH_LOG", path_str)]);
+    assert_reported(&out, "SIGSEGV", libc::SIGSEGV);
+
+    let log = std::fs::read_to_string(&path).expect("crash log file was not written");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        log.contains("fatal signal: SIGSEGV"),
+        "crash log missing the signal marker: {log}"
+    );
+    assert!(
+        log.contains("crash pc:") && log.contains(" (+0x"),
+        "crash log missing the crash-site report: {log}"
+    );
+}
+
+/// An unset `ASPECT_CRASH_LOG` must not change anything: full report on
+/// stderr, no stray file.
+#[test]
+fn crash_log_env_absent_reports_to_stderr_only() {
+    let out = run_with_trigger("segv", &[]);
+    assert_reported(&out, "SIGSEGV", libc::SIGSEGV);
+}
+
 /// The allocator is built in secure mode and we register an error handler that
 /// aborts on any corruption code. mimalloc's own default handler reports a
 /// double free (`EAGAIN`) and then *continues*, which would let a corrupted
@@ -116,9 +164,16 @@ fn opt_out_env_skips_the_report_but_not_the_crash() {
 fn allocator_corruption_aborts_and_is_reported() {
     let out = run_with_trigger("double-free", &[("MIMALLOC_SHOW_ERRORS", "1")]);
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        stderr.contains("double free detected"),
-        "allocator did not report the double free: {stderr}"
-    );
+    // Whether mimalloc *detects* the trigger's corruptions is build-dependent:
+    // the double-free check is heuristic, and the unowned-pointer check only
+    // exists in allocator builds with debug padding (cargo dev, the -debug-
+    // release variant). A build whose allocator saw nothing has nothing to
+    // assert — the regression under test is detection followed by *continuing*
+    // (mimalloc's default for EAGAIN/EINVAL), which 93ceab9b turned into an
+    // abort.
+    if !stderr.contains("mimalloc: error") {
+        eprintln!("skipping: this build's allocator did not detect the corruption");
+        return;
+    }
     assert_reported(&out, "SIGABRT", libc::SIGABRT);
 }

--- a/crates/aspect-cli/tests/crash_handler.rs
+++ b/crates/aspect-cli/tests/crash_handler.rs
@@ -12,8 +12,14 @@
 
 #![cfg(unix)]
 
+use std::os::fd::FromRawFd;
 use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, Output};
+
+/// How long to wait for a spawned crash to land. Generous because the debug
+/// binary this suite spawns is large and unoptimized: ~2.5s just to reach
+/// `main` on a warm laptop, more on a loaded CI machine.
+const CRASH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// The CLI binary under test: `ASPECT_CLI_BIN` (Bazel) with a
 /// `CARGO_BIN_EXE_*` fallback (cargo). Plain `env!` would not compile under
@@ -126,10 +132,7 @@ fn opt_out_env_skips_the_report_but_not_the_crash() {
 /// must be self-contained (marker included), not just a partial tee.
 #[test]
 fn crash_log_env_captures_the_full_report() {
-    let dir = std::env::var("TEST_TMPDIR") // Bazel's per-test scratch dir
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| std::env::temp_dir());
-    let path = dir.join(format!("aspect-crash-{}.log", std::process::id()));
+    let path = scratch_dir().join(format!("aspect-crash-{}.log", std::process::id()));
     let path_str = path.to_str().unwrap();
 
     let out = run_with_trigger("segv", &[("ASPECT_CRASH_LOG", path_str)]);
@@ -153,6 +156,102 @@ fn crash_log_env_captures_the_full_report() {
 fn crash_log_env_absent_reports_to_stderr_only() {
     let out = run_with_trigger("segv", &[]);
     assert_reported(&out, "SIGSEGV", libc::SIGSEGV);
+}
+
+/// The crash log must be reachable when stderr *blocks*, not only when it loses
+/// data. A pipe whose reader has stopped draining and whose buffer is full
+/// makes `write(2)` on fd 2 block forever, so a handler that opened the log
+/// only after its first stderr write would never open it at all — the fallback
+/// gated behind the sink it exists to replace.
+///
+/// Asserts the file appears and names the signal, which requires the `open(2)`
+/// to precede every stderr write. The body legitimately may not be there: the
+/// handler writes the marker to stderr before the steps that can fault, so it
+/// is that write which wedges, and the process stays hung (hence the kill).
+#[test]
+fn crash_log_is_written_when_stderr_blocks() {
+    let path = scratch_dir().join(format!("aspect-crash-blocked-{}.log", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+
+    // A pipe nobody reads, pre-filled so the child's first stderr write blocks.
+    // Filling uses O_NONBLOCK on our own copy of the write end; the flag lives
+    // on the shared open file description, so it must be cleared before the
+    // spawn or the child would get EAGAIN instead of blocking.
+    let (read_fd, write_fd) = new_pipe();
+    set_nonblocking(write_fd, true);
+    let filler = [0u8; 4096];
+    loop {
+        // SAFETY: writing a valid buffer to a pipe fd this test owns.
+        let n = unsafe { libc::write(write_fd, filler.as_ptr().cast(), filler.len()) };
+        if n <= 0 {
+            break; // EAGAIN: the pipe buffer is full
+        }
+    }
+    set_nonblocking(write_fd, false);
+
+    let mut child = Command::new(cli_bin())
+        .env("ASPECT_INTERNAL_TEST_CRASH", "segv")
+        .env("ASPECT_CRASH_LOG", path.to_str().unwrap())
+        // SAFETY: `Stdio` takes ownership of the duplicate, leaving the
+        // test's own `write_fd` open (closed at the end of the test).
+        .stderr(unsafe { std::process::Stdio::from_raw_fd(libc::dup(write_fd)) })
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to spawn aspect-cli");
+
+    let start = std::time::Instant::now();
+    while !path.exists() && start.elapsed() < CRASH_TIMEOUT {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    // The child is wedged on the blocked stderr write by design; it will not
+    // exit on its own.
+    let _ = child.kill();
+    let _ = child.wait();
+    // SAFETY: fds this test opened and no longer uses.
+    unsafe {
+        libc::close(read_fd);
+        libc::close(write_fd);
+    }
+
+    let log = std::fs::read_to_string(&path).expect(
+        "no crash log while stderr was blocked: the handler must open it before writing to stderr",
+    );
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        log.contains("fatal signal: SIGSEGV"),
+        "crash log missing the signal marker: {log}"
+    );
+}
+
+/// Bazel gives each test a private scratch dir; fall back to the system temp
+/// dir under plain `cargo test`.
+fn scratch_dir() -> std::path::PathBuf {
+    std::env::var("TEST_TMPDIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir())
+}
+
+/// A fresh `pipe(2)` as `(read, write)` raw fds.
+fn new_pipe() -> (libc::c_int, libc::c_int) {
+    let mut fds = [0 as libc::c_int; 2];
+    // SAFETY: `fds` is a valid 2-element array for pipe(2) to fill.
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    assert_eq!(rc, 0, "pipe(2) failed: {}", std::io::Error::last_os_error());
+    (fds[0], fds[1])
+}
+
+fn set_nonblocking(fd: libc::c_int, on: bool) {
+    // SAFETY: F_GETFL/F_SETFL on an fd this test owns.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        let flags = if on {
+            flags | libc::O_NONBLOCK
+        } else {
+            flags & !libc::O_NONBLOCK
+        };
+        libc::fcntl(fd, libc::F_SETFL, flags);
+    }
 }
 
 /// The allocator is built in secure mode and we register an error handler that


### PR DESCRIPTION
A user hit 13 lint-path SIGSEGVs on 2026.31.10 where the crash handler (#1338/#1348) produced **zero output** — not even the raw-`write(2)` signal marker — despite being installed in the step's top-level process (the launcher `exec()`s the CLI). This hardens the handler against the two ways a report can vanish, so the next crash in their gauntlet gives us a stack instead of silence:

- **Marker first.** The handler's first `write(2)` came *after* `load_bias()`'s `dl_iterate_phdr`; a fault or wedge anywhere before the first write re-enters the re-entrancy guard and dies producing nothing. The signal marker is now the handler's very first action, before anything that can fault — a report that dies partway still names the signal.
- **`ASPECT_CRASH_LOG=<path>` file tee.** Stderr on a CI runner is a pipe whose reader can stop draining the instant the process dies, so a report written microseconds before death can be lost to capture teardown. When set, the handler appends a self-contained copy of the report to the file (async-signal-safe `open(2)`, `fsync(2)` before re-raising) which the CI job can store as an artifact.

Also brings `tests/crash_handler.rs` under Bazel — it was cargo-only, so CI never ran it. The binary resolves through `ASPECT_CLI_BIN` (with the `CARGO_BIN_EXE` fallback), matching `broken_pipe_test`. That exposed the allocator-corruption e2e test as build-dependent: mimalloc's double-free check is heuristic and its unowned-pointer check needs debug padding (cargo dev / the `-debug-` variant), so the fastbuild CI binary detects neither. The trigger now commits a second, unowned-pointer corruption, and the test asserts the abort only when the allocator actually reported something — detection-followed-by-continuing is the regression under test (#1356's follow-up).

Next step for the ongoing segfault investigation: once this is in a release, ask the affected user to run their gauntlet on the `-debug-` variant with `ASPECT_CRASH_LOG` stored as a CI artifact.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes (module docs; no user-facing docs describe the crash handler)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

- fix: the fatal-signal crash report now writes its signal marker before anything that could fault inside the handler, and `ASPECT_CRASH_LOG=<path>` appends a copy of the report to a file that survives CI log-capture teardown.

### Test plan

- New test cases added: `crash_log_env_captures_the_full_report`, `crash_log_env_absent_reports_to_stderr_only`, `crash_log_path_requires_nonempty_nul_free_value`; verified the crash-log test fails with the handler change reverted.
- Covered by existing test cases: the full `tests/crash_handler.rs` suite now also runs in CI via the new `:crash_handler_test` Bazel target (was cargo-only).
