### PR TITLE
fix(bes): retry Cancelled and Unknown so a GOAWAY does not lose build events

### DIFF
--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -1044,10 +1044,8 @@ mod tests {
         /// long-lived streams expecting the client to reconnect and
         /// resume from the last acked event.
         AckThenShed(u32),
-        /// Ack the first N requests of each connection, then end the
-        /// response stream with UNKNOWN — how tonic surfaces an h2
-        /// protocol error (no gRPC status on the wire) when the backend
-        /// pod is terminated mid-stream.
+        /// Ack the first N requests on each connection, then simulate tonic
+        /// mapping an h2 failure without a gRPC status to `Unknown`.
         AckThenUnknown(u32),
     }
 

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -1015,8 +1015,6 @@ mod tests {
     use super::*;
 
     use std::pin::Pin;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
 
     use axl_proto::build_event_stream::{Progress, build_event::Payload};
@@ -1055,11 +1053,6 @@ mod tests {
 
     struct TestServer {
         mode: ServerMode,
-        /// Ordinal of the lifecycle call to fail once with CANCELLED, 1-based
-        /// over the sink's call order (build_enqueued, invocation_started,
-        /// invocation_finished, build_finished). `0` never fails.
-        cancel_lifecycle_call: u32,
-        lifecycle_calls: Arc<AtomicU32>,
     }
 
     #[tonic::async_trait]
@@ -1068,12 +1061,6 @@ mod tests {
             &self,
             _request: Request<PublishLifecycleEventRequest>,
         ) -> Result<Response<()>, Status> {
-            let nth = self.lifecycle_calls.fetch_add(1, Ordering::SeqCst) + 1;
-            if nth == self.cancel_lifecycle_call {
-                // What hyper reports when a GOAWAY retires the connection out
-                // from under a queued unary request.
-                return Err(Status::cancelled("operation was canceled"));
-            }
             Ok(Response::new(()))
         }
 
@@ -1150,25 +1137,11 @@ mod tests {
     }
 
     async fn start_server(mode: ServerMode) -> String {
-        start_server_cancelling_lifecycle(mode, 0).await
-    }
-
-    /// [`start_server`], with the `cancel_lifecycle_call`-th lifecycle RPC
-    /// failing once with CANCELLED.
-    async fn start_server_cancelling_lifecycle(
-        mode: ServerMode,
-        cancel_lifecycle_call: u32,
-    ) -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let server = TestServer {
-            mode,
-            cancel_lifecycle_call,
-            lifecycle_calls: Arc::new(AtomicU32::new(0)),
-        };
         tokio::spawn(
             tonic::transport::Server::builder()
-                .add_service(PublishBuildEventServer::new(server))
+                .add_service(PublishBuildEventServer::new(TestServer { mode }))
                 .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
         );
         format!("http://{addr}")
@@ -1462,30 +1435,6 @@ mod tests {
             "unexpected error: {err}"
         );
         assert_eq!(stats.acked, 0);
-    }
-
-    /// The post-stream `invocation_finished` lands on a connection the server
-    /// is retiring, so hyper cancels it and tonic reports CANCELLED. The call
-    /// is idempotent and never reached the application, so `retry_lifecycle`
-    /// must redial and succeed rather than end the sink.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn cancelled_lifecycle_is_retried() {
-        // 3rd lifecycle call: build_enqueued, invocation_started, then
-        // invocation_finished once the stream is done.
-        let endpoint = start_server_cancelling_lifecycle(ServerMode::Ack, 3).await;
-        let retry = RetryConfig {
-            retry_min_delay: Duration::from_millis(10),
-            ..Default::default()
-        };
-        let mut events: Vec<BuildEvent> = (0..5).map(|_| progress_event(64)).collect();
-        events.last_mut().unwrap().last_message = true;
-        let (stats, outcome) = work_against(endpoint, events, retry).await;
-        assert!(
-            outcome.is_ok(),
-            "expected success, got {:?}",
-            outcome.unwrap_err()
-        );
-        assert_eq!(stats, SinkStats { sent: 5, acked: 5 });
     }
 
     /// The backend pod is terminated mid-stream: tonic maps the h2 protocol

--- a/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/grpc.rs
@@ -1015,6 +1015,8 @@ mod tests {
     use super::*;
 
     use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
 
     use axl_proto::build_event_stream::{Progress, build_event::Payload};
@@ -1044,10 +1046,20 @@ mod tests {
         /// long-lived streams expecting the client to reconnect and
         /// resume from the last acked event.
         AckThenShed(u32),
+        /// Ack the first N requests of each connection, then end the
+        /// response stream with UNKNOWN — how tonic surfaces an h2
+        /// protocol error (no gRPC status on the wire) when the backend
+        /// pod is terminated mid-stream.
+        AckThenUnknown(u32),
     }
 
     struct TestServer {
         mode: ServerMode,
+        /// Ordinal of the lifecycle call to fail once with CANCELLED, 1-based
+        /// over the sink's call order (build_enqueued, invocation_started,
+        /// invocation_finished, build_finished). `0` never fails.
+        cancel_lifecycle_call: u32,
+        lifecycle_calls: Arc<AtomicU32>,
     }
 
     #[tonic::async_trait]
@@ -1056,6 +1068,12 @@ mod tests {
             &self,
             _request: Request<PublishLifecycleEventRequest>,
         ) -> Result<Response<()>, Status> {
+            let nth = self.lifecycle_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if nth == self.cancel_lifecycle_call {
+                // What hyper reports when a GOAWAY retires the connection out
+                // from under a queued unary request.
+                return Err(Status::cancelled("operation was canceled"));
+            }
             Ok(Response::new(()))
         }
 
@@ -1098,7 +1116,14 @@ mod tests {
                     });
                     Ok(Response::new(Box::pin(ReceiverStream::new(ack_rx))))
                 }
-                ServerMode::AckThenShed(acks_per_stream) => {
+                ServerMode::AckThenShed(acks_per_stream)
+                | ServerMode::AckThenUnknown(acks_per_stream) => {
+                    let shed = match self.mode {
+                        ServerMode::AckThenUnknown(_) => Status::unknown(
+                            "h2 protocol error: error reading a body from connection",
+                        ),
+                        _ => Status::unavailable("stream shed by server"),
+                    };
                     let (ack_tx, ack_rx) = tokio::sync::mpsc::channel(16);
                     tokio::spawn(async move {
                         let mut acked = 0;
@@ -1116,9 +1141,7 @@ mod tests {
                             }
                             acked += 1;
                         }
-                        let _ = ack_tx
-                            .send(Err(Status::unavailable("stream shed by server")))
-                            .await;
+                        let _ = ack_tx.send(Err(shed)).await;
                     });
                     Ok(Response::new(Box::pin(ReceiverStream::new(ack_rx))))
                 }
@@ -1127,11 +1150,25 @@ mod tests {
     }
 
     async fn start_server(mode: ServerMode) -> String {
+        start_server_cancelling_lifecycle(mode, 0).await
+    }
+
+    /// [`start_server`], with the `cancel_lifecycle_call`-th lifecycle RPC
+    /// failing once with CANCELLED.
+    async fn start_server_cancelling_lifecycle(
+        mode: ServerMode,
+        cancel_lifecycle_call: u32,
+    ) -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let server = TestServer {
+            mode,
+            cancel_lifecycle_call,
+            lifecycle_calls: Arc::new(AtomicU32::new(0)),
+        };
         tokio::spawn(
             tonic::transport::Server::builder()
-                .add_service(PublishBuildEventServer::new(TestServer { mode }))
+                .add_service(PublishBuildEventServer::new(server))
                 .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
         );
         format!("http://{addr}")
@@ -1425,6 +1462,58 @@ mod tests {
             "unexpected error: {err}"
         );
         assert_eq!(stats.acked, 0);
+    }
+
+    /// The post-stream `invocation_finished` lands on a connection the server
+    /// is retiring, so hyper cancels it and tonic reports CANCELLED. The call
+    /// is idempotent and never reached the application, so `retry_lifecycle`
+    /// must redial and succeed rather than end the sink.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelled_lifecycle_is_retried() {
+        // 3rd lifecycle call: build_enqueued, invocation_started, then
+        // invocation_finished once the stream is done.
+        let endpoint = start_server_cancelling_lifecycle(ServerMode::Ack, 3).await;
+        let retry = RetryConfig {
+            retry_min_delay: Duration::from_millis(10),
+            ..Default::default()
+        };
+        let mut events: Vec<BuildEvent> = (0..5).map(|_| progress_event(64)).collect();
+        events.last_mut().unwrap().last_message = true;
+        let (stats, outcome) = work_against(endpoint, events, retry).await;
+        assert!(
+            outcome.is_ok(),
+            "expected success, got {:?}",
+            outcome.unwrap_err()
+        );
+        assert_eq!(stats, SinkStats { sent: 5, acked: 5 });
+    }
+
+    /// The backend pod is terminated mid-stream: tonic maps the h2 protocol
+    /// error to UNKNOWN. The stream never reached the application beyond the
+    /// acked prefix, so the sink must reconnect and replay the rest.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unknown_mid_stream_reconnects_and_replays() {
+        let endpoint = start_server(ServerMode::AckThenUnknown(2)).await;
+        let retry = RetryConfig {
+            max_retries: 1,
+            retry_min_delay: Duration::from_millis(10),
+            ..Default::default()
+        };
+        let mut events: Vec<BuildEvent> = (0..10).map(|_| progress_event(64)).collect();
+        events.last_mut().unwrap().last_message = true;
+        let (stats, outcome) = work_against(endpoint, events, retry).await;
+        assert!(
+            outcome.is_ok(),
+            "expected success, got {:?}",
+            outcome.unwrap_err()
+        );
+        assert_eq!(
+            stats,
+            SinkStats {
+                sent: 10,
+                acked: 10
+            }
+        );
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -339,12 +339,8 @@ pub fn is_retryable(err: &ClientError) -> bool {
         // reset — all assumed transient.
         ClientError::Transport(_) => true,
         ClientError::InvalidEndpoint(_) => false,
-        // `Cancelled` and `Unknown` are how a GOAWAY reaches us: hyper cancels
-        // requests queued on a connection the server is retiring, and tonic maps
-        // an h2 protocol error carrying no gRPC status to `Unknown`. Neither
-        // request reached the application, so replaying it is safe. A local
-        // abort never lands here — it closes the upstream instead, which
-        // `drive_stream` reports as `UpstreamClosed`.
+        // GOAWAY can surface as `Cancelled` for queued requests or `Unknown` for
+        // unmapped h2 failures. BES retries are idempotent or sequence-number deduplicated.
         ClientError::Status(status) => matches!(
             status.code(),
             Code::Unavailable

--- a/crates/axl-runtime/src/engine/bazel/sink/retry.rs
+++ b/crates/axl-runtime/src/engine/bazel/sink/retry.rs
@@ -339,6 +339,12 @@ pub fn is_retryable(err: &ClientError) -> bool {
         // reset — all assumed transient.
         ClientError::Transport(_) => true,
         ClientError::InvalidEndpoint(_) => false,
+        // `Cancelled` and `Unknown` are how a GOAWAY reaches us: hyper cancels
+        // requests queued on a connection the server is retiring, and tonic maps
+        // an h2 protocol error carrying no gRPC status to `Unknown`. Neither
+        // request reached the application, so replaying it is safe. A local
+        // abort never lands here — it closes the upstream instead, which
+        // `drive_stream` reports as `UpstreamClosed`.
         ClientError::Status(status) => matches!(
             status.code(),
             Code::Unavailable
@@ -346,6 +352,8 @@ pub fn is_retryable(err: &ClientError) -> bool {
                 | Code::ResourceExhausted
                 | Code::Aborted
                 | Code::Internal
+                | Code::Cancelled
+                | Code::Unknown
         ),
     }
 }
@@ -696,13 +704,30 @@ mod tests {
 
     #[test]
     fn classifier_status_codes() {
-        let unavailable = ClientError::Status(tonic::Status::new(tonic::Code::Unavailable, "x"));
-        let unauth = ClientError::Status(tonic::Status::new(tonic::Code::Unauthenticated, "x"));
-        let internal = ClientError::Status(tonic::Status::new(tonic::Code::Internal, "x"));
-        let perm = ClientError::Status(tonic::Status::new(tonic::Code::PermissionDenied, "x"));
-        assert!(is_retryable(&unavailable));
-        assert!(is_retryable(&internal));
-        assert!(!is_retryable(&unauth));
-        assert!(!is_retryable(&perm));
+        // `Cancelled` and `Unknown` are the two a GOAWAY produces: a request
+        // hyper cancelled on a retiring connection, and an h2 protocol error
+        // tonic could not map to a gRPC status.
+        for code in [
+            tonic::Code::Unavailable,
+            tonic::Code::DeadlineExceeded,
+            tonic::Code::ResourceExhausted,
+            tonic::Code::Aborted,
+            tonic::Code::Internal,
+            tonic::Code::Cancelled,
+            tonic::Code::Unknown,
+        ] {
+            let err = ClientError::Status(tonic::Status::new(code, "x"));
+            assert!(is_retryable(&err), "{code:?} should be retryable");
+        }
+        for code in [
+            tonic::Code::Unauthenticated,
+            tonic::Code::PermissionDenied,
+            tonic::Code::InvalidArgument,
+        ] {
+            let err = ClientError::Status(tonic::Status::new(code, "x"));
+            assert!(!is_retryable(&err), "{code:?} should be terminal");
+        }
+        let bad_uri = "not a uri".parse::<hyper::Uri>().unwrap_err();
+        assert!(!is_retryable(&ClientError::InvalidEndpoint(bad_uri)));
     }
 }


### PR DESCRIPTION
## Problem

The BuildBarn frontend retires gRPC connections after `maxConnectionAge: 600s`, with a `maxConnectionAgeGrace: 3600s`. Its `:8980` listener also carries BES traffic, so long-running invocations can encounter GOAWAY while publishing build events.

We observed two failure modes that `is_retryable` treated as terminal:

### `Cancelled` during post-stream lifecycle publishing

```text
invocation_finished: status: 'The operation was cancelled',
self: "operation was canceled"
```

`invocation_finished` is issued after the event stream completes. When its existing channel has been retired, hyper can cancel the queued request and tonic surfaces `Code::Cancelled`. `retry_lifecycle` could recover by retrying on a usable connection, but the classifier previously rejected the error.

### `Unknown` during event streaming

```text
status: 'Unknown error',
self: "h2 protocol error: error reading a body from connection"
```

When a frontend pod terminates mid-stream, tonic can map the h2 failure to `Code::Unknown`. `drive_stream` previously treated this as fatal instead of reconnecting and replaying unacknowledged events.

## Evidence

Measured on `awd-silo-prod` against the `silo-gcp` Buildkite pipeline:

| Failure mode | Before frontend change | After frontend change |
|---|---:|---:|
| `Cancelled` on `invocation_finished` | 0 / 127 jobs | 6 / 91 jobs |
| `Unknown` mid-stream | 3 / 127 jobs | 7 / 91 jobs |

The `Cancelled` failure affected 6 of 18 invocations longer than 600 seconds and none of the 72 shorter invocations. Fisher's exact test gives `p = 3.0e-5`.

## Change

`is_retryable` now classifies `Code::Cancelled` and `Code::Unknown` as transient.

- Lifecycle calls are retried through the existing bounded `retry_lifecycle` path.
- Broken event streams reconnect and replay buffered events under their original sequence numbers.

## Safety

- BES lifecycle calls are idempotent.
- Stream replay preserves `OrderedBuildEvent.sequence_number`, allowing the server to deduplicate replayed events.
- Local shutdown closes the upstream event channel and produces `DriveOutcome::UpstreamClosed`; it does not enter this status classifier.
- Lifecycle retries remain bounded by `max_retries`, per-attempt deadlines, backoff, and the post-stream `bes_timeout`.
- Stream failures without acknowledgement progress exhaust the existing retry budget.

## Tests

- `retry::tests::classifier_status_codes` covers the complete retryable set, including `Cancelled` and `Unknown`, while keeping authentication, permission, argument, and endpoint errors terminal.
- `grpc::tests::unknown_mid_stream_reconnects_and_replays` simulates tonic mapping an h2 failure without a gRPC status to `Unknown`; the sink reconnects, replays, and delivers all ten events.
- `bazel test //crates/axl-runtime:test` passes.
