### PR TITLE
fix(bes): wait out a writer reconnect instead of failing the invocation

### DIFF
--- a/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
@@ -39,6 +39,46 @@ const WRITER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_mill
 /// than the microseconds between spawning the watchdog and the open it guards.
 const WRITER_RELEASE_OFFERS: u32 = 200;
 
+/// Adapts [`galvanize::Pipe`]'s three-valued read contract to the two-valued
+/// one `read_exact` accepts.
+///
+/// `Pipe` distinguishes "no writer attached this instant, but another attempt
+/// may still open the FIFO" (`Ok(0)`) from end-of-stream (`BrokenPipe`).
+/// `read_exact` collapses the two: it reports `Ok(0)` as `UnexpectedEof`,
+/// which the read loop cannot tell from a truncated record, and which it
+/// cannot resume from either — `read_exact` leaves no way to know how much of
+/// the record it consumed first. Waiting here, below the framing, is what
+/// keeps the record boundaries intact across a writer reconnect.
+///
+/// `writer_pid` bounds the wait. Only the per-invocation client can answer
+/// whether another attempt is coming; the daemon holds the path open across
+/// invocations and so always looks like a writer on its way.
+struct PendingWriterReader {
+    inner: galvanize::Pipe,
+    writer_pid: u32,
+}
+
+impl Read for PendingWriterReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // A zero-length read is legitimately `Ok(0)`; waiting on it would never
+        // end.
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            match self.inner.read(buf)? {
+                0 => {
+                    if !galvanize::is_pid_alive(self.writer_pid) {
+                        return Err(io::Error::new(ErrorKind::BrokenPipe, "end of stream"));
+                    }
+                    thread::sleep(WRITER_POLL_INTERVAL);
+                }
+                n => return Ok(n),
+            }
+        }
+    }
+}
+
 /// Release a reader parked in `Pipe::open` on `path` once `writer_pid` — the
 /// invocation expected to write there — is gone.
 ///
@@ -168,8 +208,13 @@ impl BuildEventStream {
             galvanize::Pipe::mkfifo(&path)?;
 
             let opened = spawn_open_watchdog(path.clone(), writer_pid);
-            let mut reader =
-                galvanize::Pipe::open(path, galvanize::RetryPolicy::IfOpenForPid(server_pid))?;
+            let mut reader = PendingWriterReader {
+                inner: galvanize::Pipe::open(
+                    path,
+                    galvanize::RetryPolicy::IfOpenForPid(server_pid),
+                )?,
+                writer_pid,
+            };
             opened.store(true, Ordering::Relaxed);
 
             let mut buf: Vec<u8> = Vec::with_capacity(1024 * 5);
@@ -185,7 +230,7 @@ impl BuildEventStream {
             let read_event = |buf: &mut Vec<u8>,
                               reencode_buf: &mut Vec<u8>,
                               raw_out: &mut MultiWriter<BufWriter<File>>,
-                              reader: &mut galvanize::Pipe|
+                              reader: &mut PendingWriterReader|
              -> Result<BuildEvent, BuildEventStreamError> {
                 let (size, vbuf) = read_varint(reader)?;
                 if size > buf.len() {
@@ -591,6 +636,107 @@ mod tests {
         let events: Vec<_> = std::iter::from_fn(|| sub.recv().ok()).collect();
         assert_eq!(events.len(), 1);
         assert!(!events[0].last_message);
+    }
+
+    // -------------------------------------------------------------------------
+    // Writer reconnect: Bazel closes the BEP file at the end of an attempt and
+    // reopens it for the next, so the FIFO reaches end-of-stream with the
+    // daemon still holding the path open.
+    //
+    // Both tests here pass this process as `server_pid`. The reader thread
+    // holds the FIFO's read end, so `is_path_open_for_pid` is true for the life
+    // of the test and every end-of-stream arrives as `Ok(0)` rather than
+    // `BrokenPipe` — the production race, a reopen landing between the read
+    // returning 0 and the procfs scan, made deterministic. `writer_pid` is a
+    // live process holding neither end, standing in for an invocation with
+    // another attempt still to come.
+    // -------------------------------------------------------------------------
+
+    /// A gap between attempts must not be read as the end of the stream.
+    /// Before `PendingWriterReader`, the `Ok(0)` reached `read_varint` and
+    /// failed the invocation with "failed to fill whole buffer".
+    #[test]
+    fn a_writer_reconnecting_between_records_keeps_the_stream_open() {
+        let outcome = crate::test::with_timeout(Duration::from_secs(10), || {
+            let path = temp_fifo_path();
+            let mut holder = spawn_pid_holder();
+
+            let mut stream =
+                BuildEventStream::spawn(path.clone(), std::process::id(), holder.id(), vec![])
+                    .unwrap();
+            let sub = stream.subscribe();
+            wait_for_fifo(&path);
+
+            let path_w = path.clone();
+            let _writer = std::thread::spawn(move || {
+                let mut f = OpenOptions::new().write(true).open(&path_w).unwrap();
+                f.write_all(&encode_event(&make_event(false))).unwrap();
+                drop(f);
+                // Many poll intervals, so the reader cannot pass by racing
+                // through the gap before it opens.
+                std::thread::sleep(Duration::from_millis(200));
+                let mut f = OpenOptions::new().write(true).open(&path_w).unwrap();
+                f.write_all(&encode_event(&make_event(true))).unwrap();
+            });
+
+            // The writer is deliberately not joined: opening a FIFO's write
+            // end blocks until a reader has it open, so a reader that died
+            // would park its reopen and turn a clear failure into a timeout.
+            let joined = stream.join().map_err(|e| e.to_string());
+            let events: Vec<_> = std::iter::from_fn(|| sub.recv().ok()).collect();
+            let _ = holder.kill();
+            (joined, events.len())
+        });
+        assert_eq!(
+            outcome,
+            Some((Ok(()), 2)),
+            "the gap between attempts must not end the stream"
+        );
+    }
+
+    /// The reconnect can land mid-record, which is why the wait belongs under
+    /// `read_exact` rather than in the read loop: resuming the loop after a
+    /// partially consumed record would desync the varint framing for the rest
+    /// of the build.
+    #[test]
+    fn a_record_split_across_a_writer_reconnect_is_not_desynced() {
+        let outcome = crate::test::with_timeout(Duration::from_secs(10), || {
+            let path = temp_fifo_path();
+            let mut holder = spawn_pid_holder();
+
+            let mut stream =
+                BuildEventStream::spawn(path.clone(), std::process::id(), holder.id(), vec![])
+                    .unwrap();
+            let sub = stream.subscribe();
+            wait_for_fifo(&path);
+
+            let path_w = path.clone();
+            let _writer = std::thread::spawn(move || {
+                let record = encode_event(&make_event(true));
+                // Hold back the final byte so the reconnect falls inside the
+                // record, not on its boundary.
+                let split = record.len() - 1;
+                let mut f = OpenOptions::new().write(true).open(&path_w).unwrap();
+                f.write_all(&record[..split]).unwrap();
+                drop(f);
+                std::thread::sleep(Duration::from_millis(200));
+                let mut f = OpenOptions::new().write(true).open(&path_w).unwrap();
+                f.write_all(&record[split..]).unwrap();
+            });
+
+            // The writer is deliberately not joined: opening a FIFO's write
+            // end blocks until a reader has it open, so a reader that died
+            // would park its reopen and turn a clear failure into a timeout.
+            let joined = stream.join().map_err(|e| e.to_string());
+            let events: Vec<_> = std::iter::from_fn(|| sub.recv().ok()).collect();
+            let _ = holder.kill();
+            (joined, events.len(), events.first().map(|e| e.last_message))
+        });
+        assert_eq!(
+            outcome,
+            Some((Ok(()), 1, Some(true))),
+            "a record spanning a reconnect must be delivered whole"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/build_event.rs
@@ -39,20 +39,10 @@ const WRITER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_mill
 /// than the microseconds between spawning the watchdog and the open it guards.
 const WRITER_RELEASE_OFFERS: u32 = 200;
 
-/// Adapts [`galvanize::Pipe`]'s three-valued read contract to the two-valued
-/// one `read_exact` accepts.
+/// Retries temporary FIFO EOFs below the length-delimited framing.
 ///
-/// `Pipe` distinguishes "no writer attached this instant, but another attempt
-/// may still open the FIFO" (`Ok(0)`) from end-of-stream (`BrokenPipe`).
-/// `read_exact` collapses the two: it reports `Ok(0)` as `UnexpectedEof`,
-/// which the read loop cannot tell from a truncated record, and which it
-/// cannot resume from either — `read_exact` leaves no way to know how much of
-/// the record it consumed first. Waiting here, below the framing, is what
-/// keeps the record boundaries intact across a writer reconnect.
-///
-/// `writer_pid` bounds the wait. Only the per-invocation client can answer
-/// whether another attempt is coming; the daemon holds the path open across
-/// invocations and so always looks like a writer on its way.
+/// A writer may reconnect part-way through a record. The invocation PID bounds
+/// the wait because the Bazel server can outlive the command.
 struct PendingWriterReader {
     inner: galvanize::Pipe,
     writer_pid: u32,
@@ -60,8 +50,7 @@ struct PendingWriterReader {
 
 impl Read for PendingWriterReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        // A zero-length read is legitimately `Ok(0)`; waiting on it would never
-        // end.
+        // `Read` requires an empty buffer to return immediately.
         if buf.is_empty() {
             return Ok(0);
         }
@@ -639,22 +628,13 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
-    // Writer reconnect: Bazel closes the BEP file at the end of an attempt and
-    // reopens it for the next, so the FIFO reaches end-of-stream with the
-    // daemon still holding the path open.
+    // Writer reconnect
     //
-    // Both tests here pass this process as `server_pid`. The reader thread
-    // holds the FIFO's read end, so `is_path_open_for_pid` is true for the life
-    // of the test and every end-of-stream arrives as `Ok(0)` rather than
-    // `BrokenPipe` — the production race, a reopen landing between the read
-    // returning 0 and the procfs scan, made deterministic. `writer_pid` is a
-    // live process holding neither end, standing in for an invocation with
-    // another attempt still to come.
+    // Force reconnect gaps to surface as `Ok(0)`: this process owns the FIFO's
+    // read end, while a separate live PID represents the Bazel invocation.
     // -------------------------------------------------------------------------
 
-    /// A gap between attempts must not be read as the end of the stream.
-    /// Before `PendingWriterReader`, the `Ok(0)` reached `read_varint` and
-    /// failed the invocation with "failed to fill whole buffer".
+    /// Keeps the stream open when a writer reconnects between records.
     #[test]
     fn a_writer_reconnecting_between_records_keeps_the_stream_open() {
         let outcome = crate::test::with_timeout(Duration::from_secs(10), || {
@@ -672,16 +652,14 @@ mod tests {
                 let mut f = OpenOptions::new().write(true).open(&path_w).unwrap();
                 f.write_all(&encode_event(&make_event(false))).unwrap();
                 drop(f);
-                // Many poll intervals, so the reader cannot pass by racing
-                // through the gap before it opens.
+                // Keep the writer disconnected for several polling intervals.
                 std::thread::sleep(Duration::from_millis(200));
                 let mut f = OpenOptions::new().write(true).open(&path_w).unwrap();
                 f.write_all(&encode_event(&make_event(true))).unwrap();
             });
 
-            // The writer is deliberately not joined: opening a FIFO's write
-            // end blocks until a reader has it open, so a reader that died
-            // would park its reopen and turn a clear failure into a timeout.
+            // Do not join: if the reader exits, the reconnect blocks in `open`,
+            // and the outer timeout must report the failure.
             let joined = stream.join().map_err(|e| e.to_string());
             let events: Vec<_> = std::iter::from_fn(|| sub.recv().ok()).collect();
             let _ = holder.kill();
@@ -694,10 +672,7 @@ mod tests {
         );
     }
 
-    /// The reconnect can land mid-record, which is why the wait belongs under
-    /// `read_exact` rather than in the read loop: resuming the loop after a
-    /// partially consumed record would desync the varint framing for the rest
-    /// of the build.
+    /// Preserves framing when a writer reconnects part-way through a record.
     #[test]
     fn a_record_split_across_a_writer_reconnect_is_not_desynced() {
         let outcome = crate::test::with_timeout(Duration::from_secs(10), || {
@@ -713,8 +688,7 @@ mod tests {
             let path_w = path.clone();
             let _writer = std::thread::spawn(move || {
                 let record = encode_event(&make_event(true));
-                // Hold back the final byte so the reconnect falls inside the
-                // record, not on its boundary.
+                // Reconnect before the final byte so the gap occurs inside the record.
                 let split = record.len() - 1;
                 let mut f = OpenOptions::new().write(true).open(&path_w).unwrap();
                 f.write_all(&record[..split]).unwrap();
@@ -724,9 +698,8 @@ mod tests {
                 f.write_all(&record[split..]).unwrap();
             });
 
-            // The writer is deliberately not joined: opening a FIFO's write
-            // end blocks until a reader has it open, so a reader that died
-            // would park its reopen and turn a clear failure into a timeout.
+            // Do not join: if the reader exits, the reconnect blocks in `open`,
+            // and the outer timeout must report the failure.
             let joined = stream.join().map_err(|e| e.to_string());
             let events: Vec<_> = std::iter::from_fn(|| sub.recv().ok()).collect();
             let _ = holder.kill();


### PR DESCRIPTION
## Problem

`aspect build`, `aspect test`, and `aspect run` could fail an otherwise successful Bazel invocation with:

```text
error: Traceback (most recent call last):
    File <builtin>, in <module>
    * /home/aspect-runner/.cache/aspect-cli/axl/deps/0eff858f4b96d15ff988a6c80f24a4848d4176906fe2e52a53e26f6ab30a0afc/aspect/test.axl:98, in _impl
        w = sp.wait()
    * /home/aspect-runner/.cache/aspect-cli/axl/deps/0eff858f4b96d15ff988a6c80f24a4848d4176906fe2e52a53e26f6ab30a0afc/aspect/bazel/invocation.axl:229, in lambda
        wait = lambda: _do_wait(inv, handle),
    * /home/aspect-runner/.cache/aspect-cli/axl/deps/0eff858f4b96d15ff988a6c80f24a4848d4176906fe2e52a53e26f6ab30a0afc/aspect/bazel/invocation.axl:236, in _do_wait
        status = handle.wait()
  error: build event stream thread error: io error: failed to fill whole buffer
     --> /home/aspect-runner/.cache/aspect-cli/axl/deps/0eff858f4b96d15ff988a6c80f24a4848d4176906fe2e52a53e26f6ab30a0afc/aspect/bazel/invocation.axl:236:14
      |
  236 |     status = handle.wait()
      |              ^^^^^^^^^^^^^
      |
```

Between retry attempts, Bazel closes and reopens the build-event FIFO.
`galvanize::Pipe` can return `Ok(0)` during that gap, which `read_varint` and `read_exact` interpret as EOF. If the reconnect occurs part-way through a record, the BES reader fails the invocation rather than waiting for the next writer.

## Change

Wrap the pipe in `PendingWriterReader`, which:

- retries non-empty reads returning `Ok(0)` while the per-invocation Bazel client remains alive;
- returns `BrokenPipe` once that client exits;
- performs the retry below the protobuf framing, preserving partially read records across a reconnect.

Existing `BrokenPipe`, retry, watchdog, and shutdown handling remain unchanged.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no — this fixes an internal reader failure without changing documented behaviour
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Fixed `aspect build`, `aspect test`, and `aspect run` failing when Bazel briefly closed and reopened the build-event pipe between attempts.

### Test plan

- Added a test covering a writer reconnect between records.
- Added a test covering a reconnect part-way through a record.
- Confirmed both tests fail when the adapter's retry behaviour is removed.
- Ran:

  ```text
  ASPECT_WRAPPER_SKIP=1 bazel test //crates/axl-runtime:test --nocache_test_results
  ```
