### PR TITLE
fix(gazelle): use `ph.update` instead of module-level `phases.update`

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/gazelle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/gazelle.axl
@@ -619,8 +619,7 @@ def _impl(ctx: TaskContext) -> int | TaskConclusion:
     if not check_only:
         files_label = pluralize(len(affected), "file")
         status = _pick_status(data, had_failure = False, terminal = False)
-        phases.update(
-            ctx,
+        ph.update(
             status,
             phases.ProgressStyles(
                 body = "Applying gazelle patch... (%s)" % files_label,


### PR DESCRIPTION
## Summary

- The local-apply branch (`if not check_only:`) in `crates/aspect-cli/src/builtins/aspect/gazelle.axl` called the module-level `phases.update(ctx, status, ...)`, but `update` only exists on the handle returned by `phases.new(ctx, data)` — not on the `phases` namespace itself.
- Every other call site in the file correctly uses the `ph` handle (e.g. `ph.update(...)`, `ph.dispatch(phases.Update(...))`). This one call site was missed in #1373 ("refactor(lifecycle): drive tasks through a `phases` handle").
- The bug crashes every local `aspect gazelle` run (off CI, since `--check-only=true` skips this branch) that finds a diff to apply, with:
  ```
  error: Object of type `namespace` has no attribute `update`, did you mean `Update`?
  ```
  which leaves BUILD files unpatched.

Fix: replace `phases.update(ctx, status, ...)` with `ph.update(status, ...)`, matching every other call site in the file.

Fixes #1424

## Test plan

- [ ] CI (existing gazelle test suite)
- [ ] Manually verified the diff is a straight rename to the existing `ph` handle already in scope in `_impl`, with argument order matching the other `ph.update(...)` call sites in the same file (e.g. line 578).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mRDwRKoLTjofdZv263zRz

---
_Generated by [Claude Code](https://claude.ai/code/session_015mRDwRKoLTjofdZv263zRz)_