### PR TITLE
feat(cli): add per-task quiet mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ INFO: Build Event Protocol files produced successfully.
     🧪 Test   1.2s  Run bazel tests
 ```
 
-Every `aspect <task>` ends with that per-phase breakdown, so the slow part of a CI step is always called out by name. The same content gets posted back to your PR as Buildkite annotations, GitHub Status Checks, and a PR task summary comment (see [examples below](#see-it-in-action)). [The CLI overview](https://aspect.build/docs/cli/overview#what-youll-see) shows `aspect format`, `aspect buildifier`, and `aspect lint` runs too — including the hold-the-line output (linter surfaces findings in unmodified files; the task still passes because no *new* violations were introduced).
+By default, `aspect <task>` ends with that per-phase breakdown, so the slow part of a CI step is always called out by name. The same content gets posted back to your PR as Buildkite annotations, GitHub Status Checks, and a PR task summary comment (see [examples below](#see-it-in-action)). [The CLI overview](https://aspect.build/docs/cli/overview#what-youll-see) shows `aspect format`, `aspect buildifier`, and `aspect lint` runs too — including the hold-the-line output (linter surfaces findings in unmodified files; the task still passes because no *new* violations were introduced).
+
+Use `--task:quiet` to hide Aspect's task header, progress lines, and timing breakdown. Task output, warnings and errors, exit codes, and CI status updates stay the same:
+
+```shell
+aspect test --task:quiet //...
+```
+
+Tasks can default to quiet mode too — use `--task:quiet=false` to show the header, progress lines, and breakdown for one run. See [quiet mode](docs/design.md#quiet-mode) for task and alias defaults.
 
 ## Configure and extend in AXL
 

--- a/crates/aspect-cli/BUILD.bazel
+++ b/crates/aspect-cli/BUILD.bazel
@@ -87,6 +87,16 @@ rust_test(
 )
 
 rust_test(
+    name = "quiet_test",
+    srcs = ["tests/quiet.rs"],
+    data = [":aspect-cli"],
+    env = {
+        "ASPECT_CLI_BIN": "$(rootpath :aspect-cli)",
+    },
+    deps = ["@crates//:tempfile"],
+)
+
+rust_test(
     name = "crash_handler_test",
     srcs = ["tests/crash_handler.rs"],
     data = [":aspect-cli"],

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -46,7 +46,7 @@ def _workflows_impl(ctx: FeatureContext):
         # On a Workflows runner, register the runner-environment table and the
         # Bazel server health check as `health_check` hooks. `setup_phase` runs
         # them inside the Setup phase; each prints its own BK section marker.
-        hc_trait.health_check.append(lambda ctx: print_environment_info(ctx.std, environment))
+        hc_trait.health_check.append(lambda ctx: print_environment_info(ctx.std, environment, quiet = ctx.task.quiet))
         hc_trait.health_check.append(lambda ctx: agent_health_check(ctx, environment))
 
         # Detect + repair stranded sandbox state (bazelbuild/bazel#23880) after

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/environment.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/environment.axl
@@ -605,17 +605,18 @@ def _gcp_debug_cli(runner: Runner) -> str:
             ' --format="value(jsonPayload.message)"' +
             " --freshness=30d | tac")
 
-def print_environment_info(std: std.Std, env: WorkflowsEnvironment) -> None:
+def print_environment_info(std: std.Std, env: WorkflowsEnvironment, quiet: bool = False) -> None:
     """Print debug/diagnostic info about the runner environment.
 
     Caller must gate on `env.runner != None`; the body assumes runner-shaped
     state (the metadata only makes sense on a Workflows runner).
+    `quiet` hides the Buildkite section marker while keeping the diagnostics.
     """
     runner = env.runner
     if runner == None:
         return
 
-    if env.ci and env.ci.host == "buildkite":
+    if env.ci and env.ci.host == "buildkite" and not quiet:
         # `:rocket:` mirrors the status-surface "🚀 Workflows runner metadata"
         # so the same identifier appears on CLI logs and rendered checks.
         print("--- :rocket: Workflows runner metadata")

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/health_check.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/health_check.axl
@@ -362,7 +362,7 @@ def agent_health_check(ctx, environment):
       None if healthy, or a str error message if the Bazel server is
       unhealthy.
     """
-    if environment.ci and environment.ci.host == "buildkite":
+    if environment.ci and environment.ci.host == "buildkite" and not ctx.task.quiet:
         print("--- :thermometer: Workflows runner health check")
 
     # Snapshot job-history before `_wait_for_warming` re-reads the

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/lifecycle.axl
@@ -96,7 +96,8 @@ TaskUpdate = record(
     # True iff this update crossed a phase boundary (set when `phase.name`
     # differs from the prior `current_phase().name`). Cold-start swarm
     # surfaces (GHSC, GithubStatusComments) gate phase emits on a debounce
-    # separate from the heartbeat throttle. Same trigger as the BK section header.
+    # separate from the heartbeat throttle. Preserved when quiet mode suppresses
+    # the corresponding BK section header.
     phase_change = field(bool, default = False),
     # True iff the producer's final emit. Lets surfaces distinguish live from
     # terminal even when status can't (e.g. `warning`).
@@ -784,12 +785,13 @@ def _update(ctx, status, progress, kind = "", data = None, priority = True, phas
             display_name = phase.display_name,
         )
         if phase.name != prev_phase:
-            _emit_bk_phase_section(ctx, phase, progress_styles)
-            bk_section_emitted = bool(ctx.std.env.var("BUILDKITE"))
             phase_change = True
+            if not ctx.task.quiet:
+                _emit_bk_phase_section(ctx, phase, progress_styles)
+                bk_section_emitted = bool(ctx.std.env.var("BUILDKITE"))
 
     cli_text = progress_styles.stream
-    if cli_text:
+    if cli_text and not ctx.task.quiet:
         # Phase entries lead with a styled `<emoji> <Title>` + a leading
         # blank line to break up the `→` stream; mid-phase is plain `→ <text>`.
         if phase != None:

--- a/crates/aspect-cli/src/builtins/aspect/runner_metadata.axl
+++ b/crates/aspect-cli/src/builtins/aspect/runner_metadata.axl
@@ -23,7 +23,7 @@ def _impl(ctx: TaskContext) -> int:
     if environment.runner == None:
         info(ctx.std, "Not on an Aspect Workflows runner; no runner metadata available.")
         return 0
-    print_environment_info(ctx.std, environment)
+    print_environment_info(ctx.std, environment, quiet = ctx.task.quiet)
     return 0
 
 runner_metadata = task(

--- a/crates/aspect-cli/src/cmd.rs
+++ b/crates/aspect-cli/src/cmd.rs
@@ -91,6 +91,7 @@ pub struct Dispatch {
     pub task_friendly_name: Option<String>,
     pub task_uuid: Option<String>,
     pub timing: TimingMode,
+    pub quiet: bool,
     matches: ArgMatches,
 }
 
@@ -159,6 +160,17 @@ impl<'a, 'v> Cmd<'a, 'v> {
                     .global(true)
                     .value_parser(parse_task_uuid)
                     .help("A UUID uniquely identifying this task invocation. Auto-generated if not set."),
+            )
+            .arg(
+                ClapArg::new("task:quiet")
+                    .long("task:quiet")
+                    .value_name("BOOL")
+                    .global(true)
+                    .value_parser(value_parser!(bool))
+                    .num_args(0..=1)
+                    .require_equals(true)
+                    .default_missing_value("true")
+                    .help("Suppress Aspect's informational task UI while preserving task output."),
             )
             .arg(
                 ClapArg::new("task:timing-summary")
@@ -271,6 +283,10 @@ impl<'a, 'v> Cmd<'a, 'v> {
             .get_one::<TimingMode>("task:timing-summary")
             .copied()
             .unwrap_or_default();
+        let quiet = leaf
+            .get_one::<bool>("task:quiet")
+            .copied()
+            .unwrap_or_else(|| self.tasks[task_id].quiet());
         Ok(Dispatch {
             task_id,
             task_name,
@@ -278,6 +294,7 @@ impl<'a, 'v> Cmd<'a, 'v> {
             task_friendly_name,
             task_uuid,
             timing,
+            quiet,
             matches,
         })
     }
@@ -1563,6 +1580,7 @@ fn describe_json(
                 "name": kind,
                 "summary": task.summary(),
                 "description": task.description(),
+                "quiet": task.quiet(),
                 "defined_in": defined_in_label(task.path(), aspect_root, modules),
                 "args": args,
             })
@@ -2114,6 +2132,7 @@ mod tests {
         args: SmallMap<String, Arg>,
         path: PathBuf,
         summary: String,
+        quiet: bool,
     }
 
     impl<'v> TaskLike<'v> for StubTask {
@@ -2134,6 +2153,9 @@ mod tests {
         }
         fn kind(&self) -> String {
             self.name.clone()
+        }
+        fn quiet(&self) -> bool {
+            self.quiet
         }
         fn path(&self) -> &PathBuf {
             &self.path
@@ -2160,6 +2182,7 @@ mod tests {
             args,
             path: PathBuf::from("/repo/tasks/test.axl"),
             summary: format!("Stub {name} task."),
+            quiet: false,
         }
     }
 
@@ -2507,6 +2530,7 @@ mod tests {
         // The command string is the whole point: an agent copies it verbatim.
         assert_eq!(t["command"], "aspect auth login");
         assert_eq!(t["path"], serde_json::json!(["auth", "login"]));
+        assert_eq!(t["quiet"], serde_json::json!(false));
         assert_eq!(doc["aspect_cli_version"], "1.2.3");
 
         let by_name = |n: &str| {
@@ -2871,6 +2895,40 @@ mod tests {
         assert_eq!(parse(&["aspect", "greet"]).unwrap(), TimingMode::Detailed);
         // Invalid level is rejected by the value parser at parse time.
         assert!(parse(&["aspect", "greet", "--task:timing-summary=verbose"]).is_err());
+    }
+
+    #[test]
+    fn dispatch_resolves_quiet_default_and_cli_overrides() {
+        let mut quiet_task = stub_task("test", &[], SmallMap::new());
+        quiet_task.quiet = true;
+        let cmd = Cmd {
+            tasks: vec![&quiet_task],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let root = cmd.build("0.0.0").expect("build ok");
+        let quiet = |args: &[&str]| {
+            let matches = root.clone().try_get_matches_from(args).expect("parse ok");
+            cmd.dispatch(matches).expect("dispatch ok").quiet
+        };
+
+        assert!(quiet(&["aspect", "test"]));
+        assert!(!quiet(&["aspect", "test", "--task:quiet=false"]));
+
+        let normal_task = stub_task("test", &[], SmallMap::new());
+        let normal_cmd = Cmd {
+            tasks: vec![&normal_task],
+            features: vec![],
+            aspect_root: Path::new("/repo"),
+            modules: &[],
+        };
+        let matches = normal_cmd
+            .build("0.0.0")
+            .expect("build ok")
+            .try_get_matches_from(["aspect", "--task:quiet", "test"])
+            .expect("parse ok");
+        assert!(normal_cmd.dispatch(matches).expect("dispatch ok").quiet);
     }
 
     // ── Override merge (no heap path: no overrides applied) ────────────────

--- a/crates/aspect-cli/src/main.rs
+++ b/crates/aspect-cli/src/main.rs
@@ -270,6 +270,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                 dispatch.task_id,
                 &dispatch.task_name,
                 dispatch.task_name_meaningful,
+                dispatch.quiet,
             )
             .map_err(anyhow::Error::from)?;
 
@@ -312,6 +313,7 @@ async fn run() -> Result<ExitCode, anyhow::Error> {
                     dispatch.task_friendly_name.clone(),
                     dispatch.task_uuid.clone(),
                     dispatch.timing,
+                    dispatch.quiet,
                     |t, h| dispatch.task_args(t, h),
                 )
                 .map_err(anyhow::Error::from)?;

--- a/crates/aspect-cli/tests/quiet.rs
+++ b/crates/aspect-cli/tests/quiet.rs
@@ -1,0 +1,269 @@
+//! Quiet mode changes terminal presentation while preserving task behavior.
+//! Spawn the real CLI so discovery, freezing, CLI overrides, lifecycle hooks,
+//! and the runtime's opening and closing output are exercised together.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+const TASKS: &str = r#"
+load("@aspect//private/lib/environment.axl", "error", "warn")
+load("@aspect//private/lib/health_check.axl", "HealthCheckTrait", "run_health_checks")
+load("@aspect//private/lib/lifecycle.axl", "Phase", "Phases", "phases")
+
+def _impl(ctx):
+    ctx.defer(ctx.std.io.stdout.write, "cleanup\n")
+    ctx.std.io.stdout.write("task stdout\n")
+    print("task stderr")
+    warn(ctx.std, "task warning")
+    ph = phases.new(ctx, {})
+    ph.update("running", "phase progress", phase = Phase(name = "work"))
+    ph.update("running", "same phase progress", phase = Phase(name = "work"))
+    ph.update("running", "heartbeat progress")
+    if ctx.args.hard_error:
+        fail("task hard error")
+    if ctx.args.code:
+        error(ctx.std, "task error")
+    return ph.update(
+        "failed" if ctx.args.code else "passed",
+        "final progress",
+        phase = Phase(name = "finish"),
+        final = True,
+        conclusion = "task conclusion",
+        exit_code = ctx.args.code,
+    )
+
+check = task(
+    implementation = _impl,
+    summary = "Exercise quiet task execution.",
+    quiet = True,
+    traits = [Phases],
+    args = {
+        "code": args.int(default = 0),
+        "hard_error": args.boolean(default = False),
+    },
+)
+
+# Alias metadata defaults independently of the base task.
+normal = check.alias(summary = "Exercise normal task execution.")
+
+def _runner_check(ctx):
+    def health_check():
+        ctx.std.io.stdout.write("health checked\n")
+        return struct(
+            outcome = "unhealthy" if ctx.args.code else "healthy",
+            message = "test health failure" if ctx.args.code else "",
+        )
+
+    # Exercise the registered Workflows hooks with real task metadata and I/O,
+    # replacing only the Bazel server probe.
+    hook_ctx = struct(
+        task = ctx.task,
+        std = ctx.std,
+        bazel = struct(
+            active_rc = lambda: struct(startup_flags = lambda: ["--output_base=/tmp/quiet-test"]),
+            health_check = health_check,
+        ),
+    )
+    result = run_health_checks(hook_ctx, ctx.traits[HealthCheckTrait])
+    if result != None:
+        error(ctx.std, result)
+        return 7
+    return 0
+
+runner_check = task(
+    implementation = _runner_check,
+    summary = "Exercise Workflows setup diagnostics.",
+    quiet = True,
+    traits = [HealthCheckTrait],
+    args = {"code": args.int(default = 0)},
+)
+"#;
+
+const CONFIG: &str = r#"
+load("@aspect//feature/buildkite_annotations.axl", "BuildkiteAnnotations")
+load("@aspect//private/lib/lifecycle.axl", "Phases")
+
+def _observe(ctx, update):
+    ctx.std.io.stdout.write("event:%s:%s:%s:%s:%s\n" % (
+        ctx.task.current_phase().name,
+        update.phase_change,
+        update.status,
+        update.final,
+        update.conclusion,
+    ))
+
+def config(ctx):
+    ctx.features[BuildkiteAnnotations].args.enabled = False
+    ctx.traits[Phases].task_update.append(_observe)
+"#;
+
+struct Fixture {
+    root: tempfile::TempDir,
+    bin: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let bin = std::env::var("ASPECT_CLI_BIN")
+            .ok()
+            .or_else(|| option_env!("CARGO_BIN_EXE_aspect-cli").map(str::to_owned))
+            .expect("set ASPECT_CLI_BIN or run under cargo");
+        // Resolve Bazel's runfiles-relative path before changing the child cwd.
+        let bin = std::fs::canonicalize(bin).expect("CLI binary exists");
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join(".aspect")).unwrap();
+        std::fs::create_dir(root.path().join("home")).unwrap();
+        std::fs::write(root.path().join("MODULE.aspect"), "").unwrap();
+        std::fs::write(root.path().join(".aspect/tasks.axl"), TASKS).unwrap();
+        std::fs::write(root.path().join(".aspect/config.axl"), CONFIG).unwrap();
+        Self { root, bin }
+    }
+
+    fn run(&self, args: &[&str], buildkite: bool) -> Output {
+        self.command(args, buildkite).output().expect("spawn CLI")
+    }
+
+    fn command(&self, args: &[&str], buildkite: bool) -> Command {
+        let mut cmd = Command::new(&self.bin);
+        // No user config, exporters, or inherited CI settings in this fixture.
+        cmd.env_clear()
+            .env("HOME", self.root.path().join("home"))
+            .env("ASPECT_CLI_CACHE", self.root.path().join("cache"))
+            .current_dir(self.root.path())
+            .args(args);
+        if buildkite {
+            cmd.env("BUILDKITE", "true");
+        }
+        cmd
+    }
+}
+
+fn assert_presentation(stderr: &str, quiet: bool, buildkite: bool, completed: bool) {
+    assert!(stderr.contains("task stderr"), "{stderr}");
+    assert!(stderr.contains("task warning"), "{stderr}");
+    for text in ["Running", "phase progress", "heartbeat progress"] {
+        assert_eq!(stderr.contains(text), !quiet, "{text}: {stderr}");
+    }
+    if completed {
+        assert_eq!(stderr.contains("task conclusion"), !quiet, "{stderr}");
+    }
+    assert_eq!(
+        stderr.lines().any(|line| line.starts_with("--- ")),
+        buildkite && !quiet,
+        "{stderr}"
+    );
+    if quiet {
+        assert!(!stderr.contains('→'), "{stderr}");
+        assert!(!stderr.contains("^^^ +++"), "{stderr}");
+    }
+}
+
+#[test]
+fn quiet_defaults_and_overrides_preserve_output_events_and_exit_codes() {
+    let fixture = Fixture::new();
+    for buildkite in [false, true] {
+        for code in ["0", "7"] {
+            // Exercise both default values and overrides, including a global
+            // flag before the task and an explicit false after it.
+            for (args, quiet) in [
+                (vec!["check"], true),
+                (vec!["check", "--task:quiet=false"], false),
+                (vec!["normal"], false),
+                (vec!["--task:quiet", "normal"], true),
+            ] {
+                let mut args = args;
+                args.extend(["--code", code]);
+                let output = fixture.run(&args, buildkite);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                assert_eq!(
+                    output.status.code(),
+                    Some(code.parse().unwrap()),
+                    "{stderr}"
+                );
+                let status = if code == "0" { "passed" } else { "failed" };
+                assert_eq!(
+                    String::from_utf8_lossy(&output.stdout),
+                    format!(
+                        "task stdout\nevent:work:True:running:False:\n\
+                         event:work:False:running:False:\n\
+                         event:work:False:running:False:\n\
+                         event:finish:True:{status}:True:task conclusion\ncleanup\n"
+                    ),
+                    "{stderr}"
+                );
+                assert_presentation(&stderr, quiet, buildkite, true);
+                assert_eq!(stderr.contains("task error"), code != "0", "{stderr}");
+            }
+        }
+    }
+}
+
+#[test]
+fn quiet_preserves_hard_errors_and_deferred_cleanup() {
+    let fixture = Fixture::new();
+    for (args, quiet) in [
+        (vec!["check", "--hard-error"], true),
+        (vec!["check", "--hard-error", "--task:quiet=false"], false),
+    ] {
+        let output = fixture.run(&args, false);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(output.status.code(), Some(1), "{stderr}");
+        assert!(stderr.contains("task hard error"), "{stderr}");
+        assert!(output.stdout.ends_with(b"cleanup\n"), "{stderr}");
+        assert_presentation(&stderr, quiet, false, false);
+    }
+}
+
+#[test]
+fn quiet_preserves_workflows_diagnostics_without_buildkite_sections() {
+    let fixture = Fixture::new();
+    for code in ["0", "7"] {
+        for quiet in [true, false] {
+            let mut args = vec!["runner-check", "--code", code];
+            if !quiet {
+                args.push("--task:quiet=false");
+            }
+            let output = fixture
+                .command(&args, true)
+                .env("BUILDKITE_REPO", "https://example.invalid/test/repo.git")
+                .env("ASPECT_WORKFLOWS_RUNNER", "1")
+                .env("ASPECT_WORKFLOWS_RUNNER_NO_LEGACY_CLI", "1")
+                .env("ASPECT_WORKFLOWS_RUNNER_INSTANCE_ID", "quiet-test-runner")
+                .env(
+                    "ASPECT_WORKFLOWS_RUNNER_BIN_DIR",
+                    fixture.root.path().join("bin"),
+                )
+                .output()
+                .expect("spawn CLI");
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert_eq!(
+                output.status.code(),
+                Some(code.parse().unwrap()),
+                "{stderr}"
+            );
+            assert_eq!(output.stdout, b"health checked\n", "{stderr}");
+            for text in [
+                "Workflows runner metadata",
+                "quiet-test-runner",
+                "Runner Health",
+                "Bazel Health",
+                if code == "0" {
+                    "bazel health check passed"
+                } else {
+                    "bazel health check failed: test health failure"
+                },
+            ] {
+                assert!(stderr.contains(text), "{text}: {stderr}");
+            }
+            for marker in ["--- :rocket:", "--- :thermometer:"] {
+                assert_eq!(stderr.contains(marker), !quiet, "{marker}: {stderr}");
+            }
+            if quiet {
+                assert!(
+                    !stderr.lines().any(|line| line.starts_with("--- ")),
+                    "{stderr}"
+                );
+            }
+        }
+    }
+}

--- a/crates/axl-runtime/src/engine/task.rs
+++ b/crates/axl-runtime/src/engine/task.rs
@@ -50,6 +50,8 @@ pub trait TaskLike<'v> {
     /// The task kind — the command being run (e.g. `build`, `test`, `lint`),
     /// derived from the snake_case export variable (or the `kind=` kwarg).
     fn kind(&self) -> String;
+    /// Whether Aspect's generic informational task UI is suppressed by default.
+    fn quiet(&self) -> bool;
     /// Absolute path to the .axl file the task was defined in.
     fn path(&self) -> &PathBuf;
     /// `Arguments` value carrying config.axl overrides for this task.
@@ -135,6 +137,7 @@ pub struct Task<'v> {
     pub(super) friendly_kind: RefCell<String>,
     pub(super) group: Vec<String>,
     pub(super) kind: RefCell<String>,
+    pub(super) quiet: bool,
     pub(super) traits: Vec<values::Value<'v>>,
     pub(super) path: PathBuf,
     /// Mutable override store for `ctx.tasks["k"].args.foo = ...`.
@@ -202,6 +205,7 @@ impl<'v> Task<'v> {
             friendly_kind: RefCell::new(frozen.friendly_kind.clone()),
             group: frozen.group.clone(),
             kind: RefCell::new(frozen.kind.clone()),
+            quiet: frozen.quiet,
             traits,
             path: frozen.path.clone(),
             overrides,
@@ -227,6 +231,9 @@ impl<'v> TaskLike<'v> for Task<'v> {
     }
     fn kind(&self) -> String {
         self.kind.borrow().clone()
+    }
+    fn quiet(&self) -> bool {
+        self.quiet
     }
     fn path(&self) -> &PathBuf {
         &self.path
@@ -307,6 +314,7 @@ impl<'v> values::Freeze for Task<'v> {
             friendly_kind: self.friendly_kind.into_inner(),
             group: self.group,
             kind: self.kind.into_inner(),
+            quiet: self.quiet,
             traits: frozen_traits?,
             path: self.path,
             overrides: self.overrides.freeze(freezer)?,
@@ -325,6 +333,7 @@ pub struct FrozenTask {
     pub(super) friendly_kind: String,
     pub(super) group: Vec<String>,
     pub(super) kind: String,
+    pub(super) quiet: bool,
     pub(super) traits: Vec<values::FrozenValue>,
     pub(super) path: PathBuf,
     pub(super) overrides: values::FrozenValue,
@@ -385,6 +394,9 @@ impl<'v> TaskLike<'v> for FrozenTask {
     }
     fn kind(&self) -> String {
         self.kind.clone()
+    }
+    fn quiet(&self) -> bool {
+        self.quiet
     }
     fn path(&self) -> &PathBuf {
         &self.path
@@ -458,7 +470,7 @@ fn resolve_task_metadata(
 
 /// Build a fresh `Task<'v>` that aliases `base`. The alias shares the base's
 /// `implementation` callable and `traits` vector and inherits nothing else —
-/// `kind`, `group`, `summary`, `description`, and `friendly_kind` come from
+/// `kind`, `group`, `summary`, `description`, `friendly_kind`, and `quiet` come from
 /// the alias's own kwargs. An empty `kind` defers naming to `export_as`.
 ///
 /// `defaults` may overlay new defaults onto any arg present on `base`; see
@@ -471,6 +483,7 @@ fn build_alias<'v>(
     friendly_kind: String,
     group: Vec<String>,
     kind: String,
+    quiet: bool,
     eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
 ) -> anyhow::Result<Task<'v>> {
     let friendly_kind = resolve_task_metadata("task.alias", &kind, &group, friendly_kind)?;
@@ -511,6 +524,7 @@ fn build_alias<'v>(
         friendly_kind: RefCell::new(friendly_kind),
         group,
         kind: RefCell::new(kind),
+        quiet,
         traits: base.trait_values(),
         path: Env::current_script_path(eval)?,
         overrides,
@@ -542,6 +556,7 @@ fn task_methods(builder: &mut MethodsBuilder) {
     /// - `args.trailing_var_args` carries no default in the schema and cannot
     ///   be overridden via `defaults`.
     /// - Aliases cannot add args beyond the base. Use `task()` if you need to.
+    /// - `quiet` defaults to `False` independently of the base task.
     ///
     /// ## Example
     ///
@@ -567,6 +582,7 @@ fn task_methods(builder: &mut MethodsBuilder) {
         #[starlark(require = named, default = String::new())] friendly_kind: String,
         #[starlark(require = named, default = UnpackList::default())] group: UnpackList<String>,
         #[starlark(require = named, default = String::new())] kind: String,
+        #[starlark(require = named, default = false)] quiet: bool,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<Task<'v>> {
         let base = try_as_task(this).ok_or_else(|| {
@@ -583,6 +599,7 @@ fn task_methods(builder: &mut MethodsBuilder) {
             friendly_kind,
             group.items,
             kind,
+            quiet,
             eval,
         )
     }
@@ -619,6 +636,10 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
     /// - `summary` — one-liner shown in the task list; falls back to `"<name> task defined in <file>"`.
     /// - `description` — extended prose shown in `--help` (replaces summary in that view).
     /// - `friendly_kind` — Title Case label for help section headings; auto-derived from the kind.
+    /// - `quiet` — suppress Aspect's generic informational terminal UI while preserving task output,
+    ///   diagnostics, lifecycle events, and integrations. Defaults to `False`.
+    ///   `--task:quiet[=true|false]` overrides this default for an invocation;
+    ///   the implementation reads the resolved value as `ctx.task.quiet`.
     ///
     /// ## Aliases
     ///
@@ -656,6 +677,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
         #[starlark(require = named, default = String::new())] friendly_kind: String,
         #[starlark(require = named, default = UnpackList::default())] group: UnpackList<String>,
         #[starlark(require = named, default = String::new())] kind: String,
+        #[starlark(require = named, default = false)] quiet: bool,
         #[starlark(require = named, default = UnpackList::default())] traits: UnpackList<Value<'v>>,
         eval: &mut starlark::eval::Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<Task<'v>> {
@@ -721,6 +743,7 @@ pub fn register_globals(globals: &mut GlobalsBuilder) {
             friendly_kind: RefCell::new(friendly_kind),
             group: group.items,
             kind: RefCell::new(kind),
+            quiet,
             traits: all_traits,
             path: Env::current_script_path(eval)?,
             overrides,
@@ -764,6 +787,56 @@ aliased = base.alias()
         .run_task(1)
         .expect("run_task");
         assert_eq!(exit, Some(0));
+    }
+
+    #[test]
+    fn task_quiet_defaults_false_and_accepts_true() {
+        eval_snippet("base = task(implementation = _impl)").with_value("base", |value| {
+            assert!(!super::try_as_task(value).unwrap().quiet());
+        });
+        eval_snippet("base = task(implementation = _impl, quiet = True)")
+            .with_value("base", |value| {
+                assert!(super::try_as_task(value).unwrap().quiet())
+            });
+    }
+
+    #[test]
+    fn task_execution_resolves_quiet_metadata() {
+        for quiet in ["False", "True"] {
+            let code = format!(
+                r#"
+def _impl(ctx):
+    if ctx.task.quiet != {quiet}:
+        fail("quiet metadata did not reach TaskInfo")
+    return 0
+
+check = task(implementation = _impl, quiet = {quiet})
+"#
+            );
+            assert_eq!(crate::test::eval(&code).run_task(0).unwrap(), Some(0));
+        }
+    }
+
+    #[test]
+    fn alias_quiet_does_not_mutate_base_task() {
+        eval_snippet(
+            r#"
+base = task(implementation = _impl)
+aliased = base.alias(quiet = True)
+"#,
+        )
+        .with_value("base", |value| {
+            assert!(!super::try_as_task(value).unwrap().quiet())
+        });
+        eval_snippet(
+            r#"
+base = task(implementation = _impl)
+aliased = base.alias(quiet = True)
+"#,
+        )
+        .with_value("aliased", |value| {
+            assert!(super::try_as_task(value).unwrap().quiet())
+        });
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/task_info.rs
+++ b/crates/axl-runtime/src/engine/task_info.rs
@@ -208,6 +208,8 @@ pub struct TaskInfo {
     pub name: String,
     pub friendly_name: String,
     pub task_id: String,
+    /// Whether generic terminal progress rendering is suppressed for this invocation.
+    pub quiet: bool,
 
     #[allocative(skip)]
     pub started_at: Instant,
@@ -228,6 +230,7 @@ impl TaskInfo {
         name: String,
         friendly_name: String,
         task_id: String,
+        quiet: bool,
     ) -> Self {
         Self {
             kind,
@@ -236,6 +239,7 @@ impl TaskInfo {
             name,
             friendly_name,
             task_id,
+            quiet,
             started_at: Instant::now(),
             phases: RefCell::new(Vec::new()),
             current_phase: RefCell::new(None),
@@ -348,6 +352,15 @@ fn task_info_methods(registry: &mut MethodsBuilder) {
             .downcast_ref::<TaskInfo>()
             .ok_or_else(|| anyhow::anyhow!("id: receiver is not a TaskInfo"))?;
         Ok(info.task_id.clone())
+    }
+
+    /// Whether Aspect's generic informational task UI is suppressed.
+    #[starlark(attribute)]
+    fn quiet<'v>(this: Value<'v>) -> anyhow::Result<bool> {
+        let info = this
+            .downcast_ref::<TaskInfo>()
+            .ok_or_else(|| anyhow::anyhow!("quiet: receiver is not a TaskInfo"))?;
+        Ok(info.quiet)
     }
 
     /// Task wall time so far in milliseconds (now - task spawn).

--- a/crates/axl-runtime/src/eval/multi_phase.rs
+++ b/crates/axl-runtime/src/eval/multi_phase.rs
@@ -407,10 +407,14 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         task_index: usize,
         task_name: &str,
         task_name_meaningful: bool,
+        quiet: bool,
     ) -> Result<(), EvalError> {
         let task = *self.tasks().get(task_index).ok_or_else(|| {
             EvalError::UnknownError(anyhow!("task index {} out of range", task_index))
         })?;
+        if quiet {
+            return Ok(());
+        }
         let (verb_seq, reset) = running_verb_color();
         let label = task_label(task.group(), &task.kind(), task_name, task_name_meaningful);
         // Identity banner above the task header — see `crate::banner`.
@@ -502,6 +506,7 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         task_friendly_name: Option<String>,
         task_id: Option<String>,
         timing: TimingMode,
+        quiet: bool,
         args_builder: impl FnOnce(&dyn TaskLike<'v>, Heap<'v>) -> Arguments<'v>,
     ) -> Result<Option<u8>, EvalError> {
         let task = *self.tasks().get(task_index).ok_or_else(|| {
@@ -532,6 +537,7 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
             task_name.clone(),
             task_friendly_name,
             task_id,
+            quiet,
         );
 
         // The opening `→ 🎬 Running …` (or BK `--- :aspect: Running …`)
@@ -644,6 +650,9 @@ impl<'v, 'l> MultiPhaseEval<'v, 'l> {
         }
 
         let failed = matches!(exit_code, Some(code) if code != 0);
+        if quiet {
+            return Ok(exit_code);
+        }
         let breakdown = render_phase_breakdown(&phases, timing, failed);
         let timing_segment = render_timing_segment(timing, elapsed);
         let conclusion_suffix = if conclusion.is_empty() {

--- a/crates/axl-runtime/src/test.rs
+++ b/crates/axl-runtime/src/test.rs
@@ -191,6 +191,11 @@ impl EvalBuilder {
             let scripts = vec![script_path];
             mpe.eval(&scripts, &root_mod, &modules)
                 .map_err(anyhow::Error::from)?;
+            let quiet = mpe
+                .tasks()
+                .get(task_index)
+                .ok_or_else(|| anyhow!("task index {task_index} out of range"))?
+                .quiet();
             let exit = mpe
                 .execute_tasks_with_args(
                     task_index,
@@ -199,6 +204,7 @@ impl EvalBuilder {
                     None,
                     None,
                     crate::eval::TimingMode::default(),
+                    quiet,
                     |_t, heap| {
                         let args = Arguments::new();
                         for (name, values) in &self.string_list_args {

--- a/docs/design.md
+++ b/docs/design.md
@@ -52,7 +52,7 @@ Task execution occurs when a user explicitly invokes a task (e.g., `aspect run <
 - `ctx.http()` — HTTP client (get, post, download with integrity checking)
 - `ctx.template` — template rendering
 - `ctx.traits[TraitType]` — frozen trait data (read-only, as configured)
-- `ctx.task` — task metadata (kind, friendly_kind, name, friendly_name, group, id)
+- `ctx.task` — task metadata (kind, friendly_kind, name, friendly_name, group, id, quiet)
 
 Task execution is inherently non-deterministic. It interacts with the outside world — building code, fetching URLs, writing files, running processes. The determinism guarantee applies only to evaluation; execution is where real work happens.
 
@@ -110,6 +110,35 @@ Use `name = "explicit-name"` to override the derived command name. Command names
 | `summary` | Task list and `--help` header | One line. Falls back to `"<name> task defined in <file>"`. |
 | `description` | `--help` header only | Extended prose. Replaces `summary` in `--help` when set. |
 | `friendly_kind` | Help section headings | Title Case. Auto-derived from the kind (`axl-add` → `Axl Add`). |
+
+#### Quiet mode
+
+Set `quiet = True` on `task(...)` to hide Aspect's task header, progress lines, and completion summary. It defaults to `False`. Aliases accept `quiet` too: `some_task.alias(quiet = True)` sets the alias's default and leaves the base task unchanged. Each alias defaults to `False`, even when its base task is quiet.
+
+For example, add a test alias in `.aspect/check.axl`:
+
+```python
+load("@aspect//test.axl", _test = "test")
+
+check = _test.alias(
+    summary = "Run tests in quiet mode.",
+    quiet = True,
+)
+```
+
+An explicit `--task:quiet` flag always beats the task default. The flag works before or after the task name:
+
+```shell
+aspect test --task:quiet //...
+aspect --task:quiet test //...
+aspect check --task:quiet=false //...
+```
+
+`--task:quiet` on its own means `--task:quiet=true`; use `=` when passing `true` or `false` explicitly. The implementation reads the value as `ctx.task.quiet`, after CLI overrides. `aspect describe` includes each task's `quiet` default.
+
+Quiet mode hides the banner, task header, progress lines, Buildkite log section markers, and completion summary, including its conclusion text and timing breakdown. `--task:timing-summary` has no effect while quiet mode is on.
+
+Task and subprocess output, warnings and errors, exit codes, and `ctx.defer(...)` cleanup stay the same. Lifecycle hooks receive every update, including phase changes and the final conclusion, so CI status updates and phase tracking work as usual. Task implementations and feature hooks can read `ctx.task.quiet` to hide their own progress output; ordinary writes to stdout and stderr are kept.
 
 #### CLI arguments
 


### PR DESCRIPTION
Adds per-task quiet mode to reduce build-log noise and avoid wasting agent context on repeated task UI. Task output, diagnostics, and CI integrations remain unchanged.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Tasks can now set `quiet = True` to suppress informational task UI. Use `--task:quiet[=BOOL]` to override it per invocation.

### Test plan

- New test cases added