### PR TITLE
feat(cli): apply performance defaults on Workflows runners, starting with the server heap

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/bazelrc.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazelrc.axl
@@ -18,10 +18,11 @@ What it writes depends on where it runs:
   - On a Workflows runner: the full set — generic flags, the remote-cache
     endpoint (from env), and the runner-specific flags (repository cache,
     per-runner output paths, identity header, the Workflows-cache compression
-    gates, the server heap cap). The heap cap must match the `Workflows`
-    feature's `server_heap_percent`: `--host_jvm_args` is a server startup
-    option, so a plain `bazel` reading a different value than `aspect <task>`
-    injects would restart the shared server on every alternation.
+    gates, and the `performance_defaults` bundle). The bundle switch must match
+    the `Workflows` feature's `performance_defaults`: it carries a server
+    startup option, so a plain `bazel` reading different JVM arguments than
+    `aspect <task>` injects would restart the shared server on every
+    alternation.
   - On other CI, or with an explicit `--output`: only the generic flags (plus
     the remote-cache endpoint when its env vars are set) — nothing tied to a
     runner's mounts or identity. Useful when an Aspect remote cache / BES is
@@ -43,7 +44,6 @@ Only file output is supported — there is no stdout mode.
 load("@aspect//bazel/build_metadata.axl", "version_gte")
 load(
     "./private/lib/environment.axl",
-    "DEFAULT_SERVER_HEAP_PERCENT",
     "detect_ci",
     "error",
     "get_bazelrc_flags",
@@ -148,7 +148,7 @@ def _bazelrc_impl(ctx: TaskContext) -> int:
         (startup_flags, build_flags) = get_bazelrc_flags(
             environment = environment,
             aspect_root_dir = ctx.std.env.aspect_root_dir(),
-            server_heap_percent = ctx.args.server_heap_percent,
+            performance_defaults = ctx.args.performance_defaults,
         )
         startup_flags = startup_flags_for_rc(startup_flags)
     else:
@@ -192,9 +192,9 @@ bazelrc = task(
             default = "",
             description = "Rc file to write. Defaults to `~/.bazelrc` (the first user rc Bazel loads). Parent directories are created if needed. Only file output is supported — there is no stdout mode.",
         ),
-        "server_heap_percent": args.int(
-            default = DEFAULT_SERVER_HEAP_PERCENT,
-            description = "Percent of the runner's RAM the Bazel server JVM may use as heap, written as `startup --host_jvm_args=-XX:MaxRAMPercentage=N`. 0 omits it. Must match the `Workflows` feature's `server_heap_percent` (same default), or plain `bazel` and `aspect <task>` will restart the shared server on every alternation. Only written on a Workflows runner.",
+        "performance_defaults": args.boolean(
+            default = True,
+            description = "Include Aspect's performance defaults in the rc. Today: `startup --host_jvm_args=-XX:MaxRAMPercentage=40`, capping the Bazel server heap at 40% of RAM. Must match the `Workflows` feature's `performance_defaults` (same default), or plain `bazel` and `aspect <task>` will restart the shared server on every alternation. Only written on a Workflows runner.",
         ),
     },
 )

--- a/crates/aspect-cli/src/builtins/aspect/bazelrc.axl
+++ b/crates/aspect-cli/src/builtins/aspect/bazelrc.axl
@@ -18,7 +18,10 @@ What it writes depends on where it runs:
   - On a Workflows runner: the full set — generic flags, the remote-cache
     endpoint (from env), and the runner-specific flags (repository cache,
     per-runner output paths, identity header, the Workflows-cache compression
-    gates).
+    gates, the server heap cap). The heap cap must match the `Workflows`
+    feature's `server_heap_percent`: `--host_jvm_args` is a server startup
+    option, so a plain `bazel` reading a different value than `aspect <task>`
+    injects would restart the shared server on every alternation.
   - On other CI, or with an explicit `--output`: only the generic flags (plus
     the remote-cache endpoint when its env vars are set) — nothing tied to a
     runner's mounts or identity. Useful when an Aspect remote cache / BES is
@@ -40,6 +43,7 @@ Only file output is supported — there is no stdout mode.
 load("@aspect//bazel/build_metadata.axl", "version_gte")
 load(
     "./private/lib/environment.axl",
+    "DEFAULT_SERVER_HEAP_PERCENT",
     "detect_ci",
     "error",
     "get_bazelrc_flags",
@@ -144,6 +148,7 @@ def _bazelrc_impl(ctx: TaskContext) -> int:
         (startup_flags, build_flags) = get_bazelrc_flags(
             environment = environment,
             aspect_root_dir = ctx.std.env.aspect_root_dir(),
+            server_heap_percent = ctx.args.server_heap_percent,
         )
         startup_flags = startup_flags_for_rc(startup_flags)
     else:
@@ -186,6 +191,10 @@ bazelrc = task(
         "output": args.string(
             default = "",
             description = "Rc file to write. Defaults to `~/.bazelrc` (the first user rc Bazel loads). Parent directories are created if needed. Only file output is supported — there is no stdout mode.",
+        ),
+        "server_heap_percent": args.int(
+            default = DEFAULT_SERVER_HEAP_PERCENT,
+            description = "Percent of the runner's RAM the Bazel server JVM may use as heap, written as `startup --host_jvm_args=-XX:MaxRAMPercentage=N`. 0 omits it. Must match the `Workflows` feature's `server_heap_percent` (same default), or plain `bazel` and `aspect <task>` will restart the shared server on every alternation. Only written on a Workflows runner.",
         ),
     },
 )

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -2,6 +2,7 @@ load("@aspect//bazel/build_metadata.axl", "get_build_metadata_flags", "get_task_
 load("@aspect//bazel.axl", "BazelTrait")
 load(
     "../private/lib/environment.axl",
+    "DEFAULT_SERVER_HEAP_PERCENT",
     "apply_output_base_suffix",
     "color_enabled",
     "get_bazelrc_flags",
@@ -67,6 +68,7 @@ def _workflows_impl(ctx: FeatureContext):
         (startup_flags, build_flags) = get_bazelrc_flags(
             environment = environment,
             aspect_root_dir = ctx.std.env.aspect_root_dir(),
+            server_heap_percent = ctx.args.server_heap_percent,
         )
 
         # Optionally move this task to its own Bazel server by suffixing the
@@ -184,6 +186,23 @@ Workflows = feature(
                           "runners; a no-op elsewhere. Set per repo in config.axl via " +
                           "ctx.features[Workflows].args.runner_output_base_suffix, or " +
                           "per task with --workflows:runner-output-base-suffix.",
+        ),
+        "server_heap_percent": args.int(
+            default = DEFAULT_SERVER_HEAP_PERCENT,
+            description = "Percent of the runner's RAM (or cgroup limit) the " +
+                          "Bazel server JVM may use as heap, injected as " +
+                          "--host_jvm_args=-XX:MaxRAMPercentage=N. Bazel sets no " +
+                          "heap flag itself, so the server otherwise gets the JVM " +
+                          "default of 25%. 0 disables the injection. Ignored by the " +
+                          "JVM when the repo's .bazelrc sets -Xmx, so an explicit " +
+                          "heap always wins. Keep it below what local actions need: " +
+                          "Bazel's --local_resources=memory default is 67% of RAM. " +
+                          "Changing the value restarts the Bazel server once. Only " +
+                          "takes effect on Aspect Workflows runners; `aspect ci " +
+                          "bazelrc` has the same knob so plain `bazel` calls agree " +
+                          "and do not restart the server. Set per repo in config.axl " +
+                          "via ctx.features[Workflows].args.server_heap_percent, or " +
+                          "per task with --workflows:server-heap-percent.",
         ),
         "upload_build_diagnostics": args.boolean(
             default = False,

--- a/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
+++ b/crates/aspect-cli/src/builtins/aspect/feature/workflows.axl
@@ -2,7 +2,6 @@ load("@aspect//bazel/build_metadata.axl", "get_build_metadata_flags", "get_task_
 load("@aspect//bazel.axl", "BazelTrait")
 load(
     "../private/lib/environment.axl",
-    "DEFAULT_SERVER_HEAP_PERCENT",
     "apply_output_base_suffix",
     "color_enabled",
     "get_bazelrc_flags",
@@ -68,7 +67,7 @@ def _workflows_impl(ctx: FeatureContext):
         (startup_flags, build_flags) = get_bazelrc_flags(
             environment = environment,
             aspect_root_dir = ctx.std.env.aspect_root_dir(),
-            server_heap_percent = ctx.args.server_heap_percent,
+            performance_defaults = ctx.args.performance_defaults,
         )
 
         # Optionally move this task to its own Bazel server by suffixing the
@@ -187,22 +186,23 @@ Workflows = feature(
                           "ctx.features[Workflows].args.runner_output_base_suffix, or " +
                           "per task with --workflows:runner-output-base-suffix.",
         ),
-        "server_heap_percent": args.int(
-            default = DEFAULT_SERVER_HEAP_PERCENT,
-            description = "Percent of the runner's RAM (or cgroup limit) the " +
-                          "Bazel server JVM may use as heap, injected as " +
-                          "--host_jvm_args=-XX:MaxRAMPercentage=N. Bazel sets no " +
-                          "heap flag itself, so the server otherwise gets the JVM " +
-                          "default of 25%. 0 disables the injection. Ignored by the " +
-                          "JVM when the repo's .bazelrc sets -Xmx, so an explicit " +
-                          "heap always wins. Keep it below what local actions need: " +
-                          "Bazel's --local_resources=memory default is 67% of RAM. " +
-                          "Changing the value restarts the Bazel server once. Only " +
-                          "takes effect on Aspect Workflows runners; `aspect ci " +
-                          "bazelrc` has the same knob so plain `bazel` calls agree " +
-                          "and do not restart the server. Set per repo in config.axl " +
-                          "via ctx.features[Workflows].args.server_heap_percent, or " +
-                          "per task with --workflows:server-heap-percent.",
+        "performance_defaults": args.boolean(
+            default = True,
+            description = "Apply Aspect's performance defaults to Bazel on a " +
+                          "Workflows runner. Today the bundle caps the Bazel server " +
+                          "heap at 40% of the runner's RAM (or cgroup limit) via " +
+                          "--host_jvm_args=-XX:MaxRAMPercentage=40; Bazel sets no " +
+                          "heap flag itself, so the server otherwise runs on the JVM " +
+                          "default of 25%. Command flags in the bundle are appended " +
+                          "after the repo's, so they win; a -Xmx in the repo's " +
+                          ".bazelrc still wins over the percentage, by JVM rule. A " +
+                          "new startup entry in the bundle restarts the Bazel server " +
+                          "once on upgrade. `aspect ci bazelrc` has the same switch " +
+                          "so plain `bazel` calls in the job agree and do not restart " +
+                          "the shared server. Only takes effect on Aspect Workflows " +
+                          "runners. Opt out per repo in config.axl via " +
+                          "ctx.features[Workflows].args.performance_defaults = False, " +
+                          "or per task with --workflows:performance-defaults=false.",
         ),
         "upload_build_diagnostics": args.boolean(
             default = False,

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazelrc_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazelrc_test.axl
@@ -15,12 +15,14 @@ load("@aspect//bazelrc.axl", "command_sections", "render_bazelrc", "startup_flag
 load(
     "./environment.axl",
     "CI",
+    "DEFAULT_SERVER_HEAP_PERCENT",
     "RemoteCache",
     "Runner",
     "WorkflowsEnvironment",
     "apply_output_base_suffix",
     "get_bazelrc_flags",
     "get_generic_bazelrc_flags",
+    "server_heap_startup_flags",
 )
 
 def _eq(label, got, want):
@@ -180,6 +182,37 @@ def _test_get_bazelrc_flags_output_base_and_suffix(_ctx):
     _eq("output_base moved", "--output_base=/o/my_repo/aspect-cli-delivery" in suffixed, True)
     _eq("output_user_root shared", "--output_user_root=/b/my_repo/aspect-cli" in suffixed, True)
 
+_HEAP_FLAG = "--host_jvm_args=-XX:MaxRAMPercentage="
+
+def _test_server_heap_startup_flags(_ctx):
+    # A percentage renders as one accumulating --host_jvm_args; 0 disables.
+    _eq("40", server_heap_startup_flags(40), [_HEAP_FLAG + "40"])
+    _eq("100", server_heap_startup_flags(100), [_HEAP_FLAG + "100"])
+    _eq("0 disables", server_heap_startup_flags(0), [])
+
+def _test_get_bazelrc_flags_server_heap(_ctx):
+    env = WorkflowsEnvironment(runner = Runner(bazel_root_dir = "/b", output_root_dir = "/o"))
+
+    # Default: the runner set carries the default heap cap, after the output paths.
+    startup, _build = get_bazelrc_flags(env, "/work/repo")
+    _eq("default heap flag", _HEAP_FLAG + str(DEFAULT_SERVER_HEAP_PERCENT) in startup, True)
+    _eq("heap after output_base", startup.index("--output_base=/o/repo") < startup.index(_HEAP_FLAG + str(DEFAULT_SERVER_HEAP_PERCENT)), True)
+
+    # Explicit value, and 0 emits nothing.
+    startup, _build = get_bazelrc_flags(env, "/work/repo", server_heap_percent = 55)
+    _eq("explicit heap flag", _HEAP_FLAG + "55" in startup, True)
+    startup, _build = get_bazelrc_flags(env, "/work/repo", server_heap_percent = 0)
+    _eq("no heap flag when 0", any([f.startswith("--host_jvm_args=") for f in startup]), False)
+
+    # The heap flag is a legitimate rc `startup` line: it survives the
+    # suppression filter and renders as the Bazel client would type it, so the
+    # written ~/.bazelrc and `aspect <task>` agree and the server is not restarted.
+    startup, _build = get_bazelrc_flags(env, "/work/repo")
+    kept = startup_flags_for_rc(startup)
+    _eq("heap kept for rc", _HEAP_FLAG + str(DEFAULT_SERVER_HEAP_PERCENT) in kept, True)
+    text = render_bazelrc(kept, [], ["common"])
+    _eq("heap rendered", ("startup " + _HEAP_FLAG + str(DEFAULT_SERVER_HEAP_PERCENT) + "\n") in text, True)
+
 _UNIT_TESTS = [
     _test_generic_flags_are_runner_independent,
     _test_generic_flags_include_remote_cache_env,
@@ -193,6 +226,8 @@ _UNIT_TESTS = [
     _test_apply_output_base_suffix_empty_noop,
     _test_apply_output_base_suffix_no_output_base_noop,
     _test_get_bazelrc_flags_output_base_and_suffix,
+    _test_server_heap_startup_flags,
+    _test_get_bazelrc_flags_server_heap,
 ]
 
 def _test_impl(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazelrc_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazelrc_test.axl
@@ -15,14 +15,14 @@ load("@aspect//bazelrc.axl", "command_sections", "render_bazelrc", "startup_flag
 load(
     "./environment.axl",
     "CI",
-    "DEFAULT_SERVER_HEAP_PERCENT",
     "RemoteCache",
     "Runner",
     "WorkflowsEnvironment",
     "apply_output_base_suffix",
     "get_bazelrc_flags",
     "get_generic_bazelrc_flags",
-    "server_heap_startup_flags",
+    "performance_defaults_build_flags",
+    "performance_defaults_startup_flags",
 )
 
 def _eq(label, got, want):
@@ -182,36 +182,38 @@ def _test_get_bazelrc_flags_output_base_and_suffix(_ctx):
     _eq("output_base moved", "--output_base=/o/my_repo/aspect-cli-delivery" in suffixed, True)
     _eq("output_user_root shared", "--output_user_root=/b/my_repo/aspect-cli" in suffixed, True)
 
-_HEAP_FLAG = "--host_jvm_args=-XX:MaxRAMPercentage="
+_HEAP_FLAG = "--host_jvm_args=-XX:MaxRAMPercentage=40"
 
-def _test_server_heap_startup_flags(_ctx):
-    # A percentage renders as one accumulating --host_jvm_args; 0 disables.
-    _eq("40", server_heap_startup_flags(40), [_HEAP_FLAG + "40"])
-    _eq("100", server_heap_startup_flags(100), [_HEAP_FLAG + "100"])
-    _eq("0 disables", server_heap_startup_flags(0), [])
+def _test_performance_defaults_bundle(_ctx):
+    # The bundle's startup half is the server heap cap; the command half is
+    # empty today. Pin the exact flag text: it is what a repo's own rc must
+    # match to override, and what the written ~/.bazelrc carries.
+    _eq("startup bundle", performance_defaults_startup_flags(), [_HEAP_FLAG])
+    _eq("build bundle", performance_defaults_build_flags(), [])
 
-def _test_get_bazelrc_flags_server_heap(_ctx):
+def _test_get_bazelrc_flags_performance_defaults(_ctx):
     env = WorkflowsEnvironment(runner = Runner(bazel_root_dir = "/b", output_root_dir = "/o"))
 
-    # Default: the runner set carries the default heap cap, after the output paths.
+    # On by default: the runner set carries the heap cap, after the output paths
+    # (the repo's own `startup` section is appended later still, so it wins).
     startup, _build = get_bazelrc_flags(env, "/work/repo")
-    _eq("default heap flag", _HEAP_FLAG + str(DEFAULT_SERVER_HEAP_PERCENT) in startup, True)
-    _eq("heap after output_base", startup.index("--output_base=/o/repo") < startup.index(_HEAP_FLAG + str(DEFAULT_SERVER_HEAP_PERCENT)), True)
+    _eq("heap flag", _HEAP_FLAG in startup, True)
+    _eq("heap after output_base", startup.index("--output_base=/o/repo") < startup.index(_HEAP_FLAG), True)
 
-    # Explicit value, and 0 emits nothing.
-    startup, _build = get_bazelrc_flags(env, "/work/repo", server_heap_percent = 55)
-    _eq("explicit heap flag", _HEAP_FLAG + "55" in startup, True)
-    startup, _build = get_bazelrc_flags(env, "/work/repo", server_heap_percent = 0)
-    _eq("no heap flag when 0", any([f.startswith("--host_jvm_args=") for f in startup]), False)
+    # Switched off: no bundle flag of either kind.
+    startup, build = get_bazelrc_flags(env, "/work/repo", performance_defaults = False)
+    _eq("no heap flag when off", any([f.startswith("--host_jvm_args=") for f in startup]), False)
+    _eq("output paths still there", any([f.startswith("--output_base=") for f in startup]), True)
+    _eq("generic flags still there", "--remote_upload_local_results" in build, True)
 
     # The heap flag is a legitimate rc `startup` line: it survives the
     # suppression filter and renders as the Bazel client would type it, so the
     # written ~/.bazelrc and `aspect <task>` agree and the server is not restarted.
     startup, _build = get_bazelrc_flags(env, "/work/repo")
     kept = startup_flags_for_rc(startup)
-    _eq("heap kept for rc", _HEAP_FLAG + str(DEFAULT_SERVER_HEAP_PERCENT) in kept, True)
+    _eq("heap kept for rc", _HEAP_FLAG in kept, True)
     text = render_bazelrc(kept, [], ["common"])
-    _eq("heap rendered", ("startup " + _HEAP_FLAG + str(DEFAULT_SERVER_HEAP_PERCENT) + "\n") in text, True)
+    _eq("heap rendered", ("startup " + _HEAP_FLAG + "\n") in text, True)
 
 _UNIT_TESTS = [
     _test_generic_flags_are_runner_independent,
@@ -226,8 +228,8 @@ _UNIT_TESTS = [
     _test_apply_output_base_suffix_empty_noop,
     _test_apply_output_base_suffix_no_output_base_noop,
     _test_get_bazelrc_flags_output_base_and_suffix,
-    _test_server_heap_startup_flags,
-    _test_get_bazelrc_flags_server_heap,
+    _test_performance_defaults_bundle,
+    _test_get_bazelrc_flags_performance_defaults,
 ]
 
 def _test_impl(ctx):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/environment.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/environment.axl
@@ -371,36 +371,50 @@ def get_generic_bazelrc_flags(environment: WorkflowsEnvironment) -> list:
 
     return build_flags
 
-# Default share of the runner's RAM (or cgroup limit) the Bazel server JVM may
-# use as heap. Bazel sets no heap flag of its own, so the server otherwise runs
-# on HotSpot's default of 25% — a quarter of an instance the job has to itself.
-# Kept conservative because Bazel's own `--local_resources=memory` default
-# (67% of RAM) assumes a small server; heap and local actions share the box.
-DEFAULT_SERVER_HEAP_PERCENT = 40
+# The `performance_defaults` bundle: Bazel flags the Workflows feature and
+# `aspect ci bazelrc` apply on a runner unless the repo switches them off. One
+# boolean rather than a knob per value, because every value here is already
+# overridable through Bazel itself (a repo's `.bazelrc`), so per-value args
+# would add surface without adding control. Two rules keep it safe to grow:
+#
+#   * Command flags are appended after the repo's flags (`extra_flags`), so on
+#     a Workflows runner they win. Startup flags keep the repo's `startup`
+#     section last: Bazel compares the server's JVM arguments in order, and the
+#     rc `aspect ci bazelrc` writes is read before the workspace rc, so any
+#     other order would make `aspect <task>` and plain `bazel` restart the
+#     shared server on every alternation.
+#   * A new startup entry restarts the Bazel server once on upgrade
+#     (`--host_jvm_args` is a server startup option), discarding the warm
+#     analysis cache that one time. Command flags cost nothing to add.
 
-_SERVER_HEAP_FLAG_PREFIX = "--host_jvm_args=-XX:MaxRAMPercentage="
+# Share of the runner's RAM (or cgroup limit) the Bazel server JVM may use as
+# heap. Bazel sets no heap flag of its own, so the server otherwise runs on
+# HotSpot's default of 25% — a quarter of an instance the job has to itself. On
+# silo's 16 GB runners that cap was binding: heap pinned within 100 MB of it for
+# a quarter of the build, 6% of wall time in GC (silo-gcp #61152 vs #61160).
+# Kept at 40% because Bazel's own `--local_resources=memory` default (67% of
+# RAM) assumes a small server; heap and local actions share the box.
+SERVER_HEAP_PERCENT = 40
 
-def server_heap_startup_flags(percent: int) -> list:
-    """The startup flag capping the Bazel server heap at `percent` of RAM, as a
-    list: `[--host_jvm_args=-XX:MaxRAMPercentage=N]`, or `[]` when `percent` is 0
-    (disabled). Fails on a value outside 0..100.
+def performance_defaults_startup_flags() -> list:
+    """The startup flags of the `performance_defaults` bundle.
 
-    `MaxRAMPercentage` rather than a computed `-Xmx`: the JVM already sizes
-    against the cgroup limit in a container, so no host probe is needed; the
-    flag text is the same on every machine, so it never differs between hosts
-    sharing a bazelrc; and HotSpot ignores it whenever `-Xmx` is set, so a
-    repo's own `startup --host_jvm_args=-Xmx…` wins with no collision handling.
+    `--host_jvm_args=-XX:MaxRAMPercentage=N` rather than a computed `-Xmx`: the
+    JVM already sizes against the cgroup limit in a container, so no host probe
+    is needed; the flag text is the same on every machine, so it never differs
+    between hosts sharing a bazelrc; and HotSpot ignores it whenever `-Xmx` is
+    set, so a repo's own `startup --host_jvm_args=-Xmx…` wins with no collision
+    handling. A repo can also set its own `MaxRAMPercentage`: Bazel accumulates
+    `--host_jvm_args` and the JVM takes the last, which is the repo's."""
+    return ["--host_jvm_args=-XX:MaxRAMPercentage=" + str(SERVER_HEAP_PERCENT)]
 
-    Any change to the value restarts the Bazel server on the next build
-    (`--host_jvm_args` is a server startup option), discarding the warm
-    analysis cache once."""
-    if percent < 0 or percent > 100:
-        fail("server_heap_percent must be between 0 and 100 (0 disables), got %d" % percent)
-    if percent == 0:
-        return []
-    return [_SERVER_HEAP_FLAG_PREFIX + str(percent)]
+def performance_defaults_build_flags() -> list:
+    """The command flags of the `performance_defaults` bundle. Appended after
+    the repo's own flags, so on a runner they take precedence. Empty today; the
+    bundle exists so the next entry is one line and no new arg."""
+    return []
 
-def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str, server_heap_percent: int = DEFAULT_SERVER_HEAP_PERCENT) -> (list, list):
+def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str, performance_defaults: bool = True) -> (list, list):
     """Generate the full bazelrc flag set for an Aspect Workflows runner.
 
     The generic CI flags (`get_generic_bazelrc_flags`) plus the runner-specific
@@ -416,8 +430,8 @@ def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str, s
         environment: WorkflowsEnvironment. Caller must have verified
                      `runner != None` (output_base/output_user_root come from it).
         aspect_root_dir: absolute path to the Aspect project root.
-        server_heap_percent: percent of RAM the Bazel server JVM may use as heap
-                     (see `server_heap_startup_flags`); 0 emits no heap flag.
+        performance_defaults: include the `performance_defaults` bundle (see
+                     `performance_defaults_startup_flags` / `_build_flags`).
 
     Returns:
         (startup_flags, build_flags): two lists; build_flags may contain
@@ -460,7 +474,9 @@ def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str, s
         startup_flags.append("--output_user_root=" + bazel_root + "/" + subdir)
         startup_flags.append("--output_base=" + output_root + "/" + subdir)
 
-    startup_flags.extend(server_heap_startup_flags(server_heap_percent))
+    if performance_defaults:
+        startup_flags.extend(performance_defaults_startup_flags())
+        build_flags.extend(performance_defaults_build_flags())
 
     return (startup_flags, build_flags)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/environment.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/environment.axl
@@ -371,7 +371,36 @@ def get_generic_bazelrc_flags(environment: WorkflowsEnvironment) -> list:
 
     return build_flags
 
-def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str) -> (list, list):
+# Default share of the runner's RAM (or cgroup limit) the Bazel server JVM may
+# use as heap. Bazel sets no heap flag of its own, so the server otherwise runs
+# on HotSpot's default of 25% — a quarter of an instance the job has to itself.
+# Kept conservative because Bazel's own `--local_resources=memory` default
+# (67% of RAM) assumes a small server; heap and local actions share the box.
+DEFAULT_SERVER_HEAP_PERCENT = 40
+
+_SERVER_HEAP_FLAG_PREFIX = "--host_jvm_args=-XX:MaxRAMPercentage="
+
+def server_heap_startup_flags(percent: int) -> list:
+    """The startup flag capping the Bazel server heap at `percent` of RAM, as a
+    list: `[--host_jvm_args=-XX:MaxRAMPercentage=N]`, or `[]` when `percent` is 0
+    (disabled). Fails on a value outside 0..100.
+
+    `MaxRAMPercentage` rather than a computed `-Xmx`: the JVM already sizes
+    against the cgroup limit in a container, so no host probe is needed; the
+    flag text is the same on every machine, so it never differs between hosts
+    sharing a bazelrc; and HotSpot ignores it whenever `-Xmx` is set, so a
+    repo's own `startup --host_jvm_args=-Xmx…` wins with no collision handling.
+
+    Any change to the value restarts the Bazel server on the next build
+    (`--host_jvm_args` is a server startup option), discarding the warm
+    analysis cache once."""
+    if percent < 0 or percent > 100:
+        fail("server_heap_percent must be between 0 and 100 (0 disables), got %d" % percent)
+    if percent == 0:
+        return []
+    return [_SERVER_HEAP_FLAG_PREFIX + str(percent)]
+
+def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str, server_heap_percent: int = DEFAULT_SERVER_HEAP_PERCENT) -> (list, list):
     """Generate the full bazelrc flag set for an Aspect Workflows runner.
 
     The generic CI flags (`get_generic_bazelrc_flags`) plus the runner-specific
@@ -387,6 +416,8 @@ def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str) -
         environment: WorkflowsEnvironment. Caller must have verified
                      `runner != None` (output_base/output_user_root come from it).
         aspect_root_dir: absolute path to the Aspect project root.
+        server_heap_percent: percent of RAM the Bazel server JVM may use as heap
+                     (see `server_heap_startup_flags`); 0 emits no heap flag.
 
     Returns:
         (startup_flags, build_flags): two lists; build_flags may contain
@@ -428,6 +459,8 @@ def get_bazelrc_flags(environment: WorkflowsEnvironment, aspect_root_dir: str) -
     else:
         startup_flags.append("--output_user_root=" + bazel_root + "/" + subdir)
         startup_flags.append("--output_base=" + output_root + "/" + subdir)
+
+    startup_flags.extend(server_heap_startup_flags(server_heap_percent))
 
     return (startup_flags, build_flags)
 


### PR DESCRIPTION
## Why

Bazel adds no heap flag to the server JVM ([`blaze.cc`](https://github.com/bazelbuild/bazel/blob/master/src/main/cpp/blaze.cc) sets none), so the server runs on HotSpot's default of **25% of RAM**. On a Workflows runner that is a quarter of an instance the job has to itself, and nobody writes `startup --host_jvm_args` into a CI bazelrc.

Evidence from silo-gcp Test jobs on the 4-vCPU, 16 GB runners (build 61152 on the default; 61160 after aspect-build/silo#12234 capped it at 40%):

| | 61152, default 25% | 61160, 40% cap |
|---|---|---|
| Heap ceiling | ~3.7 GB | ~5.9 GB |
| Heap in use, max | 3,833 MB | 5,255 MB |
| Time at or above 3.5 GB | 25% of the build | 38% |
| Minor GCs | 282, 37.5 s of 596 s | 124, 14.7 s of 381 s |
| Whole machine, peak | 8.5 GB of 14.8 | 9.2 GB of 14.8 |

The default was binding: heap pinned within 100 MB of the ceiling for a quarter of the build, 6% of wall in GC. The builds are on different branches, so the comparison is directional.

## What

A `performance_defaults` boolean, **default on**:

- on the `Workflows` feature (`ctx.features[Workflows].args.performance_defaults = False` / `--workflows:performance-defaults=false`), injected into the runner startup and build flags;
- on `aspect ci bazelrc` (`--performance-defaults`), written into the rc so plain `bazel` calls in the job carry the same flags.

One switch rather than a knob per value: every value in the bundle is already overridable through the repo's own `.bazelrc`, so per-value args would add surface without adding control. The bundle's first entry is `--host_jvm_args=-XX:MaxRAMPercentage=40`; `performance_defaults_build_flags()` is empty today so the next command flag is one line and no new arg.

## Precedence rules of the bundle

- **Command flags beat the repo rc on a runner.** They are appended after the repo's flags via `extra_flags`, and Bazel takes the last.
- **Startup flags keep the repo's `startup` section last.** Bazel compares the server's JVM arguments in order, and the `~/.bazelrc` that `aspect ci bazelrc` writes is read before the workspace rc, so `aspect <task>` and plain `bazel` must both produce `[ours, repo's]` or they restart the shared server on every alternation. A repo's `-Xmx` wins over the percentage by JVM rule either way, and a repo's own `MaxRAMPercentage` wins by being last.
- **A new startup entry restarts the server once on upgrade.** Documented in the arg description. Command flags cost nothing to add.

## Why `MaxRAMPercentage` rather than a computed `-Xmx`

- The JVM already sizes against the cgroup limit in a container; a MemTotal probe would hand a 4 GB pod on a 256 GB node a 100 GB ceiling.
- HotSpot ignores `MaxRAMPercentage` whenever `-Xmx` is present, so no collision handling.
- The flag text is identical on every machine, so a bazelrc shared across hosts never differs.

## Not in this PR

- `--jobs`: the same profiles show the in-flight action count at the `--jobs=40` ceiling only 1 to 3% of the build, with the Bazel server itself at 3 to 4 of the 4 cores throughout. Concurrency is not the limiter on these runners; server CPU is.
- `--local_resources`: Bazel's 67% default assumes a small server, but local actions were near zero on these RBE runners. Left for a follow-up if a local-execution profile shows contention.

## Testing

`aspect dev test-bazelrc` — 14 tests (2 new: the bundle's exact flag text; on/off through `get_bazelrc_flags`, survival through `startup_flags_for_rc`, and the rendered `startup` line). `aspect ci bazelrc --help` and `aspect feature workflows` show the new switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Field check: Ironclad

Decoded 54 complete invocations from the Workflows BEP archive of Ironclad's GCP deployment (objects uploaded 26 Aug and 3 Sep 2026; CircleCI runners on `c4-standard-16-lssd`, 16 vCPU / 60 GB; Bazel 9.2.0; remote execution with `--noremote_local_fallback`).

**Heap today.** No invocation carries any `--host_jvm_args`, so the server runs on HotSpot's default cap of 25% of RAM, about 15 GB. Against that cap:

| Signal (54 invocations) | Value |
|---|---|
| `OOM_ERROR` exits / `OUT_OF_MEMORY` aborts | 0 |
| Full GCs (`peak_post_gc_heap_size` non-zero) | 0 |
| Invocations with G1 old-gen collections | 33 of 54 |
| Builds over 5 min with old-gen collections | 11 of 11 |
| Eden bytes reclaimed per invocation, p50 / p90 / max | 23 / 522 / 698 GB |
| Skyframe nodes after invocation | 1.7M – 2.6M |
| Builds per server (servers persist across CI jobs) | median 23, max 91 |

The heap never filled, but the long builds do cross G1's ~45% initiating threshold (about 7 GB live), so a 6 GB cap would already be too small for them.

**What this PR changes for Ironclad at the current size:** the cap goes from ~15 GB to ~24 GB. No observable effect; there is no pressure to relieve.

**Where it earns its place:** the runner's Bazel server averages 1.1 cores of 16 during long builds, and 4 of 922,106 actions in the sample ran locally, so the right-size move is `c4-standard-8` (30 GB). There HotSpot's default drops to 7.5 GB, right where the long builds already live, and the resize alone would create the GC-thrash failure this PR exists to prevent. With the PR the cap is 12 GB and Ironclad needs no bazelrc change. The `--local_resources` caveat does not apply to them: nothing executes locally.
