### PR TITLE
fix(bazel): key execlog reader on client pid; probe with startup flags

### DIFF
--- a/crates/axl-runtime/src/engine/bazel/build.rs
+++ b/crates/axl-runtime/src/engine/bazel/build.rs
@@ -819,7 +819,12 @@ impl Build {
         announce: AnnounceSpawn,
         rt: AsyncRuntime,
     ) -> Result<Build, std::io::Error> {
-        let (pid, version) = super::info::server_info()?;
+        // Probe with the invocation's own startup flags so the answer describes
+        // the server this command will talk to. A bare `bazel info` reads the rc
+        // files instead, which can name a different output base — or the same
+        // one with different options, in which case the invocation restarts the
+        // server and the pid returned here is dead before the build begins.
+        let (pid, version) = super::info::server_info_with_startup_flags(&startup_flags)?;
 
         let span = tracing::info_span!(
             "ctx.bazel.build",
@@ -889,22 +894,17 @@ impl Build {
             }
         }
 
-        let mut execlog_stream = if execution_logs {
+        // The reader itself starts after `cmd.spawn()`, keyed on the child pid.
+        let execlog_out = if execution_logs {
             // If there is a CompactFile sink, let Bazel write directly to its path
             // so no separate temp file or tee step is needed for that copy.
-            let direct_path = if compact_paths.is_empty() {
-                None
+            let out = if compact_paths.is_empty() {
+                std::env::temp_dir().join(format!("execlog-out-{}.bin", uuid::Uuid::new_v4()))
             } else {
-                Some(std::path::PathBuf::from(compact_paths.remove(0)))
+                std::path::PathBuf::from(compact_paths.remove(0))
             };
-            let (out, stream) = ExecLogStream::spawn_with_file(
-                pid,
-                direct_path,
-                compact_paths,
-                !decoded_sinks.is_empty(),
-            )?;
             cmd.arg("--execution_log_compact_file").arg(&out);
-            Some(stream)
+            Some(out)
         } else {
             None
         };
@@ -928,6 +928,20 @@ impl Build {
         // CI cancellation. The guard is stored on `Self` and unregisters
         // when the `Build` is dropped (after `wait()`).
         let live_guard = super::live::register(child.id());
+
+        // Bazel closes the execlog in afterCommand, before the client exits, so
+        // the client pid bounds the stream. The server pid does not: bazel may
+        // have just replaced that server to apply this invocation's startup
+        // options.
+        let mut execlog_stream = match execlog_out {
+            Some(out) => Some(ExecLogStream::spawn_with_file(
+                out,
+                child.id(),
+                compact_paths,
+                !decoded_sinks.is_empty(),
+            )?),
+            None => None,
+        };
 
         // Now that we have the spawned child's pid, start the BES reader.
         // The child pid is the per-invocation liveness signal the BES thread
@@ -1119,41 +1133,50 @@ pub(crate) fn build_methods(registry: &mut MethodsBuilder) {
         // that window would target an unrelated process.
         build.live_guard.borrow_mut().take();
 
-        // Wait for BES stream to complete.
-        // Note: We don't take() the stream here so that build_events() can still
-        // be called after wait() to get historical events.
+        let mut stream_errors: Vec<String> = vec![];
+
+        // Note: We don't take() the BES stream here so that build_events() can
+        // still be called after wait() to get historical events.
         if let Some(ref mut event_stream) = *build.build_event_stream.borrow_mut() {
-            match event_stream.join() {
-                Ok(_) => {}
-                Err(err) => anyhow::bail!("build event stream thread error: {}", err),
+            if let Err(err) = event_stream.join() {
+                stream_errors.push(format!("build event stream thread error: {err}"));
             }
         }
-
-        // Wait for Workspace event stream to complete.
-        let workspace_event_stream = build.workspace_event_stream.take();
-        if let Some(workspace_event_stream) = workspace_event_stream {
-            match workspace_event_stream.join() {
-                Ok(_) => {}
-                Err(err) => anyhow::bail!("workspace event stream thread error: {}", err),
+        if let Some(stream) = build.workspace_event_stream.take() {
+            if let Err(err) = stream.join() {
+                stream_errors.push(format!("workspace event stream thread error: {err}"));
             }
-        };
-
-        // Wait for Execlog stream to complete.
-        let execlog_stream = build.execlog_stream.take();
-        if let Some(execlog_stream) = execlog_stream {
-            match execlog_stream.join() {
-                Ok(_) => {}
-                Err(err) => anyhow::bail!("execlog stream thread error: {}", err),
+        }
+        if let Some(stream) = build.execlog_stream.take() {
+            if let Err(err) = stream.join() {
+                stream_errors.push(format!("execlog stream thread error: {err}"));
             }
-        };
+        }
 
         // Drop the span to end the trace
         drop(build.span.replace(tracing::Span::none()));
 
-        Ok(BuildStatus {
+        let status = BuildStatus {
             success: result.success(),
             code: result.code(),
-        })
+        };
+        if stream_errors.is_empty() {
+            return Ok(status);
+        }
+        // When bazel itself failed, its exit code is the finding and a dead
+        // side stream is usually a consequence. Keep the code visible instead
+        // of replacing it with the stream error.
+        if !status.success {
+            for err in &stream_errors {
+                errln!("WARNING: {err} (bazel exited with code {:?})", status.code);
+            }
+            return Ok(status);
+        }
+        anyhow::bail!(
+            "bazel exited with code {:?} but a stream failed: {}",
+            status.code,
+            stream_errors.join("; ")
+        )
     }
 }
 

--- a/crates/axl-runtime/src/engine/bazel/mod.rs
+++ b/crates/axl-runtime/src/engine/bazel/mod.rs
@@ -136,7 +136,11 @@ fn resolve_rc_version(
         return Ok(semver::Version::parse(&s).ok());
     }
     if rc.has_version_gated_options() {
-        return Ok(info::server_info().ok().and_then(|t| t.1));
+        return Ok(
+            info::server_info_with_startup_flags(&rc.invocation_startup_flags())
+                .ok()
+                .and_then(|t| t.1),
+        );
     }
     Ok(None)
 }
@@ -171,9 +175,10 @@ fn resolve_flags<'v>(
 /// (`build` / `test` / `query`) so they filter conditional flags identically.
 fn resolve_flags_for_running_bazel<'v>(
     items: &[Either<values::StringValue<'v>, (values::StringValue<'v>, values::StringValue<'v>)>],
+    startup_flags: &[String],
 ) -> anyhow::Result<Vec<String>> {
     let version = if items.iter().any(|f| f.is_right()) {
-        info::server_info()
+        info::server_info_with_startup_flags(startup_flags)
             .map_err(|e| anyhow::anyhow!("failed to get Bazel server info: {}", e))?
             .1
     } else {
@@ -379,14 +384,17 @@ fn resolve_invocation_flags<'v>(
     rc_param: NoneOr<values::Value<'v>>,
     flags: &[Either<values::StringValue<'v>, (values::StringValue<'v>, values::StringValue<'v>)>],
 ) -> anyhow::Result<(Vec<String>, Vec<String>)> {
-    let extras = resolve_flags_for_running_bazel(flags)?;
     match effective_rc(this, rc_param) {
         Some(rc) => {
             let (startup, mut cmd) = rc.resolve_for_command(command)?;
-            cmd.extend(extras);
+            cmd.extend(resolve_flags_for_running_bazel(flags, &startup)?);
             Ok((cmd, startup))
         }
-        None => Ok((extras, read_startup_flags(this)?)),
+        None => {
+            let startup = read_startup_flags(this)?;
+            let extras = resolve_flags_for_running_bazel(flags, &startup)?;
+            Ok((extras, startup))
+        }
     }
 }
 
@@ -759,14 +767,17 @@ pub(crate) fn bazel_methods(registry: &mut MethodsBuilder) {
         #[starlark(require = named, default = false)] announce_command: bool,
     ) -> anyhow::Result<query::Query> {
         require_claimed_flags(this)?;
-        let extras = resolve_flags_for_running_bazel(&flags.items)?;
         let (startup, command_flags) = match effective_rc(this, rc) {
             Some(rc) => {
                 let (startup, mut base) = rc.resolve_for_command("query")?;
-                base.extend(extras);
+                base.extend(resolve_flags_for_running_bazel(&flags.items, &startup)?);
                 (startup, base)
             }
-            None => (read_startup_flags(this)?, extras),
+            None => {
+                let startup = read_startup_flags(this)?;
+                let extras = resolve_flags_for_running_bazel(&flags.items, &startup)?;
+                (startup, extras)
+            }
         };
         query::run(
             &expr,

--- a/crates/axl-runtime/src/engine/bazel/stream/execlog.rs
+++ b/crates/axl-runtime/src/engine/bazel/stream/execlog.rs
@@ -181,33 +181,27 @@ impl ExecLogStream {
 
     /// Spawn the execlog reader thread for a regular file.
     ///
-    /// `pid` is the Bazel server process ID, used to detect when Bazel has finished
-    /// writing the file. `out_path` is the file Bazel will write
-    /// `--execution_log_compact_file` to. Pass `Some(path)` to reuse an existing sink
-    /// path (e.g. a `CompactFile` sink so Bazel writes directly to the caller's
-    /// destination without a tee step). Pass `None` to have a UUID-named temp file
-    /// created automatically.
+    /// `path` is the file Bazel was given as `--execution_log_compact_file`.
+    /// `writer_pid` is the bazel client pid of the invocation writing it: the
+    /// server closes the log before the client exits, so the client's exit is
+    /// the end-of-stream signal. Call this after the client has been spawned.
     ///
     /// The thread streams the file as Bazel writes it using [`galvanize::StreamingFile`],
-    /// which busy-polls for file existence at open time and retries reads while Bazel
-    /// holds the file open. It self-terminates when Bazel closes the file.
+    /// which busy-polls for file existence at open time and retries reads while the
+    /// client is alive.
     pub fn spawn_with_file(
-        pid: u32,
-        out_path: Option<PathBuf>,
+        path: PathBuf,
+        writer_pid: u32,
         compact_sink_paths: Vec<String>,
         has_file_sinks: bool,
-    ) -> io::Result<(PathBuf, Self)> {
-        let out = out_path.unwrap_or_else(|| {
-            env::temp_dir().join(format!("execlog-out-{}.bin", uuid::Uuid::new_v4()))
-        });
+    ) -> io::Result<Self> {
         let (mut sender, recv) = bounded::<ExecLogEntry>(1000);
-        let path = out.clone();
         let handle = thread::spawn(move || {
             let mut buf: Vec<u8> = Vec::with_capacity(1024 * 5);
             // 10 is the maximum size of a varint so start with that size.
             buf.resize(10, 0);
 
-            let out_raw = galvanize::StreamingFile::open(path.clone(), pid)?;
+            let out_raw = galvanize::StreamingFile::open(path, writer_pid)?;
             let writers = compact_sink_paths
                 .iter()
                 .map(|p| Ok(BufWriter::new(File::create(p)?)))
@@ -262,14 +256,11 @@ impl ExecLogStream {
             }
         });
 
-        Ok((
-            out,
-            Self {
-                handle,
-                recv: Some(recv),
-                file_sink_handles: vec![],
-            },
-        ))
+        Ok(Self {
+            handle,
+            recv: Some(recv),
+            file_sink_handles: vec![],
+        })
     }
 
     pub fn receiver(&self) -> Receiver<ExecLogEntry> {

--- a/crates/galvanize/src/lib.rs
+++ b/crates/galvanize/src/lib.rs
@@ -238,13 +238,15 @@ impl Read for Pipe {
     }
 }
 
-/// A regular file that streams its contents as the writer (identified by `pid`) appends to it.
+/// A regular file that streams its contents while the process `pid` is alive.
 ///
-/// Busy-polls for file existence at open time, then reads with the same retry logic as
-/// [`Pipe`] with [`RetryPolicy::IfOpenForPid`]: on EOF, checks whether the writer process
-/// still has the file open. Returns `BrokenPipe` when the writer closes the file.
+/// `pid` is whichever process's lifetime bounds the stream — not necessarily
+/// the one holding the file open. For a bazel execlog that is the client: the
+/// server writes the file but closes it before the client exits, and the
+/// server itself may be replaced mid-invocation. Busy-polls for file existence
+/// at open time; on EOF returns `Ok(0)` while `pid` is alive and `BrokenPipe`
+/// once it has exited.
 pub struct StreamingFile {
-    path: PathBuf,
     inner: File,
     pid: u32,
 }
@@ -252,7 +254,6 @@ pub struct StreamingFile {
 impl StreamingFile {
     /// Polls until `path` exists (10 ms sleep between checks), then opens it.
     /// Returns `BrokenPipe` immediately if `pid` exits before the file appears.
-    /// Path is canonicalized after open for accurate fd matching.
     pub fn open(path: PathBuf, pid: u32) -> io::Result<Self> {
         while !path.exists() {
             if !is_pid_alive(pid) {
@@ -264,21 +265,20 @@ impl StreamingFile {
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
         let inner = File::open(&path)?;
-        let path = path.canonicalize()?;
-        Ok(Self { path, inner, pid })
+        Ok(Self { inner, pid })
     }
 }
 
 impl Read for StreamingFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self.inner.read(buf) {
-            // Ok(0): at the current end of the file. If the writer still has it open,
-            // return Ok(0) to signal "no data yet, try again later". If the writer
-            // has closed the file, the stream is done — signal BrokenPipe.
+            // Ok(0): at the current end of the file. While `pid` lives more may
+            // arrive, so signal "no data yet, try again later". Once it has
+            // exited the file is complete — signal BrokenPipe.
             // Callers that cannot tolerate Ok(0) (e.g. a zstd Decoder) should wrap
             // this in a blocking retry adapter.
             Ok(0) => {
-                if is_path_open_for_pid(&self.path, self.pid)? {
+                if is_pid_alive(self.pid) {
                     Ok(0)
                 } else {
                     Err(std::io::Error::new(ErrorKind::BrokenPipe, "end of stream"))
@@ -404,6 +404,78 @@ mod tests {
             b"beforeafter".to_vec(),
             "a poke beside a live writer must not truncate the stream"
         );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A regular-file path of our own; the test decides when (or whether) it exists.
+    fn scratch_file() -> PathBuf {
+        static NEXT: AtomicU32 = AtomicU32::new(0);
+        std::env::temp_dir().join(format!(
+            "galvanize-test-{}-{}.log",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    /// A live pid that holds nothing open: `StreamingFile` must key on the pid
+    /// alone, so the writer handle is deliberately closed in these tests.
+    fn spawn_pid_holder() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("60")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("failed to spawn sleep")
+    }
+
+    fn dead_pid() -> u32 {
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("failed to spawn true");
+        let pid = child.id();
+        child.wait().expect("failed to reap true");
+        pid
+    }
+
+    #[test]
+    fn streaming_file_gives_up_when_the_pid_dies_before_the_file_appears() {
+        let err = StreamingFile::open(scratch_file(), dead_pid())
+            .err()
+            .expect("must not open a file that never appears");
+        assert_eq!(err.kind(), ErrorKind::BrokenPipe);
+    }
+
+    #[test]
+    fn streaming_file_ends_on_pid_exit_not_on_the_writer_closing() {
+        use std::io::Write as _;
+
+        let path = scratch_file();
+        let mut holder = spawn_pid_holder();
+        std::fs::write(&path, b"abc").expect("write");
+
+        let mut file = StreamingFile::open(path.clone(), holder.id()).expect("open");
+        let mut buf = [0u8; 8];
+        assert_eq!(file.read(&mut buf).expect("read"), 3);
+        assert_eq!(
+            file.read(&mut buf).expect("eof while the pid lives"),
+            0,
+            "no process holds the file open, but the bounding pid is alive: not the end yet"
+        );
+
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .and_then(|mut f| f.write_all(b"de"))
+            .expect("append");
+        assert_eq!(file.read(&mut buf).expect("read appended bytes"), 2);
+
+        holder.kill().expect("kill");
+        holder.wait().expect("reap");
+        let err = file
+            .read(&mut buf)
+            .err()
+            .expect("end of stream once the pid is gone");
+        assert_eq!(err.kind(), ErrorKind::BrokenPipe);
         let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## Problem

A customer's `aspect test` jobs started failing after a successful build:

```text
INFO: Build completed successfully, 2 total actions
...
error: execlog stream thread error: io error: process exited before the file was created
```

1. A pre-command hook ran `aspect ci bazelrc`, writing `--output_base=/mnt/ephemeral/output/dirt/dirt` into `~/.bazelrc`.
2. `Build::spawn` probed `bazel info server_pid release` **with no startup flags**. Bazel resolved that from the rc files, so the probe landed on the task's own output base but with rc-derived startup options, and returned that server's pid.
3. The real `bazel test` ran with the runner's explicit startup flags. Bazel saw different startup options on the running server and restarted it — `Starting local Bazel server (9.2.0)` three seconds after `bazel health check passed`.
4. The execlog reader had been started before spawn with the probed server pid as its liveness signal. That pid was gone, so `StreamingFile::open` returned `BrokenPipe` immediately.
5. `wait()` joined the streams after a green build, hit the stream error and `bail!`ed, never reporting bazel's exit status.

Until that hook change the rc files pointed the probe at a *different*, long-lived output base (Rosetta's `__main__`), so the wrong-but-alive pid masked the bug. It only bites with an exec-log sink registered (the artifacts feature's `upload_exec_log`).

## Fix

- **Probe the server the invocation will use.** `Build::spawn` now calls `server_info_with_startup_flags(&startup_flags)`, as `query` already did. The version probes behind version-gated flags (`resolve_flags_for_running_bazel`, `resolve_rc_version`) take the startup flags too, so they no longer read rc files and never start a stray server.
- **Bound the execlog reader by the client pid.** The `--execution_log_compact_file` path is chosen before spawn; the reader thread starts after `cmd.spawn()` with `child.id()`, mirroring the BES reader. Bazel's `CompactSpawnLogContext` opens the file in its constructor and closes it in `afterCommand`, both before the client exits, so the client's exit is the end-of-stream signal. `galvanize::StreamingFile` keys on `is_pid_alive(pid)` instead of "does `pid` hold the file open" — the server holds it, and the server may be replaced mid-invocation.
- **Keep bazel's exit code visible.** `wait()` collects stream errors instead of bailing on the first. If bazel failed, the stream errors are printed as warnings and bazel's status is returned. If bazel succeeded and a stream failed, the call still fails (a truncated artifact must not pass silently), but the message now carries the exit code.

Not changed here: `WorkspaceEventStream::spawn_with_pipe` and the BES `Pipe`'s `IfOpenForPid` policy still receive the pre-spawn server pid. With the probe fixed that pid is the right server, so they are correct unless bazel restarts for some other reason; making them client-pid-bounded is a follow-up.

## Test plan

- [x] `bazel test //crates/galvanize:galvanize_test` — two new tests: the reader gives up when the bounding pid is already dead before the file appears, and it keeps reading past EOF while the pid lives (with no process holding the file open) and ends only when the pid exits.
- [x] `bazel build //crates/axl-runtime`
- [x] `bazel test //crates/axl-runtime:test`
- [ ] Manual: on a Workflows runner with `aspect ci bazelrc` in a pre-command hook and `upload_exec_log` on, `aspect test` completes and the `.execlog.zstd` sink is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTa7Rk2dND4P5AXWZ7VBcV
