### PR TITLE
fix(mcp): Lower the Workflows requirement note to 6.0.30

### DIFF
--- a/crates/aspect-cli/src/builtins/aspect/mcp.axl
+++ b/crates/aspect-cli/src/builtins/aspect/mcp.axl
@@ -14,7 +14,7 @@ Setup, once per developer:
   3. Register the server in the AI tool's MCP config, e.g. `.mcp.json`:
        {"mcpServers": {"aspect": {"command": "aspect", "args": ["mcp"]}}}
 
-The server targets the default configured deployment; add `--deployment <name>` to the args to pin one. For several deployments, register one entry per deployment (e.g. `aspect-staging`, `aspect-prod`) with distinct `--deployment` args. Requires the deployment to run Aspect Workflows 6.1+ with `webapp.web.api_enabled = true`; each tool call authenticates with the stored credential and refreshes it automatically.""",
+The server targets the default configured deployment; add `--deployment <name>` to the args to pin one. For several deployments, register one entry per deployment (e.g. `aspect-staging`, `aspect-prod`) with distinct `--deployment` args. Requires the deployment to run Aspect Workflows 6.0.30+ with `webapp.web.api_enabled = true`; each tool call authenticates with the stored credential and refreshes it automatically.""",
     implementation = _mcp_impl,
     args = {
         "deployment": args.string(

--- a/crates/axl-runtime/src/engine/aspect/mcp.rs
+++ b/crates/axl-runtime/src/engine/aspect/mcp.rs
@@ -9,7 +9,7 @@
 //!
 //! The API host comes from the deployment's advertised build-results viewer URL
 //! (`aspect_bes_results_url`, recorded by `aspect auth configure`). The REST
-//! API ships in Aspect Workflows 6.1 and is opt-in (`webapp.web.api_enabled`),
+//! API ships in Aspect Workflows 6.0.30 and is opt-in (`webapp.web.api_enabled`),
 //! and the CLI reaches customers before their deployments upgrade — so when the
 //! one startup probe (the RFC 9728 discovery document, the only unauthenticated
 //! path) finds no API, the server still starts and every tool returns the
@@ -58,7 +58,7 @@ const MAX_LIMIT: u64 = 100;
 fn api_unavailable_message(deployment: &str, api_origin: &str) -> String {
     format!(
         "The deployment '{deployment}' ({api_origin}) does not expose the REST API the MCP server \
-         needs. It requires Aspect Workflows 6.1 or later with `webapp.web.api_enabled = true` — \
+         needs. It requires Aspect Workflows 6.0.30 or later with `webapp.web.api_enabled = true` — \
          see {DOCS_URL}. Ask your Workflows operator to enable it."
     )
 }


### PR DESCRIPTION
## Summary

The build results REST API that `aspect mcp` depends on shipped on the 6.0 line in Workflows 6.0.30, so the requirement notes that pointed operators at 6.1 are now too strict. This lowers the version in the MCP startup error, the module doc comment, and the `aspect mcp` help text to 6.0.30. Text only; no behaviour change. The "known values as of Workflows 6.1" notes on the filter parameters are left as they are, since they describe enum sets rather than the minimum version.

## Test plan

- `grep -rn 'Workflows 6.1' crates` shows only the three "known values" notes remain.
- No test references the changed strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYXXKxPJSEgTfXL3yP3228
