### PR TITLE
test(mcp): Match the gating message's 6.0.30 version in its unit test

### DIFF
--- a/crates/axl-runtime/src/engine/aspect/mcp.rs
+++ b/crates/axl-runtime/src/engine/aspect/mcp.rs
@@ -938,7 +938,7 @@ mod tests {
     #[test]
     fn gating_message_names_version_flag_and_docs() {
         let msg = api_unavailable_message("acme", "https://app.acme.example.com");
-        for needle in ["6.1", "webapp.web.api_enabled", DOCS_URL, "acme"] {
+        for needle in ["6.0.30", "webapp.web.api_enabled", DOCS_URL, "acme"] {
             assert!(msg.contains(needle), "missing {needle}: {msg}");
         }
     }


### PR DESCRIPTION
## Summary

#1430 lowered the Workflows requirement in the MCP gating message from 6.1 to 6.0.30 but left `gating_message_names_version_flag_and_docs` asserting the message contains `"6.1"`, so the axl-runtime unit tests fail on main. This updates the expected needle to `"6.0.30"`.

## Test plan

- `gating_message_names_version_flag_and_docs` passes in CI; that test is the only reference to the old version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYXXKxPJSEgTfXL3yP3228
