### PR TITLE
feat(auth): Aspect Cloud is a deployment, and a profile is an identity

### DIFF
--- a/crates/aspect-cli/BUILD.bazel
+++ b/crates/aspect-cli/BUILD.bazel
@@ -98,6 +98,19 @@ rust_test(
     ],
 )
 
+rust_test(
+    name = "auth_status_test",
+    srcs = ["tests/auth_status.rs"],
+    data = [":aspect-cli"],
+    env = {
+        "ASPECT_CLI_BIN": "$(rootpath :aspect-cli)",
+    },
+    deps = [
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+    ],
+)
+
 multi_platform_rust_binaries(
     name = "bins",
     tags = ["no-macos"],

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -309,7 +309,7 @@ def _discover_deployment(ctx, host):
             error(ctx.std, "Double-check the URL — it should be the deployment's remote-cache or BES host (e.g. remote.<deployment>.example.com).")
             return None
         if info.status == "issuer_not_advertised":
-            # `reason` is the issuer actually looked for — for `--name aspect` that
+            # `reason` is the issuer actually looked for — for `--name aspect-cloud` that
             # is the account's own, pinned rather than taken from `--issuer`.
             error(ctx.std, "'" + (info.reason or issuer) + "' is not one of the authorization servers this deployment advertises.")
             error(ctx.std, "Choose one of: " + _advertised_issuers(info.auth_servers))
@@ -338,7 +338,7 @@ def _configure_impl(ctx: TaskContext) -> int:
     if info == None:
         return 1
 
-    # `--name aspect` attaches the endpoints to Aspect Cloud rather than
+    # `--name aspect-cloud` attaches the endpoints to Aspect Cloud rather than
     # recording a deployment beside it, so say which happened.
     account = ctx.aspect.auth.deployment_summary(info.name)
     is_account = account != None and account.builtin

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -57,12 +57,33 @@ def shadowed_warning(s) -> str:
 
 def status_line(d) -> str:
     """The Status row value for a summary: the logged-in identity + token status,
-    or a logged-out note pointing at how to log in."""
+    or a bare `logged out`.
+
+    What to do about being logged out is the `Log in` row's job (see
+    `login_options`), which has room for all of the ways rather than one of them
+    in a parenthetical."""
     if not d.logged_in:
-        return "logged out (run `" + login_command(d) + "`)"
+        return "logged out"
     who = identity(d)
     line = "logged in" + (" as " + who if who else "")
     return line + (", " + d.status if d.status else "")
+
+def login_options(d) -> list[str]:
+    """The ways to authenticate `d`, one per line, for the `Log in` row.
+
+    Three, because they suit different places: the browser flow for a person at a
+    terminal, an API token piped in for a script that has one to hand, and an API
+    token in an environment variable for CI or any other unattended run.
+
+    The variable is named in full rather than described, since its name is derived
+    from the deployment's and is the one thing here a reader cannot work out (see
+    `api_token_env`). The `$` marks it as a variable to set, so the name does not
+    read as the token itself."""
+    return [
+        "run `" + login_command(d) + "`,",
+        "or add --with-api-token to read an API token from stdin,",
+        "or set $" + d.api_token_env,
+    ]
 
 def _print_deployment(d, header = True):
     """Print one entry's aligned detail table (Status, Issuer, and the build
@@ -86,18 +107,19 @@ def _print_deployment(d, header = True):
 
     _row("Status", status_line(d))
 
+    # Only when logged out, which is the only time it is worth acting on. The first
+    # option takes the label; the rest align under it as continuation lines.
+    if not d.logged_in:
+        options = login_options(d)
+        _row("Log in", options[0])
+        for option in options[1:]:
+            _row("", option)
+
     # Only for a deployment, whose issuer is worth knowing because it varies — its
     # own FrontEgg environment, or a customer's IdP. Aspect Cloud's is fixed, so
     # naming it says nothing the heading did not.
     if d.issuer and not d.builtin:
         _row("Issuer", d.issuer)
-
-    # Only for a deployment: Aspect Cloud's is the documented `ASPECT_API_TOKEN`,
-    # while a deployment's is derived from its name, so this is the one place that
-    # answers "which variable do I set on CI for this one" without the reader
-    # having to reproduce the normalization.
-    if not d.builtin:
-        _row("Token", d.api_token_env)
 
     # Short column headers of their own, not the prose `capability_labels` names.
     for (kind, value) in [("Cache", d.cache), ("Exec", d.exec), ("BES", d.bes), ("Results", d.results_url)]:
@@ -137,14 +159,14 @@ def _print_default_usage_hint(summary, others: int = 0):
     if others:
         print("Add --deployment <name> to target a specific deployment instead of the default.")
 
-def _print_account_usage_hint(ctx: TaskContext):
+def _print_aspect_cloud_usage_hint(ctx: TaskContext):
     """The `--remote` hint for Aspect Cloud, read from the recorded entries so
-    it names the endpoints the account actually has and mentions `--deployment` only
+    it names the endpoints Aspect Cloud actually has and mentions `--deployment` only
     when there is another deployment to name."""
     entries = ctx.aspect.auth.list()
-    account = [d for d in entries if d.builtin]
-    if account:
-        _print_default_usage_hint(account[0], len([d for d in entries if not d.builtin]))
+    aspect_cloud = [d for d in entries if d.builtin]
+    if aspect_cloud:
+        _print_default_usage_hint(aspect_cloud[0], len([d for d in entries if not d.builtin]))
 
 def _print_configured_usage_hint(summary):
     """Post-configure hint naming the just-configured deployment and the remote
@@ -166,15 +188,17 @@ def _login_impl(ctx: TaskContext) -> int:
     deployment = ctx.args.deployment
     browser_login = not ctx.args.with_token and not ctx.args.with_api_token
 
-    # A bare interactive login also records the Aspect-hosted deployment, so
+    # A bare interactive login also records the Aspect Cloud deployment, so
     # --remote works without a separate `auth configure`. Skipped when the user
-    # targeted a specific deployment or pinned a --profile (both say where this
-    # credential belongs), and skipped for the stdin-token flows: those are the CI
-    # paths, where a discovery probe would add a network round trip to a login that
-    # makes none, and where the deployment is normally declared in the repo's own
+    # named a deployment, and for the stdin-token flows: those are the CI paths,
+    # where a discovery probe would add a network round trip to a login that makes
+    # none, and where the deployment is normally declared in the repo's own
     # .aspect/config.json instead.
-    account_login = browser_login and not deployment and not ctx.args.profile
-    account_info = None
+    #
+    # Not skipped for --profile: that names who is logging in, and a second
+    # identity wants the same endpoints recorded as the first.
+    aspect_cloud_login = browser_login and not deployment
+    aspect_cloud_info = None
     if ctx.args.with_token:
         token = ctx.std.io.stdin.read_to_string().strip()
         if not token:
@@ -188,13 +212,13 @@ def _login_impl(ctx: TaskContext) -> int:
             return 1
         creds = ctx.aspect.auth.login(api_token = inp, deployment = deployment)
     else:
-        # Discover before authenticating, not after: the login reads the account's
+        # Discover before authenticating, not after: the login reads Aspect Cloud's
         # relay URI and PKCE client, so discovering afterwards would use a stale
         # value for this login and only correct the next one. A login already talks
         # to the network, so this is one more request rather than a new dependency,
         # and a failed probe simply leaves the seeded values in place.
-        if account_login:
-            account_info = ctx.aspect.auth.configure_default()
+        if aspect_cloud_login:
+            aspect_cloud_info = ctx.aspect.auth.configure_default()
         creds = _run_browser_login(ctx, deployment)
         if creds == None:
             error(ctx.std, "No authorization code entered; not logged in.")
@@ -204,7 +228,7 @@ def _login_impl(ctx: TaskContext) -> int:
     # host) unless the user pinned an explicit --profile.
     ctx.aspect.auth.persist(creds, deployment = deployment, profile = ctx.args.profile)
     _print_login_summary(ctx, deployment, creds)
-    _print_account_followups(ctx, account_info)
+    _print_aspect_cloud_followups(ctx, aspect_cloud_info)
     return 0
 
 def login_target_label(deployment: str, builtin: bool) -> str:
@@ -241,7 +265,7 @@ def _print_login_summary(ctx: TaskContext, deployment: str, creds):
     elif capability_labels(target, only = REMOTE_DEFAULT_CAPS):
         _print_configured_usage_hint(target)
 
-def _print_account_followups(ctx: TaskContext, info):
+def _print_aspect_cloud_followups(ctx: TaskContext, info):
     """Anything still needed after an Aspect Cloud login, printed below its summary.
 
     `not_recorded` means the login worked but the endpoints could not be written
@@ -276,14 +300,14 @@ login = task(
             description = "Log in with an 'id:secret' API token read from stdin instead of the browser flow.",
         ),
         "deployment": args.string(
-            description = "Log in to this configured Aspect Workflows deployment (see `aspect auth configure`) instead of Aspect Cloud. Selects which account/deployment to authenticate.",
+            description = "Log in to this configured Aspect Workflows deployment (see `aspect auth configure`) instead of Aspect Cloud. Selects which deployment to authenticate against.",
         ),
         "no_browser": args.boolean(
             default = False,
             description = "Don't open a browser locally; print the URL and ask for the callback URL or authorization code. Use this when the browser is on another machine, such as over SSH.",
         ),
         "profile": args.string(
-            description = "Advanced: the credential store key to save under (defaults to the deployment name, or \"default\" for Aspect Cloud). Unlike --deployment (which picks who to authenticate), --profile only changes where the credential is filed — use it to keep two identities for the same account/deployment side by side. Also settable via $ASPECT_AUTH_PROFILE.",
+            description = "The identity to file this login under, defaulting to \"default\". A profile holds one credential per deployment, so --profile bob covers Aspect Cloud and every deployment bob uses; switching profiles switches all of them. Unlike --deployment (which picks what to authenticate against), this picks who. Also settable via $ASPECT_AUTH_PROFILE, which the Bazel credential helper reads too.",
         ),
     },
 )
@@ -316,7 +340,7 @@ def _discover_deployment(ctx, host):
             return None
         if info.status == "issuer_not_advertised":
             # `reason` is the issuer actually looked for — for `--name aspect-cloud` that
-            # is the account's own, pinned rather than taken from `--issuer`.
+            # is Aspect Cloud's own, pinned rather than taken from `--issuer`.
             error(ctx.std, "'" + (info.reason or issuer) + "' is not one of the authorization servers this deployment advertises.")
             error(ctx.std, "Choose one of: " + _advertised_issuers(info.auth_servers))
             return None
@@ -346,9 +370,9 @@ def _configure_impl(ctx: TaskContext) -> int:
 
     # `--name aspect-cloud` attaches the endpoints to Aspect Cloud rather than
     # recording a deployment beside it, so say which happened.
-    account = ctx.aspect.auth.deployment_summary(info.name)
-    is_account = account != None and account.builtin
-    if is_account:
+    recorded = ctx.aspect.auth.deployment_summary(info.name)
+    is_aspect_cloud = recorded != None and recorded.builtin
+    if is_aspect_cloud:
         print("Configured remote cache and BES for Aspect Cloud.")
     else:
         print("Configured deployment '" + info.name + "'.")
@@ -360,7 +384,7 @@ def _configure_impl(ctx: TaskContext) -> int:
         return 1
     if not ctx.args.login:
         print("")
-        if is_account:
+        if is_aspect_cloud:
             print("Run `aspect auth login` to authenticate")
         else:
             print("Run `aspect auth login --deployment " + info.name + "` to authenticate")
@@ -378,11 +402,11 @@ def _configure_impl(ctx: TaskContext) -> int:
     if summary == None:
         return 0
 
-    # The account is its own thing, not one of a list, so it needs no name line and
+    # Aspect Cloud is its own thing, not one of a list, so it needs no name line and
     # is reached by `--remote` alone rather than `--deployment`.
-    _print_deployment(summary, header = not is_account)
-    if is_account:
-        _print_account_usage_hint(ctx)
+    _print_deployment(summary, header = not is_aspect_cloud)
+    if is_aspect_cloud:
+        _print_aspect_cloud_usage_hint(ctx)
     else:
         _print_configured_usage_hint(summary)
     return 0
@@ -414,6 +438,9 @@ configure = task(
             default = False,
             description = "Don't open a browser locally; print the URL and ask for the callback URL or authorization code. Use this when the browser is on another machine, such as over SSH.",
         ),
+        "profile": args.string(
+            description = "The identity to file the login under, defaulting to \"default\". Same meaning as `aspect auth login --profile`; applies only when --login runs.",
+        ),
     },
 )
 
@@ -437,10 +464,10 @@ logout = task(
         ),
         "all": args.boolean(
             default = False,
-            description = "Log out everywhere — clear every stored credential (Aspect Cloud and all deployments).",
+            description = "Log out everywhere — clear every stored credential, for every deployment and every profile.",
         ),
         "profile": args.string(
-            description = "Advanced: the exact credential store key to clear, overriding the one derived from --deployment. See `aspect auth login --help`.",
+            description = "The identity to log out, defaulting to \"default\". Clears only this profile's credential for the deployment; other profiles keep theirs. See `aspect auth login --help`.",
         ),
     },
 )
@@ -490,15 +517,16 @@ def _status_impl(ctx: TaskContext) -> int:
     entries = ctx.aspect.auth.list()
     ignored = ctx.aspect.auth.shadowed()
 
-    # The built-in Aspect *account* (no build endpoints) vs. the configured
-    # Workflows *deployments* are two different things — show them apart.
-    account = [d for d in entries if d.builtin]
+    # Aspect Cloud is multi-tenant and every installation has it; the configured
+    # ones are single-tenant and particular to this user — show them apart.
+    # The `account` JSON key is the released name for the first of those.
+    aspect_cloud = [d for d in entries if d.builtin]
     deployments = [d for d in entries if not d.builtin]
 
     if ctx.args.output == "json":
         default_names = [d.name for d in deployments if d.default]
         doc = {
-            "account": [_entry_json(d) for d in account],
+            "account": [_entry_json(d) for d in aspect_cloud],
             "deployments": [_entry_json(d) for d in deployments],
             "default_deployment": default_names[0] if default_names else None,
             "ignored": [_ignored_json(s) for s in ignored],
@@ -511,7 +539,7 @@ def _status_impl(ctx: TaskContext) -> int:
         warn(ctx.std, shadowed_warning(s))
 
     print("Aspect Cloud:")
-    for d in account:
+    for d in aspect_cloud:
         _print_deployment(d, header = False)
 
     print("")
@@ -522,7 +550,7 @@ def _status_impl(ctx: TaskContext) -> int:
             _print_deployment(d)
         print("")
         print("● = default. Switch with `aspect auth use <name>`.")
-        default = ([d for d in deployments if d.default] + account)[0]
+        default = ([d for d in deployments if d.default] + aspect_cloud)[0]
         _print_default_usage_hint(default, len(deployments))
     else:
         print("No single-tenant Aspect Workflows deployments configured.")

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -197,9 +197,8 @@ def _login_impl(ctx: TaskContext) -> int:
     # host) unless the user pinned an explicit --profile.
     profile = ctx.args.profile or ctx.aspect.auth.login_profile(deployment = deployment)
     ctx.aspect.auth.persist(creds, profile = profile)
-    endpoints_filed = _file_account_endpoints(ctx, creds, account_info)
     _print_login_summary(ctx, deployment, creds)
-    _print_account_followups(ctx, account_info, endpoints_filed)
+    _print_account_followups(ctx, account_info)
     return 0
 
 def login_target_label(deployment: str, builtin: bool) -> str:
@@ -236,52 +235,13 @@ def _print_login_summary(ctx: TaskContext, deployment: str, creds):
     elif capability_labels(target, only = REMOTE_DEFAULT_CAPS):
         _print_configured_usage_hint(target)
 
-def _persist_endpoint_login(ctx: TaskContext, creds, name: str) -> bool:
-    """File the grant's id_token under `name`, the credential a deployment's
-    cache/BES edges validate. The caller has already filed the access_token under
-    its own profile — for Aspect Cloud that is the default profile, which
-    every Aspect Cloud caller reads, so the two live side by side.
-
-    Returns False when the grant carried no id_token, leaving the deployment
-    configured but unauthenticated; callers say so rather than leaving
-    `auth status` to reveal it.
-    """
-    endpoint_creds = creds.for_endpoint()
-    if endpoint_creds == None:
-        return False
-    ctx.aspect.auth.persist(endpoint_creds, profile = name)
-    return True
-
-def _file_account_endpoints(ctx: TaskContext, creds, info) -> bool:
-    """File `creds` against the Aspect Cloud endpoints `info` recorded.
-
-    Prints nothing, so the login's summary stays in one place — see
-    `_print_account_followups` for what is said about the outcome.
-
-    The endpoint credential is the same grant's id_token, what a cache/BES edge
-    validates, so there is no second browser round trip. Returns False only when
-    those endpoints were recorded but the grant carried no id_token to authenticate
-    them with; `info` describing no usable endpoints is not a failure, just nothing
-    to do.
-    """
-    if info == None or info.status != "ok" or not info.can_login:
-        return True
-    return _persist_endpoint_login(ctx, creds, info.name)
-
-def _print_account_followups(ctx: TaskContext, info, endpoints_filed: bool):
+def _print_account_followups(ctx: TaskContext, info):
     """Anything still needed after an Aspect Cloud login, printed below its summary.
 
-    An unfiled endpoint credential leaves the endpoints recorded but unauthenticated
-    — which `auth status` would otherwise be the only place to notice. It should not
-    happen: a credential carries no id_token only when it came from a refresh grant
-    (permitted to omit one) or was read back from the store (which never keeps it),
-    and this is always a fresh authorization-code result. So the warning doubles as
-    the signal that something upstream changed.
-
-    `not_recorded` is the other side of that: the login worked but the endpoints
-    could not be written down, so `--remote` would fail later with nothing pointing
-    back here. Every other non-`ok` status means the probe found nothing worth
-    recording, which is not the user's problem and says nothing.
+    `not_recorded` means the login worked but the endpoints could not be written
+    down, so `--remote` would fail later with nothing pointing back here. Every
+    other non-`ok` status means the probe found nothing worth recording, which is
+    not the user's problem and says nothing.
     """
     if info == None:
         return
@@ -291,10 +251,7 @@ def _print_account_followups(ctx: TaskContext, info, endpoints_filed: bool):
         return
     if info.status != "ok" or not info.can_login:
         return
-    if not endpoints_filed:
-        warn(ctx.std, "Recorded the remote cache and BES but could not authenticate them: the login returned no id_token.")
-        print("Run `aspect auth login` again to finish setting them up.")
-    elif not info.is_default:
+    if not info.is_default:
         print("")
         print("Run `aspect auth use " + info.name + "` to make it the default deployment.")
 
@@ -407,16 +364,10 @@ def _configure_impl(ctx: TaskContext) -> int:
     if creds == None:
         error(ctx.std, "No authorization code entered; the deployment is configured but not logged in.")
         return 1
-    if is_account:
-        # Filed the way a bare login files them: the access_token under the default
-        # profile for Aspect Cloud, the same grant's id_token under the account's
-        # name for its edges.
-        ctx.aspect.auth.persist(creds, profile = ctx.aspect.auth.login_profile())
-        if not _persist_endpoint_login(ctx, creds, info.name):
-            warn(ctx.std, "Configured the endpoints but could not authenticate them: the login returned no id_token.")
-            return 1
-    else:
-        ctx.aspect.auth.persist(creds, profile = info.name)
+
+    # Filed under the deployment's own profile, which for Aspect Cloud is the
+    # default one rather than its name — `login_profile` owns that distinction.
+    ctx.aspect.auth.persist(creds, profile = ctx.aspect.auth.login_profile(deployment = info.name))
 
     print("")
     summary = ctx.aspect.auth.deployment_summary(info.name)

--- a/crates/aspect-cli/src/builtins/aspect/auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth.axl
@@ -92,6 +92,13 @@ def _print_deployment(d, header = True):
     if d.issuer and not d.builtin:
         _row("Issuer", d.issuer)
 
+    # Only for a deployment: Aspect Cloud's is the documented `ASPECT_API_TOKEN`,
+    # while a deployment's is derived from its name, so this is the one place that
+    # answers "which variable do I set on CI for this one" without the reader
+    # having to reproduce the normalization.
+    if not d.builtin:
+        _row("Token", d.api_token_env)
+
     # Short column headers of their own, not the prose `capability_labels` names.
     for (kind, value) in [("Cache", d.cache), ("Exec", d.exec), ("BES", d.bes), ("Results", d.results_url)]:
         if value:
@@ -195,8 +202,7 @@ def _login_impl(ctx: TaskContext) -> int:
 
     # Persist under the deployment's own profile (so endpoint auth resolves it by
     # host) unless the user pinned an explicit --profile.
-    profile = ctx.args.profile or ctx.aspect.auth.login_profile(deployment = deployment)
-    ctx.aspect.auth.persist(creds, profile = profile)
+    ctx.aspect.auth.persist(creds, deployment = deployment, profile = ctx.args.profile)
     _print_login_summary(ctx, deployment, creds)
     _print_account_followups(ctx, account_info)
     return 0
@@ -365,9 +371,7 @@ def _configure_impl(ctx: TaskContext) -> int:
         error(ctx.std, "No authorization code entered; the deployment is configured but not logged in.")
         return 1
 
-    # Filed under the deployment's own profile, which for Aspect Cloud is the
-    # default one rather than its name — `login_profile` owns that distinction.
-    ctx.aspect.auth.persist(creds, profile = ctx.aspect.auth.login_profile(deployment = info.name))
+    ctx.aspect.auth.persist(creds, deployment = info.name, profile = ctx.args.profile)
 
     print("")
     summary = ctx.aspect.auth.deployment_summary(info.name)
@@ -459,6 +463,9 @@ def _entry_json(d) -> dict:
         "email": d.email,
         "issuer": d.issuer,
         "login_command": login_command(d),
+        # So a CI generator can emit the right variable per deployment without
+        # reproducing the name normalization.
+        "api_token_env": d.api_token_env,
     }
     if not d.builtin:
         doc["cache"] = d.cache

--- a/crates/aspect-cli/src/builtins/aspect/auth_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/auth_test.axl
@@ -10,7 +10,7 @@ Run with:
   aspect dev test-auth
 """
 
-load("@aspect//auth.axl", "identity", "login_command", "login_target_label", "shadowed_warning", "status_line")
+load("@aspect//auth.axl", "identity", "login_command", "login_options", "login_target_label", "shadowed_warning", "status_line")
 
 def _eq(label, got, want):
     if got != want:
@@ -27,7 +27,8 @@ def _summary(
         cache = "",
         bes = "",
         exec = "",
-        results_url = ""):
+        results_url = "",
+        api_token_env = "ASPECT_API_TOKEN_GCP"):
     return struct(
         name = name,
         builtin = builtin,
@@ -39,6 +40,7 @@ def _summary(
         cache = cache,
         bes = bes,
         results_url = results_url,
+        api_token_env = api_token_env,
         exec = exec,
     )
 
@@ -71,11 +73,9 @@ def _test_login_target_label(_):
     )
 
 def _test_status_line(_):
-    _eq(
-        "logged out → login hint",
-        status_line(_summary(name = "gcp")),
-        "logged out (run `aspect auth login --deployment gcp`)",
-    )
+    # Bare: what to do about it is the `Log in` row's job, which has room for all
+    # three ways rather than one of them in a parenthetical.
+    _eq("logged out → bare", status_line(_summary(name = "gcp")), "logged out")
     _eq(
         "logged in with identity + expiry",
         status_line(_summary(logged_in = True, display_name = "Greg", email = "g@x.io", status = "expires in 2h")),
@@ -86,6 +86,38 @@ def _test_status_line(_):
         status_line(_summary(logged_in = True)),
         "logged in",
     )
+
+def _test_login_options(_):
+    # All three ways, so a reader on CI is not left thinking the browser flow is
+    # the only one. The env var is named in full because its name is derived from
+    # the deployment's — the one thing here a reader cannot work out.
+    _eq(
+        "deployment → command, stdin flag, its own variable",
+        login_options(_summary(name = "gcp.acme", api_token_env = "ASPECT_API_TOKEN_GCP_ACME")),
+        [
+            "run `aspect auth login --deployment gcp.acme`,",
+            "or add --with-api-token to read an API token from stdin,",
+            "or set $ASPECT_API_TOKEN_GCP_ACME",
+        ],
+    )
+
+    # Aspect Cloud gets the same treatment: a bare login, and the unsuffixed
+    # variable every installation needs anyway.
+    _eq(
+        "Aspect Cloud → bare login and the unsuffixed variable",
+        login_options(_summary(builtin = True, name = "aspect-cloud", api_token_env = "ASPECT_API_TOKEN")),
+        [
+            "run `aspect auth login`,",
+            "or add --with-api-token to read an API token from stdin,",
+            "or set $ASPECT_API_TOKEN",
+        ],
+    )
+
+    # The `$` is load-bearing: without it the name reads as the token itself,
+    # which is what sent this row back for a rewrite.
+    for option in login_options(_summary()):
+        if "ASPECT_API_TOKEN" in option and "$ASPECT_API_TOKEN" not in option:
+            fail("the variable must be marked with $: %s" % option)
 
 def _shadowed(name = "aspect", path = "/home/u/.aspect/config.json", user_config = True):
     return struct(name = name, path = path, user_config = user_config)
@@ -111,6 +143,7 @@ def _test_shadowed_warning(_):
 _UNIT_TESTS = [
     _test_identity,
     _test_login_command,
+    _test_login_options,
     _test_login_target_label,
     _test_shadowed_warning,
     _test_status_line,

--- a/crates/aspect-cli/src/builtins/aspect/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/github.axl
@@ -1,3 +1,4 @@
+load("./private/lib/aspect_cloud_api.axl", "aspect_cloud_credentials", "aspect_cloud_url")
 load("./private/lib/environment.axl", "error")
 load("./private/lib/github.axl", "github")
 
@@ -11,10 +12,7 @@ def _token_impl(ctx: TaskContext) -> int:
         error(ctx.std, "Repo must be in owner/repo format (e.g. my-org/my-repo).")
         return 1
 
-    creds = ctx.aspect.auth.credentials(
-        deployment = ctx.aspect.auth.aspect_cloud_deployment,
-        profile = ctx.args.profile,
-    )
+    creds = aspect_cloud_credentials(ctx, profile = ctx.args.profile)
     if creds == None:
         error(ctx.std, github.missing_credentials_reason(ctx))
         return 1
@@ -27,7 +25,7 @@ def _token_impl(ctx: TaskContext) -> int:
 
     body = json.encode({"owner": owner, "repo": repo_name})
 
-    url = ctx.aspect.auth.aspect_cloud_api_url + "/github/token"
+    url = aspect_cloud_url(ctx, "/github/token")
     if ctx.args.roles:
         url = url + "?roles=" + ",".join(ctx.args.roles)
 

--- a/crates/aspect-cli/src/builtins/aspect/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/github.axl
@@ -11,7 +11,10 @@ def _token_impl(ctx: TaskContext) -> int:
         error(ctx.std, "Repo must be in owner/repo format (e.g. my-org/my-repo).")
         return 1
 
-    creds = ctx.aspect.auth.credentials(profile = ctx.args.profile)
+    creds = ctx.aspect.auth.credentials(
+        deployment = ctx.aspect.auth.aspect_cloud_deployment,
+        profile = ctx.args.profile,
+    )
     if creds == None:
         error(ctx.std, github.missing_credentials_reason(ctx))
         return 1
@@ -24,7 +27,7 @@ def _token_impl(ctx: TaskContext) -> int:
 
     body = json.encode({"owner": owner, "repo": repo_name})
 
-    url = ctx.aspect.auth.api_url + "/github/token"
+    url = ctx.aspect.auth.aspect_cloud_api_url + "/github/token"
     if ctx.args.roles:
         url = url + "?roles=" + ",".join(ctx.args.roles)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_cloud_api.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_cloud_api.axl
@@ -1,0 +1,32 @@
+"""Addressing the Aspect Cloud API.
+
+`api.aspect.build` serves routes that exist nowhere else: the GitHub and GitLab
+App token exchanges, status-comment contribution, status-check registration, and
+the budget query. They are Aspect Cloud's, not a deployment's — a self-hosted
+deployment has no equivalent — so they must be addressed with Aspect Cloud's URL
+*and* authenticated with Aspect Cloud's credential, whichever deployment happens
+to be the default.
+
+Those two go together, which is why they live together here: taking the URL from
+one deployment and the credential from another sends a request the server rejects,
+and the failure looks like a login problem rather than a routing one.
+
+A route a deployment serves itself is the other case, and does not belong here —
+it uses `ctx.aspect.auth.deployment_api_url(deployment = …)`, which resolves that
+deployment's own advertised `api` and errors rather than falling back here.
+"""
+
+def aspect_cloud_url(ctx, path: str) -> str:
+    """Aspect Cloud's API base with `path` appended (`"/github/token"`)."""
+    return ctx.aspect.auth.aspect_cloud_api_url + path
+
+def aspect_cloud_credentials(ctx, profile = None, required: bool = True):
+    """Aspect Cloud's credential, or `None` when the profile holds none.
+
+    `profile` is the identity to read it from, defaulting to the resolved one
+    (`--profile`, then `$ASPECT_AUTH_PROFILE`, then `default`)."""
+    return ctx.aspect.auth.credentials(
+        deployment = ctx.aspect.auth.aspect_cloud_deployment,
+        profile = profile,
+        required = required,
+    )

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
@@ -172,18 +172,13 @@ def resolve_aspect_bearer(ctx, what: str, uri: str = "") -> str:
     Callers gate on `needs_aspect_token`, so `uri` is always a host a configured
     deployment owns; `deployment_for_host` resolves its name.
 
-    A deployment's name is not always its credential-store key — Aspect Cloud is
-    named `aspect` but files under the default profile — so the key comes from
-    `login_profile`, which is the one place that mapping lives.
-
     Returns `"Bearer <jwt>"`, or `""` if the user is not authenticated (never
     logged in, or an expired session that cannot be refreshed). In the
     unauthenticated case a warning is printed; the caller proceeds without auth.
     """
     deployment = ctx.aspect.auth.deployment_for_host(endpoint_host(uri)) if uri else None
 
-    profile = ctx.aspect.auth.login_profile(deployment = deployment) if deployment else None
-    creds = ctx.aspect.auth.credentials(profile = profile, required = False)
+    creds = ctx.aspect.auth.credentials(deployment = deployment, required = False)
     if creds == None or not creds.access_token:
         warn(ctx.std, _NOT_AUTHENTICATED_MSG % (what, login_hint(deployment)))
         return ""

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/aspect_endpoint_auth.axl
@@ -172,14 +172,18 @@ def resolve_aspect_bearer(ctx, what: str, uri: str = "") -> str:
     Callers gate on `needs_aspect_token`, so `uri` is always a host a configured
     deployment owns; `deployment_for_host` resolves its name.
 
+    A deployment's name is not always its credential-store key — Aspect Cloud is
+    named `aspect` but files under the default profile — so the key comes from
+    `login_profile`, which is the one place that mapping lives.
+
     Returns `"Bearer <jwt>"`, or `""` if the user is not authenticated (never
     logged in, or an expired session that cannot be refreshed). In the
     unauthenticated case a warning is printed; the caller proceeds without auth.
     """
     deployment = ctx.aspect.auth.deployment_for_host(endpoint_host(uri)) if uri else None
 
-    # The deployment name is also its credential-store key (the `profile`).
-    creds = ctx.aspect.auth.credentials(profile = deployment, required = False)
+    profile = ctx.aspect.auth.login_profile(deployment = deployment) if deployment else None
+    creds = ctx.aspect.auth.credentials(profile = profile, required = False)
     if creds == None or not creds.access_token:
         warn(ctx.std, _NOT_AUTHENTICATED_MSG % (what, login_hint(deployment)))
         return ""

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/auth_fakes.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/auth_fakes.axl
@@ -1,0 +1,37 @@
+"""A stand-in for `ctx.aspect.auth` in tests that must not reach a credential
+store.
+
+`ctx.aspect.auth` is a Rust Starlark value: its attributes and its methods'
+parameters are declared in `auth.rs`, and nothing type-checks an AXL caller
+against them. A test that builds its own `struct(...)` fake therefore duplicates
+that surface by hand, and the duplicate is invisible to everything until the suite
+is run — a parameter added in Rust fails as `Found <x> extra named parameter(s)`,
+in whichever test files happen to have their own copy.
+
+So there is one copy, here. Widening the real surface means widening `fake_auth`,
+and every test that uses it keeps working.
+
+Only what tests actually need is modelled. Add to it when a test needs more,
+matching the real signature rather than just the call being made — the point is
+that the fake does not have to be revisited the next time a caller changes.
+"""
+
+# Aspect Cloud's own name, as `auth.rs` defines it. A literal rather than a read
+# of the real value: a test fake that asked the engine would not be a fake.
+FAKE_ASPECT_CLOUD_DEPLOYMENT = "aspect-cloud"
+FAKE_ASPECT_CLOUD_API_URL = "https://api.aspect.build"
+
+def fake_auth(credentials = None, owned_hosts = None):
+    """`ctx.aspect.auth` returning `credentials` from every lookup.
+
+    `owned_hosts` maps a host to the deployment that owns it, for the endpoint
+    auth path; an unlisted host resolves to `None`, the "no configured deployment
+    claims it" answer."""
+    owned = owned_hosts or {}
+    return struct(
+        aspect_cloud_deployment = FAKE_ASPECT_CLOUD_DEPLOYMENT,
+        aspect_cloud_api_url = FAKE_ASPECT_CLOUD_API_URL,
+        deployment_for_host = lambda host: owned.get(host),
+        credentials = lambda deployment = None, profile = None, required = True: credentials,
+        login_profile = lambda deployment = None: deployment or FAKE_ASPECT_CLOUD_DEPLOYMENT,
+    )

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
@@ -5,6 +5,7 @@ Run with:
 """
 
 load("@aspect//bazel.axl", "BazelTrait", "bazel", "testonly_config_names", "testonly_flags_delta")
+load("./auth_fakes.axl", "fake_auth")
 load("./deployment_flags.axl", "deployment_auth_flags")
 
 def _eq(label, got, want):
@@ -408,11 +409,7 @@ def _fake_auth_ctx(access_token = "", owned_hosts = []):
             io = struct(stdout = struct(is_tty = False)),
             env = struct(var = lambda name: None),
         ),
-        aspect = struct(auth = struct(
-            deployment_for_host = lambda host: owned.get(host),
-            aspect_cloud_deployment = "aspect-cloud",
-            credentials = lambda deployment = None, profile = None, required = True: creds,
-        )),
+        aspect = struct(auth = fake_auth(credentials = creds, owned_hosts = owned)),
     )
 
 _TOK = "fake-access-token"

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/bazel_flags_test.axl
@@ -410,7 +410,8 @@ def _fake_auth_ctx(access_token = "", owned_hosts = []):
         ),
         aspect = struct(auth = struct(
             deployment_for_host = lambda host: owned.get(host),
-            credentials = lambda profile = None, required = True: creds,
+            aspect_cloud_deployment = "aspect-cloud",
+            credentials = lambda deployment = None, profile = None, required = True: creds,
         )),
     )
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -13,6 +13,7 @@ HTTP failure contract (every helper below):
 load("@std//base64.axl", "base64")
 load("@std//time.axl", "time")
 load("./ansi.axl", "ansi")
+load("./aspect_cloud_api.axl", "aspect_cloud_credentials", "aspect_cloud_url")
 load("./environment.axl", "color_enabled", "info", "warn")
 load("./gitlab_detect.axl", "detect_gitlab_mr_base_sha", "is_gitlab_synthesized_merge_pipeline")
 load(
@@ -386,10 +387,7 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
         _set_auth_reason(_reason, _AUTH_KIND_NO_OWNER_REPO, "owner/repo not provided")
         return None
 
-    creds = ctx.aspect.auth.credentials(
-        deployment = ctx.aspect.auth.aspect_cloud_deployment,
-        profile = profile,
-    )
+    creds = aspect_cloud_credentials(ctx, profile = profile)
     if not creds:
         kind, msg = _classify_missing_credentials(ctx)
         _set_auth_reason(_reason, kind, msg)
@@ -403,7 +401,7 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
                 msg = "unknown role %r, valid roles: %s" % (role, ", ".join(VALID_ROLES))
                 fail(msg)
 
-    url = ctx.aspect.auth.aspect_cloud_api_url + "/github/token"
+    url = aspect_cloud_url(ctx, "/github/token")
     if roles:
         url = url + "?roles=" + ",".join(roles)
 
@@ -510,16 +508,13 @@ def _status_comment_contribute(ctx, request, profile = None):
     raises — transport errors and non-2xx responses come back as
     `success=False` so the caller can fall back to local coordination.
     """
-    creds = ctx.aspect.auth.credentials(
-        deployment = ctx.aspect.auth.aspect_cloud_deployment,
-        profile = profile,
-    )
+    creds = aspect_cloud_credentials(ctx, profile = profile)
     if not creds:
         _, msg = _classify_missing_credentials(ctx)
         return {"success": False, "error": msg, "status": 0}
 
     resp = ctx.http().post(
-        url = ctx.aspect.auth.aspect_cloud_api_url + "/status-comments/contribute",
+        url = aspect_cloud_url(ctx, "/status-comments/contribute"),
         headers = {
             "Authorization": "Bearer " + creds.access_token,
             "Content-Type": "application/json",
@@ -564,14 +559,11 @@ def _status_check_register(ctx, request, profile = None):
     `{"success": bool, "status": int}`. A miss just widens the sweep's job; the
     caller never blocks on it.
     """
-    creds = ctx.aspect.auth.credentials(
-        deployment = ctx.aspect.auth.aspect_cloud_deployment,
-        profile = profile,
-    )
+    creds = aspect_cloud_credentials(ctx, profile = profile)
     if not creds:
         return {"success": False, "status": 0}
 
-    url = ctx.aspect.auth.aspect_cloud_api_url + "/status-checks/register"
+    url = aspect_cloud_url(ctx, "/status-checks/register")
     headers = {
         "Authorization": "Bearer " + creds.access_token,
         "Content-Type": "application/json",
@@ -656,12 +648,12 @@ def _post_budget(ctx, request):
     installation_proof, remaining, reset}` + optional `limit` (the proof comes
     from the token mint; see the server's RequestSchema). Never raises — a
     failure just leaves the prior budget/cadence in place."""
-    creds = ctx.aspect.auth.credentials(deployment = ctx.aspect.auth.aspect_cloud_deployment)
+    creds = aspect_cloud_credentials(ctx)
     if not creds:
         return
 
     resp = ctx.http().post(
-        url = ctx.aspect.auth.aspect_cloud_api_url + "/github/budget",
+        url = aspect_cloud_url(ctx, "/github/budget"),
         headers = {
             "Authorization": "Bearer " + creds.access_token,
             "Content-Type": "application/json",

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github.axl
@@ -386,7 +386,10 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
         _set_auth_reason(_reason, _AUTH_KIND_NO_OWNER_REPO, "owner/repo not provided")
         return None
 
-    creds = ctx.aspect.auth.credentials(profile = profile)
+    creds = ctx.aspect.auth.credentials(
+        deployment = ctx.aspect.auth.aspect_cloud_deployment,
+        profile = profile,
+    )
     if not creds:
         kind, msg = _classify_missing_credentials(ctx)
         _set_auth_reason(_reason, kind, msg)
@@ -400,7 +403,7 @@ def _authenticate(ctx, owner, repo, profile = None, roles = None, _reason = None
                 msg = "unknown role %r, valid roles: %s" % (role, ", ".join(VALID_ROLES))
                 fail(msg)
 
-    url = ctx.aspect.auth.api_url + "/github/token"
+    url = ctx.aspect.auth.aspect_cloud_api_url + "/github/token"
     if roles:
         url = url + "?roles=" + ",".join(roles)
 
@@ -507,13 +510,16 @@ def _status_comment_contribute(ctx, request, profile = None):
     raises — transport errors and non-2xx responses come back as
     `success=False` so the caller can fall back to local coordination.
     """
-    creds = ctx.aspect.auth.credentials(profile = profile)
+    creds = ctx.aspect.auth.credentials(
+        deployment = ctx.aspect.auth.aspect_cloud_deployment,
+        profile = profile,
+    )
     if not creds:
         _, msg = _classify_missing_credentials(ctx)
         return {"success": False, "error": msg, "status": 0}
 
     resp = ctx.http().post(
-        url = ctx.aspect.auth.api_url + "/status-comments/contribute",
+        url = ctx.aspect.auth.aspect_cloud_api_url + "/status-comments/contribute",
         headers = {
             "Authorization": "Bearer " + creds.access_token,
             "Content-Type": "application/json",
@@ -558,11 +564,14 @@ def _status_check_register(ctx, request, profile = None):
     `{"success": bool, "status": int}`. A miss just widens the sweep's job; the
     caller never blocks on it.
     """
-    creds = ctx.aspect.auth.credentials(profile = profile)
+    creds = ctx.aspect.auth.credentials(
+        deployment = ctx.aspect.auth.aspect_cloud_deployment,
+        profile = profile,
+    )
     if not creds:
         return {"success": False, "status": 0}
 
-    url = ctx.aspect.auth.api_url + "/status-checks/register"
+    url = ctx.aspect.auth.aspect_cloud_api_url + "/status-checks/register"
     headers = {
         "Authorization": "Bearer " + creds.access_token,
         "Content-Type": "application/json",
@@ -647,12 +656,12 @@ def _post_budget(ctx, request):
     installation_proof, remaining, reset}` + optional `limit` (the proof comes
     from the token mint; see the server's RequestSchema). Never raises — a
     failure just leaves the prior budget/cadence in place."""
-    creds = ctx.aspect.auth.credentials()
+    creds = ctx.aspect.auth.credentials(deployment = ctx.aspect.auth.aspect_cloud_deployment)
     if not creds:
         return
 
     resp = ctx.http().post(
-        url = ctx.aspect.auth.api_url + "/github/budget",
+        url = ctx.aspect.auth.aspect_cloud_api_url + "/github/budget",
         headers = {
             "Authorization": "Bearer " + creds.access_token,
             "Content-Type": "application/json",

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github_detect_test.axl
@@ -794,7 +794,10 @@ def _test_aspect_api_token_tip_gate(ctx):
         # `_authenticate` short-circuits before any HTTP call.
         return struct(
             std = struct(env = struct(var = lambda name: env_vars.get(name, ""))),
-            aspect = struct(auth = struct(credentials = lambda profile = None: None)),
+            aspect = struct(auth = struct(
+                aspect_cloud_deployment = "aspect-cloud",
+                credentials = lambda deployment = None, profile = None: None,
+            )),
             traits = ctx.traits,
         )
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/github_detect_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/github_detect_test.axl
@@ -27,6 +27,7 @@ Run with:
   aspect dev test-github-detect
 """
 
+load("./auth_fakes.axl", "fake_auth")
 load(
     "./github.axl",
     "detect_ci_base_ref",
@@ -794,10 +795,7 @@ def _test_aspect_api_token_tip_gate(ctx):
         # `_authenticate` short-circuits before any HTTP call.
         return struct(
             std = struct(env = struct(var = lambda name: env_vars.get(name, ""))),
-            aspect = struct(auth = struct(
-                aspect_cloud_deployment = "aspect-cloud",
-                credentials = lambda deployment = None, profile = None: None,
-            )),
+            aspect = struct(auth = fake_auth()),
             traits = ctx.traits,
         )
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
@@ -446,7 +446,7 @@ def _set_auth_reason(_reason, kind, msg):
         _reason["reason"] = msg
 
 def _classify_missing_credentials(ctx):
-    """Return `(kind, msg)` for `ctx.aspect.auth.credentials()` returning
+    """Return `(kind, msg)` for `ctx.aspect.auth.credentials(deployment = ctx.aspect.auth.aspect_cloud_deployment)` returning
     None. The kind discriminates the CI case (where setting
     `ASPECT_API_TOKEN` is the fix) from the local case (`aspect auth login`)."""
     setup_url = "https://aspect.build/docs/cli/authentication"
@@ -465,7 +465,7 @@ def _classify_missing_credentials(ctx):
     return kind, msg + ". Setup guide: " + setup_url
 
 def _missing_credentials_reason(ctx):
-    """Human-readable explanation for `ctx.aspect.auth.credentials()`
+    """Human-readable explanation for `ctx.aspect.auth.credentials(deployment = ctx.aspect.auth.aspect_cloud_deployment)`
     returning None, tailored to the environment the CLI is running in."""
     _, msg = _classify_missing_credentials(ctx)
     return msg
@@ -487,7 +487,10 @@ def _authenticate(ctx, project_path, project_id = None, profile = None, roles = 
         _set_auth_reason(_reason, _AUTH_KIND_NO_PROJECT_PATH, "project_path not provided")
         return None
 
-    creds = ctx.aspect.auth.credentials(profile = profile)
+    creds = ctx.aspect.auth.credentials(
+        deployment = ctx.aspect.auth.aspect_cloud_deployment,
+        profile = profile,
+    )
     if not creds:
         kind, msg = _classify_missing_credentials(ctx)
         _set_auth_reason(_reason, kind, msg)
@@ -499,7 +502,7 @@ def _authenticate(ctx, project_path, project_id = None, profile = None, roles = 
                 msg = "unknown role %r, valid roles: %s" % (role, ", ".join(VALID_ROLES))
                 fail(msg)
 
-    url = ctx.aspect.auth.api_url + "/gitlab/token"
+    url = ctx.aspect.auth.aspect_cloud_api_url + "/gitlab/token"
     if roles:
         url = url + "?roles=" + ",".join(roles)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab.axl
@@ -11,6 +11,7 @@ OAuth bearer); `auth_kind` picks the header convention:
     project access tokens; opt-in).
 """
 
+load("./aspect_cloud_api.axl", "aspect_cloud_credentials", "aspect_cloud_url")
 load("./rate_limit.axl", "BUCKET_APP", "record_from_headers")
 
 DEFAULT_GITLAB_API = "https://gitlab.com/api/v4"
@@ -446,9 +447,9 @@ def _set_auth_reason(_reason, kind, msg):
         _reason["reason"] = msg
 
 def _classify_missing_credentials(ctx):
-    """Return `(kind, msg)` for `ctx.aspect.auth.credentials(deployment = ctx.aspect.auth.aspect_cloud_deployment)` returning
-    None. The kind discriminates the CI case (where setting
-    `ASPECT_API_TOKEN` is the fix) from the local case (`aspect auth login`)."""
+    """Return `(kind, msg)` for an absent Aspect Cloud credential. The kind
+    discriminates the CI case (where setting `ASPECT_API_TOKEN` is the fix) from
+    the local case (`aspect auth login`)."""
     setup_url = "https://aspect.build/docs/cli/authentication"
     if ctx.std.env.var("GITHUB_ACTIONS"):
         msg = "no Aspect credentials — use the aspect-build/setup-aspect action with aspect-api-token (https://github.com/aspect-build/setup-aspect)"
@@ -465,8 +466,8 @@ def _classify_missing_credentials(ctx):
     return kind, msg + ". Setup guide: " + setup_url
 
 def _missing_credentials_reason(ctx):
-    """Human-readable explanation for `ctx.aspect.auth.credentials(deployment = ctx.aspect.auth.aspect_cloud_deployment)`
-    returning None, tailored to the environment the CLI is running in."""
+    """Human-readable explanation for an absent Aspect Cloud credential, tailored
+    to the environment the CLI is running in."""
     _, msg = _classify_missing_credentials(ctx)
     return msg
 
@@ -487,10 +488,7 @@ def _authenticate(ctx, project_path, project_id = None, profile = None, roles = 
         _set_auth_reason(_reason, _AUTH_KIND_NO_PROJECT_PATH, "project_path not provided")
         return None
 
-    creds = ctx.aspect.auth.credentials(
-        deployment = ctx.aspect.auth.aspect_cloud_deployment,
-        profile = profile,
-    )
+    creds = aspect_cloud_credentials(ctx, profile = profile)
     if not creds:
         kind, msg = _classify_missing_credentials(ctx)
         _set_auth_reason(_reason, kind, msg)
@@ -502,7 +500,7 @@ def _authenticate(ctx, project_path, project_id = None, profile = None, roles = 
                 msg = "unknown role %r, valid roles: %s" % (role, ", ".join(VALID_ROLES))
                 fail(msg)
 
-    url = ctx.aspect.auth.aspect_cloud_api_url + "/gitlab/token"
+    url = aspect_cloud_url(ctx, "/gitlab/token")
     if roles:
         url = url + "?roles=" + ",".join(roles)
 

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_test.axl
@@ -10,6 +10,7 @@ Run with:
   aspect dev test-gitlab-client
 """
 
+load("./auth_fakes.axl", "fake_auth")
 load("./gitlab.axl", "gitlab")
 
 def _eq(label, got, want):
@@ -201,10 +202,7 @@ def _test_impl(ctx):
     def _ctx_no_creds(env_vars):
         return struct(
             std = struct(env = struct(var = lambda name: env_vars.get(name, ""))),
-            aspect = struct(auth = struct(
-                aspect_cloud_deployment = "aspect-cloud",
-                credentials = lambda deployment = None, profile = None: None,
-            )),
+            aspect = struct(auth = fake_auth()),
         )
 
     # Missing project_path short-circuits before touching creds.

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/gitlab_test.axl
@@ -201,7 +201,10 @@ def _test_impl(ctx):
     def _ctx_no_creds(env_vars):
         return struct(
             std = struct(env = struct(var = lambda name: env_vars.get(name, ""))),
-            aspect = struct(auth = struct(credentials = lambda profile = None: None)),
+            aspect = struct(auth = struct(
+                aspect_cloud_deployment = "aspect-cloud",
+                credentials = lambda deployment = None, profile = None: None,
+            )),
         )
 
     # Missing project_path short-circuits before touching creds.

--- a/crates/aspect-cli/src/credential_helper.rs
+++ b/crates/aspect-cli/src/credential_helper.rs
@@ -18,7 +18,7 @@
 //! name; a user task cannot shadow it.
 
 use anyhow::Context;
-use axl_runtime::engine::{login_hint, profile_for_uri, resolve_access_token};
+use axl_runtime::engine::{login_hint, profile_for_uri, resolve_access_token, resolve_profile};
 
 /// The credential-helper command, as the spec passes it (`argv[1]`). Also the
 /// reserved top-level command name the CLI guards in `cmd`.
@@ -60,7 +60,7 @@ pub fn run() -> anyhow::Result<()> {
     // other host return no headers so the helper self-scopes by the URI Bazel
     // passes (a global `--credential_helper=aspect` never sends a token to a
     // third-party host) and Bazel falls back to whatever it would otherwise use.
-    let (Some(deployment), Some(profile)) = (resolved.deployment, resolved.profile) else {
+    let Some(deployment) = resolved.deployment else {
         write_response(&no_credential_response())?;
         return Ok(());
     };
@@ -69,25 +69,30 @@ pub fn run() -> anyhow::Result<()> {
         .enable_all()
         .build()
         .context("building the credential-helper runtime")?;
-    // Resolve on a blocking worker so the runtime's `block_on` keeps driving the
-    // reactor while `resolve_access_token`'s inner refresh `block_on` runs.
-    let key = profile.clone();
+    // The helper takes no flags, so $ASPECT_AUTH_PROFILE is the only way to point
+    // it at an identity other than the default one. Resolve on a blocking worker so
+    // the runtime's `block_on` keeps driving the reactor while
+    // `resolve_access_token`'s inner refresh `block_on` runs.
+    let profile = resolve_profile(None);
+    let target = deployment.clone();
     let token = runtime
-        .block_on(
-            async move { tokio::task::spawn_blocking(move || resolve_access_token(&key)).await },
-        )
+        .block_on(async move {
+            tokio::task::spawn_blocking(move || resolve_access_token(&profile, &target)).await
+        })
         .context("running the credential-helper token resolution")?
         .context("resolving the Aspect access token")?
         .with_context(|| {
-            // Named the way the user knows it, and told the command that actually
-            // re-authenticates it — neither of which is the profile the credential
-            // is filed under.
-            let target = if resolved.builtin {
+            // Named the way the user knows it, and given the command that actually
+            // re-authenticates it.
+            let named = if resolved.builtin {
                 "Aspect Cloud".to_string()
             } else {
                 format!("the Aspect Workflows deployment '{deployment}'")
             };
-            format!("not logged in to {target}; run `{}`", login_hint(&profile))
+            format!(
+                "not logged in to {named}; run `{}`",
+                login_hint(&deployment)
+            )
         })?;
 
     write_response(&bearer_response(&token))

--- a/crates/aspect-cli/src/credential_helper.rs
+++ b/crates/aspect-cli/src/credential_helper.rs
@@ -18,7 +18,7 @@
 //! name; a user task cannot shadow it.
 
 use anyhow::Context;
-use axl_runtime::engine::{profile_for_uri, resolve_access_token};
+use axl_runtime::engine::{login_hint, profile_for_uri, resolve_access_token};
 
 /// The credential-helper command, as the spec passes it (`argv[1]`). Also the
 /// reserved top-level command name the CLI guards in `cmd`.
@@ -60,7 +60,7 @@ pub fn run() -> anyhow::Result<()> {
     // other host return no headers so the helper self-scopes by the URI Bazel
     // passes (a global `--credential_helper=aspect` never sends a token to a
     // third-party host) and Bazel falls back to whatever it would otherwise use.
-    let Some(deployment) = resolved.deployment else {
+    let (Some(deployment), Some(profile)) = (resolved.deployment, resolved.profile) else {
         write_response(&no_credential_response())?;
         return Ok(());
     };
@@ -69,18 +69,25 @@ pub fn run() -> anyhow::Result<()> {
         .enable_all()
         .build()
         .context("building the credential-helper runtime")?;
-    // A configured deployment stores its credential under its own name. Resolve on
-    // a blocking worker so the runtime's `block_on` keeps driving the reactor while
-    // `resolve_access_token`'s inner refresh `block_on` runs.
-    let profile = deployment.clone();
+    // Resolve on a blocking worker so the runtime's `block_on` keeps driving the
+    // reactor while `resolve_access_token`'s inner refresh `block_on` runs.
+    let key = profile.clone();
     let token = runtime
-        .block_on(async move { tokio::task::spawn_blocking(move || resolve_access_token(&profile)).await })
+        .block_on(
+            async move { tokio::task::spawn_blocking(move || resolve_access_token(&key)).await },
+        )
         .context("running the credential-helper token resolution")?
         .context("resolving the Aspect access token")?
         .with_context(|| {
-            format!(
-                "not logged in to the Aspect Workflows deployment '{deployment}'; run `aspect auth login --deployment {deployment}`"
-            )
+            // Named the way the user knows it, and told the command that actually
+            // re-authenticates it — neither of which is the profile the credential
+            // is filed under.
+            let target = if resolved.builtin {
+                "Aspect Cloud".to_string()
+            } else {
+                format!("the Aspect Workflows deployment '{deployment}'")
+            };
+            format!("not logged in to {target}; run `{}`", login_hint(&profile))
         })?;
 
     write_response(&bearer_response(&token))

--- a/crates/aspect-cli/tests/auth_status.rs
+++ b/crates/aspect-cli/tests/auth_status.rs
@@ -1,0 +1,126 @@
+//! `aspect auth status` must render every row it asks for.
+//!
+//! The `auth` AXL reads a `DeploymentSummary` field by field, but the summary is
+//! a Rust Starlark value whose attributes are declared separately from the struct
+//! itself. Adding a field without its `#[starlark(attribute)]` accessor compiles,
+//! passes every unit test, and then fails at runtime with "has no attribute" the
+//! first time the row is printed.
+//!
+//! Neither suite covers that contract: the Rust tests never evaluate AXL, and
+//! `auth_test.axl` substitutes a plain Starlark struct for the summary, which has
+//! whatever fields the test gives it. Running the real command is the only thing
+//! that reads the real value, so this does exactly that.
+//!
+//! Deliberately assertion-light about *what* is rendered — that is `auth_test.axl`'s
+//! job, where it can be checked without a subprocess. This asserts the command
+//! completes, which is the part only an end-to-end run can tell us.
+
+use std::process::Command;
+
+/// Locate the CLI under test.
+///
+/// Bazel sets `ASPECT_CLI_BIN` from the `rust_test` rule's `env` via
+/// `$(rootpath :aspect-cli)`, relative to the runfiles root that is a Bazel-run
+/// test's cwd. Under cargo, `CARGO_BIN_EXE_*` points at the binary cargo already
+/// built for this test.
+fn aspect_cli() -> String {
+    match std::env::var("ASPECT_CLI_BIN") {
+        Ok(p) => std::fs::canonicalize(&p)
+            .unwrap_or_else(|e| panic!("ASPECT_CLI_BIN={p:?} not found: {e}"))
+            .to_string_lossy()
+            .into_owned(),
+        // `option_env!`, not `env!`: the cargo variable does not exist in a Bazel
+        // build, and `env!` would fail to compile there.
+        Err(_) => option_env!("CARGO_BIN_EXE_aspect-cli")
+            .expect("set ASPECT_CLI_BIN or run under cargo")
+            .to_string(),
+    }
+}
+
+/// Run `auth status` against an empty credential store.
+///
+/// `$ASPECT_CREDENTIALS_FILE` forces the file backend, so the test never reaches
+/// the developer's real keyring — which on macOS would block on an authorization
+/// dialog, and which must not be read or written by a test either way.
+///
+/// `$HOME` is left alone, so any deployments in the developer's own
+/// `config.json` are listed too. The assertions are about the built-in Aspect
+/// Cloud entry, which is present whatever else is configured; overriding `$HOME`
+/// would isolate them at the cost of re-extracting the AXL bundle on every run.
+fn auth_status(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(aspect_cli())
+        .args(["auth", "status"])
+        .args(args)
+        .env("ASPECT_CREDENTIALS_FILE", dir.join("credentials.json"))
+        // Keep the run off any ambient profile selection.
+        .env_remove("ASPECT_AUTH_PROFILE")
+        .env_remove("ASPECT_API_TOKEN")
+        .output()
+        .expect("running `aspect auth status`")
+}
+
+/// Assert the run succeeded, and return `(stdout, stderr)`.
+///
+/// Both matter, and they carry different things: the aligned table is written by
+/// AXL `print()`, which goes through starlark's print handler to **stderr**, while
+/// the JSON document is written to stdout through `ctx.std.io.stdout`. A test that
+/// looks only at stdout sees nothing at all for the text output.
+fn assert_ok(output: &std::process::Output, what: &str) -> (String, String) {
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        output.status.success(),
+        "{what} exited {:?}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}",
+        output.status.code()
+    );
+    // A Starlark failure does not always change the exit code, so look for it.
+    assert!(
+        !stderr.contains("has no attribute"),
+        "{what} hit a missing Starlark attribute:\n{stderr}"
+    );
+    (stdout, stderr)
+}
+
+/// The logged-out path renders every row, including the `Log in` block whose
+/// options name the deployment's API-token variable.
+#[test]
+fn auth_status_renders_a_logged_out_store() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let (_, rendered) = assert_ok(&auth_status(dir.path(), &[]), "auth status");
+
+    // Aspect Cloud is always listed, logged in or not.
+    assert!(
+        rendered.contains("Aspect Cloud"),
+        "expected Aspect Cloud in:\n{rendered}"
+    );
+    // The rows that read the attributes this test exists to guard.
+    assert!(
+        rendered.contains("ASPECT_API_TOKEN"),
+        "expected the API-token variable in:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Log in"),
+        "expected the login options in:\n{rendered}"
+    );
+}
+
+/// The JSON document goes through a different builder than the text table, so it
+/// reads its own set of attributes.
+#[test]
+fn auth_status_renders_json() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let (stdout, _) = assert_ok(
+        &auth_status(dir.path(), &["--output", "json"]),
+        "auth status --output json",
+    );
+
+    let start = stdout.find('{').expect("a JSON document on stdout");
+    let doc: serde_json::Value =
+        serde_json::from_str(&stdout[start..]).expect("stdout parses as JSON");
+    let cloud = doc["account"]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .expect("an Aspect Cloud row");
+    assert_eq!(cloud["api_token_env"], "ASPECT_API_TOKEN");
+    assert_eq!(cloud["login_command"], "aspect auth login");
+}

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -537,28 +537,30 @@ fn select_account_or_deployment(
     }
 }
 
-/// The name of the configured deployment that owns `host` — an exact or
-/// dot-anchored suffix match against any deployment's `hosts`. Returns `None`
-/// when no configured deployment claims the host. Used so endpoint auth attaches
-/// the token of the deployment serving a given cache/BES endpoint, whichever
-/// profile it was logged in under.
-fn deployment_name_for_host(deployments: &[Deployment], host: &str) -> Option<String> {
+/// The configured deployment that owns `host` — an exact or dot-anchored suffix
+/// match against any deployment's `hosts`. `None` when no configured deployment
+/// claims it. Endpoint auth uses this to attach the token of the deployment
+/// serving a given cache/BES endpoint; ask [`login_profile_for`] for the profile
+/// that token is filed under, which is not always the deployment's name.
+fn deployment_for_host<'a>(deployments: &'a [Deployment], host: &str) -> Option<&'a Deployment> {
     // Normalize a trailing dot so an absolute FQDN (`host.example.com.`) still
     // matches its configured host.
     let host = host.trim_end_matches('.').to_lowercase();
-    deployments
-        .iter()
-        .find(|d| {
-            d.hosts.iter().any(|h| {
-                let h = h
-                    .trim()
-                    .trim_start_matches('.')
-                    .trim_end_matches('.')
-                    .to_lowercase();
-                !h.is_empty() && (host == h || host.ends_with(&format!(".{h}")))
-            })
+    deployments.iter().find(|d| {
+        d.hosts.iter().any(|h| {
+            let h = h
+                .trim()
+                .trim_start_matches('.')
+                .trim_end_matches('.')
+                .to_lowercase();
+            !h.is_empty() && (host == h || host.ends_with(&format!(".{h}")))
         })
-        .map(|d| d.name.clone())
+    })
+}
+
+/// The name of the deployment owning `host` — see [`deployment_for_host`].
+fn deployment_name_for_host(deployments: &[Deployment], host: &str) -> Option<String> {
+    deployment_for_host(deployments, host).map(|d| d.name.clone())
 }
 
 /// Resolve the issuer + client_id for a login / api-token / refresh flow against
@@ -2192,7 +2194,7 @@ fn merged_refresh_token(prior: &str, fresh: &str) -> String {
 /// deployment stores under its name, so the profile is the deployment name and
 /// gets an explicit `--deployment`; the default profile (the built-in Aspect
 /// deployment, or a `$ASPECT_AUTH_PROFILE`) gets a bare `login`.
-pub(crate) fn login_hint(profile: &str) -> String {
+pub fn login_hint(profile: &str) -> String {
     if profile == DEFAULT_PROFILE {
         "aspect auth login".to_string()
     } else {
@@ -2251,27 +2253,43 @@ pub fn resolve_profile(explicit: Option<&str>) -> String {
         .unwrap_or_else(|| DEFAULT_PROFILE.to_owned())
 }
 
-/// Which configured deployment owns the endpoint `uri`, for the credential helper:
-/// the `host` parsed from the URI and the `deployment` (name = credential profile)
-/// that claims it, or `None` when no configured deployment does. The helper emits
-/// a credential only when a deployment owns the host, so it self-scopes by the URI
-/// Bazel passes — a global `--credential_helper=aspect` never sends a token to an
-/// unclaimed (e.g. third-party) host.
+/// Which configured deployment owns the endpoint `uri`, for the credential helper.
+/// `deployment` is `None` when no configured deployment claims the host: the helper
+/// emits a credential only when one does, so it self-scopes by the URI Bazel passes
+/// — a global `--credential_helper=aspect` never sends a token to an unclaimed
+/// (e.g. third-party) host.
 pub struct UriProfile {
     pub host: String,
+    /// The owning deployment's name — what the user calls it.
     pub deployment: Option<String>,
+    /// The credential-store key its login is filed under. Not always the name: see
+    /// [`login_profile_for`]. `None` exactly when `deployment` is.
+    pub profile: Option<String>,
+    /// Whether the owner is the built-in Aspect Cloud entry, so a caller can name
+    /// it the way the user knows it rather than by its config name.
+    pub builtin: bool,
 }
 
 /// Resolve the [`UriProfile`] for a credential-helper request, so a Bazel request
 /// for a configured deployment's cache/BES gets *that* deployment's token.
 pub fn profile_for_uri(uri: &str) -> anyhow::Result<UriProfile> {
     let host = endpoint_host_str(uri);
-    let deployment = if host.is_empty() {
-        None
-    } else {
-        deployment_name_for_host(&load_deployments()?, &host)
-    };
-    Ok(UriProfile { host, deployment })
+    if host.is_empty() {
+        return Ok(UriProfile {
+            host,
+            deployment: None,
+            profile: None,
+            builtin: false,
+        });
+    }
+    let deployments = load_deployments()?;
+    let owner = deployment_for_host(&deployments, &host);
+    Ok(UriProfile {
+        host,
+        deployment: owner.map(|d| d.name.clone()),
+        profile: owner.map(login_profile_for),
+        builtin: owner.is_some_and(|d| d.builtin),
+    })
 }
 
 /// Resolve the current access token (JWT) for `profile` (already resolved, e.g.
@@ -2279,8 +2297,8 @@ pub fn profile_for_uri(uri: &str) -> anyhow::Result<UriProfile> {
 /// `ASPECT_API_TOKEN` (exchanged against Aspect Cloud issuer) takes
 /// precedence over stored credentials; other profiles always use their stored
 /// credential. Auto-refreshes an expired-but-refreshable token, persisting the
-/// refresh — for this profile, and for any sibling on the same refresh chain (see
-/// [`carry_rotated_refresh_token`]). Returns `None` when no credential exists for the profile, and errors
+/// refresh. Each stored credential is its own grant now, so a rotated refresh token
+/// concerns only the profile being refreshed. Returns `None` when no credential exists for the profile, and errors
 /// when the stored token is expired and cannot be refreshed: it never returns a
 /// known-expired token, so a consumer (e.g. the credential helper) does not emit
 /// one a server will 401. Requires a Tokio runtime (the refresh path blocks on
@@ -2305,45 +2323,8 @@ pub fn resolve_access_token(profile: &str) -> anyhow::Result<Option<String>> {
             let refreshed = block_on(refresh_access_token(&entry))
                 .map_err(|_| anyhow::anyhow!(session_expired_message(profile)))?;
             map.insert(profile.to_string(), refreshed.clone());
-            carry_rotated_refresh_token(
-                &mut map,
-                profile,
-                &entry.refresh_token,
-                &refreshed.refresh_token,
-            );
             save_all_credentials(&map)?;
             Ok(Some(refreshed.access_token))
-        }
-    }
-}
-
-/// Hand a rotated refresh token to every other entry that was on the same chain.
-///
-/// One browser grant can file more than one credential — Aspect Cloud keeps the
-/// access_token under the default profile and the same grant's id_token under its
-/// deployment name — and those copies share a refresh token. An issuer that rotates
-/// on refresh invalidates the predecessor, so without this the sibling that
-/// refreshed second would be told its session expired and the user would be sent
-/// back through a browser login it did not need.
-///
-/// Only the refresh token moves. Each entry keeps its own bearer and its own
-/// `prefer_id_token`, and refreshes itself onto the shared chain when its own token
-/// comes due.
-///
-/// A no-op when the issuer returned no new token (`fresh` empty, or unchanged) or
-/// when there was no prior one to match against.
-fn carry_rotated_refresh_token(
-    map: &mut HashMap<String, CredentialsEntry>,
-    refreshed_profile: &str,
-    prior: &str,
-    fresh: &str,
-) {
-    if prior.is_empty() || fresh.is_empty() || prior == fresh {
-        return;
-    }
-    for (name, entry) in map.iter_mut() {
-        if name != refreshed_profile && entry.refresh_token == prior {
-            entry.refresh_token = fresh.to_string();
         }
     }
 }
@@ -2361,12 +2342,6 @@ pub struct AuthCredentials {
     pub(crate) auth_domain: Option<String>,
     pub(crate) auth_client_id: Option<String>,
     pub(crate) prefer_id_token: bool,
-    /// The `id_token` from the same grant, kept beside the chosen bearer so one
-    /// browser flow can file both an account credential and an endpoint one (see
-    /// [`Self::for_endpoint`]). Empty for a login that never saw a token response
-    /// (`--with-token`) or whose grant omitted an id_token, and never persisted —
-    /// [`AuthCredentials::to_entry`] writes only the bearer in `access_token`.
-    pub(crate) id_token: String,
 }
 
 starlark_simple_value!(AuthCredentials);
@@ -2425,29 +2400,6 @@ fn auth_credentials_methods(registry: &mut MethodsBuilder) {
     fn token_status<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
         attr_str!(this, AuthCredentials, token_status)
     }
-
-    /// The same login re-cast as an endpoint credential: the bearer becomes this
-    /// grant's `id_token`, which is what a deployment's cache/BES edge validates,
-    /// and `prefer_id_token` is set so a later refresh keeps minting one rather
-    /// than downgrading to the access_token.
-    ///
-    /// Lets a single browser flow serve both Aspect Cloud (access_token,
-    /// filed under the default profile) and the Aspect-hosted deployment
-    /// (id_token, filed under its own) — see the bare-login path in `auth.axl`.
-    /// Returns `None` when the grant issued no id_token, so the caller skips the
-    /// endpoint credential instead of persisting a bearer the edge would reject.
-    fn for_endpoint<'v>(
-        this: values::Value<'v>,
-        heap: values::Heap<'v>,
-    ) -> anyhow::Result<values::Value<'v>> {
-        let creds = this
-            .downcast_ref_err::<AuthCredentials>()
-            .into_anyhow_result()?;
-        Ok(match creds.endpoint_entry()? {
-            Some(entry) => heap.alloc(AuthCredentials::from_entry(&entry)),
-            None => values::Value::new_none(),
-        })
-    }
 }
 
 impl AuthCredentials {
@@ -2464,32 +2416,7 @@ impl AuthCredentials {
             auth_domain: entry.auth_domain.clone(),
             auth_client_id: entry.auth_client_id.clone(),
             prefer_id_token: entry.prefer_id_token,
-            // A stored entry keeps only its bearer; the id_token is transport-only
-            // and is attached by `finish_auth_session` when a grant supplied one.
-            id_token: String::new(),
         }
-    }
-
-    /// This login re-cast as an endpoint credential — the grant's `id_token` as the
-    /// bearer, `prefer_id_token` set so refresh keeps minting one. `None` when the
-    /// grant issued no id_token. Backs [`Self::for_endpoint`]; see it for why.
-    ///
-    /// The refresh token and issuer/client are carried over deliberately: it is the
-    /// same grant, so the endpoint credential renews on the same chain rather than
-    /// needing its own login. Sharing the chain is what
-    /// [`carry_rotated_refresh_token`] exists to keep working across a rotating
-    /// issuer.
-    fn endpoint_entry(&self) -> anyhow::Result<Option<CredentialsEntry>> {
-        if self.id_token.is_empty() {
-            return Ok(None);
-        }
-        Ok(Some(CredentialsEntry::from_bearer(
-            self.id_token.clone(),
-            self.refresh_token.clone(),
-            self.auth_domain.clone(),
-            self.auth_client_id.clone(),
-            true,
-        )?))
     }
 
     fn to_entry(&self) -> CredentialsEntry {
@@ -2529,16 +2456,15 @@ impl AuthSessionInner {
     /// With `require_state = false`, an omitted state is allowed but a supplied one
     /// is still validated.
     ///
-    /// Returns the credential for this session's own bearer, plus the grant's
-    /// `id_token` (empty when it issued none) so the caller can also file an
-    /// endpoint credential from the same exchange without a second browser round
-    /// trip — see [`AuthCredentials::for_endpoint`].
+    /// Returns the credential for this session's bearer — the `id_token` for a
+    /// self-hosted deployment, the `access_token` for Aspect Cloud, per
+    /// `prefer_id_token`. One grant, one credential.
     async fn complete(
         self,
         code: String,
         state: Option<String>,
         require_state: bool,
-    ) -> anyhow::Result<(CredentialsEntry, String)> {
+    ) -> anyhow::Result<CredentialsEntry> {
         if !callback_state_matches(&self.expected_state, state.as_deref(), require_state) {
             return Err(anyhow::anyhow!(
                 "authentication failed: callback state did not match"
@@ -2554,18 +2480,16 @@ impl AuthSessionInner {
         )
         .await?;
         let refresh_token = token_resp.refresh_token.clone();
-        let id_token = token_resp.id_token.clone();
         // Recorded so refresh keeps minting the same kind rather than downgrading
         // to whatever the grant happens to return.
         let prefer_id_token = self.prefer_id_token;
-        let entry = CredentialsEntry::from_bearer(
+        CredentialsEntry::from_bearer(
             token_resp.bearer(prefer_id_token)?,
             refresh_token,
             Some(self.env.domain.clone()),
             Some(self.env.client_id.clone()),
             prefer_id_token,
-        )?;
-        Ok((entry, id_token))
+        )
     }
 }
 
@@ -2597,7 +2521,7 @@ fn finish_auth_session(
         .take()
         .ok_or_else(|| anyhow::anyhow!("auth session already consumed"))?;
     drop(guard);
-    let (entry, id_token) = if let Some(pasted) = pasted {
+    let entry = if let Some(pasted) = pasted {
         let (code, state) = parse_pasted_callback(pasted)?;
         block_on(inner.complete(code, state, false))?
     } else {
@@ -2610,9 +2534,7 @@ fn finish_auth_session(
             inner.complete(code, state, true).await
         })?
     };
-    let mut creds = AuthCredentials::from_entry(&entry);
-    creds.id_token = id_token;
-    Ok(creds)
+    Ok(AuthCredentials::from_entry(&entry))
 }
 
 #[derive(Display, ProvidesStaticType, NoSerialize, Allocative)]
@@ -3430,18 +3352,18 @@ fn auth_methods(registry: &mut MethodsBuilder) {
     }
 }
 
-/// The credentials profile a login against `selected` persists under: a
-/// configured deployment stores under its name, so
-/// [`Auth::deployment_for_host`] later resolves the same profile for its
-/// endpoints; the built-in Aspect Cloud entry stores under the resolved default
-/// profile.
+/// The credentials profile a login against `selected` persists under: a configured
+/// deployment stores under its name; the built-in Aspect Cloud entry stores under
+/// the resolved default profile, which every Aspect Cloud caller reads and which
+/// `$ASPECT_API_TOKEN` stands in for on CI.
 ///
-/// Keyed on `builtin`, an identity question, because the account now carries the
-/// Aspect-hosted cache/BES itself (see [`configure_default`]) and would otherwise
-/// file its own login away from the default profile that every Aspect-cloud
-/// caller reads. Its endpoints are still reachable: the bare-login path files a
-/// second credential under the account's *name* for them, which is what
-/// [`Auth::deployment_for_host`] resolves.
+/// Keyed on `builtin`, an identity question, not on whether the entry has hosts —
+/// Aspect Cloud carries its own cache/BES now (see [`configure_default`]) and would
+/// otherwise file its login away from that profile.
+///
+/// This is the one place the name/profile distinction lives. Everything resolving a
+/// credential for an endpoint goes through it rather than assuming a deployment's
+/// name is its profile — see [`profile_for_uri`] and the AXL `resolve_aspect_bearer`.
 fn login_profile_for(selected: &Deployment) -> String {
     if selected.builtin {
         resolve_profile(None)
@@ -3553,13 +3475,23 @@ mod tests {
         assert!(can_refresh(&e));
     }
 
+    /// Serializes every test that reads or writes `$ASPECT_AUTH_PROFILE`. The
+    /// process env is global and cargo runs tests on parallel threads, so without
+    /// this a reader intermittently observes the writer's value mid-flight — two
+    /// calls inside one assertion can even straddle the change. Poison is ignored:
+    /// one failing test should not cascade into the others.
+    static PROFILE_ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    fn profile_env_guard() -> std::sync::MutexGuard<'static, ()> {
+        PROFILE_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn resolve_profile_prefers_explicit_then_env_then_default() {
         // An explicit, non-empty profile always wins, regardless of the env.
         assert_eq!(resolve_profile(Some("ci")), "ci");
 
-        // This test mutates the process env, so it must run serially with any
-        // other PROFILE_ENV reader; it is currently the only one.
+        let _guard = profile_env_guard();
         let saved = std::env::var(PROFILE_ENV).ok();
 
         // SAFETY: single-threaded test body; restored before returning.
@@ -4911,11 +4843,12 @@ mod tests {
     /// would file its login away from the profile every Aspect-cloud caller reads.
     #[test]
     fn the_account_keeps_the_default_profile_once_it_has_endpoints() {
+        let _guard = profile_env_guard();
         let mut seed = default_deployment();
         seed.hosts = vec!["remote.app.aspect.build".to_string()];
-        // Compared against `resolve_profile`, not the literal: a sibling test sets
-        // $ASPECT_AUTH_PROFILE, and the invariant is that the account files under
-        // whatever the default profile resolves to.
+        // Compared against `resolve_profile`, not the literal: the invariant is that
+        // the account files under whatever the default profile resolves to, and a
+        // sibling test sets $ASPECT_AUTH_PROFILE (hence the guard above).
         assert_eq!(login_profile_for(&seed), resolve_profile(None));
 
         let mut configured = dep("acme", false);
@@ -4969,78 +4902,30 @@ mod tests {
         ));
     }
 
-    /// A rotating issuer invalidates the predecessor, so the profile that refreshes
-    /// first has to hand the new token to the sibling filed from the same grant —
-    /// or that sibling reports an expired session and demands a needless re-login.
+    /// The invariant every endpoint-credential lookup rests on: a host resolves to
+    /// the *profile* its deployment's login is filed under, which is not the
+    /// deployment's name for Aspect Cloud. Getting this wrong sends a build to an
+    /// Aspect Cloud endpoint with no credential at all.
     #[test]
-    fn a_rotated_refresh_token_reaches_every_profile_on_the_same_chain() {
-        let entry = |refresh: &str| CredentialsEntry {
-            access_token: "token".to_string(),
-            refresh_token: refresh.to_string(),
-            email: "a@b.c".to_string(),
-            name: "A".to_string(),
-            tenant_id: "t".to_string(),
-            auth_domain: Some(DEFAULT_ISSUER.to_string()),
-            auth_client_id: Some(DEFAULT_CLIENT_ID.to_string()),
-            prefer_id_token: false,
-        };
-        let mut map = HashMap::from([
-            (DEFAULT_PROFILE.to_string(), entry("r2")),
-            (DEFAULT_DEPLOYMENT_NAME.to_string(), entry("r1")),
-            // A separate login, so a coincidental refresh is not its business.
-            ("acme".to_string(), entry("other")),
-        ]);
-        carry_rotated_refresh_token(&mut map, DEFAULT_PROFILE, "r1", "r2");
-        assert_eq!(map[DEFAULT_DEPLOYMENT_NAME].refresh_token, "r2");
-        assert_eq!(map["acme"].refresh_token, "other");
+    fn an_endpoint_resolves_to_its_deployments_profile_not_its_name() {
+        let _guard = profile_env_guard();
+        let mut seed = default_deployment();
+        seed.endpoints.cache = "cache.aspect.build".to_string();
+        seed.hosts = vec!["cache.aspect.build".to_string()];
+        let deployments = vec![seed, dep("acme", false)];
 
-        // An issuer that does not rotate returns the same token: nothing to carry,
-        // and nothing else may be touched.
-        let mut unchanged = HashMap::from([
-            (DEFAULT_PROFILE.to_string(), entry("r1")),
-            (DEFAULT_DEPLOYMENT_NAME.to_string(), entry("r1")),
-        ]);
-        carry_rotated_refresh_token(&mut unchanged, DEFAULT_PROFILE, "r1", "r1");
-        assert_eq!(unchanged[DEFAULT_DEPLOYMENT_NAME].refresh_token, "r1");
+        let cloud = deployment_for_host(&deployments, "cache.aspect.build").expect("owned");
+        assert_eq!(cloud.name, DEFAULT_DEPLOYMENT_NAME);
+        // Compared against `resolve_profile`, not the literal: whatever the default
+        // profile resolves to is where the account files.
+        assert_eq!(login_profile_for(cloud), resolve_profile(None));
+        assert_ne!(login_profile_for(cloud), cloud.name);
 
-        // An entry with no refresh token of its own is not on anyone's chain, so an
-        // empty prior must not sweep it up.
-        let mut empty = HashMap::from([
-            (DEFAULT_PROFILE.to_string(), entry("")),
-            (DEFAULT_DEPLOYMENT_NAME.to_string(), entry("")),
-        ]);
-        carry_rotated_refresh_token(&mut empty, DEFAULT_PROFILE, "", "fresh");
-        assert_eq!(empty[DEFAULT_DEPLOYMENT_NAME].refresh_token, "");
-    }
+        // A self-hosted deployment's name *is* its profile.
+        let acme = deployment_for_host(&deployments, "remote.acme.aspect.build").expect("owned");
+        assert_eq!(login_profile_for(acme), "acme");
 
-    /// One browser grant files two credentials: the account keeps the access_token,
-    /// the endpoint gets the id_token on the same refresh chain.
-    #[test]
-    fn endpoint_entry_recasts_the_same_grant_onto_the_id_token() {
-        let entry = CredentialsEntry::from_bearer(
-            jwt_with_payload(r#"{"email":"a@b.c","name":"A","tenantId":"t"}"#),
-            "refresh-abc".to_string(),
-            Some(DEFAULT_ISSUER.to_string()),
-            Some(DEFAULT_CLIENT_ID.to_string()),
-            false,
-        )
-        .unwrap();
-        let mut creds = AuthCredentials::from_entry(&entry);
-        creds.id_token = jwt_with_payload(r#"{"email":"a@b.c","name":"A","tenantId":"t"}"#);
-
-        let endpoint = creds.endpoint_entry().unwrap().expect("an id_token grant");
-        assert_eq!(endpoint.access_token, creds.id_token);
-        // Set so a later refresh keeps minting an id_token rather than downgrading
-        // to the access_token the edge would reject.
-        assert!(endpoint.prefer_id_token);
-        // Same grant, so it renews on the same chain instead of needing its own login.
-        assert_eq!(endpoint.refresh_token, "refresh-abc");
-        assert_eq!(endpoint.auth_client_id.as_deref(), Some(DEFAULT_CLIENT_ID));
-
-        // A grant with no id_token yields nothing rather than a bearer the edge
-        // would reject.
-        creds.id_token = String::new();
-        assert!(creds.endpoint_entry().unwrap().is_none());
+        assert!(deployment_for_host(&deployments, "cache.example.com").is_none());
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -115,6 +115,11 @@ pub(crate) struct Endpoints {
     bes: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     exec: String,
+    /// The deployment's own API host. Only Aspect Cloud advertises one today; a
+    /// self-hosted deployment that grows API routes advertises its own here and
+    /// [`resolve_deployment_api_url`] picks it up with no CLI change.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    api: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub(crate) results_url: String,
 }
@@ -124,6 +129,7 @@ impl Endpoints {
         self.cache.is_empty()
             && self.bes.is_empty()
             && self.exec.is_empty()
+            && self.api.is_empty()
             && self.results_url.is_empty()
     }
 
@@ -167,7 +173,7 @@ struct AuthEnv {
 /// What Aspect Cloud calls itself — the name `auth status` shows, `--deployment`
 /// takes, and every Aspect Cloud edge advertises as RFC 9728 `resource_name`.
 ///
-/// Deliberately not "default" anything: [`DEFAULT_PROFILE`] is the credential slot,
+/// Deliberately not "default" anything: [`RESERVED_DEFAULT_NAME`] is the credential slot,
 /// and `Deployment::default` is which deployment `--remote` targets, which
 /// `auth use` can point at a configured one instead. Aspect Cloud is neither by
 /// definition.
@@ -182,9 +188,8 @@ const ASPECT_CLOUD_DEPLOYMENT_NAME: &str = "aspect-cloud";
 /// anything the CLI records uses the canonical name, so a config carrying this one
 /// heals on the next discovery write.
 ///
-/// Worth honouring on its own terms — it is the obvious short thing to type — and
-/// it is also what builds of #1429 wrote before Aspect Cloud took the name it
-/// advertises. Reserved, so no configured deployment can claim it.
+/// The obvious short thing to type, and a name a hand-written or older
+/// `config.json` may carry. Reserved, so no configured deployment can claim it.
 const ASPECT_CLOUD_DEPLOYMENT_ALIAS: &str = "aspect";
 const DEFAULT_ISSUER: &str = "https://auth.aspect.build";
 /// The account's PKCE client — the "Aspect Build" application client.
@@ -276,13 +281,13 @@ const ASPECT_DOMAIN_SUFFIX: &str = ".aspect.build";
 
 /// Names a configured deployment may not take, because each would shadow the
 /// built-in Aspect Cloud entry: [`ASPECT_CLOUD_DEPLOYMENT_NAME`] is the account's own
-/// name, and [`DEFAULT_PROFILE`] is the credential profile the account files
+/// name, and [`RESERVED_DEFAULT_NAME`] is the credential profile the account files
 /// under (a deployment's credential is stored under its name, so a deployment
 /// named `default` would share the account's slot).
 const RESERVED_NAMES: &[&str] = &[
     ASPECT_CLOUD_DEPLOYMENT_NAME,
     ASPECT_CLOUD_DEPLOYMENT_ALIAS,
-    DEFAULT_PROFILE,
+    RESERVED_DEFAULT_NAME,
 ];
 
 /// Whether `name` addresses the built-in Aspect Cloud entry — its own name, or its
@@ -606,16 +611,47 @@ fn resolve_auth_env(name: Option<&str>) -> anyhow::Result<AuthEnv> {
     auth_env_from(&deployment)
 }
 
-/// The Aspect-cloud API base for `ctx.aspect.auth.api_url`, used by Aspect-cloud
-/// features (GitHub/GitLab token exchange, status comments, budget). Independent
-/// of which deployment serves the cache/BES endpoints: the first deployment that
-/// carries an `api_url` (the built-in Aspect seed, unless overridden), then the
-/// compile-time default.
-fn resolve_api_url() -> anyhow::Result<String> {
-    Ok(load_deployments()?
-        .into_iter()
-        .find_map(|d| d.api_url)
+/// Aspect Cloud's API base, whatever deployment is selected or default.
+///
+/// The GitHub and GitLab App routes (`/github/token`, `/gitlab/token`,
+/// `/status-comments/contribute`, `/status-checks/register`, `/github/budget`) are
+/// served only here, so every caller of those must resolve this and pair it with
+/// Aspect Cloud's own credential — see [`Auth::aspect_cloud_deployment`].
+///
+/// Its advertised `api` endpoint when discovery has recorded one, then its
+/// `api_url`, then the compiled-in default, so the host can move without a CLI
+/// release.
+fn resolve_aspect_cloud_api_url() -> anyhow::Result<String> {
+    let deployments = load_deployments()?;
+    let cloud = deployments.iter().find(|d| d.builtin);
+    Ok(cloud
+        .map(|d| &d.endpoints.api)
+        .filter(|api| !api.is_empty())
+        .map(|api| format!("https://{api}"))
+        .or_else(|| cloud.and_then(|d| d.api_url.clone()))
         .unwrap_or_else(|| DEFAULT_API_URL.to_string()))
+}
+
+/// The API base of the deployment named `name` — its own advertised `api`.
+///
+/// For a route a deployment serves itself. Errors when it advertises none, which
+/// is every deployment but Aspect Cloud today: a caller that reaches here for a
+/// deployment without an API is asking for something that does not exist, and
+/// silently falling back to Aspect Cloud's would send a deployment-scoped request
+/// to the wrong place.
+fn resolve_deployment_api_url(name: Option<&str>) -> anyhow::Result<String> {
+    let deployments = load_deployments()?;
+    let selected = select_deployment(&deployments, name)?;
+    if !selected.endpoints.api.is_empty() {
+        return Ok(format!("https://{}", selected.endpoints.api));
+    }
+    if let Some(url) = selected.api_url.clone() {
+        return Ok(url);
+    }
+    Err(anyhow::anyhow!(
+        "deployment {:?} advertises no API endpoint",
+        selected.name
+    ))
 }
 
 fn auth_env_from(deployment: &Deployment) -> anyhow::Result<AuthEnv> {
@@ -648,10 +684,6 @@ fn login_scopes(advertised: &[String]) -> Vec<String> {
     } else {
         advertised.to_vec()
     }
-}
-
-fn resolve_aspect_env() -> anyhow::Result<AuthEnv> {
-    resolve_auth_env(None)
 }
 
 /// How long a discovery fetch may take before the CLI gives up and uses what it
@@ -1057,6 +1089,7 @@ fn deployment_from_discovery(
         cache: endpoint_host_str(&info.aspect_endpoints.cache),
         bes: endpoint_host_str(&info.aspect_endpoints.bes),
         exec: endpoint_host_str(&info.aspect_endpoints.exec),
+        api: endpoint_host_str(&info.aspect_endpoints.api),
         // A viewer URL, kept verbatim: it is passed to --bes_results_url, not
         // dialed as a gRPC endpoint, so it is neither host-normalized nor pushed
         // onto the auth gate below.
@@ -1324,10 +1357,16 @@ fn remove_deployment(name: &str) -> anyhow::Result<()> {
     let mut existing = load_config_file(&config_path()?)?;
     apply_remove(&mut existing, name)?;
     write_user_config(existing)?;
-    // Also clear its stored credential (the profile is the deployment name).
-    let mut creds = load_all_credentials()?;
-    if creds.remove(name).is_some() {
-        save_all_credentials(&creds)?;
+    // Also clear its stored credential in every profile: the deployment is gone,
+    // so no identity has anything left to say to it.
+    let mut all = load_all_credentials()?;
+    let mut changed = false;
+    for entries in all.values_mut() {
+        changed |= entries.remove(name).is_some();
+    }
+    if changed {
+        all.retain(|_, entries| !entries.is_empty());
+        save_all_credentials(&all)?;
     }
     Ok(())
 }
@@ -1381,12 +1420,71 @@ impl CredentialsEntry {
     }
 }
 
-fn load_all_credentials() -> anyhow::Result<HashMap<String, CredentialsEntry>> {
+/// One profile's credentials, keyed by deployment name.
+type ProfileCredentials = HashMap<String, CredentialsEntry>;
+
+/// Every profile's credentials: `{ profile: { deployment: entry } }`.
+///
+/// The two keys answer different questions. The profile is *who you are* — a
+/// person, a CI role, a second account on the same deployment — selected by
+/// `--profile` or [`PROFILE_ENV`]. The deployment is *what you are talking to*.
+/// One profile therefore holds a credential per deployment at once, so
+/// `--profile bob` covers Aspect Cloud and every self-hosted deployment bob uses,
+/// and switching to `--profile susan` switches all of them together.
+type AllCredentials = HashMap<String, ProfileCredentials>;
+
+fn load_all_credentials() -> anyhow::Result<AllCredentials> {
     CredentialStore::resolve()?.load_all()
 }
 
-fn save_all_credentials(map: &HashMap<String, CredentialsEntry>) -> anyhow::Result<()> {
+fn save_all_credentials(map: &AllCredentials) -> anyhow::Result<()> {
     CredentialStore::resolve()?.save_all(map)
+}
+
+/// The credentials filed under `profile`, empty when it holds none.
+fn load_profile_credentials(profile: &str) -> anyhow::Result<ProfileCredentials> {
+    Ok(load_all_credentials()?.remove(profile).unwrap_or_default())
+}
+
+/// Read one deployment's credential from `profile`.
+fn load_credential(profile: &str, deployment: &str) -> anyhow::Result<Option<CredentialsEntry>> {
+    Ok(load_all_credentials()?
+        .get(profile)
+        .and_then(|p| p.get(deployment))
+        .cloned())
+}
+
+/// File `entry` for `deployment` under `profile`, leaving every other profile and
+/// every other deployment in this one untouched.
+fn store_credential(
+    profile: &str,
+    deployment: &str,
+    entry: CredentialsEntry,
+) -> anyhow::Result<()> {
+    let mut all = load_all_credentials()?;
+    all.entry(profile.to_string())
+        .or_default()
+        .insert(deployment.to_string(), entry);
+    save_all_credentials(&all)
+}
+
+/// Drop one deployment's credential from `profile`, and the profile itself once it
+/// holds nothing — an empty profile is indistinguishable from an absent one, and
+/// leaving the husk would have `auth status` list a profile with no logins.
+/// Returns whether anything was removed.
+fn forget_credential(profile: &str, deployment: &str) -> anyhow::Result<bool> {
+    let mut all = load_all_credentials()?;
+    let Some(entries) = all.get_mut(profile) else {
+        return Ok(false);
+    };
+    if entries.remove(deployment).is_none() {
+        return Ok(false);
+    }
+    if entries.is_empty() {
+        all.remove(profile);
+    }
+    save_all_credentials(&all)?;
+    Ok(true)
 }
 
 #[derive(Debug, Deserialize)]
@@ -1583,28 +1681,85 @@ fn api_token_cache() -> &'static Mutex<Option<ApiTokenCacheEntry>> {
     API_TOKEN_CACHE.get_or_init(|| Mutex::new(None))
 }
 
-/// Exchange an ASPECT_API_TOKEN from an explicit source — the env var or the
-/// Buildkite secret store — for a fresh credentials entry. Returns Ok(None)
-/// only when no such source is present; a malformed token or a failed
-/// exchange is surfaced as an error so CI misconfigurations fail loudly
-/// instead of falling through to whatever happens to be cached on disk
+/// The API-token variable for `deployment`: `ASPECT_API_TOKEN` for Aspect Cloud,
+/// `ASPECT_API_TOKEN_<NAME>` for anything else, with the name uppercased and every
+/// character outside `[A-Z0-9]` replaced by `_`.
+///
+/// Aspect Cloud takes the unsuffixed name because a token for it is the one every
+/// installation needs — the GitHub and GitLab App features are served only there,
+/// so a self-hosted customer sets this one *and* the suffixed one for their own
+/// deployment. It is pinned to Aspect Cloud rather than tracking the default
+/// deployment so that `aspect auth use` cannot silently change which issuer a CI
+/// credential is minted by.
+///
+/// The same name is used for the Buildkite secret store, so one scheme documents
+/// both.
+///
+/// Two deployment names can normalize to one variable (`gcp.acme` and `gcp-acme`);
+/// [`api_token_env_collisions`] reports that rather than letting one silently
+/// answer for the other.
+pub(crate) fn api_token_env_var(deployment: &str) -> String {
+    if deployment == ASPECT_CLOUD_DEPLOYMENT_NAME {
+        return API_TOKEN_ENV.to_string();
+    }
+    let suffix: String = deployment
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("{API_TOKEN_ENV}_{suffix}")
+}
+
+const API_TOKEN_ENV: &str = "ASPECT_API_TOKEN";
+
+/// Configured deployments whose [`api_token_env_var`] collide, as
+/// `(variable, names)`. Empty in every ordinary configuration.
+fn api_token_env_collisions(deployments: &[Deployment]) -> Vec<(String, Vec<String>)> {
+    let mut by_var: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for d in deployments {
+        by_var
+            .entry(api_token_env_var(&d.name))
+            .or_default()
+            .push(d.name.clone());
+    }
+    by_var
+        .into_iter()
+        .filter(|(_, names)| names.len() > 1)
+        .collect()
+}
+
+/// Exchange `deployment`'s API token from an explicit source — its env var (see
+/// [`api_token_env_var`]) or the Buildkite secret store — for a fresh credentials
+/// entry. Returns Ok(None) only when no such source is present; a malformed token
+/// or a failed exchange is surfaced as an error so CI misconfigurations fail
+/// loudly instead of falling through to whatever happens to be cached on disk
 /// (e.g. from a previous job on a persistent runner).
 ///
-/// Subsequent calls within the same process reuse the cached exchange
-/// result until the JWT approaches expiry.
-fn credentials_from_api_token_env() -> anyhow::Result<Option<CredentialsEntry>> {
-    let token = std::env::var("ASPECT_API_TOKEN")
+/// Exchanged against `deployment`'s own issuer, because that is who issued it. A
+/// token is minted by one IdP for one deployment, so one exchanged against
+/// another's issuer would be rejected by the endpoints it was meant for.
+///
+/// Subsequent calls within the same process reuse the cached exchange result until
+/// the JWT approaches expiry.
+fn credentials_from_api_token_env(deployment: &str) -> anyhow::Result<Option<CredentialsEntry>> {
+    let var = api_token_env_var(deployment);
+    let token = std::env::var(&var)
         .ok()
         .filter(|s| !s.is_empty())
-        .or_else(buildkite_aspect_api_token);
+        .or_else(|| buildkite_aspect_api_token(&var));
     let Some(token) = token else {
         return Ok(None);
     };
 
-    // Resolve the default deployment's issuer each call so a config change
-    // within a single process (test harnesses, multi-step tooling) re-exchanges
-    // against the new issuer instead of returning a stale token.
-    let env = resolve_aspect_env()?;
+    // Resolved each call so a config change within a single process (test
+    // harnesses, multi-step tooling) re-exchanges against the new issuer instead
+    // of returning a stale token.
+    let env = resolve_auth_env(Some(deployment))?;
 
     // Fast path: a cached exchange for the same source token AND issuer whose
     // JWT hasn't entered the 60-second pre-expiry buffer.
@@ -1621,7 +1776,7 @@ fn credentials_from_api_token_env() -> anyhow::Result<Option<CredentialsEntry>> 
 
     let (client_id, secret) = token
         .split_once(':')
-        .ok_or_else(|| anyhow::anyhow!("ASPECT_API_TOKEN must be in 'client_id:secret' format"))?;
+        .ok_or_else(|| anyhow::anyhow!("{var} must be in 'client_id:secret' format"))?;
     let entry = block_on(exchange_api_token(client_id, secret, &env))?;
 
     // Store for subsequent calls. Clearing on lock-poison is fine — the
@@ -1636,18 +1791,18 @@ fn credentials_from_api_token_env() -> anyhow::Result<Option<CredentialsEntry>> 
     Ok(Some(entry))
 }
 
-/// Read ASPECT_API_TOKEN from Buildkite's secret store when running on a
+/// Read the API token named `var` from Buildkite's secret store when running on a
 /// Buildkite agent. Returns None if not on a Buildkite agent, the CLI is
 /// missing, or the secret is not defined — callers should fall through to
 /// the "not authenticated" path rather than surface the error.
-fn buildkite_aspect_api_token() -> Option<String> {
+fn buildkite_aspect_api_token(var: &str) -> Option<String> {
     // BUILDKITE_AGENT_ACCESS_TOKEN is injected into every job on a Buildkite
     // agent; checking it avoids shelling out when we're not on Buildkite.
     if std::env::var_os("BUILDKITE_AGENT_ACCESS_TOKEN").is_none() {
         return None;
     }
     let output = std::process::Command::new("buildkite-agent")
-        .args(["secret", "get", "ASPECT_API_TOKEN"])
+        .args(["secret", "get", var])
         .output()
         .ok()?;
     if !output.status.success() {
@@ -2231,7 +2386,7 @@ fn merged_refresh_token(prior: &str, fresh: &str) -> String {
 /// gets an explicit `--deployment`; the default profile (the built-in Aspect
 /// deployment, or a `$ASPECT_AUTH_PROFILE`) gets a bare `login`.
 pub fn login_hint(profile: &str) -> String {
-    if profile == DEFAULT_PROFILE {
+    if profile == ASPECT_CLOUD_DEPLOYMENT_NAME {
         "aspect auth login".to_string()
     } else {
         format!("aspect auth login --deployment {profile}")
@@ -2273,20 +2428,26 @@ fn classify_token(entry: &CredentialsEntry) -> TokenAction {
 /// `export ASPECT_AUTH_PROFILE=...` drives both.
 pub const PROFILE_ENV: &str = "ASPECT_AUTH_PROFILE";
 
-/// The credentials profile when none is configured.
-const DEFAULT_PROFILE: &str = "default";
+/// Reserved as a deployment name: it is the word `auth use` and `auth status` use
+/// for *which* deployment `--remote` targets, so a deployment actually called
+/// `default` would make `aspect auth use default` ambiguous.
+const RESERVED_DEFAULT_NAME: &str = "default";
 
-/// Resolve the effective profile name: an explicit (non-empty) value wins, then
-/// [`PROFILE_ENV`] (non-empty), then [`DEFAULT_PROFILE`]. An empty `explicit` is
-/// treated as absent (the `auth` tasks pass `""` when `--profile` is omitted),
-/// so it still falls through to the env var.
+/// Resolve the effective credential-store key: an explicit (non-empty) value wins,
+/// then [`PROFILE_ENV`] (non-empty), then Aspect Cloud's own name. An empty
+/// `explicit` is treated as absent (the `auth` tasks pass `""` when `--profile` is
+/// omitted), so it still falls through to the env var.
+///
+/// The final fallback is Aspect Cloud because that is what "no deployment named"
+/// means everywhere else in the CLI. A caller that knows its deployment passes the
+/// name instead — see [`login_profile_for`].
 pub fn resolve_profile(explicit: Option<&str>) -> String {
     let non_empty = |s: String| (!s.is_empty()).then_some(s);
     explicit
         .map(str::to_owned)
         .and_then(non_empty)
         .or_else(|| std::env::var(PROFILE_ENV).ok().and_then(non_empty))
-        .unwrap_or_else(|| DEFAULT_PROFILE.to_owned())
+        .unwrap_or_else(|| ASPECT_CLOUD_DEPLOYMENT_NAME.to_owned())
 }
 
 /// Which configured deployment owns the endpoint `uri`, for the credential helper.
@@ -2296,11 +2457,9 @@ pub fn resolve_profile(explicit: Option<&str>) -> String {
 /// (e.g. third-party) host.
 pub struct UriProfile {
     pub host: String,
-    /// The owning deployment's name — what the user calls it.
+    /// The owning deployment's name, which is also the credential-store key its
+    /// login is filed under — see [`login_profile_for`].
     pub deployment: Option<String>,
-    /// The credential-store key its login is filed under. Not always the name: see
-    /// [`login_profile_for`]. `None` exactly when `deployment` is.
-    pub profile: Option<String>,
     /// Whether the owner is the built-in Aspect Cloud entry, so a caller can name
     /// it the way the user knows it rather than by its config name.
     pub builtin: bool,
@@ -2314,7 +2473,6 @@ pub fn profile_for_uri(uri: &str) -> anyhow::Result<UriProfile> {
         return Ok(UriProfile {
             host,
             deployment: None,
-            profile: None,
             builtin: false,
         });
     }
@@ -2322,44 +2480,39 @@ pub fn profile_for_uri(uri: &str) -> anyhow::Result<UriProfile> {
     let owner = deployment_for_host(&deployments, &host);
     Ok(UriProfile {
         host,
-        deployment: owner.map(|d| d.name.clone()),
-        profile: owner.map(login_profile_for),
+        deployment: owner.map(login_profile_for),
         builtin: owner.is_some_and(|d| d.builtin),
     })
 }
 
 /// Resolve the current access token (JWT) for `profile` (already resolved, e.g.
-/// via [`resolve_profile`]). For the default profile an explicit
-/// `ASPECT_API_TOKEN` (exchanged against Aspect Cloud issuer) takes
-/// precedence over stored credentials; other profiles always use their stored
-/// credential. Auto-refreshes an expired-but-refreshable token, persisting the
-/// refresh. Each stored credential is its own grant now, so a rotated refresh token
-/// concerns only the profile being refreshed. Returns `None` when no credential exists for the profile, and errors
-/// when the stored token is expired and cannot be refreshed: it never returns a
-/// known-expired token, so a consumer (e.g. the credential helper) does not emit
-/// one a server will 401. Requires a Tokio runtime (the refresh path blocks on
-/// async HTTP).
-pub fn resolve_access_token(profile: &str) -> anyhow::Result<Option<String>> {
-    // ASPECT_API_TOKEN is exchanged against the default (Aspect Cloud) issuer,
-    // so it only stands in for the default profile — a self-hosted deployment's
-    // profile must use its own stored credential, not the account token.
-    if profile == DEFAULT_PROFILE {
-        if let Some(entry) = credentials_from_api_token_env()? {
-            return Ok(Some(entry.access_token));
-        }
+/// Resolve the current access token (JWT) for `deployment` as `profile` — the
+/// identity, already resolved via [`resolve_profile`].
+///
+/// `deployment`'s API token (see [`api_token_env_var`]) takes precedence over a
+/// stored credential, and is exchanged against that deployment's own issuer. It is
+/// an identity in its own right, so it applies whichever profile is selected.
+///
+/// Auto-refreshes an expired-but-refreshable token, persisting the refresh against
+/// this profile's entry for this deployment alone. Returns `None` when the profile
+/// holds no credential for the deployment, and errors when the stored token is
+/// expired and cannot be refreshed: it never returns a known-expired token, so a
+/// consumer (e.g. the credential helper) does not emit one a server will 401.
+/// Requires a Tokio runtime (the refresh path blocks on async HTTP).
+pub fn resolve_access_token(profile: &str, deployment: &str) -> anyhow::Result<Option<String>> {
+    if let Some(entry) = credentials_from_api_token_env(deployment)? {
+        return Ok(Some(entry.access_token));
     }
-    let mut map = load_all_credentials()?;
-    let Some(entry) = map.get(profile).cloned() else {
+    let Some(entry) = load_credential(profile, deployment)? else {
         return Ok(None);
     };
     match classify_token(&entry) {
         TokenAction::Use => Ok(Some(entry.access_token)),
-        TokenAction::Expired => Err(anyhow::anyhow!(session_expired_message(profile))),
+        TokenAction::Expired => Err(anyhow::anyhow!(session_expired_message(deployment))),
         TokenAction::Refresh => {
             let refreshed = block_on(refresh_access_token(&entry))
-                .map_err(|_| anyhow::anyhow!(session_expired_message(profile)))?;
-            map.insert(profile.to_string(), refreshed.clone());
-            save_all_credentials(&map)?;
+                .map_err(|_| anyhow::anyhow!(session_expired_message(deployment)))?;
+            store_credential(profile, deployment, refreshed.clone())?;
             Ok(Some(refreshed.access_token))
         }
     }
@@ -2795,6 +2948,10 @@ pub struct DeploymentSummary {
     /// Advertised build-result viewer (a full URL, not a host), empty when the
     /// deployment serves no web UI.
     pub results_url: String,
+    /// The environment variable holding this deployment's API token — reported so
+    /// nobody has to work out the name from the deployment's own (see
+    /// [`api_token_env_var`]).
+    pub api_token_env: String,
 }
 
 starlark_simple_value!(DeploymentSummary);
@@ -2850,6 +3007,11 @@ fn deployment_summary_methods(registry: &mut MethodsBuilder) {
     }
 
     #[starlark(attribute)]
+    fn api_token_env<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
+        attr_str!(this, DeploymentSummary, api_token_env)
+    }
+
+    #[starlark(attribute)]
     fn cache<'v>(this: values::Value<'v>) -> anyhow::Result<String> {
         attr_str!(this, DeploymentSummary, cache)
     }
@@ -2878,7 +3040,14 @@ fn deployment_summary_methods(registry: &mut MethodsBuilder) {
 /// effective default (matching [`select_deployment`]).
 fn list_deployment_summaries() -> anyhow::Result<Vec<DeploymentSummary>> {
     let deployments = load_deployments()?;
-    let creds = load_all_credentials()?;
+    for (var, names) in api_token_env_collisions(&deployments) {
+        tracing::warn!(
+            "deployments {} share the API-token variable {var}; rename one so each \
+             has its own",
+            names.join(", ")
+        );
+    }
+    let creds = load_profile_credentials(&resolve_profile(None))?;
     let any_configured_default = deployments.iter().any(|d| d.default && !d.builtin);
     Ok(deployments
         .iter()
@@ -2917,6 +3086,7 @@ fn summarize_deployment(
         email,
         display_name,
         status,
+        api_token_env: api_token_env_var(&d.name),
         issuer: d
             .issuer
             .as_deref()
@@ -2934,7 +3104,7 @@ fn summarize_deployment(
 /// deployment with the same detail as `list`.
 fn one_deployment_summary(name: &str) -> anyhow::Result<Option<DeploymentSummary>> {
     let deployments = load_deployments()?;
-    let creds = load_all_credentials()?;
+    let creds = load_profile_credentials(&resolve_profile(None))?;
     let any_configured_default = deployments.iter().any(|d| d.default && !d.builtin);
     Ok(deployments
         .iter()
@@ -3053,9 +3223,32 @@ impl<'v> values::StarlarkValue<'v> for Auth {
 
 #[starlark_module]
 fn auth_methods(registry: &mut MethodsBuilder) {
+    /// Aspect Cloud's API base. Pair it with a credential for
+    /// [`Self::aspect_cloud_deployment`]: the routes served here accept only
+    /// Aspect Cloud's own tokens.
     #[starlark(attribute)]
-    fn api_url<'v>(#[allow(unused)] this: values::Value<'v>) -> anyhow::Result<String> {
-        Ok(resolve_api_url()?)
+    fn aspect_cloud_api_url<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+    ) -> anyhow::Result<String> {
+        resolve_aspect_cloud_api_url()
+    }
+
+    /// Aspect Cloud's deployment name, for addressing its credential explicitly
+    /// rather than taking whichever deployment happens to be default.
+    #[starlark(attribute)]
+    fn aspect_cloud_deployment<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+    ) -> anyhow::Result<String> {
+        Ok(ASPECT_CLOUD_DEPLOYMENT_NAME.to_string())
+    }
+
+    /// The API base of `deployment` (or the default one), for a route a deployment
+    /// serves itself. Errors when it advertises no API.
+    fn deployment_api_url<'v>(
+        #[allow(unused)] this: values::Value<'v>,
+        #[starlark(require = named, default = NoneOr::None)] deployment: NoneOr<String>,
+    ) -> anyhow::Result<String> {
+        resolve_deployment_api_url(deployment.into_option().as_deref())
     }
 
     fn login<'v>(
@@ -3106,31 +3299,43 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         Ok(heap.alloc(session))
     }
 
+    /// File `creds` for `deployment` under `profile`.
+    ///
+    /// `deployment` names what the credential talks to — omitted means the
+    /// effective default deployment — and is normalized, so the Aspect Cloud alias
+    /// files where Aspect Cloud's canonical name does. `profile` names who holds
+    /// it, defaulting to [`resolve_profile`]; every other deployment in that
+    /// profile, and every other profile, is left alone.
     fn persist<'v>(
         #[allow(unused)] this: values::Value<'v>,
         creds: values::Value<'v>,
+        #[starlark(require = named, default = NoneOr::None)] deployment: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] profile: NoneOr<String>,
     ) -> anyhow::Result<values::Value<'v>> {
         let creds = creds
             .downcast_ref_err::<AuthCredentials>()
             .into_anyhow_result()?;
         let profile = resolve_profile(profile.into_option().as_deref());
-        let mut map = load_all_credentials()?;
-        map.insert(profile, creds.to_entry());
-        save_all_credentials(&map)?;
+        let deployments = load_deployments()?;
+        let selected =
+            select_account_or_deployment(&deployments, deployment.into_option().as_deref())?;
+        store_credential(&profile, &selected.name, creds.to_entry())?;
         Ok(values::Value::new_none())
     }
 
-    /// Log out. `all` clears every stored credential. Otherwise the target is the
-    /// deployment named `deployment`, or — when none is given — the effective
-    /// default deployment (a configured default, else the built-in Aspect seed).
-    /// An explicit `profile` overrides the resolved profile for advanced use.
+    /// Log out. `all` clears every credential of every profile. Otherwise it clears
+    /// one deployment's credential in one profile: the deployment named
+    /// `deployment` — or, when none is given, the effective default deployment —
+    /// as `profile`, defaulting to [`resolve_profile`].
+    ///
+    /// Only that one credential: logging out of one deployment leaves the same
+    /// profile's other logins alone, and logging out as one profile never touches
+    /// another identity's.
     ///
     /// Logging out of the current default configured deployment also clears the
     /// default (there is no fall-through to another configured deployment): a
-    /// later command with no `--deployment` then resolves the built-in Aspect
-    /// seed, or errors if it needs a login. Returns the name that was logged out
-    /// (empty for `all`).
+    /// later command with no `--deployment` then resolves Aspect Cloud, or errors
+    /// if it needs a login. Returns the name that was logged out (empty for `all`).
     fn logout<'v>(
         #[allow(unused)] this: values::Value<'v>,
         #[starlark(require = named, default = NoneOr::None)] deployment: NoneOr<String>,
@@ -3139,20 +3344,15 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         heap: values::Heap<'v>,
     ) -> anyhow::Result<values::Value<'v>> {
         if all {
-            // Clear every stored profile (empties the file / deletes the keyring entry).
-            save_all_credentials(&HashMap::new())?;
+            // Empties the file / deletes the keyring entry outright.
+            save_all_credentials(&AllCredentials::new())?;
             return Ok(heap.alloc(""));
         }
         let deployments = load_deployments()?;
         let selected =
             select_account_or_deployment(&deployments, deployment.into_option().as_deref())?;
-        let profile = match profile.into_option() {
-            Some(p) if !p.is_empty() => p,
-            _ => login_profile_for(&selected),
-        };
-        let mut map = load_all_credentials()?;
-        map.remove(&profile);
-        save_all_credentials(&map)?;
+        let profile = resolve_profile(profile.into_option().as_deref());
+        forget_credential(&profile, &selected.name)?;
         // If the logged-out deployment was the current default, clear the default
         // rather than letting selection fall through to another deployment.
         if selected.default && !selected.builtin {
@@ -3220,23 +3420,28 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         Ok(values::Value::new_none())
     }
 
+    /// `profile`'s credential for `deployment`, or `None` when it holds none.
+    ///
+    /// `deployment` is taken as given rather than normalized: callers pass a name
+    /// `deployment_for_host` resolved, which is already canonical.
     fn credentials<'v>(
         #[allow(unused)] this: values::Value<'v>,
+        #[starlark(require = named, default = NoneOr::None)] deployment: NoneOr<String>,
         #[starlark(require = named, default = NoneOr::None)] profile: NoneOr<String>,
         #[starlark(require = named, default = true)] required: bool,
         heap: values::Heap<'v>,
     ) -> anyhow::Result<values::Value<'v>> {
         let profile = resolve_profile(profile.into_option().as_deref());
-        // Prefer an explicit ASPECT_API_TOKEN over stored credentials, but only for
-        // the default profile: the token is exchanged against Aspect Cloud
-        // issuer, so it can't stand in for a self-hosted deployment's profile.
-        if profile == DEFAULT_PROFILE {
-            if let Some(entry) = credentials_from_api_token_env()? {
-                return Ok(heap.alloc(AuthCredentials::from_entry(&entry)));
-            }
+        let deployment = match deployment.into_option() {
+            Some(name) if !name.is_empty() => name,
+            _ => select_deployment(&load_deployments()?, None)?.name,
+        };
+        // An API token is an identity in its own right, so it takes precedence
+        // over anything stored and applies whichever profile is selected.
+        if let Some(entry) = credentials_from_api_token_env(&deployment)? {
+            return Ok(heap.alloc(AuthCredentials::from_entry(&entry)));
         }
-        let mut map = load_all_credentials()?;
-        let Some(entry) = map.get(&profile).cloned() else {
+        let Some(entry) = load_credential(&profile, &deployment)? else {
             return Ok(values::Value::new_none());
         };
         // Never hand back a known-expired token (an endpoint would 401 on it).
@@ -3247,15 +3452,16 @@ fn auth_methods(registry: &mut MethodsBuilder) {
             TokenAction::Use => entry,
             TokenAction::Refresh => match block_on(refresh_access_token(&entry)) {
                 Ok(refreshed) => {
-                    map.insert(profile.clone(), refreshed.clone());
-                    save_all_credentials(&map)?;
+                    store_credential(&profile, &deployment, refreshed.clone())?;
                     refreshed
                 }
                 Err(_) if !required => return Ok(values::Value::new_none()),
-                Err(_) => return Err(anyhow::anyhow!(session_expired_message(&profile))),
+                Err(_) => return Err(anyhow::anyhow!(session_expired_message(&deployment))),
             },
             TokenAction::Expired if !required => return Ok(values::Value::new_none()),
-            TokenAction::Expired => return Err(anyhow::anyhow!(session_expired_message(&profile))),
+            TokenAction::Expired => {
+                return Err(anyhow::anyhow!(session_expired_message(&deployment)));
+            }
         };
         Ok(heap.alloc(AuthCredentials::from_entry(&entry)))
     }
@@ -3388,24 +3594,21 @@ fn auth_methods(registry: &mut MethodsBuilder) {
     }
 }
 
-/// The credentials profile a login against `selected` persists under: a configured
-/// deployment stores under its name; the built-in Aspect Cloud entry stores under
-/// the resolved default profile, which every Aspect Cloud caller reads and which
-/// `$ASPECT_API_TOKEN` stands in for on CI.
+/// The credential-store key a login against `selected` persists under, and the one
+/// its endpoints are later read from: the deployment's own name, Aspect Cloud
+/// included. So `deployment_for_host` hands back a key that needs no translation.
 ///
-/// Keyed on `builtin`, an identity question, not on whether the entry has hosts —
-/// Aspect Cloud carries its own cache/BES now (see [`configure_default`]) and would
-/// otherwise file its login away from that profile.
-///
-/// This is the one place the name/profile distinction lives. Everything resolving a
-/// credential for an endpoint goes through it rather than assuming a deployment's
-/// name is its profile — see [`profile_for_uri`] and the AXL `resolve_aspect_bearer`.
+/// [`PROFILE_ENV`] overrides it, which is what keeps a second identity for the same
+/// deployment usable: `--profile` steers the `auth` tasks, but the Bazel credential
+/// helper takes no flags, so the env var is the only thing that can steer both. It
+/// applies to whichever deployment is being addressed, so exporting it while using
+/// two deployments points both at one key — which is why it is an override to reach
+/// for deliberately, not a default.
 fn login_profile_for(selected: &Deployment) -> String {
-    if selected.builtin {
-        resolve_profile(None)
-    } else {
-        selected.name.clone()
-    }
+    std::env::var(PROFILE_ENV)
+        .ok()
+        .and_then(|v| (!v.is_empty()).then_some(v))
+        .unwrap_or_else(|| selected.name.clone())
 }
 
 /// Extract a bare host from a possibly-URL argument (`https://h/p` → `h`), so
@@ -3538,10 +3741,11 @@ mod tests {
         // An explicit profile still overrides the env.
         assert_eq!(resolve_profile(Some("explicit")), "explicit");
 
-        // With the env unset, everything falls through to the default.
+        // With the env unset, everything falls through to Aspect Cloud — which is
+        // what "no deployment named" means everywhere else in the CLI.
         unsafe { std::env::remove_var(PROFILE_ENV) };
-        assert_eq!(resolve_profile(None), DEFAULT_PROFILE);
-        assert_eq!(resolve_profile(Some("")), DEFAULT_PROFILE);
+        assert_eq!(resolve_profile(None), ASPECT_CLOUD_DEPLOYMENT_NAME);
+        assert_eq!(resolve_profile(Some("")), ASPECT_CLOUD_DEPLOYMENT_NAME);
 
         match saved {
             Some(v) => unsafe { std::env::set_var(PROFILE_ENV, v) },
@@ -3650,16 +3854,69 @@ mod tests {
     }
 
     #[test]
-    fn login_hint_names_the_deployment_except_for_the_default() {
-        // The default profile → bare login (no deployment assumed).
-        assert_eq!(login_hint(DEFAULT_PROFILE), "aspect auth login");
+    fn login_hint_names_the_deployment_except_for_aspect_cloud() {
+        // Aspect Cloud → bare login, which is what targets it.
+        assert_eq!(
+            login_hint(ASPECT_CLOUD_DEPLOYMENT_NAME),
+            "aspect auth login"
+        );
         // A configured deployment's profile is its name → explicit --deployment.
         assert_eq!(
             login_hint("gcp.acme"),
             "aspect auth login --deployment gcp.acme"
         );
         assert!(session_expired_message("gcp.acme").contains("--deployment gcp.acme"));
-        assert!(!session_expired_message(DEFAULT_PROFILE).contains("--deployment"));
+        assert!(!session_expired_message(ASPECT_CLOUD_DEPLOYMENT_NAME).contains("--deployment"));
+    }
+
+    /// The variable scheme customers are documented against: the unsuffixed name
+    /// is Aspect Cloud's, everything else is suffixed with its own name. Aspect
+    /// Cloud takes the unsuffixed one because every installation needs a token for
+    /// it — the GitHub and GitLab App routes are served only there — so a
+    /// self-hosted customer sets this one *and* the suffixed one for their own
+    /// deployment.
+    #[test]
+    fn api_token_env_var_names_aspect_cloud_unsuffixed() {
+        assert_eq!(
+            api_token_env_var(ASPECT_CLOUD_DEPLOYMENT_NAME),
+            "ASPECT_API_TOKEN"
+        );
+        assert_eq!(api_token_env_var("acme"), "ASPECT_API_TOKEN_ACME");
+        // Every character a deployment name may hold that an env var may not.
+        assert_eq!(
+            api_token_env_var("aws-cci-test-dev"),
+            "ASPECT_API_TOKEN_AWS_CCI_TEST_DEV"
+        );
+        assert_eq!(api_token_env_var("gcp.acme"), "ASPECT_API_TOKEN_GCP_ACME");
+        // The alias is a name in its own right here: it is not Aspect Cloud's
+        // canonical name, so it gets suffixed like anything else. Nothing records
+        // the alias, so no deployment is ever looked up under it.
+        assert_eq!(
+            api_token_env_var(ASPECT_CLOUD_DEPLOYMENT_ALIAS),
+            "ASPECT_API_TOKEN_ASPECT"
+        );
+    }
+
+    /// Two names can normalize to one variable, in which case one token would
+    /// silently answer for both deployments. Reported rather than resolved: only
+    /// the user can say which deployment should be renamed.
+    #[test]
+    fn colliding_api_token_env_vars_are_reported() {
+        let deployments = vec![
+            aspect_cloud_deployment(),
+            dep("gcp.acme", false),
+            dep("gcp-acme", false),
+            dep("other", false),
+        ];
+        let collisions = api_token_env_collisions(&deployments);
+        assert_eq!(collisions.len(), 1, "{collisions:?}");
+        assert_eq!(collisions[0].0, "ASPECT_API_TOKEN_GCP_ACME");
+        assert_eq!(collisions[0].1, vec!["gcp.acme", "gcp-acme"]);
+
+        // The ordinary configuration reports nothing.
+        assert!(
+            api_token_env_collisions(&[aspect_cloud_deployment(), dep("acme", false)]).is_empty()
+        );
     }
 
     #[test]
@@ -3690,10 +3947,10 @@ mod tests {
         // Why `default` is reserved: a deployment files under its own name, so one
         // named `default` would share the account's credential slot.
         assert_eq!(
-            login_profile_for(&dep(DEFAULT_PROFILE, true)),
-            DEFAULT_PROFILE
+            login_profile_for(&dep(RESERVED_DEFAULT_NAME, true)),
+            RESERVED_DEFAULT_NAME
         );
-        assert!(is_reserved_name(DEFAULT_PROFILE));
+        assert!(is_reserved_name(RESERVED_DEFAULT_NAME));
     }
 
     #[test]
@@ -3758,7 +4015,7 @@ mod tests {
             ),
             // The alias is reserved too, so a host cannot derive its way onto it.
             ("remote.aspect.aspect.build", ASPECT_CLOUD_DEPLOYMENT_ALIAS),
-            ("remote.default.aspect.build", DEFAULT_PROFILE),
+            ("remote.default.aspect.build", RESERVED_DEFAULT_NAME),
         ] {
             let name = deployment_name_from_host(host);
             assert_eq!(name, want);
@@ -3778,7 +4035,7 @@ mod tests {
         // take neither — as is the credential slot every deployment files under.
         assert!(RESERVED_NAMES.contains(&ASPECT_CLOUD_DEPLOYMENT_NAME));
         assert!(RESERVED_NAMES.contains(&ASPECT_CLOUD_DEPLOYMENT_ALIAS));
-        assert!(RESERVED_NAMES.contains(&DEFAULT_PROFILE));
+        assert!(RESERVED_NAMES.contains(&RESERVED_DEFAULT_NAME));
         assert_eq!(RESERVED_NAMES, ["aspect-cloud", "aspect", "default"]);
 
         for name in RESERVED_NAMES {
@@ -3857,24 +4114,27 @@ mod tests {
         // A repo-config entry is checked in: `auth remove` only edits the user
         // file, so the advice must point at the repo path instead.
         let (_, found) = overlay_config_sources(vec![
-            src(REPO, vec![dep(DEFAULT_PROFILE, false)], false),
+            src(REPO, vec![dep(RESERVED_DEFAULT_NAME, false)], false),
             src(USER, vec![dep("acme", false)], true),
         ]);
         assert_eq!(found.len(), 1);
-        assert_eq!(found[0].name, DEFAULT_PROFILE);
+        assert_eq!(found[0].name, RESERVED_DEFAULT_NAME);
         assert!(!found[0].user_config);
         assert_eq!(found[0].path, REPO);
 
         // A user-config entry is removable.
-        let (_, found) =
-            overlay_config_sources(vec![src(USER, vec![dep(DEFAULT_PROFILE, false)], true)]);
+        let (_, found) = overlay_config_sources(vec![src(
+            USER,
+            vec![dep(RESERVED_DEFAULT_NAME, false)],
+            true,
+        )]);
         assert_eq!(found.len(), 1);
         assert!(found[0].user_config);
 
         // Declared in both files → reported once, against the first (repo).
         let (_, found) = overlay_config_sources(vec![
-            src(REPO, vec![dep(DEFAULT_PROFILE, false)], false),
-            src(USER, vec![dep(DEFAULT_PROFILE, false)], true),
+            src(REPO, vec![dep(RESERVED_DEFAULT_NAME, false)], false),
+            src(USER, vec![dep(RESERVED_DEFAULT_NAME, false)], true),
         ]);
         assert_eq!(found.len(), 1);
         assert!(!found[0].user_config);
@@ -4075,6 +4335,7 @@ mod tests {
                 cache: "https://remote.acme.aspect.build".to_string(),
                 bes: "bes.acme.aspect.build".to_string(),
                 exec: "https://remote.acme.aspect.build".to_string(),
+                api: String::new(),
                 results_url: String::new(),
             },
             aspect_bes_results_url: "https://app.acme.aspect.build/i/".to_string(),
@@ -4128,6 +4389,7 @@ mod tests {
                 cache: "remote.acme.aspect.build".to_string(),
                 bes: "bes.acme.aspect.build".to_string(),
                 exec: String::new(),
+                api: String::new(),
                 results_url: String::new(),
             },
             // A deployment with no web UI omits it entirely.
@@ -4431,6 +4693,7 @@ mod tests {
                 cache: "remote.aws.awd-cci-test-dev.aspect.build".to_string(),
                 bes: String::new(),
                 exec: String::new(),
+                api: String::new(),
                 results_url: String::new(),
             },
             aspect_bes_results_url: String::new(),
@@ -4456,7 +4719,7 @@ mod tests {
         // the account first; see `parses_the_aspect_cloud_document_as_served`.
         assert_eq!(advertised_name(&doc(ASPECT_CLOUD_DEPLOYMENT_NAME)), None);
         assert_eq!(advertised_name(&doc(ASPECT_CLOUD_DEPLOYMENT_ALIAS)), None);
-        assert_eq!(advertised_name(&doc(DEFAULT_PROFILE)), None);
+        assert_eq!(advertised_name(&doc(RESERVED_DEFAULT_NAME)), None);
 
         // `^[a-z][a-z0-9-]*$` — what the charts and Terraform modules enforce, so a
         // name reaching the CLI outside it means something upstream went wrong.
@@ -4584,9 +4847,8 @@ mod tests {
         );
     }
 
-    /// A `config.json` entry under the alias — which is what builds of #1429 wrote
-    /// — must fold into the seed rather than appear beside it as a second
-    /// deployment claiming Aspect Cloud's hosts.
+    /// A `config.json` entry under the alias must fold into the seed rather than
+    /// appear beside it as a second deployment claiming Aspect Cloud's hosts.
     #[test]
     fn a_config_entry_under_the_alias_folds_into_the_seed() {
         let mut aliased = dep(ASPECT_CLOUD_DEPLOYMENT_ALIAS, false);
@@ -4623,6 +4885,7 @@ mod tests {
             cache: "cache.example".to_string(),
             bes: "bes.example".to_string(),
             exec: String::new(),
+            api: String::new(),
             results_url: String::new(),
         };
 
@@ -4671,6 +4934,7 @@ mod tests {
                 cache: "cache.acme.example".to_string(),
                 bes: "bes.acme.example".to_string(),
                 exec: String::new(),
+                api: String::new(),
                 results_url: String::new(),
             },
             aspect_bes_results_url: String::new(),
@@ -4729,6 +4993,7 @@ mod tests {
                 cache: cache.to_string(),
                 bes: bes.to_string(),
                 exec: String::new(),
+                api: String::new(),
                 results_url: String::new(),
             };
             d
@@ -4787,6 +5052,7 @@ mod tests {
                 cache: String::new(),
                 bes: String::new(),
                 exec: String::new(),
+                api: String::new(),
                 results_url: "https://app.aspect.build".to_string(),
             },
             aspect_bes_results_url: String::new(),
@@ -4803,6 +5069,7 @@ mod tests {
                 cache: "cache.aspect.build".to_string(),
                 bes: "bes.aspect.build".to_string(),
                 exec: String::new(),
+                api: String::new(),
                 results_url: String::new(),
             },
             client_id: "client".to_string(),
@@ -4827,7 +5094,9 @@ mod tests {
         assert!(upsert_deployment(&mut Vec::new(), account(), true).is_ok());
         assert!(upsert_deployment(&mut Vec::new(), account(), false).is_err());
         // The credential slot is refused however it is asked for.
-        assert!(upsert_deployment(&mut Vec::new(), dep(DEFAULT_PROFILE, false), true).is_err());
+        assert!(
+            upsert_deployment(&mut Vec::new(), dep(RESERVED_DEFAULT_NAME, false), true).is_err()
+        );
     }
 
     /// The entry `configure_default` writes enriches the seed rather than
@@ -4841,6 +5110,7 @@ mod tests {
             cache: "remote.app.aspect.build".to_string(),
             bes: "bes.app.aspect.build".to_string(),
             exec: String::new(),
+            api: String::new(),
             results_url: String::new(),
         };
         // A hand-edited file could also carry identity fields; they must not win.
@@ -4962,6 +5232,7 @@ mod tests {
                 cache: DEFAULT_DISCOVERY_HOST.to_string(),
                 bes: "bes.app.aspect.build".to_string(),
                 exec: String::new(),
+                api: String::new(),
                 results_url: String::new(),
             },
             aspect_bes_results_url: String::new(),
@@ -4987,11 +5258,10 @@ mod tests {
     }
 
     /// The invariant every endpoint-credential lookup rests on: a host resolves to
-    /// the *profile* its deployment's login is filed under, which is not the
-    /// deployment's name for Aspect Cloud. Getting this wrong sends a build to an
-    /// Aspect Cloud endpoint with no credential at all.
+    /// its deployment's name, and that name is the credential-store key. Getting it
+    /// wrong sends a build to an endpoint with no credential at all.
     #[test]
-    fn an_endpoint_resolves_to_its_deployments_profile_not_its_name() {
+    fn an_endpoint_resolves_to_the_key_its_deployment_filed_under() {
         let _guard = profile_env_guard();
         let mut seed = aspect_cloud_deployment();
         seed.endpoints.cache = "cache.aspect.build".to_string();
@@ -5000,16 +5270,66 @@ mod tests {
 
         let cloud = deployment_for_host(&deployments, "cache.aspect.build").expect("owned");
         assert_eq!(cloud.name, ASPECT_CLOUD_DEPLOYMENT_NAME);
-        // Compared against `resolve_profile`, not the literal: whatever the default
-        // profile resolves to is where the account files.
-        assert_eq!(login_profile_for(cloud), resolve_profile(None));
-        assert_ne!(login_profile_for(cloud), cloud.name);
+        // With no $ASPECT_AUTH_PROFILE override in play (see the guard above).
+        assert_eq!(login_profile_for(cloud), cloud.name);
 
-        // A self-hosted deployment's name *is* its profile.
         let acme = deployment_for_host(&deployments, "remote.acme.aspect.build").expect("owned");
-        assert_eq!(login_profile_for(acme), "acme");
+        assert_eq!(login_profile_for(acme), acme.name);
 
         assert!(deployment_for_host(&deployments, "cache.example.com").is_none());
+    }
+
+    /// `$ASPECT_API_TOKEN` is exchanged against Aspect Cloud's issuer, so it stands
+    /// in for Aspect Cloud's credential and no other. Getting this wrong breaks CI
+    /// logins silently, since CI sets the env var and never notices a credential
+    /// was not used.
+    #[test]
+    fn the_api_token_env_stands_in_for_aspect_cloud_only() {
+        let _guard = profile_env_guard();
+        // The key a bare login files under is the key the env token stands in for.
+        assert_eq!(
+            login_profile_for(&aspect_cloud_deployment()),
+            ASPECT_CLOUD_DEPLOYMENT_NAME
+        );
+        // And a self-hosted deployment's key is not it, so the account token can
+        // never be handed to a deployment on another issuer.
+        assert_ne!(
+            login_profile_for(&dep("acme", false)),
+            ASPECT_CLOUD_DEPLOYMENT_NAME
+        );
+    }
+
+    /// `$ASPECT_AUTH_PROFILE` has to steer where a login is filed *and* where the
+    /// credential helper reads it back, because the helper takes no flags. Both go
+    /// through `login_profile_for`, so one override covers both.
+    #[test]
+    fn the_profile_env_overrides_the_key_a_deployment_files_under() {
+        let _guard = profile_env_guard();
+        let saved = std::env::var(PROFILE_ENV).ok();
+
+        // SAFETY: single-threaded test body, guarded above, restored before return.
+        unsafe { std::env::set_var(PROFILE_ENV, "second-identity") };
+        assert_eq!(
+            login_profile_for(&aspect_cloud_deployment()),
+            "second-identity"
+        );
+        assert_eq!(login_profile_for(&dep("acme", false)), "second-identity");
+
+        // Empty reads as unset, so an exported-but-blank var does not send every
+        // login to a key named "".
+        unsafe { std::env::set_var(PROFILE_ENV, "") };
+        assert_eq!(
+            login_profile_for(&aspect_cloud_deployment()),
+            ASPECT_CLOUD_DEPLOYMENT_NAME
+        );
+
+        unsafe { std::env::remove_var(PROFILE_ENV) };
+        assert_eq!(login_profile_for(&dep("acme", false)), "acme");
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var(PROFILE_ENV, v) },
+            None => unsafe { std::env::remove_var(PROFILE_ENV) },
+        }
     }
 
     #[test]
@@ -5234,13 +5554,15 @@ mod tests {
         // rather than silently clear every default (which would send `--remote`
         // back to the account while reporting success).
         ds[0].default = true;
-        let err = apply_set_default(&mut ds, Some(DEFAULT_PROFILE)).unwrap_err();
+        let err = apply_set_default(&mut ds, Some(RESERVED_DEFAULT_NAME)).unwrap_err();
         assert!(err.to_string().contains("unknown deployment"), "{err}");
         assert!(ds[0].default, "`use default` must not clear the default");
     }
 
     #[test]
     fn summarize_deployment_reflects_credential_and_default() {
+        // Reads $ASPECT_AUTH_PROFILE through `login_profile_for`.
+        let _guard = profile_env_guard();
         let jwt = jwt_with_payload(r#"{"email":"u@x.io","name":"U"}"#);
         let mut creds = HashMap::new();
         creds.insert(
@@ -5255,6 +5577,7 @@ mod tests {
             cache: "remote.acme".to_string(),
             bes: "bes.acme".to_string(),
             exec: String::new(),
+            api: String::new(),
             results_url: "https://app.acme/i/".to_string(),
         };
         let s = summarize_deployment(&acme, &creds, true);

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -36,7 +36,7 @@ pub(crate) struct Deployment {
     #[serde(default, skip_serializing_if = "is_false")]
     default: bool,
     /// Whether this is the built-in Aspect Cloud entry rather than a configured
-    /// Aspect Workflows deployment. Set only by [`default_deployment`]; `#[serde(skip)]`
+    /// Aspect Workflows deployment. Set only by [`aspect_cloud_deployment`]; `#[serde(skip)]`
     /// keeps a hand-edited `config.json` from claiming account status and keeps the
     /// flag out of the written file.
     ///
@@ -87,7 +87,7 @@ pub(crate) struct Deployment {
 }
 
 /// The OAuth scopes the login flow requests when the deployment advertises none,
-/// and the set [`default_deployment`] states for the built-in Aspect Cloud entry.
+/// and the set [`aspect_cloud_deployment`] states for the built-in Aspect Cloud entry.
 /// A deployment that advertises its own set is authoritative and this does not
 /// apply to it. `offline_access` requests a refresh token so the credential renews
 /// without re-login; a provider that gates one differently (Google) advertises the
@@ -164,7 +164,28 @@ struct AuthEnv {
 /// and discovery fills in the endpoints it cannot know; a `config.json` entry
 /// under this name is folded in rather than replacing it, so the account can be
 /// extended but never redirected. See [`overlay_config_sources`].
-const DEFAULT_DEPLOYMENT_NAME: &str = "aspect";
+/// What Aspect Cloud calls itself — the name `auth status` shows, `--deployment`
+/// takes, and every Aspect Cloud edge advertises as RFC 9728 `resource_name`.
+///
+/// Deliberately not "default" anything: [`DEFAULT_PROFILE`] is the credential slot,
+/// and `Deployment::default` is which deployment `--remote` targets, which
+/// `auth use` can point at a configured one instead. Aspect Cloud is neither by
+/// definition.
+///
+/// The entry is still identified by its `builtin` flag rather than by this string
+/// (see [`Deployment::builtin`]); the name is what the user types.
+const ASPECT_CLOUD_DEPLOYMENT_NAME: &str = "aspect-cloud";
+
+/// A second name that addresses Aspect Cloud. Accepted wherever a deployment is
+/// named — `--deployment`, `--name` — and a `config.json` entry under it folds into
+/// the seed exactly as one under [`ASPECT_CLOUD_DEPLOYMENT_NAME`] does. Never written:
+/// anything the CLI records uses the canonical name, so a config carrying this one
+/// heals on the next discovery write.
+///
+/// Worth honouring on its own terms — it is the obvious short thing to type — and
+/// it is also what builds of #1429 wrote before Aspect Cloud took the name it
+/// advertises. Reserved, so no configured deployment can claim it.
+const ASPECT_CLOUD_DEPLOYMENT_ALIAS: &str = "aspect";
 const DEFAULT_ISSUER: &str = "https://auth.aspect.build";
 /// The account's PKCE client — the "Aspect Build" application client.
 ///
@@ -254,11 +275,21 @@ fn is_account_host(host: &str) -> bool {
 const ASPECT_DOMAIN_SUFFIX: &str = ".aspect.build";
 
 /// Names a configured deployment may not take, because each would shadow the
-/// built-in Aspect Cloud entry: [`DEFAULT_DEPLOYMENT_NAME`] is the account's own
+/// built-in Aspect Cloud entry: [`ASPECT_CLOUD_DEPLOYMENT_NAME`] is the account's own
 /// name, and [`DEFAULT_PROFILE`] is the credential profile the account files
 /// under (a deployment's credential is stored under its name, so a deployment
 /// named `default` would share the account's slot).
-const RESERVED_NAMES: &[&str] = &[DEFAULT_DEPLOYMENT_NAME, DEFAULT_PROFILE];
+const RESERVED_NAMES: &[&str] = &[
+    ASPECT_CLOUD_DEPLOYMENT_NAME,
+    ASPECT_CLOUD_DEPLOYMENT_ALIAS,
+    DEFAULT_PROFILE,
+];
+
+/// Whether `name` addresses the built-in Aspect Cloud entry — its own name, or its
+/// [`ASPECT_CLOUD_DEPLOYMENT_ALIAS`].
+fn names_the_account(name: &str) -> bool {
+    name == ASPECT_CLOUD_DEPLOYMENT_NAME || name == ASPECT_CLOUD_DEPLOYMENT_ALIAS
+}
 
 fn is_reserved_name(name: &str) -> bool {
     RESERVED_NAMES.contains(&name)
@@ -275,9 +306,12 @@ fn reserved_name_error(name: &str) -> anyhow::Error {
     )
 }
 
-fn default_deployment() -> Deployment {
+/// The built-in Aspect Cloud entry, re-created on every config load and enriched
+/// from `config.json` by [`merge_into_seed`]. Never read from disk: `builtin` is
+/// `#[serde(skip)]`, so this is the only thing that can produce one.
+fn aspect_cloud_deployment() -> Deployment {
     Deployment {
-        name: DEFAULT_DEPLOYMENT_NAME.to_string(),
+        name: ASPECT_CLOUD_DEPLOYMENT_NAME.to_string(),
         default: true,
         builtin: true,
         issuer: Some(DEFAULT_ISSUER.to_string()),
@@ -387,11 +421,11 @@ fn shadowed_deployments() -> anyhow::Result<Vec<ShadowedDeployment>> {
 fn overlay_config_sources(
     sources: Vec<ConfigSource>,
 ) -> (Vec<Deployment>, Vec<ShadowedDeployment>) {
-    let mut merged: Vec<Deployment> = vec![default_deployment()];
+    let mut merged: Vec<Deployment> = vec![aspect_cloud_deployment()];
     let mut shadowed: Vec<ShadowedDeployment> = Vec::new();
     for source in sources {
         for entry in source.entries {
-            if entry.name == DEFAULT_DEPLOYMENT_NAME {
+            if names_the_account(&entry.name) {
                 if let Some(seed) = merged.iter_mut().find(|d| d.builtin) {
                     merge_into_seed(seed, entry);
                 }
@@ -939,11 +973,12 @@ fn resolve_deployment_name(
 ) -> (String, bool) {
     let explicit = explicit.filter(|name| !name.is_empty());
     let account = match explicit.as_deref() {
-        Some(name) => name == DEFAULT_DEPLOYMENT_NAME,
+        Some(name) => names_the_account(name),
         None => is_account_host(host),
     };
     let name = explicit
-        .or_else(|| account.then(|| DEFAULT_DEPLOYMENT_NAME.to_string()))
+        .filter(|name| !names_the_account(name))
+        .or_else(|| account.then(|| ASPECT_CLOUD_DEPLOYMENT_NAME.to_string()))
         .or_else(|| advertised_name(info))
         .unwrap_or_else(|| deployment_name_from_host(host));
     (name, account)
@@ -1067,10 +1102,11 @@ fn upsert_deployment(
     //
     // The account's own name is writable, but only when the caller asked for it by
     // name: such an entry enriches the seed (see `overlay_config_sources`), which
-    // is what `configure --name aspect` is for. A name that merely *derives* to it
-    // — `remote.aspect.aspect.build` — is an accident, and is still refused so the
-    // user picks a real one rather than silently extending their account.
-    let permitted = explicit_account && deployment.name == DEFAULT_DEPLOYMENT_NAME;
+    // is what `configure --name aspect-cloud` is for. A name that merely *derives*
+    // to it — `remote.aspect-cloud.aspect.build` — is an accident, and is still
+    // refused so the user picks a real one rather than silently extending their
+    // account.
+    let permitted = explicit_account && deployment.name == ASPECT_CLOUD_DEPLOYMENT_NAME;
     if !permitted && is_reserved_name(&deployment.name) {
         return Err(reserved_name_error(&deployment.name));
     }
@@ -1249,12 +1285,12 @@ fn set_default_deployment(name: Option<&str>) -> anyhow::Result<()> {
 }
 
 /// Mutate a configured-deployment list (the file's contents, excluding the seed)
-/// so `name` is the sole default, or — for `None` or [`DEFAULT_DEPLOYMENT_NAME`] —
+/// so `name` is the sole default, or — for `None` or [`ASPECT_CLOUD_DEPLOYMENT_NAME`] —
 /// so no configured deployment is default. Errors if `name` is any other name
 /// absent from the list. See [`set_default_deployment`].
 ///
 /// This operates on the file, which never contains the seed, so it matches by name
-/// rather than the `builtin` flag: [`DEFAULT_DEPLOYMENT_NAME`] here means "the
+/// rather than the `builtin` flag: [`ASPECT_CLOUD_DEPLOYMENT_NAME`] here means "the
 /// account", expressed as the absence of a configured default.
 ///
 /// That one name is the sentinel, *not* all of [`RESERVED_NAMES`]. `default` is
@@ -1263,7 +1299,7 @@ fn set_default_deployment(name: Option<&str>) -> anyhow::Result<()> {
 /// quietly send `--remote` back to the account.
 fn apply_set_default(deployments: &mut [Deployment], name: Option<&str>) -> anyhow::Result<()> {
     // Selecting the built-in account (or None) means "no configured default".
-    let target = name.filter(|n| *n != DEFAULT_DEPLOYMENT_NAME);
+    let target = name.filter(|n| !names_the_account(n));
     if let Some(target) = target {
         if !deployments.iter().any(|d| d.name == target) {
             return Err(anyhow::anyhow!(
@@ -3255,7 +3291,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
     }
 
     /// Discover and record the Aspect Cloud endpoints the built-in entry fronts
-    /// ([`DEFAULT_DISCOVERY_HOST`] under [`DEFAULT_DEPLOYMENT_NAME`]), so a bare
+    /// ([`DEFAULT_DISCOVERY_HOST`] under [`ASPECT_CLOUD_DEPLOYMENT_NAME`]), so a bare
     /// `aspect auth login` leaves `--remote` working without a separate
     /// `auth configure`. Returns the same [`DeploymentInfo`] shape as
     /// [`Self::configure`]; the caller treats any non-`"ok"` status as "skip and
@@ -3279,14 +3315,14 @@ fn auth_methods(registry: &mut MethodsBuilder) {
     ) -> anyhow::Result<values::Value<'v>> {
         let info = configure_deployment(
             DEFAULT_DISCOVERY_HOST,
-            Some(DEFAULT_DEPLOYMENT_NAME.to_string()),
+            Some(ASPECT_CLOUD_DEPLOYMENT_NAME.to_string()),
             false,
             Some(DEFAULT_ISSUER.to_string()),
         )
         .unwrap_or_else(|e| DeploymentInfo {
             status: "not_recorded".to_string(),
             reason: e.to_string(),
-            name: DEFAULT_DEPLOYMENT_NAME.to_string(),
+            name: ASPECT_CLOUD_DEPLOYMENT_NAME.to_string(),
             can_login: false,
             is_default: false,
             hosts: Vec::new(),
@@ -3559,7 +3595,7 @@ mod tests {
 
     #[test]
     fn select_deployment_by_explicit_name() {
-        let deployments = vec![default_deployment(), dep("acme", false)];
+        let deployments = vec![aspect_cloud_deployment(), dep("acme", false)];
         assert_eq!(
             select_deployment(&deployments, Some("acme")).unwrap().name,
             "acme"
@@ -3570,24 +3606,24 @@ mod tests {
     #[test]
     fn select_deployment_with_no_name_uses_the_default_flag() {
         // Only the seed → the seed.
-        let seed_only = vec![default_deployment()];
+        let seed_only = vec![aspect_cloud_deployment()];
         assert_eq!(
             select_deployment(&seed_only, None).unwrap().name,
-            DEFAULT_DEPLOYMENT_NAME
+            ASPECT_CLOUD_DEPLOYMENT_NAME
         );
 
         // The entry marked default wins (upsert makes the first configured entry
         // default, so a single configured deployment is selected here).
-        let mut one = vec![default_deployment(), dep("acme", true)];
+        let mut one = vec![aspect_cloud_deployment(), dep("acme", true)];
         one[0].default = false;
         assert_eq!(select_deployment(&one, None).unwrap().name, "acme");
 
         // An explicit default on the seed is respected even with a configured
         // deployment present — configuring does not implicitly hijack selection.
-        let explicit_seed = vec![default_deployment(), dep("acme", false)];
+        let explicit_seed = vec![aspect_cloud_deployment(), dep("acme", false)];
         assert_eq!(
             select_deployment(&explicit_seed, None).unwrap().name,
-            DEFAULT_DEPLOYMENT_NAME
+            ASPECT_CLOUD_DEPLOYMENT_NAME
         );
     }
 
@@ -3596,11 +3632,11 @@ mod tests {
         // Even with a configured deployment marked default (the build default),
         // a bare auth login/logout targets Aspect Cloud (the seed) — the
         // default-deployment concept governs builds, not the account.
-        let mut ds = vec![default_deployment(), dep("acme", true)];
+        let mut ds = vec![aspect_cloud_deployment(), dep("acme", true)];
         ds[0].default = false;
         assert_eq!(
             select_account_or_deployment(&ds, None).unwrap().name,
-            DEFAULT_DEPLOYMENT_NAME
+            ASPECT_CLOUD_DEPLOYMENT_NAME
         );
         // An explicit name still picks that deployment.
         assert_eq!(
@@ -3641,7 +3677,7 @@ mod tests {
         // The built-in account → the default profile, with or without endpoints
         // (see `the_account_keeps_the_default_profile_once_it_has_endpoints`).
         assert_eq!(
-            login_profile_for(&default_deployment()),
+            login_profile_for(&aspect_cloud_deployment()),
             resolve_profile(None)
         );
         // Any configured deployment → its own name, hosts or not: it is a
@@ -3716,7 +3752,12 @@ mod tests {
         // Under Aspect's own domain the stripped remainder still can be reserved,
         // so derivation alone is not a guarantee — `upsert_deployment` rejects it.
         for (host, want) in [
-            ("remote.aspect.aspect.build", DEFAULT_DEPLOYMENT_NAME),
+            (
+                "remote.aspect-cloud.aspect.build",
+                ASPECT_CLOUD_DEPLOYMENT_NAME,
+            ),
+            // The alias is reserved too, so a host cannot derive its way onto it.
+            ("remote.aspect.aspect.build", ASPECT_CLOUD_DEPLOYMENT_ALIAS),
             ("remote.default.aspect.build", DEFAULT_PROFILE),
         ] {
             let name = deployment_name_from_host(host);
@@ -3729,12 +3770,16 @@ mod tests {
     #[test]
     fn upsert_deployment_rejects_reserved_names() {
         // The write choke point refuses a reserved name whatever its origin: an
-        // explicit `--deployment=aspect`, or a name derived from an
-        // `aspect.aspect.build`-style host.
+        // explicit `--deployment=aspect-cloud`, or a name derived from an
+        // `aspect-cloud.aspect.build`-style host.
         // Pin the membership as well as the behavior: iterating the constant keeps
         // this in sync as names are added, but would pass vacuously if it emptied.
-        assert!(RESERVED_NAMES.contains(&DEFAULT_DEPLOYMENT_NAME));
+        // Both of Aspect Cloud's names are its own — a configured deployment may
+        // take neither — as is the credential slot every deployment files under.
+        assert!(RESERVED_NAMES.contains(&ASPECT_CLOUD_DEPLOYMENT_NAME));
+        assert!(RESERVED_NAMES.contains(&ASPECT_CLOUD_DEPLOYMENT_ALIAS));
         assert!(RESERVED_NAMES.contains(&DEFAULT_PROFILE));
+        assert_eq!(RESERVED_NAMES, ["aspect-cloud", "aspect", "default"]);
 
         for name in RESERVED_NAMES {
             let mut existing = vec![dep("acme", true)];
@@ -3753,14 +3798,14 @@ mod tests {
     fn seed_identity_is_the_builtin_flag_not_the_name() {
         // A deployment merely *named* `aspect` is an ordinary deployment: only
         // the seed carries `builtin`.
-        assert!(default_deployment().builtin);
+        assert!(aspect_cloud_deployment().builtin);
         assert!(!dep("aspect", false).builtin);
 
         // ...so it is never mistaken for the account in a summary.
         let creds = HashMap::new();
         let impostor = summarize_deployment(&dep("aspect", false), &creds, false);
         assert!(!impostor.builtin);
-        let seed = summarize_deployment(&default_deployment(), &creds, false);
+        let seed = summarize_deployment(&aspect_cloud_deployment(), &creds, false);
         assert!(seed.builtin);
     }
 
@@ -3837,8 +3882,8 @@ mod tests {
         // The account's own name is never reported from either file: it merges
         // into the seed rather than shadowing it.
         let (_, found) = overlay_config_sources(vec![
-            src(REPO, vec![dep(DEFAULT_DEPLOYMENT_NAME, false)], false),
-            src(USER, vec![dep(DEFAULT_DEPLOYMENT_NAME, false)], true),
+            src(REPO, vec![dep(ASPECT_CLOUD_DEPLOYMENT_NAME, false)], false),
+            src(USER, vec![dep(ASPECT_CLOUD_DEPLOYMENT_NAME, false)], true),
         ]);
         assert!(found.is_empty());
     }
@@ -3857,7 +3902,7 @@ mod tests {
         ]);
         assert!(shadowed.is_empty());
         let names: Vec<_> = merged.iter().map(|d| d.name.as_str()).collect();
-        assert_eq!(names, [DEFAULT_DEPLOYMENT_NAME, "acme", "shared"]);
+        assert_eq!(names, [ASPECT_CLOUD_DEPLOYMENT_NAME, "acme", "shared"]);
         // The user entry won, so its `default` claim is the one that took effect.
         let shared = merged.iter().find(|d| d.name == "shared").unwrap();
         assert!(shared.default);
@@ -3887,7 +3932,7 @@ mod tests {
         // status, and keeps the flag out of the written file.
         let parsed: Deployment = serde_json::from_str(r#"{"name":"acme","builtin":true}"#).unwrap();
         assert!(!parsed.builtin);
-        let json = serde_json::to_string(&default_deployment()).unwrap();
+        let json = serde_json::to_string(&aspect_cloud_deployment()).unwrap();
         assert!(
             !json.contains("builtin"),
             "flag leaked into config.json: {json}"
@@ -4325,7 +4370,7 @@ mod tests {
     /// token is kept is independent of how the browser came back.
     #[test]
     fn the_account_relays_but_keeps_the_access_token() {
-        let mut seed = default_deployment();
+        let mut seed = aspect_cloud_deployment();
         // Seeded, so even a first login relays — no probe, nothing discovered.
         assert_eq!(
             login_redirect_uri(&seed).as_deref(),
@@ -4347,7 +4392,7 @@ mod tests {
     #[test]
     fn the_account_adopts_a_relay_only_from_its_own_issuer() {
         let seed_redirect = |issuer: &str| {
-            let mut e = dep(DEFAULT_DEPLOYMENT_NAME, false);
+            let mut e = dep(ASPECT_CLOUD_DEPLOYMENT_NAME, false);
             e.issuer = Some(issuer.to_string());
             e.login_redirect_uri = Some("https://app.aspect.build/auth/cli/callback".to_string());
             let (merged, _) = overlay_config_sources(vec![ConfigSource {
@@ -4404,14 +4449,18 @@ mod tests {
         );
         assert_eq!(advertised_name(&doc("   ")), None);
         assert_eq!(advertised_name(&doc("")), None);
-        // The CLI's own names are not a deployment's to take: `aspect` is the
-        // account, `default` the credential slot every deployment files under.
-        assert_eq!(advertised_name(&doc(DEFAULT_DEPLOYMENT_NAME)), None);
+        // The CLI's own names are not a deployment's to take: `aspect-cloud` is
+        // Aspect Cloud and `aspect` its alias, `default` the credential slot every
+        // deployment files under. Aspect Cloud
+        // advertises its own name, but its hosts never reach here — they resolve to
+        // the account first; see `parses_the_aspect_cloud_document_as_served`.
+        assert_eq!(advertised_name(&doc(ASPECT_CLOUD_DEPLOYMENT_NAME)), None);
+        assert_eq!(advertised_name(&doc(ASPECT_CLOUD_DEPLOYMENT_ALIAS)), None);
         assert_eq!(advertised_name(&doc(DEFAULT_PROFILE)), None);
 
         // `^[a-z][a-z0-9-]*$` — what the charts and Terraform modules enforce, so a
         // name reaching the CLI outside it means something upstream went wrong.
-        for ok in ["acme2", "a", "cci-test", "aspect-cloud"] {
+        for ok in ["acme2", "a", "cci-test", "acme-cloud"] {
             assert_eq!(advertised_name(&doc(ok)).as_deref(), Some(ok), "{ok}");
         }
         for bad in [
@@ -4462,16 +4511,20 @@ mod tests {
         // An Aspect Cloud host is the account, whatever it calls itself.
         assert_eq!(
             resolve_deployment_name(None, "cache.aspect.build", &named("Aspect Cloud")),
-            (DEFAULT_DEPLOYMENT_NAME.to_string(), true)
+            (ASPECT_CLOUD_DEPLOYMENT_NAME.to_string(), true)
         );
         // Typing the account's name claims it.
         assert_eq!(
-            resolve_deployment_name(Some(DEFAULT_DEPLOYMENT_NAME.to_string()), host, &named("x")),
-            (DEFAULT_DEPLOYMENT_NAME.to_string(), true)
+            resolve_deployment_name(
+                Some(ASPECT_CLOUD_DEPLOYMENT_NAME.to_string()),
+                host,
+                &named("x")
+            ),
+            (ASPECT_CLOUD_DEPLOYMENT_NAME.to_string(), true)
         );
         // A document may not claim the account by naming it.
         assert_eq!(
-            resolve_deployment_name(None, host, &named(DEFAULT_DEPLOYMENT_NAME)),
+            resolve_deployment_name(None, host, &named(ASPECT_CLOUD_DEPLOYMENT_NAME)),
             ("aws.awd-cci-test-dev".to_string(), false)
         );
     }
@@ -4518,14 +4571,45 @@ mod tests {
         );
         assert!(parsed.aspect_endpoints.serves_build_endpoints());
 
-        // Aspect Cloud calls itself `aspect-cloud`, but its hosts resolve to the
-        // account, whose name is structural — the built-in flag is the identity,
-        // not the name, so the advertised one is not applied there.
-        assert_eq!(advertised_name(&parsed).as_deref(), Some("aspect-cloud"));
+        // Aspect Cloud calls itself what the CLI now calls it, so the served
+        // document and `ASPECT_CLOUD_DEPLOYMENT_NAME` agree.
+        assert_eq!(parsed.resource_name, ASPECT_CLOUD_DEPLOYMENT_NAME);
+        // Its hosts resolve to the account without consulting the advertised name —
+        // identity is the `builtin` flag, not the string — and the name is reserved,
+        // so a host that is *not* Aspect Cloud's cannot claim it either.
+        assert_eq!(advertised_name(&parsed), None);
         assert_eq!(
             resolve_deployment_name(None, "bes.aspect.build", &parsed),
-            (DEFAULT_DEPLOYMENT_NAME.to_string(), true)
+            (ASPECT_CLOUD_DEPLOYMENT_NAME.to_string(), true)
         );
+    }
+
+    /// A `config.json` entry under the alias — which is what builds of #1429 wrote
+    /// — must fold into the seed rather than appear beside it as a second
+    /// deployment claiming Aspect Cloud's hosts.
+    #[test]
+    fn a_config_entry_under_the_alias_folds_into_the_seed() {
+        let mut aliased = dep(ASPECT_CLOUD_DEPLOYMENT_ALIAS, false);
+        aliased.hosts = vec!["cache.aspect.build".to_string()];
+        aliased.endpoints.cache = "cache.aspect.build".to_string();
+
+        let (merged, shadowed) = overlay_config_sources(vec![src(
+            "/home/u/.aspect/config.json",
+            vec![aliased],
+            true,
+        )]);
+
+        // Absorbed, not listed: one entry, and it is the seed under its own name.
+        assert_eq!(merged.len(), 1);
+        assert!(merged[0].builtin);
+        assert_eq!(merged[0].name, ASPECT_CLOUD_DEPLOYMENT_NAME);
+        assert_eq!(merged[0].endpoints.cache, "cache.aspect.build");
+        // Absorbing is not shadowing, so nothing is reported against the file.
+        assert!(shadowed.is_empty());
+
+        // The alias addresses the account too, so an explicit one resolves to the
+        // canonical entry rather than recording a stray deployment.
+        assert!(names_the_account(ASPECT_CLOUD_DEPLOYMENT_ALIAS));
     }
 
     /// A deployment's own advertised redirect wins over anything the CLI would
@@ -4739,7 +4823,7 @@ mod tests {
     /// `the_account_only_absorbs_endpoints_on_its_own_issuer`.
     #[test]
     fn the_account_name_is_writable_only_when_asked_for_by_name() {
-        let account = || dep(DEFAULT_DEPLOYMENT_NAME, false);
+        let account = || dep(ASPECT_CLOUD_DEPLOYMENT_NAME, false);
         assert!(upsert_deployment(&mut Vec::new(), account(), true).is_ok());
         assert!(upsert_deployment(&mut Vec::new(), account(), false).is_err());
         // The credential slot is refused however it is asked for.
@@ -4751,7 +4835,7 @@ mod tests {
     /// `auth status` shows one Aspect entry and `--remote` resolves it.
     #[test]
     fn an_account_named_entry_merges_into_the_seed() {
-        let mut entry = dep(DEFAULT_DEPLOYMENT_NAME, false);
+        let mut entry = dep(ASPECT_CLOUD_DEPLOYMENT_NAME, false);
         entry.hosts = vec!["remote.app.aspect.build".to_string()];
         entry.endpoints = Endpoints {
             cache: "remote.app.aspect.build".to_string(),
@@ -4773,7 +4857,7 @@ mod tests {
         assert_eq!(
             merged
                 .iter()
-                .filter(|d| d.name == DEFAULT_DEPLOYMENT_NAME)
+                .filter(|d| d.name == ASPECT_CLOUD_DEPLOYMENT_NAME)
                 .count(),
             1
         );
@@ -4795,7 +4879,7 @@ mod tests {
     #[test]
     fn the_account_adopts_a_client_discovered_on_its_own_issuer() {
         let entry_with = |issuer: &str, client_id: &str| {
-            let mut e = dep(DEFAULT_DEPLOYMENT_NAME, false);
+            let mut e = dep(ASPECT_CLOUD_DEPLOYMENT_NAME, false);
             e.issuer = Some(issuer.to_string());
             e.client_id = Some(client_id.to_string());
             e
@@ -4844,7 +4928,7 @@ mod tests {
     #[test]
     fn the_account_keeps_the_default_profile_once_it_has_endpoints() {
         let _guard = profile_env_guard();
-        let mut seed = default_deployment();
+        let mut seed = aspect_cloud_deployment();
         seed.hosts = vec!["remote.app.aspect.build".to_string()];
         // Compared against `resolve_profile`, not the literal: the invariant is that
         // the account files under whatever the default profile resolves to, and a
@@ -4909,13 +4993,13 @@ mod tests {
     #[test]
     fn an_endpoint_resolves_to_its_deployments_profile_not_its_name() {
         let _guard = profile_env_guard();
-        let mut seed = default_deployment();
+        let mut seed = aspect_cloud_deployment();
         seed.endpoints.cache = "cache.aspect.build".to_string();
         seed.hosts = vec!["cache.aspect.build".to_string()];
         let deployments = vec![seed, dep("acme", false)];
 
         let cloud = deployment_for_host(&deployments, "cache.aspect.build").expect("owned");
-        assert_eq!(cloud.name, DEFAULT_DEPLOYMENT_NAME);
+        assert_eq!(cloud.name, ASPECT_CLOUD_DEPLOYMENT_NAME);
         // Compared against `resolve_profile`, not the literal: whatever the default
         // profile resolves to is where the account files.
         assert_eq!(login_profile_for(cloud), resolve_profile(None));
@@ -5050,7 +5134,7 @@ mod tests {
 
     #[test]
     fn deployment_name_for_host_matches_owning_deployment() {
-        let deployments = vec![default_deployment(), dep("acme", false)];
+        let deployments = vec![aspect_cloud_deployment(), dep("acme", false)];
         // dep("acme") owns remote.acme.aspect.build.
         assert_eq!(
             deployment_name_for_host(&deployments, "remote.acme.aspect.build").as_deref(),
@@ -5111,13 +5195,13 @@ mod tests {
     #[test]
     fn reconcile_seed_default_yields_to_configured_default() {
         // Seed loads default=true; a configured default clears it.
-        let mut merged = vec![default_deployment(), dep("acme", true)];
+        let mut merged = vec![aspect_cloud_deployment(), dep("acme", true)];
         reconcile_seed_default(&mut merged);
         assert!(!merged[0].default, "seed yields to configured default");
         assert!(merged[1].default);
 
         // No configured default → the seed stays default (the fallback state).
-        let mut none_configured = vec![default_deployment(), dep("acme", false)];
+        let mut none_configured = vec![aspect_cloud_deployment(), dep("acme", false)];
         reconcile_seed_default(&mut none_configured);
         assert!(none_configured[0].default, "seed is the default fallback");
     }
@@ -5132,7 +5216,7 @@ mod tests {
 
         // Selecting the built-in seed clears every configured default (no
         // configured deployment is default → seed is the fallback).
-        apply_set_default(&mut ds, Some(DEFAULT_DEPLOYMENT_NAME)).unwrap();
+        apply_set_default(&mut ds, Some(ASPECT_CLOUD_DEPLOYMENT_NAME)).unwrap();
         assert!(ds.iter().all(|d| !d.default));
 
         // None also clears (the logged-out-of-default state).
@@ -5187,8 +5271,8 @@ mod tests {
         assert!(!s.logged_in && s.email.is_empty() && s.status.is_empty());
 
         // The built-in seed is default only when nothing configured claims it.
-        assert!(summarize_deployment(&default_deployment(), &creds, false).default);
-        assert!(!summarize_deployment(&default_deployment(), &creds, true).default);
+        assert!(summarize_deployment(&aspect_cloud_deployment(), &creds, false).default);
+        assert!(!summarize_deployment(&aspect_cloud_deployment(), &creds, true).default);
     }
 
     #[test]
@@ -5297,12 +5381,12 @@ mod tests {
         // expires like any other, so it asks for offline_access; without the scope an
         // expired cloud credential forces an interactive re-login, since the
         // issuer-agnostic refresh path has nothing to refresh from.
-        let scopes = auth_env_from(&default_deployment()).unwrap().scopes;
+        let scopes = auth_env_from(&aspect_cloud_deployment()).unwrap().scopes;
         assert!(scopes.iter().any(|s| s == "offline_access"));
         // One list, shared with the no-advertisement fallback.
         assert_eq!(scopes, DEFAULT_LOGIN_SCOPES);
         // And nothing extra on the wire: the cloud IdP gates refresh on the scope.
-        assert!(default_deployment().authorize_params.is_empty());
+        assert!(aspect_cloud_deployment().authorize_params.is_empty());
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -37,7 +37,7 @@ pub(crate) struct Deployment {
     default: bool,
     /// Whether this is the built-in Aspect Cloud entry rather than a configured
     /// Aspect Workflows deployment. Set only by [`aspect_cloud_deployment`]; `#[serde(skip)]`
-    /// keeps a hand-edited `config.json` from claiming account status and keeps the
+    /// keeps a hand-edited `config.json` from claiming Aspect Cloud status and keeps the
     /// flag out of the written file.
     ///
     /// Account identity is this flag, never the name, so a deployment that happens
@@ -48,7 +48,7 @@ pub(crate) struct Deployment {
     issuer: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     client_id: Option<String>,
-    /// Aspect-cloud API base (`ctx.aspect.auth.api_url`), used by Aspect-cloud
+    /// Aspect Cloud API base (`ctx.aspect.auth.api_url`), used by Aspect Cloud
     /// features (GitHub/GitLab token exchange, status comments, budget). Present
     /// only for the built-in Aspect Cloud entry; self-hosted deployments don't run
     /// these endpoints, so it is absent for configured deployments.
@@ -139,7 +139,7 @@ impl Endpoints {
     /// Distinct from [`Self::is_empty`], which also counts `results_url`: the
     /// build-result viewer advertises one alongside no cache or BES at all
     /// (`app.aspect.build` serves exactly that), and treating it as a deployment
-    /// would record an entry that cannot serve a build — and, under the account's
+    /// would record an entry that cannot serve a build — and, under Aspect Cloud's
     /// own name, would replace the endpoints that can.
     fn serves_build_endpoints(&self) -> bool {
         !self.cache.is_empty() || !self.bes.is_empty() || !self.exec.is_empty()
@@ -168,12 +168,12 @@ struct AuthEnv {
 /// Aspect Cloud, seeded so a fresh install can `aspect auth login` with no
 /// `configure` step. The seed states the identity — issuer, PKCE client, API —
 /// and discovery fills in the endpoints it cannot know; a `config.json` entry
-/// under this name is folded in rather than replacing it, so the account can be
+/// under this name is folded in rather than replacing it, so Aspect Cloud can be
 /// extended but never redirected. See [`overlay_config_sources`].
 /// What Aspect Cloud calls itself — the name `auth status` shows, `--deployment`
 /// takes, and every Aspect Cloud edge advertises as RFC 9728 `resource_name`.
 ///
-/// Deliberately not "default" anything: [`RESERVED_DEFAULT_NAME`] is the credential slot,
+/// Deliberately not "default" anything: [`DEFAULT_PROFILE`] is the credential slot,
 /// and `Deployment::default` is which deployment `--remote` targets, which
 /// `auth use` can point at a configured one instead. Aspect Cloud is neither by
 /// definition.
@@ -217,32 +217,32 @@ const DEFAULT_LOGIN_REDIRECT_URI: &str = "https://app.aspect.build/auth/cli/call
 /// `aspect auth configure` by hand — see [`configure_default`].
 ///
 /// The API rather than a cache/BES edge: every Aspect Cloud resource advertises
-/// the same capability map, so any would serve, but this one is the account's own
+/// the same capability map, so any would serve, but this one is Aspect Cloud's own
 /// ([`DEFAULT_API_URL`]) and so is the least likely to be renamed out from under
 /// the CLI — which the edges have been.
 ///
-/// What it finds is recorded under the account's own name, not a second one, so
+/// What it finds is recorded under Aspect Cloud's own name, not a second one, so
 /// `auth status` shows a single entry and `--remote` needs no `--deployment`.
 const DEFAULT_DISCOVERY_HOST: &str = "api.aspect.build";
 
 /// The hosts Aspect Cloud serves itself. `configure` records their endpoints on
-/// the built-in account rather than deriving a deployment name from the host, so
+/// the built-in Aspect Cloud entry rather than deriving a deployment name from the host, so
 /// `aspect auth configure cache.aspect.build` lands in the same place as a bare
-/// login instead of creating a `cache` deployment beside the account.
+/// login instead of creating a `cache` deployment beside Aspect Cloud.
 ///
 /// An allowlist rather than "anything on [`DEFAULT_ISSUER`]": the issuer is the
 /// right *safety* check (see [`configure_deployment`]) but too broad an identity
-/// one — a future Aspect-hosted deployment sharing that issuer would silently
-/// absorb into the account. An explicit `--name` still wins, so a second entry
+/// one — a future Aspect Cloud deployment sharing that issuer would silently
+/// absorb into Aspect Cloud. An explicit `--name` still wins, so a second entry
 /// for these hosts stays possible when someone wants one.
 ///
 /// `exec` and `remote` are listed ahead of resolving anywhere: `exec` arrives with
 /// remote execution, and `remote` may return as a single multiplexed endpoint.
 /// Naming them costs nothing — configuring a host that does not resolve fails as
 /// unreachable either way — while a host *missing* from this list becomes a stray
-/// deployment beside the account the day it ships. Do not prune them for looking
+/// deployment beside Aspect Cloud the day it ships. Do not prune them for looking
 /// dead.
-const ACCOUNT_HOSTS: &[&str] = &[
+const ASPECT_CLOUD_HOSTS: &[&str] = &[
     "api.aspect.build",
     "app.aspect.build",
     "bes.aspect.build",
@@ -254,45 +254,46 @@ const ACCOUNT_HOSTS: &[&str] = &[
 /// The regional aliases of those same endpoints — `bes.us.aspect.build`,
 /// `api.eu.aspect.build`, and so on. They answer with the global names in their
 /// discovery document, but a user may well configure the host they were handed,
-/// so every service under a region resolves to the account.
+/// so every service under a region resolves to Aspect Cloud.
 ///
 /// Matched as a suffix so this covers each service in a region without naming the
 /// cross product, but the regions themselves are enumerated: an unknown
 /// `<service>.<anything>.aspect.build` is far more likely to be another
-/// Aspect-hosted deployment than a new region, and absorbing one of those into
-/// the account is the failure this allowlist exists to prevent. A genuinely new
+/// Aspect Cloud deployment than a new region, and absorbing one of those into
+/// Aspect Cloud is the failure this allowlist exists to prevent. A genuinely new
 /// region is a one-line change here.
-const ACCOUNT_HOST_SUFFIXES: &[&str] = &[".us.aspect.build", ".eu.aspect.build"];
+const ASPECT_CLOUD_HOST_SUFFIXES: &[&str] = &[".us.aspect.build", ".eu.aspect.build"];
 
-/// Whether `host` is served by Aspect Cloud itself — see [`ACCOUNT_HOSTS`].
+/// Whether `host` is served by Aspect Cloud itself — see [`ASPECT_CLOUD_HOSTS`].
 /// `host` is already normalized by [`endpoint_host_str`]; the trailing dot of an
 /// absolute FQDN is stripped so `app.aspect.build.` still matches.
-fn is_account_host(host: &str) -> bool {
+fn is_aspect_cloud_host(host: &str) -> bool {
     let host = host.trim_end_matches('.').to_ascii_lowercase();
-    ACCOUNT_HOSTS.contains(&host.as_str())
-        || ACCOUNT_HOST_SUFFIXES.iter().any(|s| host.ends_with(s))
+    ASPECT_CLOUD_HOSTS.contains(&host.as_str())
+        || ASPECT_CLOUD_HOST_SUFFIXES.iter().any(|s| host.ends_with(s))
 }
 
-/// The dot-anchored suffix for Aspect's own domain, which Aspect-hosted endpoints
+/// The dot-anchored suffix for Aspect's own domain, which Aspect Cloud endpoints
 /// sit under (`remote.<deployment>.aspect.build`).
-/// [`deployment_name_from_host`] strips it so an Aspect-hosted endpoint yields a
+/// [`deployment_name_from_host`] strips it so an Aspect Cloud endpoint yields a
 /// bare deployment name, while a self-hosted one keeps its full domain.
 const ASPECT_DOMAIN_SUFFIX: &str = ".aspect.build";
 
-/// Names a configured deployment may not take, because each would shadow the
-/// built-in Aspect Cloud entry: [`ASPECT_CLOUD_DEPLOYMENT_NAME`] is the account's own
-/// name, and [`RESERVED_DEFAULT_NAME`] is the credential profile the account files
-/// under (a deployment's credential is stored under its name, so a deployment
-/// named `default` would share the account's slot).
+/// Names a configured deployment may not take. The first two are Aspect Cloud's
+/// own ([`ASPECT_CLOUD_DEPLOYMENT_NAME`] and [`ASPECT_CLOUD_DEPLOYMENT_ALIAS`]), so
+/// an entry under either would shadow it. [`DEFAULT_PROFILE`] is the profile a
+/// login lands in when none is named, and the word `auth use` uses for the default
+/// deployment, so a deployment called `default` would read ambiguously against
+/// both.
 const RESERVED_NAMES: &[&str] = &[
     ASPECT_CLOUD_DEPLOYMENT_NAME,
     ASPECT_CLOUD_DEPLOYMENT_ALIAS,
-    RESERVED_DEFAULT_NAME,
+    DEFAULT_PROFILE,
 ];
 
 /// Whether `name` addresses the built-in Aspect Cloud entry — its own name, or its
 /// [`ASPECT_CLOUD_DEPLOYMENT_ALIAS`].
-fn names_the_account(name: &str) -> bool {
+fn names_aspect_cloud(name: &str) -> bool {
     name == ASPECT_CLOUD_DEPLOYMENT_NAME || name == ASPECT_CLOUD_DEPLOYMENT_ALIAS
 }
 
@@ -302,7 +303,7 @@ fn is_reserved_name(name: &str) -> bool {
 
 /// The error for a configured deployment claiming a [`RESERVED_NAMES`] entry,
 /// whether the name came from an explicit `--deployment` or was derived from an
-/// Aspect-hosted endpoint (see [`deployment_name_from_host`]). Either way the
+/// Aspect Cloud endpoint (see [`deployment_name_from_host`]). Either way the
 /// remedy is an explicit name, so the message asks for one.
 fn reserved_name_error(name: &str) -> anyhow::Error {
     anyhow::anyhow!(
@@ -399,8 +400,8 @@ fn config_sources() -> anyhow::Result<Vec<ConfigSource>> {
 /// Overlay is by `name` (a later entry replaces an earlier one), so a user can
 /// override a repo-declared deployment. The seed is the exception — an entry
 /// claiming a [`RESERVED_NAMES`] name is skipped rather than allowed to replace
-/// it, since shadowing the account is silent and confusing (`auth status` would
-/// render the impostor in the account's section).
+/// it, since shadowing Aspect Cloud is silent and confusing (`auth status` would
+/// render the impostor in Aspect Cloud's section).
 ///
 /// Skipping rather than erroring keeps a config that already holds such an entry
 /// usable: erroring would fail *every* auth command, including the `auth remove`
@@ -430,7 +431,7 @@ fn overlay_config_sources(
     let mut shadowed: Vec<ShadowedDeployment> = Vec::new();
     for source in sources {
         for entry in source.entries {
-            if names_the_account(&entry.name) {
+            if names_aspect_cloud(&entry.name) {
                 if let Some(seed) = merged.iter_mut().find(|d| d.builtin) {
                     merge_into_seed(seed, entry);
                 }
@@ -465,20 +466,20 @@ fn overlay_config_sources(
     (merged, shadowed)
 }
 
-/// Fold a `config.json` entry under the account's own name into the seed.
+/// Fold a `config.json` entry under Aspect Cloud's own name into the seed.
 ///
 /// An enrichment, not a shadow: Aspect Cloud's endpoints are discovered rather
 /// than compiled in, so `configure_default` records them under that name and this
 /// puts them back on the entry they belong to.
 ///
 /// The endpoints are taken unconditionally. The PKCE client and login redirect are
-/// taken only from an entry naming the account's own issuer, which is the whole
+/// taken only from an entry naming Aspect Cloud's own issuer, which is the whole
 /// safety argument: each is only ever exercised against the issuer it was
 /// discovered from, so one taken from a document on [`DEFAULT_ISSUER`] cannot send
 /// a login anywhere new. What that buys is rotation without a CLI release.
 ///
 /// The issuer and `api_url` are never taken, so a hand-edited config can extend
-/// the account but cannot redirect its login. Neither are scopes or
+/// Aspect Cloud but cannot redirect its login. Neither are scopes or
 /// `authorize_params`: the seed states its own, and widening the adopted set is a
 /// separate decision from rotating the client.
 fn merge_into_seed(seed: &mut Deployment, entry: Deployment) {
@@ -559,9 +560,9 @@ pub(crate) fn select_deployment(
 /// *account* by default rather than the default *deployment*: an explicit
 /// `name` picks that deployment (erroring if unknown); an empty `name` resolves
 /// the built-in Aspect Cloud entry (the seed). The default-deployment concept (set by
-/// `auth use`) governs builds (`--remote`), not the account login — so a
-/// bare `auth login` always means the account, never a configured default.
-fn select_account_or_deployment(
+/// `auth use`) governs builds (`--remote`), not the Aspect Cloud login — so a
+/// bare `auth login` always means Aspect Cloud, never a configured default.
+fn select_aspect_cloud_or_deployment(
     deployments: &[Deployment],
     name: Option<&str>,
 ) -> anyhow::Result<Deployment> {
@@ -961,9 +962,9 @@ fn transport_error_reason(e: &reqwest::Error) -> String {
 /// Only Aspect's own domain is stripped, because only there does the remainder
 /// name the deployment; a self-hosted host keeps its full domain, which reads
 /// unambiguously and can never collide with [`RESERVED_NAMES`]
-/// (`remote.aspect.foo.com` → `aspect.foo.com`, not the account's `aspect`).
+/// (`remote.aspect.foo.com` → `aspect.foo.com`, not Aspect Cloud's `aspect`).
 ///
-/// An Aspect-hosted host still can collide — `remote.aspect.aspect.build` →
+/// An Aspect Cloud host still can collide — `remote.aspect.aspect.build` →
 /// `aspect` — so this does not itself guarantee a usable name;
 /// [`upsert_deployment`] rejects a reserved one.
 ///
@@ -988,16 +989,16 @@ fn deployment_name_from_host(host: &str) -> String {
 }
 
 /// The name to record a discovered deployment under, and whether that name claims
-/// the account.
+/// Aspect Cloud.
 ///
-/// In precedence: the name the user typed, then the account when the host is one
+/// In precedence: the name the user typed, then Aspect Cloud when the host is one
 /// Aspect Cloud serves, then the name the deployment advertises
 /// ([`advertised_name`]), then one derived from the host.
 ///
-/// The account is claimed only by naming it or by configuring an Aspect Cloud host.
-/// A name that merely *derives* to it (`remote.aspect.aspect.build` → `aspect`) is
-/// not the account and is refused by [`upsert_deployment`], so nobody extends their
-/// account by accident.
+/// Aspect Cloud is claimed only by naming it or by configuring one of its hosts. A
+/// name that merely *derives* to it (`remote.aspect-cloud.aspect.build` →
+/// `aspect-cloud`) is refused by [`upsert_deployment`], so nobody extends Aspect
+/// Cloud by accident.
 fn resolve_deployment_name(
     explicit: Option<String>,
     host: &str,
@@ -1005,11 +1006,11 @@ fn resolve_deployment_name(
 ) -> (String, bool) {
     let explicit = explicit.filter(|name| !name.is_empty());
     let account = match explicit.as_deref() {
-        Some(name) => names_the_account(name),
-        None => is_account_host(host),
+        Some(name) => names_aspect_cloud(name),
+        None => is_aspect_cloud_host(host),
     };
     let name = explicit
-        .filter(|name| !names_the_account(name))
+        .filter(|name| !names_aspect_cloud(name))
         .or_else(|| account.then(|| ASPECT_CLOUD_DEPLOYMENT_NAME.to_string()))
         .or_else(|| advertised_name(info))
         .unwrap_or_else(|| deployment_name_from_host(host));
@@ -1128,10 +1129,10 @@ fn deployment_from_discovery(
 fn upsert_deployment(
     existing: &mut Vec<Deployment>,
     mut deployment: Deployment,
-    explicit_account: bool,
+    explicit_aspect_cloud: bool,
 ) -> anyhow::Result<bool> {
     // `default` is a credential-store key, never a deployment name: an entry under
-    // it would share the account's credential slot, so it is refused outright.
+    // it would share Aspect Cloud's credential slot, so it is refused outright.
     //
     // The account's own name is writable, but only when the caller asked for it by
     // name: such an entry enriches the seed (see `overlay_config_sources`), which
@@ -1139,7 +1140,7 @@ fn upsert_deployment(
     // to it — `remote.aspect-cloud.aspect.build` — is an accident, and is still
     // refused so the user picks a real one rather than silently extending their
     // account.
-    let permitted = explicit_account && deployment.name == ASPECT_CLOUD_DEPLOYMENT_NAME;
+    let permitted = explicit_aspect_cloud && deployment.name == ASPECT_CLOUD_DEPLOYMENT_NAME;
     if !permitted && is_reserved_name(&deployment.name) {
         return Err(reserved_name_error(&deployment.name));
     }
@@ -1183,9 +1184,12 @@ fn write_user_config(deployments: Vec<Deployment>) -> anyhow::Result<()> {
 
 /// Write (or replace by name) a deployment in the user's `~/.aspect/config.json`
 /// via [`upsert_deployment`]. Returns whether the written record is the default.
-fn save_user_deployment(deployment: Deployment, explicit_account: bool) -> anyhow::Result<bool> {
+fn save_user_deployment(
+    deployment: Deployment,
+    explicit_aspect_cloud: bool,
+) -> anyhow::Result<bool> {
     let mut existing = load_config_file(&config_path()?)?;
-    let is_default = upsert_deployment(&mut existing, deployment, explicit_account)?;
+    let is_default = upsert_deployment(&mut existing, deployment, explicit_aspect_cloud)?;
     write_user_config(existing)?;
     Ok(is_default)
 }
@@ -1193,7 +1197,7 @@ fn save_user_deployment(deployment: Deployment, explicit_account: bool) -> anyho
 /// Discover `host`'s deployment and record it in the user's `config.json`,
 /// returning the [`DeploymentInfo`] the `configure` task renders. Shared by
 /// [`Auth::configure`] (a host the user typed) and [`Auth::configure_default`]
-/// (the compiled-in Aspect-hosted endpoint).
+/// (the compiled-in Aspect Cloud endpoint).
 ///
 /// The returned `status` distinguishes every outcome the caller reports:
 /// `"unreachable"` (transport failure, `reason` carries a terse cause),
@@ -1230,15 +1234,15 @@ fn configure_deployment(
         Discovery::Unreachable(reason) => return Ok(mk("unreachable", reason)),
         Discovery::NotADeployment => return Ok(mk("not_a_deployment", String::new())),
     };
-    let (name, explicit_account) = resolve_deployment_name(name, &host, &info);
-    // Endpoints recorded under the account's own name are folded into the seed and
-    // reached with the account's own credential, so only a deployment on the
+    let (name, explicit_aspect_cloud) = resolve_deployment_name(name, &host, &info);
+    // Endpoints recorded under Aspect Cloud's own name are folded into the seed and
+    // reached with Aspect Cloud's own credential, so only a deployment on the
     // account's issuer may claim them: `hosts` is the auth gate, and a host on some
-    // other issuer would be handed the account's bearer. Pinning here — rather than
+    // other issuer would be handed Aspect Cloud's bearer. Pinning here — rather than
     // refusing the name outright — is what lets `configure --name aspect` do
     // exactly what a bare login's discovery does. A host that does not advertise
     // this issuer comes back `issuer_not_advertised` and records nothing.
-    let requested = if explicit_account {
+    let requested = if explicit_aspect_cloud {
         Some(DEFAULT_ISSUER.to_string())
     } else {
         issuer.filter(|s| !s.is_empty())
@@ -1247,7 +1251,7 @@ fn configure_deployment(
     // Hand the advertised choices back so the task can prompt from them or list
     // the valid values when `--issuer` names one that isn't advertised.
     // `reason` carries the issuer actually looked for, which is not always the one
-    // the user typed: the account's is pinned (above), so an empty `--issuer` would
+    // the user typed: Aspect Cloud's is pinned (above), so an empty `--issuer` would
     // otherwise be reported back as `''`.
     let with_candidates = |status: &str| DeploymentInfo {
         status: status.to_string(),
@@ -1271,7 +1275,7 @@ fn configure_deployment(
     deployment.default = make_default;
     let can_login = deployment.issuer.is_some() && deployment.client_id.is_some();
     let hosts = deployment.hosts.clone();
-    let is_default = save_user_deployment(deployment, explicit_account)?;
+    let is_default = save_user_deployment(deployment, explicit_aspect_cloud)?;
     Ok(DeploymentInfo {
         status: "ok".to_string(),
         reason: String::new(),
@@ -1286,7 +1290,7 @@ fn configure_deployment(
 /// Drop the entry named `name` from a configured-deployment list (the file's
 /// contents, which never include the seed).
 ///
-/// A [`RESERVED_NAMES`] name means the built-in account — and is refused — *unless*
+/// A [`RESERVED_NAMES`] name means the built-in Aspect Cloud entry — and is refused — *unless*
 /// the file really holds an entry under it, which is how a shadowed `config.json`
 /// is cleaned up.
 fn apply_remove(deployments: &mut Vec<Deployment>, name: &str) -> anyhow::Result<()> {
@@ -1327,12 +1331,12 @@ fn set_default_deployment(name: Option<&str>) -> anyhow::Result<()> {
 /// account", expressed as the absence of a configured default.
 ///
 /// That one name is the sentinel, *not* all of [`RESERVED_NAMES`]. `default` is
-/// reserved from being configured but is not the account, so `auth use default`
+/// reserved from being configured but is not Aspect Cloud, so `auth use default`
 /// must fail the unknown-deployment check rather than clear every default and
-/// quietly send `--remote` back to the account.
+/// quietly send `--remote` back to Aspect Cloud.
 fn apply_set_default(deployments: &mut [Deployment], name: Option<&str>) -> anyhow::Result<()> {
-    // Selecting the built-in account (or None) means "no configured default".
-    let target = name.filter(|n| !names_the_account(n));
+    // Selecting the built-in Aspect Cloud entry (or None) means "no configured default".
+    let target = name.filter(|n| !names_aspect_cloud(n));
     if let Some(target) = target {
         if !deployments.iter().any(|d| d.name == target) {
             return Err(anyhow::anyhow!(
@@ -1348,11 +1352,11 @@ fn apply_set_default(deployments: &mut [Deployment], name: Option<&str>) -> anyh
 }
 
 /// Forget a configured deployment: drop its `~/.aspect/config.json` entry and its
-/// stored credential. Errors on an unknown name. The built-in account isn't in the
+/// stored credential. Errors on an unknown name. The built-in Aspect Cloud entry isn't in the
 /// file, so it can't be removed — but a *file entry* under a reserved name can be,
 /// which is the only way to clear one (the loader skips such entries). When the
 /// removed deployment was the default, the file simply has no default afterward
-/// (selection falls back to the account).
+/// (selection falls back to Aspect Cloud).
 fn remove_deployment(name: &str) -> anyhow::Result<()> {
     let mut existing = load_config_file(&config_path()?)?;
     apply_remove(&mut existing, name)?;
@@ -1385,7 +1389,7 @@ struct CredentialsEntry {
     auth_client_id: Option<String>,
     // True when this session's bearer is the OIDC id_token (the self-hosted
     // endpoint flow), so a subsequent refresh keeps minting an id_token rather
-    // than downgrading to the access_token. Absent/false for the Aspect-cloud
+    // than downgrading to the access_token. Absent/false for the Aspect Cloud
     // flow (access_token bearer). Defaulted so entries written before this field
     // existed load as cloud sessions.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -1454,34 +1458,53 @@ fn load_credential(profile: &str, deployment: &str) -> anyhow::Result<Option<Cre
         .cloned())
 }
 
-/// File `entry` for `deployment` under `profile`, leaving every other profile and
-/// every other deployment in this one untouched.
+/// Put `entry` at `(profile, deployment)`, leaving every other profile and every
+/// other deployment in this one untouched. Split from [`store_credential`] so the
+/// nesting is testable without a credential store behind it.
+fn insert_credential(
+    all: &mut AllCredentials,
+    profile: &str,
+    deployment: &str,
+    entry: CredentialsEntry,
+) {
+    all.entry(profile.to_string())
+        .or_default()
+        .insert(deployment.to_string(), entry);
+}
+
+/// Drop `(profile, deployment)`, and the profile itself once it holds nothing — an
+/// empty profile is indistinguishable from an absent one, and leaving the husk
+/// would have a profile with no logins show up wherever profiles are listed.
+/// Returns whether anything was removed.
+fn remove_credential(all: &mut AllCredentials, profile: &str, deployment: &str) -> bool {
+    let Some(entries) = all.get_mut(profile) else {
+        return false;
+    };
+    if entries.remove(deployment).is_none() {
+        return false;
+    }
+    if entries.is_empty() {
+        all.remove(profile);
+    }
+    true
+}
+
+/// File `entry` for `deployment` under `profile`.
 fn store_credential(
     profile: &str,
     deployment: &str,
     entry: CredentialsEntry,
 ) -> anyhow::Result<()> {
     let mut all = load_all_credentials()?;
-    all.entry(profile.to_string())
-        .or_default()
-        .insert(deployment.to_string(), entry);
+    insert_credential(&mut all, profile, deployment, entry);
     save_all_credentials(&all)
 }
 
-/// Drop one deployment's credential from `profile`, and the profile itself once it
-/// holds nothing — an empty profile is indistinguishable from an absent one, and
-/// leaving the husk would have `auth status` list a profile with no logins.
-/// Returns whether anything was removed.
+/// Clear `profile`'s credential for `deployment`. Returns whether there was one.
 fn forget_credential(profile: &str, deployment: &str) -> anyhow::Result<bool> {
     let mut all = load_all_credentials()?;
-    let Some(entries) = all.get_mut(profile) else {
+    if !remove_credential(&mut all, profile, deployment) {
         return Ok(false);
-    };
-    if entries.remove(deployment).is_none() {
-        return Ok(false);
-    }
-    if entries.is_empty() {
-        all.remove(profile);
     }
     save_all_credentials(&all)?;
     Ok(true)
@@ -1940,7 +1963,7 @@ async fn accept_callback(listener: TcpListener) -> anyhow::Result<(String, Optio
 
 /// An OAuth token response. The bearer the CLI attaches to endpoints is the
 /// `id_token` when present (self-hosted edges validate the OIDC id_token), else
-/// the `access_token` (the Aspect-cloud flow).
+/// the `access_token` (the Aspect Cloud flow).
 #[derive(Deserialize)]
 struct TokenResponse {
     #[serde(default)]
@@ -1957,7 +1980,7 @@ impl TokenResponse {
     /// id_token and error if the grant omitted it, rather than silently returning
     /// the access_token: a refresh grant that drops the id_token (permitted by RFC
     /// 6749 §5.1) would otherwise downgrade a working session to a bearer the edge
-    /// rejects with 401. When not preferring the id_token (the Aspect-cloud flow,
+    /// rejects with 401. When not preferring the id_token (the Aspect Cloud flow,
     /// which validates the access_token), return the access_token, falling back to
     /// the id_token only if the access_token is absent.
     fn bearer(self, prefer_id_token: bool) -> anyhow::Result<String> {
@@ -2380,16 +2403,13 @@ fn merged_refresh_token(prior: &str, fresh: &str) -> String {
     }
 }
 
-/// The `aspect auth login` invocation that re-authenticates `profile`, naming
-/// the deployment so the hint doesn't assume the default. A self-hosted
-/// deployment stores under its name, so the profile is the deployment name and
-/// gets an explicit `--deployment`; the default profile (the built-in Aspect
-/// deployment, or a `$ASPECT_AUTH_PROFILE`) gets a bare `login`.
-pub fn login_hint(profile: &str) -> String {
-    if profile == ASPECT_CLOUD_DEPLOYMENT_NAME {
+/// The `aspect auth login` invocation that re-authenticates `deployment`. Aspect
+/// Cloud is what a bare `login` targets; anything else needs naming.
+pub fn login_hint(deployment: &str) -> String {
+    if deployment == ASPECT_CLOUD_DEPLOYMENT_NAME {
         "aspect auth login".to_string()
     } else {
-        format!("aspect auth login --deployment {profile}")
+        format!("aspect auth login --deployment {deployment}")
     }
 }
 
@@ -2422,32 +2442,34 @@ fn classify_token(entry: &CredentialsEntry) -> TokenAction {
     }
 }
 
-/// Environment variable naming the credentials profile to use when no explicit
-/// profile is given. The single selector shared by the `auth` tasks and the
-/// Bazel credential helper (which has no way to pass a flag), so one
-/// `export ASPECT_AUTH_PROFILE=...` drives both.
+/// Environment variable naming the profile to use when `--profile` is not given.
+/// The single selector shared by the `auth` tasks and the Bazel credential helper
+/// (which has no way to pass a flag), so one `export ASPECT_AUTH_PROFILE=...`
+/// drives both.
 pub const PROFILE_ENV: &str = "ASPECT_AUTH_PROFILE";
 
-/// Reserved as a deployment name: it is the word `auth use` and `auth status` use
-/// for *which* deployment `--remote` targets, so a deployment actually called
-/// `default` would make `aspect auth use default` ambiguous.
-const RESERVED_DEFAULT_NAME: &str = "default";
+/// The profile holding a login when none is named.
+///
+/// Also reserved as a deployment name: it is the word `auth use` and `auth status`
+/// use for *which* deployment `--remote` targets, so a deployment actually called
+/// `default` would be ambiguous against both this and `aspect auth use default`.
+const DEFAULT_PROFILE: &str = "default";
 
-/// Resolve the effective credential-store key: an explicit (non-empty) value wins,
-/// then [`PROFILE_ENV`] (non-empty), then Aspect Cloud's own name. An empty
+/// Resolve the profile — the identity a credential is filed under. An explicit
+/// (non-empty) value wins, then [`PROFILE_ENV`], then [`DEFAULT_PROFILE`]. An empty
 /// `explicit` is treated as absent (the `auth` tasks pass `""` when `--profile` is
 /// omitted), so it still falls through to the env var.
 ///
-/// The final fallback is Aspect Cloud because that is what "no deployment named"
-/// means everywhere else in the CLI. A caller that knows its deployment passes the
-/// name instead — see [`login_profile_for`].
+/// This is one of the credential store's two axes and answers *who*; the other is
+/// the deployment, which answers *what you are talking to* — see
+/// [`login_profile_for`] and [`AllCredentials`].
 pub fn resolve_profile(explicit: Option<&str>) -> String {
     let non_empty = |s: String| (!s.is_empty()).then_some(s);
     explicit
         .map(str::to_owned)
         .and_then(non_empty)
         .or_else(|| std::env::var(PROFILE_ENV).ok().and_then(non_empty))
-        .unwrap_or_else(|| ASPECT_CLOUD_DEPLOYMENT_NAME.to_owned())
+        .unwrap_or_else(|| DEFAULT_PROFILE.to_owned())
 }
 
 /// Which configured deployment owns the endpoint `uri`, for the credential helper.
@@ -3036,10 +3058,27 @@ fn deployment_summary_methods(registry: &mut MethodsBuilder) {
 /// (`builtin`) plus every configured deployment, each tagged with whether it is
 /// the default and whether a credential is stored under its profile. The account
 /// is always included (the `auth status` task renders it in its own section, logged
-/// in or not); when no configured deployment is the default, the account is the
+/// in or not); when no configured deployment is the default, Aspect Cloud is the
 /// effective default (matching [`select_deployment`]).
-fn list_deployment_summaries() -> anyhow::Result<Vec<DeploymentSummary>> {
+/// Everything [`summarize_deployment`] needs, read once: the configured
+/// deployments, the selected profile's credentials, and whether any configured
+/// deployment claims the default (which decides whether Aspect Cloud shows as it).
+///
+/// The credentials are the selected profile's alone — a login held by another
+/// identity is not one this shell can use, so reporting it as logged in would be a
+/// lie.
+fn summary_inputs() -> anyhow::Result<(Vec<Deployment>, ProfileCredentials, bool)> {
     let deployments = load_deployments()?;
+    let creds = load_profile_credentials(&resolve_profile(None))?;
+    let any_configured_default = deployments.iter().any(|d| d.default && !d.builtin);
+    Ok((deployments, creds, any_configured_default))
+}
+
+fn list_deployment_summaries() -> anyhow::Result<Vec<DeploymentSummary>> {
+    let (deployments, creds, any_configured_default) = summary_inputs()?;
+    // Reported here rather than at load: `auth status` is where a user is looking
+    // at their deployments, so it is where a clash between two of them is
+    // actionable.
     for (var, names) in api_token_env_collisions(&deployments) {
         tracing::warn!(
             "deployments {} share the API-token variable {var}; rename one so each \
@@ -3047,8 +3086,6 @@ fn list_deployment_summaries() -> anyhow::Result<Vec<DeploymentSummary>> {
             names.join(", ")
         );
     }
-    let creds = load_profile_credentials(&resolve_profile(None))?;
-    let any_configured_default = deployments.iter().any(|d| d.default && !d.builtin);
     Ok(deployments
         .iter()
         .map(|d| summarize_deployment(d, &creds, any_configured_default))
@@ -3103,9 +3140,7 @@ fn summarize_deployment(
 /// such deployment is configured. Used by `configure` to render the recorded
 /// deployment with the same detail as `list`.
 fn one_deployment_summary(name: &str) -> anyhow::Result<Option<DeploymentSummary>> {
-    let deployments = load_deployments()?;
-    let creds = load_profile_credentials(&resolve_profile(None))?;
-    let any_configured_default = deployments.iter().any(|d| d.default && !d.builtin);
+    let (deployments, creds, any_configured_default) = summary_inputs()?;
     Ok(deployments
         .iter()
         .find(|d| d.name == name)
@@ -3259,7 +3294,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         heap: values::Heap<'v>,
     ) -> anyhow::Result<values::Value<'v>> {
         let deployments = load_deployments()?;
-        let selected = select_account_or_deployment(&deployments, deployment)?;
+        let selected = select_aspect_cloud_or_deployment(&deployments, deployment)?;
         let env = auth_env_from(&selected)?;
 
         if let Some(token) = token {
@@ -3318,7 +3353,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         let profile = resolve_profile(profile.into_option().as_deref());
         let deployments = load_deployments()?;
         let selected =
-            select_account_or_deployment(&deployments, deployment.into_option().as_deref())?;
+            select_aspect_cloud_or_deployment(&deployments, deployment.into_option().as_deref())?;
         store_credential(&profile, &selected.name, creds.to_entry())?;
         Ok(values::Value::new_none())
     }
@@ -3350,7 +3385,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         }
         let deployments = load_deployments()?;
         let selected =
-            select_account_or_deployment(&deployments, deployment.into_option().as_deref())?;
+            select_aspect_cloud_or_deployment(&deployments, deployment.into_option().as_deref())?;
         let profile = resolve_profile(profile.into_option().as_deref());
         forget_credential(&profile, &selected.name)?;
         // If the logged-out deployment was the current default, clear the default
@@ -3512,7 +3547,7 @@ fn auth_methods(registry: &mut MethodsBuilder) {
     /// The issuer is pinned to [`DEFAULT_ISSUER`] rather than taken from the
     /// document: discovery here is not user-initiated (the host is compiled in,
     /// not typed), so the endpoint may name the PKCE client to use but may not
-    /// redirect the account's login to a different authorization server. A
+    /// redirect Aspect Cloud's login to a different authorization server. A
     /// document advertising only some other issuer resolves to
     /// `"issuer_not_advertised"` and records nothing.
     fn configure_default<'v>(
@@ -3577,11 +3612,9 @@ fn auth_methods(registry: &mut MethodsBuilder) {
         })
     }
 
-    /// The credentials profile a login against `deployment` should persist under,
-    /// so it matches what [`Self::deployment_for_host`] later resolves for that
-    /// deployment's endpoints. A configured deployment (one with its own hosts)
-    /// stores under its name; the built-in Aspect Cloud entry — whose endpoints go
-    /// through the default profile — stores under the resolved default profile.
+    /// The key a login against `deployment` is filed under within a profile: its
+    /// canonical name, so an alias resolves to the name
+    /// [`Self::deployment_for_host`] later hands back for its endpoints.
     fn login_profile<'v>(
         #[allow(unused)] this: values::Value<'v>,
         #[starlark(require = named, default = NoneOr::None)] deployment: NoneOr<String>,
@@ -3589,26 +3622,20 @@ fn auth_methods(registry: &mut MethodsBuilder) {
     ) -> anyhow::Result<values::Value<'v>> {
         let deployments = load_deployments()?;
         let selected =
-            select_account_or_deployment(&deployments, deployment.into_option().as_deref())?;
+            select_aspect_cloud_or_deployment(&deployments, deployment.into_option().as_deref())?;
         Ok(heap.alloc(login_profile_for(&selected)))
     }
 }
 
-/// The credential-store key a login against `selected` persists under, and the one
-/// its endpoints are later read from: the deployment's own name, Aspect Cloud
+/// The key a login against `selected` is filed under *within* a profile, and the
+/// one its endpoints are read back from: the deployment's own name, Aspect Cloud
 /// included. So `deployment_for_host` hands back a key that needs no translation.
 ///
-/// [`PROFILE_ENV`] overrides it, which is what keeps a second identity for the same
-/// deployment usable: `--profile` steers the `auth` tasks, but the Bazel credential
-/// helper takes no flags, so the env var is the only thing that can steer both. It
-/// applies to whichever deployment is being addressed, so exporting it while using
-/// two deployments points both at one key — which is why it is an override to reach
-/// for deliberately, not a default.
+/// Which profile holds it is the other axis, chosen by `--profile` or
+/// [`PROFILE_ENV`] — see [`resolve_profile`]. Keeping them separate is what lets
+/// one profile hold a credential for every deployment at once.
 fn login_profile_for(selected: &Deployment) -> String {
-    std::env::var(PROFILE_ENV)
-        .ok()
-        .and_then(|v| (!v.is_empty()).then_some(v))
-        .unwrap_or_else(|| selected.name.clone())
+    selected.name.clone()
 }
 
 /// Extract a bare host from a possibly-URL argument (`https://h/p` → `h`), so
@@ -3741,11 +3768,10 @@ mod tests {
         // An explicit profile still overrides the env.
         assert_eq!(resolve_profile(Some("explicit")), "explicit");
 
-        // With the env unset, everything falls through to Aspect Cloud — which is
-        // what "no deployment named" means everywhere else in the CLI.
+        // With the env unset, everything falls through to the default profile.
         unsafe { std::env::remove_var(PROFILE_ENV) };
-        assert_eq!(resolve_profile(None), ASPECT_CLOUD_DEPLOYMENT_NAME);
-        assert_eq!(resolve_profile(Some("")), ASPECT_CLOUD_DEPLOYMENT_NAME);
+        assert_eq!(resolve_profile(None), DEFAULT_PROFILE);
+        assert_eq!(resolve_profile(Some("")), DEFAULT_PROFILE);
 
         match saved {
             Some(v) => unsafe { std::env::set_var(PROFILE_ENV, v) },
@@ -3832,25 +3858,25 @@ mod tests {
     }
 
     #[test]
-    fn select_account_or_deployment_defaults_to_the_account_not_the_default_deployment() {
+    fn select_aspect_cloud_or_deployment_defaults_to_the_account_not_the_default_deployment() {
         // Even with a configured deployment marked default (the build default),
         // a bare auth login/logout targets Aspect Cloud (the seed) — the
-        // default-deployment concept governs builds, not the account.
+        // default-deployment concept governs builds, not Aspect Cloud.
         let mut ds = vec![aspect_cloud_deployment(), dep("acme", true)];
         ds[0].default = false;
         assert_eq!(
-            select_account_or_deployment(&ds, None).unwrap().name,
+            select_aspect_cloud_or_deployment(&ds, None).unwrap().name,
             ASPECT_CLOUD_DEPLOYMENT_NAME
         );
         // An explicit name still picks that deployment.
         assert_eq!(
-            select_account_or_deployment(&ds, Some("acme"))
+            select_aspect_cloud_or_deployment(&ds, Some("acme"))
                 .unwrap()
                 .name,
             "acme"
         );
         // Unknown name errors.
-        assert!(select_account_or_deployment(&ds, Some("nope")).is_err());
+        assert!(select_aspect_cloud_or_deployment(&ds, Some("nope")).is_err());
     }
 
     #[test]
@@ -3919,6 +3945,89 @@ mod tests {
         );
     }
 
+    fn cred(email: &str) -> CredentialsEntry {
+        CredentialsEntry::from_bearer(
+            jwt_with_payload(&format!(r#"{{"email":"{email}","name":"U"}}"#)),
+            "refresh".to_string(),
+            Some(DEFAULT_ISSUER.to_string()),
+            Some(DEFAULT_CLIENT_ID.to_string()),
+            false,
+        )
+        .unwrap()
+    }
+
+    /// A profile holds one credential per deployment, and profiles do not see each
+    /// other. This is the whole point of the two axes: `--profile bob` covers every
+    /// deployment bob uses, and switching to susan switches all of them at once.
+    #[test]
+    fn a_profile_holds_one_credential_per_deployment() {
+        let mut all = AllCredentials::new();
+        insert_credential(
+            &mut all,
+            "bob",
+            ASPECT_CLOUD_DEPLOYMENT_NAME,
+            cred("bob@x.io"),
+        );
+        insert_credential(&mut all, "bob", "acme", cred("bob@acme.io"));
+        insert_credential(
+            &mut all,
+            "susan",
+            ASPECT_CLOUD_DEPLOYMENT_NAME,
+            cred("susan@x.io"),
+        );
+
+        assert_eq!(all["bob"].len(), 2);
+        assert_eq!(all["bob"][ASPECT_CLOUD_DEPLOYMENT_NAME].email, "bob@x.io");
+        assert_eq!(all["bob"]["acme"].email, "bob@acme.io");
+        // Same deployment, different identity: separate credentials.
+        assert_eq!(
+            all["susan"][ASPECT_CLOUD_DEPLOYMENT_NAME].email,
+            "susan@x.io"
+        );
+        assert!(!all["susan"].contains_key("acme"));
+
+        // Re-filing one deployment leaves its siblings alone.
+        insert_credential(&mut all, "bob", "acme", cred("bob2@acme.io"));
+        assert_eq!(all["bob"]["acme"].email, "bob2@acme.io");
+        assert_eq!(all["bob"][ASPECT_CLOUD_DEPLOYMENT_NAME].email, "bob@x.io");
+    }
+
+    /// Logging out is one deployment in one profile. The profile goes only once it
+    /// is empty, since a profile holding nothing is not a profile.
+    #[test]
+    fn removing_a_credential_leaves_siblings_and_prunes_an_empty_profile() {
+        let mut all = AllCredentials::new();
+        insert_credential(
+            &mut all,
+            "bob",
+            ASPECT_CLOUD_DEPLOYMENT_NAME,
+            cred("bob@x.io"),
+        );
+        insert_credential(&mut all, "bob", "acme", cred("bob@acme.io"));
+        insert_credential(
+            &mut all,
+            "susan",
+            ASPECT_CLOUD_DEPLOYMENT_NAME,
+            cred("susan@x.io"),
+        );
+
+        assert!(remove_credential(&mut all, "bob", "acme"));
+        assert_eq!(all["bob"].len(), 1, "the sibling survives");
+        assert!(all.contains_key("susan"), "another identity is untouched");
+
+        assert!(remove_credential(
+            &mut all,
+            "bob",
+            ASPECT_CLOUD_DEPLOYMENT_NAME
+        ));
+        assert!(!all.contains_key("bob"), "the emptied profile is pruned");
+
+        // Removing what is not there reports so rather than writing.
+        assert!(!remove_credential(&mut all, "bob", "acme"));
+        assert!(!remove_credential(&mut all, "susan", "acme"));
+        assert!(all.contains_key("susan"));
+    }
+
     #[test]
     fn oidc_endpoints_fallback_uses_conventional_paths() {
         let e = oidc_endpoints_fallback("https://acme.auth.aspect.build");
@@ -3929,34 +4038,35 @@ mod tests {
         assert_eq!(e.token, "https://acme.auth.aspect.build/oauth/token");
     }
 
+    /// Every deployment files under its own name, Aspect Cloud included and with or
+    /// without hosts. Nothing keys on `builtin`, so no deployment can end up
+    /// sharing another's credential.
     #[test]
-    fn login_profile_keys_on_the_account_flag_not_hosts() {
-        // The built-in account → the default profile, with or without endpoints
-        // (see `the_account_keeps_the_default_profile_once_it_has_endpoints`).
+    fn every_deployment_files_under_its_own_name() {
+        let _guard = profile_env_guard();
         assert_eq!(
             login_profile_for(&aspect_cloud_deployment()),
-            resolve_profile(None)
+            ASPECT_CLOUD_DEPLOYMENT_NAME
         );
-        // Any configured deployment → its own name, hosts or not: it is a
-        // separate identity, so it never shares the account's slot.
+        let mut with_hosts = aspect_cloud_deployment();
+        with_hosts.hosts = vec!["remote.app.aspect.build".to_string()];
+        assert_eq!(login_profile_for(&with_hosts), ASPECT_CLOUD_DEPLOYMENT_NAME);
+
         let mut hostless = dep("acme", false);
         hostless.hosts = Vec::new();
         assert_eq!(login_profile_for(&hostless), "acme");
         assert_eq!(login_profile_for(&dep("acme", true)), "acme");
 
-        // Why `default` is reserved: a deployment files under its own name, so one
-        // named `default` would share the account's credential slot.
-        assert_eq!(
-            login_profile_for(&dep(RESERVED_DEFAULT_NAME, true)),
-            RESERVED_DEFAULT_NAME
-        );
-        assert!(is_reserved_name(RESERVED_DEFAULT_NAME));
+        // Why `default` is reserved as a deployment name: it names the profile a
+        // login lands in when none is given, so a deployment called `default` would
+        // read ambiguously wherever either appears.
+        assert!(is_reserved_name(DEFAULT_PROFILE));
     }
 
     #[test]
     fn deployment_name_from_host_strips_service_label_and_aspect_domain() {
         for (host, want) in [
-            // Aspect-hosted: the service label and `.aspect.build` both go, so
+            // Aspect Cloud: the service label and `.aspect.build` both go, so
             // the deployment segment is left bare.
             ("remote.acme.aspect.build", "acme"),
             ("bes.acme.aspect.build", "acme"),
@@ -3968,7 +4078,7 @@ mod tests {
             // domain itself names it.
             ("remote.aspect.build", "aspect.build"),
             // Self-hosted: only the service label goes; the domain is kept, which
-            // is what keeps these names distinct from the built-in account.
+            // is what keeps these names distinct from the built-in Aspect Cloud entry.
             ("remote.foo.bar.com", "foo.bar.com"),
             ("cache.app.corp.io", "app.corp.io"),
             ("cache.team.acme.co.uk", "team.acme.co.uk"),
@@ -4015,7 +4125,7 @@ mod tests {
             ),
             // The alias is reserved too, so a host cannot derive its way onto it.
             ("remote.aspect.aspect.build", ASPECT_CLOUD_DEPLOYMENT_ALIAS),
-            ("remote.default.aspect.build", RESERVED_DEFAULT_NAME),
+            ("remote.default.aspect.build", DEFAULT_PROFILE),
         ] {
             let name = deployment_name_from_host(host);
             assert_eq!(name, want);
@@ -4035,7 +4145,7 @@ mod tests {
         // take neither — as is the credential slot every deployment files under.
         assert!(RESERVED_NAMES.contains(&ASPECT_CLOUD_DEPLOYMENT_NAME));
         assert!(RESERVED_NAMES.contains(&ASPECT_CLOUD_DEPLOYMENT_ALIAS));
-        assert!(RESERVED_NAMES.contains(&RESERVED_DEFAULT_NAME));
+        assert!(RESERVED_NAMES.contains(&DEFAULT_PROFILE));
         assert_eq!(RESERVED_NAMES, ["aspect-cloud", "aspect", "default"]);
 
         for name in RESERVED_NAMES {
@@ -4058,7 +4168,7 @@ mod tests {
         assert!(aspect_cloud_deployment().builtin);
         assert!(!dep("aspect", false).builtin);
 
-        // ...so it is never mistaken for the account in a summary.
+        // ...so it is never mistaken for Aspect Cloud in a summary.
         let creds = HashMap::new();
         let impostor = summarize_deployment(&dep("aspect", false), &creds, false);
         assert!(!impostor.builtin);
@@ -4067,9 +4177,9 @@ mod tests {
     }
 
     /// A `config.json` entry under a reserved name must not replace the built-in
-    /// account on load — that is what made the account vanish from `auth status`
+    /// account on load — that is what made Aspect Cloud vanish from `auth status`
     /// with the deployment rendered in its place. `default` is the remaining such
-    /// name; an entry under the account's own name merges instead, covered by
+    /// name; an entry under Aspect Cloud's own name merges instead, covered by
     /// `an_account_named_entry_merges_into_the_seed`.
     #[test]
     fn config_json_entry_cannot_shadow_the_account() {
@@ -4100,7 +4210,7 @@ mod tests {
         assert_eq!(accounts.len(), 1);
         assert_eq!(accounts[0].issuer.as_deref(), Some(DEFAULT_ISSUER));
         assert!(accounts[0].hosts.is_empty());
-        // The impostor is dropped rather than silently taking the account's slot.
+        // The impostor is dropped rather than silently taking Aspect Cloud's slot.
         assert!(!merged.iter().any(|d| d.name == "default"));
         // A legitimate deployment sharing that issuer is unaffected.
         assert!(merged.iter().any(|d| d.name == "silo-gcp"));
@@ -4114,27 +4224,24 @@ mod tests {
         // A repo-config entry is checked in: `auth remove` only edits the user
         // file, so the advice must point at the repo path instead.
         let (_, found) = overlay_config_sources(vec![
-            src(REPO, vec![dep(RESERVED_DEFAULT_NAME, false)], false),
+            src(REPO, vec![dep(DEFAULT_PROFILE, false)], false),
             src(USER, vec![dep("acme", false)], true),
         ]);
         assert_eq!(found.len(), 1);
-        assert_eq!(found[0].name, RESERVED_DEFAULT_NAME);
+        assert_eq!(found[0].name, DEFAULT_PROFILE);
         assert!(!found[0].user_config);
         assert_eq!(found[0].path, REPO);
 
         // A user-config entry is removable.
-        let (_, found) = overlay_config_sources(vec![src(
-            USER,
-            vec![dep(RESERVED_DEFAULT_NAME, false)],
-            true,
-        )]);
+        let (_, found) =
+            overlay_config_sources(vec![src(USER, vec![dep(DEFAULT_PROFILE, false)], true)]);
         assert_eq!(found.len(), 1);
         assert!(found[0].user_config);
 
         // Declared in both files → reported once, against the first (repo).
         let (_, found) = overlay_config_sources(vec![
-            src(REPO, vec![dep(RESERVED_DEFAULT_NAME, false)], false),
-            src(USER, vec![dep(RESERVED_DEFAULT_NAME, false)], true),
+            src(REPO, vec![dep(DEFAULT_PROFILE, false)], false),
+            src(USER, vec![dep(DEFAULT_PROFILE, false)], true),
         ]);
         assert_eq!(found.len(), 1);
         assert!(!found[0].user_config);
@@ -4179,7 +4286,7 @@ mod tests {
         assert_eq!(ds.len(), 1);
         assert_eq!(ds[0].name, "acme");
 
-        // The same name with no file entry means the built-in account — refused.
+        // The same name with no file entry means the built-in Aspect Cloud entry — refused.
         let mut ds = vec![dep("acme", true)];
         let err = apply_remove(&mut ds, "aspect").unwrap_err();
         assert!(err.to_string().contains("cannot be removed"), "{err}");
@@ -4573,7 +4680,7 @@ mod tests {
         }
     }
 
-    /// Aspect Cloud's own hosts resolve to the account; everything else derives a
+    /// Aspect Cloud's own hosts resolve to Aspect Cloud; everything else derives a
     /// deployment name from the host as before. An explicit `--name` still wins,
     /// so a separate entry for these hosts stays possible.
     #[test]
@@ -4604,11 +4711,14 @@ mod tests {
             // Case and an absolute FQDN's trailing dot are tolerated.
             "Cache.EU.Aspect.Build.",
         ] {
-            assert!(is_account_host(host), "{host} should belong to the account");
+            assert!(
+                is_aspect_cloud_host(host),
+                "{host} should belong to Aspect Cloud"
+            );
         }
 
         for host in [
-            // Another Aspect-hosted deployment is its own thing.
+            // Another Aspect Cloud deployment is its own thing.
             "remote.silo-aws.aspect.build",
             "bes.gcp.awd-gha-test-dev.aspect.build",
             // Self-hosted, and lookalikes that must not match a suffix.
@@ -4616,11 +4726,11 @@ mod tests {
             "cache.us.aspect.build.evil.com",
             "notcache.aspect.build",
             // An unenumerated region is not assumed to be one: far likelier to be
-            // another Aspect-hosted deployment than a new Aspect Cloud region.
+            // another Aspect Cloud deployment than a new Aspect Cloud region.
             "cache.ap.aspect.build",
         ] {
             assert!(
-                !is_account_host(host),
+                !is_aspect_cloud_host(host),
                 "{host} should be its own deployment"
             );
         }
@@ -4648,7 +4758,7 @@ mod tests {
         assert!(seed.builtin);
     }
 
-    /// The relay page is named by the deployment, so the account takes it from a
+    /// The relay page is named by the deployment, so Aspect Cloud takes it from a
     /// document on its own issuer and refuses one from anywhere else — the gate
     /// that already guards the adopted client.
     #[test]
@@ -4679,7 +4789,7 @@ mod tests {
     }
 
     /// A deployment naming itself beats a name derived from DNS, but never beats a
-    /// name the user typed, never claims the account, and never takes a name the
+    /// name the user typed, never claims Aspect Cloud, and never takes a name the
     /// CLI reserves for itself.
     #[test]
     fn a_deployment_may_name_itself() {
@@ -4716,10 +4826,10 @@ mod tests {
         // Aspect Cloud and `aspect` its alias, `default` the credential slot every
         // deployment files under. Aspect Cloud
         // advertises its own name, but its hosts never reach here — they resolve to
-        // the account first; see `parses_the_aspect_cloud_document_as_served`.
+        // Aspect Cloud first; see `parses_the_aspect_cloud_document_as_served`.
         assert_eq!(advertised_name(&doc(ASPECT_CLOUD_DEPLOYMENT_NAME)), None);
         assert_eq!(advertised_name(&doc(ASPECT_CLOUD_DEPLOYMENT_ALIAS)), None);
-        assert_eq!(advertised_name(&doc(RESERVED_DEFAULT_NAME)), None);
+        assert_eq!(advertised_name(&doc(DEFAULT_PROFILE)), None);
 
         // `^[a-z][a-z0-9-]*$` — what the charts and Terraform modules enforce, so a
         // name reaching the CLI outside it means something upstream went wrong.
@@ -4771,12 +4881,12 @@ mod tests {
             resolve_deployment_name(None, host, &named("")),
             ("aws.awd-cci-test-dev".to_string(), false)
         );
-        // An Aspect Cloud host is the account, whatever it calls itself.
+        // An Aspect Cloud host is Aspect Cloud, whatever it calls itself.
         assert_eq!(
             resolve_deployment_name(None, "cache.aspect.build", &named("Aspect Cloud")),
             (ASPECT_CLOUD_DEPLOYMENT_NAME.to_string(), true)
         );
-        // Typing the account's name claims it.
+        // Typing Aspect Cloud's name claims it.
         assert_eq!(
             resolve_deployment_name(
                 Some(ASPECT_CLOUD_DEPLOYMENT_NAME.to_string()),
@@ -4785,7 +4895,7 @@ mod tests {
             ),
             (ASPECT_CLOUD_DEPLOYMENT_NAME.to_string(), true)
         );
-        // A document may not claim the account by naming it.
+        // A document may not claim Aspect Cloud by naming it.
         assert_eq!(
             resolve_deployment_name(None, host, &named(ASPECT_CLOUD_DEPLOYMENT_NAME)),
             ("aws.awd-cci-test-dev".to_string(), false)
@@ -4837,7 +4947,7 @@ mod tests {
         // Aspect Cloud calls itself what the CLI now calls it, so the served
         // document and `ASPECT_CLOUD_DEPLOYMENT_NAME` agree.
         assert_eq!(parsed.resource_name, ASPECT_CLOUD_DEPLOYMENT_NAME);
-        // Its hosts resolve to the account without consulting the advertised name —
+        // Its hosts resolve to Aspect Cloud without consulting the advertised name —
         // identity is the `builtin` flag, not the string — and the name is reserved,
         // so a host that is *not* Aspect Cloud's cannot claim it either.
         assert_eq!(advertised_name(&parsed), None);
@@ -4869,9 +4979,9 @@ mod tests {
         // Absorbing is not shadowing, so nothing is reported against the file.
         assert!(shadowed.is_empty());
 
-        // The alias addresses the account too, so an explicit one resolves to the
+        // The alias addresses Aspect Cloud too, so an explicit one resolves to the
         // canonical entry rather than recording a stray deployment.
-        assert!(names_the_account(ASPECT_CLOUD_DEPLOYMENT_ALIAS));
+        assert!(names_aspect_cloud(ASPECT_CLOUD_DEPLOYMENT_ALIAS));
     }
 
     /// A deployment's own advertised redirect wins over anything the CLI would
@@ -5034,7 +5144,7 @@ mod tests {
 
     /// A resource advertising only a build-result viewer is not a deployment.
     /// `app.aspect.build` serves that shape — a `results_url` and an issuer, with
-    /// no cache, no BES and no `client_id`. Recording it under the account's name
+    /// no cache, no BES and no `client_id`. Recording it under Aspect Cloud's name
     /// would replace the endpoints that do serve builds with ones that cannot,
     /// behind a client that can never complete a login.
     ///
@@ -5083,9 +5193,9 @@ mod tests {
     /// that entry enriches the seed rather than shadowing it, which is what
     /// `configure --name aspect` is for. A name that merely derives to it is still
     /// refused, and `default` is refused either way: it is a credential-store key,
-    /// so an entry under it would share the account's slot.
+    /// so an entry under it would share Aspect Cloud's slot.
     ///
-    /// What keeps the account safe is not this check but the issuer pin in
+    /// What keeps Aspect Cloud safe is not this check but the issuer pin in
     /// `configure_deployment` — see
     /// `the_account_only_absorbs_endpoints_on_its_own_issuer`.
     #[test]
@@ -5094,13 +5204,11 @@ mod tests {
         assert!(upsert_deployment(&mut Vec::new(), account(), true).is_ok());
         assert!(upsert_deployment(&mut Vec::new(), account(), false).is_err());
         // The credential slot is refused however it is asked for.
-        assert!(
-            upsert_deployment(&mut Vec::new(), dep(RESERVED_DEFAULT_NAME, false), true).is_err()
-        );
+        assert!(upsert_deployment(&mut Vec::new(), dep(DEFAULT_PROFILE, false), true).is_err());
     }
 
     /// The entry `configure_default` writes enriches the seed rather than
-    /// shadowing it: the account keeps its identity and gains the endpoints, so
+    /// shadowing it: Aspect Cloud keeps its identity and gains the endpoints, so
     /// `auth status` shows one Aspect entry and `--remote` resolves it.
     #[test]
     fn an_account_named_entry_merges_into_the_seed() {
@@ -5135,7 +5243,7 @@ mod tests {
         let seed = merged.iter().find(|d| d.builtin).unwrap();
         assert_eq!(seed.endpoints.cache, "remote.app.aspect.build");
         assert_eq!(seed.endpoints.bes, "bes.app.aspect.build");
-        // The issuer stays the seed's — the file may extend the account, never
+        // The issuer stays the seed's — the file may extend Aspect Cloud, never
         // redirect its login — and a client offered alongside a foreign issuer is
         // refused with it.
         assert_eq!(seed.issuer.as_deref(), Some(DEFAULT_ISSUER));
@@ -5143,7 +5251,7 @@ mod tests {
         assert_eq!(seed.api_url.as_deref(), Some(DEFAULT_API_URL));
     }
 
-    /// A client discovered from the account's own issuer *is* adopted, which is
+    /// A client discovered from Aspect Cloud's own issuer *is* adopted, which is
     /// what lets the deployed client rotate without a CLI release. The compiled-in
     /// one is the fallback for before discovery has run.
     #[test]
@@ -5192,28 +5300,10 @@ mod tests {
         );
     }
 
-    /// The account keeps the default credential profile after it gains endpoints —
-    /// that keys on `builtin`, not on whether hosts are present, or the account
-    /// would file its login away from the profile every Aspect-cloud caller reads.
-    #[test]
-    fn the_account_keeps_the_default_profile_once_it_has_endpoints() {
-        let _guard = profile_env_guard();
-        let mut seed = aspect_cloud_deployment();
-        seed.hosts = vec!["remote.app.aspect.build".to_string()];
-        // Compared against `resolve_profile`, not the literal: the invariant is that
-        // the account files under whatever the default profile resolves to, and a
-        // sibling test sets $ASPECT_AUTH_PROFILE (hence the guard above).
-        assert_eq!(login_profile_for(&seed), resolve_profile(None));
-
-        let mut configured = dep("acme", false);
-        configured.hosts = vec!["remote.acme.example.com".to_string()];
-        assert_eq!(login_profile_for(&configured), "acme");
-    }
-
-    /// Anything recorded under the account's name — a bare login's discovery or
+    /// Anything recorded under Aspect Cloud's name — a bare login's discovery or
     /// an explicit `configure --name aspect` — takes the endpoint's PKCE client
     /// but not its issuer. `hosts` is the auth gate, so a host on a different
-    /// issuer would be handed the account's own bearer; pinning keeps the account
+    /// issuer would be handed Aspect Cloud's own bearer; pinning keeps Aspect Cloud
     /// absorbing endpoints only from deployments that share its issuer.
     #[test]
     fn the_account_only_absorbs_endpoints_on_its_own_issuer() {
@@ -5245,11 +5335,11 @@ mod tests {
         let advertised = doc(DEFAULT_ISSUER, "new-client-id");
         match resolve_auth_server(&advertised.auth_servers(), Some(DEFAULT_ISSUER)) {
             AuthServerChoice::Selected(s) => assert_eq!(s.client_id, "new-client-id"),
-            _ => panic!("the account's own issuer should resolve"),
+            _ => panic!("Aspect Cloud's own issuer should resolve"),
         }
 
         // A host on some other issuer records nothing, so it can never be handed
-        // the account's credential.
+        // Aspect Cloud's credential.
         let hijacked = doc("https://auth.evil.example.com", "new-client-id");
         assert!(matches!(
             resolve_auth_server(&hijacked.auth_servers(), Some(DEFAULT_ISSUER)),
@@ -5291,7 +5381,7 @@ mod tests {
             login_profile_for(&aspect_cloud_deployment()),
             ASPECT_CLOUD_DEPLOYMENT_NAME
         );
-        // And a self-hosted deployment's key is not it, so the account token can
+        // And a self-hosted deployment's key is not it, so Aspect Cloud token can
         // never be handed to a deployment on another issuer.
         assert_ne!(
             login_profile_for(&dep("acme", false)),
@@ -5299,32 +5389,28 @@ mod tests {
         );
     }
 
-    /// `$ASPECT_AUTH_PROFILE` has to steer where a login is filed *and* where the
-    /// credential helper reads it back, because the helper takes no flags. Both go
-    /// through `login_profile_for`, so one override covers both.
+    /// The store's two axes stay independent: `$ASPECT_AUTH_PROFILE` chooses the
+    /// profile and never the key within it. Crossing them would have one identity's
+    /// credential answer for another deployment.
+    ///
+    /// An env var rather than a flag because the Bazel credential helper takes no
+    /// flags, so it is the only thing that can steer the CLI and the helper alike.
     #[test]
-    fn the_profile_env_overrides_the_key_a_deployment_files_under() {
+    fn the_profile_env_chooses_the_profile_not_the_deployment_key() {
         let _guard = profile_env_guard();
         let saved = std::env::var(PROFILE_ENV).ok();
 
         // SAFETY: single-threaded test body, guarded above, restored before return.
-        unsafe { std::env::set_var(PROFILE_ENV, "second-identity") };
-        assert_eq!(
-            login_profile_for(&aspect_cloud_deployment()),
-            "second-identity"
-        );
-        assert_eq!(login_profile_for(&dep("acme", false)), "second-identity");
-
-        // Empty reads as unset, so an exported-but-blank var does not send every
-        // login to a key named "".
-        unsafe { std::env::set_var(PROFILE_ENV, "") };
+        unsafe { std::env::set_var(PROFILE_ENV, "bob") };
+        assert_eq!(resolve_profile(None), "bob");
+        // The key a deployment files under is unmoved by it.
         assert_eq!(
             login_profile_for(&aspect_cloud_deployment()),
             ASPECT_CLOUD_DEPLOYMENT_NAME
         );
-
-        unsafe { std::env::remove_var(PROFILE_ENV) };
         assert_eq!(login_profile_for(&dep("acme", false)), "acme");
+        // An explicit `--profile` still wins over the env.
+        assert_eq!(resolve_profile(Some("susan")), "susan");
 
         match saved {
             Some(v) => unsafe { std::env::set_var(PROFILE_ENV, v) },
@@ -5334,7 +5420,7 @@ mod tests {
 
     #[test]
     fn cloud_bearer_prefers_access_token_then_id_token() {
-        // The Aspect-cloud flow (prefer_id_token = false) validates the
+        // The Aspect Cloud flow (prefer_id_token = false) validates the
         // access_token, falling back to the id_token only if absent.
         assert_eq!(token_response("acc", "idt").bearer(false).unwrap(), "acc");
         assert_eq!(token_response("", "idt").bearer(false).unwrap(), "idt");
@@ -5552,9 +5638,9 @@ mod tests {
         // `default` is reserved from being *configured*, but it is not the
         // account — so `auth use default` must error like any unknown name
         // rather than silently clear every default (which would send `--remote`
-        // back to the account while reporting success).
+        // back to Aspect Cloud while reporting success).
         ds[0].default = true;
-        let err = apply_set_default(&mut ds, Some(RESERVED_DEFAULT_NAME)).unwrap_err();
+        let err = apply_set_default(&mut ds, Some(DEFAULT_PROFILE)).unwrap_err();
         assert!(err.to_string().contains("unknown deployment"), "{err}");
         assert!(ds[0].default, "`use default` must not clear the default");
     }

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -297,6 +297,13 @@ fn names_aspect_cloud(name: &str) -> bool {
     name == ASPECT_CLOUD_DEPLOYMENT_NAME || name == ASPECT_CLOUD_DEPLOYMENT_ALIAS
 }
 
+/// Whether `name`, as a user typed it, addresses `deployment`. Its own name, plus
+/// the alias for Aspect Cloud — which no configured deployment can take, so this
+/// cannot resolve two.
+fn names_deployment(deployment: &Deployment, name: &str) -> bool {
+    deployment.name == name || (deployment.builtin && names_aspect_cloud(name))
+}
+
 fn is_reserved_name(name: &str) -> bool {
     RESERVED_NAMES.contains(&name)
 }
@@ -525,13 +532,18 @@ fn repo_config_path() -> Option<PathBuf> {
     Some(PathBuf::from(root).join(".aspect").join("config.json"))
 }
 
-/// Select a deployment by name, or the default when `name` is `None`. An
-/// explicit name must match a configured deployment. With no name, the entry
-/// marked `default` wins (the first configured deployment claims `default` when
-/// written, so a single configured deployment is the default), falling back to
-/// the built-in seed. The default flag is the single source of truth —
-/// configuring a deployment does not implicitly hijack selection away from an
-/// explicit default.
+/// Select a deployment by name, or the default when `name` is `None`.
+///
+/// An explicit name must name a deployment: its own, or — for Aspect Cloud —
+/// [`ASPECT_CLOUD_DEPLOYMENT_ALIAS`]. Every path that takes a `--deployment` comes
+/// through here, so the alias works for `--remote` and `deployment_endpoints` as
+/// well as the `auth` commands.
+///
+/// With no name, the entry marked `default` wins (the first configured deployment
+/// claims `default` when written, so a single configured deployment is the
+/// default), falling back to Aspect Cloud. The default flag is the single source of
+/// truth — configuring a deployment does not implicitly hijack selection away from
+/// an explicit default.
 pub(crate) fn select_deployment(
     deployments: &[Deployment],
     name: Option<&str>,
@@ -539,7 +551,7 @@ pub(crate) fn select_deployment(
     if let Some(name) = name.filter(|n| !n.is_empty()) {
         return deployments
             .iter()
-            .find(|d| d.name == name)
+            .find(|d| names_deployment(d, name))
             .cloned()
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -580,8 +592,7 @@ fn select_aspect_cloud_or_deployment(
 /// The configured deployment that owns `host` — an exact or dot-anchored suffix
 /// match against any deployment's `hosts`. `None` when no configured deployment
 /// claims it. Endpoint auth uses this to attach the token of the deployment
-/// serving a given cache/BES endpoint; ask [`login_profile_for`] for the profile
-/// that token is filed under, which is not always the deployment's name.
+/// serving a given cache/BES endpoint.
 fn deployment_for_host<'a>(deployments: &'a [Deployment], host: &str) -> Option<&'a Deployment> {
     // Normalize a trailing dot so an absolute FQDN (`host.example.com.`) still
     // matches its configured host.
@@ -3831,6 +3842,36 @@ mod tests {
             "acme"
         );
         assert!(select_deployment(&deployments, Some("nope")).is_err());
+    }
+
+    /// The alias reaches Aspect Cloud everywhere a deployment is named, not just in
+    /// the `auth` commands: `select_deployment` is the one gate `--remote`,
+    /// `deployment_endpoints` and `credentials` all come through, so an alias that
+    /// worked only in `auth use` would fail a build with "unknown deployment".
+    #[test]
+    fn select_deployment_accepts_the_aspect_cloud_alias() {
+        let deployments = vec![aspect_cloud_deployment(), dep("acme", false)];
+        for name in [ASPECT_CLOUD_DEPLOYMENT_NAME, ASPECT_CLOUD_DEPLOYMENT_ALIAS] {
+            let selected = select_deployment(&deployments, Some(name)).unwrap();
+            assert!(selected.builtin, "{name} should select Aspect Cloud");
+            // Resolved to the canonical entry, so a caller never sees the alias as
+            // a credential key or in output.
+            assert_eq!(selected.name, ASPECT_CLOUD_DEPLOYMENT_NAME);
+        }
+
+        // The alias is Aspect Cloud's alone: it does not make some other
+        // deployment reachable under two names.
+        assert_eq!(
+            select_deployment(&deployments, Some("acme")).unwrap().name,
+            "acme"
+        );
+        assert!(select_deployment(&deployments, Some("nope")).is_err());
+
+        // And the `auth` commands' selection funnels through the same gate.
+        let via_auth =
+            select_aspect_cloud_or_deployment(&deployments, Some(ASPECT_CLOUD_DEPLOYMENT_ALIAS))
+                .unwrap();
+        assert_eq!(via_auth.name, ASPECT_CLOUD_DEPLOYMENT_NAME);
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/aspect/auth.rs
+++ b/crates/axl-runtime/src/engine/aspect/auth.rs
@@ -136,11 +136,11 @@ impl Endpoints {
     /// Whether this advertises somewhere Bazel can actually talk to, which is
     /// what makes a resource a *deployment* rather than merely an Aspect service.
     ///
-    /// Distinct from [`Self::is_empty`], which also counts `results_url`: the
-    /// build-result viewer advertises one alongside no cache or BES at all
-    /// (`app.aspect.build` serves exactly that), and treating it as a deployment
-    /// would record an entry that cannot serve a build — and, under Aspect Cloud's
-    /// own name, would replace the endpoints that can.
+    /// Deliberately narrower than [`Self::is_empty`], which counts `results_url`
+    /// and `api` as well. Both are served alongside no cache or BES at all
+    /// (`app.aspect.build` serves exactly that), and treating such a resource as a
+    /// deployment would record an entry that cannot serve a build — and, under
+    /// Aspect Cloud's own name, would replace the endpoints that can.
     fn serves_build_endpoints(&self) -> bool {
         !self.cache.is_empty() || !self.bes.is_empty() || !self.exec.is_empty()
     }
@@ -634,13 +634,10 @@ fn resolve_auth_env(name: Option<&str>) -> anyhow::Result<AuthEnv> {
 /// `api_url`, then the compiled-in default, so the host can move without a CLI
 /// release.
 fn resolve_aspect_cloud_api_url() -> anyhow::Result<String> {
-    let deployments = load_deployments()?;
-    let cloud = deployments.iter().find(|d| d.builtin);
-    Ok(cloud
-        .map(|d| &d.endpoints.api)
-        .filter(|api| !api.is_empty())
-        .map(|api| format!("https://{api}"))
-        .or_else(|| cloud.and_then(|d| d.api_url.clone()))
+    Ok(load_deployments()?
+        .iter()
+        .find(|d| d.builtin)
+        .and_then(deployment_api_base)
         .unwrap_or_else(|| DEFAULT_API_URL.to_string()))
 }
 
@@ -654,16 +651,22 @@ fn resolve_aspect_cloud_api_url() -> anyhow::Result<String> {
 fn resolve_deployment_api_url(name: Option<&str>) -> anyhow::Result<String> {
     let deployments = load_deployments()?;
     let selected = select_deployment(&deployments, name)?;
-    if !selected.endpoints.api.is_empty() {
-        return Ok(format!("https://{}", selected.endpoints.api));
+    deployment_api_base(&selected)
+        .ok_or_else(|| anyhow::anyhow!("deployment {:?} advertises no API endpoint", selected.name))
+}
+
+/// A deployment's own API base: the `api` endpoint it advertises, else the
+/// `api_url` recorded for it. `None` when it has neither, which is every
+/// deployment but Aspect Cloud today.
+///
+/// The two callers differ only in what they do with that `None` — Aspect Cloud
+/// falls back to the compiled-in default, a named deployment errors — which is the
+/// whole distinction between them.
+fn deployment_api_base(deployment: &Deployment) -> Option<String> {
+    if !deployment.endpoints.api.is_empty() {
+        return Some(format!("https://{}", deployment.endpoints.api));
     }
-    if let Some(url) = selected.api_url.clone() {
-        return Ok(url);
-    }
-    Err(anyhow::anyhow!(
-        "deployment {:?} advertises no API endpoint",
-        selected.name
-    ))
+    deployment.api_url.clone()
 }
 
 fn auth_env_from(deployment: &Deployment) -> anyhow::Result<AuthEnv> {
@@ -4067,6 +4070,31 @@ mod tests {
         assert!(!remove_credential(&mut all, "bob", "acme"));
         assert!(!remove_credential(&mut all, "susan", "acme"));
         assert!(all.contains_key("susan"));
+    }
+
+    /// A deployment's API comes from what it advertises, so the host can move
+    /// without a CLI release. The recorded `api_url` stands in for a document that
+    /// predates the `api` endpoint.
+    #[test]
+    fn a_deployments_api_base_prefers_what_it_advertises() {
+        let mut cloud = aspect_cloud_deployment();
+        // The seed carries `api_url`; with nothing advertised that is what is used.
+        assert_eq!(
+            deployment_api_base(&cloud).as_deref(),
+            Some(DEFAULT_API_URL)
+        );
+
+        // An advertised endpoint wins, and is given a scheme — `aspect_endpoints`
+        // carries bare hosts.
+        cloud.endpoints.api = "api.eu.aspect.build".to_string();
+        assert_eq!(
+            deployment_api_base(&cloud).as_deref(),
+            Some("https://api.eu.aspect.build")
+        );
+
+        // A deployment advertising neither has no API, which the named lookup
+        // reports rather than silently addressing Aspect Cloud's.
+        assert_eq!(deployment_api_base(&dep("acme", false)), None);
     }
 
     #[test]

--- a/crates/axl-runtime/src/engine/aspect/credential_store.rs
+++ b/crates/axl-runtime/src/engine/aspect/credential_store.rs
@@ -1,5 +1,10 @@
-//! Persistent credential storage for `aspect auth`: a `{ profile: entry }` map
-//! held in one of two backends behind [`CredentialStore`].
+//! Persistent credential storage for `aspect auth`: a `{ profile: T }` map held in
+//! one of two backends behind [`CredentialStore`].
+//!
+//! Generic in `T`, and deliberately incurious about it — `auth` stores a map of
+//! its own (a credential per deployment) as the value, which this never has to
+//! know. What it owns is backend selection, whole-map read/write, and the
+//! tolerance rules below.
 //!
 //! - **keyring** — the OS secret service (macOS Keychain, Linux Secret Service,
 //!   Windows Credential Manager), holding the whole map as one entry. The default
@@ -114,8 +119,8 @@ fn keyring_available() -> bool {
     keyring_entry().is_ok()
 }
 
-/// Parse a stored `{ profile: entry }` blob, treating an unparseable one (a
-/// legacy/corrupt layout) as "no credentials" rather than an error, so the user
+/// Parse a stored `{ profile: T }` blob, treating an unparseable one (a corrupt or
+/// differently-shaped layout) as "no credentials" rather than an error, so the user
 /// re-runs `aspect auth login` instead of every command hard-failing. Shared by
 /// both backends so the tolerance is identical.
 fn parse_stored_map<T: DeserializeOwned>(raw: &str) -> HashMap<String, T> {

--- a/crates/axl-runtime/src/engine/aspect/mcp.rs
+++ b/crates/axl-runtime/src/engine/aspect/mcp.rs
@@ -560,9 +560,11 @@ impl BuildResultsServer {
             return Ok(cached.clone());
         }
         let deployment = self.deployment.clone();
-        let resolved = tokio::task::spawn_blocking(move || auth::resolve_access_token(&deployment))
-            .await
-            .map_err(|e| format!("token resolution failed: {e}"))?;
+        let profile = auth::resolve_profile(None);
+        let resolved =
+            tokio::task::spawn_blocking(move || auth::resolve_access_token(&profile, &deployment))
+                .await
+                .map_err(|e| format!("token resolution failed: {e}"))?;
         match resolved {
             Ok(Some(token)) => {
                 *self.token_cache.lock().expect("token cache lock") = Some(token.clone());

--- a/crates/axl-runtime/src/engine/mod.rs
+++ b/crates/axl-runtime/src/engine/mod.rs
@@ -15,7 +15,9 @@ mod wasm;
 /// Re-exported for the credential helper: resolve the effective credentials
 /// profile, and resolve the current Aspect access token (JWT) for a profile,
 /// auto-refreshing if needed.
-pub use aspect::auth::{UriProfile, profile_for_uri, resolve_access_token, resolve_profile};
+pub use aspect::auth::{
+    UriProfile, login_hint, profile_for_uri, resolve_access_token, resolve_profile,
+};
 
 pub mod feature;
 pub mod grpc;


### PR DESCRIPTION
Aspect Cloud becomes an ordinary deployment, and a profile becomes an identity that spans every deployment.

Follows #1429.

### Aspect Cloud is a deployment like any other

It is named `aspect-cloud` — what every one of its endpoints already advertises as RFC 9728 `resource_name`. `aspect` remains an alias, accepted wherever a deployment is named (`--deployment`, `--name`) and folded into the built-in entry when a `config.json` carries it. Both names are reserved, so no configured deployment can take either.

### A profile is an identity, not a key

The credential store is `{ profile: { deployment: entry } }`. `--profile bob` holds bob's credential for Aspect Cloud *and* every self-hosted deployment bob uses; switching to `--profile susan` switches all of them together. `$ASPECT_AUTH_PROFILE` selects the profile for the CLI and the Bazel credential helper alike, since the helper takes no flags.

Within a profile the key is the deployment's own name, so a host resolves to a key that needs no translation. `logout` clears one deployment in one profile; `logout --all` clears everything.

### API tokens are per-deployment

`ASPECT_API_TOKEN` is Aspect Cloud's; `ASPECT_API_TOKEN_<NAME>` is a deployment's, uppercased with non-alphanumerics replaced. Each is exchanged against **its own** deployment's issuer.

A logged-out entry says all three ways to authenticate, naming the variable in full because its name is derived:

```
○ aws-cci-test-dev
    Status  logged out
    Log in  run `aspect auth login --deployment aws-cci-test-dev`,
            or add --with-api-token to read an API token from stdin,
            or set $ASPECT_API_TOKEN_AWS_CCI_TEST_DEV
```

Two deployment names that normalize to one variable are reported rather than letting one token answer for both.

### Aspect Cloud API routes are addressed as such

`ctx.aspect.auth.api_url` is replaced by `aspect_cloud_api_url` and `deployment_api_url(deployment=…)`. Removing the bare attribute is what makes the distinction stick: a new call site has to say which API it means.

All six current call sites — `/github/token`, `/gitlab/token`, `/status-comments/contribute`, `/status-checks/register`, `/github/budget` — are served only on `api.aspect.build`, so they go through `private/lib/aspect_cloud_api.axl`, which pairs the URL with Aspect Cloud's credential.

`deployment_api_url` resolves a deployment's own advertised `api` and errors rather than falling back to Aspect Cloud's, so a future deployment-served route cannot silently address the wrong host. `Endpoints` gained `api`, so the advertised value is recorded instead of dropped.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Suggested release notes

- Aspect Cloud is now named `aspect-cloud`, matching what its endpoints advertise. `aspect` still works wherever a deployment is named.
- `--profile` now selects an identity rather than a single credential slot: one profile holds a login per deployment, and `$ASPECT_AUTH_PROFILE` switches them together.
- An API token is now per-deployment: `ASPECT_API_TOKEN` for Aspect Cloud, `ASPECT_API_TOKEN_<DEPLOYMENT>` for a configured one. `aspect auth status` names the variable for each.
- Stored credentials are read in a new layout; existing logins prompt a re-login.

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:

Verified live against prod, on a real browser login:

```
$ aspect get <<< '{"uri":"https://cache.aspect.build"}'   # claims decoded, token not shown
iss         : https://auth.aspect.build
aud         : efcf21f7-ebdc-4ffa-9f93-12129dbfdc44
type        : userToken
permissions : 25 present

$ aspect build --remote --define=cachebust=$(date +%s) //crates/axl-proto:axl-proto
INFO: Using deployment 'aspect-cloud' for remote cache (grpcs://cache.aspect.build)
INFO: Build completed successfully, 1 total action
INFO: Streamed 29 build events to grpcs://bes.aspect.build.
```

`aud` is the jwt-validator's `clientId` and the API gateway's `frontegg_jwt_audience`; `permissions` is what the API requires and the id_token lacks. No `UNAUTHENTICATED` or `PERMISSION_DENIED` from either edge.

The profile model was exercised against a store holding two identities (`$ASPECT_CREDENTIALS_FILE` forces the file backend):

| request | profile | result |
|---|---|---|
| `cache.aspect.build` | default | the default profile's credential |
| `cache.aspect.build` | `bob` | bob's credential |
| `remote.aws.awd-cci-test-dev…` | `bob` | not logged in — bob holds no credential for it |
| `cache.evil.example.com` | default | no credential (unowned host) |

**New:** `crates/aspect-cli/tests/auth_status.rs` runs the real binary and asserts `auth status` completes in text and JSON form. `DeploymentSummary`'s Starlark attributes are declared separately from its struct fields, so a field added without its accessor compiles, passes every unit test, and fails at runtime on the first render. Verified to fail with the accessor removed.

**New:** `private/lib/auth_fakes.axl` gives the three AXL suites that stub `ctx.aspect.auth` one shared `fake_auth()`. Nothing type-checks an AXL caller against a Rust Starlark value, so each hand-rolled copy of that surface was invisible until its suite ran.

Note for reviewers: `aspect tests axl` does not cover the 45 `aspect dev test-*` suites — CI runs those individually in `axl-smoke`. Both were run for this branch.

Also fixes a flake #1429 introduced: `resolve_profile_prefers_explicit_then_env_then_default` mutates `$ASPECT_AUTH_PROFILE` while other tests read it, and cargo runs tests in parallel. All readers now take a shared guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
