### PR TITLE
fix(cache): honor Bazel test selection in cache diff

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -14,6 +14,7 @@ load("@aspect//private/lib/aspect_endpoint_auth_test.axl", "aspect_endpoint_auth
 load("@aspect//private/lib/bazel_flags_test.axl", "bazel_flags_tests")
 load("@aspect//private/lib/bazel_results_test.axl", "bazel_results_unit_tests", "template_snapshot_tests")
 load("@aspect//private/lib/bazelrc_test.axl", "bazelrc_tests")
+load("@aspect//private/lib/cache_selection_test.axl", "cache_selection_tests")
 load("@aspect//private/lib/ci_test.axl", "ci_tests")
 load("@aspect//private/lib/circleci_test.axl", "circleci_tests")
 load("@aspect//private/lib/delivery_results_test.axl", "delivery_results_unit_tests", "delivery_template_snapshot_tests")
@@ -329,6 +330,7 @@ def config(ctx: ConfigContext):
     # canonical_label normalization (local/external/bzlmod @@module+version → @module).
     # Run with: aspect dev test-runnable
     ctx.tasks.add(runnable_tests)
+    ctx.tasks.add(cache_selection_tests)
 
     # `aspect ci bazelrc` pure helpers — version-constraint gating
     # (assumed-latest when the Bazel version is unknown), mixed plain/tuple

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -401,6 +401,17 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || matrix.preset == 'shell' }}
         working-directory: ${{ runner.temp }}/proj
         run: aspect build --task:name init-${{ matrix.preset }} -- //...
+  cache-diff-integration:
+    runs-on: ubuntu-latest
+    needs: [pre-build]
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: ./.github/actions/install-prebuilt-aspect-cli
+      - name: Verify cache hits, misses, and exclusions
+        run: python3 tools/cache-diff-integration.py --aspect "$(command -v aspect)"
   # `aspect cache diff` probes the remote cache with --experimental_remote_require_cached
   # to list the test targets affected by this commit — running nothing. It needs
   # cache access, so (like build/test) it runs on a self-hosted aspect-workflows

--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -402,6 +402,10 @@ jobs:
         working-directory: ${{ runner.temp }}/proj
         run: aspect build --task:name init-${{ matrix.preset }} -- //...
   cache-diff-integration:
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel: ["7.4.0", "8.6.0", "9.2.0"]
     runs-on: ubuntu-latest
     needs: [pre-build]
     timeout-minutes: 15
@@ -411,7 +415,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/install-prebuilt-aspect-cli
       - name: Verify cache hits, misses, and exclusions
-        run: python3 tools/cache-diff-integration.py --aspect "$(command -v aspect)"
+        run: python3 tools/cache-diff-integration.py --aspect "$(command -v aspect)" --bazel-version "${{ matrix.bazel }}"
   # `aspect cache diff` probes the remote cache with --experimental_remote_require_cached
   # to list the test targets affected by this commit — running nothing. It needs
   # cache access, so (like build/test) it runs on a self-hosted aspect-workflows

--- a/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
+++ b/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
@@ -60,10 +60,12 @@ both sides or neither). The probe resolves flags from the same rc/config as
 `aspect test`/`build`, so they align by default.
 """
 
+load("@aspect//bazel/invocation.axl", "target_patterns")
 load("@aspect//bazel.axl", "BazelTrait", bzl = "bazel")
 load("@bazel//proto/remote_logging.axl", "remote_logging")
 load("@std//time.axl", "time")
 load("./private/lib/ansi.axl", "ansi")
+load("./private/lib/cache_selection.axl", "select_tests")
 load("./private/lib/environment.axl", "color_enabled", "warn")
 load("./private/lib/remote_executor.axl", "start_dummy_executor", "stop_dummy_executor")
 load("./private/lib/runnable.axl", "apparent_label")
@@ -131,6 +133,7 @@ def _invalidate_action_nodes(ctx: TaskContext, rc, endpoint_auth_flags: list, an
     err_path = "/tmp/aspect-cache-diff-invalidate-{}.log".format(ctx.task.name)
     flags = endpoint_auth_flags + [
         "--experimental_remote_require_cached",
+        "--target_pattern_file=",  # the anchor is explicit, even with a pattern-file scope
         "--remote_default_exec_properties=" + _SALT_SENTINEL + "=1",
         "--keep_going",
         "--remote_download_outputs=minimal",
@@ -241,9 +244,11 @@ def _build_missing_non_test(ctx: TaskContext, patterns: list, rc, endpoint_auth_
     returned on a hard build failure (a real broken target, not a cache miss)."""
     err_path = "/tmp/aspect-cache-diff-build-{}.log".format(ctx.task.name)
     _t = time.monotonic()
+    pattern_file = rc.flag_value("--target_pattern_file", command = "test")
+    pattern_flags = ["--target_pattern_file=" + pattern_file] if pattern_file else []
     status = ctx.bazel.build(
         rc = rc,
-        flags = endpoint_auth_flags + ["--remote_upload_local_results", "--keep_going"],
+        flags = endpoint_auth_flags + pattern_flags + ["--remote_upload_local_results", "--keep_going"],
         stdout = None,
         stderr = ctx.std.fs.create(err_path),
         announce_version = announce_version,
@@ -311,7 +316,7 @@ def _classify_and_stream(ctx: TaskContext, entries: list, test_targets: list, rc
             continue
         cause = {"target": e.label, "mnemonic": e.mnemonic}
         _tq = time.monotonic()
-        dep_tests = [apparent_label(t.name) for t in ctx.bazel.query("tests(rdeps(//..., {}))".format(e.label), rc = rc)]
+        dep_tests = [apparent_label(t.name) for t in ctx.bazel.query("tests(rdeps(//..., {}))".format(json.encode(e.label)), rc = rc)]
         rdeps_secs += time.monotonic() - _tq
         for label in dep_tests:
             if label in test_set:
@@ -338,7 +343,6 @@ def _emit_json(ctx: TaskContext, mode: str, test_targets: list, affected: list, 
 def _impl(ctx: TaskContext) -> int:
     color = color_enabled(ctx.std)
     patterns = list(ctx.args.targets)
-    union = " + ".join(patterns)
     mode = ctx.args.mode
     timing = {}  # seconds per phase — split bazel work vs our analysis at the end
 
@@ -354,6 +358,7 @@ def _impl(ctx: TaskContext) -> int:
     # `--nokeep_state_after_build --nouse_action_cache` (see `_run_probe`), so it
     # needs no separate or wiped base.
     rc = ctx.bazel.parse_rc(startup_flags = startup_flags, flags = flags)
+    patterns = target_patterns(ctx.args.is_explicit("targets"), patterns, "", rc, "test")
 
     # Explicit, up-front requirement: no remote cache → nothing to diff against.
     if not rc.flag_value("--remote_cache", command = "test") and not rc.flag_value("--remote_executor", command = "test"):
@@ -365,14 +370,15 @@ def _impl(ctx: TaskContext) -> int:
     # the probe and pre-build below both hit it.
     endpoint_auth_flags = bzl.rc_flags(ctx, rc, "test")
 
-    # Enumerate + reverse-dep under the same resolved flags as the probe/build,
-    # so a `--config`/`--bazel-flag` that changes package loading or the test set
-    # can't make the queries see a different graph than the probe.
+    # Bazel owns ordered patterns, suite expansion, and test filters. Query's
+    # tests() does not have the same selection semantics as `bazel test`.
     _t = time.monotonic()
-    test_targets = sorted([apparent_label(t.name) for t in ctx.bazel.query("tests(%s)" % union, rc = rc)])
+    test_targets = select_tests(ctx, patterns, rc, endpoint_auth_flags = endpoint_auth_flags)
     timing["enumerate"] = time.monotonic() - _t
+    if test_targets == None:
+        return 1
     if not test_targets:
-        _err(ctx, "No test targets in scope for: " + union)
+        _err(ctx, "No test targets in scope for: " + " ".join(patterns))
         return 0
 
     _err(ctx, ansi.style("Diffing {} test target(s) against the remote cache [--mode={}]…".format(len(test_targets), mode), ansi.BOLD, color))
@@ -519,7 +525,8 @@ diff = task(
             description = (
                 "Bazel target patterns scoping the affected set (e.g. " +
                 "`//services/...`). Defaults to `//...` — every test in the " +
-                "workspace. Intersected with `tests(<patterns>)`."
+                "workspace. Uses Bazel test filters. Separate negative patterns " +
+                "from flags with `--` (e.g. `-- //... -//personal/...`)."
             ),
         ),
     } | bzl.flags.args("the cache-diff probe") | bzl.announce.args("the cache-diff probe"),

--- a/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
+++ b/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
@@ -65,7 +65,7 @@ load("@aspect//bazel.axl", "BazelTrait", bzl = "bazel")
 load("@bazel//proto/remote_logging.axl", "remote_logging")
 load("@std//time.axl", "time")
 load("./private/lib/ansi.axl", "ansi")
-load("./private/lib/cache_selection.axl", "select_tests")
+load("./private/lib/cache_selection.axl", "attribution_rc", "select_tests")
 load("./private/lib/environment.axl", "color_enabled", "warn")
 load("./private/lib/remote_executor.axl", "start_dummy_executor", "stop_dummy_executor")
 load("./private/lib/runnable.axl", "apparent_label")
@@ -291,6 +291,7 @@ def _classify_and_stream(ctx: TaskContext, entries: list, test_targets: list, rc
     time (`timing["attribute"]`) from our own bookkeeping (`timing["classify"]`)."""
     _t_all = time.monotonic()
     test_set = {t: None for t in test_targets}
+    query_rc = attribution_rc(ctx, rc)
 
     # Frontier misses, de-duplicated by label (first mnemonic wins).
     missed = []
@@ -316,7 +317,7 @@ def _classify_and_stream(ctx: TaskContext, entries: list, test_targets: list, rc
             continue
         cause = {"target": e.label, "mnemonic": e.mnemonic}
         _tq = time.monotonic()
-        dep_tests = [apparent_label(t.name) for t in ctx.bazel.query("tests(rdeps(//..., {}))".format(json.encode(e.label)), rc = rc)]
+        dep_tests = [apparent_label(t.name) for t in ctx.bazel.query("tests(rdeps(//..., {}))".format(json.encode(e.label)), rc = query_rc)]
         rdeps_secs += time.monotonic() - _tq
         for label in dep_tests:
             if label in test_set:

--- a/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
+++ b/crates/aspect-cli/src/builtins/aspect/cache_diff.axl
@@ -8,6 +8,10 @@ miss, so the probe runs no actions. The gRPC log records one `GetActionResult`
 per action Bazel probed; a miss anywhere in a test's transitive closure trips at
 that action (the *frontier*), and the affected tests are attributed from there.
 
+Selection follows Bazel test patterns and filters (Bazel 7+). Wildcards exclude
+manual-tagged tests; explicit manual targets remain selectable. Negative
+patterns are processed in order and must follow `--`.
+
 Output contract (built for pipes):
 
   - stdout — the affected test labels, one per line, nothing else. Pipe it:
@@ -291,7 +295,7 @@ def _classify_and_stream(ctx: TaskContext, entries: list, test_targets: list, rc
     time (`timing["attribute"]`) from our own bookkeeping (`timing["classify"]`)."""
     _t_all = time.monotonic()
     test_set = {t: None for t in test_targets}
-    query_rc = attribution_rc(ctx, rc)
+    query_rc = None
 
     # Frontier misses, de-duplicated by label (first mnemonic wins).
     missed = []
@@ -317,6 +321,8 @@ def _classify_and_stream(ctx: TaskContext, entries: list, test_targets: list, rc
             continue
         cause = {"target": e.label, "mnemonic": e.mnemonic}
         _tq = time.monotonic()
+        if query_rc == None:
+            query_rc = attribution_rc(ctx, rc)
         dep_tests = [apparent_label(t.name) for t in ctx.bazel.query("tests(rdeps(//..., {}))".format(json.encode(e.label)), rc = query_rc)]
         rdeps_secs += time.monotonic() - _tq
         for label in dep_tests:
@@ -354,10 +360,9 @@ def _impl(ctx: TaskContext) -> int:
     flags = list(bazel_trait.base_flags) + bzl.flags.resolve(ctx)
     announce_version, announce_command = bzl.announce.resolve(ctx)
 
-    # One run command for the queries, the precise pre-build, and the probe — all
-    # on the default output base. The probe forces fresh remote lookups via
-    # `--nokeep_state_after_build --nouse_action_cache` (see `_run_probe`), so it
-    # needs no separate or wiped base.
+    # Share the RC and default output base across selection, precise prebuild,
+    # and probe. The salt-delete pass refreshes action execution without
+    # discarding analysis; --nouse_action_cache bypasses persistent action hits.
     rc = ctx.bazel.parse_rc(startup_flags = startup_flags, flags = flags)
     patterns = target_patterns(ctx.args.is_explicit("targets"), patterns, "", rc, "test")
 
@@ -374,12 +379,13 @@ def _impl(ctx: TaskContext) -> int:
     # Bazel owns ordered patterns, suite expansion, and test filters. Query's
     # tests() does not have the same selection semantics as `bazel test`.
     _t = time.monotonic()
-    test_targets = select_tests(ctx, patterns, rc, endpoint_auth_flags = endpoint_auth_flags)
+    test_targets = select_tests(ctx, patterns, rc, endpoint_auth_flags = endpoint_auth_flags, announce_version = announce_version, announce_command = announce_command)
     timing["enumerate"] = time.monotonic() - _t
     if test_targets == None:
         return 1
     if not test_targets:
-        _err(ctx, "No test targets in scope for: " + " ".join(patterns))
+        scope = " ".join(patterns) if patterns else "--target_pattern_file=" + (rc.flag_value("--target_pattern_file", command = "test") or "")
+        _err(ctx, "No test targets in scope for: " + scope)
         return 0
 
     _err(ctx, ansi.style("Diffing {} test target(s) against the remote cache [--mode={}]…".format(len(test_targets), mode), ansi.BOLD, color))
@@ -465,6 +471,9 @@ diff = task(
         "action results must already be uploaded (e.g. `bazel test //... " +
         "--remote_upload_local_results`). Against a sparse cache the result " +
         "over-reports.\n\n" +
+        "Selection follows Bazel test patterns and filters (Bazel 7+). Wildcards " +
+        "exclude manual-tagged tests; explicit manual targets remain selectable. " +
+        "Pass negative patterns after `--`.\n\n" +
         "Output: affected labels stream to stdout (one per line, pipeable: " +
         "`aspect cache diff | xargs bazel test`); progress, per-target reasons, " +
         "and the summary go to stderr. Pass --exec=\"<cmd>\" to run `<cmd> " +

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection.axl
@@ -1,0 +1,81 @@
+"""Resolve cache-diff test scope through Bazel's test loading phase."""
+
+load("./runnable.axl", "apparent_label")
+
+def selected_tests(events: list, exit_code: int) -> list[str] | None:
+    """Accept only a complete, successful loading-only test selection."""
+
+    # With analysis disabled, `test` exits NO_TESTS_FOUND even when loading
+    # selected tests. Never treat that exit code alone as successful selection.
+    if exit_code != 4:
+        return None
+    labels = {}
+    aborted = {}
+    expansions = 0
+    finished = False
+    complete = False
+    for event in events:
+        if complete:
+            return None
+        complete = event.get("lastMessage", False)
+        if "expanded" in event:
+            expansions += 1
+            for child in event.get("children", []):
+                if "targetConfigured" not in child:
+                    return None
+                labels[child["targetConfigured"]["label"]] = None
+        if "aborted" in event:
+            label = event.get("id", {}).get("targetConfigured", {}).get("label")
+            if event["aborted"].get("reason") != "NO_ANALYZE" or not label:
+                return None
+            aborted[label] = None
+        if "finished" in event:
+            if finished or event["finished"].get("exitCode", {}).get("code") != 4:
+                return None
+            finished = True
+    if not complete or not finished or expansions != 1 or labels != aborted:
+        return None
+    return sorted({apparent_label(label): None for label in labels})
+
+def select_tests(ctx: TaskContext, patterns: list[str], rc, directory: str | None = None, endpoint_auth_flags: list = []) -> list[str] | None:
+    """Load the original patterns with test-command RC and filtering semantics."""
+    work = ctx.std.fs.mkdtemp(prefix = "aspect-cache-selection-")
+    ctx.defer(lambda: ctx.std.fs.remove_dir_all(work))
+    event_path = work + "/events.json"
+    error_path = work + "/stderr"
+    status = ctx.bazel.test(
+        rc = rc,
+        directory = directory,
+        # --build overrides a user's --nobuild (which changes test's exit
+        # code). --noanalyze still prevents analysis and all build/test actions.
+        flags = endpoint_auth_flags + [
+            "--build",
+            "--noanalyze",
+            "--build_tests_only",
+            "--nokeep_going",
+            "--build_event_json_file=" + event_path,
+            # Keep this private log local; uploading its referenced files would
+            # contact the cache even for an empty selection.
+            "--nobuild_event_json_file_path_conversion",
+        ],
+        build_events = False,
+        stdout = None,
+        stderr = ctx.std.fs.create(error_path),
+        announce_version = False,
+        announce_command = False,
+        *patterns
+    ).wait()
+    events = []
+    if ctx.std.fs.exists(event_path):
+        for line in ctx.std.fs.read_to_string(event_path).splitlines():
+            if line:
+                event = json.try_decode(line, None)
+                if type(event) != "dict":
+                    events = []
+                    break
+                events.append(event)
+    tests = selected_tests(events, status.code)
+    if tests == None:
+        ctx.std.io.stderr.write("ERROR: cache diff could not establish the selected tests from Bazel's loading events (exit {}).\n".format(status.code))
+        ctx.std.io.stderr.write(ctx.std.fs.read_to_string(error_path))
+    return tests

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection.axl
@@ -102,7 +102,8 @@ def attribution_flags(flags: list) -> list:
         if value.split("=", 1)[0] in _SELECTION_FLAGS:
             skip_value = "=" not in value
         else:
-            result.append(flag)
+            # expand_all already evaluated version conditions against the source RC.
+            result.append(value)
     return result
 
 def attribution_rc(ctx: TaskContext, rc):

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection.axl
@@ -2,12 +2,12 @@
 
 load("./runnable.axl", "apparent_label")
 
-def selected_tests(events: list, exit_code: int) -> list[str] | None:
+def testonly_selected_tests(events: list, exit_code: int) -> list[str] | None:
     """Accept only a complete, successful loading-only test selection."""
 
     # With analysis disabled, `test` exits NO_TESTS_FOUND even when loading
     # selected tests. Never treat that exit code alone as successful selection.
-    if exit_code != 4:
+    if exit_code not in [0, 4]:
         return None
     labels = {}
     aborted = {}
@@ -30,17 +30,21 @@ def selected_tests(events: list, exit_code: int) -> list[str] | None:
                 return None
             aborted[label] = None
         if "finished" in event:
-            if finished or event["finished"].get("exitCode", {}).get("code") != 4:
+            if finished or event["finished"].get("exitCode", {}).get("code") != exit_code:
                 return None
             finished = True
     if not complete or not finished or expansions != 1 or labels != aborted:
         return None
     return sorted({apparent_label(label): None for label in labels})
 
-def select_tests(ctx: TaskContext, patterns: list[str], rc, directory: str | None = None, endpoint_auth_flags: list = []) -> list[str] | None:
+def select_tests(ctx: TaskContext, patterns: list[str], rc, directory: str | None = None, endpoint_auth_flags: list = [], announce_version: bool = False, announce_command: bool = False) -> list[str] | None:
     """Load the original patterns with test-command RC and filtering semantics."""
+    version = ctx.bazel.version()
+    if version != None and int(version.split(".")[0]) < 7:
+        ctx.std.io.stderr.write("ERROR: cache diff test selection requires Bazel 7 or newer (found {}).\n".format(version))
+        return None
     work = ctx.std.fs.mkdtemp(prefix = "aspect-cache-selection-")
-    ctx.defer(lambda: ctx.std.fs.remove_dir_all(work))
+    ctx.defer(lambda: ctx.std.fs.remove_dir_all(work) if ctx.std.fs.exists(work) else None)
     event_path = work + "/events.json"
     error_path = work + "/stderr"
     status = ctx.bazel.test(
@@ -49,6 +53,7 @@ def select_tests(ctx: TaskContext, patterns: list[str], rc, directory: str | Non
         # --build overrides a user's --nobuild (which changes test's exit
         # code). --noanalyze still prevents analysis and all build/test actions.
         flags = endpoint_auth_flags + [
+            "--bes_backend=",
             "--build",
             "--noanalyze",
             "--build_tests_only",
@@ -61,8 +66,8 @@ def select_tests(ctx: TaskContext, patterns: list[str], rc, directory: str | Non
         build_events = False,
         stdout = None,
         stderr = ctx.std.fs.create(error_path),
-        announce_version = False,
-        announce_command = False,
+        announce_version = announce_version,
+        announce_command = announce_command,
         *patterns
     ).wait()
     events = []
@@ -74,38 +79,40 @@ def select_tests(ctx: TaskContext, patterns: list[str], rc, directory: str | Non
                     events = []
                     break
                 events.append(event)
-    tests = selected_tests(events, status.code)
+    tests = testonly_selected_tests(events, status.code)
     if tests == None:
-        ctx.std.io.stderr.write("ERROR: cache diff could not establish the selected tests from Bazel's loading events (exit {}).\n".format(status.code))
+        ctx.std.io.stderr.write("ERROR: cache diff could not establish the selected tests from Bazel's loading events (Bazel {}, exit {}). This requires Bazel 7+ with complete loading-only BEP events; no query fallback is used because it cannot preserve test filters.\n".format(version or "unknown", status.code))
         ctx.std.io.stderr.write(ctx.std.fs.read_to_string(error_path))
+    ctx.std.fs.remove_dir_all(work)
     return tests
 
-# These options select tests/patterns, not the dependency graph queried during
-# attribution. CLI-supplied options otherwise reach every RC command verbatim.
-_SELECTION_FLAGS = [
-    "--test_tag_filters",
-    "--test_size_filters",
-    "--test_timeout_filters",
-    "--test_lang_filters",
-    "--test_filter",
-    "--target_pattern_file",
-]
+# Negative filter values are valid Bazel argv values even though they start
+# with '-'. Other two-token pairs use the same non-flag guard as BazelRC.
+_NEGATIVE_FILTER_FLAGS = ["--test_tag_filters", "--test_size_filters", "--test_timeout_filters", "--test_lang_filters", "--test_filter"]
 
-def attribution_flags(flags: list) -> list:
+def testonly_attribution_flags(flags: list) -> list:
+    """Let Bazel ignore command-inapplicable flags through its common section."""
+    values = [flag[0] if type(flag) == "tuple" else flag for flag in flags]
     result = []
-    skip_value = False
-    for flag in flags:
-        if skip_value:
-            skip_value = False
+    consumed = False
+    for i, value in enumerate(values):
+        if consumed:
+            consumed = False
             continue
-        value = flag[0] if type(flag) == "tuple" else flag
-        if value.split("=", 1)[0] in _SELECTION_FLAGS:
-            skip_value = "=" not in value
-        else:
-            # expand_all already evaluated version conditions against the source RC.
+        if value.startswith("--default_override="):
             result.append(value)
+            continue
+        if value.startswith("-") and "=" not in value and i + 1 < len(values):
+            following = values[i + 1]
+            if not following.startswith("-") or (value in _NEGATIVE_FILTER_FLAGS and not following.startswith("--")):
+                value += "=" + following
+                consumed = True
+
+        # expand_all has already evaluated version conditions against the source RC.
+        result.append("--default_override=0:common=" + value)
     return result
 
 def attribution_rc(ctx: TaskContext, rc):
     _, flags = rc.expand_all(command = "query")
-    return ctx.bazel.new_rc(startup_flags = rc.startup_flags(), flags = attribution_flags(flags))
+    startup = [f for f in rc.startup_flags() if f != "--ignore_all_rc_files"]
+    return ctx.bazel.new_rc(startup_flags = startup, flags = testonly_attribution_flags(flags))

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection.axl
@@ -79,3 +79,32 @@ def select_tests(ctx: TaskContext, patterns: list[str], rc, directory: str | Non
         ctx.std.io.stderr.write("ERROR: cache diff could not establish the selected tests from Bazel's loading events (exit {}).\n".format(status.code))
         ctx.std.io.stderr.write(ctx.std.fs.read_to_string(error_path))
     return tests
+
+# These options select tests/patterns, not the dependency graph queried during
+# attribution. CLI-supplied options otherwise reach every RC command verbatim.
+_SELECTION_FLAGS = [
+    "--test_tag_filters",
+    "--test_size_filters",
+    "--test_timeout_filters",
+    "--test_lang_filters",
+    "--test_filter",
+    "--target_pattern_file",
+]
+
+def attribution_flags(flags: list) -> list:
+    result = []
+    skip_value = False
+    for flag in flags:
+        if skip_value:
+            skip_value = False
+            continue
+        value = flag[0] if type(flag) == "tuple" else flag
+        if value.split("=", 1)[0] in _SELECTION_FLAGS:
+            skip_value = "=" not in value
+        else:
+            result.append(flag)
+    return result
+
+def attribution_rc(ctx: TaskContext, rc):
+    _, flags = rc.expand_all(command = "query")
+    return ctx.bazel.new_rc(startup_flags = rc.startup_flags(), flags = attribution_flags(flags))

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
@@ -1,0 +1,118 @@
+"""Cache selection contracts, including real Bazel loading without actions."""
+
+load("./cache_selection.axl", "select_tests", "selected_tests")
+
+def _eq(name, got, want):
+    if got != want:
+        fail("%s: got %r, want %r" % (name, got, want))
+
+def _events(labels):
+    return [
+        {"expanded": {}, "children": [{"targetConfigured": {"label": t}} for t in labels]},
+        {"finished": {"exitCode": {"code": 4}}},
+    ] + [{"id": {"targetConfigured": {"label": t}}, "aborted": {"reason": "NO_ANALYZE"}} for t in labels] + [{"lastMessage": True}]
+
+def _parser_tests():
+    good = _events(["//:b", "//:a"])
+    _eq("selected labels", selected_tests(good, 4), ["//:a", "//:b"])
+    _eq("empty scope", selected_tests(_events([]), 4), [])
+    for code in [0, 1, 2, 3, 8, 130]:
+        _eq("unexpected process exit", selected_tests(good, code), None)
+    _eq("no events", selected_tests([], 4), None)
+    _eq("missing terminal event", selected_tests(good[:-1], 4), None)
+    _eq("missing expansion", selected_tests(good[1:], 4), None)
+    _eq("missing finish", selected_tests(good[:1] + good[2:], 4), None)
+    _eq("missing target abort", selected_tests(good[:2] + good[3:], 4), None)
+    _eq("duplicate expansion", selected_tests(good[:1] + good, 4), None)
+    _eq("duplicate finish", selected_tests(good[:2] + good[1:], 4), None)
+    _eq("trailing events", selected_tests(good + [{}], 4), None)
+    for reason in ["LOADING_FAILURE", "INTERNAL", "USER_INTERRUPTED", "ANALYSIS_FAILURE"]:
+        bad = {"aborted": {"reason": reason}}
+        _eq("abort " + reason, selected_tests(good[:-1] + [bad, good[-1]], 4), None)
+    _eq("partial expansion", selected_tests([
+        {"expanded": {}, "children": [{"pattern": {"pattern": ["//missing/..."]}}]},
+    ] + good[1:], 4), None)
+
+def _impl(ctx: TaskContext) -> int:
+    _parser_tests()
+    root = ctx.std.fs.mkdtemp(prefix = "aspect-selection-test-")
+    ctx.defer(lambda: ctx.std.fs.remove_dir_all(root))
+    workspace = root + "/workspace"
+    ctx.std.fs.create_dir_all(workspace + "/personal")
+    ctx.std.fs.write(workspace + "/MODULE.bazel", "module(name = 'selection_fixture')\n")
+    ctx.std.fs.write(workspace + "/WORKSPACE", "")
+    ctx.std.fs.write(workspace + "/defs.bzl", """
+def _impl(ctx):
+    fail("selection must never analyze targets")
+fixture_test = rule(implementation = _impl, test = True)
+""")
+    ctx.std.fs.write(workspace + "/BUILD", """
+load(":defs.bzl", "fixture_test")
+fixture_test(name = "ci", size = "small", timeout = "short")
+fixture_test(name = "skip", tags = ["noci"], size = "large", timeout = "long")
+fixture_test(name = "manual", tags = ["manual"])
+fixture_test(name = "name+equals=x", tags = ["manual"])
+filegroup(name = "shared")
+test_suite(name = "suite", tests = [":ci", ":skip"], tags = ["manual"])
+""")
+    ctx.std.fs.write(workspace + "/personal/BUILD", """
+load("//:defs.bzl", "fixture_test")
+fixture_test(name = "private_test")
+""")
+    startup = ["--batch", "--output_base=" + root + "/output"]
+    ctx.bazel.use_rc(ctx.bazel.new_rc(startup_flags = startup))
+    cases = [
+        ("positive", ["//:ci"], [], ["//:ci"]),
+        ("default wildcard", ["//..."], [], ["//:ci", "//:skip", "//personal:private_test"]),
+        ("negative", ["//...", "-//personal/..."], [], ["//:ci", "//:skip"]),
+        ("reinclude", ["//...", "-//personal/...", "//personal:private_test"], [], ["//:ci", "//:skip", "//personal:private_test"]),
+        ("only negative", ["-//personal/..."], [], []),
+        ("empty", ["//...", "-//..."], [], []),
+        ("non-test", ["//:shared"], [], []),
+        ("relative", [":ci"], [], ["//:ci"]),
+        ("duplicate", ["//:ci", "//:ci"], [], ["//:ci"]),
+        ("unusual label", ["//:name+equals=x"], [], ["//:name+equals=x"]),
+        ("explicit manual", ["//:manual"], [], ["//:manual"]),
+        ("suite", ["//:suite"], [], ["//:ci", "//:skip"]),
+        ("tag filter", ["//..."], ["--test_tag_filters=-noci"], ["//:ci", "//personal:private_test"]),
+        ("suite filter", ["//:suite"], ["--test_tag_filters=-noci"], ["//:ci"]),
+        ("explicit filtered", ["//:skip"], ["--test_tag_filters=-noci"], []),
+        ("positive tag", ["//..."], ["--test_tag_filters=noci"], ["//:skip"]),
+        ("two-token flag", ["//..."], ["--test_tag_filters", "-noci"], ["//:ci", "//personal:private_test"]),
+        ("size filter", ["//:suite"], ["--test_size_filters=small"], ["//:ci"]),
+        ("timeout filter", ["//:suite"], ["--test_timeout_filters=short"], ["//:ci"]),
+        ("language filter", ["//..."], ["--test_lang_filters=-fixture"], []),
+        ("build filters do not filter tests", ["//:skip"], ["--build_tag_filters=-noci"], ["//:skip"]),
+        ("selection does not upload BEP files", ["//:ci"], ["--remote_cache=grpc://127.0.0.1:1"], ["//:ci"]),
+        ("override nobuild", ["//:ci"], ["--nobuild"], ["//:ci"]),
+        ("bad pattern", ["//missing/..."], [], None),
+        ("partial loading failure", ["//:ci", "//missing/..."], ["--keep_going"], None),
+        ("unknown flag", ["//:ci"], ["--definitely_not_a_flag"], None),
+    ]
+    for name, patterns, flags, want in cases:
+        rc = ctx.bazel.new_rc(startup_flags = startup, flags = flags)
+        _eq(name, select_tests(ctx, patterns, rc, directory = workspace), want)
+    ctx.std.fs.create_dir_all(root + "/external")
+    ctx.std.fs.write(root + "/external/MODULE.bazel", "module(name = 'selection_external')\n")
+    ctx.std.fs.write(root + "/external/defs.bzl", ctx.std.fs.read_to_string(workspace + "/defs.bzl"))
+    ctx.std.fs.write(root + "/external/BUILD", "load(':defs.bzl', 'fixture_test')\nfixture_test(name = 'remote_test')\n")
+    ctx.std.fs.write(workspace + "/MODULE.bazel", "module(name = 'selection_fixture')\nbazel_dep(name = 'selection_external', version = '1.0')\nlocal_path_override(module_name = 'selection_external', path = '../external')\n")
+    rc = ctx.bazel.new_rc(startup_flags = startup)
+    _eq("external pattern", select_tests(ctx, ["@selection_external//..."], rc, directory = workspace), ["@selection_external//:remote_test"])
+    ctx.std.fs.write(workspace + "/patterns", "//...\n-//personal/...\n")
+    rc = ctx.bazel.new_rc(startup_flags = startup, flags = ["--target_pattern_file=" + workspace + "/patterns", "--test_tag_filters=-noci"])
+    _eq("pattern file", select_tests(ctx, [], rc, directory = workspace), ["//:ci"])
+    _eq("pattern file conflict", select_tests(ctx, ["//:ci"], rc, directory = workspace), None)
+    ctx.std.fs.write(workspace + "/.bazelrc", "build --test_tag_filters=noci\nquery --output=label_kind\ntest --test_tag_filters=-noci\ntest:ci --config=inner\ntest:inner --test_size_filters=small\n")
+    rc = ctx.bazel.parse_rc(root = workspace, startup_flags = startup + ["--nosystem_rc", "--nohome_rc"], flags = ["--config=ci"])
+    _eq("test RC and nested config", select_tests(ctx, ["//:suite"], rc, directory = workspace), ["//:ci"])
+    print("cache_selection: parser checks and %d real Bazel cases passed" % (len(cases) + 4))
+    return 0
+
+cache_selection_tests = task(
+    summary = "Verify cache-diff selection against real Bazel loading semantics.",
+    kind = "test-cache-selection",
+    group = ["dev"],
+    implementation = _impl,
+    args = {},
+)

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
@@ -1,6 +1,6 @@
 """Cache selection contracts, including real Bazel loading without actions."""
 
-load("./cache_selection.axl", "attribution_flags", "attribution_rc", "select_tests", "selected_tests")
+load("./cache_selection.axl", "attribution_rc", "select_tests", "testonly_attribution_flags", "testonly_selected_tests")
 
 def _eq(name, got, want):
     if got != want:
@@ -14,48 +14,59 @@ def _events(labels):
 
 def _parser_tests():
     good = _events(["//:b", "//:a"])
-    _eq("selected labels", selected_tests(good, 4), ["//:a", "//:b"])
-    _eq("empty scope", selected_tests(_events([]), 4), [])
+    _eq("selected labels", testonly_selected_tests(good, 4), ["//:a", "//:b"])
+    success = [good[0], {"finished": {"exitCode": {"code": 0}}}] + good[2:]
+    _eq("successful loading exit", testonly_selected_tests(success, 0), ["//:a", "//:b"])
+    _eq("empty scope", testonly_selected_tests(_events([]), 4), [])
     for code in [0, 1, 2, 3, 8, 130]:
-        _eq("unexpected process exit", selected_tests(good, code), None)
-    _eq("no events", selected_tests([], 4), None)
-    _eq("missing terminal event", selected_tests(good[:-1], 4), None)
-    _eq("missing expansion", selected_tests(good[1:], 4), None)
-    _eq("missing finish", selected_tests(good[:1] + good[2:], 4), None)
-    _eq("missing target abort", selected_tests(good[:2] + good[3:], 4), None)
-    _eq("duplicate expansion", selected_tests(good[:1] + good, 4), None)
-    _eq("duplicate finish", selected_tests(good[:2] + good[1:], 4), None)
-    _eq("trailing events", selected_tests(good + [{}], 4), None)
+        _eq("unexpected process exit", testonly_selected_tests(good, code), None)
+    _eq("no events", testonly_selected_tests([], 4), None)
+    _eq("missing terminal event", testonly_selected_tests(good[:-1], 4), None)
+    _eq("missing expansion", testonly_selected_tests(good[1:], 4), None)
+    _eq("missing finish", testonly_selected_tests(good[:1] + good[2:], 4), None)
+    _eq("missing target abort", testonly_selected_tests(good[:2] + good[3:], 4), None)
+    _eq("duplicate expansion", testonly_selected_tests(good[:1] + good, 4), None)
+    _eq("duplicate finish", testonly_selected_tests(good[:2] + good[1:], 4), None)
+    _eq("trailing events", testonly_selected_tests(good + [{}], 4), None)
     for reason in ["LOADING_FAILURE", "INTERNAL", "USER_INTERRUPTED", "ANALYSIS_FAILURE"]:
         bad = {"aborted": {"reason": reason}}
-        _eq("abort " + reason, selected_tests(good[:-1] + [bad, good[-1]], 4), None)
-    _eq("partial expansion", selected_tests([
+        _eq("abort " + reason, testonly_selected_tests(good[:-1] + [bad, good[-1]], 4), None)
+    _eq("partial expansion", testonly_selected_tests([
         {"expanded": {}, "children": [{"pattern": {"pattern": ["//missing/..."]}}]},
     ] + good[1:], 4), None)
 
 def _impl(ctx: TaskContext) -> int:
     _parser_tests()
-    _eq("attribution keeps graph flags", attribution_flags([
-        "--define=foo=bar",
-        "--test_tag_filters",
-        "-noci",
-        "--test_size_filters=small",
-        "--target_pattern_file=/tmp/patterns",
-        "--test_filter=selected_case",
-        "--test_timeout_filters",
-        "short",
-        "--test_lang_filters=go",
-        "--keep_going",
-    ]), ["--define=foo=bar", "--keep_going"])
-    _eq("versioned selection flag", attribution_flags([("--test_tag_filters=-noci", ">=7")]), [])
-    _eq("common overrides remain Bazel-owned", attribution_flags(["--default_override=0:common=--test_tag_filters=-noci"]), ["--default_override=0:common=--test_tag_filters=-noci"])
+    _eq("command-inapplicable flags use common", testonly_attribution_flags([
+        "--test_env=FOO=1",
+        "--runs_per_test=2",
+        "--build_tests_only",
+        "--remote_download_outputs=minimal",
+        "--remote_cache=grpc://127.0.0.1:1",
+    ]), ["--default_override=0:common=" + flag for flag in [
+        "--test_env=FOO=1",
+        "--runs_per_test=2",
+        "--build_tests_only",
+        "--remote_download_outputs=minimal",
+        "--remote_cache=grpc://127.0.0.1:1",
+    ]])
+    _eq("do not consume a following flag", testonly_attribution_flags(["--test_filter", "--keep_going"]), [
+        "--default_override=0:common=--test_filter",
+        "--default_override=0:common=--keep_going",
+    ])
+    _eq("two-token and negative values", testonly_attribution_flags(["--test_env", "FOO=1", "--test_tag_filters", "-noci", "--keep_going"]), [
+        "--default_override=0:common=--test_env=FOO=1",
+        "--default_override=0:common=--test_tag_filters=-noci",
+        "--default_override=0:common=--keep_going",
+    ])
+    _eq("common overrides remain Bazel-owned", testonly_attribution_flags(["--default_override=0:common=--test_tag_filters=-noci"]), ["--default_override=0:common=--test_tag_filters=-noci"])
     versioned = ctx.bazel.new_rc(version = "7.4.0", flags = [
         ("--define=old_graph=yes", "<8"),
         ("--define=new_graph=yes", ">=8"),
         ("--test_tag_filters=-noci", "<8"),
     ])
     _, query_flags = attribution_rc(ctx, versioned).expand_all(command = "query")
-    _eq("attribution preserves resolved version conditions", query_flags, ["--define=old_graph=yes"])
+    _eq("attribution preserves resolved version conditions", query_flags, ["--default_override=0:common=--define=old_graph=yes", "--default_override=0:common=--test_tag_filters=-noci"])
     root = ctx.std.fs.mkdtemp(prefix = "aspect-selection-test-")
     ctx.defer(lambda: ctx.std.fs.remove_dir_all(root))
     workspace = root + "/workspace"
@@ -81,6 +92,7 @@ fixture_test(name = "private_test")
     startup = ["--batch", "--output_base=" + root + "/output"]
     ctx.bazel.use_rc(ctx.bazel.new_rc(startup_flags = startup))
     cases = [
+        ("BES disabled for loading", ["//:ci"], ["--bes_backend=grpc://127.0.0.1:1", "--bes_timeout=1s"], ["//:ci"]),
         ("positive", ["//:ci"], [], ["//:ci"]),
         ("default wildcard", ["//..."], [], ["//:ci", "//:skip", "//personal:private_test"]),
         ("negative", ["//...", "-//personal/..."], [], ["//:ci", "//:skip"]),

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
@@ -1,6 +1,6 @@
 """Cache selection contracts, including real Bazel loading without actions."""
 
-load("./cache_selection.axl", "attribution_flags", "select_tests", "selected_tests")
+load("./cache_selection.axl", "attribution_flags", "attribution_rc", "select_tests", "selected_tests")
 
 def _eq(name, got, want):
     if got != want:
@@ -49,6 +49,13 @@ def _impl(ctx: TaskContext) -> int:
     ]), ["--define=foo=bar", "--keep_going"])
     _eq("versioned selection flag", attribution_flags([("--test_tag_filters=-noci", ">=7")]), [])
     _eq("common overrides remain Bazel-owned", attribution_flags(["--default_override=0:common=--test_tag_filters=-noci"]), ["--default_override=0:common=--test_tag_filters=-noci"])
+    versioned = ctx.bazel.new_rc(version = "7.4.0", flags = [
+        ("--define=old_graph=yes", "<8"),
+        ("--define=new_graph=yes", ">=8"),
+        ("--test_tag_filters=-noci", "<8"),
+    ])
+    _, query_flags = attribution_rc(ctx, versioned).expand_all(command = "query")
+    _eq("attribution preserves resolved version conditions", query_flags, ["--define=old_graph=yes"])
     root = ctx.std.fs.mkdtemp(prefix = "aspect-selection-test-")
     ctx.defer(lambda: ctx.std.fs.remove_dir_all(root))
     workspace = root + "/workspace"

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
@@ -1,6 +1,6 @@
 """Cache selection contracts, including real Bazel loading without actions."""
 
-load("./cache_selection.axl", "select_tests", "selected_tests")
+load("./cache_selection.axl", "attribution_flags", "select_tests", "selected_tests")
 
 def _eq(name, got, want):
     if got != want:
@@ -35,6 +35,20 @@ def _parser_tests():
 
 def _impl(ctx: TaskContext) -> int:
     _parser_tests()
+    _eq("attribution keeps graph flags", attribution_flags([
+        "--define=foo=bar",
+        "--test_tag_filters",
+        "-noci",
+        "--test_size_filters=small",
+        "--target_pattern_file=/tmp/patterns",
+        "--test_filter=selected_case",
+        "--test_timeout_filters",
+        "short",
+        "--test_lang_filters=go",
+        "--keep_going",
+    ]), ["--define=foo=bar", "--keep_going"])
+    _eq("versioned selection flag", attribution_flags([("--test_tag_filters=-noci", ">=7")]), [])
+    _eq("common overrides remain Bazel-owned", attribution_flags(["--default_override=0:common=--test_tag_filters=-noci"]), ["--default_override=0:common=--test_tag_filters=-noci"])
     root = ctx.std.fs.mkdtemp(prefix = "aspect-selection-test-")
     ctx.defer(lambda: ctx.std.fs.remove_dir_all(root))
     workspace = root + "/workspace"

--- a/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
+++ b/crates/aspect-cli/src/builtins/aspect/private/lib/cache_selection_test.axl
@@ -60,8 +60,7 @@ def _impl(ctx):
     fail("selection must never analyze targets")
 fixture_test = rule(implementation = _impl, test = True)
 """)
-    ctx.std.fs.write(workspace + "/BUILD", """
-load(":defs.bzl", "fixture_test")
+    ctx.std.fs.write(workspace + "/BUILD", """load(":defs.bzl", "fixture_test")
 fixture_test(name = "ci", size = "small", timeout = "short")
 fixture_test(name = "skip", tags = ["noci"], size = "large", timeout = "long")
 fixture_test(name = "manual", tags = ["manual"])
@@ -69,8 +68,7 @@ fixture_test(name = "name+equals=x", tags = ["manual"])
 filegroup(name = "shared")
 test_suite(name = "suite", tests = [":ci", ":skip"], tags = ["manual"])
 """)
-    ctx.std.fs.write(workspace + "/personal/BUILD", """
-load("//:defs.bzl", "fixture_test")
+    ctx.std.fs.write(workspace + "/personal/BUILD", """load("//:defs.bzl", "fixture_test")
 fixture_test(name = "private_test")
 """)
     startup = ["--batch", "--output_base=" + root + "/output"]

--- a/tools/cache-diff-integration.py
+++ b/tools/cache-diff-integration.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Exercise cache diff against an isolated REAPI cache. Requires Bazel and the CLI.
+
+Usage: python3 tools/cache-diff-integration.py --aspect /path/to/aspect-cli
+The pinned cache binary is downloaded and checksum-verified; no Docker or cloud
+credentials are needed. All fixtures, cache entries and servers are temporary.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import shlex
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.request
+
+CACHE_VERSION = "2.6.2"
+CACHE_SHA256 = {
+    "darwin-amd64": "fc3b8f5d8edcf94f578cf6ffa8071d8859f5f02a38c14ae00cd3d22aa44974b6",
+    "darwin-arm64": "1d6bc5fe5be7a66c7aeea6723280402414e280ae579016d3b5e6e5c77278ad04",
+    "linux-amd64": "62e236bf8396e69396928e0d0c32062fbd5575f20fe55dc10a82eb791297e1a0",
+    "linux-arm64": "b2cabd5bf674e8d0649de2c95dddfea8d875db1a06ed9d431674c9293df273ed",
+}
+
+
+def free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--aspect", required=True)
+    parser.add_argument("--bazel", default="bazel")
+    args = parser.parse_args()
+    aspect = str(Path(shutil.which(args.aspect) or args.aspect).resolve())
+    bazel = str(Path(shutil.which(args.bazel) or args.bazel).resolve())
+    started = time.monotonic()
+    with tempfile.TemporaryDirectory(prefix="cache-diff-integration-") as tmp:
+        root = Path(tmp)
+        arch = {"x86_64": "amd64", "aarch64": "arm64"}.get(platform.machine(), platform.machine())
+        target = f"{platform.system().lower()}-{arch}"
+        binary = root / "bazel-remote"
+        url = f"https://github.com/buchgr/bazel-remote/releases/download/v{CACHE_VERSION}/bazel-remote-{CACHE_VERSION}-{target}"
+        with urllib.request.urlopen(url, timeout=60) as response:
+            content = response.read()
+        assert hashlib.sha256(content).hexdigest() == CACHE_SHA256[target], "cache binary checksum mismatch"
+        binary.write_bytes(content)
+        binary.chmod(0o700)
+        http_port, grpc_port = free_port(), free_port()
+        while grpc_port == http_port:
+            grpc_port = free_port()
+        env = {k: v for k, v in os.environ.items() if k != "CI" and not k.startswith(("BAZEL_REMOTE_", "ASPECT_", "GITHUB_", "BUILDKITE_"))}
+        env["BAZEL_REAL"] = bazel
+        workspace = root / "workspace"
+        workspace.mkdir()
+        (workspace / ".bazelversion").write_text("9.2.0\n")
+        (workspace / "MODULE.bazel").write_text('module(name = "cache_fixture")\n')
+        (workspace / "MODULE.aspect").write_text("")
+        (workspace / "shared.in").write_text("baseline\n")
+        (workspace / "personal").mkdir()
+        markers = root / "markers"
+        markers.mkdir()
+        (workspace / "defs.bzl").write_text('''
+def _shared(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".out")
+    ctx.actions.run_shell(inputs = [ctx.file.src], outputs = [out],
+        command = BUILD_COMMAND,
+        arguments = [ctx.file.src.path, out.path], mnemonic = "FixtureCopy")
+    return [DefaultInfo(files = depset([out]))]
+shared = rule(implementation = _shared, attrs = {"src": attr.label(allow_single_file = True)})
+def _test(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".sh")
+    ctx.actions.write(out, TEST_SCRIPT, is_executable = True)
+    return [DefaultInfo(executable = out, runfiles = ctx.runfiles(files = ctx.files.data))]
+fixture_test = rule(implementation = _test, test = True, attrs = {"data": attr.label_list(allow_files = True)})
+'''.replace("BUILD_COMMAND", json.dumps(f'echo build >> {shlex.quote(str(markers / "build"))}; cat "$1" > "$2"')).replace(
+            "TEST_SCRIPT", json.dumps(f"#!/bin/sh\necho test >> {shlex.quote(str(markers / 'test'))}\nexit 0\n")))
+        (workspace / "BUILD").write_text('''
+load(":defs.bzl", "fixture_test", "shared")
+shared(name = "shared", src = "shared.in", visibility = ["//visibility:public"])
+fixture_test(name = "a", data = [":shared"])
+fixture_test(name = "b", data = [":shared"])
+fixture_test(name = "noci", data = [":shared"], tags = ["noci"])
+fixture_test(name = "unrelated")
+test_suite(name = "suite", tests = [":a", ":b", ":noci"], tags = ["manual"])
+''')
+        (workspace / "personal/BUILD").write_text('''
+load("//:defs.bzl", "fixture_test")
+fixture_test(name = "excluded", data = ["//:shared"])
+''')
+        startup = [ f"--output_base={root / 'output'}", "--host_jvm_args=-Xmx512m"]
+        flags = [f"--remote_cache=grpc://127.0.0.1:{grpc_port}", "--remote_upload_local_results",
+                 "--jobs=2", "--local_test_jobs=2", "--remote_timeout=15", "--remote_retries=0",
+                 f"--sandbox_writable_path={markers}", "--lockfile_mode=off", "--bes_backend="]
+        (workspace / ".bazelrc").write_text("".join(f"startup {f}\n" for f in startup) + "".join(f"build {f}\n" for f in flags))
+        timings = {}
+
+        def run(name, command, expected=0):
+            before = time.monotonic()
+            result = subprocess.run(command, cwd=workspace, env=env, text=True, capture_output=True, timeout=180)
+            timings[name] = round(time.monotonic() - before, 3)
+            print(f"{name}: exit={result.returncode}, seconds={timings[name]}", flush=True)
+            assert result.returncode == expected, result.stdout + result.stderr
+            return result
+
+        def count(kind):
+            path = markers / kind
+            return len(path.read_text().splitlines()) if path.exists() else 0
+
+        def probe(name, mode="overreport", patterns=None, expected=None, total=3):
+            before_tests, before_builds = count("test"), count("build")
+            result = run(name, [aspect, "cache", "diff", "--bazel-startup-flag=--nosystem_rc", "--bazel-startup-flag=--nohome_rc", f"--mode={mode}", "--output=json", "--test_tag_filters=-noci", "--"] + (patterns or ["//...", "-//personal/..."]))
+            doc = json.loads(result.stdout)
+            got = {row["label"] for row in doc["affected"]}
+            assert got == set(expected or []), (name, doc)
+            assert doc["total_tests"] == total, (name, doc)
+            assert count("test") == before_tests, f"{name}: probe executed a test"
+            if mode == "overreport":
+                assert count("build") == before_builds, f"{name}: probe executed a build action"
+            return doc
+
+        with (root / "server.log").open("w+") as log:
+            server = subprocess.Popen([str(binary), "--dir", str(root / "cache"), "--max_size", "1",
+                                       "--http_address", f"127.0.0.1:{http_port}",
+                                       "--grpc_address", f"127.0.0.1:{grpc_port}"], env=env, stdout=log, stderr=subprocess.STDOUT)
+            try:
+                for _ in range(100):
+                    try:
+                        with urllib.request.urlopen(f"http://127.0.0.1:{http_port}/status", timeout=1):
+                            break
+                    except OSError:
+                        if server.poll() is not None:
+                            log.seek(0)
+                            raise AssertionError(log.read())
+                        time.sleep(0.1)
+                else:
+                    raise AssertionError("cache server did not become ready")
+                run("seed", [bazel, "--nosystem_rc", "--nohome_rc", "test", "//..."])
+                assert count("test") == 5, "baseline did not execute every fixture test"
+                assert count("build") == 1, "baseline did not build the shared dependency"
+                probe("warm_hits")
+                (workspace / "shared.in").write_text("changed\n")
+                doc = probe("dependency_miss", expected=["//:a", "//:b"])
+                assert all(any(c["target"] == "//:shared" for c in row["caused_by"]) for row in doc["affected"]), doc
+                probe("suite_miss", patterns=["//:suite", "//:unrelated"], expected=["//:a", "//:b"])
+                probe("reinclude_miss", patterns=["//...", "-//personal/...", "//personal:excluded"],
+                      expected=["//:a", "//:b", "//personal:excluded"], total=4)
+                probe("precise_miss", mode="precise", expected=["//:a", "//:b"])
+                assert count("build") == 2, "precise mode did not build the changed dependency"
+                run("refresh_baseline", [bazel, "--nosystem_rc", "--nohome_rc", "test", "//..."])
+                probe("warm_hits_after_change")
+                before = count("test")
+                result = run("empty_scope", [aspect, "cache", "diff", "--bazel-startup-flag=--nosystem_rc", "--bazel-startup-flag=--nohome_rc", "--exec=exit 99", "--", "//...", "-//..."])
+                assert not result.stdout and count("test") == before
+                with urllib.request.urlopen(f"http://127.0.0.1:{http_port}/status", timeout=5) as response:
+                    status = json.load(response)
+                print(json.dumps({"timings": timings, "total_seconds": round(time.monotonic() - started, 3),
+                                  "cache_bytes": status["CurrSize"], "cache_files": status["NumFiles"]}, indent=2), flush=True)
+            finally:
+                try:
+                    subprocess.run([bazel, "--nosystem_rc", "--nohome_rc", "shutdown"], cwd=workspace, env=env, capture_output=True, timeout=30)
+                finally:
+                    server.terminate()
+                    try:
+                        server.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        server.kill()
+                        server.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/cache-diff-integration.py
+++ b/tools/cache-diff-integration.py
@@ -7,6 +7,7 @@ credentials are needed. All fixtures, cache entries and servers are temporary.
 """
 
 import argparse
+from contextlib import ExitStack
 import hashlib
 import json
 import os
@@ -35,33 +36,86 @@ def free_port():
         return sock.getsockname()[1]
 
 
+def download_cache(binary, target):
+    if target not in CACHE_SHA256:
+        raise RuntimeError(f"unsupported cache integration platform: {target}")
+    url = f"https://github.com/buchgr/bazel-remote/releases/download/v{CACHE_VERSION}/bazel-remote-{CACHE_VERSION}-{target}"
+    for attempt in range(3):
+        try:
+            # urlopen uses the standard HTTP(S)_PROXY / NO_PROXY environment.
+            with urllib.request.urlopen(url, timeout=60) as response:
+                content = response.read()
+            break
+        except OSError:
+            if attempt == 2:
+                raise
+            time.sleep(attempt + 1)
+    if hashlib.sha256(content).hexdigest() != CACHE_SHA256[target]:
+        raise RuntimeError("cache binary checksum mismatch")
+    binary.write_bytes(content)
+    binary.chmod(0o700)
+
+
+def stop_cache(server):
+    server.terminate()
+    try:
+        server.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        server.kill()
+        server.wait()
+
+
+def start_cache(binary, root, env, log):
+    for attempt in range(3):
+        http_port, grpc_port = free_port(), free_port()
+        while grpc_port == http_port:
+            grpc_port = free_port()
+        log.seek(0)
+        log.truncate()
+        server = subprocess.Popen([str(binary), "--dir", str(root / "cache"), "--max_size", "1",
+                                   "--http_address", f"127.0.0.1:{http_port}",
+                                   "--grpc_address", f"127.0.0.1:{grpc_port}"], env=env, stdout=log, stderr=subprocess.STDOUT)
+        for _ in range(100):
+            if server.poll() is not None:
+                break
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{http_port}/status", timeout=1):
+                    return server, http_port, grpc_port
+            except OSError:
+                time.sleep(0.1)
+        stop_cache(server)
+        log.seek(0)
+        message = log.read()
+        # Port reservation cannot be handed to bazel-remote. Retry a bind race
+        # with fresh ports; holding sockets through Popen would prevent its bind.
+        if "address already in use" not in message.lower() or attempt == 2:
+            raise RuntimeError("cache server did not become ready: " + message)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--aspect", required=True)
     parser.add_argument("--bazel", default="bazel")
+    parser.add_argument("--bazel-version", default="9.2.0")
     args = parser.parse_args()
     aspect = str(Path(shutil.which(args.aspect) or args.aspect).resolve())
     bazel = str(Path(shutil.which(args.bazel) or args.bazel).resolve())
     started = time.monotonic()
-    with tempfile.TemporaryDirectory(prefix="cache-diff-integration-") as tmp:
+    with tempfile.TemporaryDirectory(prefix="cache-diff-integration-") as tmp, ExitStack() as cleanup:
         root = Path(tmp)
         arch = {"x86_64": "amd64", "aarch64": "arm64"}.get(platform.machine(), platform.machine())
         target = f"{platform.system().lower()}-{arch}"
         binary = root / "bazel-remote"
-        url = f"https://github.com/buchgr/bazel-remote/releases/download/v{CACHE_VERSION}/bazel-remote-{CACHE_VERSION}-{target}"
-        with urllib.request.urlopen(url, timeout=60) as response:
-            content = response.read()
-        assert hashlib.sha256(content).hexdigest() == CACHE_SHA256[target], "cache binary checksum mismatch"
-        binary.write_bytes(content)
-        binary.chmod(0o700)
-        http_port, grpc_port = free_port(), free_port()
-        while grpc_port == http_port:
-            grpc_port = free_port()
+        download_cache(binary, target)
         env = {k: v for k, v in os.environ.items() if k != "CI" and not k.startswith(("BAZEL_REMOTE_", "ASPECT_", "GITHUB_", "BUILDKITE_"))}
         env["BAZEL_REAL"] = bazel
+        env["USE_BAZEL_VERSION"] = args.bazel_version
+        log = cleanup.enter_context((root / "server.log").open("w+"))
+        server, http_port, grpc_port = start_cache(binary, root, env, log)
+        cleanup.callback(stop_cache, server)
         workspace = root / "workspace"
         workspace.mkdir()
-        (workspace / ".bazelversion").write_text("9.2.0\n")
+        (workspace / ".bazelversion").write_text(args.bazel_version + "\n")
         (workspace / "MODULE.bazel").write_text('module(name = "cache_fixture")\n')
         (workspace / "MODULE.aspect").write_text("")
         (workspace / "shared.in").write_text("baseline\n")
@@ -99,7 +153,7 @@ fixture_test(name = "excluded", data = ["//:shared"])
         startup = [ f"--output_base={root / 'output'}", "--host_jvm_args=-Xmx512m"]
         flags = [f"--remote_cache=grpc://127.0.0.1:{grpc_port}", "--remote_upload_local_results",
                  "--jobs=2", "--local_test_jobs=2", "--remote_timeout=15", "--remote_retries=0",
-                 f"--sandbox_writable_path={markers}", "--lockfile_mode=off", "--bes_backend="]
+                 f"--sandbox_writable_path={markers}", "--lockfile_mode=off", "--bes_backend=", "--test_env=FOO=1"]
         (workspace / ".bazelrc").write_text("".join(f"startup {f}\n" for f in startup) + "".join(f"build {f}\n" for f in flags))
         timings = {}
 
@@ -115,9 +169,11 @@ fixture_test(name = "excluded", data = ["//:shared"])
             path = markers / kind
             return len(path.read_text().splitlines()) if path.exists() else 0
 
-        def probe(name, mode="overreport", patterns=None, expected=None, total=3):
+        def probe(name, mode="overreport", patterns=None, expected=None, total=3, extra_flags=None):
             before_tests, before_builds = count("test"), count("build")
-            result = run(name, [aspect, "cache", "diff", "--bazel-startup-flag=--nosystem_rc", "--bazel-startup-flag=--nohome_rc", f"--mode={mode}", "--output=json", "--test_tag_filters=-noci", "--"] + (patterns or ["//...", "-//personal/..."]))
+            result = run(name, [aspect, "cache", "diff", "--bazel-startup-flag=--nosystem_rc", "--bazel-startup-flag=--nohome_rc", f"--mode={mode}", "--output=json", "--test_tag_filters=-noci"] + (extra_flags or []) + ["--"] + (patterns or ["//...", "-//personal/..."]))
+            if "--announce-bazel-command=true" in (extra_flags or []):
+                assert "--noanalyze" in result.stderr, result.stderr
             doc = json.loads(result.stdout)
             got = {row["label"] for row in doc["affected"]}
             assert got == set(expected or []), (name, doc)
@@ -127,53 +183,45 @@ fixture_test(name = "excluded", data = ["//:shared"])
                 assert count("build") == before_builds, f"{name}: probe executed a build action"
             return doc
 
-        with (root / "server.log").open("w+") as log:
-            server = subprocess.Popen([str(binary), "--dir", str(root / "cache"), "--max_size", "1",
-                                       "--http_address", f"127.0.0.1:{http_port}",
-                                       "--grpc_address", f"127.0.0.1:{grpc_port}"], env=env, stdout=log, stderr=subprocess.STDOUT)
-            try:
-                for _ in range(100):
-                    try:
-                        with urllib.request.urlopen(f"http://127.0.0.1:{http_port}/status", timeout=1):
-                            break
-                    except OSError:
-                        if server.poll() is not None:
-                            log.seek(0)
-                            raise AssertionError(log.read())
-                        time.sleep(0.1)
-                else:
-                    raise AssertionError("cache server did not become ready")
-                run("seed", [bazel, "--nosystem_rc", "--nohome_rc", "test", "//..."])
-                assert count("test") == 5, "baseline did not execute every fixture test"
-                assert count("build") == 1, "baseline did not build the shared dependency"
-                probe("warm_hits")
-                (workspace / "shared.in").write_text("changed\n")
-                doc = probe("dependency_miss", expected=["//:a", "//:b"])
-                assert all(any(c["target"] == "//:shared" for c in row["caused_by"]) for row in doc["affected"]), doc
-                probe("suite_miss", patterns=["//:suite", "//:unrelated"], expected=["//:a", "//:b"])
-                probe("reinclude_miss", patterns=["//...", "-//personal/...", "//personal:excluded"],
-                      expected=["//:a", "//:b", "//personal:excluded"], total=4)
-                probe("precise_miss", mode="precise", expected=["//:a", "//:b"])
-                assert count("build") == 2, "precise mode did not build the changed dependency"
-                run("refresh_baseline", [bazel, "--nosystem_rc", "--nohome_rc", "test", "//..."])
-                probe("warm_hits_after_change")
-                before = count("test")
-                result = run("empty_scope", [aspect, "cache", "diff", "--bazel-startup-flag=--nosystem_rc", "--bazel-startup-flag=--nohome_rc", "--exec=exit 99", "--", "//...", "-//..."])
-                assert not result.stdout and count("test") == before
-                with urllib.request.urlopen(f"http://127.0.0.1:{http_port}/status", timeout=5) as response:
-                    status = json.load(response)
-                print(json.dumps({"timings": timings, "total_seconds": round(time.monotonic() - started, 3),
-                                  "cache_bytes": status["CurrSize"], "cache_files": status["NumFiles"]}, indent=2), flush=True)
-            finally:
-                try:
-                    subprocess.run([bazel, "--nosystem_rc", "--nohome_rc", "shutdown"], cwd=workspace, env=env, capture_output=True, timeout=30)
-                finally:
-                    server.terminate()
-                    try:
-                        server.wait(timeout=10)
-                    except subprocess.TimeoutExpired:
-                        server.kill()
-                        server.wait()
+        try:
+            version = run("bazel_version", [bazel, "--version"])
+            assert version.stdout.strip() == f"bazel {args.bazel_version}", version.stdout + version.stderr
+            run("seed", [bazel, "--nosystem_rc", "--nohome_rc", "test", "//..."])
+            assert count("test") == 5, "baseline did not execute every fixture test"
+            assert count("build") == 1, "baseline did not build the shared dependency"
+            probe("warm_hits")
+            with (workspace / ".bazelrc").open("a") as rc:
+                rc.write("build:selection_only --test_env=FOO=1\n")
+            probe("build_only_config_warm_hits", extra_flags=["--config=selection_only"])
+            probe("announced_selection", extra_flags=["--announce-bazel-command=true"])
+            (workspace / "shared.in").write_text("changed\n")
+            doc = probe("dependency_miss", expected=["//:a", "//:b"])
+            assert all(any(c["target"] == "//:shared" for c in row["caused_by"]) for row in doc["affected"]), doc
+            probe("command_specific_flags_miss", expected=["//:a", "//:b"], extra_flags=[
+                "--test_env", "FOO=1", "--runs_per_test=1", "--build_tests_only",
+                "--remote_download_outputs=minimal", f"--remote_cache=grpc://127.0.0.1:{grpc_port}",
+            ])
+            probe("suite_miss", patterns=["//:suite", "//:unrelated"], expected=["//:a", "//:b"])
+            probe("reinclude_miss", patterns=["//...", "-//personal/...", "//personal:excluded"],
+                  expected=["//:a", "//:b", "//personal:excluded"], total=4)
+            probe("precise_miss", mode="precise", expected=["//:a", "//:b"])
+            assert count("build") == 2, "precise mode did not build the changed dependency"
+            run("refresh_baseline", [bazel, "--nosystem_rc", "--nohome_rc", "test", "//..."])
+            probe("warm_hits_after_change")
+            before = count("test")
+            result = run("empty_scope", [aspect, "cache", "diff", "--bazel-startup-flag=--nosystem_rc", "--bazel-startup-flag=--nohome_rc", "--exec=exit 99", "--", "//...", "-//..."])
+            assert not result.stdout and count("test") == before
+            pattern_file = workspace / "empty-patterns"
+            pattern_file.write_text("//...\n-//...\n")
+            result = run("empty_pattern_file", [aspect, "cache", "diff", "--bazel-startup-flag=--nosystem_rc", "--bazel-startup-flag=--nohome_rc", f"--target_pattern_file={pattern_file}", "--exec=exit 99"])
+            assert not result.stdout and count("test") == before
+            assert f"--target_pattern_file={pattern_file}" in result.stderr
+            with urllib.request.urlopen(f"http://127.0.0.1:{http_port}/status", timeout=5) as response:
+                status = json.load(response)
+            print(json.dumps({"timings": timings, "total_seconds": round(time.monotonic() - started, 3),
+                              "cache_bytes": status["CurrSize"], "cache_files": status["NumFiles"]}, indent=2), flush=True)
+        finally:
+            subprocess.run([bazel, "--nosystem_rc", "--nohome_rc", "shutdown"], cwd=workspace, env=env, capture_output=True, timeout=30)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`aspect cache diff -- //... -//excluded/...` currently constructs an invalid query, and query-based enumeration can report tests excluded by Bazel's test filters. Resolve the affected-test scope through Bazel's loading-only test phase so ordered patterns, suites, filters, and pattern files follow Bazel's selection behavior. Wildcards exclude `manual` tests; explicit manual targets remain selectable. Requires Bazel 7+.

Require complete selection events and reject loading failures or partial results. Disable BES for the private selection pass, honor command announcements, and release its temporary files promptly. Construct the attribution query RC only when a dependency miss requires it, retain resolved version-conditional flags, and render options through Bazel's common section so command-inapplicable flags are ignored by Bazel. Preserve pattern-file scope through the probe and precise prebuild.

Add an automatically discovered AXL regression suite and a GitHub Actions integration matrix for Bazel 7.4.0, 8.6.0, and 9.2.0. Each job downloads the CLI artifact built from this PR in the same workflow run, starts a checksum-pinned local `bazel-remote`, and checks real hits/misses against a controlled baseline. Execution markers assert that probes never run tests and overreport never runs build actions. Each job uses two Bazel workers and a 512 MiB JVM heap limit; no shared-cache credentials or Docker are needed. Downloads and port-bind races have bounded retries.

### Validation

- Parser/RC checks and 31 real-Bazel selection cases pass locally, including negative patterns, filters, suites, external targets, loading failures, and unreachable BES/cache endpoints.
- Expanded real-cache integration passes locally on Bazel 7.4.0, 8.6.0, and 9.2.0 in 118–129 seconds per version, storing 220–224 KiB.
- Integration covers unchanged hits, dependency misses, command-specific CLI flags, build-only configs on warm hits, announcements, suites, re-inclusion, precise prebuild, refreshed hits, and empty-scope pattern files/`--exec` suppression.
- Builtin import-style check and formatting pass locally.
- Selection was compared with native Bazel on a larger repository across 15 scenarios, with matching results.
- [CI passed on 6e95359d](https://github.com/aspect-build/aspect-cli/actions/runs/34728197294), including both shared-cache probes, full build/test jobs, and all 46 discovered AXL suites. The selection suite passed 31 real-Bazel cases in 83 seconds.
- The three GitHub-hosted cache-integration jobs passed in 47, 44, and 108 seconds of test time (Bazel 7, 8, and 9), or about 3.8 runner-minutes total including setup. Fixture timings do not establish whole-repository cache-diff performance.
